### PR TITLE
feat(audit): add admin audit log read endpoint with filters and pagination

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -2,6 +2,7 @@ import express, { type NextFunction, type Request, type Response } from "express
 import cookieParser from "cookie-parser";
 import cors from "cors";
 
+import adminAuditRoutes from "./routes/admin-audit.routes";
 import adminAuthRoutes from "./routes/admin-auth.routes";
 import adminParticularTokensRoutes from "./routes/admin-particular-tokens.routes";
 import adminReportAccessTokensRoutes from "./routes/admin-report-access-tokens.routes";
@@ -95,7 +96,7 @@ app.use(
 
       return res.status(400).json({
         success: false,
-        error: "JSON inv√°lido",
+        error: "JSON inv·lido",
       });
     }
 
@@ -116,6 +117,7 @@ app.use("/api/health", healthRoutes);
 
 app.use("/api/auth", authRoutes);
 app.use("/api/admin/auth", adminAuthRoutes);
+app.use("/api/admin/audit-log", adminAuditRoutes);
 app.use("/api/clinic/profile", clinicPublicProfileRoutes);
 app.use("/api/admin/particular/tokens", adminParticularTokensRoutes);
 app.use("/api/admin/report-access-tokens", adminReportAccessTokensRoutes);

--- a/server/db-audit.ts
+++ b/server/db-audit.ts
@@ -1,8 +1,11 @@
+import type { AuditActorType, AuditEvent } from "../drizzle/schema";
+import type { AdminAuditListFilters } from "./lib/admin-audit";
+import { serializeAuditLogListItem } from "./lib/admin-audit";
 import { pgClient } from "./db";
 
 type CreateAuditLogInput = {
-  event: string;
-  actorType: string;
+  event: AuditEvent;
+  actorType: AuditActorType;
   actorAdminUserId?: number | null;
   actorClinicUserId?: number | null;
   actorReportAccessTokenId?: number | null;
@@ -23,6 +26,7 @@ type CreateAuditLogInput = {
 };
 
 type InsertValue = string | number | null;
+type QueryValue = string | number | Date;
 
 type ColumnSpec = {
   column: string;
@@ -44,9 +48,7 @@ async function getAuditLogColumns(): Promise<Set<string>> {
       and table_name = 'audit_log'
   `;
 
-  auditLogColumnsCache = new Set(
-    rows.map((row) => String(row.column_name))
-  );
+  auditLogColumnsCache = new Set(rows.map((row) => String(row.column_name)));
 
   return auditLogColumnsCache;
 }
@@ -56,25 +58,11 @@ function deriveLegacyEntity(input: CreateAuditLogInput): string {
     return input.entity;
   }
 
-  if (input.event.startsWith("auth.admin.")) {
-    return "admin_user";
-  }
-
-  if (input.event.startsWith("auth.clinic.")) {
-    return "clinic_user";
-  }
-
-  if (input.event.startsWith("report_access_token.")) {
-    return "report_access_token";
-  }
-
-  if (input.event === "report.public_accessed") {
-    return "report_access_token";
-  }
-
-  if (input.event.startsWith("report.")) {
-    return "report";
-  }
+  if (input.event.startsWith("auth.admin.")) return "admin_user";
+  if (input.event.startsWith("auth.clinic.")) return "clinic_user";
+  if (input.event.startsWith("report_access_token.")) return "report_access_token";
+  if (input.event === "report.public_accessed") return "report_access_token";
+  if (input.event.startsWith("report.")) return "report";
 
   return "audit_log";
 }
@@ -97,6 +85,53 @@ function deriveLegacyEntityId(input: CreateAuditLogInput): number | null {
   );
 }
 
+function buildAuditLogWhere(filters: AdminAuditListFilters): {
+  whereSql: string;
+  values: QueryValue[];
+} {
+  const clauses: string[] = [];
+  const values: QueryValue[] = [];
+
+  const addClause = (sqlFragment: string, value: QueryValue) => {
+    values.push(value);
+    clauses.push(`${sqlFragment} $${values.length}`);
+  };
+
+  if (filters.event) addClause(`"event" =`, filters.event);
+  if (filters.actorType) addClause(`"actor_type" =`, filters.actorType);
+  if (typeof filters.clinicId === "number") addClause(`"clinic_id" =`, filters.clinicId);
+  if (typeof filters.reportId === "number") addClause(`"report_id" =`, filters.reportId);
+  if (typeof filters.actorAdminUserId === "number") {
+    addClause(`"actor_admin_user_id" =`, filters.actorAdminUserId);
+  }
+  if (typeof filters.actorClinicUserId === "number") {
+    addClause(`"actor_clinic_user_id" =`, filters.actorClinicUserId);
+  }
+  if (typeof filters.actorReportAccessTokenId === "number") {
+    addClause(`"actor_report_access_token_id" =`, filters.actorReportAccessTokenId);
+  }
+  if (typeof filters.targetReportAccessTokenId === "number") {
+    addClause(`"target_report_access_token_id" =`, filters.targetReportAccessTokenId);
+  }
+  if (filters.from instanceof Date) addClause(`"created_at" >=`, filters.from);
+  if (filters.to instanceof Date) addClause(`"created_at" <=`, filters.to);
+
+  return {
+    whereSql: clauses.length > 0 ? `where ${clauses.join(" and ")}` : "",
+    values,
+  };
+}
+
+function buildOptionalSelect(
+  columnsPresent: Set<string>,
+  column: string,
+  fallbackSql: string,
+): string {
+  return columnsPresent.has(column)
+    ? `"${column}"`
+    : `${fallbackSql} as "${column}"`;
+}
+
 export async function createAuditLog(input: CreateAuditLogInput) {
   const columnsPresent = await getAuditLogColumns();
   const metadataJson =
@@ -107,145 +142,114 @@ export async function createAuditLog(input: CreateAuditLogInput) {
   const specs: ColumnSpec[] = [];
 
   if (columnsPresent.has("event")) {
-    specs.push({
-      column: "event",
-      value: input.event
-    });
+    specs.push({ column: "event", value: input.event });
   }
 
   if (columnsPresent.has("action")) {
-    specs.push({
-      column: "action",
-      value: input.action ?? input.event
-    });
+    specs.push({ column: "action", value: input.action ?? input.event });
   }
 
   if (columnsPresent.has("entity")) {
-    specs.push({
-      column: "entity",
-      value: deriveLegacyEntity(input)
-    });
+    specs.push({ column: "entity", value: deriveLegacyEntity(input) });
   }
 
   if (columnsPresent.has("entity_id")) {
-    specs.push({
-      column: "entity_id",
-      value: deriveLegacyEntityId(input)
-    });
+    specs.push({ column: "entity_id", value: deriveLegacyEntityId(input) });
   }
 
   if (columnsPresent.has("actor_type")) {
-    specs.push({
-      column: "actor_type",
-      value: input.actorType
-    });
+    specs.push({ column: "actor_type", value: input.actorType });
   }
 
   if (columnsPresent.has("actor_admin_user_id")) {
     specs.push({
       column: "actor_admin_user_id",
-      value: input.actorAdminUserId ?? null
+      value: input.actorAdminUserId ?? null,
     });
   }
 
   if (columnsPresent.has("actor_clinic_user_id")) {
     specs.push({
       column: "actor_clinic_user_id",
-      value: input.actorClinicUserId ?? null
+      value: input.actorClinicUserId ?? null,
     });
   }
 
   if (columnsPresent.has("actor_report_access_token_id")) {
     specs.push({
       column: "actor_report_access_token_id",
-      value: input.actorReportAccessTokenId ?? null
+      value: input.actorReportAccessTokenId ?? null,
     });
   }
 
   if (columnsPresent.has("clinic_id")) {
-    specs.push({
-      column: "clinic_id",
-      value: input.clinicId ?? null
-    });
+    specs.push({ column: "clinic_id", value: input.clinicId ?? null });
   }
 
   if (columnsPresent.has("report_id")) {
-    specs.push({
-      column: "report_id",
-      value: input.reportId ?? null
-    });
+    specs.push({ column: "report_id", value: input.reportId ?? null });
   }
 
   if (columnsPresent.has("target_admin_user_id")) {
     specs.push({
       column: "target_admin_user_id",
-      value: input.targetAdminUserId ?? null
+      value: input.targetAdminUserId ?? null,
     });
   }
 
   if (columnsPresent.has("target_clinic_user_id")) {
     specs.push({
       column: "target_clinic_user_id",
-      value: input.targetClinicUserId ?? null
+      value: input.targetClinicUserId ?? null,
     });
   }
 
   if (columnsPresent.has("target_report_access_token_id")) {
     specs.push({
       column: "target_report_access_token_id",
-      value: input.targetReportAccessTokenId ?? null
+      value: input.targetReportAccessTokenId ?? null,
     });
   }
 
   if (columnsPresent.has("request_id")) {
-    specs.push({
-      column: "request_id",
-      value: input.requestId ?? null
-    });
+    specs.push({ column: "request_id", value: input.requestId ?? null });
   }
 
   if (columnsPresent.has("request_method")) {
     specs.push({
       column: "request_method",
-      value: input.requestMethod ?? null
+      value: input.requestMethod ?? null,
     });
   }
 
   if (columnsPresent.has("request_path")) {
-    specs.push({
-      column: "request_path",
-      value: input.requestPath ?? null
-    });
+    specs.push({ column: "request_path", value: input.requestPath ?? null });
   }
 
   if (columnsPresent.has("ip_address")) {
-    specs.push({
-      column: "ip_address",
-      value: input.ipAddress ?? null
-    });
+    specs.push({ column: "ip_address", value: input.ipAddress ?? null });
   }
 
   if (columnsPresent.has("user_agent")) {
-    specs.push({
-      column: "user_agent",
-      value: input.userAgent ?? null
-    });
+    specs.push({ column: "user_agent", value: input.userAgent ?? null });
   }
 
   if (columnsPresent.has("metadata")) {
     specs.push({
       column: "metadata",
       value: metadataJson,
-      cast: "jsonb"
+      cast: "jsonb",
     });
   }
 
   const query = `
     insert into "audit_log" (${specs.map((spec) => `"${spec.column}"`).join(", ")})
-    values (${specs.map((spec, index) => {
-      const placeholder = `$${index + 1}`;
-      return spec.cast ? `${placeholder}::${spec.cast}` : placeholder;
-    }).join(", ")})
+    values (${specs
+      .map((spec, index) => {
+        const placeholder = `$${index + 1}`;
+        return spec.cast ? `${placeholder}::${spec.cast}` : placeholder;
+      })
+      .join(", ")})
     returning *
   `;
 
@@ -253,4 +257,66 @@ export async function createAuditLog(input: CreateAuditLogInput) {
   const result = await pgClient.unsafe(query, values);
 
   return result[0];
+}
+
+export async function listAuditLog(filters: AdminAuditListFilters) {
+  const columnsPresent = await getAuditLogColumns();
+  const { whereSql, values } = buildAuditLogWhere(filters);
+
+  const selectAction = buildOptionalSelect(columnsPresent, "action", "null::text");
+  const selectEntity = buildOptionalSelect(columnsPresent, "entity", "null::text");
+  const selectEntityId = buildOptionalSelect(
+    columnsPresent,
+    "entity_id",
+    "null::integer",
+  );
+
+  const rows = await pgClient.unsafe(
+    `
+      select
+        "id",
+        "event",
+        ${selectAction},
+        ${selectEntity},
+        ${selectEntityId},
+        "actor_type",
+        "actor_admin_user_id",
+        "actor_clinic_user_id",
+        "actor_report_access_token_id",
+        "clinic_id",
+        "report_id",
+        "target_admin_user_id",
+        "target_clinic_user_id",
+        "target_report_access_token_id",
+        "request_id",
+        "request_method",
+        "request_path",
+        "ip_address",
+        "user_agent",
+        "metadata",
+        "created_at"
+      from "audit_log"
+      ${whereSql}
+      order by "created_at" desc, "id" desc
+      limit $${values.length + 1}
+      offset $${values.length + 2}
+    `,
+    [...values, filters.limit, filters.offset],
+  );
+
+  const countRows = await pgClient.unsafe(
+    `
+      select count(*)::int as count
+      from "audit_log"
+      ${whereSql}
+    `,
+    values,
+  );
+
+  return {
+    items: rows.map((row) =>
+      serializeAuditLogListItem(row as Record<string, unknown>),
+    ),
+    total: Number(countRows[0]?.count ?? 0),
+  };
 }

--- a/server/lib/admin-audit.ts
+++ b/server/lib/admin-audit.ts
@@ -1,0 +1,278 @@
+export const ADMIN_AUDIT_ACTOR_TYPES = [
+  "system",
+  "admin_user",
+  "clinic_user",
+  "public_report_access_token",
+] as const;
+
+export type AdminAuditActorType = (typeof ADMIN_AUDIT_ACTOR_TYPES)[number];
+
+export const ADMIN_AUDIT_EVENTS = [
+  "auth.admin.login.succeeded",
+  "auth.clinic.login.succeeded",
+  "report.status.changed",
+  "report_access_token.created",
+  "report_access_token.revoked",
+  "report.public_accessed",
+] as const;
+
+export type AdminAuditEvent = (typeof ADMIN_AUDIT_EVENTS)[number];
+
+export type AdminAuditListFilters = {
+  event?: AdminAuditEvent;
+  actorType?: AdminAuditActorType;
+  clinicId?: number;
+  reportId?: number;
+  actorAdminUserId?: number;
+  actorClinicUserId?: number;
+  actorReportAccessTokenId?: number;
+  targetReportAccessTokenId?: number;
+  from?: Date;
+  to?: Date;
+  limit: number;
+  offset: number;
+};
+
+export type AdminAuditListFilterBuildResult = {
+  filters: AdminAuditListFilters;
+  errors: string[];
+};
+
+export type AuditLogListItem = {
+  id: number;
+  event: string;
+  action: string | null;
+  entity: string | null;
+  entityId: number | null;
+  actorType: string | null;
+  actorAdminUserId: number | null;
+  actorClinicUserId: number | null;
+  actorReportAccessTokenId: number | null;
+  clinicId: number | null;
+  reportId: number | null;
+  targetAdminUserId: number | null;
+  targetClinicUserId: number | null;
+  targetReportAccessTokenId: number | null;
+  requestId: string | null;
+  requestMethod: string | null;
+  requestPath: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date | string | null;
+};
+
+function isBlank(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === "string" && value.trim().length === 0)
+  );
+}
+
+function parsePositiveInt(
+  value: unknown,
+  fallback: number,
+  max?: number,
+): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  if (typeof max === "number") {
+    return Math.min(parsed, max);
+  }
+
+  return parsed;
+}
+
+function parseOffset(value: unknown, fallback = 0): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function parseOptionalPositiveId(value: unknown): number | undefined | null {
+  if (isBlank(value)) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseOptionalDate(value: unknown): Date | undefined | null {
+  if (isBlank(value)) {
+    return undefined;
+  }
+
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parseOptionalAuditEvent(
+  value: unknown,
+): AdminAuditEvent | undefined | null {
+  if (isBlank(value)) {
+    return undefined;
+  }
+
+  const normalized = String(value).trim();
+
+  return (ADMIN_AUDIT_EVENTS as readonly string[]).includes(normalized)
+    ? (normalized as AdminAuditEvent)
+    : null;
+}
+
+function parseOptionalAuditActorType(
+  value: unknown,
+): AdminAuditActorType | undefined | null {
+  if (isBlank(value)) {
+    return undefined;
+  }
+
+  const normalized = String(value).trim();
+
+  return (ADMIN_AUDIT_ACTOR_TYPES as readonly string[]).includes(normalized)
+    ? (normalized as AdminAuditActorType)
+    : null;
+}
+
+function toNullableNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+export function normalizeAuditListMetadata(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return null;
+}
+
+export function serializeAuditLogListItem(
+  row: Record<string, unknown>,
+): AuditLogListItem {
+  return {
+    id: Number(row.id),
+    event: String(row.event),
+    action: toNullableString(row.action),
+    entity: toNullableString(row.entity),
+    entityId: toNullableNumber(row.entity_id),
+    actorType: toNullableString(row.actor_type),
+    actorAdminUserId: toNullableNumber(row.actor_admin_user_id),
+    actorClinicUserId: toNullableNumber(row.actor_clinic_user_id),
+    actorReportAccessTokenId: toNullableNumber(row.actor_report_access_token_id),
+    clinicId: toNullableNumber(row.clinic_id),
+    reportId: toNullableNumber(row.report_id),
+    targetAdminUserId: toNullableNumber(row.target_admin_user_id),
+    targetClinicUserId: toNullableNumber(row.target_clinic_user_id),
+    targetReportAccessTokenId: toNullableNumber(row.target_report_access_token_id),
+    requestId: toNullableString(row.request_id),
+    requestMethod: toNullableString(row.request_method),
+    requestPath: toNullableString(row.request_path),
+    ipAddress: toNullableString(row.ip_address),
+    userAgent: toNullableString(row.user_agent),
+    metadata: normalizeAuditListMetadata(row.metadata),
+    createdAt:
+      row.created_at instanceof Date || typeof row.created_at === "string"
+        ? row.created_at
+        : null,
+  };
+}
+
+export function buildAdminAuditListFilters(
+  query: Record<string, unknown>,
+): AdminAuditListFilterBuildResult {
+  const errors: string[] = [];
+
+  const event = parseOptionalAuditEvent(query.event);
+  const actorType = parseOptionalAuditActorType(query.actorType);
+  const clinicId = parseOptionalPositiveId(query.clinicId);
+  const reportId = parseOptionalPositiveId(query.reportId);
+  const actorAdminUserId = parseOptionalPositiveId(query.actorAdminUserId);
+  const actorClinicUserId = parseOptionalPositiveId(query.actorClinicUserId);
+  const actorReportAccessTokenId = parseOptionalPositiveId(
+    query.actorReportAccessTokenId,
+  );
+  const targetReportAccessTokenId = parseOptionalPositiveId(
+    query.targetReportAccessTokenId,
+  );
+  const from = parseOptionalDate(query.from);
+  const to = parseOptionalDate(query.to);
+
+  if (event === null) errors.push("event invalido");
+  if (actorType === null) errors.push("actorType invalido");
+  if (clinicId === null) errors.push("clinicId invalido");
+  if (reportId === null) errors.push("reportId invalido");
+  if (actorAdminUserId === null) errors.push("actorAdminUserId invalido");
+  if (actorClinicUserId === null) errors.push("actorClinicUserId invalido");
+  if (actorReportAccessTokenId === null) {
+    errors.push("actorReportAccessTokenId invalido");
+  }
+  if (targetReportAccessTokenId === null) {
+    errors.push("targetReportAccessTokenId invalido");
+  }
+  if (from === null) errors.push("from invalido");
+  if (to === null) errors.push("to invalido");
+
+  const limit = parsePositiveInt(query.limit, 50, 100);
+  const offset = parseOffset(query.offset, 0);
+
+  return {
+    errors,
+    filters: {
+      event: event ?? undefined,
+      actorType: actorType ?? undefined,
+      clinicId: clinicId ?? undefined,
+      reportId: reportId ?? undefined,
+      actorAdminUserId: actorAdminUserId ?? undefined,
+      actorClinicUserId: actorClinicUserId ?? undefined,
+      actorReportAccessTokenId: actorReportAccessTokenId ?? undefined,
+      targetReportAccessTokenId: targetReportAccessTokenId ?? undefined,
+      from: from ?? undefined,
+      to: to ?? undefined,
+      limit,
+      offset,
+    },
+  };
+}

--- a/server/routes/admin-audit.routes.ts
+++ b/server/routes/admin-audit.routes.ts
@@ -1,0 +1,52 @@
+import { Router } from "express";
+import { listAuditLog } from "../db-audit";
+import { buildAdminAuditListFilters } from "../lib/admin-audit";
+import { requireAdminAuth } from "../middlewares/admin-auth";
+import { asyncHandler } from "../utils/async-handler";
+
+const router = Router();
+
+router.use(requireAdminAuth);
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const { filters, errors } = buildAdminAuditListFilters(
+      req.query as Record<string, unknown>,
+    );
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const result = await listAuditLog(filters);
+
+    return res.json({
+      success: true,
+      count: result.items.length,
+      items: result.items,
+      pagination: {
+        limit: filters.limit,
+        offset: filters.offset,
+        total: result.total,
+      },
+      filters: {
+        event: filters.event ?? null,
+        actorType: filters.actorType ?? null,
+        clinicId: filters.clinicId ?? null,
+        reportId: filters.reportId ?? null,
+        actorAdminUserId: filters.actorAdminUserId ?? null,
+        actorClinicUserId: filters.actorClinicUserId ?? null,
+        actorReportAccessTokenId: filters.actorReportAccessTokenId ?? null,
+        targetReportAccessTokenId: filters.targetReportAccessTokenId ?? null,
+        from: filters.from ?? null,
+        to: filters.to ?? null,
+      },
+    });
+  }),
+);
+
+export default router;

--- a/test/admin-audit.test.ts
+++ b/test/admin-audit.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildAdminAuditListFilters,
+  normalizeAuditListMetadata,
+  serializeAuditLogListItem,
+} from "../server/lib/admin-audit.ts";
+
+test("buildAdminAuditListFilters parsea filtros validos", () => {
+  const { filters, errors } = buildAdminAuditListFilters({
+    event: "report.public_accessed",
+    actorType: "public_report_access_token",
+    clinicId: "4",
+    reportId: "1",
+    actorReportAccessTokenId: "5",
+    targetReportAccessTokenId: "5",
+    from: "2026-04-17T00:00:00.000Z",
+    to: "2026-04-18T00:00:00.000Z",
+    limit: "20",
+    offset: "5",
+  });
+
+  assert.deepEqual(errors, []);
+  assert.equal(filters.event, "report.public_accessed");
+  assert.equal(filters.actorType, "public_report_access_token");
+  assert.equal(filters.clinicId, 4);
+  assert.equal(filters.reportId, 1);
+  assert.equal(filters.actorReportAccessTokenId, 5);
+  assert.equal(filters.targetReportAccessTokenId, 5);
+  assert.equal(filters.limit, 20);
+  assert.equal(filters.offset, 5);
+  assert.equal(filters.from?.toISOString(), "2026-04-17T00:00:00.000Z");
+  assert.equal(filters.to?.toISOString(), "2026-04-18T00:00:00.000Z");
+});
+
+test("buildAdminAuditListFilters informa error para event invalido", () => {
+  const { errors } = buildAdminAuditListFilters({
+    event: "cualquier-cosa",
+  });
+
+  assert.deepEqual(errors, ["event invalido"]);
+});
+
+test("buildAdminAuditListFilters aplica defaults seguros", () => {
+  const { filters, errors } = buildAdminAuditListFilters({});
+
+  assert.deepEqual(errors, []);
+  assert.equal(filters.limit, 50);
+  assert.equal(filters.offset, 0);
+});
+
+test("normalizeAuditListMetadata parsea JSON string", () => {
+  const metadata = normalizeAuditListMetadata(
+    '{"tokenLast4":"43de","accessCount":2}',
+  );
+
+  assert.deepEqual(metadata, {
+    tokenLast4: "43de",
+    accessCount: 2,
+  });
+});
+
+test("serializeAuditLogListItem mapea snake_case y metadata", () => {
+  const item = serializeAuditLogListItem({
+    id: 16,
+    event: "report.public_accessed",
+    action: "report.public_accessed",
+    entity: "report_access_token",
+    entity_id: 1,
+    actor_type: "public_report_access_token",
+    actor_admin_user_id: null,
+    actor_clinic_user_id: null,
+    actor_report_access_token_id: 5,
+    clinic_id: 4,
+    report_id: 1,
+    target_admin_user_id: null,
+    target_clinic_user_id: null,
+    target_report_access_token_id: 5,
+    request_id: null,
+    request_method: "GET",
+    request_path: "/api/public/report-access/[REDACTED]",
+    ip_address: "127.0.0.1",
+    user_agent: "test-agent",
+    metadata: '{"tokenLast4":"43de","accessCount":2}',
+    created_at: "2026-04-17 17:10:58.921445",
+  });
+
+  assert.equal(item.actorType, "public_report_access_token");
+  assert.equal(item.actorReportAccessTokenId, 5);
+  assert.deepEqual(item.metadata, {
+    tokenLast4: "43de",
+    accessCount: 2,
+  });
+  assert.equal(item.requestPath, "/api/public/report-access/[REDACTED]");
+});


### PR DESCRIPTION
## Summary
- add admin audit log read endpoint
- add filters and pagination for audit log queries
- normalize audit log rows and metadata for API responses
- add tests for query parsing and audit row serialization

## Validation
- pnpm test
- pnpm typecheck
- manual validation:
  - admin login works
  - GET /api/admin/audit-log with filters returns 200
  - invalid event returns 400