### PR TITLE
feat(public): add public professionals detail rate limit

### DIFF
--- a/server/lib/public-professionals-rate-limit.ts
+++ b/server/lib/public-professionals-rate-limit.ts
@@ -5,6 +5,11 @@ export const PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS = 10;
 export const PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE =
   "Demasiadas consultas al directorio público. Intente más tarde.";
 
+export const PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+export const PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS = 20;
+export const PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE =
+  "Demasiadas consultas al perfil público. Intente más tarde.";
+
 export function buildPublicProfessionalsSearchRateLimitOptions(): Partial<Options> {
   return {
     windowMs: PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS,
@@ -20,4 +25,21 @@ export function buildPublicProfessionalsSearchRateLimitOptions(): Partial<Option
 
 export function createPublicProfessionalsSearchRateLimit() {
   return rateLimit(buildPublicProfessionalsSearchRateLimitOptions());
+}
+
+export function buildPublicProfessionalDetailRateLimitOptions(): Partial<Options> {
+  return {
+    windowMs: PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS,
+    max: PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE,
+    },
+  };
+}
+
+export function createPublicProfessionalDetailRateLimit() {
+  return rateLimit(buildPublicProfessionalDetailRateLimitOptions());
 }

--- a/server/routes/public-professionals.routes.ts
+++ b/server/routes/public-professionals.routes.ts
@@ -4,13 +4,18 @@ import {
   getPublicProfessionalByClinicId,
   searchPublicProfessionals,
 } from "../db-public-professionals";
-import { createPublicProfessionalsSearchRateLimit } from "../lib/public-professionals-rate-limit";
+import {
+  createPublicProfessionalDetailRateLimit,
+  createPublicProfessionalsSearchRateLimit,
+} from "../lib/public-professionals-rate-limit";
 import { createSignedStorageUrl } from "../lib/supabase";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
 const publicProfessionalsSearchRateLimit =
   createPublicProfessionalsSearchRateLimit();
+const publicProfessionalDetailRateLimit =
+  createPublicProfessionalDetailRateLimit();
 
 function normalizeText(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -125,6 +130,7 @@ router.get(
 
 router.get(
   "/:clinicId",
+  publicProfessionalDetailRateLimit,
   asyncHandler(async (req, res) => {
     const clinicId = parseClinicId(req.params.clinicId);
 

--- a/test/public-professionals-rate-limit.test.ts
+++ b/test/public-professionals-rate-limit.test.ts
@@ -4,8 +4,13 @@ import {
   PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
   PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS,
   PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS,
+  PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE,
+  PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS,
+  PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS,
   buildPublicProfessionalsSearchRateLimitOptions,
+  buildPublicProfessionalDetailRateLimitOptions,
   createPublicProfessionalsSearchRateLimit,
+  createPublicProfessionalDetailRateLimit,
 } from "../server/lib/public-professionals-rate-limit.ts";
 
 test("buildPublicProfessionalsSearchRateLimitOptions expone configuracion esperada", () => {
@@ -32,6 +37,34 @@ test("constantes de public professionals search rate limit son estables", () => 
 
 test("createPublicProfessionalsSearchRateLimit devuelve middleware invocable", () => {
   const middleware = createPublicProfessionalsSearchRateLimit();
+
+  assert.equal(typeof middleware, "function");
+});
+
+test("buildPublicProfessionalDetailRateLimitOptions expone configuracion esperada", () => {
+  const options = buildPublicProfessionalDetailRateLimitOptions();
+
+  assert.equal(options.windowMs, 15 * 60 * 1000);
+  assert.equal(options.max, 20);
+  assert.equal(options.standardHeaders, true);
+  assert.equal(options.legacyHeaders, false);
+  assert.deepEqual(options.message, {
+    success: false,
+    error: "Demasiadas consultas al perfil público. Intente más tarde.",
+  });
+});
+
+test("constantes de public professional detail rate limit son estables", () => {
+  assert.equal(PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS, 15 * 60 * 1000);
+  assert.equal(PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS, 20);
+  assert.equal(
+    PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE,
+    "Demasiadas consultas al perfil público. Intente más tarde.",
+  );
+});
+
+test("createPublicProfessionalDetailRateLimit devuelve middleware invocable", () => {
+  const middleware = createPublicProfessionalDetailRateLimit();
 
   assert.equal(typeof middleware, "function");
 });


### PR DESCRIPTION
﻿## Summary
- extend public professionals rate limiting to the detail endpoint
- apply rate limiting to `GET /api/public/professionals/:clinicId`
- keep the existing search rate limiter in place
- add tests for public professional detail rate limit configuration

## Testing
- pnpm test -- test/public-professionals-rate-limit.test.ts test/report-access-token-rate-limit.test.ts test/public-report-access-rate-limit.test.ts test/login-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts test/request-logger.test.ts
- pnpm typecheck
- manual smoke test for `/api/public/professionals/search?limit=1`
- manual smoke test for `/api/public/professionals/4`

## Notes
- the detail endpoint now has its own limiter with a higher threshold than search
- the search limiter remains unchanged
