### PR TITLE
feat(logging): mark rate-limited requests in logs

### DIFF
--- a/server/middlewares/request-logger.ts
+++ b/server/middlewares/request-logger.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from "express";
+﻿import type { NextFunction, Request, Response } from "express";
 
 export function sanitizeUrlForLogs(url: string): string {
   return url
@@ -9,6 +9,24 @@ export function sanitizeUrlForLogs(url: string): string {
     .replace(/([?&](?:token|reportAccessToken)=)([^&#]+)/gi, "$1[REDACTED]");
 }
 
+export function buildRequestLogLine(input: {
+  timestamp: string;
+  method: string;
+  url: string;
+  statusCode: number;
+  durationMs: number;
+}) {
+  const baseLine =
+    `[${input.timestamp}] ${input.method} ${input.url} ` +
+    `${input.statusCode} ${input.durationMs.toFixed(1)}ms`;
+
+  if (input.statusCode === 429) {
+    return `${baseLine} RATE_LIMITED`;
+  }
+
+  return baseLine;
+}
+
 export function requestLogger(req: Request, res: Response, next: NextFunction) {
   const startTime = process.hrtime.bigint();
 
@@ -17,7 +35,13 @@ export function requestLogger(req: Request, res: Response, next: NextFunction) {
     const safeUrl = sanitizeUrlForLogs(req.originalUrl);
 
     console.log(
-      `[${new Date().toISOString()}] ${req.method} ${safeUrl} ${res.statusCode} ${durationMs.toFixed(1)}ms`,
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: req.method,
+        url: safeUrl,
+        statusCode: res.statusCode,
+        durationMs,
+      }),
     );
   });
 

--- a/test/request-logger.test.ts
+++ b/test/request-logger.test.ts
@@ -1,6 +1,9 @@
-import test from "node:test";
+﻿import test from "node:test";
 import assert from "node:assert/strict";
-import { sanitizeUrlForLogs } from "../server/middlewares/request-logger.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../server/middlewares/request-logger.ts";
 
 test("sanitizeUrlForLogs redacts public report access token in path", () => {
   const rawUrl = `/api/public/report-access/${"a".repeat(64)}?foo=bar`;
@@ -21,4 +24,34 @@ test("sanitizeUrlForLogs preserves unrelated urls", () => {
   const sanitized = sanitizeUrlForLogs(rawUrl);
 
   assert.equal(sanitized, rawUrl);
+});
+
+test("buildRequestLogLine marca respuestas 429 como RATE_LIMITED", () => {
+  const line = buildRequestLogLine({
+    timestamp: "2026-04-19T12:00:00.000Z",
+    method: "GET",
+    url: "/api/public/professionals/search?limit=1",
+    statusCode: 429,
+    durationMs: 12.34,
+  });
+
+  assert.equal(
+    line,
+    "[2026-04-19T12:00:00.000Z] GET /api/public/professionals/search?limit=1 429 12.3ms RATE_LIMITED",
+  );
+});
+
+test("buildRequestLogLine no agrega marker para respuestas no limitadas", () => {
+  const line = buildRequestLogLine({
+    timestamp: "2026-04-19T12:00:00.000Z",
+    method: "GET",
+    url: "/api/health",
+    statusCode: 200,
+    durationMs: 5,
+  });
+
+  assert.equal(
+    line,
+    "[2026-04-19T12:00:00.000Z] GET /api/health 200 5.0ms",
+  );
 });


### PR DESCRIPTION
﻿## Summary
- add a dedicated request log line builder
- mark HTTP 429 responses with `RATE_LIMITED` in the request logger
- keep URL sanitization behavior unchanged
- add tests for rate-limited and non-rate-limited log lines

## Testing
- pnpm test -- test/request-logger.test.ts test/public-professionals-rate-limit.test.ts test/report-access-token-rate-limit.test.ts test/public-report-access-rate-limit.test.ts test/login-rate-limit.test.ts test/admin-audit.test.ts test/clinic-audit.test.ts test/report-access-token.test.ts
- pnpm typecheck
- manual smoke test for `/api/public/professionals/search?limit=1`

## Notes
- the logger now makes rate-limit blocks visible in backend logs without exposing sensitive tokens
