### PR TITLE
feat(clinic): export audit log as csv

### DIFF
--- a/server/routes/clinic-audit.routes.ts
+++ b/server/routes/clinic-audit.routes.ts
@@ -1,12 +1,63 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import { listAuditLog } from "../db-audit";
-import { buildClinicAuditListFilters } from "../lib/admin-audit";
+import {
+  buildAdminAuditCsv,
+  buildClinicAuditListFilters,
+} from "../lib/admin-audit";
 import { requireAuth } from "../middlewares/auth";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
+
+function buildClinicAuditCsvFilename(now = new Date()): string {
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  return `clinic-audit-log-${timestamp}.csv`;
+}
 
 router.use(requireAuth);
+
+router.get(
+  "/export.csv",
+  asyncHandler(async (req, res) => {
+    const auth = req.auth!;
+
+    const { filters, errors } = buildClinicAuditListFilters(
+      req.query as Record<string, unknown>,
+      auth.clinicId,
+    );
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const exportFilters = {
+      ...filters,
+      limit: CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS,
+      offset: 0,
+    };
+
+    const result = await listAuditLog(exportFilters);
+
+    if (result.total > CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS) {
+      return res.status(400).json({
+        success: false,
+        error: `Demasiados registros para exportar. Aplica filtros mas especificos (maximo ${CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS}).`,
+      });
+    }
+
+    const csv = buildAdminAuditCsv(result.items);
+    const filename = buildClinicAuditCsvFilename();
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+
+    return res.status(200).send(csv);
+  }),
+);
 
 router.get(
   "/",

--- a/test/clinic-audit.test.ts
+++ b/test/clinic-audit.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+﻿import test from "node:test";
 import assert from "node:assert/strict";
 import { buildClinicAuditListFilters } from "../server/lib/admin-audit.ts";
 
@@ -46,4 +46,28 @@ test("buildClinicAuditListFilters conserva errores base", () => {
   );
 
   assert.deepEqual(errors, ["event invalido"]);
+});
+
+test("buildClinicAuditListFilters parsea fechas validas y conserva scope de clinica", () => {
+  const { filters, errors } = buildClinicAuditListFilters(
+    {
+      clinicId: "999",
+      event: "report.public_accessed",
+      actorReportAccessTokenId: "5",
+      from: "2026-04-01T00:00:00.000Z",
+      to: "2026-04-18T23:59:59.999Z",
+      limit: "100",
+      offset: "0",
+    },
+    4,
+  );
+
+  assert.deepEqual(errors, []);
+  assert.equal(filters.clinicId, 4);
+  assert.equal(filters.event, "report.public_accessed");
+  assert.equal(filters.actorReportAccessTokenId, 5);
+  assert.equal(filters.limit, 100);
+  assert.equal(filters.offset, 0);
+  assert.equal(filters.from?.toISOString(), "2026-04-01T00:00:00.000Z");
+  assert.equal(filters.to?.toISOString(), "2026-04-18T23:59:59.999Z");
 });


### PR DESCRIPTION
﻿## Summary
- add clinic audit log CSV export endpoint at `GET /api/clinic/audit-log/export.csv`
- reuse clinic audit filters and force clinic scope from authenticated session
- return UTF-8 BOM CSV with escaped cells and stable filename
- add clinic audit filter coverage for valid date parsing and clinic scoping

## Testing
- pnpm test -- test/admin-audit.test.ts test/clinic-audit.test.ts
- pnpm typecheck
- manual smoke test for `/api/clinic/audit-log/export.csv`
- manual smoke test for filtered export with `event`, `from`, and `to`
