### PR TITLE
feat(audit): persist audit log for auth, report status, and public access tokens

### DIFF
--- a/drizzle/migrations/0016_audit_log.sql
+++ b/drizzle/migrations/0016_audit_log.sql
@@ -1,0 +1,146 @@
+CREATE TABLE IF NOT EXISTS "audit_log" (
+  "id" serial PRIMARY KEY NOT NULL
+);
+
+ALTER TABLE "audit_log"
+  ADD COLUMN IF NOT EXISTS "event" varchar(120),
+  ADD COLUMN IF NOT EXISTS "actor_type" varchar(40) DEFAULT 'system',
+  ADD COLUMN IF NOT EXISTS "actor_admin_user_id" integer,
+  ADD COLUMN IF NOT EXISTS "actor_clinic_user_id" integer,
+  ADD COLUMN IF NOT EXISTS "actor_report_access_token_id" integer,
+  ADD COLUMN IF NOT EXISTS "clinic_id" integer,
+  ADD COLUMN IF NOT EXISTS "report_id" integer,
+  ADD COLUMN IF NOT EXISTS "target_admin_user_id" integer,
+  ADD COLUMN IF NOT EXISTS "target_clinic_user_id" integer,
+  ADD COLUMN IF NOT EXISTS "target_report_access_token_id" integer,
+  ADD COLUMN IF NOT EXISTS "request_id" varchar(64),
+  ADD COLUMN IF NOT EXISTS "request_method" varchar(16),
+  ADD COLUMN IF NOT EXISTS "request_path" text,
+  ADD COLUMN IF NOT EXISTS "ip_address" varchar(64),
+  ADD COLUMN IF NOT EXISTS "user_agent" text,
+  ADD COLUMN IF NOT EXISTS "metadata" jsonb,
+  ADD COLUMN IF NOT EXISTS "created_at" timestamp DEFAULT now();
+
+UPDATE "audit_log"
+SET
+  "event" = COALESCE("event", 'legacy.audit_log.row'),
+  "actor_type" = COALESCE("actor_type", 'system'),
+  "created_at" = COALESCE("created_at", now());
+
+ALTER TABLE "audit_log"`r`n  ALTER COLUMN "event" TYPE varchar(120),`r`n  ALTER COLUMN "actor_type" TYPE varchar(40),`r`n  ALTER COLUMN "event" SET NOT NULL,
+  ALTER COLUMN "actor_type" SET NOT NULL,
+  ALTER COLUMN "created_at" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "audit_log_event_idx" ON "audit_log" ("event");
+CREATE INDEX IF NOT EXISTS "audit_log_created_at_idx" ON "audit_log" ("created_at");
+CREATE INDEX IF NOT EXISTS "audit_log_actor_type_idx" ON "audit_log" ("actor_type");
+CREATE INDEX IF NOT EXISTS "audit_log_actor_admin_user_id_idx" ON "audit_log" ("actor_admin_user_id");
+CREATE INDEX IF NOT EXISTS "audit_log_actor_clinic_user_id_idx" ON "audit_log" ("actor_clinic_user_id");
+CREATE INDEX IF NOT EXISTS "audit_log_actor_report_access_token_id_idx" ON "audit_log" ("actor_report_access_token_id");
+CREATE INDEX IF NOT EXISTS "audit_log_clinic_id_idx" ON "audit_log" ("clinic_id");
+CREATE INDEX IF NOT EXISTS "audit_log_report_id_idx" ON "audit_log" ("report_id");
+CREATE INDEX IF NOT EXISTS "audit_log_target_report_access_token_id_idx" ON "audit_log" ("target_report_access_token_id");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_actor_admin_user_id_admin_users_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_actor_admin_user_id_admin_users_id_fk"
+      FOREIGN KEY ("actor_admin_user_id") REFERENCES "admin_users"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_actor_clinic_user_id_clinic_users_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_actor_clinic_user_id_clinic_users_id_fk"
+      FOREIGN KEY ("actor_clinic_user_id") REFERENCES "clinic_users"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_actor_report_access_token_id_report_access_tokens_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_actor_report_access_token_id_report_access_tokens_id_fk"
+      FOREIGN KEY ("actor_report_access_token_id") REFERENCES "report_access_tokens"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_clinic_id_clinics_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_clinic_id_clinics_id_fk"
+      FOREIGN KEY ("clinic_id") REFERENCES "clinics"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_report_id_reports_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_report_id_reports_id_fk"
+      FOREIGN KEY ("report_id") REFERENCES "reports"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_target_admin_user_id_admin_users_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_target_admin_user_id_admin_users_id_fk"
+      FOREIGN KEY ("target_admin_user_id") REFERENCES "admin_users"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_target_clinic_user_id_clinic_users_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_target_clinic_user_id_clinic_users_id_fk"
+      FOREIGN KEY ("target_clinic_user_id") REFERENCES "clinic_users"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_log_target_report_access_token_id_report_access_tokens_id_fk'
+  ) THEN
+    ALTER TABLE "audit_log"
+      ADD CONSTRAINT "audit_log_target_report_access_token_id_report_access_tokens_id_fk"
+      FOREIGN KEY ("target_report_access_token_id") REFERENCES "report_access_tokens"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
                         "when":  1776251728425,
                         "tag":  "0015_report_access_tokens_runtime_reconcile",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  16,
