### PR TITLE
feat(auth): implement persistent clinic roles and backend permission matrix

### DIFF
--- a/drizzle/migrations/0011_hot_luminals.sql
+++ b/drizzle/migrations/0011_hot_luminals.sql
@@ -1,0 +1,43 @@
+ALTER TABLE "clinic_users"
+ADD COLUMN IF NOT EXISTS "role" varchar(32) NOT NULL DEFAULT 'clinic_staff';
+
+UPDATE "clinic_users" cu
+SET "role" = ranked.assigned_role
+FROM (
+  SELECT
+    id,
+    CASE
+      WHEN row_number() OVER (PARTITION BY clinic_id ORDER BY created_at ASC, id ASC) = 1
+        THEN 'clinic_owner'
+      ELSE 'clinic_staff'
+    END AS assigned_role
+  FROM "clinic_users"
+) AS ranked
+WHERE cu.id = ranked.id
+  AND (cu.role IS NULL OR cu.role NOT IN ('clinic_owner', 'clinic_staff'));
+
+UPDATE "clinic_users"
+SET "role" = 'clinic_staff'
+WHERE "role" IS NULL;
+
+ALTER TABLE "clinic_users"
+ALTER COLUMN "role" SET DEFAULT 'clinic_staff';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'clinic_users_role_check'
+  ) THEN
+    ALTER TABLE "clinic_users"
+    ADD CONSTRAINT "clinic_users_role_check"
+    CHECK ("role" IN ('clinic_owner', 'clinic_staff'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "clinic_users_clinic_id_idx"
+ON "clinic_users" ("clinic_id");
+
+CREATE INDEX IF NOT EXISTS "clinic_users_clinic_id_role_idx"
+ON "clinic_users" ("clinic_id", "role");

--- a/drizzle/migrations/meta/0011_snapshot.json
+++ b/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1794 @@
+{
+  "id": "9fdd984a-ff9d-4c3b-a0d1-1ed4b8fc908a",
+  "prevId": "19b75033-a9f4-452d-a0cb-773b1ae43118",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_sessions": {
+      "name": "active_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_user_id": {
+          "name": "clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_access": {
+          "name": "last_access",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_sessions_token_hash_idx": {
+          "name": "active_sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_sessions_clinic_user_id_idx": {
+          "name": "active_sessions_clinic_user_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_sessions_clinic_user_id_clinic_users_id_fk": {
+          "name": "active_sessions_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "active_sessions",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "active_sessions_token_hash_unique": {
+          "name": "active_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.admin_sessions": {
+      "name": "admin_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_access": {
+          "name": "last_access",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_sessions_token_hash_idx": {
+          "name": "admin_sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_sessions_admin_user_id_idx": {
+          "name": "admin_sessions_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_sessions_admin_user_id_admin_users_id_fk": {
+          "name": "admin_sessions_admin_user_id_admin_users_id_fk",
+          "tableFrom": "admin_sessions",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_sessions_token_hash_unique": {
+          "name": "admin_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.clinic_public_profiles": {
+      "name": "clinic_public_profiles",
+      "schema": "",
+      "columns": {
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_storage_path": {
+          "name": "avatar_storage_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about_text": {
+          "name": "about_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_text": {
+          "name": "specialty_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services_text": {
+          "name": "services_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_public_profiles_is_public_idx": {
+          "name": "clinic_public_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_profiles_country_idx": {
+          "name": "clinic_public_profiles_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_profiles_locality_idx": {
+          "name": "clinic_public_profiles_locality_idx",
+          "columns": [
+            {
+              "expression": "locality",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_public_profiles_clinic_id_clinics_id_fk": {
+          "name": "clinic_public_profiles_clinic_id_clinics_id_fk",
+          "tableFrom": "clinic_public_profiles",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.clinic_public_search": {
+      "name": "clinic_public_search",
+      "schema": "",
+      "columns": {
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_storage_path": {
+          "name": "avatar_storage_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about_text": {
+          "name": "about_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_text": {
+          "name": "specialty_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services_text": {
+          "name": "services_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_required_public_fields": {
+          "name": "has_required_public_fields",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_search_eligible": {
+          "name": "is_search_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_quality_score": {
+          "name": "profile_quality_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_public_search_is_public_idx": {
+          "name": "clinic_public_search_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_search_is_search_eligible_idx": {
+          "name": "clinic_public_search_is_search_eligible_idx",
+          "columns": [
+            {
+              "expression": "is_search_eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_search_profile_quality_score_idx": {
+          "name": "clinic_public_search_profile_quality_score_idx",
+          "columns": [
+            {
+              "expression": "profile_quality_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_search_updated_at_idx": {
+          "name": "clinic_public_search_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_public_search_clinic_id_clinics_id_fk": {
+          "name": "clinic_public_search_clinic_id_clinics_id_fk",
+          "tableFrom": "clinic_public_search",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.clinic_users": {
+      "name": "clinic_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_pro_id": {
+          "name": "auth_pro_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clinic_staff'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_users_clinic_id_idx": {
+          "name": "clinic_users_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_users_clinic_id_role_idx": {
+          "name": "clinic_users_clinic_id_role_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_users_clinic_id_clinics_id_fk": {
+          "name": "clinic_users_clinic_id_clinics_id_fk",
+          "tableFrom": "clinic_users",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clinic_users_username_unique": {
+          "name": "clinic_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.clinics": {
+      "name": "clinics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.particular_sessions": {
+      "name": "particular_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "particular_token_id": {
+          "name": "particular_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_access": {
+          "name": "last_access",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "particular_sessions_token_hash_idx": {
+          "name": "particular_sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_sessions_particular_token_id_idx": {
+          "name": "particular_sessions_particular_token_id_idx",
+          "columns": [
+            {
+              "expression": "particular_token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "particular_sessions_particular_token_id_particular_tokens_id_fk": {
+          "name": "particular_sessions_particular_token_id_particular_tokens_id_fk",
+          "tableFrom": "particular_sessions",
+          "tableTo": "particular_tokens",
+          "columnsFrom": [
+            "particular_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "particular_sessions_token_hash_unique": {
+          "name": "particular_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.particular_tokens": {
+      "name": "particular_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_admin_id": {
+          "name": "created_by_admin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_clinic_user_id": {
+          "name": "created_by_clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tutor_last_name": {
+          "name": "tutor_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_name": {
+          "name": "pet_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_age": {
+          "name": "pet_age",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_breed": {
+          "name": "pet_breed",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_sex": {
+          "name": "pet_sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_species": {
+          "name": "pet_species",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_location": {
+          "name": "sample_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_evolution": {
+          "name": "sample_evolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details_lesion": {
+          "name": "details_lesion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_date": {
+          "name": "extraction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_date": {
+          "name": "shipping_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "particular_tokens_token_hash_idx": {
+          "name": "particular_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_tokens_clinic_id_idx": {
+          "name": "particular_tokens_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_tokens_report_id_idx": {
+          "name": "particular_tokens_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_tokens_clinic_created_at_idx": {
+          "name": "particular_tokens_clinic_created_at_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "particular_tokens_clinic_id_clinics_id_fk": {
+          "name": "particular_tokens_clinic_id_clinics_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "particular_tokens_report_id_reports_id_fk": {
+          "name": "particular_tokens_report_id_reports_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "particular_tokens_created_by_admin_id_admin_users_id_fk": {
+          "name": "particular_tokens_created_by_admin_id_admin_users_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "created_by_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "particular_tokens_created_by_clinic_user_id_clinic_users_id_fk": {
+          "name": "particular_tokens_created_by_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "created_by_clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "particular_tokens_token_hash_unique": {
+          "name": "particular_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_date": {
+          "name": "upload_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "study_type": {
+          "name": "study_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_name": {
+          "name": "patient_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_clinic_id_idx": {
+          "name": "reports_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_clinic_upload_date_idx": {
+          "name": "reports_clinic_upload_date_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upload_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_clinic_study_type_idx": {
+          "name": "reports_clinic_study_type_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "study_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_clinic_id_clinics_id_fk": {
+          "name": "reports_clinic_id_clinics_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_storage_path_unique": {
+          "name": "reports_storage_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_path"
+          ]
+        }
+      }
+    },
+    "public.study_tracking_cases": {
+      "name": "study_tracking_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "particular_token_id": {
+          "name": "particular_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_admin_id": {
+          "name": "created_by_admin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_clinic_user_id": {
+          "name": "created_by_clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reception_at": {
+          "name": "reception_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_delivery_at": {
+          "name": "estimated_delivery_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_delivery_auto_calculated_at": {
+          "name": "estimated_delivery_auto_calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_delivery_was_manually_adjusted": {
+          "name": "estimated_delivery_was_manually_adjusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reception'"
+        },
+        "processing_at": {
+          "name": "processing_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_at": {
+          "name": "evaluation_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_development_at": {
+          "name": "report_development_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_stain_required": {
+          "name": "special_stain_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "special_stain_notified_at": {
+          "name": "special_stain_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_url": {
+          "name": "payment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_contact_email": {
+          "name": "admin_contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_contact_phone": {
+          "name": "admin_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "study_tracking_cases_clinic_id_idx": {
+          "name": "study_tracking_cases_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_cases_current_stage_idx": {
+          "name": "study_tracking_cases_current_stage_idx",
+          "columns": [
+            {
+              "expression": "current_stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_cases_estimated_delivery_at_idx": {
+          "name": "study_tracking_cases_estimated_delivery_at_idx",
+          "columns": [
+            {
+              "expression": "estimated_delivery_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_cases_created_at_idx": {
+          "name": "study_tracking_cases_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_tracking_cases_clinic_id_clinics_id_fk": {
+          "name": "study_tracking_cases_clinic_id_clinics_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_report_id_reports_id_fk": {
+          "name": "study_tracking_cases_report_id_reports_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_particular_token_id_particular_tokens_id_fk": {
+          "name": "study_tracking_cases_particular_token_id_particular_tokens_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "particular_tokens",
+          "columnsFrom": [
+            "particular_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_created_by_admin_id_admin_users_id_fk": {
+          "name": "study_tracking_cases_created_by_admin_id_admin_users_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "created_by_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_created_by_clinic_user_id_clinic_users_id_fk": {
+          "name": "study_tracking_cases_created_by_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "created_by_clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_tracking_cases_report_id_unique": {
+          "name": "study_tracking_cases_report_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "report_id"
+          ]
+        },
+        "study_tracking_cases_particular_token_id_unique": {
+          "name": "study_tracking_cases_particular_token_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "particular_token_id"
+          ]
+        }
+      }
+    },
+    "public.study_tracking_notifications": {
+      "name": "study_tracking_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "study_tracking_case_id": {
+          "name": "study_tracking_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "particular_token_id": {
+          "name": "particular_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "study_tracking_notifications_case_id_idx": {
+          "name": "study_tracking_notifications_case_id_idx",
+          "columns": [
+            {
+              "expression": "study_tracking_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_notifications_clinic_id_idx": {
+          "name": "study_tracking_notifications_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_notifications_particular_token_id_idx": {
+          "name": "study_tracking_notifications_particular_token_id_idx",
+          "columns": [
+            {
+              "expression": "particular_token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_notifications_unread_idx": {
+          "name": "study_tracking_notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_tracking_notifications_study_tracking_case_id_study_tracking_cases_id_fk": {
+          "name": "study_tracking_notifications_study_tracking_case_id_study_tracking_cases_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "study_tracking_cases",
+          "columnsFrom": [
+            "study_tracking_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "study_tracking_notifications_clinic_id_clinics_id_fk": {
+          "name": "study_tracking_notifications_clinic_id_clinics_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "study_tracking_notifications_report_id_reports_id_fk": {
+          "name": "study_tracking_notifications_report_id_reports_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_notifications_particular_token_id_particular_tokens_id_fk": {
+          "name": "study_tracking_notifications_particular_token_id_particular_tokens_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "particular_tokens",
+          "columnsFrom": [
+            "particular_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1776178279540,
       "tag": "0010_nervous_captain_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776185343998,
+      "tag": "0011_hot_luminals",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -10,6 +10,9 @@ import {
 } from "drizzle-orm/pg-core";
 import { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
+export const CLINIC_USER_ROLES = ["clinic_owner", "clinic_staff"] as const;
+export type ClinicUserRole = (typeof CLINIC_USER_ROLES)[number];
+
 export const clinics = pgTable("clinics", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
@@ -19,17 +22,31 @@ export const clinics = pgTable("clinics", {
   updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
 });
 
-export const clinicUsers = pgTable("clinic_users", {
-  id: serial("id").primaryKey(),
-  clinicId: integer("clinic_id")
-    .notNull()
-    .references(() => clinics.id, { onDelete: "cascade" }),
-  username: varchar("username", { length: 100 }).notNull().unique(),
-  passwordHash: varchar("password_hash", { length: 255 }).notNull(),
-  authProId: varchar("auth_pro_id", { length: 100 }),
-  createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
-});
+export const clinicUsers = pgTable(
+  "clinic_users",
+  {
+    id: serial("id").primaryKey(),
+    clinicId: integer("clinic_id")
+      .notNull()
+      .references(() => clinics.id, { onDelete: "cascade" }),
+    username: varchar("username", { length: 100 }).notNull().unique(),
+    passwordHash: varchar("password_hash", { length: 255 }).notNull(),
+    authProId: varchar("auth_pro_id", { length: 100 }),
+    role: varchar("role", { length: 32 })
+      .$type<ClinicUserRole>()
+      .notNull()
+      .default("clinic_staff"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    clinicIdIdx: index("clinic_users_clinic_id_idx").on(table.clinicId),
+    clinicIdRoleIdx: index("clinic_users_clinic_id_role_idx").on(
+      table.clinicId,
+      table.role,
+    ),
+  }),
+);
 
 export const adminUsers = pgTable("admin_users", {
   id: serial("id").primaryKey(),

--- a/list-or-create-clinic-user.mjs
+++ b/list-or-create-clinic-user.mjs
@@ -42,7 +42,7 @@ try {
     `;
 
     if (clinics.length === 0) {
-      throw new Error("No existe ninguna clínica en la base");
+      throw new Error("No existe ninguna clÃ­nica en la base");
     }
 
     const clinic = clinics[0];
@@ -67,7 +67,7 @@ try {
         null,
         now(),
         now(),
-        'clinic_staff'
+        'clinic_owner'
       )
       returning
         id,

--- a/prepare-known-clinic-user.mjs
+++ b/prepare-known-clinic-user.mjs
@@ -28,7 +28,7 @@ try {
   `;
 
   if (clinicRows.length === 0) {
-    throw new Error(`No existe la clínica ${clinicId}`);
+    throw new Error(`No existe la clÃ­nica ${clinicId}`);
   }
 
   const existing = await sql`
@@ -47,7 +47,7 @@ try {
         clinic_id = ${clinicId},
         password_hash = ${passwordHash},
         updated_at = now(),
-        role = 'clinic_staff'
+        role = 'clinic_owner'
       where id = ${existing[0].id}
       returning id, clinic_id, username, updated_at
     `;
@@ -79,7 +79,7 @@ try {
         null,
         now(),
         now(),
-        'clinic_staff'
+        'clinic_owner'
       )
       returning id, clinic_id, username, created_at, updated_at
     `;

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,4 +1,4 @@
-import postgres from "postgres";
+﻿import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { and, desc, eq, ilike, isNotNull, lte, or } from "drizzle-orm";
 import {
@@ -8,8 +8,10 @@ import {
   clinicUsers,
   clinics,
   reports,
+  type ClinicUserRole,
 } from "../drizzle/schema";
 import { ENV } from "./lib/env";
+import { normalizeClinicUserRole } from "./lib/permissions";
 
 const client = postgres(ENV.databaseUrl, {
   prepare: false,
@@ -61,8 +63,10 @@ export async function upsertClinicUser(user: {
   username: string;
   passwordHash: string;
   authProId?: string | null;
+  role?: ClinicUserRole;
 }) {
   const now = new Date();
+  const normalizedRole = normalizeClinicUserRole(user.role, "clinic_staff");
 
   const result = await db
     .insert(clinicUsers)
@@ -71,6 +75,7 @@ export async function upsertClinicUser(user: {
       username: user.username.trim(),
       passwordHash: user.passwordHash,
       authProId: user.authProId ?? null,
+      role: normalizedRole,
       updatedAt: now,
     })
     .onConflictDoUpdate({
@@ -79,6 +84,7 @@ export async function upsertClinicUser(user: {
         clinicId: user.clinicId,
         passwordHash: user.passwordHash,
         authProId: user.authProId ?? null,
+        role: normalizedRole,
         updatedAt: now,
       },
     })
@@ -326,3 +332,4 @@ export async function getStudyTypes(clinicId: number) {
     .map((r) => r.studyType)
     .filter((v): v is string => !!v);
 }
+

--- a/server/lib/permissions.ts
+++ b/server/lib/permissions.ts
@@ -1,26 +1,43 @@
-import { ENV } from "./env";
+import type { ClinicUserRole } from "../../drizzle/schema";
 
-function normalize(value: string): string {
-  return value.trim().toLowerCase();
+export function isClinicUserRole(value: unknown): value is ClinicUserRole {
+  return value === "clinic_owner" || value === "clinic_staff";
 }
 
-const labUploadUsernames = new Set(
-  ENV.labUploadUsernames.map((username) => normalize(username)),
-);
-
-export function canUploadReports(user: {
-  username: string;
-  authProId?: string | null;
-}): boolean {
-  const normalizedUsername = normalize(user.username);
-
-  if (labUploadUsernames.has(normalizedUsername)) {
-    return true;
+export function normalizeClinicUserRole(
+  value: unknown,
+  fallback: ClinicUserRole = "clinic_staff",
+): ClinicUserRole {
+  if (typeof value !== "string") {
+    return fallback;
   }
 
-  if (ENV.ownerOpenId && typeof user.authProId === "string") {
-    return user.authProId === ENV.ownerOpenId;
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized === "clinic_owner" || normalized === "clinic_staff") {
+    return normalized;
   }
 
-  return false;
+  return fallback;
+}
+
+export type ClinicPermissions = {
+  canUploadReports: boolean;
+  canManageClinicUsers: boolean;
+};
+
+export function getClinicPermissions(role: ClinicUserRole): ClinicPermissions {
+  switch (role) {
+    case "clinic_owner":
+      return {
+        canUploadReports: true,
+        canManageClinicUsers: true,
+      };
+    case "clinic_staff":
+    default:
+      return {
+        canUploadReports: true,
+        canManageClinicUsers: false,
+      };
+  }
 }

--- a/server/middlewares/auth.ts
+++ b/server/middlewares/auth.ts
@@ -8,25 +8,20 @@ import {
 } from "../db";
 import { hashSessionToken } from "../lib/auth-security";
 import { ENV } from "../lib/env";
-import { canUploadReports } from "../lib/permissions";
+import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions";
 import { asyncHandler } from "../utils/async-handler";
 
-type AuthenticatedUser = {
+export type AuthenticatedUser = {
   id: number;
   clinicId: number;
   username: string;
   authProId: string | null;
+  role: import("../../drizzle/schema").ClinicUserRole;
+  permissions: import("../lib/permissions").ClinicPermissions;
   canUploadReports: boolean;
+  canManageClinicUsers: boolean;
   sessionToken: string;
 };
-
-declare global {
-  namespace Express {
-    interface Request {
-      auth?: AuthenticatedUser;
-    }
-  }
-}
 
 function getSessionToken(req: Request): string | undefined {
   const raw = req.cookies?.[ENV.cookieName];
@@ -96,15 +91,18 @@ export const requireAuth = asyncHandler(
 
     await updateSessionLastAccess(tokenHash);
 
+    const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+    const permissions = getClinicPermissions(role);
+
     req.auth = {
       id: clinicUser.id,
       clinicId: clinicUser.clinicId,
       username: clinicUser.username,
       authProId: clinicUser.authProId ?? null,
-      canUploadReports: canUploadReports({
-        username: clinicUser.username,
-        authProId: clinicUser.authProId ?? null,
-      }),
+      role,
+      permissions,
+      canUploadReports: permissions.canUploadReports,
+      canManageClinicUsers: permissions.canManageClinicUsers,
       sessionToken: token,
     };
 

--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -1,4 +1,4 @@
-﻿import { Router } from "express";
+import { Router } from "express";
 import rateLimit from "express-rate-limit";
 
 import {
@@ -14,7 +14,7 @@ import {
   verifyPassword,
 } from "../lib/auth-security";
 import { ENV } from "../lib/env";
-import { canUploadReports } from "../lib/permissions";
+import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
@@ -67,6 +67,8 @@ router.post(
       });
     }
 
+    const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+
     if (passwordCheck.needsRehash) {
       const newHash = await hashPassword(password);
 
@@ -75,6 +77,7 @@ router.post(
         username: clinicUser.username,
         passwordHash: newHash,
         authProId: clinicUser.authProId ?? null,
+        role,
       });
     }
 
@@ -104,13 +107,10 @@ router.post(
         id: clinicUser.id,
         clinicId: clinicUser.clinicId,
         username: clinicUser.username,
+        authProId: clinicUser.authProId ?? null,
+        role,
       },
-      permissions: {
-        canUploadReports: canUploadReports({
-          username: clinicUser.username,
-          authProId: clinicUser.authProId ?? null,
-        }),
-      },
+      permissions: getClinicPermissions(role),
     });
   }),
 );
@@ -127,10 +127,10 @@ router.get(
         id: auth.id,
         clinicId: auth.clinicId,
         username: auth.username,
+        authProId: auth.authProId,
+        role: auth.role,
       },
-      permissions: {
-        canUploadReports: auth.canUploadReports,
-      },
+      permissions: auth.permissions,
     });
   }),
 );

--- a/server/types/express.d.ts
+++ b/server/types/express.d.ts
@@ -1,5 +1,8 @@
 import "express";
 
+import type { ClinicUserRole } from "../../drizzle/schema";
+import type { ClinicPermissions } from "../lib/permissions";
+
 declare global {
   namespace Express {
     interface Request {
@@ -9,7 +12,10 @@ declare global {
         clinicId: number;
         username: string;
         authProId: string | null;
+        role: ClinicUserRole;
+        permissions: ClinicPermissions;
         canUploadReports: boolean;
+        canManageClinicUsers: boolean;
         sessionToken: string;
       };
       adminAuth?: {


### PR DESCRIPTION
﻿## Objetivo
Implementar roles persistentes en `clinic_users` y reemplazar la autorización estructural basada en environment por una matriz de permisos backend respaldada por datos persistentes.

## Incluye
- agregado de `clinic_users.role` al schema runtime
- migración de reconciliación para roles persistentes
- lectura y persistencia de `role` en `server/db.ts`
- propagación de `role` en `req.auth`
- `/api/auth/login` y `/api/auth/me` devolviendo rol real y permisos
- reemplazo de permisos backend basados en ENV por permisos basados en rol
- actualización de scripts demo para preparar usuario owner

## Validación manual
- `pnpm install`
- `pnpm typecheck`
- `pnpm build`
- `pnpm db:generate`
- `pnpm db:migrate`
- `node .\prepare-known-clinic-user.mjs`
- `pnpm dev`
- login clínica con `publicdemo`
- `GET /api/auth/me` devolviendo `role=clinic_owner`
- `GET /api/reports` respondiendo correctamente
- logout clínica

## Riesgos
- Mantiene `canUploadReports=true` también para `clinic_staff` para no romper el flujo actual
- No introduce todavía auditoría persistente ni gestión de usuarios por UI
- No cierra todavía tokens públicos, pagos ni dashboard
