### PR TITLE
test(study-tracking): add unit coverage and preserve null date updates

### DIFF
--- a/server/lib/study-tracking.ts
+++ b/server/lib/study-tracking.ts
@@ -1,4 +1,4 @@
-﻿import { z } from "zod";
+import { z } from "zod";
 import type {
   StudyTrackingCase,
   StudyTrackingNotification,
@@ -33,7 +33,7 @@ const optionalTrimmedText = (max: number, label: string) =>
     );
 
 const optionalDateSchema = z
-  .union([z.coerce.date(), z.undefined(), z.null()])
+  .union([z.null(), z.undefined(), z.coerce.date()])
   .transform((value) => {
     if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
       return undefined;
@@ -116,7 +116,7 @@ export const updateStudyTrackingSchema = z.object({
     z.undefined(),
   ]),
   receptionAt: optionalDateSchema,
-  estimatedDeliveryAt: z.union([z.coerce.date(), z.null(), z.undefined()]).transform((value) => {
+  estimatedDeliveryAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
     if (value === null) {
       return null;
     }
@@ -128,7 +128,7 @@ export const updateStudyTrackingSchema = z.object({
     return value;
   }),
   currentStage: stageSchema.optional(),
-  processingAt: z.union([z.coerce.date(), z.null(), z.undefined()]).transform((value) => {
+  processingAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
     if (value === null) {
       return null;
     }
@@ -139,7 +139,7 @@ export const updateStudyTrackingSchema = z.object({
 
     return value;
   }),
-  evaluationAt: z.union([z.coerce.date(), z.null(), z.undefined()]).transform((value) => {
+  evaluationAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
     if (value === null) {
       return null;
     }
@@ -150,7 +150,7 @@ export const updateStudyTrackingSchema = z.object({
 
     return value;
   }),
-  reportDevelopmentAt: z.union([z.coerce.date(), z.null(), z.undefined()]).transform((value) => {
+  reportDevelopmentAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
     if (value === null) {
       return null;
     }
@@ -161,7 +161,7 @@ export const updateStudyTrackingSchema = z.object({
 
     return value;
   }),
-  deliveredAt: z.union([z.coerce.date(), z.null(), z.undefined()]).transform((value) => {
+  deliveredAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
     if (value === null) {
       return null;
     }

--- a/test/particular-token.test.ts
+++ b/test/particular-token.test.ts
@@ -1,0 +1,146 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildValidationError,
+  clinicCreateParticularTokenSchema,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeParticularToken,
+  serializeParticularTokenDetail,
+  updateParticularTokenReportSchema,
+} from "../server/lib/particular-token.ts";
+
+test("clinicCreateParticularTokenSchema normaliza detailsLesion vacío y reportId null", () => {
+  const parsed = clinicCreateParticularTokenSchema.safeParse({
+    tutorLastName: " Gomez ",
+    petName: " Luna ",
+    petAge: " 8 años ",
+    petBreed: " Caniche ",
+    petSex: " Hembra ",
+    petSpecies: " Canina ",
+    sampleLocation: " Pabellón auricular ",
+    sampleEvolution: " 15 días de evolución ",
+    detailsLesion: "   ",
+    extractionDate: "2026-04-20T00:00:00.000Z",
+    shippingDate: "2026-04-21T00:00:00.000Z",
+    reportId: null,
+  });
+
+  assert.equal(parsed.success, true);
+
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  assert.equal(parsed.data.detailsLesion, undefined);
+  assert.equal(parsed.data.reportId, null);
+  assert.equal(parsed.data.tutorLastName, "Gomez");
+  assert.equal(parsed.data.petName, "Luna");
+  assert.ok(parsed.data.extractionDate instanceof Date);
+  assert.ok(parsed.data.shippingDate instanceof Date);
+});
+
+test("updateParticularTokenReportSchema acepta número positivo y null", () => {
+  const withReport = updateParticularTokenReportSchema.safeParse({ reportId: "12" });
+  const withoutReport = updateParticularTokenReportSchema.safeParse({ reportId: null });
+
+  assert.equal(withReport.success, true);
+  assert.equal(withoutReport.success, true);
+
+  if (!withReport.success || !withoutReport.success) {
+    throw new Error("El schema no aceptó entradas válidas");
+  }
+
+  assert.equal(withReport.data.reportId, 12);
+  assert.equal(withoutReport.data.reportId, null);
+});
+
+test("helpers numéricos de particular-token respetan fallback y límites", () => {
+  assert.equal(parsePositiveInt("25", 50, 100), 25);
+  assert.equal(parsePositiveInt("250", 50, 100), 100);
+  assert.equal(parsePositiveInt("0", 50, 100), 50);
+
+  assert.equal(parseOffset("15", 0), 15);
+  assert.equal(parseOffset("-1", 0), 0);
+  assert.equal(parseOffset("texto", 3), 3);
+
+  assert.equal(parseEntityId("7"), 7);
+  assert.equal(parseEntityId("0"), undefined);
+  assert.equal(parseEntityId("abc"), undefined);
+});
+
+test("buildValidationError devuelve el primer mensaje del schema", () => {
+  const parsed = clinicCreateParticularTokenSchema.safeParse({
+    tutorLastName: "",
+    petName: "",
+    petAge: "",
+    petBreed: "",
+    petSex: "",
+    petSpecies: "",
+    sampleLocation: "",
+    sampleEvolution: "",
+    extractionDate: "invalida",
+    shippingDate: "invalida",
+  });
+
+  assert.equal(parsed.success, false);
+
+  if (parsed.success) {
+    throw new Error("La validación debió fallar");
+  }
+
+  assert.equal(buildValidationError(parsed.error), "Tutor: apellido es obligatorio");
+});
+
+test("serializeParticularToken y serializeParticularTokenDetail exponen banderas y reporte vinculado", () => {
+  const token = {
+    id: 10,
+    clinicId: 3,
+    reportId: 22,
+    tokenHash: "hash",
+    tokenLast4: "1a2b",
+    tutorLastName: "Gomez",
+    petName: "Luna",
+    petAge: "8 años",
+    petBreed: "Caniche",
+    petSex: "Hembra",
+    petSpecies: "Canina",
+    sampleLocation: "Pabellón auricular",
+    sampleEvolution: "15 días",
+    detailsLesion: "Lesión nodular",
+    extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+    shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+    isActive: true,
+    lastLoginAt: new Date("2026-04-22T10:00:00.000Z"),
+    createdAt: new Date("2026-04-20T08:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T10:00:00.000Z"),
+    createdByAdminId: null,
+    createdByClinicUserId: 9,
+  };
+
+  const report = {
+    id: 22,
+    clinicId: 3,
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatología",
+    patientName: "Luna",
+    fileName: "informe-luna.pdf",
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+  };
+
+  const serialized = serializeParticularToken(token as any);
+  const detailed = serializeParticularTokenDetail(token as any, report as any);
+  const withoutReport = serializeParticularTokenDetail(
+    { ...token, reportId: null } as any,
+    null,
+  );
+
+  assert.equal(serialized.hasLinkedReport, true);
+  assert.equal(serialized.createdByClinicUserId, 9);
+  assert.equal(detailed.report?.id, 22);
+  assert.equal(detailed.report?.studyType, "Histopatología");
+  assert.equal(withoutReport.hasLinkedReport, false);
+  assert.equal(withoutReport.report, null);
+});

--- a/test/study-tracking.test.ts
+++ b/test/study-tracking.test.ts
@@ -1,0 +1,279 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  adminCreateStudyTrackingSchema,
+  applyEstimatedDeliveryRules,
+  applyStageTimestampDefaults,
+  buildValidationError,
+  calculateEstimatedDeliveryAt,
+  getArgentinaNationalHolidayKeys,
+  getBusinessDayWeight,
+  isArgentinaNationalHoliday,
+  parseBooleanQuery,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeStudyTrackingCase,
+  serializeStudyTrackingNotification,
+  shouldCreateSpecialStainNotification,
+  updateStudyTrackingSchema,
+} from "../server/lib/study-tracking.ts";
+
+test("adminCreateStudyTrackingSchema normaliza booleanos, textos y fechas", () => {
+  const parsed = adminCreateStudyTrackingSchema.safeParse({
+    clinicId: "4",
+    reportId: "12",
+    particularTokenId: null,
+    receptionAt: "2026-04-20T10:00:00.000Z",
+    estimatedDeliveryAt: "2026-05-12T10:00:00.000Z",
+    currentStage: "processing",
+    specialStainRequired: "si",
+    paymentUrl: "  https://example.com/pay/123  ",
+    adminContactEmail: " lab@example.com ",
+    adminContactPhone: " 3511234567 ",
+    notes: "  Caso prioritario  ",
+  });
+
+  assert.equal(parsed.success, true);
+
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  assert.equal(parsed.data.clinicId, 4);
+  assert.equal(parsed.data.reportId, 12);
+  assert.equal(parsed.data.particularTokenId, undefined);
+  assert.equal(parsed.data.specialStainRequired, true);
+  assert.equal(parsed.data.paymentUrl, "https://example.com/pay/123");
+  assert.equal(parsed.data.adminContactEmail, "lab@example.com");
+  assert.equal(parsed.data.adminContactPhone, "3511234567");
+  assert.equal(parsed.data.notes, "Caso prioritario");
+  assert.ok(parsed.data.receptionAt instanceof Date);
+});
+
+test("updateStudyTrackingSchema permite limpiar campos opcionales con null", () => {
+  const parsed = updateStudyTrackingSchema.safeParse({
+    reportId: null,
+    particularTokenId: "18",
+    estimatedDeliveryAt: null,
+    processingAt: null,
+    evaluationAt: undefined,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+    specialStainRequired: "0",
+    paymentUrl: "   ",
+    adminContactEmail: null,
+    adminContactPhone: "   ",
+    notes: null,
+  });
+
+  assert.equal(parsed.success, true);
+
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  assert.equal(parsed.data.reportId, null);
+  assert.equal(parsed.data.particularTokenId, 18);
+  assert.equal(parsed.data.estimatedDeliveryAt, null);
+  assert.equal(parsed.data.processingAt, null);
+  assert.equal(parsed.data.reportDevelopmentAt, null);
+  assert.equal(parsed.data.deliveredAt, null);
+  assert.equal(parsed.data.specialStainRequired, false);
+  assert.equal(parsed.data.paymentUrl, null);
+  assert.equal(parsed.data.adminContactEmail, null);
+  assert.equal(parsed.data.adminContactPhone, null);
+  assert.equal(parsed.data.notes, null);
+});
+
+test("helpers de query parsing en study-tracking son estables", () => {
+  assert.equal(parsePositiveInt("25", 50, 100), 25);
+  assert.equal(parsePositiveInt("250", 50, 100), 100);
+  assert.equal(parsePositiveInt(undefined, 50, 100), 50);
+
+  assert.equal(parseOffset("20", 0), 20);
+  assert.equal(parseOffset("-5", 3), 3);
+
+  assert.equal(parseEntityId("9"), 9);
+  assert.equal(parseEntityId("0"), undefined);
+
+  assert.equal(parseBooleanQuery("true"), true);
+  assert.equal(parseBooleanQuery("si"), true);
+  assert.equal(parseBooleanQuery("false"), false);
+  assert.equal(parseBooleanQuery("otro"), undefined);
+});
+
+test("buildValidationError devuelve el primer error de study-tracking", () => {
+  const parsed = adminCreateStudyTrackingSchema.safeParse({
+    clinicId: "0",
+    receptionAt: "fecha-invalida",
+  });
+
+  assert.equal(parsed.success, false);
+
+  if (parsed.success) {
+    throw new Error("La validación debió fallar");
+  }
+
+  assert.equal(buildValidationError(parsed.error), "clinicId es obligatorio");
+});
+
+test("feriados nacionales y pesos de días hábiles se calculan correctamente", () => {
+  const holidays2026 = getArgentinaNationalHolidayKeys(2026);
+
+  assert.equal(holidays2026.has("2026-01-01"), true);
+  assert.equal(holidays2026.has("2026-02-16"), true);
+  assert.equal(holidays2026.has("2026-02-17"), true);
+  assert.equal(holidays2026.has("2026-04-03"), true);
+
+  assert.equal(isArgentinaNationalHoliday(new Date("2026-05-25T00:00:00.000Z")), true);
+  assert.equal(getBusinessDayWeight(new Date("2026-05-25T00:00:00.000Z")), 0);
+  assert.equal(getBusinessDayWeight(new Date("2026-05-23T00:00:00.000Z")), 0.5);
+  assert.equal(getBusinessDayWeight(new Date("2026-05-26T00:00:00.000Z")), 1);
+});
+
+test("calculateEstimatedDeliveryAt contempla sábado como medio día hábil", () => {
+  const deliveryAt = calculateEstimatedDeliveryAt(
+    new Date("2026-01-02T00:00:00.000Z"),
+    2,
+  );
+
+  assert.equal(deliveryAt.toISOString(), "2026-01-05T00:00:00.000Z");
+});
+
+test("applyEstimatedDeliveryRules diferencia ajuste manual y cálculo automático", () => {
+  const receptionAt = new Date("2026-01-02T00:00:00.000Z");
+  const manualEstimatedDeliveryAt = new Date("2026-01-06T00:00:00.000Z");
+
+  const automatic = applyEstimatedDeliveryRules({ receptionAt });
+  const manual = applyEstimatedDeliveryRules({
+    receptionAt,
+    manualEstimatedDeliveryAt,
+  });
+
+  assert.equal(automatic.estimatedDeliveryAt.toISOString(), "2026-01-21T00:00:00.000Z");
+  assert.equal(automatic.estimatedDeliveryWasManuallyAdjusted, false);
+  assert.equal(manual.estimatedDeliveryAt.toISOString(), "2026-01-06T00:00:00.000Z");
+  assert.equal(manual.estimatedDeliveryAutoCalculatedAt.toISOString(), "2026-01-21T00:00:00.000Z");
+  assert.equal(manual.estimatedDeliveryWasManuallyAdjusted, true);
+});
+
+test("applyStageTimestampDefaults completa únicamente la marca requerida por la etapa", () => {
+  const current = {
+    currentStage: "reception",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+  };
+
+  const processing = applyStageTimestampDefaults(current as any, {
+    currentStage: "processing",
+  });
+
+  const delivered = applyStageTimestampDefaults(
+    {
+      ...current,
+      currentStage: "report_development",
+      deliveredAt: null,
+    } as any,
+    {
+      currentStage: "delivered",
+      processingAt: null,
+    },
+  );
+
+  assert.ok(processing.processingAt instanceof Date);
+  assert.equal(processing.evaluationAt, undefined);
+  assert.equal(processing.reportDevelopmentAt, undefined);
+  assert.ok(delivered.deliveredAt instanceof Date);
+});
+
+test("shouldCreateSpecialStainNotification sólo crea cuando corresponde", () => {
+  assert.equal(
+    shouldCreateSpecialStainNotification({
+      previousRequired: false,
+      nextRequired: true,
+      notifiedAt: null,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldCreateSpecialStainNotification({
+      previousRequired: true,
+      nextRequired: true,
+      notifiedAt: null,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldCreateSpecialStainNotification({
+      previousRequired: true,
+      nextRequired: false,
+      notifiedAt: null,
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldCreateSpecialStainNotification({
+      previousRequired: false,
+      nextRequired: true,
+      notifiedAt: new Date("2026-04-20T00:00:00.000Z"),
+    }),
+    false,
+  );
+});
+
+test("serializers de study-tracking mantienen la forma pública esperada", () => {
+  const trackingCase = {
+    id: 5,
+    clinicId: 3,
+    reportId: 12,
+    particularTokenId: 18,
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-12T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryWasManuallyAdjusted: true,
+    currentStage: "processing",
+    processingAt: new Date("2026-04-21T00:00:00.000Z"),
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+    specialStainRequired: true,
+    specialStainNotifiedAt: null,
+    paymentUrl: "https://example.com/pay/123",
+    adminContactEmail: "lab@example.com",
+    adminContactPhone: "3511234567",
+    notes: "Caso prioritario",
+    createdAt: new Date("2026-04-20T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-21T00:00:00.000Z"),
+  };
+
+  const notification = {
+    id: 9,
+    studyTrackingCaseId: 5,
+    clinicId: 3,
+    reportId: 12,
+    particularTokenId: 18,
+    type: "special_stain_required",
+    title: "Tinción especial requerida",
+    message: "Se requiere tinción especial para continuar.",
+    isRead: false,
+    readAt: null,
+    createdAt: new Date("2026-04-21T00:00:00.000Z"),
+  };
+
+  const serializedCase = serializeStudyTrackingCase(trackingCase as any);
+  const serializedNotification = serializeStudyTrackingNotification(notification as any);
+
+  assert.equal(serializedCase.estimatedDeliveryWasManuallyAdjusted, true);
+  assert.equal(serializedCase.currentStage, "processing");
+  assert.equal(serializedCase.paymentUrl, "https://example.com/pay/123");
+  assert.equal(serializedNotification.type, "special_stain_required");
+  assert.equal(serializedNotification.isRead, false);
+});


### PR DESCRIPTION
﻿## Summary
- add dedicated unit tests for particular token helpers and serializers
- add dedicated unit tests for study tracking parsing, serialization and delivery rules
- fix study tracking date coercion so null updates are preserved instead of becoming 1970-01-01

## Testing
- pnpm test
