### PR TITLE
feat(tokens): add report access token mutation rate limit

### DIFF
--- a/server/lib/report-access-token-rate-limit.ts
+++ b/server/lib/report-access-token-rate-limit.ts
@@ -1,0 +1,23 @@
+﻿import rateLimit, { type Options } from "express-rate-limit";
+
+export const REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+export const REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS = 10;
+export const REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE =
+  "Demasiadas operaciones sobre tokens públicos de informes. Intente más tarde.";
+
+export function buildReportAccessTokenMutationRateLimitOptions(): Partial<Options> {
+  return {
+    windowMs: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
+    max: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+    },
+  };
+}
+
+export function createReportAccessTokenMutationRateLimit() {
+  return rateLimit(buildReportAccessTokenMutationRateLimitOptions());
+}

--- a/server/routes/admin-report-access-tokens.routes.ts
+++ b/server/routes/admin-report-access-tokens.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import { getClinicById, getReportById } from "../db";
 import {
   createReportAccessToken,
@@ -21,17 +21,21 @@ import {
   serializeReportAccessTokenDetail,
 } from "../lib/report-access-token";
 import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
+import { createReportAccessTokenMutationRateLimit } from "../lib/report-access-token-rate-limit";
 import { requireAdminAuth } from "../middlewares/admin-auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const reportAccessTokenMutationRateLimit =
+  createReportAccessTokenMutationRateLimit();
 
 router.use(requireAdminAuth);
 
 router.post(
   "/",
   requireTrustedOrigin,
+  reportAccessTokenMutationRateLimit,
   asyncHandler(async (req, res) => {
     const parsed = adminCreateReportAccessTokenSchema.safeParse(req.body);
 
@@ -168,6 +172,7 @@ router.get(
 router.patch(
   "/:tokenId/revoke",
   requireTrustedOrigin,
+  reportAccessTokenMutationRateLimit,
   asyncHandler(async (req, res) => {
     const tokenId = parseEntityId(req.params.tokenId);
 

--- a/server/routes/report-access-tokens.routes.ts
+++ b/server/routes/report-access-tokens.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import { getReportById } from "../db";
 import {
   createReportAccessToken,
@@ -21,11 +21,14 @@ import {
   serializeReportAccessTokenDetail,
 } from "../lib/report-access-token";
 import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
+import { createReportAccessTokenMutationRateLimit } from "../lib/report-access-token-rate-limit";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const reportAccessTokenMutationRateLimit =
+  createReportAccessTokenMutationRateLimit();
 
 router.use(requireAuth);
 
@@ -45,6 +48,7 @@ const requireReportAccessTokenManagementPermission = asyncHandler(
 router.post(
   "/",
   requireTrustedOrigin,
+  reportAccessTokenMutationRateLimit,
   requireReportAccessTokenManagementPermission,
   asyncHandler(async (req, res) => {
     const parsed = clinicCreateReportAccessTokenSchema.safeParse(req.body);
@@ -164,6 +168,7 @@ router.get(
 router.patch(
   "/:tokenId/revoke",
   requireTrustedOrigin,
+  reportAccessTokenMutationRateLimit,
   requireReportAccessTokenManagementPermission,
   asyncHandler(async (req, res) => {
     const tokenId = parseEntityId(req.params.tokenId);

--- a/test/report-access-token-rate-limit.test.ts
+++ b/test/report-access-token-rate-limit.test.ts
@@ -1,0 +1,40 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
+  buildReportAccessTokenMutationRateLimitOptions,
+  createReportAccessTokenMutationRateLimit,
+} from "../server/lib/report-access-token-rate-limit.ts";
+
+test("buildReportAccessTokenMutationRateLimitOptions expone configuracion esperada", () => {
+  const options = buildReportAccessTokenMutationRateLimitOptions();
+
+  assert.equal(options.windowMs, 15 * 60 * 1000);
+  assert.equal(options.max, 10);
+  assert.equal(options.standardHeaders, true);
+  assert.equal(options.legacyHeaders, false);
+  assert.deepEqual(options.message, {
+    success: false,
+    error: "Demasiadas operaciones sobre tokens públicos de informes. Intente más tarde.",
+  });
+});
+
+test("constantes de report access token mutation rate limit son estables", () => {
+  assert.equal(
+    REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
+    15 * 60 * 1000,
+  );
+  assert.equal(REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS, 10);
+  assert.equal(
+    REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+    "Demasiadas operaciones sobre tokens públicos de informes. Intente más tarde.",
+  );
+});
+
+test("createReportAccessTokenMutationRateLimit devuelve middleware invocable", () => {
+  const middleware = createReportAccessTokenMutationRateLimit();
+
+  assert.equal(typeof middleware, "function");
+});


### PR DESCRIPTION
﻿## Summary
- add dedicated rate limit helper for report access token mutation endpoints
- apply rate limiting to clinic token creation and revoke routes
- apply rate limiting to admin token creation and revoke routes
- add tests for report access token mutation rate limit configuration

## Testing
- pnpm test -- test/report-access-token-rate-limit.test.ts test/public-report-access-rate-limit.test.ts test/login-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts test/request-logger.test.ts
- pnpm typecheck
- manual smoke test for `POST /api/report-access-tokens`

## Notes
- the limiter applies per route and blocks repeated token mutation attempts from the same client within the configured window
