### PR TITLE
feat(reports): add report status history and legacy-compatible transitions

### DIFF
--- a/drizzle/migrations/0012_unusual_arclight.sql
+++ b/drizzle/migrations/0012_unusual_arclight.sql
@@ -1,0 +1,375 @@
+ALTER TABLE "reports"
+ADD COLUMN IF NOT EXISTS "current_status" varchar(32) NOT NULL DEFAULT 'uploaded';
+
+ALTER TABLE "reports"
+ADD COLUMN IF NOT EXISTS "status_changed_at" timestamp NOT NULL DEFAULT now();
+
+ALTER TABLE "reports"
+ADD COLUMN IF NOT EXISTS "status_changed_by_clinic_user_id" integer;
+
+ALTER TABLE "reports"
+ADD COLUMN IF NOT EXISTS "status_changed_by_admin_user_id" integer;
+
+UPDATE "reports"
+SET "current_status" = 'uploaded'
+WHERE "current_status" IS NULL
+   OR "current_status" NOT IN ('uploaded', 'processing', 'ready', 'delivered');
+
+UPDATE "reports"
+SET "status_changed_at" = COALESCE("status_changed_at", "updated_at", "created_at", now())
+WHERE "status_changed_at" IS NULL;
+
+ALTER TABLE "reports"
+ALTER COLUMN "current_status" SET DEFAULT 'uploaded';
+
+ALTER TABLE "reports"
+ALTER COLUMN "status_changed_at" SET DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'reports_current_status_check'
+  ) THEN
+    ALTER TABLE "reports"
+    ADD CONSTRAINT "reports_current_status_check"
+    CHECK ("current_status" IN ('uploaded', 'processing', 'ready', 'delivered'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'reports_status_changed_by_clinic_user_id_fk'
+  ) THEN
+    ALTER TABLE "reports"
+    ADD CONSTRAINT "reports_status_changed_by_clinic_user_id_fk"
+    FOREIGN KEY ("status_changed_by_clinic_user_id")
+    REFERENCES "clinic_users"("id")
+    ON DELETE SET NULL;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'reports_status_changed_by_admin_user_id_fk'
+  ) THEN
+    ALTER TABLE "reports"
+    ADD CONSTRAINT "reports_status_changed_by_admin_user_id_fk"
+    FOREIGN KEY ("status_changed_by_admin_user_id")
+    REFERENCES "admin_users"("id")
+    ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "report_status_history" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "report_id" integer,
+  "from_status" varchar(32),
+  "to_status" varchar(32),
+  "changed_by_clinic_user_id" integer,
+  "changed_by_admin_user_id" integer,
+  "note" text,
+  "created_at" timestamp DEFAULT now()
+);
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "report_id" integer;
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "from_status" varchar(32);
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "to_status" varchar(32);
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "changed_by_clinic_user_id" integer;
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "changed_by_admin_user_id" integer;
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "note" text;
+
+ALTER TABLE "report_status_history"
+ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
+
+DO $$
+DECLARE
+  has_legacy_status boolean;
+  has_legacy_changed_at boolean;
+  has_legacy_changed_by_type boolean;
+  legacy_actor_type text;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'status'
+  ) INTO has_legacy_status;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'changed_by_type'
+  ) INTO has_legacy_changed_by_type;
+
+  IF has_legacy_status THEN
+    EXECUTE '
+      UPDATE "report_status_history"
+      SET "to_status" = COALESCE("to_status", "status")
+      WHERE "to_status" IS NULL
+    ';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'changed_at'
+  ) INTO has_legacy_changed_at;
+
+  IF has_legacy_changed_at THEN
+    EXECUTE '
+      UPDATE "report_status_history"
+      SET "created_at" = COALESCE("created_at", "changed_at", now())
+      WHERE "created_at" IS NULL
+    ';
+  ELSE
+    UPDATE "report_status_history"
+    SET "created_at" = now()
+    WHERE "created_at" IS NULL;
+  END IF;
+
+  IF has_legacy_changed_by_type THEN
+    EXECUTE '
+      SELECT COALESCE(
+        (
+          SELECT "changed_by_type"
+          FROM "report_status_history"
+          WHERE "changed_by_type" IS NOT NULL
+          LIMIT 1
+        ),
+        ''system''
+      )
+    ' INTO legacy_actor_type;
+
+    EXECUTE format(
+      'UPDATE "report_status_history" SET "changed_by_type" = %L WHERE "changed_by_type" IS NULL',
+      legacy_actor_type
+    );
+  END IF;
+END $$;
+
+UPDATE "report_status_history"
+SET "to_status" = 'uploaded'
+WHERE "to_status" IS NULL;
+
+ALTER TABLE "report_status_history"
+ALTER COLUMN "report_id" SET NOT NULL;
+
+ALTER TABLE "report_status_history"
+ALTER COLUMN "to_status" SET NOT NULL;
+
+ALTER TABLE "report_status_history"
+ALTER COLUMN "created_at" SET NOT NULL;
+
+ALTER TABLE "report_status_history"
+ALTER COLUMN "created_at" SET DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'report_status_history_report_id_fk'
+  ) THEN
+    ALTER TABLE "report_status_history"
+    ADD CONSTRAINT "report_status_history_report_id_fk"
+    FOREIGN KEY ("report_id")
+    REFERENCES "reports"("id")
+    ON DELETE CASCADE;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'report_status_history_changed_by_clinic_user_id_fk'
+  ) THEN
+    ALTER TABLE "report_status_history"
+    ADD CONSTRAINT "report_status_history_changed_by_clinic_user_id_fk"
+    FOREIGN KEY ("changed_by_clinic_user_id")
+    REFERENCES "clinic_users"("id")
+    ON DELETE SET NULL;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'report_status_history_changed_by_admin_user_id_fk'
+  ) THEN
+    ALTER TABLE "report_status_history"
+    ADD CONSTRAINT "report_status_history_changed_by_admin_user_id_fk"
+    FOREIGN KEY ("changed_by_admin_user_id")
+    REFERENCES "admin_users"("id")
+    ON DELETE SET NULL;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'report_status_history_from_status_check'
+  ) THEN
+    ALTER TABLE "report_status_history"
+    ADD CONSTRAINT "report_status_history_from_status_check"
+    CHECK (
+      "from_status" IS NULL
+      OR "from_status" IN ('uploaded', 'processing', 'ready', 'delivered')
+    );
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'report_status_history_to_status_check'
+  ) THEN
+    ALTER TABLE "report_status_history"
+    ADD CONSTRAINT "report_status_history_to_status_check"
+    CHECK ("to_status" IN ('uploaded', 'processing', 'ready', 'delivered'));
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  has_legacy_status boolean;
+  has_legacy_changed_by_type boolean;
+  legacy_actor_type text;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'status'
+  ) INTO has_legacy_status;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'changed_by_type'
+  ) INTO has_legacy_changed_by_type;
+
+  IF has_legacy_changed_by_type THEN
+    EXECUTE '
+      SELECT COALESCE(
+        (
+          SELECT "changed_by_type"
+          FROM "report_status_history"
+          WHERE "changed_by_type" IS NOT NULL
+          LIMIT 1
+        ),
+        ''system''
+      )
+    ' INTO legacy_actor_type;
+  ELSE
+    legacy_actor_type := 'system';
+  END IF;
+
+  IF has_legacy_status THEN
+    EXECUTE format($insert$
+      INSERT INTO "report_status_history" (
+        "report_id",
+        "status",
+        "previous_status",
+        "changed_by",
+        "changed_by_type",
+        "notes",
+        "created_at",
+        "from_status",
+        "to_status",
+        "changed_by_clinic_user_id",
+        "changed_by_admin_user_id",
+        "note"
+      )
+      SELECT
+        r."id",
+        r."current_status",
+        NULL,
+        COALESCE(r."status_changed_by_clinic_user_id", r."status_changed_by_admin_user_id"),
+        %L,
+        'Historial inicial reconciliado',
+        COALESCE(r."created_at", r."status_changed_at", now()),
+        NULL,
+        r."current_status",
+        r."status_changed_by_clinic_user_id",
+        r."status_changed_by_admin_user_id",
+        'Historial inicial reconciliado'
+      FROM "reports" r
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM "report_status_history" h
+        WHERE h."report_id" = r."id"
+      )
+    $insert$, legacy_actor_type);
+  ELSE
+    INSERT INTO "report_status_history" (
+      "report_id",
+      "from_status",
+      "to_status",
+      "changed_by_clinic_user_id",
+      "changed_by_admin_user_id",
+      "note",
+      "created_at"
+    )
+    SELECT
+      r."id",
+      NULL,
+      r."current_status",
+      r."status_changed_by_clinic_user_id",
+      r."status_changed_by_admin_user_id",
+      'Historial inicial reconciliado',
+      COALESCE(r."created_at", r."status_changed_at", now())
+    FROM "reports" r
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "report_status_history" h
+      WHERE h."report_id" = r."id"
+    );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "reports_clinic_current_status_idx"
+ON "reports" ("clinic_id", "current_status");
+
+CREATE INDEX IF NOT EXISTS "reports_status_changed_at_idx"
+ON "reports" ("status_changed_at");
+
+CREATE INDEX IF NOT EXISTS "report_status_history_report_id_created_at_idx"
+ON "report_status_history" ("report_id", "created_at");
+
+CREATE INDEX IF NOT EXISTS "report_status_history_to_status_idx"
+ON "report_status_history" ("to_status");

