### PR TITLE
feat(http): move root and health endpoints to native Fastify

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -25,8 +25,15 @@ import reportAccessTokensRoutes from "./routes/report-access-tokens.routes";
 import reportsRoutes from "./routes/reports.routes";
 import studyTrackingRoutes from "./routes/study-tracking.routes";
 import { ENV } from "./lib/env";
+import { buildServiceInfoPayload } from "./lib/http-runtime";
 import { errorHandler, notFoundHandler } from "./middlewares/error-handler";
 import { requestLogger } from "./middlewares/request-logger";
+
+export type CreateExpressAppOptions = {
+  apiBasePath?: string;
+  includeRootRoute?: boolean;
+  includeHealthRoutes?: boolean;
+};
 
 function getAllowedOrigins(): string[] {
   const configuredOrigins = ENV.corsOrigins.map((origin) =>
@@ -51,9 +58,22 @@ function getAllowedOrigins(): string[] {
   return [];
 }
 
-export function createExpressApp(): Express {
+function buildMountedPath(basePath: string, suffix: string) {
+  return basePath ? `${basePath}${suffix}` : suffix;
+}
+
+export function createExpressApp(
+  options: CreateExpressAppOptions = {},
+): Express {
   const app = express();
   const allowedOrigins = new Set(getAllowedOrigins());
+  const apiBasePath = options.apiBasePath ?? "/api";
+  const includeRootRoute = options.includeRootRoute ?? true;
+  const includeHealthRoutes = options.includeHealthRoutes ?? true;
+
+  const mountApiRoute = (suffix: string, router: any) => {
+    app.use(buildMountedPath(apiBasePath, suffix), router);
+  };
 
   app.set("trust proxy", ENV.trustProxy);
 
@@ -86,7 +106,6 @@ export function createExpressApp(): Express {
   );
   app.use(express.urlencoded({ extended: true }));
   app.use(requestLogger);
-
   app.use(
     (err: unknown, _req: Request, res: Response, next: NextFunction) => {
       const isJsonSyntaxError =
@@ -110,33 +129,32 @@ export function createExpressApp(): Express {
     },
   );
 
-  app.get("/", (_req: Request, res: Response) => {
-    res.status(200).json({
-      success: true,
-      service: "portal-vetneb-api",
-      environment: ENV.nodeEnv,
+  if (includeRootRoute) {
+    app.get("/", (_req: Request, res: Response) => {
+      res.status(200).json(buildServiceInfoPayload());
     });
-  });
+  }
 
-  app.use("/health", healthRoutes);
-  app.use("/api/health", healthRoutes);
-
-  app.use("/api/auth", authRoutes);
-  app.use("/api/admin/auth", adminAuthRoutes);
-  app.use("/api/admin/audit-log", adminAuditRoutes);
-  app.use("/api/clinic/profile", clinicPublicProfileRoutes);
-  app.use("/api/clinic/audit-log", clinicAuditRoutes);
-  app.use("/api/admin/particular/tokens", adminParticularTokensRoutes);
-  app.use("/api/admin/report-access-tokens", adminReportAccessTokensRoutes);
-  app.use("/api/admin/study-tracking", adminStudyTrackingRoutes);
-  app.use("/api/particular/tokens", particularTokensRoutes);
-  app.use("/api/particular/auth", particularAuthRoutes);
-  app.use("/api/particular/study-tracking", particularStudyTrackingRoutes);
-  app.use("/api/public/professionals", publicProfessionalsRoutes);
-  app.use("/api/public/report-access", publicReportAccessRoutes);
-  app.use("/api/report-access-tokens", reportAccessTokensRoutes);
-  app.use("/api/reports", reportsRoutes);
-  app.use("/api/study-tracking", studyTrackingRoutes);
+  if (includeHealthRoutes) {
+    app.use("/health", healthRoutes);
+    mountApiRoute("/health", healthRoutes);
+  }
+  mountApiRoute("/auth", authRoutes);
+  mountApiRoute("/admin/auth", adminAuthRoutes);
+  mountApiRoute("/admin/audit-log", adminAuditRoutes);
+  mountApiRoute("/clinic/profile", clinicPublicProfileRoutes);
+  mountApiRoute("/clinic/audit-log", clinicAuditRoutes);
+  mountApiRoute("/admin/particular/tokens", adminParticularTokensRoutes);
+  mountApiRoute("/admin/report-access-tokens", adminReportAccessTokensRoutes);
+  mountApiRoute("/admin/study-tracking", adminStudyTrackingRoutes);
+  mountApiRoute("/particular/tokens", particularTokensRoutes);
+  mountApiRoute("/particular/auth", particularAuthRoutes);
+  mountApiRoute("/particular/study-tracking", particularStudyTrackingRoutes);
+  mountApiRoute("/public/professionals", publicProfessionalsRoutes);
+  mountApiRoute("/public/report-access", publicReportAccessRoutes);
+  mountApiRoute("/report-access-tokens", reportAccessTokensRoutes);
+  mountApiRoute("/reports", reportsRoutes);
+  mountApiRoute("/study-tracking", studyTrackingRoutes);
 
   app.use(notFoundHandler);
   app.use(errorHandler);

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -1,25 +1,102 @@
-﻿import Fastify, { type FastifyInstance } from "fastify";
+﻿import Fastify, {
+  type FastifyInstance,
+  type FastifyReply,
+  type FastifyRequest,
+} from "fastify";
 import fastifyExpress from "@fastify/express";
 
 import { ENV } from "./lib/env.ts";
 
-type LegacyAppFactory = () => unknown | Promise<unknown>;
+type HealthCheckResponse = {
+  statusCode: number;
+  payload: Record<string, unknown>;
+};
+
+type LegacyExpressHandler = (
+  req: unknown,
+  res: unknown,
+  next: (error?: unknown) => void,
+) => unknown;
+
+type LegacyAppFactory =
+  () => LegacyExpressHandler | Promise<LegacyExpressHandler>;
+type HealthCheckFactory = () => Promise<HealthCheckResponse>;
+type ServiceInfoFactory = () => Record<string, unknown>;
+
+export type CreateFastifyAppOptions = {
+  createLegacyApp?: LegacyAppFactory;
+  getNativeHealthCheckResponse?: HealthCheckFactory;
+  getServiceInfoPayload?: ServiceInfoFactory;
+};
+
+function shouldBypassLegacyApi(url: unknown) {
+  if (typeof url !== "string") {
+    return false;
+  }
+
+  const path = url.split("?")[0];
+  return path === "/health" || path === "/health/";
+}
 
 export async function createFastifyApp(
-  createLegacyApp?: LegacyAppFactory,
+  options: CreateFastifyAppOptions = {},
 ): Promise<FastifyInstance> {
   const app = Fastify({
     logger: false,
     trustProxy: ENV.trustProxy,
   });
+  const getNativeHealthCheckResponse =
+    options.getNativeHealthCheckResponse ??
+    (async () => (await import("./lib/http-runtime.ts")).getHealthCheckResponse());
+
+  const getServiceInfoPayload =
+    options.getServiceInfoPayload ??
+    (() => ({
+      success: true,
+      service: "portal-vetneb-api",
+      environment: ENV.nodeEnv,
+    }));
+
+  app.get("/", async (_request: FastifyRequest, reply: FastifyReply) => {
+    const payload = JSON.stringify(getServiceInfoPayload());
+
+    reply.code(200);
+    reply.header("content-type", "application/json; charset=utf-8");
+    reply.raw.end(payload);
+  });
+
+  const nativeHealthHandler = async (
+    _request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const health = await getNativeHealthCheckResponse();
+    const payload = JSON.stringify(health.payload);
+
+    reply.code(health.statusCode);
+    reply.header("content-type", "application/json; charset=utf-8");
+    reply.raw.end(payload);
+  };
+
+  app.get("/health", nativeHealthHandler);
+  app.get("/api/health", nativeHealthHandler);
 
   await app.register(fastifyExpress);
 
-  const legacyExpressApp = createLegacyApp
-    ? await createLegacyApp()
-    : (await import("./app.ts")).createExpressApp();
+  const legacyExpressApp = options.createLegacyApp
+    ? await options.createLegacyApp()
+    : ((await import("./app.ts")).createExpressApp({
+        apiBasePath: "",
+        includeRootRoute: false,
+        includeHealthRoutes: false,
+      }) as unknown as LegacyExpressHandler);
+  app.use("/api", (req, res, next) => {
+    if (shouldBypassLegacyApi((req as { url?: unknown }).url)) {
+      next();
+      return;
+    }
 
-  app.use(legacyExpressApp as any);
+    legacyExpressApp(req, res, next);
+  });
 
   return app;
 }

--- a/server/lib/http-runtime.ts
+++ b/server/lib/http-runtime.ts
@@ -1,0 +1,75 @@
+﻿import { sql } from "drizzle-orm";
+
+import { db } from "../db.ts";
+import { ENV } from "./env.ts";
+import { checkStorageHealth } from "./supabase.ts";
+
+type DependencyStatus = "up" | "down";
+
+export type HealthCheckPayload = {
+  success: boolean;
+  status: "ok" | "degraded";
+  checks: {
+    database: DependencyStatus;
+    storage: DependencyStatus;
+  };
+  uptimeSeconds: number;
+  responseTimeMs: number;
+  timestamp: string;
+  details?: Record<string, unknown>;
+};
+
+export type HealthCheckResponse = {
+  statusCode: 200 | 503;
+  payload: HealthCheckPayload;
+};
+
+export function buildServiceInfoPayload() {
+  return {
+    success: true,
+    service: "portal-vetneb-api",
+    environment: ENV.nodeEnv,
+  };
+}
+
+export async function getHealthCheckResponse(): Promise<HealthCheckResponse> {
+  const startedAt = Date.now();
+
+  let database: DependencyStatus = "down";
+  let storage: DependencyStatus = "down";
+  const details: Record<string, unknown> = {};
+
+  try {
+    await db.execute(sql`select 1`);
+    database = "up";
+  } catch (error) {
+    details.databaseError =
+      error instanceof Error ? error.message : "unknown database error";
+  }
+
+  try {
+    await checkStorageHealth();
+    storage = "up";
+  } catch (error) {
+    details.storageError =
+      error instanceof Error ? error.message : "unknown storage error";
+  }
+
+  const ok = database === "up" && storage === "up";
+
+  return {
+    statusCode: ok ? 200 : 503,
+    payload: {
+      success: ok,
+      status: ok ? "ok" : "degraded",
+      checks: {
+        database,
+        storage,
+      },
+      uptimeSeconds: Math.round(process.uptime()),
+      responseTimeMs: Date.now() - startedAt,
+      timestamp: new Date().toISOString(),
+      ...(Object.keys(details).length ? { details } : {}),
+    },
+  };
+}

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -11,30 +11,75 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { createFastifyApp } = await import("../server/fastify-app.ts");
 
 test(
-  "createFastifyApp monta una app Express mediante la capa de compatibilidad",
+  "createFastifyApp expone root y health nativos y mantiene el bridge Express bajo /api",
   async () => {
-    const app = await createFastifyApp(() => {
-      const legacyApp = express();
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
 
-      legacyApp.get("/", (_req, res) => {
-        res.setHeader("x-legacy-bridge", "ok");
-        res.status(204).end();
-      });
+        legacyApp.get("/bridge", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "ok");
+          res.status(204).end();
+        });
 
-      return legacyApp;
+        return legacyApp as any;
+      },
+      getServiceInfoPayload: () => ({
+        success: true,
+        service: "portal-vetneb-api",
+        environment: "test",
+      }),
+      getNativeHealthCheckResponse: async () => ({
+        statusCode: 200,
+        payload: {
+          success: true,
+          status: "ok",
+          checks: {
+            database: "up",
+            storage: "up",
+          },
+          uptimeSeconds: 123,
+          responseTimeMs: 1,
+          timestamp: "2026-04-22T00:00:00.000Z",
+        },
+      }),
     });
 
     try {
-      const response = await app.inject({
+      const rootResponse = await app.inject({
         method: "GET",
         url: "/",
       });
 
-      assert.equal(response.statusCode, 204);
-      assert.equal(response.headers["x-legacy-bridge"], "ok");
-      assert.equal(response.body, "");
+      assert.equal(rootResponse.statusCode, 200);
+
+      const healthResponse = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+      assert.equal(healthResponse.statusCode, 200);
+      assert.equal(healthResponse.headers["x-legacy-bridge"], undefined);
+
+      const apiHealthResponse = await app.inject({
+        method: "GET",
+        url: "/api/health",
+      });
+
+      assert.equal(apiHealthResponse.statusCode, 200);
+      assert.equal(apiHealthResponse.headers["x-legacy-bridge"], undefined);
+
+      const legacyResponse = await app.inject({
+        method: "GET",
+        url: "/api/bridge",
+      });
+
+      assert.equal(legacyResponse.statusCode, 204);
+      assert.equal(legacyResponse.headers["x-legacy-bridge"], "ok");
+      assert.equal(legacyResponse.body, "");
     } finally {
       await app.close();
     }
   },
 );
+
+


### PR DESCRIPTION
﻿## Summary
- move `/`, `/health` and `/api/health` to native Fastify handlers
- keep the legacy Express API mounted under `/api`
- share service info and health response helpers between runtimes

## Testing
- pnpm test
- pnpm typecheck

## Risk
Low. This PR peels only infrastructure endpoints out of Express while keeping the legacy API bridge in place.
