### PR TITLE
feat(public): add public professionals search rate limit

### DIFF
--- a/server/lib/public-professionals-rate-limit.ts
+++ b/server/lib/public-professionals-rate-limit.ts
@@ -1,0 +1,23 @@
+﻿import rateLimit, { type Options } from "express-rate-limit";
+
+export const PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+export const PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS = 10;
+export const PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE =
+  "Demasiadas consultas al directorio público. Intente más tarde.";
+
+export function buildPublicProfessionalsSearchRateLimitOptions(): Partial<Options> {
+  return {
+    windowMs: PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS,
+    max: PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
+    },
+  };
+}
+
+export function createPublicProfessionalsSearchRateLimit() {
+  return rateLimit(buildPublicProfessionalsSearchRateLimitOptions());
+}

--- a/server/routes/public-professionals.routes.ts
+++ b/server/routes/public-professionals.routes.ts
@@ -1,13 +1,16 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 
 import {
   getPublicProfessionalByClinicId,
   searchPublicProfessionals,
 } from "../db-public-professionals";
+import { createPublicProfessionalsSearchRateLimit } from "../lib/public-professionals-rate-limit";
 import { createSignedStorageUrl } from "../lib/supabase";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
+const publicProfessionalsSearchRateLimit =
+  createPublicProfessionalsSearchRateLimit();
 
 function normalizeText(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -82,6 +85,7 @@ async function serializeProfessional(row: {
 
 router.get(
   "/search",
+  publicProfessionalsSearchRateLimit,
   asyncHandler(async (req, res) => {
     const query = normalizeText(req.query.q ?? req.query.query);
     const locality = normalizeText(req.query.locality);

--- a/test/public-professionals-rate-limit.test.ts
+++ b/test/public-professionals-rate-limit.test.ts
@@ -1,0 +1,37 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
+  PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS,
+  PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS,
+  buildPublicProfessionalsSearchRateLimitOptions,
+  createPublicProfessionalsSearchRateLimit,
+} from "../server/lib/public-professionals-rate-limit.ts";
+
+test("buildPublicProfessionalsSearchRateLimitOptions expone configuracion esperada", () => {
+  const options = buildPublicProfessionalsSearchRateLimitOptions();
+
+  assert.equal(options.windowMs, 15 * 60 * 1000);
+  assert.equal(options.max, 10);
+  assert.equal(options.standardHeaders, true);
+  assert.equal(options.legacyHeaders, false);
+  assert.deepEqual(options.message, {
+    success: false,
+    error: "Demasiadas consultas al directorio público. Intente más tarde.",
+  });
+});
+
+test("constantes de public professionals search rate limit son estables", () => {
+  assert.equal(PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS, 15 * 60 * 1000);
+  assert.equal(PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS, 10);
+  assert.equal(
+    PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
+    "Demasiadas consultas al directorio público. Intente más tarde.",
+  );
+});
+
+test("createPublicProfessionalsSearchRateLimit devuelve middleware invocable", () => {
+  const middleware = createPublicProfessionalsSearchRateLimit();
+
+  assert.equal(typeof middleware, "function");
+});


### PR DESCRIPTION
﻿## Summary
- add dedicated rate limit helper for public professionals search
- apply rate limiting to `GET /api/public/professionals/search`
- keep public professional detail lookup unchanged
- add tests for public professionals search rate limit configuration

## Testing
- pnpm test -- test/public-professionals-rate-limit.test.ts test/report-access-token-rate-limit.test.ts test/public-report-access-rate-limit.test.ts test/login-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts test/request-logger.test.ts
- pnpm typecheck
- manual smoke test for `/api/public/professionals/4`
- manual smoke test for `/api/public/professionals/search?limit=1`

## Notes
- the limiter applies only to the public search endpoint
- public professional detail lookup remains unaffected
