### PR TITLE
test(audit): add writeAuditLog coverage

### DIFF
--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -1,7 +1,6 @@
-import type { Request } from "express";
+﻿import type { Request } from "express";
 import type { AuditActorType, AuditEvent } from "../../drizzle/schema";
 import { sanitizeUrlForLogs } from "../middlewares/request-logger.ts";
-import { logError, logInfo, serializeError } from "./logger.ts";
 
 export const AUDIT_EVENTS = {
   ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
@@ -182,27 +181,65 @@ export function buildAuditLogInsert(
   };
 }
 
-export async function writeAuditLog(
-  req: Request,
-  input: AuditWriteInput,
-): Promise<void> {
-  try {
-    const payload = buildAuditLogInsert(req as RequestWithContext, input);
-    const { createAuditLog } = await import("../db-audit.ts");
+type AuditLogInsert = ReturnType<typeof buildAuditLogInsert>;
 
-    await createAuditLog(payload);
+type WriteAuditLogDeps = {
+  createAuditLog: (payload: AuditLogInsert) => Promise<unknown>;
+  logInfo: (message: string, data?: unknown) => void;
+  logError: (message: string, data?: unknown) => void;
+  serializeError: (error: unknown) => unknown;
+};
 
-    logInfo("AUDIT_LOG_WRITTEN", {
-      event: payload.event,
-      actorType: payload.actorType,
-      clinicId: payload.clinicId,
-      reportId: payload.reportId,
-      targetReportAccessTokenId: payload.targetReportAccessTokenId,
-    });
-  } catch (error) {
-    logError("AUDIT_LOG_WRITE_ERROR", {
-      event: input.event,
-      error: serializeError(error),
-    });
+let defaultWriteAuditLogDepsPromise: Promise<WriteAuditLogDeps> | undefined;
+
+async function loadWriteAuditLogDeps(): Promise<WriteAuditLogDeps> {
+  if (!defaultWriteAuditLogDepsPromise) {
+    defaultWriteAuditLogDepsPromise = (async (): Promise<WriteAuditLogDeps> => {
+      const dbAudit = await import("../db-audit.ts");
+      const logger = await import("./logger.ts");
+
+      return {
+        createAuditLog: async (payload) => {
+          await dbAudit.createAuditLog(payload);
+        },
+        logInfo: logger.logInfo,
+        logError: logger.logError,
+        serializeError: logger.serializeError,
+      };
+    })();
   }
+
+  return defaultWriteAuditLogDepsPromise;
 }
+
+export function createWriteAuditLog(
+  injectedDeps?: WriteAuditLogDeps,
+) {
+  return async function writeAuditLog(
+    req: Request,
+    input: AuditWriteInput,
+  ): Promise<void> {
+    const deps = injectedDeps ?? (await loadWriteAuditLogDeps());
+
+    try {
+      const payload = buildAuditLogInsert(req as RequestWithContext, input);
+
+      await deps.createAuditLog(payload);
+
+      deps.logInfo("AUDIT_LOG_WRITTEN", {
+        event: payload.event,
+        actorType: payload.actorType,
+        clinicId: payload.clinicId,
+        reportId: payload.reportId,
+        targetReportAccessTokenId: payload.targetReportAccessTokenId,
+      });
+    } catch (error) {
+      deps.logError("AUDIT_LOG_WRITE_ERROR", {
+        event: input.event,
+        error: deps.serializeError(error),
+      });
+    }
+  };
+}
+
+export const writeAuditLog = createWriteAuditLog();

--- a/test/audit-write.test.ts
+++ b/test/audit-write.test.ts
@@ -1,0 +1,162 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+
+const { AUDIT_EVENTS, createWriteAuditLog } = await import(
+  "../server/lib/audit.ts"
+);
+
+test("writeAuditLog inserta payload y registra éxito", async () => {
+  const createAuditLogCalls: unknown[] = [];
+  const logInfoCalls: Array<{ message: string; data: unknown }> = [];
+  const logErrorCalls: Array<{ message: string; data: unknown }> = [];
+  const serializeErrorCalls: unknown[] = [];
+
+  const writeAuditLog = createWriteAuditLog({
+    createAuditLog: async (payload) => {
+      createAuditLogCalls.push(payload);
+    },
+    logInfo: (message, data) => {
+      logInfoCalls.push({ message, data });
+    },
+    logError: (message, data) => {
+      logErrorCalls.push({ message, data });
+    },
+    serializeError: (error) => {
+      serializeErrorCalls.push(error);
+      return { serialized: true };
+    },
+  });
+
+  const originalUrl =
+    `/api/public/report-access/${"a".repeat(64)}?token=${"b".repeat(64)}`;
+
+  await writeAuditLog(
+    {
+      method: "POST",
+      originalUrl,
+      ip: "127.0.0.1",
+      headers: {
+        "user-agent": "UnitTest",
+      },
+      requestId: "req-1",
+      auth: {
+        id: 9,
+        clinicId: 7,
+        username: "clinic-user",
+        role: "clinic_owner",
+      },
+    } as any,
+    {
+      event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED,
+      reportId: 22,
+      targetReportAccessTokenId: 55,
+      metadata: {
+        when: new Date("2026-04-21T12:00:00.000Z"),
+        nested: {
+          ok: true,
+          skip: undefined,
+        },
+      },
+    },
+  );
+
+  assert.equal(createAuditLogCalls.length, 1);
+
+  const payload = createAuditLogCalls[0] as any;
+
+  assert.equal(payload.event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED);
+  assert.equal(payload.actorType, "clinic_user");
+  assert.equal(payload.actorClinicUserId, 9);
+  assert.equal(payload.clinicId, 7);
+  assert.equal(payload.reportId, 22);
+  assert.equal(payload.targetReportAccessTokenId, 55);
+  assert.equal(payload.requestId, "req-1");
+  assert.equal(payload.requestMethod, "POST");
+  assert.equal(payload.ipAddress, "127.0.0.1");
+  assert.equal(payload.userAgent, "UnitTest");
+  assert.equal(payload.requestPath === originalUrl, false);
+  assert.match(payload.requestPath, /\/api\/public\/report-access\//);
+  assert.deepEqual(payload.metadata, {
+    when: "2026-04-21T12:00:00.000Z",
+    nested: {
+      ok: true,
+    },
+  });
+
+  assert.deepEqual(logErrorCalls, []);
+  assert.deepEqual(serializeErrorCalls, []);
+  assert.deepEqual(logInfoCalls, [
+    {
+      message: "AUDIT_LOG_WRITTEN",
+      data: {
+        event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED,
+        actorType: "clinic_user",
+        clinicId: 7,
+        reportId: 22,
+        targetReportAccessTokenId: 55,
+      },
+    },
+  ]);
+});
+
+test("writeAuditLog absorbe errores de escritura y registra error serializado", async () => {
+  const expectedError = new Error("db down");
+  const logInfoCalls: Array<{ message: string; data: unknown }> = [];
+  const logErrorCalls: Array<{ message: string; data: unknown }> = [];
+  const serializeErrorCalls: unknown[] = [];
+
+  const writeAuditLog = createWriteAuditLog({
+    createAuditLog: async () => {
+      throw expectedError;
+    },
+    logInfo: (message, data) => {
+      logInfoCalls.push({ message, data });
+    },
+    logError: (message, data) => {
+      logErrorCalls.push({ message, data });
+    },
+    serializeError: (error) => {
+      serializeErrorCalls.push(error);
+      return {
+        message: "db down",
+      };
+    },
+  });
+
+  await writeAuditLog(
+    {
+      method: "PATCH",
+      originalUrl: "/api/reports/4/status",
+      ip: "127.0.0.1",
+      headers: {},
+      requestId: "req-2",
+      adminAuth: {
+        id: 1,
+        username: "VETNEB",
+      },
+    } as any,
+    {
+      event: AUDIT_EVENTS.REPORT_STATUS_CHANGED,
+      clinicId: 3,
+      reportId: 4,
+      metadata: {
+        from: "processing",
+        to: "ready",
+      },
+    },
+  );
+
+  assert.deepEqual(logInfoCalls, []);
+  assert.deepEqual(serializeErrorCalls, [expectedError]);
+  assert.deepEqual(logErrorCalls, [
+    {
+      message: "AUDIT_LOG_WRITE_ERROR",
+      data: {
+        event: AUDIT_EVENTS.REPORT_STATUS_CHANGED,
+        error: {
+          message: "db down",
+        },
+      },
+    },
+  ]);
+});


### PR DESCRIPTION
﻿## Summary
- add unit tests for writeAuditLog success and failure flows
- refactor audit write path to support dependency injection and lazy runtime loading
- add coverage for createAuditLog calls, success logging and serialized error logging

## Testing
- pnpm typecheck
- pnpm test
