### PR TITLE
feat(authz): enforce clinic management permission on sensitive clinic mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 - Confirmed database migration flow with Drizzle after environment completion.
 - Public report access tokens are stored hashed and no longer leak through request logs.
 - Trusted origin enforcement is now applied at router level before cookie auth in clinic public profile and reports routes, including report upload mutations.
+- Clinic management permission is now enforced on sensitive clinic mutations for public profile, particular tokens and study tracking.

--- a/server/middlewares/clinic-permissions.ts
+++ b/server/middlewares/clinic-permissions.ts
@@ -1,0 +1,14 @@
+﻿import type { NextFunction, Request, Response } from "express";
+export function requireClinicManagementPermission(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (!req.auth?.canManageClinicUsers) {
+    return res.status(403).json({
+      success: false,
+      error: "No autorizado para administrar recursos de la clinica",
+    });
+  }
+  next();
+}

--- a/server/routes/clinic-public-profile.routes.ts
+++ b/server/routes/clinic-public-profile.routes.ts
@@ -18,6 +18,7 @@ import {
   deleteStorageObject,
   uploadClinicAvatar,
 } from "../lib/supabase";
+import { requireClinicManagementPermission } from "../middlewares/clinic-permissions";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
@@ -140,6 +141,7 @@ router.get(
 
 router.patch(
   "/",
+  requireClinicManagementPermission,
   asyncHandler(async (req, res) => {
     const clinicId = req.auth!.clinicId;
     const clinic = await getClinicById(clinicId);
@@ -210,6 +212,7 @@ router.patch(
 
 router.post(
   "/avatar",
+  requireClinicManagementPermission,
   upload.single("avatar"),
   asyncHandler(async (req, res) => {
     const clinicId = req.auth!.clinicId;
@@ -266,6 +269,7 @@ router.post(
 
 router.delete(
   "/avatar",
+  requireClinicManagementPermission,
   asyncHandler(async (req, res) => {
     const clinicId = req.auth!.clinicId;
     const clinic = await getClinicById(clinicId);

--- a/server/routes/particular-tokens.routes.ts
+++ b/server/routes/particular-tokens.routes.ts
@@ -20,6 +20,7 @@ import {
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
 } from "../lib/particular-token";
+import { requireClinicManagementPermission } from "../middlewares/clinic-permissions";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
@@ -31,6 +32,7 @@ router.use(requireAuth);
 router.post(
   "/",
   requireTrustedOrigin,
+  requireClinicManagementPermission,
   asyncHandler(async (req, res) => {
     const parsed = clinicCreateParticularTokenSchema.safeParse(req.body);
 
@@ -154,6 +156,7 @@ router.get(
 router.patch(
   "/:tokenId/report",
   requireTrustedOrigin,
+  requireClinicManagementPermission,
   asyncHandler(async (req, res) => {
     const tokenId = parseEntityId(req.params.tokenId);
 

--- a/server/routes/study-tracking.routes.ts
+++ b/server/routes/study-tracking.routes.ts
@@ -24,6 +24,7 @@ import {
   serializeStudyTrackingCase,
   serializeStudyTrackingNotification,
 } from "../lib/study-tracking";
+import { requireClinicManagementPermission } from "../middlewares/clinic-permissions";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
@@ -106,6 +107,7 @@ router.get(
 router.post(
   "/",
   requireTrustedOrigin,
+  requireClinicManagementPermission,
   asyncHandler(async (req, res) => {
     const parsed = clinicCreateStudyTrackingSchema.safeParse(req.body);
 

--- a/test/clinic-management-route-policy.test.ts
+++ b/test/clinic-management-route-policy.test.ts
@@ -1,0 +1,25 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+function readRouteSource(relativeRoutePath: string) {
+  return readFileSync(resolve(process.cwd(), relativeRoutePath), "utf8");
+}
+test("clinic-public-profile exige management permission en mutaciones sensibles", () => {
+  const source = readRouteSource("server/routes/clinic-public-profile.routes.ts");
+  assert.match(source, /import \{ requireClinicManagementPermission \} from "\.\.\/middlewares\/clinic-permissions";/);
+  assert.match(source, /router\.patch\(\s*"\/",\s*requireClinicManagementPermission,/s);
+  assert.match(source, /router\.post\(\s*"\/avatar",\s*requireClinicManagementPermission,\s*upload\.single\("avatar"\),/s);
+  assert.match(source, /router\.delete\(\s*"\/avatar",\s*requireClinicManagementPermission,/s);
+});
+test("particular-tokens exige management permission en create y report link", () => {
+  const source = readRouteSource("server/routes/particular-tokens.routes.ts");
+  assert.match(source, /import \{ requireClinicManagementPermission \} from "\.\.\/middlewares\/clinic-permissions";/);
+  assert.match(source, /router\.post\(\s*"\/",\s*requireTrustedOrigin,\s*requireClinicManagementPermission,/s);
+  assert.match(source, /router\.patch\(\s*"\/:tokenId\/report",\s*requireTrustedOrigin,\s*requireClinicManagementPermission,/s);
+});
+test("study-tracking exige management permission al crear casos", () => {
+  const source = readRouteSource("server/routes/study-tracking.routes.ts");
+  assert.match(source, /import \{ requireClinicManagementPermission \} from "\.\.\/middlewares\/clinic-permissions";/);
+  assert.match(source, /router\.post\(\s*"\/",\s*requireTrustedOrigin,\s*requireClinicManagementPermission,/s);
+});

--- a/test/clinic-permissions-middleware.test.ts
+++ b/test/clinic-permissions-middleware.test.ts
@@ -1,0 +1,65 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import { requireClinicManagementPermission } from "../server/middlewares/clinic-permissions.ts";
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    jsonPayload: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+test("requireClinicManagementPermission deja pasar cuando canManageClinicUsers es true", () => {
+  const req = {
+    auth: {
+      canManageClinicUsers: true,
+    },
+  };
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+  requireClinicManagementPermission(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+  assert.equal(nextCalls.length, 1);
+  assert.equal(nextCalls[0], undefined);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.jsonPayload, undefined);
+});
+test("requireClinicManagementPermission bloquea cuando canManageClinicUsers es false", () => {
+  const req = {
+    auth: {
+      canManageClinicUsers: false,
+    },
+  };
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+  requireClinicManagementPermission(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "No autorizado para administrar recursos de la clinica",
+  });
+});
+test("requireClinicManagementPermission bloquea cuando no hay auth", () => {
+  const req = {};
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+  requireClinicManagementPermission(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "No autorizado para administrar recursos de la clinica",
+  });
+});


### PR DESCRIPTION
﻿## Summary
- enforce clinic management permission on sensitive clinic mutations
- protect public profile, particular token and study tracking writes with a shared middleware
- add middleware and route policy coverage to prevent authorization regressions

## Testing
- pnpm typecheck
- pnpm test
