### PR TITLE
test(auth): add unit coverage for auth, permissions and report status

### DIFF
--- a/test/auth-security.test.ts
+++ b/test/auth-security.test.ts
@@ -1,0 +1,71 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateSessionToken,
+  hashLegacyPassword,
+  hashPassword,
+  hashSessionToken,
+  verifyPassword,
+} from "../server/lib/auth-security.ts";
+
+test("hashLegacyPassword genera sha256 hex estable", () => {
+  assert.equal(
+    hashLegacyPassword("abc123"),
+    "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+  );
+});
+
+test("hashSessionToken genera sha256 hex estable", () => {
+  assert.equal(
+    hashSessionToken("abc123"),
+    "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+  );
+});
+
+test("generateSessionToken devuelve token hex de 64 caracteres y no repite fácilmente", () => {
+  const tokenA = generateSessionToken();
+  const tokenB = generateSessionToken();
+
+  assert.match(tokenA, /^[0-9a-f]{64}$/);
+  assert.match(tokenB, /^[0-9a-f]{64}$/);
+  assert.notEqual(tokenA, tokenB);
+});
+
+test("verifyPassword valida hash legacy y marca needsRehash", async () => {
+  const storedHash = hashLegacyPassword("abc123");
+
+  const validResult = await verifyPassword("abc123", storedHash);
+  const invalidResult = await verifyPassword("otro", storedHash);
+
+  assert.deepEqual(validResult, {
+    valid: true,
+    needsRehash: true,
+  });
+
+  assert.deepEqual(invalidResult, {
+    valid: false,
+    needsRehash: false,
+  });
+});
+
+test("hashPassword genera hash argon2 y verifyPassword lo valida", async () => {
+  const hash = await hashPassword("abc123");
+
+  assert.match(hash, /^\$argon2/);
+
+  const result = await verifyPassword("abc123", hash);
+
+  assert.equal(result.valid, true);
+  assert.equal(typeof result.needsRehash, "boolean");
+});
+
+test("verifyPassword rechaza password inválida contra hash argon2", async () => {
+  const hash = await hashPassword("abc123");
+
+  const result = await verifyPassword("incorrecta", hash);
+
+  assert.deepEqual(result, {
+    valid: false,
+    needsRehash: false,
+  });
+});

--- a/test/permissions-and-report-status.test.ts
+++ b/test/permissions-and-report-status.test.ts
@@ -1,0 +1,81 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getClinicPermissions,
+  isClinicUserRole,
+  normalizeClinicUserRole,
+} from "../server/lib/permissions.ts";
+import {
+  REPORT_STATUSES,
+  canTransitionReportStatus,
+  isReportStatus,
+  normalizeReportStatus,
+} from "../server/lib/report-status.ts";
+
+test("isClinicUserRole reconoce únicamente roles válidos", () => {
+  assert.equal(isClinicUserRole("clinic_owner"), true);
+  assert.equal(isClinicUserRole("clinic_staff"), true);
+  assert.equal(isClinicUserRole("admin"), false);
+  assert.equal(isClinicUserRole(null), false);
+});
+
+test("normalizeClinicUserRole normaliza strings y aplica fallback", () => {
+  assert.equal(normalizeClinicUserRole(" clinic_owner "), "clinic_owner");
+  assert.equal(normalizeClinicUserRole("CLINIC_STAFF"), "clinic_staff");
+  assert.equal(normalizeClinicUserRole("otro"), "clinic_staff");
+  assert.equal(normalizeClinicUserRole(undefined, "clinic_owner"), "clinic_owner");
+});
+
+test("getClinicPermissions devuelve permisos consistentes por rol", () => {
+  assert.deepEqual(getClinicPermissions("clinic_owner"), {
+    canUploadReports: true,
+    canManageClinicUsers: true,
+  });
+
+  assert.deepEqual(getClinicPermissions("clinic_staff"), {
+    canUploadReports: true,
+    canManageClinicUsers: false,
+  });
+});
+
+test("REPORT_STATUSES conserva el orden público esperado", () => {
+  assert.deepEqual(REPORT_STATUSES, [
+    "uploaded",
+    "processing",
+    "ready",
+    "delivered",
+  ]);
+});
+
+test("isReportStatus reconoce únicamente estados válidos", () => {
+  assert.equal(isReportStatus("uploaded"), true);
+  assert.equal(isReportStatus("processing"), true);
+  assert.equal(isReportStatus("ready"), true);
+  assert.equal(isReportStatus("delivered"), true);
+  assert.equal(isReportStatus("draft"), false);
+  assert.equal(isReportStatus(null), false);
+});
+
+test("normalizeReportStatus normaliza y aplica fallback", () => {
+  assert.equal(normalizeReportStatus(" READY "), "ready");
+  assert.equal(normalizeReportStatus("Delivered"), "delivered");
+  assert.equal(normalizeReportStatus("desconocido"), undefined);
+  assert.equal(normalizeReportStatus("desconocido", "processing"), "processing");
+  assert.equal(normalizeReportStatus(undefined, "uploaded"), "uploaded");
+});
+
+test("canTransitionReportStatus permite transiciones válidas y bloquea inválidas", () => {
+  assert.equal(canTransitionReportStatus("uploaded", "processing"), true);
+  assert.equal(canTransitionReportStatus("uploaded", "ready"), true);
+  assert.equal(canTransitionReportStatus("uploaded", "delivered"), true);
+
+  assert.equal(canTransitionReportStatus("processing", "ready"), true);
+  assert.equal(canTransitionReportStatus("processing", "delivered"), true);
+  assert.equal(canTransitionReportStatus("ready", "delivered"), true);
+
+  assert.equal(canTransitionReportStatus("uploaded", "uploaded"), false);
+  assert.equal(canTransitionReportStatus("processing", "uploaded"), false);
+  assert.equal(canTransitionReportStatus("ready", "processing"), false);
+  assert.equal(canTransitionReportStatus("delivered", "ready"), false);
+  assert.equal(canTransitionReportStatus("delivered", "delivered"), false);
+});


### PR DESCRIPTION
﻿## Summary
- add unit tests for auth security helpers including legacy hashing, session tokens and password verification
- add unit tests for clinic role permissions and normalization helpers
- add unit tests for report status normalization and allowed transitions

## Testing
- pnpm test
