### PR TITLE
feat(admin): export audit log as csv

### DIFF
--- a/server/db-audit.ts
+++ b/server/db-audit.ts
@@ -1,4 +1,4 @@
-import type { AuditActorType, AuditEvent } from "../drizzle/schema";
+﻿import type { AuditActorType, AuditEvent } from "../drizzle/schema";
 import type { AdminAuditListFilters } from "./lib/admin-audit";
 import { serializeAuditLogListItem } from "./lib/admin-audit";
 import { pgClient } from "./db";
@@ -26,7 +26,7 @@ type CreateAuditLogInput = {
 };
 
 type InsertValue = string | number | null;
-type QueryValue = string | number | Date;
+type QueryValue = string | number;
 
 type ColumnSpec = {
   column: string;
@@ -97,6 +97,11 @@ function buildAuditLogWhere(filters: AdminAuditListFilters): {
     clauses.push(`${sqlFragment} $${values.length}`);
   };
 
+  const addUtcDateClause = (sqlFragment: string, value: Date) => {
+    values.push(value.toISOString());
+    clauses.push(`${sqlFragment} ($${values.length}::timestamptz AT TIME ZONE 'UTC')`);
+  };
+
   if (filters.event) addClause(`"event" =`, filters.event);
   if (filters.actorType) addClause(`"actor_type" =`, filters.actorType);
   if (typeof filters.clinicId === "number") addClause(`"clinic_id" =`, filters.clinicId);
@@ -113,8 +118,12 @@ function buildAuditLogWhere(filters: AdminAuditListFilters): {
   if (typeof filters.targetReportAccessTokenId === "number") {
     addClause(`"target_report_access_token_id" =`, filters.targetReportAccessTokenId);
   }
-  if (filters.from instanceof Date) addClause(`"created_at" >=`, filters.from);
-  if (filters.to instanceof Date) addClause(`"created_at" <=`, filters.to);
+  if (filters.from instanceof Date) {
+    addUtcDateClause(`"created_at" >=`, filters.from);
+  }
+  if (filters.to instanceof Date) {
+    addUtcDateClause(`"created_at" <=`, filters.to);
+  }
 
   return {
     whereSql: clauses.length > 0 ? `where ${clauses.join(" and ")}` : "",

--- a/server/lib/admin-audit.ts
+++ b/server/lib/admin-audit.ts
@@ -1,4 +1,4 @@
-export const ADMIN_AUDIT_ACTOR_TYPES = [
+﻿export const ADMIN_AUDIT_ACTOR_TYPES = [
   "system",
   "admin_user",
   "clinic_user",
@@ -61,6 +61,30 @@ export type AuditLogListItem = {
   metadata: Record<string, unknown> | null;
   createdAt: Date | string | null;
 };
+
+export const AUDIT_LOG_CSV_HEADERS = [
+  "id",
+  "event",
+  "action",
+  "entity",
+  "entityId",
+  "actorType",
+  "actorAdminUserId",
+  "actorClinicUserId",
+  "actorReportAccessTokenId",
+  "clinicId",
+  "reportId",
+  "targetAdminUserId",
+  "targetClinicUserId",
+  "targetReportAccessTokenId",
+  "requestId",
+  "requestMethod",
+  "requestPath",
+  "ipAddress",
+  "userAgent",
+  "metadata",
+  "createdAt",
+] as const;
 
 function isBlank(value: unknown): boolean {
   return (
@@ -159,6 +183,67 @@ function toNullableNumber(value: unknown): number | null {
 
 function toNullableString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
+}
+
+function serializeCsvPrimitive(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+function escapeCsvCell(value: unknown): string {
+  const serialized = serializeCsvPrimitive(value);
+
+  if (/[",\r\n]/.test(serialized)) {
+    return `"${serialized.replace(/"/g, '""')}"`;
+  }
+
+  return serialized;
+}
+
+function parseAuditTimestampString(value: string): Date | null {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const normalizedSqlTimestamp = trimmed.replace(" ", "T");
+
+  if (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(
+      normalizedSqlTimestamp,
+    )
+  ) {
+    const parsed = new Date(`${normalizedSqlTimestamp}Z`);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function formatAuditCsvCreatedAt(value: AuditLogListItem["createdAt"]): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const parsed = parseAuditTimestampString(value);
+  return parsed ? parsed.toISOString() : value;
 }
 
 export function normalizeAuditListMetadata(
@@ -276,6 +361,7 @@ export function buildAdminAuditListFilters(
     },
   };
 }
+
 export function buildClinicAuditListFilters(
   query: Record<string, unknown>,
   clinicId: number,
@@ -290,4 +376,42 @@ export function buildClinicAuditListFilters(
       actorAdminUserId: undefined,
     },
   };
+}
+
+export function buildAdminAuditCsv(items: AuditLogListItem[]): string {
+  const headerRow = AUDIT_LOG_CSV_HEADERS.join(",");
+  const rows = items.map((item) => {
+    const values = [
+      item.id,
+      item.event,
+      item.action,
+      item.entity,
+      item.entityId,
+      item.actorType,
+      item.actorAdminUserId,
+      item.actorClinicUserId,
+      item.actorReportAccessTokenId,
+      item.clinicId,
+      item.reportId,
+      item.targetAdminUserId,
+      item.targetClinicUserId,
+      item.targetReportAccessTokenId,
+      item.requestId,
+      item.requestMethod,
+      item.requestPath,
+      item.ipAddress,
+      item.userAgent,
+      item.metadata,
+      formatAuditCsvCreatedAt(item.createdAt),
+    ];
+
+    return values.map((value) => escapeCsvCell(value)).join(",");
+  });
+
+  return `\uFEFF${[headerRow, ...rows].join("\n")}`;
+}
+
+export function buildAdminAuditCsvFilename(now = new Date()): string {
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  return `admin-audit-log-${timestamp}.csv`;
 }

--- a/server/routes/admin-audit.routes.ts
+++ b/server/routes/admin-audit.routes.ts
@@ -1,12 +1,56 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import { listAuditLog } from "../db-audit";
-import { buildAdminAuditListFilters } from "../lib/admin-audit";
+import {
+  buildAdminAuditCsv,
+  buildAdminAuditCsvFilename,
+  buildAdminAuditListFilters,
+} from "../lib/admin-audit";
 import { requireAdminAuth } from "../middlewares/admin-auth";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 router.use(requireAdminAuth);
+
+router.get(
+  "/export.csv",
+  asyncHandler(async (req, res) => {
+    const { filters, errors } = buildAdminAuditListFilters(
+      req.query as Record<string, unknown>,
+    );
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const exportFilters = {
+      ...filters,
+      limit: ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS,
+      offset: 0,
+    };
+
+    const result = await listAuditLog(exportFilters);
+
+    if (result.total > ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS) {
+      return res.status(400).json({
+        success: false,
+        error: `Demasiados registros para exportar. Aplica filtros mas especificos (maximo ${ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS}).`,
+      });
+    }
+
+    const csv = buildAdminAuditCsv(result.items);
+    const filename = buildAdminAuditCsvFilename();
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+
+    return res.status(200).send(csv);
+  }),
+);
 
 router.get(
   "/",

--- a/test/admin-audit.test.ts
+++ b/test/admin-audit.test.ts
@@ -1,6 +1,8 @@
-import test from "node:test";
+﻿import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildAdminAuditCsv,
+  buildAdminAuditCsvFilename,
   buildAdminAuditListFilters,
   normalizeAuditListMetadata,
   serializeAuditLogListItem,
@@ -92,4 +94,51 @@ test("serializeAuditLogListItem mapea snake_case y metadata", () => {
     accessCount: 2,
   });
   assert.equal(item.requestPath, "/api/public/report-access/[REDACTED]");
+});
+
+test("buildAdminAuditCsv genera cabecera, escapa valores y serializa metadata", () => {
+  const csv = buildAdminAuditCsv([
+    {
+      id: 16,
+      event: "report.public_accessed",
+      action: "report.public_accessed",
+      entity: "report_access_token",
+      entityId: 1,
+      actorType: "public_report_access_token",
+      actorAdminUserId: null,
+      actorClinicUserId: null,
+      actorReportAccessTokenId: 5,
+      clinicId: 4,
+      reportId: 1,
+      targetAdminUserId: null,
+      targetClinicUserId: null,
+      targetReportAccessTokenId: 5,
+      requestId: "req-123",
+      requestMethod: "GET",
+      requestPath: "/api/admin/audit-log/export.csv?event=report.public_accessed",
+      ipAddress: "127.0.0.1",
+      userAgent: 'Mozilla/5.0 "Windows"',
+      metadata: {
+        tokenLast4: "43de",
+        note: "linea 1\nlinea 2",
+      },
+      createdAt: "2026-04-17 17:10:58.921445",
+    },
+  ]);
+
+  const lines = csv.split("\n");
+
+  assert.match(lines[0], /^\uFEFFid,event,action,entity,entityId,/);
+  assert.match(lines[1], /report\.public_accessed/);
+  assert.match(lines[1], /"Mozilla\/5\.0 ""Windows"""/);
+  assert.match(lines[1], /"\{""tokenLast4"":""43de"",""note"":""linea 1\\nlinea 2""\}"/);
+  assert.match(lines[1], /2026-04-17T17:10:58\.921Z$/);
+});
+
+test("buildAdminAuditCsvFilename genera nombre estable y seguro", () => {
+  const filename = buildAdminAuditCsvFilename(
+    new Date("2026-04-18T13:22:33.456Z"),
+  );
+
+  assert.equal(filename, "admin-audit-log-2026-04-18T13-22-33-456Z.csv");
 });


### PR DESCRIPTION
﻿## Summary
- add admin audit log CSV export endpoint at `GET /api/admin/audit-log/export.csv`
- reuse admin audit filters for CSV exports
- generate UTF-8 BOM CSV with escaped cells and stable download filename
- normalize naive SQL timestamps when serializing audit CSV rows
- fix audit log date filtering with explicit UTC handling in SQL conditions
- add tests for CSV generation and filename formatting

## Testing
- pnpm test -- test/admin-audit.test.ts test/clinic-audit.test.ts
- pnpm typecheck
- manual smoke test for `/api/admin/audit-log/export.csv`
- manual smoke test for filtered export with `event`, `clinicId`, `from`, and `to`
