### PR TITLE
test(auth): add clinic auth middleware coverage

### DIFF
--- a/server/middlewares/auth.ts
+++ b/server/middlewares/auth.ts
@@ -1,30 +1,51 @@
-import type { NextFunction, Request, Response } from "express";
+﻿import type { NextFunction, Request, Response } from "express";
+import type { ClinicUserRole } from "../../drizzle/schema";
+import type { ClinicPermissions } from "../lib/permissions.ts";
 
-import {
-  deleteActiveSession,
-  getActiveSessionByToken,
-  getClinicUserById,
-  updateSessionLastAccess,
-} from "../db";
-import { hashSessionToken } from "../lib/auth-security";
-import { ENV } from "../lib/env";
-import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions";
-import { asyncHandler } from "../utils/async-handler";
+import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions.ts";
 
 export type AuthenticatedUser = {
   id: number;
   clinicId: number;
   username: string;
   authProId: string | null;
-  role: import("../../drizzle/schema").ClinicUserRole;
-  permissions: import("../lib/permissions").ClinicPermissions;
+  role: ClinicUserRole;
+  permissions: ClinicPermissions;
   canUploadReports: boolean;
   canManageClinicUsers: boolean;
   sessionToken: string;
 };
 
-function getSessionToken(req: Request): string | undefined {
-  const raw = req.cookies?.[ENV.cookieName];
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+};
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type AuthDeps = {
+  deleteActiveSession: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken: (tokenHash: string) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById: (id: number) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess: (tokenHash: string) => Promise<void>;
+  hashSessionToken: (token: string) => string;
+  cookieName: string;
+  cookieSameSite: "lax" | "strict" | "none";
+  cookieSecure: boolean;
+  now: () => number;
+};
+
+function getSessionToken(
+  req: Request,
+  cookieName: string,
+): string | undefined {
+  const raw = req.cookies?.[cookieName];
 
   if (typeof raw !== "string") {
     return undefined;
@@ -34,78 +55,118 @@ function getSessionToken(req: Request): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export const requireAuth = asyncHandler(
-  async (req: Request, res: Response, next: NextFunction) => {
-    const token = getSessionToken(req);
+let defaultDepsPromise: Promise<AuthDeps> | null = null;
 
-    if (!token) {
-      return res.status(401).json({
-        success: false,
-        error: "No autenticado",
-      });
+async function loadDefaultDeps(): Promise<AuthDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const envModule = await import("../lib/env.ts");
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        cookieName: envModule.ENV.cookieName,
+        cookieSameSite: envModule.ENV.cookieSameSite,
+        cookieSecure: envModule.ENV.cookieSecure,
+        now: () => Date.now(),
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+export function createRequireAuth(
+  injectedDeps?: AuthDeps,
+) {
+  return async function requireAuth(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      const deps = injectedDeps ?? (await loadDefaultDeps());
+      const token = getSessionToken(req, deps.cookieName);
+
+      if (!token) {
+        return res.status(401).json({
+          success: false,
+          error: "No autenticado",
+        });
+      }
+
+      const tokenHash = deps.hashSessionToken(token);
+      const session = await deps.getActiveSessionByToken(tokenHash);
+
+      if (!session) {
+        return res.status(401).json({
+          success: false,
+          error: "Sesión inválida",
+        });
+      }
+
+      if (session.expiresAt && session.expiresAt.getTime() <= deps.now()) {
+        await deps.deleteActiveSession(tokenHash);
+
+        res.clearCookie(deps.cookieName, {
+          httpOnly: true,
+          path: "/",
+          sameSite: deps.cookieSameSite,
+          secure: deps.cookieSecure,
+        });
+
+        return res.status(401).json({
+          success: false,
+          error: "Sesión expirada",
+        });
+      }
+
+      const clinicUser = await deps.getClinicUserById(session.clinicUserId);
+
+      if (!clinicUser) {
+        await deps.deleteActiveSession(tokenHash);
+
+        res.clearCookie(deps.cookieName, {
+          httpOnly: true,
+          path: "/",
+          sameSite: deps.cookieSameSite,
+          secure: deps.cookieSecure,
+        });
+
+        return res.status(401).json({
+          success: false,
+          error: "Usuario de sesión no encontrado",
+        });
+      }
+
+      await deps.updateSessionLastAccess(tokenHash);
+
+      const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+      const permissions = getClinicPermissions(role);
+
+      req.auth = {
+        id: clinicUser.id,
+        clinicId: clinicUser.clinicId,
+        username: clinicUser.username,
+        authProId: clinicUser.authProId ?? null,
+        role,
+        permissions,
+        canUploadReports: permissions.canUploadReports,
+        canManageClinicUsers: permissions.canManageClinicUsers,
+        sessionToken: token,
+      };
+
+      next();
+    } catch (error) {
+      next(error);
     }
+  };
+}
 
-    const tokenHash = hashSessionToken(token);
-    const session = await getActiveSessionByToken(tokenHash);
+export const requireAuth = createRequireAuth();
 
-    if (!session) {
-      return res.status(401).json({
-        success: false,
-        error: "Sesión inválida",
-      });
-    }
-
-    if (session.expiresAt && session.expiresAt.getTime() <= Date.now()) {
-      await deleteActiveSession(tokenHash);
-
-      res.clearCookie(ENV.cookieName, {
-        httpOnly: true,
-        path: "/",
-        sameSite: ENV.cookieSameSite,
-        secure: ENV.cookieSecure,
-      });
-
-      return res.status(401).json({
-        success: false,
-        error: "Sesión expirada",
-      });
-    }
-
-    const clinicUser = await getClinicUserById(session.clinicUserId);
-
-    if (!clinicUser) {
-      await deleteActiveSession(tokenHash);
-
-      res.clearCookie(ENV.cookieName, {
-        httpOnly: true,
-        path: "/",
-        sameSite: ENV.cookieSameSite,
-        secure: ENV.cookieSecure,
-      });
-
-      return res.status(401).json({
-        success: false,
-        error: "Usuario de sesión no encontrado",
-      });
-    }
-
-    await updateSessionLastAccess(tokenHash);
-
-    const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
-    const permissions = getClinicPermissions(role);
-
-    req.auth = {
-      id: clinicUser.id,
-      clinicId: clinicUser.clinicId,
-      username: clinicUser.username,
-      authProId: clinicUser.authProId ?? null,
-      role,
-      permissions,
-      canUploadReports: permissions.canUploadReports,
-      canManageClinicUsers: permissions.canManageClinicUsers,
-      sessionToken: token,
-    };
-
-    next();
-  },
-);

--- a/test/auth-middleware.test.ts
+++ b/test/auth-middleware.test.ts
@@ -1,0 +1,372 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { createRequireAuth } = await import(
+  "../server/middlewares/auth.ts"
+);
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    jsonPayload: undefined as unknown,
+    clearedCookies: [] as Array<{ name: string; options: unknown }>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonPayload = payload;
+      return this;
+    },
+    clearCookie(name: string, options: unknown) {
+      this.clearedCookies.push({ name, options });
+      return this;
+    },
+  };
+}
+
+function createDeps(
+  overrides?: Partial<{
+    deleteActiveSession: (tokenHash: string) => Promise<void>;
+    getActiveSessionByToken: (tokenHash: string) => Promise<any>;
+    getClinicUserById: (id: number) => Promise<any>;
+    updateSessionLastAccess: (tokenHash: string) => Promise<void>;
+    hashSessionToken: (token: string) => string;
+    cookieName: string;
+    cookieSameSite: "lax" | "strict" | "none";
+    cookieSecure: boolean;
+    now: () => number;
+  }>,
+) {
+  const calls = {
+    deleteActiveSession: [] as string[],
+    getActiveSessionByToken: [] as string[],
+    getClinicUserById: [] as number[],
+    updateSessionLastAccess: [] as string[],
+    hashSessionToken: [] as string[],
+  };
+
+  const deps = {
+    deleteActiveSession: async (tokenHash: string) => {
+      calls.deleteActiveSession.push(tokenHash);
+    },
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return null;
+    },
+    getClinicUserById: async (id: number) => {
+      calls.getClinicUserById.push(id);
+      return null;
+    },
+    updateSessionLastAccess: async (tokenHash: string) => {
+      calls.updateSessionLastAccess.push(tokenHash);
+    },
+    hashSessionToken: (token: string) => {
+      calls.hashSessionToken.push(token);
+      return `hashed:${token}`;
+    },
+    cookieName: "clinic_session",
+    cookieSameSite: "lax" as const,
+    cookieSecure: false,
+    now: () => new Date("2026-04-21T12:00:00.000Z").getTime(),
+    ...overrides,
+  };
+
+  return { deps, calls };
+}
+
+test("requireAuth responde 401 cuando no hay cookie", async () => {
+  const { deps, calls } = createDeps();
+  const middleware = createRequireAuth(deps as any);
+
+  const req = {
+    cookies: {},
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req as any,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "No autenticado",
+  });
+  assert.equal(nextCalls.length, 0);
+  assert.deepEqual(calls.hashSessionToken, []);
+});
+
+test("requireAuth responde 401 cuando la sesión no existe", async () => {
+  const { deps, calls } = createDeps();
+  const middleware = createRequireAuth(deps as any);
+
+  const req = {
+    cookies: {
+      clinic_session: " raw-clinic-token ",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req as any,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.hashSessionToken, ["raw-clinic-token"]);
+  assert.deepEqual(calls.getActiveSessionByToken, ["hashed:raw-clinic-token"]);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Sesión inválida",
+  });
+  assert.equal(nextCalls.length, 0);
+});
+
+test("requireAuth elimina y limpia cookie cuando la sesión expiró", async () => {
+  const { deps, calls } = createDeps({
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return {
+        clinicUserId: 77,
+        expiresAt: new Date("2026-04-21T11:59:59.000Z"),
+      };
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req = {
+    cookies: {
+      clinic_session: "token-expirado",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req as any,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.deleteActiveSession, ["hashed:token-expirado"]);
+  assert.equal(res.clearedCookies.length, 1);
+  assert.deepEqual(res.clearedCookies[0], {
+    name: "clinic_session",
+    options: {
+      httpOnly: true,
+      path: "/",
+      sameSite: "lax",
+      secure: false,
+    },
+  });
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Sesión expirada",
+  });
+  assert.equal(nextCalls.length, 0);
+});
+
+test("requireAuth elimina sesión cuando el usuario clinic no existe", async () => {
+  const { deps, calls } = createDeps({
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return {
+        clinicUserId: 88,
+        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+      };
+    },
+    getClinicUserById: async (id: number) => {
+      calls.getClinicUserById.push(id);
+      return null;
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req = {
+    cookies: {
+      clinic_session: "token-sin-usuario",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req as any,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.getClinicUserById, [88]);
+  assert.deepEqual(calls.deleteActiveSession, ["hashed:token-sin-usuario"]);
+  assert.equal(res.clearedCookies.length, 1);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Usuario de sesión no encontrado",
+  });
+  assert.equal(nextCalls.length, 0);
+});
+
+test("requireAuth autentica owner y actualiza lastAccess", async () => {
+  const { deps, calls } = createDeps({
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return {
+        clinicUserId: 99,
+        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+      };
+    },
+    getClinicUserById: async (id: number) => {
+      calls.getClinicUserById.push(id);
+      return {
+        id,
+        clinicId: 7,
+        username: "owner-user",
+        authProId: "authpro-1",
+        role: "clinic_owner",
+      };
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req: any = {
+    cookies: {
+      clinic_session: "token-valido",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.updateSessionLastAccess, ["hashed:token-valido"]);
+  assert.deepEqual(req.auth, {
+    id: 99,
+    clinicId: 7,
+    username: "owner-user",
+    authProId: "authpro-1",
+    role: "clinic_owner",
+    permissions: {
+      canUploadReports: true,
+      canManageClinicUsers: true,
+    },
+    canUploadReports: true,
+    canManageClinicUsers: true,
+    sessionToken: "token-valido",
+  });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+  assert.deepEqual(nextCalls, [undefined]);
+});
+
+test("requireAuth normaliza role inválido a clinic_staff", async () => {
+  const { deps, calls } = createDeps({
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return {
+        clinicUserId: 44,
+        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+      };
+    },
+    getClinicUserById: async (id: number) => {
+      calls.getClinicUserById.push(id);
+      return {
+        id,
+        clinicId: 4,
+        username: "staff-user",
+        authProId: null,
+        role: "ROL_INVALIDO",
+      };
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req: any = {
+    cookies: {
+      clinic_session: "token-reciente",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.updateSessionLastAccess, ["hashed:token-reciente"]);
+  assert.deepEqual(req.auth, {
+    id: 44,
+    clinicId: 4,
+    username: "staff-user",
+    authProId: null,
+    role: "clinic_staff",
+    permissions: {
+      canUploadReports: true,
+      canManageClinicUsers: false,
+    },
+    canUploadReports: true,
+    canManageClinicUsers: false,
+    sessionToken: "token-reciente",
+  });
+  assert.deepEqual(nextCalls, [undefined]);
+});
+
+test("requireAuth propaga errores inesperados a next", async () => {
+  const expectedError = new Error("fallo db");
+
+  const { deps } = createDeps({
+    getActiveSessionByToken: async () => {
+      throw expectedError;
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req = {
+    cookies: {
+      clinic_session: "token-error",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req as any,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+  assert.deepEqual(nextCalls, [expectedError]);
+});


### PR DESCRIPTION
﻿## Summary
- add unit tests for clinic auth middleware success and failure flows
- refactor clinic auth middleware to support dependency injection and lazy runtime loading
- add coverage for session expiration, missing clinic user, role normalization and error propagation

## Testing
- pnpm typecheck
- pnpm test
