### PR TITLE
test(origin): add trusted origin and env coverage

### DIFF
--- a/server/middlewares/trusted-origin.ts
+++ b/server/middlewares/trusted-origin.ts
@@ -1,5 +1,5 @@
-﻿import type { NextFunction, Request, Response } from "express";
-import { ENV } from "../lib/env";
+import type { NextFunction, Request, Response } from "express";
+import { ENV } from "../lib/env.ts";
 
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,73 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+
+test("ENV expone un contrato base consistente", () => {
+  assert.ok(["development", "test", "production"].includes(ENV.nodeEnv));
+  assert.equal(typeof ENV.isDevelopment, "boolean");
+  assert.equal(typeof ENV.isProduction, "boolean");
+  assert.equal(typeof ENV.port, "number");
+  assert.equal(Number.isInteger(ENV.port), true);
+  assert.equal(ENV.port > 0, true);
+
+  assert.equal(typeof ENV.databaseUrl, "string");
+  assert.equal(ENV.databaseUrl.length > 0, true);
+
+  assert.equal(ENV.cookieSecure, ENV.isProduction);
+  assert.equal(
+    ENV.cookieSameSite,
+    ENV.isProduction ? "none" : "lax",
+  );
+});
+
+test("ENV expone colecciones limpias y strings no vacíos donde corresponde", () => {
+  assert.equal(Array.isArray(ENV.corsOrigins), true);
+  assert.equal(Array.isArray(ENV.labUploadUsernames), true);
+
+  for (const origin of ENV.corsOrigins) {
+    assert.equal(typeof origin, "string");
+    assert.equal(origin.trim(), origin);
+    assert.equal(origin.length > 0, true);
+  }
+
+  for (const username of ENV.labUploadUsernames) {
+    assert.equal(typeof username, "string");
+    assert.equal(username.trim(), username);
+    assert.equal(username.length > 0, true);
+  }
+
+  assert.equal(typeof ENV.cookieName, "string");
+  assert.equal(ENV.cookieName.length > 0, true);
+
+  assert.equal(typeof ENV.adminCookieName, "string");
+  assert.equal(ENV.adminCookieName.length > 0, true);
+
+  assert.equal(typeof ENV.particularCookieName, "string");
+  assert.equal(ENV.particularCookieName.length > 0, true);
+});
+
+test("ENV.smtp mantiene tipos e invariantes esperadas", () => {
+  assert.equal(typeof ENV.smtp.enabled, "boolean");
+  assert.equal(typeof ENV.smtp.host, "string");
+  assert.equal(typeof ENV.smtp.port, "number");
+  assert.equal(Number.isInteger(ENV.smtp.port), true);
+  assert.equal(ENV.smtp.port > 0, true);
+  assert.equal(typeof ENV.smtp.secure, "boolean");
+  assert.equal(typeof ENV.smtp.user, "string");
+  assert.equal(typeof ENV.smtp.pass, "string");
+  assert.equal(typeof ENV.smtp.from, "string");
+
+  if (ENV.smtp.enabled) {
+    assert.equal(ENV.smtp.host.length > 0, true);
+    assert.equal(ENV.smtp.user.length > 0, true);
+    assert.equal(ENV.smtp.pass.length > 0, true);
+    assert.equal(ENV.smtp.from.length > 0, true);
+  }
+});

--- a/test/trusted-origin.test.ts
+++ b/test/trusted-origin.test.ts
@@ -1,0 +1,142 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { requireTrustedOrigin } = await import("../server/middlewares/trusted-origin.ts");
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    jsonPayload: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+function createRequest(method: string, headers?: Record<string, string | undefined>) {
+  const normalizedHeaders = new Map<string, string>();
+
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    if (typeof value === "string") {
+      normalizedHeaders.set(key.toLowerCase(), value);
+    }
+  }
+
+  return {
+    method,
+    get(name: string) {
+      return normalizedHeaders.get(name.toLowerCase());
+    },
+  };
+}
+
+test("requireTrustedOrigin deja pasar métodos seguros aunque el origin sea externo", () => {
+  const req = createRequest("GET", {
+    origin: "https://blocked.invalid",
+  });
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+
+  assert.equal(nextCalls.length, 1);
+  assert.equal(nextCalls[0], undefined);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+});
+
+test("requireTrustedOrigin deja pasar métodos inseguros sin origin ni referer", () => {
+  const req = createRequest("POST");
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+
+  assert.equal(nextCalls.length, 1);
+  assert.equal(nextCalls[0], undefined);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+});
+
+test("requireTrustedOrigin deja pasar referer permitido cuando existe allowlist", (t) => {
+  const allowedOrigin =
+    ENV.corsOrigins[0] ??
+    (ENV.isDevelopment ? "http://localhost:3000" : undefined);
+
+  if (!allowedOrigin) {
+    t.skip("No hay origen permitido disponible en este entorno");
+    return;
+  }
+
+  const req = createRequest("POST", {
+    referer: `${allowedOrigin}/panel/reportes?x=1`,
+  });
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+
+  assert.equal(nextCalls.length, 1);
+  assert.equal(nextCalls[0], undefined);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+});
+
+test("requireTrustedOrigin bloquea origin no permitido en métodos inseguros", () => {
+  const req = createRequest("DELETE", {
+    origin: "https://blocked.invalid",
+  });
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Origen no permitido",
+  });
+});
+
+test("requireTrustedOrigin ignora referer inválido y deja pasar", () => {
+  const req = createRequest("PATCH", {
+    referer: "::::referer-invalido::::",
+  });
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+
+  assert.equal(nextCalls.length, 1);
+  assert.equal(nextCalls[0], undefined);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+});


### PR DESCRIPTION
﻿## Summary
- add unit tests for ENV exported configuration invariants
- add unit tests for trusted origin middleware allowed and blocked flows
- fix trusted origin env import to use explicit TypeScript extension for the ESM test runtime

## Testing
- pnpm typecheck
- pnpm test
