### PR TITLE
refactor(http): extract bootstrap boundary to prepare Fastify migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# CHANGELOG
+﻿# CHANGELOG
 
 ## [Unreleased]
 
@@ -9,6 +9,7 @@
 - `report_access_tokens` lifecycle support with clinic/admin creation, revocation, expiration and access counters.
 - Public report access endpoint backed by hashed tokens and signed Supabase URLs.
 - Node test baseline for report access token rules and log redaction.
+- HTTP bootstrap test coverage with injected dependencies to prepare the Fastify migration.
 
 ### Changed
 - Local backend baseline stabilized for Windows + pnpm.
@@ -17,6 +18,7 @@
 - Backend CI now executes `pnpm test` in addition to typecheck and build.
 - Request logging now redacts public report access tokens from URLs before writing to logs.
 - Drizzle migration metadata now tracks both the PR4 legacy compatibility migration and the new PR5 token migration.
+- Express app construction is now separated from HTTP bootstrap to prepare the migration to Fastify.
 
 ### Removed
 - `server/app.ts.bak` from the tracked repository state.

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,9 @@
-import express, { type NextFunction, type Request, type Response } from "express";
+﻿import express, {
+  type Express,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 
@@ -23,10 +28,6 @@ import { ENV } from "./lib/env";
 import { errorHandler, notFoundHandler } from "./middlewares/error-handler";
 import { requestLogger } from "./middlewares/request-logger";
 
-const app = express();
-
-app.set("trust proxy", ENV.trustProxy);
-
 function getAllowedOrigins(): string[] {
   const configuredOrigins = ENV.corsOrigins.map((origin) =>
     origin.trim().toLowerCase(),
@@ -50,90 +51,99 @@ function getAllowedOrigins(): string[] {
   return [];
 }
 
-const allowedOrigins = new Set(getAllowedOrigins());
+export function createExpressApp(): Express {
+  const app = express();
+  const allowedOrigins = new Set(getAllowedOrigins());
 
-app.use(
-  cors({
-    origin: (origin, callback) => {
-      if (!origin) {
-        callback(null, true);
-        return;
+  app.set("trust proxy", ENV.trustProxy);
+
+  app.use(
+    cors({
+      origin: (origin, callback) => {
+        if (!origin) {
+          callback(null, true);
+          return;
+        }
+
+        const normalizedOrigin = origin.trim().toLowerCase();
+
+        if (allowedOrigins.has(normalizedOrigin)) {
+          callback(null, true);
+          return;
+        }
+
+        callback(new Error("Origen no permitido por CORS"));
+      },
+      credentials: true,
+    }),
+  );
+
+  app.use(cookieParser());
+  app.use(
+    express.json({
+      strict: true,
+    }),
+  );
+  app.use(express.urlencoded({ extended: true }));
+  app.use(requestLogger);
+
+  app.use(
+    (err: unknown, _req: Request, res: Response, next: NextFunction) => {
+      const isJsonSyntaxError =
+        err instanceof SyntaxError &&
+        typeof err === "object" &&
+        err !== null &&
+        "body" in err &&
+        "status" in err &&
+        (err as { status?: number }).status === 400;
+
+      if (isJsonSyntaxError) {
+        console.error("JSON PARSE ERROR:", (err as Error).message);
+
+        return res.status(400).json({
+          success: false,
+          error: "JSON inválido",
+        });
       }
 
-      const normalizedOrigin = origin.trim().toLowerCase();
-
-      if (allowedOrigins.has(normalizedOrigin)) {
-        callback(null, true);
-        return;
-      }
-
-      callback(new Error("Origen no permitido por CORS"));
+      next(err);
     },
-    credentials: true,
-  }),
-);
+  );
 
-app.use(cookieParser());
-app.use(
-  express.json({
-    strict: true,
-  }),
-);
-app.use(express.urlencoded({ extended: true }));
-app.use(requestLogger);
-
-app.use(
-  (err: unknown, _req: Request, res: Response, next: NextFunction) => {
-    const isJsonSyntaxError =
-      err instanceof SyntaxError &&
-      typeof err === "object" &&
-      err !== null &&
-      "body" in err &&
-      "status" in err &&
-      (err as { status?: number }).status === 400;
-
-    if (isJsonSyntaxError) {
-      console.error("JSON PARSE ERROR:", (err as Error).message);
-
-      return res.status(400).json({
-        success: false,
-        error: "JSON inv�lido",
-      });
-    }
-
-    next(err);
-  },
-);
-
-app.get("/", (_req: Request, res: Response) => {
-  res.status(200).json({
-    success: true,
-    service: "portal-vetneb-api",
-    environment: ENV.nodeEnv,
+  app.get("/", (_req: Request, res: Response) => {
+    res.status(200).json({
+      success: true,
+      service: "portal-vetneb-api",
+      environment: ENV.nodeEnv,
+    });
   });
-});
 
-app.use("/health", healthRoutes);
-app.use("/api/health", healthRoutes);
+  app.use("/health", healthRoutes);
+  app.use("/api/health", healthRoutes);
 
-app.use("/api/auth", authRoutes);
-app.use("/api/admin/auth", adminAuthRoutes);
-app.use("/api/admin/audit-log", adminAuditRoutes);
-app.use("/api/clinic/profile", clinicPublicProfileRoutes);
-app.use("/api/clinic/audit-log", clinicAuditRoutes);
-app.use("/api/admin/particular/tokens", adminParticularTokensRoutes);
-app.use("/api/admin/report-access-tokens", adminReportAccessTokensRoutes);
-app.use("/api/admin/study-tracking", adminStudyTrackingRoutes);
-app.use("/api/particular/tokens", particularTokensRoutes);
-app.use("/api/particular/auth", particularAuthRoutes);
-app.use("/api/particular/study-tracking", particularStudyTrackingRoutes);
-app.use("/api/public/professionals", publicProfessionalsRoutes);
-app.use("/api/public/report-access", publicReportAccessRoutes);
-app.use("/api/report-access-tokens", reportAccessTokensRoutes);
-app.use("/api/reports", reportsRoutes);
-app.use("/api/study-tracking", studyTrackingRoutes);
+  app.use("/api/auth", authRoutes);
+  app.use("/api/admin/auth", adminAuthRoutes);
+  app.use("/api/admin/audit-log", adminAuditRoutes);
+  app.use("/api/clinic/profile", clinicPublicProfileRoutes);
+  app.use("/api/clinic/audit-log", clinicAuditRoutes);
+  app.use("/api/admin/particular/tokens", adminParticularTokensRoutes);
+  app.use("/api/admin/report-access-tokens", adminReportAccessTokensRoutes);
+  app.use("/api/admin/study-tracking", adminStudyTrackingRoutes);
+  app.use("/api/particular/tokens", particularTokensRoutes);
+  app.use("/api/particular/auth", particularAuthRoutes);
+  app.use("/api/particular/study-tracking", particularStudyTrackingRoutes);
+  app.use("/api/public/professionals", publicProfessionalsRoutes);
+  app.use("/api/public/report-access", publicReportAccessRoutes);
+  app.use("/api/report-access-tokens", reportAccessTokensRoutes);
+  app.use("/api/reports", reportsRoutes);
+  app.use("/api/study-tracking", studyTrackingRoutes);
 
-app.use(notFoundHandler);
-app.use(errorHandler);
+  app.use(notFoundHandler);
+  app.use(errorHandler);
+
+  return app;
+}
+
+const app = createExpressApp();
 
 export { app };

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -1,0 +1,115 @@
+﻿import type { Server } from "node:http";
+
+export type StartupCleanupSummary = {
+  deletedClinicSessions: number;
+  deletedAdminSessions: number;
+  deletedParticularSessions: number;
+};
+
+type LoggerLike = Pick<Console, "log" | "error">;
+type ProcessLike = Pick<NodeJS.Process, "on" | "exit">;
+
+export type BootstrapHttpServerDeps = {
+  port: number;
+  preflight: () => Promise<StartupCleanupSummary>;
+  listen: (port: number, onListening: () => void) => Server;
+  closeResources: () => Promise<void>;
+  logger?: LoggerLike;
+  processApi?: ProcessLike;
+};
+
+export function createGracefulShutdown(deps: {
+  getServer: () => Server | undefined;
+  closeResources: () => Promise<void>;
+  logger?: LoggerLike;
+  exit?: (code: number) => void;
+}) {
+  const logger = deps.logger ?? console;
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+
+  return async function shutdown(signal: string) {
+    logger.log(`Received ${signal}. Shutting down gracefully...`);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const server = deps.getServer();
+
+        if (!server) {
+          resolve();
+          return;
+        }
+
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+
+      await deps.closeResources();
+      exit(0);
+    } catch (error) {
+      logger.error("Shutdown error:", error);
+      exit(1);
+    }
+  };
+}
+
+export async function bootstrapHttpServer(
+  deps: BootstrapHttpServerDeps,
+): Promise<Server> {
+  const logger = deps.logger ?? console;
+  const processApi = deps.processApi ?? process;
+
+  let server: Server | undefined;
+
+  try {
+    const cleanupSummary = await deps.preflight();
+
+    server = deps.listen(deps.port, () => {
+      logger.log(`API listening on http://localhost:${deps.port}`);
+      logger.log(
+        `Expired clinic sessions cleaned: ${cleanupSummary.deletedClinicSessions}`,
+      );
+      logger.log(
+        `Expired admin sessions cleaned: ${cleanupSummary.deletedAdminSessions}`,
+      );
+      logger.log(
+        `Expired particular sessions cleaned: ${cleanupSummary.deletedParticularSessions}`,
+      );
+    });
+
+    const shutdown = createGracefulShutdown({
+      getServer: () => server,
+      closeResources: deps.closeResources,
+      logger,
+      exit: (code) => {
+        processApi.exit(code);
+      },
+    });
+
+    processApi.on("SIGINT", () => {
+      void shutdown("SIGINT");
+    });
+
+    processApi.on("SIGTERM", () => {
+      void shutdown("SIGTERM");
+    });
+
+    return server;
+  } catch (error) {
+    logger.error("Failed to start server:", error);
+
+    try {
+      await deps.closeResources();
+    } catch {
+      // ignore close errors during failed bootstrap
+    }
+
+    processApi.exit(1);
+    throw error;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
-import type { Server } from "node:http";
-import { sql } from "drizzle-orm";
+﻿import { sql } from "drizzle-orm";
 
-import { app } from "./app";
+import { createExpressApp } from "./app";
+import { bootstrapHttpServer } from "./bootstrap";
 import {
   closeDbConnection,
   db,
@@ -12,75 +12,37 @@ import { deleteExpiredParticularSessions } from "./db-particular";
 import { ENV } from "./lib/env";
 import { ensureStorageBucketExists } from "./lib/supabase";
 
+async function preflight() {
+  await db.execute(sql`select 1`);
+  await ensureStorageBucketExists();
+
+  const [deletedClinicSessions, deletedAdminSessions, deletedParticularSessions] =
+    await Promise.all([
+      deleteExpiredSessions(),
+      deleteExpiredAdminSessions(),
+      deleteExpiredParticularSessions(),
+    ]);
+
+  return {
+    deletedClinicSessions,
+    deletedAdminSessions,
+    deletedParticularSessions,
+  };
+}
+
+async function closeResources() {
+  await closeDbConnection();
+}
+
 async function bootstrap() {
-  let server: Server | undefined;
+  const app = createExpressApp();
 
-  try {
-    await db.execute(sql`select 1`);
-    await ensureStorageBucketExists();
-
-    const [deletedClinicSessions, deletedAdminSessions, deletedParticularSessions] =
-      await Promise.all([
-        deleteExpiredSessions(),
-        deleteExpiredAdminSessions(),
-        deleteExpiredParticularSessions(),
-      ]);
-
-    server = app.listen(ENV.port, () => {
-      console.log(`API listening on http://localhost:${ENV.port}`);
-      console.log(`Expired clinic sessions cleaned: ${deletedClinicSessions}`);
-      console.log(`Expired admin sessions cleaned: ${deletedAdminSessions}`);
-      console.log(
-        `Expired particular sessions cleaned: ${deletedParticularSessions}`,
-      );
-    });
-
-    const shutdown = async (signal: string) => {
-      console.log(`Received ${signal}. Shutting down gracefully...`);
-
-      try {
-        await new Promise<void>((resolve, reject) => {
-          if (!server) {
-            resolve();
-            return;
-          }
-
-          server.close((error) => {
-            if (error) {
-              reject(error);
-              return;
-            }
-
-            resolve();
-          });
-        });
-
-        await closeDbConnection();
-        process.exit(0);
-      } catch (error) {
-        console.error("Shutdown error:", error);
-        process.exit(1);
-      }
-    };
-
-    process.on("SIGINT", () => {
-      void shutdown("SIGINT");
-    });
-
-    process.on("SIGTERM", () => {
-      void shutdown("SIGTERM");
-    });
-  } catch (error) {
-    console.error("Failed to start server:", error);
-
-    try {
-      await closeDbConnection();
-    } catch {
-      // ignore close errors during failed bootstrap
-    }
-
-    process.exit(1);
-  }
+  await bootstrapHttpServer({
+    port: ENV.port,
+    preflight,
+    closeResources,
+    listen: (port, onListening) => app.listen(port, onListening),
+  });
 }
 
 void bootstrap();

--- a/test/http-bootstrap.test.ts
+++ b/test/http-bootstrap.test.ts
@@ -1,0 +1,183 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  bootstrapHttpServer,
+  createGracefulShutdown,
+} from "../server/bootstrap.ts";
+
+function createMockLogger() {
+  const logs: unknown[][] = [];
+  const errors: unknown[][] = [];
+
+  return {
+    logs,
+    errors,
+    logger: {
+      log: (...args: unknown[]) => {
+        logs.push(args);
+      },
+      error: (...args: unknown[]) => {
+        errors.push(args);
+      },
+    },
+  };
+}
+
+function createMockProcessApi() {
+  const handlers = new Map<string, () => void>();
+  const exitCodes: number[] = [];
+
+  return {
+    handlers,
+    exitCodes,
+    processApi: {
+      on: (signal: string, handler: () => void) => {
+        handlers.set(signal, handler);
+        return undefined as any;
+      },
+      exit: (code: number) => {
+        exitCodes.push(code);
+        return undefined as never;
+      },
+    },
+  };
+}
+
+function createMockServer(options?: { closeError?: Error }) {
+  let closeCalls = 0;
+
+  const server = {
+    close: (callback: (error?: Error | undefined) => void) => {
+      closeCalls += 1;
+      callback(options?.closeError);
+      return server as any;
+    },
+  };
+
+  return {
+    server: server as any,
+    getCloseCalls: () => closeCalls,
+  };
+}
+
+test(
+  "createGracefulShutdown cierra server y recursos y sale con codigo 0",
+  async () => {
+    const { logger, logs, errors } = createMockLogger();
+    const { server, getCloseCalls } = createMockServer();
+
+    let closeResourcesCalls = 0;
+    const exitCodes: number[] = [];
+
+    const shutdown = createGracefulShutdown({
+      getServer: () => server,
+      closeResources: async () => {
+        closeResourcesCalls += 1;
+      },
+      logger: logger as any,
+      exit: (code) => {
+        exitCodes.push(code);
+      },
+    });
+
+    await shutdown("SIGTERM");
+
+    assert.equal(getCloseCalls(), 1);
+    assert.equal(closeResourcesCalls, 1);
+    assert.deepEqual(exitCodes, [0]);
+    assert.equal(errors.length, 0);
+    assert.deepEqual(logs[0], [
+      "Received SIGTERM. Shutting down gracefully...",
+    ]);
+  },
+);
+
+test(
+  "bootstrapHttpServer ejecuta preflight listen y registra senales",
+  async () => {
+    const { logger, logs, errors } = createMockLogger();
+    const { processApi, handlers, exitCodes } = createMockProcessApi();
+    const { server } = createMockServer();
+
+    let preflightCalls = 0;
+    let closeResourcesCalls = 0;
+    const listenPorts: number[] = [];
+
+    const startedServer = await bootstrapHttpServer({
+      port: 3000,
+      preflight: async () => {
+        preflightCalls += 1;
+
+        return {
+          deletedClinicSessions: 4,
+          deletedAdminSessions: 2,
+          deletedParticularSessions: 1,
+        };
+      },
+      listen: (port, onListening) => {
+        listenPorts.push(port);
+        onListening();
+        return server;
+      },
+      closeResources: async () => {
+        closeResourcesCalls += 1;
+      },
+      logger: logger as any,
+      processApi: processApi as any,
+    });
+
+    assert.equal(startedServer, server);
+    assert.equal(preflightCalls, 1);
+    assert.equal(closeResourcesCalls, 0);
+    assert.deepEqual(listenPorts, [3000]);
+    assert.ok(handlers.has("SIGINT"));
+    assert.ok(handlers.has("SIGTERM"));
+    assert.deepEqual(exitCodes, []);
+    assert.equal(errors.length, 0);
+
+    assert.deepEqual(logs, [
+      ["API listening on http://localhost:3000"],
+      ["Expired clinic sessions cleaned: 4"],
+      ["Expired admin sessions cleaned: 2"],
+      ["Expired particular sessions cleaned: 1"],
+    ]);
+  },
+);
+
+test(
+  "bootstrapHttpServer cierra recursos y sale con codigo 1 cuando preflight falla",
+  async () => {
+    const expectedError = new Error("db down");
+    const { logger, errors } = createMockLogger();
+    const { processApi, exitCodes } = createMockProcessApi();
+
+    let closeResourcesCalls = 0;
+    let listenCalls = 0;
+
+    await assert.rejects(
+      () =>
+        bootstrapHttpServer({
+          port: 3000,
+          preflight: async () => {
+            throw expectedError;
+          },
+          listen: (_port, _onListening) => {
+            listenCalls += 1;
+            return createMockServer().server;
+          },
+          closeResources: async () => {
+            closeResourcesCalls += 1;
+          },
+          logger: logger as any,
+          processApi: processApi as any,
+        }),
+      expectedError,
+    );
+
+    assert.equal(listenCalls, 0);
+    assert.equal(closeResourcesCalls, 1);
+    assert.deepEqual(exitCodes, [1]);
+    assert.deepEqual(errors[0], ["Failed to start server:", expectedError]);
+  },
+);


### PR DESCRIPTION
﻿## Summary
- extract Express app construction from the HTTP bootstrap path
- add a reusable bootstrap boundary for future Fastify migration
- add test coverage for startup and graceful shutdown orchestration

## Testing
- pnpm test
- pnpm typecheck

## Risk
Low. No route contracts or payloads change in this PR; it only separates framework construction from server startup.
