### PR TITLE
PR56: homogeneizar trusted-origin en mutaciones con sesión cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 - Revalidated clinic and admin session flows after the local baseline hardening.
 - Confirmed database migration flow with Drizzle after environment completion.
 - Public report access tokens are stored hashed and no longer leak through request logs.
+- Trusted origin enforcement is now applied at router level before cookie auth in clinic public profile and reports routes, including report upload mutations.

--- a/server/routes/clinic-public-profile.routes.ts
+++ b/server/routes/clinic-public-profile.routes.ts
@@ -19,6 +19,7 @@ import {
   uploadClinicAvatar,
 } from "../lib/supabase";
 import { requireAuth } from "../middlewares/auth";
+import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
@@ -95,6 +96,7 @@ function buildPatchInput(body: Record<string, unknown> | undefined): UpsertClini
   };
 }
 
+router.use(requireTrustedOrigin);
 router.use(requireAuth);
 
 router.get(

--- a/server/routes/reports.routes.ts
+++ b/server/routes/reports.routes.ts
@@ -181,6 +181,7 @@ async function serializeReports(reports: Report[]) {
   return Promise.all(reports.map((report) => serializeReport(report)));
 }
 
+router.use(requireTrustedOrigin);
 router.use(requireAuth);
 
 const requireUploadPermission = asyncHandler(async (req, res, next) => {
@@ -428,7 +429,6 @@ router.get(
 
 router.patch(
   "/:reportId/status",
-  requireTrustedOrigin,
   requireReportStatusWritePermission,
   asyncHandler(async (req, res) => {
     const reportId = parseReportId(req.params.reportId);

--- a/test/trusted-origin-router-policy.test.ts
+++ b/test/trusted-origin-router-policy.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function readRouteSource(relativeRoutePath: string) {
+  return readFileSync(resolve(process.cwd(), relativeRoutePath), "utf8");
+}
+
+function assertTrustedOriginRunsBeforeAuth(source: string, routePath: string) {
+  const trustedOriginUseIndex = source.indexOf("router.use(requireTrustedOrigin);");
+  const requireAuthUseIndex = source.indexOf("router.use(requireAuth);");
+
+  assert.notEqual(
+    trustedOriginUseIndex,
+    -1,
+    `${routePath} debe registrar requireTrustedOrigin a nivel router`,
+  );
+  assert.notEqual(
+    requireAuthUseIndex,
+    -1,
+    `${routePath} debe registrar requireAuth a nivel router`,
+  );
+  assert.ok(
+    trustedOriginUseIndex < requireAuthUseIndex,
+    `${routePath} debe ejecutar requireTrustedOrigin antes de requireAuth`,
+  );
+}
+
+test("clinic-public-profile usa trusted-origin antes de auth en politica de router", () => {
+  const routePath = "server/routes/clinic-public-profile.routes.ts";
+  const source = readRouteSource(routePath);
+
+  assertTrustedOriginRunsBeforeAuth(source, routePath);
+});
+
+test("reports usa trusted-origin antes de auth y evita duplicacion por ruta", () => {
+  const routePath = "server/routes/reports.routes.ts";
+  const source = readRouteSource(routePath);
+
+  assertTrustedOriginRunsBeforeAuth(source, routePath);
+  assert.doesNotMatch(
+    source,
+    /router\.patch\(\s*"\/:reportId\/status"\s*,\s*requireTrustedOrigin/s,
+    "reports.routes.ts no debe duplicar requireTrustedOrigin en PATCH /:reportId/status",
+  );
+});


### PR DESCRIPTION
﻿## Resumen
Homogeneiza la policy de `requireTrustedOrigin` en rutas de mutacion con sesion por cookie para evitar cobertura parcial por endpoint.

## Cambios
- `clinic-public-profile.routes.ts`
  - agrega `requireTrustedOrigin` a nivel router antes de `requireAuth`.
- `reports.routes.ts`
  - agrega `requireTrustedOrigin` a nivel router antes de `requireAuth`.
  - elimina middleware duplicado en `PATCH /:reportId/status`.
- `test/trusted-origin-router-policy.test.ts`
  - agrega contrato estatico de policy:
    - orden `requireTrustedOrigin -> requireAuth` en ambos routers.
    - no duplicacion por endpoint en `PATCH /:reportId/status`.
- `CHANGELOG.md`
  - agrega nota de seguridad de PR56.

## Validacion
- `pnpm typecheck` OK
- `pnpm test` OK

## Riesgo
Bajo. No cambia payloads ni permisos de rol; solo homogeneiza enforcement de origen en mutaciones cookie-auth.