+                        "version":  "7",
+                        "when":  1776442203568,
+                        "tag":  "0016_audit_log",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -2,6 +2,7 @@ import {
   boolean,
   index,
   integer,
+  jsonb,
   pgTable,
   serial,
   text,
@@ -20,6 +21,24 @@ export const REPORT_STATUSES = [
   "delivered",
 ] as const;
 export type ReportStatus = (typeof REPORT_STATUSES)[number];
+export const AUDIT_ACTOR_TYPES = [
+  "system",
+  "admin_user",
+  "clinic_user",
+  "public_report_access_token",
+] as const;
+export type AuditActorType = (typeof AUDIT_ACTOR_TYPES)[number];
+
+export const AUDIT_EVENTS = [
+  "auth.admin.login.succeeded",
+  "auth.clinic.login.succeeded",
+  "report.status.changed",
+  "report_access_token.created",
+  "report_access_token.revoked",
+  "report.public_accessed",
+] as const;
+export type AuditEvent = (typeof AUDIT_EVENTS)[number];
+
 
 export const clinics = pgTable("clinics", {
   id: serial("id").primaryKey(),
@@ -191,6 +210,74 @@ export const reportAccessTokens = pgTable(
     ).on(table.clinicId, table.reportId, table.createdAt),
     expiresAtIdx: index("report_access_tokens_expires_at_idx").on(table.expiresAt),
     revokedAtIdx: index("report_access_tokens_revoked_at_idx").on(table.revokedAt),
+  }),
+);
+
+export const auditLog = pgTable(
+  "audit_log",
+  {
+    id: serial("id").primaryKey(),
+    event: varchar("event", { length: 120 }).$type<AuditEvent>().notNull(),
+    actorType: varchar("actor_type", { length: 40 })
+      .$type<AuditActorType>()
+      .notNull()
+      .default("system"),
+    actorAdminUserId: integer("actor_admin_user_id").references(
+      () => adminUsers.id,
+      { onDelete: "set null" },
+    ),
+    actorClinicUserId: integer("actor_clinic_user_id").references(
+      () => clinicUsers.id,
+      { onDelete: "set null" },
+    ),
+    actorReportAccessTokenId: integer("actor_report_access_token_id").references(
+      () => reportAccessTokens.id,
+      { onDelete: "set null" },
+    ),
+    clinicId: integer("clinic_id").references(() => clinics.id, {
+      onDelete: "set null",
+    }),
+    reportId: integer("report_id").references(() => reports.id, {
+      onDelete: "set null",
+    }),
+    targetAdminUserId: integer("target_admin_user_id").references(
+      () => adminUsers.id,
+      { onDelete: "set null" },
+    ),
+    targetClinicUserId: integer("target_clinic_user_id").references(
+      () => clinicUsers.id,
+      { onDelete: "set null" },
+    ),
+    targetReportAccessTokenId: integer("target_report_access_token_id").references(
+      () => reportAccessTokens.id,
+      { onDelete: "set null" },
+    ),
+    requestId: varchar("request_id", { length: 64 }),
+    requestMethod: varchar("request_method", { length: 16 }),
+    requestPath: text("request_path"),
+    ipAddress: varchar("ip_address", { length: 64 }),
+    userAgent: text("user_agent"),
+    metadata: jsonb("metadata").$type<Record<string, unknown> | null>(),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    eventIdx: index("audit_log_event_idx").on(table.event),
+    createdAtIdx: index("audit_log_created_at_idx").on(table.createdAt),
+    actorTypeIdx: index("audit_log_actor_type_idx").on(table.actorType),
+    actorAdminUserIdIdx: index("audit_log_actor_admin_user_id_idx").on(
+      table.actorAdminUserId,
+    ),
+    actorClinicUserIdIdx: index("audit_log_actor_clinic_user_id_idx").on(
+      table.actorClinicUserId,
+    ),
+    actorReportAccessTokenIdIdx: index(
+      "audit_log_actor_report_access_token_id_idx",
+    ).on(table.actorReportAccessTokenId),
+    clinicIdIdx: index("audit_log_clinic_id_idx").on(table.clinicId),
+    reportIdIdx: index("audit_log_report_id_idx").on(table.reportId),
+    targetReportAccessTokenIdIdx: index(
+      "audit_log_target_report_access_token_id_idx",
+    ).on(table.targetReportAccessTokenId),
   }),
 );
 
