### PR TITLE
feat(audit): add clinic audit log read endpoint scoped to session clinic

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -9,6 +9,7 @@ import adminReportAccessTokensRoutes from "./routes/admin-report-access-tokens.r
 import adminStudyTrackingRoutes from "./routes/admin-study-tracking.routes";
 import authRoutes from "./routes/auth.routes";
 import clinicPublicProfileRoutes from "./routes/clinic-public-profile.routes";
+import clinicAuditRoutes from "./routes/clinic-audit.routes";
 import healthRoutes from "./routes/health.routes";
 import particularAuthRoutes from "./routes/particular-auth.routes";
 import particularStudyTrackingRoutes from "./routes/particular-study-tracking.routes";
@@ -119,6 +120,7 @@ app.use("/api/auth", authRoutes);
 app.use("/api/admin/auth", adminAuthRoutes);
 app.use("/api/admin/audit-log", adminAuditRoutes);
 app.use("/api/clinic/profile", clinicPublicProfileRoutes);
+app.use("/api/clinic/audit-log", clinicAuditRoutes);
 app.use("/api/admin/particular/tokens", adminParticularTokensRoutes);
 app.use("/api/admin/report-access-tokens", adminReportAccessTokensRoutes);
 app.use("/api/admin/study-tracking", adminStudyTrackingRoutes);

--- a/server/lib/admin-audit.ts
+++ b/server/lib/admin-audit.ts
@@ -276,3 +276,18 @@ export function buildAdminAuditListFilters(
     },
   };
 }
+export function buildClinicAuditListFilters(
+  query: Record<string, unknown>,
+  clinicId: number,
+): AdminAuditListFilterBuildResult {
+  const { filters, errors } = buildAdminAuditListFilters(query);
+
+  return {
+    errors,
+    filters: {
+      ...filters,
+      clinicId,
+      actorAdminUserId: undefined,
+    },
+  };
+}

--- a/server/routes/clinic-audit.routes.ts
+++ b/server/routes/clinic-audit.routes.ts
@@ -1,0 +1,54 @@
+import { Router } from "express";
+import { listAuditLog } from "../db-audit";
+import { buildClinicAuditListFilters } from "../lib/admin-audit";
+import { requireAuth } from "../middlewares/auth";
+import { asyncHandler } from "../utils/async-handler";
+
+const router = Router();
+
+router.use(requireAuth);
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const auth = req.auth!;
+
+    const { filters, errors } = buildClinicAuditListFilters(
+      req.query as Record<string, unknown>,
+      auth.clinicId,
+    );
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const result = await listAuditLog(filters);
+
+    return res.json({
+      success: true,
+      count: result.items.length,
+      items: result.items,
+      pagination: {
+        limit: filters.limit,
+        offset: filters.offset,
+        total: result.total,
+      },
+      filters: {
+        event: filters.event ?? null,
+        actorType: filters.actorType ?? null,
+        clinicId: auth.clinicId,
+        reportId: filters.reportId ?? null,
+        actorClinicUserId: filters.actorClinicUserId ?? null,
+        actorReportAccessTokenId: filters.actorReportAccessTokenId ?? null,
+        targetReportAccessTokenId: filters.targetReportAccessTokenId ?? null,
+        from: filters.from ?? null,
+        to: filters.to ?? null,
+      },
+    });
+  }),
+);
+
+export default router;

--- a/test/clinic-audit.test.ts
+++ b/test/clinic-audit.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildClinicAuditListFilters } from "../server/lib/admin-audit.ts";
+
+test("buildClinicAuditListFilters fuerza clinicId de sesion", () => {
+  const { filters, errors } = buildClinicAuditListFilters(
+    {
+      clinicId: "999",
+      reportId: "1",
+      event: "report.public_accessed",
+      limit: "20",
+      offset: "0",
+    },
+    4,
+  );
+
+  assert.deepEqual(errors, []);
+  assert.equal(filters.clinicId, 4);
+  assert.equal(filters.reportId, 1);
+  assert.equal(filters.event, "report.public_accessed");
+  assert.equal(filters.limit, 20);
+  assert.equal(filters.offset, 0);
+});
+
+test("buildClinicAuditListFilters limpia actorAdminUserId", () => {
+  const { filters, errors } = buildClinicAuditListFilters(
+    {
+      actorAdminUserId: "1",
+      actorType: "admin_user",
+    },
+    4,
+  );
+
+  assert.deepEqual(errors, []);
+  assert.equal(filters.clinicId, 4);
+  assert.equal(filters.actorAdminUserId, undefined);
+  assert.equal(filters.actorType, "admin_user");
+});
+
+test("buildClinicAuditListFilters conserva errores base", () => {
+  const { errors } = buildClinicAuditListFilters(
+    {
+      event: "evento-invalido",
+    },
+    4,
+  );
+
+  assert.deepEqual(errors, ["event invalido"]);
+});


### PR DESCRIPTION
## Summary
- add clinic audit log read endpoint
- scope clinic audit queries to the authenticated clinic session
- reuse audit filter parsing and pagination support
- add tests for clinic-scoped filter behavior

## Validation
- pnpm test
- pnpm typecheck
- manual validation:
  - clinic login works
  - GET /api/clinic/audit-log returns 200
  - clinicId query is ignored in favor of session clinicId
  - invalid event returns 400