### PR TITLE
feat(public): add public report access rate limit

### DIFF
--- a/server/lib/public-report-access-rate-limit.ts
+++ b/server/lib/public-report-access-rate-limit.ts
@@ -1,0 +1,23 @@
+﻿import rateLimit, { type Options } from "express-rate-limit";
+
+export const PUBLIC_REPORT_ACCESS_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+export const PUBLIC_REPORT_ACCESS_RATE_LIMIT_MAX_ATTEMPTS = 10;
+export const PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE =
+  "Demasiados accesos públicos al informe. Intente más tarde.";
+
+export function buildPublicReportAccessRateLimitOptions(): Partial<Options> {
+  return {
+    windowMs: PUBLIC_REPORT_ACCESS_RATE_LIMIT_WINDOW_MS,
+    max: PUBLIC_REPORT_ACCESS_RATE_LIMIT_MAX_ATTEMPTS,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+    },
+  };
+}
+
+export function createPublicReportAccessRateLimit() {
+  return rateLimit(buildPublicReportAccessRateLimitOptions());
+}

--- a/server/routes/public-report-access.routes.ts
+++ b/server/routes/public-report-access.routes.ts
@@ -1,10 +1,15 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import {
   getReportAccessTokenWithReportByTokenHash,
   recordReportAccessTokenAccess,
 } from "../db-report-access";
-import { buildPublicReportAccessTokenActor, AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
+import {
+  buildPublicReportAccessTokenActor,
+  AUDIT_EVENTS,
+  writeAuditLog,
+} from "../lib/audit";
 import { hashSessionToken } from "../lib/auth-security";
+import { createPublicReportAccessRateLimit } from "../lib/public-report-access-rate-limit";
 import {
   canAccessReportPublicly,
   getReportAccessTokenState,
@@ -18,9 +23,11 @@ import {
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const publicReportAccessRateLimit = createPublicReportAccessRateLimit();
 
 router.get(
   "/:token",
+  publicReportAccessRateLimit,
   asyncHandler(async (req, res) => {
     const parsed = reportAccessTokenRawTokenSchema.safeParse(req.params.token);
 

--- a/test/public-report-access-rate-limit.test.ts
+++ b/test/public-report-access-rate-limit.test.ts
@@ -1,0 +1,37 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_MAX_ATTEMPTS,
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_WINDOW_MS,
+  buildPublicReportAccessRateLimitOptions,
+  createPublicReportAccessRateLimit,
+} from "../server/lib/public-report-access-rate-limit.ts";
+
+test("buildPublicReportAccessRateLimitOptions expone configuracion esperada", () => {
+  const options = buildPublicReportAccessRateLimitOptions();
+
+  assert.equal(options.windowMs, 15 * 60 * 1000);
+  assert.equal(options.max, 10);
+  assert.equal(options.standardHeaders, true);
+  assert.equal(options.legacyHeaders, false);
+  assert.deepEqual(options.message, {
+    success: false,
+    error: "Demasiados accesos públicos al informe. Intente más tarde.",
+  });
+});
+
+test("constantes de public report access rate limit son estables", () => {
+  assert.equal(PUBLIC_REPORT_ACCESS_RATE_LIMIT_WINDOW_MS, 15 * 60 * 1000);
+  assert.equal(PUBLIC_REPORT_ACCESS_RATE_LIMIT_MAX_ATTEMPTS, 10);
+  assert.equal(
+    PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+    "Demasiados accesos públicos al informe. Intente más tarde.",
+  );
+});
+
+test("createPublicReportAccessRateLimit devuelve middleware invocable", () => {
+  const middleware = createPublicReportAccessRateLimit();
+
+  assert.equal(typeof middleware, "function");
+});


### PR DESCRIPTION
﻿## Summary
- add dedicated rate limit helper for public report access
- apply rate limiting to `GET /api/public/report-access/:token`
- keep the public report access contract unchanged on successful requests
- add tests for public report access rate limit configuration

## Testing
- pnpm test -- test/public-report-access-rate-limit.test.ts test/login-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts test/request-logger.test.ts
- pnpm typecheck
- manual smoke test for `/api/public/report-access/:token`

## Notes
- the limiter applies per route and blocks repeated public token access attempts from the same client within the configured window
