### PR TITLE
feat(auth): add shared login rate limit

### DIFF
--- a/server/lib/login-rate-limit.ts
+++ b/server/lib/login-rate-limit.ts
@@ -1,0 +1,23 @@
+﻿import rateLimit, { type Options } from "express-rate-limit";
+
+export const LOGIN_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+export const LOGIN_RATE_LIMIT_MAX_ATTEMPTS = 10;
+export const LOGIN_RATE_LIMIT_ERROR_MESSAGE =
+  "Demasiados intentos de inicio de sesión. Intente más tarde.";
+
+export function buildLoginRateLimitOptions(): Partial<Options> {
+  return {
+    windowMs: LOGIN_RATE_LIMIT_WINDOW_MS,
+    max: LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+    },
+  };
+}
+
+export function createLoginRateLimit() {
+  return rateLimit(buildLoginRateLimitOptions());
+}

--- a/server/routes/admin-auth.routes.ts
+++ b/server/routes/admin-auth.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import {
   createAdminSession,
   deleteAdminSession,
@@ -11,15 +11,18 @@ import {
 } from "../lib/auth-security";
 import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { ENV } from "../lib/env";
+import { createLoginRateLimit } from "../lib/login-rate-limit";
 import { requireAdminAuth } from "../middlewares/admin-auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const loginRateLimit = createLoginRateLimit();
 
 router.post(
   "/login",
   requireTrustedOrigin,
+  loginRateLimit,
   asyncHandler(async (req, res) => {
     const username =
       typeof req.body?.username === "string" ? req.body.username.trim() : "";

--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -1,5 +1,4 @@
-import { Router } from "express";
-import rateLimit from "express-rate-limit";
+﻿import { Router } from "express";
 
 import {
   createActiveSession,
@@ -15,23 +14,14 @@ import {
 } from "../lib/auth-security";
 import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
 import { ENV } from "../lib/env";
+import { createLoginRateLimit } from "../lib/login-rate-limit";
 import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
-
-const loginRateLimit = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: {
-    success: false,
-    error: "Demasiados intentos de inicio de sesión. Intente más tarde.",
-  },
-});
+const loginRateLimit = createLoginRateLimit();
 
 router.post(
   "/login",

--- a/server/routes/particular-auth.routes.ts
+++ b/server/routes/particular-auth.routes.ts
@@ -1,5 +1,4 @@
-import { Router } from "express";
-import rateLimit from "express-rate-limit";
+﻿import { Router } from "express";
 import { getReportById } from "../db";
 import {
   createParticularSession,
@@ -13,6 +12,7 @@ import {
   hashSessionToken,
 } from "../lib/auth-security";
 import { ENV } from "../lib/env";
+import { createLoginRateLimit } from "../lib/login-rate-limit";
 import { serializeParticularTokenDetail } from "../lib/particular-token";
 import {
   createSignedReportDownloadUrl,
@@ -23,17 +23,7 @@ import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
-
-const loginRateLimit = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: {
-    success: false,
-    error: "Demasiados intentos de inicio de sesión. Intente más tarde.",
-  },
-});
+const loginRateLimit = createLoginRateLimit();
 
 async function buildParticularResponse(tokenId: number) {
   const particularToken = await getParticularTokenById(tokenId);

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -1,0 +1,37 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+  LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
+  LOGIN_RATE_LIMIT_WINDOW_MS,
+  buildLoginRateLimitOptions,
+  createLoginRateLimit,
+} from "../server/lib/login-rate-limit.ts";
+
+test("buildLoginRateLimitOptions expone configuracion esperada", () => {
+  const options = buildLoginRateLimitOptions();
+
+  assert.equal(options.windowMs, 15 * 60 * 1000);
+  assert.equal(options.max, 10);
+  assert.equal(options.standardHeaders, true);
+  assert.equal(options.legacyHeaders, false);
+  assert.deepEqual(options.message, {
+    success: false,
+    error: "Demasiados intentos de inicio de sesión. Intente más tarde.",
+  });
+});
+
+test("constantes de login rate limit son estables", () => {
+  assert.equal(LOGIN_RATE_LIMIT_WINDOW_MS, 15 * 60 * 1000);
+  assert.equal(LOGIN_RATE_LIMIT_MAX_ATTEMPTS, 10);
+  assert.equal(
+    LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+    "Demasiados intentos de inicio de sesión. Intente más tarde.",
+  );
+});
+
+test("createLoginRateLimit devuelve middleware invocable", () => {
+  const middleware = createLoginRateLimit();
+
+  assert.equal(typeof middleware, "function");
+});


### PR DESCRIPTION
﻿## Summary
- add shared login rate limit helper for auth endpoints
- apply login rate limiting to admin login
- reuse the shared limiter in clinic and particular login routes
- add tests for login rate limit configuration

## Testing
- pnpm test -- test/login-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts test/request-logger.test.ts
- pnpm typecheck
- manual smoke test for `/api/admin/auth/login`
- manual regression test for `/api/auth/login`

## Notes
- the limiter applies per route and counts total requests within the window, including successful login attempts
