### PR TITLE
chore(tsconfig): align editor diagnostics with no-emit typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "allowImportingTsExtensions": true,
+    "noEmit": true,
     "types": ["node", "express"],
     "outDir": "dist"
   },


### PR DESCRIPTION
﻿## Summary
- add noEmit to tsconfig compilerOptions
- align editor diagnostics with the existing no-emit typecheck workflow
- keep TypeScript extension imports valid for the current test/runtime setup

## Testing
- pnpm typecheck
- pnpm test