@@ -507,6 +594,9 @@ export type NewReportStatusHistory = InferInsertModel<typeof reportStatusHistory
 
 export type ReportAccessToken = InferSelectModel<typeof reportAccessTokens>;
 export type NewReportAccessToken = InferInsertModel<typeof reportAccessTokens>;
+
+export type AuditLog = InferSelectModel<typeof auditLog>;
+export type NewAuditLog = InferInsertModel<typeof auditLog>;
 
 export type ActiveSession = InferSelectModel<typeof activeSessions>;
 export type NewActiveSession = InferInsertModel<typeof activeSessions>;

--- a/server/db-audit.ts
+++ b/server/db-audit.ts
@@ -1,0 +1,256 @@
+import { pgClient } from "./db";
+
+type CreateAuditLogInput = {
+  event: string;
+  actorType: string;
+  actorAdminUserId?: number | null;
+  actorClinicUserId?: number | null;
+  actorReportAccessTokenId?: number | null;
+  clinicId?: number | null;
+  reportId?: number | null;
+  targetAdminUserId?: number | null;
+  targetClinicUserId?: number | null;
+  targetReportAccessTokenId?: number | null;
+  requestId?: string | null;
+  requestMethod?: string | null;
+  requestPath?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  metadata?: Record<string, unknown> | null;
+  action?: string | null;
+  entity?: string | null;
+  entityId?: number | null;
+};
+
+type InsertValue = string | number | null;
+
+type ColumnSpec = {
+  column: string;
+  value: InsertValue;
+  cast?: "jsonb";
+};
+
+let auditLogColumnsCache: Set<string> | null = null;
+
+async function getAuditLogColumns(): Promise<Set<string>> {
+  if (auditLogColumnsCache !== null) {
+    return auditLogColumnsCache;
+  }
+
+  const rows = await pgClient`
+    select column_name
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'audit_log'
+  `;
+
+  auditLogColumnsCache = new Set(
+    rows.map((row) => String(row.column_name))
+  );
+
+  return auditLogColumnsCache;
+}
+
+function deriveLegacyEntity(input: CreateAuditLogInput): string {
+  if (input.entity && input.entity.trim().length > 0) {
+    return input.entity;
+  }
+
+  if (input.event.startsWith("auth.admin.")) {
+    return "admin_user";
+  }
+
+  if (input.event.startsWith("auth.clinic.")) {
+    return "clinic_user";
+  }
+
+  if (input.event.startsWith("report_access_token.")) {
+    return "report_access_token";
+  }
+
+  if (input.event === "report.public_accessed") {
+    return "report_access_token";
+  }
+
+  if (input.event.startsWith("report.")) {
+    return "report";
+  }
+
+  return "audit_log";
+}
+
+function deriveLegacyEntityId(input: CreateAuditLogInput): number | null {
+  if (input.entityId !== undefined) {
+    return input.entityId;
+  }
+
+  return (
+    input.reportId ??
+    input.targetReportAccessTokenId ??
+    input.clinicId ??
+    input.targetAdminUserId ??
+    input.targetClinicUserId ??
+    input.actorAdminUserId ??
+    input.actorClinicUserId ??
+    input.actorReportAccessTokenId ??
+    null
+  );
+}
+
+export async function createAuditLog(input: CreateAuditLogInput) {
+  const columnsPresent = await getAuditLogColumns();
+  const metadataJson =
+    input.metadata === undefined || input.metadata === null
+      ? null
+      : JSON.stringify(input.metadata);
+
+  const specs: ColumnSpec[] = [];
+
+  if (columnsPresent.has("event")) {
+    specs.push({
+      column: "event",
+      value: input.event
+    });
+  }
+
+  if (columnsPresent.has("action")) {
+    specs.push({
+      column: "action",
+      value: input.action ?? input.event
+    });
+  }
+
+  if (columnsPresent.has("entity")) {
+    specs.push({
+      column: "entity",
+      value: deriveLegacyEntity(input)
+    });
+  }
+
+  if (columnsPresent.has("entity_id")) {
+    specs.push({
+      column: "entity_id",
+      value: deriveLegacyEntityId(input)
+    });
+  }
+
+  if (columnsPresent.has("actor_type")) {
+    specs.push({
+      column: "actor_type",
+      value: input.actorType
+    });
+  }
+
+  if (columnsPresent.has("actor_admin_user_id")) {
+    specs.push({
+      column: "actor_admin_user_id",
+      value: input.actorAdminUserId ?? null
+    });
+  }
+
+  if (columnsPresent.has("actor_clinic_user_id")) {
+    specs.push({
+      column: "actor_clinic_user_id",
+      value: input.actorClinicUserId ?? null
+    });
+  }
+
+  if (columnsPresent.has("actor_report_access_token_id")) {
+    specs.push({
+      column: "actor_report_access_token_id",
+      value: input.actorReportAccessTokenId ?? null
+    });
+  }
+
+  if (columnsPresent.has("clinic_id")) {
+    specs.push({
+      column: "clinic_id",
+      value: input.clinicId ?? null
+    });
+  }
+
+  if (columnsPresent.has("report_id")) {
+    specs.push({
+      column: "report_id",
+      value: input.reportId ?? null
+    });
+  }
+
+  if (columnsPresent.has("target_admin_user_id")) {
+    specs.push({
+      column: "target_admin_user_id",
+      value: input.targetAdminUserId ?? null
+    });
+  }
+
+  if (columnsPresent.has("target_clinic_user_id")) {
+    specs.push({
+      column: "target_clinic_user_id",
+      value: input.targetClinicUserId ?? null
+    });
+  }
+
+  if (columnsPresent.has("target_report_access_token_id")) {
+    specs.push({
+      column: "target_report_access_token_id",
+      value: input.targetReportAccessTokenId ?? null
+    });
+  }
+
+  if (columnsPresent.has("request_id")) {
+    specs.push({
+      column: "request_id",
+      value: input.requestId ?? null
+    });
+  }
+
+  if (columnsPresent.has("request_method")) {
+    specs.push({
+      column: "request_method",
+      value: input.requestMethod ?? null
+    });
+  }
+
+  if (columnsPresent.has("request_path")) {
+    specs.push({
+      column: "request_path",
+      value: input.requestPath ?? null
+    });
+  }
+
+  if (columnsPresent.has("ip_address")) {
+    specs.push({
+      column: "ip_address",
+      value: input.ipAddress ?? null
+    });
+  }
+
+  if (columnsPresent.has("user_agent")) {
+    specs.push({
+      column: "user_agent",
+      value: input.userAgent ?? null
+    });
+  }
+
+  if (columnsPresent.has("metadata")) {
+    specs.push({
+      column: "metadata",
+      value: metadataJson,
+      cast: "jsonb"
+    });
+  }
+
+  const query = `
+    insert into "audit_log" (${specs.map((spec) => `"${spec.column}"`).join(", ")})
+    values (${specs.map((spec, index) => {
+      const placeholder = `$${index + 1}`;
+      return spec.cast ? `${placeholder}::${spec.cast}` : placeholder;
+    }).join(", ")})
+    returning *
+  `;
+
+  const values = specs.map((spec) => spec.value);
+  const result = await pgClient.unsafe(query, values);
+
+  return result[0];
+}

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -1,61 +1,208 @@
-import { Request } from 'express';
-import { logError, logInfo, logWarn, serializeError } from './logger.js';
+import type { Request } from "express";
+import type { AuditActorType, AuditEvent } from "../../drizzle/schema";
+import { sanitizeUrlForLogs } from "../middlewares/request-logger";
+import { logError, logInfo, serializeError } from "./logger";
+
+export const AUDIT_EVENTS = {
+  ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
+  CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
+  REPORT_STATUS_CHANGED: "report.status.changed",
+  REPORT_ACCESS_TOKEN_CREATED: "report_access_token.created",
+  REPORT_ACCESS_TOKEN_REVOKED: "report_access_token.revoked",
+  REPORT_PUBLIC_ACCESSED: "report.public_accessed",
+} as const satisfies Record<string, AuditEvent>;
+
+export type AuditActor = {
+  type: AuditActorType;
+  adminUserId?: number | null;
+  clinicUserId?: number | null;
+  reportAccessTokenId?: number | null;
+};
+
+export type AuditWriteInput = {
+  event: AuditEvent;
+  clinicId?: number | null;
+  reportId?: number | null;
+  targetAdminUserId?: number | null;
+  targetClinicUserId?: number | null;
+  targetReportAccessTokenId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: AuditActor;
+};
 
 type RequestWithContext = Request & {
   requestId?: string;
   auth?: {
-    userId?: string | number;
-    clinicId?: string | number;
+    id: number;
+    clinicId: number;
+    username: string;
     role?: string;
   };
-  admin?: {
-    adminId?: string | number;
-    role?: string;
+  adminAuth?: {
+    id: number;
+    username: string;
+  };
+  particularAuth?: {
+    tokenId: number;
+    clinicId: number;
+    reportId: number | null;
   };
 };
 
-function getReq(req: Request): RequestWithContext {
-  return req as RequestWithContext;
+function normalizeScalar(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeScalar(entry));
+  }
+
+  if (typeof value === "object") {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, entry] of Object.entries(value)) {
+      if (typeof entry === "undefined") {
+        continue;
+      }
+
+      result[key] = normalizeScalar(entry);
+    }
+
+    return result;
+  }
+
+  return String(value);
 }
 
