### PR TITLE
feat(auth): count only failed login attempts

### DIFF
--- a/server/lib/login-rate-limit.ts
+++ b/server/lib/login-rate-limit.ts
@@ -11,6 +11,7 @@ export function buildLoginRateLimitOptions(): Partial<Options> {
     max: LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
     standardHeaders: true,
     legacyHeaders: false,
+    skipSuccessfulRequests: true,
     message: {
       success: false,
       error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -15,6 +15,7 @@ test("buildLoginRateLimitOptions expone configuracion esperada", () => {
   assert.equal(options.max, 10);
   assert.equal(options.standardHeaders, true);
   assert.equal(options.legacyHeaders, false);
+  assert.equal(options.skipSuccessfulRequests, true);
   assert.deepEqual(options.message, {
     success: false,
     error: "Demasiados intentos de inicio de sesión. Intente más tarde.",


### PR DESCRIPTION
﻿## Summary
- update shared login rate limit configuration to count only failed login attempts
- keep shared login rate limiting for admin, clinic, and particular auth routes
- preserve the existing error message and rate limit window
- update tests to cover failed-only counting behavior

## Testing
- pnpm test -- test/login-rate-limit.test.ts test/public-report-access-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts test/request-logger.test.ts
- pnpm typecheck
- manual smoke test for `/api/admin/auth/login`
- manual regression test for `/api/auth/login`

## Notes
- successful login requests are now skipped by the limiter
- failed login attempts still count toward the configured limit