--- a/drizzle/migrations/0013_report_status_history_legacy_compat.sql
+++ b/drizzle/migrations/0013_report_status_history_legacy_compat.sql
@@ -1,0 +1,22 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'status'
+  ) THEN
+    EXECUTE 'ALTER TABLE "report_status_history" ALTER COLUMN "status" DROP NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'report_status_history'
+      AND column_name = 'changed_by_type'
+  ) THEN
+    EXECUTE 'ALTER TABLE "report_status_history" ALTER COLUMN "changed_by_type" DROP NOT NULL';
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/0012_snapshot.json
+++ b/drizzle/migrations/meta/0012_snapshot.json
@@ -1,0 +1,2018 @@
+{
+  "id": "fcaae192-03b0-4086-b0b6-c672fa5b51a7",
+  "prevId": "9fdd984a-ff9d-4c3b-a0d1-1ed4b8fc908a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_sessions": {
+      "name": "active_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_user_id": {
+          "name": "clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_access": {
+          "name": "last_access",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_sessions_token_hash_idx": {
+          "name": "active_sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_sessions_clinic_user_id_idx": {
+          "name": "active_sessions_clinic_user_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_sessions_clinic_user_id_clinic_users_id_fk": {
+          "name": "active_sessions_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "active_sessions",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "active_sessions_token_hash_unique": {
+          "name": "active_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.admin_sessions": {
+      "name": "admin_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_access": {
+          "name": "last_access",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_sessions_token_hash_idx": {
+          "name": "admin_sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_sessions_admin_user_id_idx": {
+          "name": "admin_sessions_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_sessions_admin_user_id_admin_users_id_fk": {
+          "name": "admin_sessions_admin_user_id_admin_users_id_fk",
+          "tableFrom": "admin_sessions",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_sessions_token_hash_unique": {
+          "name": "admin_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.clinic_public_profiles": {
+      "name": "clinic_public_profiles",
+      "schema": "",
+      "columns": {
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_storage_path": {
+          "name": "avatar_storage_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about_text": {
+          "name": "about_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_text": {
+          "name": "specialty_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services_text": {
+          "name": "services_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_public_profiles_is_public_idx": {
+          "name": "clinic_public_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_profiles_country_idx": {
+          "name": "clinic_public_profiles_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_profiles_locality_idx": {
+          "name": "clinic_public_profiles_locality_idx",
+          "columns": [
+            {
+              "expression": "locality",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_public_profiles_clinic_id_clinics_id_fk": {
+          "name": "clinic_public_profiles_clinic_id_clinics_id_fk",
+          "tableFrom": "clinic_public_profiles",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.clinic_public_search": {
+      "name": "clinic_public_search",
+      "schema": "",
+      "columns": {
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_storage_path": {
+          "name": "avatar_storage_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about_text": {
+          "name": "about_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_text": {
+          "name": "specialty_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services_text": {
+          "name": "services_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locality": {
+          "name": "locality",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_required_public_fields": {
+          "name": "has_required_public_fields",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_search_eligible": {
+          "name": "is_search_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_quality_score": {
+          "name": "profile_quality_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_public_search_is_public_idx": {
+          "name": "clinic_public_search_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_search_is_search_eligible_idx": {
+          "name": "clinic_public_search_is_search_eligible_idx",
+          "columns": [
+            {
+              "expression": "is_search_eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_search_profile_quality_score_idx": {
+          "name": "clinic_public_search_profile_quality_score_idx",
+          "columns": [
+            {
+              "expression": "profile_quality_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_public_search_updated_at_idx": {
+          "name": "clinic_public_search_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_public_search_clinic_id_clinics_id_fk": {
+          "name": "clinic_public_search_clinic_id_clinics_id_fk",
+          "tableFrom": "clinic_public_search",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.clinic_users": {
+      "name": "clinic_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_pro_id": {
+          "name": "auth_pro_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clinic_staff'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_users_clinic_id_idx": {
+          "name": "clinic_users_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_users_clinic_id_role_idx": {
+          "name": "clinic_users_clinic_id_role_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_users_clinic_id_clinics_id_fk": {
+          "name": "clinic_users_clinic_id_clinics_id_fk",
+          "tableFrom": "clinic_users",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clinic_users_username_unique": {
+          "name": "clinic_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.clinics": {
+      "name": "clinics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.particular_sessions": {
+      "name": "particular_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "particular_token_id": {
+          "name": "particular_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_access": {
+          "name": "last_access",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "particular_sessions_token_hash_idx": {
+          "name": "particular_sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_sessions_particular_token_id_idx": {
+          "name": "particular_sessions_particular_token_id_idx",
+          "columns": [
+            {
+              "expression": "particular_token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "particular_sessions_particular_token_id_particular_tokens_id_fk": {
+          "name": "particular_sessions_particular_token_id_particular_tokens_id_fk",
+          "tableFrom": "particular_sessions",
+          "tableTo": "particular_tokens",
+          "columnsFrom": [
+            "particular_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "particular_sessions_token_hash_unique": {
+          "name": "particular_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.particular_tokens": {
+      "name": "particular_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_admin_id": {
+          "name": "created_by_admin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_clinic_user_id": {
+          "name": "created_by_clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tutor_last_name": {
+          "name": "tutor_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_name": {
+          "name": "pet_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_age": {
+          "name": "pet_age",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_breed": {
+          "name": "pet_breed",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_sex": {
+          "name": "pet_sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_species": {
+          "name": "pet_species",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_location": {
+          "name": "sample_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_evolution": {
+          "name": "sample_evolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details_lesion": {
+          "name": "details_lesion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_date": {
+          "name": "extraction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_date": {
+          "name": "shipping_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "particular_tokens_token_hash_idx": {
+          "name": "particular_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_tokens_clinic_id_idx": {
+          "name": "particular_tokens_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_tokens_report_id_idx": {
+          "name": "particular_tokens_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "particular_tokens_clinic_created_at_idx": {
+          "name": "particular_tokens_clinic_created_at_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "particular_tokens_clinic_id_clinics_id_fk": {
+          "name": "particular_tokens_clinic_id_clinics_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "particular_tokens_report_id_reports_id_fk": {
+          "name": "particular_tokens_report_id_reports_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "particular_tokens_created_by_admin_id_admin_users_id_fk": {
+          "name": "particular_tokens_created_by_admin_id_admin_users_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "created_by_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "particular_tokens_created_by_clinic_user_id_clinic_users_id_fk": {
+          "name": "particular_tokens_created_by_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "particular_tokens",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "created_by_clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "particular_tokens_token_hash_unique": {
+          "name": "particular_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.report_status_history": {
+      "name": "report_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_clinic_user_id": {
+          "name": "changed_by_clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_admin_user_id": {
+          "name": "changed_by_admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_status_history_report_id_created_at_idx": {
+          "name": "report_status_history_report_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_status_history_to_status_idx": {
+          "name": "report_status_history_to_status_idx",
+          "columns": [
+            {
+              "expression": "to_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_status_history_report_id_reports_id_fk": {
+          "name": "report_status_history_report_id_reports_id_fk",
+          "tableFrom": "report_status_history",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_status_history_changed_by_clinic_user_id_clinic_users_id_fk": {
+          "name": "report_status_history_changed_by_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "report_status_history",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "changed_by_clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "report_status_history_changed_by_admin_user_id_admin_users_id_fk": {
+          "name": "report_status_history_changed_by_admin_user_id_admin_users_id_fk",
+          "tableFrom": "report_status_history",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "changed_by_admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_date": {
+          "name": "upload_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "study_type": {
+          "name": "study_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_name": {
+          "name": "patient_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_status": {
+          "name": "current_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_changed_by_clinic_user_id": {
+          "name": "status_changed_by_clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_by_admin_user_id": {
+          "name": "status_changed_by_admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_clinic_id_idx": {
+          "name": "reports_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_clinic_upload_date_idx": {
+          "name": "reports_clinic_upload_date_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upload_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_clinic_study_type_idx": {
+          "name": "reports_clinic_study_type_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "study_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_clinic_current_status_idx": {
+          "name": "reports_clinic_current_status_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_changed_at_idx": {
+          "name": "reports_status_changed_at_idx",
+          "columns": [
+            {
+              "expression": "status_changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_clinic_id_clinics_id_fk": {
+          "name": "reports_clinic_id_clinics_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reports_status_changed_by_clinic_user_id_clinic_users_id_fk": {
+          "name": "reports_status_changed_by_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "status_changed_by_clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reports_status_changed_by_admin_user_id_admin_users_id_fk": {
+          "name": "reports_status_changed_by_admin_user_id_admin_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "status_changed_by_admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_storage_path_unique": {
+          "name": "reports_storage_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_path"
+          ]
+        }
+      }
+    },
+    "public.study_tracking_cases": {
+      "name": "study_tracking_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "particular_token_id": {
+          "name": "particular_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_admin_id": {
+          "name": "created_by_admin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_clinic_user_id": {
+          "name": "created_by_clinic_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reception_at": {
+          "name": "reception_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_delivery_at": {
+          "name": "estimated_delivery_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_delivery_auto_calculated_at": {
+          "name": "estimated_delivery_auto_calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_delivery_was_manually_adjusted": {
+          "name": "estimated_delivery_was_manually_adjusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reception'"
+        },
+        "processing_at": {
+          "name": "processing_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_at": {
+          "name": "evaluation_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_development_at": {
+          "name": "report_development_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_stain_required": {
+          "name": "special_stain_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "special_stain_notified_at": {
+          "name": "special_stain_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_url": {
+          "name": "payment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_contact_email": {
+          "name": "admin_contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_contact_phone": {
+          "name": "admin_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "study_tracking_cases_clinic_id_idx": {
+          "name": "study_tracking_cases_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_cases_current_stage_idx": {
+          "name": "study_tracking_cases_current_stage_idx",
+          "columns": [
+            {
+              "expression": "current_stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_cases_estimated_delivery_at_idx": {
+          "name": "study_tracking_cases_estimated_delivery_at_idx",
+          "columns": [
+            {
+              "expression": "estimated_delivery_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_cases_created_at_idx": {
+          "name": "study_tracking_cases_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_tracking_cases_clinic_id_clinics_id_fk": {
+          "name": "study_tracking_cases_clinic_id_clinics_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_report_id_reports_id_fk": {
+          "name": "study_tracking_cases_report_id_reports_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_particular_token_id_particular_tokens_id_fk": {
+          "name": "study_tracking_cases_particular_token_id_particular_tokens_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "particular_tokens",
+          "columnsFrom": [
+            "particular_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_created_by_admin_id_admin_users_id_fk": {
+          "name": "study_tracking_cases_created_by_admin_id_admin_users_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "admin_users",
+          "columnsFrom": [
+            "created_by_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_cases_created_by_clinic_user_id_clinic_users_id_fk": {
+          "name": "study_tracking_cases_created_by_clinic_user_id_clinic_users_id_fk",
+          "tableFrom": "study_tracking_cases",
+          "tableTo": "clinic_users",
+          "columnsFrom": [
+            "created_by_clinic_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_tracking_cases_report_id_unique": {
+          "name": "study_tracking_cases_report_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "report_id"
+          ]
+        },
+        "study_tracking_cases_particular_token_id_unique": {
+          "name": "study_tracking_cases_particular_token_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "particular_token_id"
+          ]
+        }
+      }
+    },
+    "public.study_tracking_notifications": {
+      "name": "study_tracking_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "study_tracking_case_id": {
+          "name": "study_tracking_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_id": {
+          "name": "clinic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "particular_token_id": {
+          "name": "particular_token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "study_tracking_notifications_case_id_idx": {
+          "name": "study_tracking_notifications_case_id_idx",
+          "columns": [
+            {
+              "expression": "study_tracking_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_notifications_clinic_id_idx": {
+          "name": "study_tracking_notifications_clinic_id_idx",
+          "columns": [
+            {
+              "expression": "clinic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_notifications_particular_token_id_idx": {
+          "name": "study_tracking_notifications_particular_token_id_idx",
+          "columns": [
+            {
+              "expression": "particular_token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_tracking_notifications_unread_idx": {
+          "name": "study_tracking_notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_tracking_notifications_study_tracking_case_id_study_tracking_cases_id_fk": {
+          "name": "study_tracking_notifications_study_tracking_case_id_study_tracking_cases_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "study_tracking_cases",
+          "columnsFrom": [
+            "study_tracking_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "study_tracking_notifications_clinic_id_clinics_id_fk": {
+          "name": "study_tracking_notifications_clinic_id_clinics_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "clinics",
+          "columnsFrom": [
+            "clinic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "study_tracking_notifications_report_id_reports_id_fk": {
+          "name": "study_tracking_notifications_report_id_reports_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "study_tracking_notifications_particular_token_id_particular_tokens_id_fk": {
+          "name": "study_tracking_notifications_particular_token_id_particular_tokens_id_fk",
+          "tableFrom": "study_tracking_notifications",
+          "tableTo": "particular_tokens",
+          "columnsFrom": [
+            "particular_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776185343998,
       "tag": "0011_hot_luminals",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776191939854,
+      "tag": "0012_unusual_arclight",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -13,6 +13,14 @@ import { InferInsertModel, InferSelectModel } from "drizzle-orm";
 export const CLINIC_USER_ROLES = ["clinic_owner", "clinic_staff"] as const;
 export type ClinicUserRole = (typeof CLINIC_USER_ROLES)[number];
 
+export const REPORT_STATUSES = [
+  "uploaded",
+  "processing",
+  "ready",
+  "delivered",
+] as const;
+export type ReportStatus = (typeof REPORT_STATUSES)[number];
+
 export const clinics = pgTable("clinics", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
@@ -70,6 +78,21 @@ export const reports = pgTable(
     storagePath: varchar("storage_path", { length: 255 }).notNull().unique(),
     previewUrl: text("preview_url"),
     downloadUrl: text("download_url"),
+    currentStatus: varchar("current_status", { length: 32 })
+      .$type<ReportStatus>()
+      .notNull()
+      .default("uploaded"),
+    statusChangedAt: timestamp("status_changed_at", { mode: "date" })
+      .defaultNow()
+      .notNull(),
+    statusChangedByClinicUserId: integer("status_changed_by_clinic_user_id").references(
+      () => clinicUsers.id,
+      { onDelete: "set null" },
+    ),
+    statusChangedByAdminUserId: integer("status_changed_by_admin_user_id").references(
+      () => adminUsers.id,
+      { onDelete: "set null" },
+    ),
     createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
   },
@@ -83,6 +106,44 @@ export const reports = pgTable(
       table.clinicId,
       table.studyType,
     ),
+    clinicCurrentStatusIdx: index("reports_clinic_current_status_idx").on(
+      table.clinicId,
+      table.currentStatus,
+    ),
+    statusChangedAtIdx: index("reports_status_changed_at_idx").on(
+      table.statusChangedAt,
+    ),
+  }),
+);
+
+export const reportStatusHistory = pgTable(
+  "report_status_history",
+  {
+    id: serial("id").primaryKey(),
+    reportId: integer("report_id")
+      .notNull()
+      .references(() => reports.id, { onDelete: "cascade" }),
+    fromStatus: varchar("from_status", { length: 32 }).$type<ReportStatus>(),
+    toStatus: varchar("to_status", { length: 32 })
+      .$type<ReportStatus>()
+      .notNull(),
+    changedByClinicUserId: integer("changed_by_clinic_user_id").references(
+      () => clinicUsers.id,
+      { onDelete: "set null" },
+    ),
+    changedByAdminUserId: integer("changed_by_admin_user_id").references(
+      () => adminUsers.id,
+      { onDelete: "set null" },
+    ),
+    note: text("note"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    reportIdCreatedAtIdx: index("report_status_history_report_id_created_at_idx").on(
+      table.reportId,
+      table.createdAt,
+    ),
+    toStatusIdx: index("report_status_history_to_status_idx").on(table.toStatus),
   }),
 );
 
@@ -393,6 +454,9 @@ export type NewAdminUser = InferInsertModel<typeof adminUsers>;
 
 export type Report = InferSelectModel<typeof reports>;
 export type NewReport = InferInsertModel<typeof reports>;
+
+export type ReportStatusHistory = InferSelectModel<typeof reportStatusHistory>;
+export type NewReportStatusHistory = InferInsertModel<typeof reportStatusHistory>;
 
 export type ActiveSession = InferSelectModel<typeof activeSessions>;
 export type NewActiveSession = InferInsertModel<typeof activeSessions>;

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,6 +1,6 @@
-import postgres from "postgres";
+﻿import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { and, desc, eq, ilike, isNotNull, lte, or } from "drizzle-orm";
+import { and, desc, eq, ilike, isNotNull, lte, or, sql } from "drizzle-orm";
 import {
   activeSessions,
   adminSessions,
@@ -304,15 +304,66 @@ export async function upsertReport(input: {
 
     const report = inserted[0];
 
-    await tx.insert(reportStatusHistory).values({
-      reportId: report.id,
-      fromStatus: null,
-      toStatus: "uploaded",
-      changedByClinicUserId: input.createdByClinicUserId ?? null,
-      changedByAdminUserId: input.createdByAdminUserId ?? null,
-      note: "Informe cargado inicialmente",
-      createdAt: now,
-    });
+    const initialChangedBy =
+      input.createdByClinicUserId ?? input.createdByAdminUserId ?? null;
+    const initialChangedByType =
+      input.createdByClinicUserId != null
+        ? "clinic_user"
+        : input.createdByAdminUserId != null
+          ? "admin_user"
+          : "system";
+
+    try {
+      await tx.execute(sql`
+        INSERT INTO "report_status_history" (
+          "report_id",
+          "status",
+          "previous_status",
+          "changed_by",
+          "changed_by_type",
+          "notes",
+          "created_at",
+          "from_status",
+          "to_status",
+          "changed_by_clinic_user_id",
+          "changed_by_admin_user_id",
+          "note"
+        )
+        VALUES (
+          ${report.id},
+          ${"uploaded"},
+          ${null},
+          ${initialChangedBy},
+          ${initialChangedByType},
+          ${"Informe cargado inicialmente"},
+          ${now.toISOString()},
+          ${null},
+          ${"uploaded"},
+          ${input.createdByClinicUserId ?? null},
+          ${input.createdByAdminUserId ?? null},
+          ${"Informe cargado inicialmente"}
+        )
+      `);
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "42703"
+      ) {
+        throw error;
+      }
+
+      await tx.insert(reportStatusHistory).values({
+        reportId: report.id,
+        fromStatus: null,
+        toStatus: "uploaded",
+        changedByClinicUserId: input.createdByClinicUserId ?? null,
+        changedByAdminUserId: input.createdByAdminUserId ?? null,
+        note: "Informe cargado inicialmente",
+        createdAt: now,
+      });
+    }
 
     return report;
   });
@@ -352,15 +403,66 @@ export async function updateReportStatus(input: {
       .where(eq(reports.id, input.reportId))
       .returning();
 
-    await tx.insert(reportStatusHistory).values({
-      reportId: report.id,
-      fromStatus: report.currentStatus,
-      toStatus: input.toStatus,
-      changedByClinicUserId: input.changedByClinicUserId ?? null,
-      changedByAdminUserId: input.changedByAdminUserId ?? null,
-      note: input.note ?? null,
-      createdAt: now,
-    });
+    const changedBy =
+      input.changedByClinicUserId ?? input.changedByAdminUserId ?? null;
+    const changedByType =
+      input.changedByClinicUserId != null
+        ? "clinic_user"
+        : input.changedByAdminUserId != null
+          ? "admin_user"
+          : "system";
+
+    try {
+      await tx.execute(sql`
+        INSERT INTO "report_status_history" (
+          "report_id",
+          "status",
+          "previous_status",
+          "changed_by",
+          "changed_by_type",
+          "notes",
+          "created_at",
+          "from_status",
+          "to_status",
+          "changed_by_clinic_user_id",
+          "changed_by_admin_user_id",
+          "note"
+        )
+        VALUES (
+          ${report.id},
+          ${input.toStatus},
+          ${report.currentStatus},
+          ${changedBy},
+          ${changedByType},
+          ${input.note ?? null},
+          ${now.toISOString()},
+          ${report.currentStatus},
+          ${input.toStatus},
+          ${input.changedByClinicUserId ?? null},
+          ${input.changedByAdminUserId ?? null},
+          ${input.note ?? null}
+        )
+      `);
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "42703"
+      ) {
+        throw error;
+      }
+
+      await tx.insert(reportStatusHistory).values({
+        reportId: report.id,
+        fromStatus: report.currentStatus,
+        toStatus: input.toStatus,
+        changedByClinicUserId: input.changedByClinicUserId ?? null,
+        changedByAdminUserId: input.changedByAdminUserId ?? null,
+        note: input.note ?? null,
+        createdAt: now,
+      });
+    }
 
     return updated[0];
   });
@@ -434,4 +536,5 @@ export async function getStudyTypes(clinicId: number) {
     .map((r) => r.studyType)
     .filter((v): v is string => !!v);
 }
+
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,4 +1,4 @@
-﻿import postgres from "postgres";
+import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { and, desc, eq, ilike, isNotNull, lte, or } from "drizzle-orm";
 import {
@@ -8,7 +8,9 @@ import {
   clinicUsers,
   clinics,
   reports,
+  reportStatusHistory,
   type ClinicUserRole,
+  type ReportStatus,
 } from "../drizzle/schema";
 import { ENV } from "./lib/env";
 import { normalizeClinicUserRole } from "./lib/permissions";
@@ -237,6 +239,14 @@ export async function getReportById(id: number) {
   return result[0];
 }
 
+export async function getReportStatusHistory(reportId: number) {
+  return db
+    .select()
+    .from(reportStatusHistory)
+    .where(eq(reportStatusHistory.reportId, reportId))
+    .orderBy(desc(reportStatusHistory.createdAt), desc(reportStatusHistory.id));
+}
+
 export async function upsertReport(input: {
   clinicId: number;
   uploadDate?: Date | null;
@@ -244,47 +254,134 @@ export async function upsertReport(input: {
   patientName?: string | null;
   fileName?: string | null;
   storagePath: string;
+  createdByClinicUserId?: number | null;
+  createdByAdminUserId?: number | null;
 }) {
   const now = new Date();
 
-  const result = await db
-    .insert(reports)
-    .values({
-      clinicId: input.clinicId,
-      uploadDate: input.uploadDate ?? null,
-      studyType: input.studyType ?? null,
-      patientName: input.patientName ?? null,
-      fileName: input.fileName ?? null,
-      storagePath: input.storagePath,
-      previewUrl: null,
-      downloadUrl: null,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: reports.storagePath,
-      set: {
+  return db.transaction(async (tx) => {
+    const existing = await tx
+      .select()
+      .from(reports)
+      .where(eq(reports.storagePath, input.storagePath))
+      .limit(1);
+
+    if (existing[0]) {
+      const updated = await tx
+        .update(reports)
+        .set({
+          uploadDate: input.uploadDate ?? null,
+          studyType: input.studyType ?? null,
+          patientName: input.patientName ?? null,
+          fileName: input.fileName ?? null,
+          updatedAt: now,
+        })
+        .where(eq(reports.id, existing[0].id))
+        .returning();
+
+      return updated[0];
+    }
+
+    const inserted = await tx
+      .insert(reports)
+      .values({
+        clinicId: input.clinicId,
         uploadDate: input.uploadDate ?? null,
         studyType: input.studyType ?? null,
         patientName: input.patientName ?? null,
         fileName: input.fileName ?? null,
+        storagePath: input.storagePath,
+        previewUrl: null,
+        downloadUrl: null,
+        currentStatus: "uploaded",
+        statusChangedAt: now,
+        statusChangedByClinicUserId: input.createdByClinicUserId ?? null,
+        statusChangedByAdminUserId: input.createdByAdminUserId ?? null,
+        createdAt: now,
         updatedAt: now,
-      },
-    })
-    .returning();
+      })
+      .returning();
 
-  return result[0];
+    const report = inserted[0];
+
+    await tx.insert(reportStatusHistory).values({
+      reportId: report.id,
+      fromStatus: null,
+      toStatus: "uploaded",
+      changedByClinicUserId: input.createdByClinicUserId ?? null,
+      changedByAdminUserId: input.createdByAdminUserId ?? null,
+      note: "Informe cargado inicialmente",
+      createdAt: now,
+    });
+
+    return report;
+  });
+}
+
+export async function updateReportStatus(input: {
+  reportId: number;
+  toStatus: ReportStatus;
+  note?: string | null;
+  changedByClinicUserId?: number | null;
+  changedByAdminUserId?: number | null;
+}) {
+  const now = new Date();
+
+  return db.transaction(async (tx) => {
+    const existing = await tx
+      .select()
+      .from(reports)
+      .where(eq(reports.id, input.reportId))
+      .limit(1);
+
+    const report = existing[0];
+
+    if (!report) {
+      return undefined;
+    }
+
+    const updated = await tx
+      .update(reports)
+      .set({
+        currentStatus: input.toStatus,
+        statusChangedAt: now,
+        statusChangedByClinicUserId: input.changedByClinicUserId ?? null,
+        statusChangedByAdminUserId: input.changedByAdminUserId ?? null,
+        updatedAt: now,
+      })
+      .where(eq(reports.id, input.reportId))
+      .returning();
+
+    await tx.insert(reportStatusHistory).values({
+      reportId: report.id,
+      fromStatus: report.currentStatus,
+      toStatus: input.toStatus,
+      changedByClinicUserId: input.changedByClinicUserId ?? null,
+      changedByAdminUserId: input.changedByAdminUserId ?? null,
+      note: input.note ?? null,
+      createdAt: now,
+    });
+
+    return updated[0];
+  });
 }
 
 export async function getReportsByClinicId(
   clinicId: number,
   limit = 50,
   offset = 0,
+  currentStatus?: ReportStatus,
 ) {
+  const filters = [eq(reports.clinicId, clinicId)];
+
+  if (currentStatus) {
+    filters.push(eq(reports.currentStatus, currentStatus));
+  }
+
   return db
     .select()
     .from(reports)
-    .where(eq(reports.clinicId, clinicId))
+    .where(and(...filters))
     .orderBy(desc(reports.createdAt))
     .limit(limit)
     .offset(offset);
@@ -296,11 +393,16 @@ export async function searchReports(
   studyType?: string,
   limit = 50,
   offset = 0,
+  currentStatus?: ReportStatus,
 ) {
   const filters = [eq(reports.clinicId, clinicId)];
 
   if (studyType) {
     filters.push(eq(reports.studyType, studyType));
+  }
+
+  if (currentStatus) {
+    filters.push(eq(reports.currentStatus, currentStatus));
   }
 
   if (query) {

--- a/server/lib/report-status.ts
+++ b/server/lib/report-status.ts
@@ -1,0 +1,64 @@
+import type { ReportStatus } from "../../drizzle/schema";
+
+export const REPORT_STATUSES: ReadonlyArray<ReportStatus> = [
+  "uploaded",
+  "processing",
+  "ready",
+  "delivered",
+] as const;
+
+export function isReportStatus(value: unknown): value is ReportStatus {
+  return (
+    value === "uploaded" ||
+    value === "processing" ||
+    value === "ready" ||
+    value === "delivered"
+  );
+}
+
+export function normalizeReportStatus(
+  value: unknown,
+  fallback?: ReportStatus,
+): ReportStatus | undefined {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized === "uploaded") {
+    return "uploaded";
+  }
+
+  if (normalized === "processing") {
+    return "processing";
+  }
+
+  if (normalized === "ready") {
+    return "ready";
+  }
+
+  if (normalized === "delivered") {
+    return "delivered";
+  }
+
+  return fallback;
+}
+
+const allowedTransitions: Record<ReportStatus, ReadonlyArray<ReportStatus>> = {
+  uploaded: ["processing", "ready", "delivered"],
+  processing: ["ready", "delivered"],
+  ready: ["delivered"],
+  delivered: [],
+};
+
+export function canTransitionReportStatus(
+  currentStatus: ReportStatus,
+  nextStatus: ReportStatus,
+): boolean {
+  if (currentStatus === nextStatus) {
+    return false;
+  }
+
+  return allowedTransitions[currentStatus].includes(nextStatus);
+}

--- a/server/routes/reports.routes.ts
+++ b/server/routes/reports.routes.ts
@@ -1,17 +1,24 @@
-﻿import { Router } from "express";
+import { Router } from "express";
 import multer from "multer";
-import type { Report } from "../../drizzle/schema";
+import type { Report, ReportStatus } from "../../drizzle/schema";
 import {
   getReportById,
+  getReportStatusHistory,
   getReportsByClinicId,
   getStudyTypes,
   searchReports,
+  updateReportStatus,
   upsertReport,
 } from "../db";
 import {
   getClinicScopedStudyTrackingCase,
   updateStudyTrackingCase,
 } from "../db-study-tracking";
+import {
+  REPORT_STATUSES,
+  canTransitionReportStatus,
+  normalizeReportStatus,
+} from "../lib/report-status";
 import { ENV } from "../lib/env";
 import {
   ALLOWED_MIME_TYPES,
@@ -20,6 +27,7 @@ import {
   uploadReport,
 } from "../lib/supabase";
 import { requireAuth } from "../middlewares/auth";
+import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
@@ -73,6 +81,15 @@ function normalizeSearchText(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function normalizeOptionalNote(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 2000) : null;
+}
+
 function parseOptionalDate(value: unknown): Date | undefined {
   if (typeof value !== "string" || !value.trim()) {
     return undefined;
@@ -90,6 +107,10 @@ function parseClinicId(value: unknown): number | undefined {
   }
 
   return undefined;
+}
+
+function parseReportStatus(value: unknown): ReportStatus | undefined {
+  return normalizeReportStatus(value);
 }
 
 function getReadClinicScope(reqClinicId: unknown, authClinicId: number) {
@@ -172,6 +193,17 @@ const requireUploadPermission = asyncHandler(async (req, res, next) => {
   next();
 });
 
+const requireReportStatusWritePermission = asyncHandler(async (req, res, next) => {
+  if (!req.auth?.canManageClinicUsers) {
+    return res.status(403).json({
+      success: false,
+      error: "No autorizado para cambiar el estado de informes",
+    });
+  }
+
+  next();
+});
+
 router.post(
   "/upload",
   requireUploadPermission,
@@ -219,6 +251,7 @@ router.post(
       uploadDate: uploadDate ?? null,
       fileName: req.file.originalname,
       storagePath,
+      createdByClinicUserId: req.auth!.id,
     });
 
     if (typeof trackingCaseId === "number") {
@@ -239,6 +272,7 @@ router.get(
   "/",
   asyncHandler(async (req, res) => {
     const scope = getReadClinicScope(req.query.clinicId, req.auth!.clinicId);
+    const currentStatus = parseReportStatus(req.query.status);
     const limit = parsePositiveInt(req.query.limit, 50, 100);
     const offset = parseOffset(req.query.offset, 0);
 
@@ -249,13 +283,29 @@ router.get(
       });
     }
 
+    if (typeof req.query.status !== "undefined" && !currentStatus) {
+      return res.status(400).json({
+        success: false,
+        error: "Estado de informe invalido",
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
     const clinicId = scope.clinicId;
-    const reports = await getReportsByClinicId(clinicId, limit, offset);
+    const reports = await getReportsByClinicId(
+      clinicId,
+      limit,
+      offset,
+      currentStatus,
+    );
 
     return res.json({
       success: true,
       count: reports.length,
       reports: await serializeReports(reports),
+      filters: {
+        status: currentStatus ?? null,
+      },
       pagination: {
         limit,
         offset,
@@ -270,6 +320,7 @@ router.get(
     const scope = getReadClinicScope(req.query.clinicId, req.auth!.clinicId);
     const query = normalizeSearchText(req.query.query);
     const studyType = normalizeSearchText(req.query.studyType);
+    const currentStatus = parseReportStatus(req.query.status);
     const limit = parsePositiveInt(req.query.limit, 50, 100);
     const offset = parseOffset(req.query.offset, 0);
 
@@ -280,6 +331,14 @@ router.get(
       });
     }
 
+    if (typeof req.query.status !== "undefined" && !currentStatus) {
+      return res.status(400).json({
+        success: false,
+        error: "Estado de informe invalido",
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
     const clinicId = scope.clinicId;
     const reports = await searchReports(
       clinicId,
@@ -287,6 +346,7 @@ router.get(
       studyType,
       limit,
       offset,
+      currentStatus,
     );
 
     return res.json({
@@ -296,6 +356,7 @@ router.get(
       filters: {
         query: query ?? null,
         studyType: studyType ?? null,
+        status: currentStatus ?? null,
       },
       pagination: {
         limit,
@@ -323,6 +384,119 @@ router.get(
     return res.json({
       success: true,
       studyTypes,
+    });
+  }),
+);
+
+router.get(
+  "/:reportId/history",
+  asyncHandler(async (req, res) => {
+    const reportId = parseReportId(req.params.reportId);
+
+    if (typeof reportId !== "number") {
+      return res.status(400).json({
+        success: false,
+        error: "ID de informe invalido",
+      });
+    }
+
+    const reportResult = await getAuthorizedReport(
+      reportId,
+      req.auth!.clinicId,
+      "No autorizado para consultar el historial de este informe",
+    );
+
+    if (!("report" in reportResult)) {
+      return res.status(reportResult.status).json({
+        success: false,
+        error: reportResult.error,
+      });
+    }
+
+    const history = await getReportStatusHistory(reportId);
+
+    return res.json({
+      success: true,
+      reportId,
+      currentStatus: reportResult.report.currentStatus,
+      count: history.length,
+      history,
+    });
+  }),
+);
+
+router.patch(
+  "/:reportId/status",
+  requireTrustedOrigin,
+  requireReportStatusWritePermission,
+  asyncHandler(async (req, res) => {
+    const reportId = parseReportId(req.params.reportId);
+    const nextStatus = parseReportStatus(req.body?.status);
+    const note = normalizeOptionalNote(req.body?.note);
+
+    if (typeof reportId !== "number") {
+      return res.status(400).json({
+        success: false,
+        error: "ID de informe invalido",
+      });
+    }
+
+    if (!nextStatus) {
+      return res.status(400).json({
+        success: false,
+        error: "Estado de informe invalido",
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
+    const reportResult = await getAuthorizedReport(
+      reportId,
+      req.auth!.clinicId,
+      "No autorizado para cambiar el estado de este informe",
+    );
+
+    if (!("report" in reportResult)) {
+      return res.status(reportResult.status).json({
+        success: false,
+        error: reportResult.error,
+      });
+    }
+
+    if (reportResult.report.currentStatus === nextStatus) {
+      return res.status(400).json({
+        success: false,
+        error: "El informe ya se encuentra en ese estado",
+      });
+    }
+
+    if (!canTransitionReportStatus(reportResult.report.currentStatus, nextStatus)) {
+      return res.status(400).json({
+        success: false,
+        error: "La transición de estado no está permitida",
+        currentStatus: reportResult.report.currentStatus,
+        requestedStatus: nextStatus,
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
+    const updated = await updateReportStatus({
+      reportId,
+      toStatus: nextStatus,
+      note,
+      changedByClinicUserId: req.auth!.id,
+    });
+
+    if (!updated) {
+      return res.status(404).json({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    return res.json({
+      success: true,
+      message: "Estado de informe actualizado correctamente",
+      report: await serializeReport(updated),
     });
   }),
 );


### PR DESCRIPTION
﻿## Objetivo
Extender `reports` con estado actual e historial persistente de estados, incluyendo compatibilidad con la tabla legacy `report_status_history` ya existente en la base.

## Incluye
- nuevas columnas en `reports`:
  - `current_status`
  - `status_changed_at`
  - `status_changed_by_clinic_user_id`
  - `status_changed_by_admin_user_id`
- nueva lógica de historial en runtime
- soporte para `GET /api/reports/:reportId/history`
- soporte para `PATCH /api/reports/:reportId/status`
- filtros por estado en listados y búsqueda
- compatibilidad legacy para columnas previas:
  - `status`
  - `previous_status`
  - `changed_by`
  - `changed_by_type`
  - `notes`
- migraciones `0012` y `0013`

## Validación manual
- `pnpm typecheck`
- `pnpm build`
- `pnpm db:migrate`
- login clínica owner
- `GET /api/reports`
- `PATCH /api/reports/1/status`
- `GET /api/reports/1/history`

## Resultado validado
- el reporte pasa de `uploaded` a `processing`
- el historial devuelve ambas entradas correctamente

## Riesgos
- mantiene compatibilidad con esquema legacy de historial
- no incorpora todavía auditoría persistente general
- no incorpora todavía tokens públicos ni pagos