-export function auditInfo(req: Request, action: string, metadata: Record<string, unknown> = {}) {
-  const r = getReq(req);
+export function normalizeAuditMetadata(
+  metadata?: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!metadata) {
+    return null;
+  }
 
-  logInfo('AUDIT_INFO', {
-    action,
-    requestId: r.requestId ?? null,
-    auth: r.auth ?? null,
-    admin: r.admin ?? null,
-    metadata
-  });
+  const normalized = normalizeScalar(metadata);
+
+  if (!normalized || Array.isArray(normalized) || typeof normalized !== "object") {
+    return null;
+  }
+
+  return normalized as Record<string, unknown>;
 }
 
-export function auditWarn(req: Request, action: string, metadata: Record<string, unknown> = {}) {
-  const r = getReq(req);
+export function resolveAuditActorFromRequest(
+  req: Pick<RequestWithContext, "auth" | "adminAuth">,
+  override?: AuditActor,
+): AuditActor {
+  if (override) {
+    return {
+      type: override.type,
+      adminUserId: override.adminUserId ?? null,
+      clinicUserId: override.clinicUserId ?? null,
+      reportAccessTokenId: override.reportAccessTokenId ?? null,
+    };
+  }
 
-  logWarn('AUDIT_WARN', {
-    action,
-    requestId: r.requestId ?? null,
-    auth: r.auth ?? null,
-    admin: r.admin ?? null,
-    metadata
-  });
+  if (req.adminAuth?.id) {
+    return {
+      type: "admin_user",
+      adminUserId: req.adminAuth.id,
+      clinicUserId: null,
+      reportAccessTokenId: null,
+    };
+  }
+
+  if (req.auth?.id) {
+    return {
+      type: "clinic_user",
+      adminUserId: null,
+      clinicUserId: req.auth.id,
+      reportAccessTokenId: null,
+    };
+  }
+
+  return {
+    type: "system",
+    adminUserId: null,
+    clinicUserId: null,
+    reportAccessTokenId: null,
+  };
 }
 
-export function auditError(
-  req: Request,
-  action: string,
-  error: unknown,
-  metadata: Record<string, unknown> = {}
+export function buildPublicReportAccessTokenActor(
+  reportAccessTokenId: number,
+): AuditActor {
+  return {
+    type: "public_report_access_token",
+    adminUserId: null,
+    clinicUserId: null,
+    reportAccessTokenId,
+  };
+}
+
+export function buildAuditLogInsert(
+  req: Pick<
+    RequestWithContext,
+    "method" | "originalUrl" | "ip" | "headers" | "requestId" | "auth" | "adminAuth"
+  >,
+  input: AuditWriteInput,
 ) {
-  const r = getReq(req);
+  const actor = resolveAuditActorFromRequest(req, input.actor);
 
-  logError('AUDIT_ERROR', {
-    action,
-    requestId: r.requestId ?? null,
-    auth: r.auth ?? null,
-    admin: r.admin ?? null,
-    metadata,
-    error: serializeError(error)
-  });
+  return {
+    event: input.event,
+    actorType: actor.type,
+    actorAdminUserId: actor.adminUserId ?? null,
+    actorClinicUserId: actor.clinicUserId ?? null,
+    actorReportAccessTokenId: actor.reportAccessTokenId ?? null,
+    clinicId: input.clinicId ?? req.auth?.clinicId ?? null,
+    reportId: input.reportId ?? null,
+    targetAdminUserId: input.targetAdminUserId ?? null,
+    targetClinicUserId: input.targetClinicUserId ?? null,
+    targetReportAccessTokenId: input.targetReportAccessTokenId ?? null,
+    requestId: req.requestId ?? null,
+    requestMethod: req.method ?? null,
+    requestPath: req.originalUrl ? sanitizeUrlForLogs(req.originalUrl) : null,
+    ipAddress: req.ip ?? null,
+    userAgent:
+      typeof req.headers?.["user-agent"] === "string"
+        ? req.headers["user-agent"]
+        : null,
+    metadata: normalizeAuditMetadata(input.metadata),
+  };
+}
+
+export async function writeAuditLog(
+  req: Request,
+  input: AuditWriteInput,
+): Promise<void> {
+  try {
+    const payload = buildAuditLogInsert(req as RequestWithContext, input);
+    const { createAuditLog } = await import("../db-audit");
+
+    await createAuditLog(payload);
+
+    logInfo("AUDIT_LOG_WRITTEN", {
+      event: payload.event,
+      actorType: payload.actorType,
+      clinicId: payload.clinicId,
+      reportId: payload.reportId,
+      targetReportAccessTokenId: payload.targetReportAccessTokenId,
+    });
+  } catch (error) {
+    logError("AUDIT_LOG_WRITE_ERROR", {
+      event: input.event,
+      error: serializeError(error),
+    });
+  }
 }

--- a/server/routes/admin-auth.routes.ts
+++ b/server/routes/admin-auth.routes.ts
@@ -1,4 +1,4 @@
-﻿import { Router } from "express";
+import { Router } from "express";
 import {
   createAdminSession,
   deleteAdminSession,
@@ -9,6 +9,7 @@ import {
   hashSessionToken,
   verifyPassword,
 } from "../lib/auth-security";
+import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { ENV } from "../lib/env";
 import { requireAdminAuth } from "../middlewares/admin-auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
@@ -61,6 +62,19 @@ router.post(
       adminUserId: admin.id,
       tokenHash,
       expiresAt,
+    });
+
+    await writeAuditLog(req, {
+      event: AUDIT_EVENTS.ADMIN_LOGIN_SUCCEEDED,
+      targetAdminUserId: admin.id,
+      metadata: {
+        username: admin.username,
+        sessionExpiresAt: expiresAt,
+      },
+      actor: {
+        type: "admin_user",
+        adminUserId: admin.id,
+      },
     });
 
     res.cookie(ENV.adminCookieName, token, {

--- a/server/routes/admin-report-access-tokens.routes.ts
+++ b/server/routes/admin-report-access-tokens.routes.ts
@@ -20,6 +20,7 @@ import {
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
 } from "../lib/report-access-token";
+import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { requireAdminAuth } from "../middlewares/admin-auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
@@ -79,6 +80,18 @@ router.post(
       createdByAdminUserId: req.adminAuth!.id,
       revokedByClinicUserId: null,
       revokedByAdminUserId: null,
+    });
+
+    await writeAuditLog(req, {
+      event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED,
+      clinicId: reportAccessToken.clinicId,
+      reportId: reportAccessToken.reportId,
+      targetReportAccessTokenId: reportAccessToken.id,
+      metadata: {
+        tokenLast4: reportAccessToken.tokenLast4,
+        expiresAt: reportAccessToken.expiresAt,
+        createdVia: "admin",
+      },
     });
 
     return res.status(201).json({
@@ -181,6 +194,20 @@ router.patch(
     });
 
     const report = revoked ? await getReportById(revoked.reportId) : null;
+
+    if (revoked) {
+      await writeAuditLog(req, {
+        event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED,
+        clinicId: revoked.clinicId,
+        reportId: revoked.reportId,
+        targetReportAccessTokenId: revoked.id,
+        metadata: {
+          tokenLast4: revoked.tokenLast4,
+          revokedAt: revoked.revokedAt,
+          revokedVia: "admin",
+        },
+      });
+    }
 
     return res.json({
       success: true,

--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -13,6 +13,7 @@ import {
   hashSessionToken,
   verifyPassword,
 } from "../lib/auth-security";
+import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { ENV } from "../lib/env";
 import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions";
 import { requireAuth } from "../middlewares/auth";
@@ -91,6 +92,21 @@ router.post(
       clinicUserId: clinicUser.id,
       tokenHash,
       expiresAt,
+    });
+
+    await writeAuditLog(req, {
+      event: AUDIT_EVENTS.CLINIC_LOGIN_SUCCEEDED,
+      clinicId: clinicUser.clinicId,
+      targetClinicUserId: clinicUser.id,
+      metadata: {
+        username: clinicUser.username,
+        role,
+        sessionExpiresAt: expiresAt,
+      },
+      actor: {
+        type: "clinic_user",
+        clinicUserId: clinicUser.id,
+      },
     });
 
     res.cookie(ENV.cookieName, token, {

--- a/server/routes/public-report-access.routes.ts
+++ b/server/routes/public-report-access.routes.ts
@@ -3,6 +3,7 @@ import {
   getReportAccessTokenWithReportByTokenHash,
   recordReportAccessTokenAccess,
 } from "../db-report-access";
+import { buildPublicReportAccessTokenActor, AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { hashSessionToken } from "../lib/auth-security";
 import {
   canAccessReportPublicly,
@@ -72,6 +73,19 @@ router.get(
         record.report.fileName ?? undefined,
       ),
     ]);
+
+    await writeAuditLog(req, {
+      event: AUDIT_EVENTS.REPORT_PUBLIC_ACCESSED,
+      clinicId: record.token.clinicId,
+      reportId: record.token.reportId,
+      targetReportAccessTokenId: record.token.id,
+      actor: buildPublicReportAccessTokenActor(record.token.id),
+      metadata: {
+        tokenLast4: record.token.tokenLast4,
+        accessCount: updatedToken?.accessCount ?? record.token.accessCount + 1,
+        lastAccessAt: updatedToken?.lastAccessAt ?? new Date(),
+      },
+    });
 
     return res.json({
       success: true,

--- a/server/routes/report-access-tokens.routes.ts
+++ b/server/routes/report-access-tokens.routes.ts
@@ -20,6 +20,7 @@ import {
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
 } from "../lib/report-access-token";
+import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
@@ -77,6 +78,18 @@ router.post(
       createdByAdminUserId: null,
       revokedByClinicUserId: null,
       revokedByAdminUserId: null,
+    });
+
+    await writeAuditLog(req, {
+      event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED,
+      clinicId: reportAccessToken.clinicId,
+      reportId: reportAccessToken.reportId,
+      targetReportAccessTokenId: reportAccessToken.id,
+      metadata: {
+        tokenLast4: reportAccessToken.tokenLast4,
+        expiresAt: reportAccessToken.expiresAt,
+        createdVia: "clinic",
+      },
     });
 
     return res.status(201).json({
@@ -178,6 +191,20 @@ router.patch(
     });
 
     const report = revoked ? await getReportById(revoked.reportId) : null;
+
+    if (revoked) {
+      await writeAuditLog(req, {
+        event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED,
+        clinicId: revoked.clinicId,
+        reportId: revoked.reportId,
+        targetReportAccessTokenId: revoked.id,
+        metadata: {
+          tokenLast4: revoked.tokenLast4,
+          revokedAt: revoked.revokedAt,
+          revokedVia: "clinic",
+        },
+      });
+    }
 
     return res.json({
       success: true,

--- a/server/routes/reports.routes.ts
+++ b/server/routes/reports.routes.ts
@@ -19,6 +19,7 @@ import {
   canTransitionReportStatus,
   normalizeReportStatus,
 } from "../lib/report-status";
+import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { ENV } from "../lib/env";
 import {
   ALLOWED_MIME_TYPES,
@@ -492,6 +493,17 @@ router.patch(
         error: "Informe no encontrado",
       });
     }
+
+    await writeAuditLog(req, {
+      event: AUDIT_EVENTS.REPORT_STATUS_CHANGED,
+      clinicId: updated.clinicId,
+      reportId: updated.id,
+      metadata: {
+        fromStatus: reportResult.report.currentStatus,
+        toStatus: nextStatus,
+        note,
+      },
+    });
 
     return res.json({
       success: true,


### PR DESCRIPTION
## Summary
- add persisted audit_log support with legacy-compatible runtime writes
- add centralized audit helper and actor resolution for admin, clinic user, and public report access token
- audit admin login, clinic login, report status changes, report access token create/revoke, and public report access
- add audit_log migration and schema support

## Validation
- pnpm db:migrate
- pnpm test
- pnpm typecheck
- manual validation:
  - admin login audited
  - clinic login audited
  - report status change audited
  - clinic token create/revoke audited
  - admin token create/revoke audited
  - public report access audited