### PR TITLE
chore(test): add editor tsconfig for node test files

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,14 @@
+﻿{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "express"],
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": [
+    "./**/*.ts",
+    "../server/**/*.ts",
+    "../drizzle/**/*.ts",
+    "../*.ts"
+  ]
+}


### PR DESCRIPTION
﻿## Summary
- add a dedicated test tsconfig for editor support on node:test files
- keep root typecheck scope unchanged
- support test imports that reach ../server and ../drizzle without editor rootDir errors

## Testing
- pnpm typecheck
- pnpm test
