### PR TITLE
feat(http): move public professionals routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -6,6 +6,10 @@
 import fastifyExpress from "@fastify/express";
 
 import { ENV } from "./lib/env.ts";
+import {
+  publicProfessionalsNativeRoutes,
+  type PublicProfessionalsNativeRoutesOptions,
+} from "./routes/public-professionals.fastify.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -27,7 +31,13 @@ export type CreateFastifyAppOptions = {
   createLegacyApp?: LegacyAppFactory;
   getNativeHealthCheckResponse?: HealthCheckFactory;
   getServiceInfoPayload?: ServiceInfoFactory;
+  publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
 };
+
+const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
+  "/health",
+  "/public/professionals",
+];
 
 function shouldBypassLegacyApi(url: unknown) {
   if (typeof url !== "string") {
@@ -35,7 +45,14 @@ function shouldBypassLegacyApi(url: unknown) {
   }
 
   const path = url.split("?")[0];
-  return path === "/health" || path === "/health/";
+
+  return NATIVE_API_BRIDGE_BYPASS_PREFIXES.some((prefix) => {
+    return (
+      path === prefix ||
+      path === `${prefix}/` ||
+      path.startsWith(`${prefix}/`)
+    );
+  });
 }
 
 export async function createFastifyApp(
@@ -80,6 +97,11 @@ export async function createFastifyApp(
   app.get("/health", nativeHealthHandler);
   app.get("/api/health", nativeHealthHandler);
 
+  await app.register(publicProfessionalsNativeRoutes, {
+    prefix: "/api/public/professionals",
+    ...(options.publicProfessionalsRoutes ?? {}),
+  });
+
   await app.register(fastifyExpress);
 
   const legacyExpressApp = options.createLegacyApp
@@ -89,6 +111,7 @@ export async function createFastifyApp(
         includeRootRoute: false,
         includeHealthRoutes: false,
       }) as unknown as LegacyExpressHandler);
+
   app.use("/api", (req, res, next) => {
     if (shouldBypassLegacyApi((req as { url?: unknown }).url)) {
       next();

--- a/server/routes/public-professionals.fastify.ts
+++ b/server/routes/public-professionals.fastify.ts
@@ -1,0 +1,445 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import {
+  PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
+  PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS,
+  PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS,
+  PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE,
+  PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS,
+  PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS,
+} from "../lib/public-professionals-rate-limit.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type PublicProfessionalRow = {
+  clinicId: number;
+  displayName: string;
+  avatarStoragePath: string | null;
+  aboutText: string | null;
+  specialtyText: string | null;
+  servicesText: string | null;
+  email: string | null;
+  phone: string | null;
+  locality: string | null;
+  country: string | null;
+  updatedAt: Date;
+  profileQualityScore?: number;
+  rank?: number;
+  similarity?: number;
+  score?: number;
+};
+
+type SearchPublicProfessionalsInput = {
+  query?: string;
+  locality?: string;
+  country?: string;
+  limit: number;
+  offset: number;
+};
+
+type SearchPublicProfessionalsResult = {
+  rows: PublicProfessionalRow[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+type SearchPublicProfessionalsFn = (
+  input: SearchPublicProfessionalsInput,
+) => Promise<SearchPublicProfessionalsResult>;
+
+type GetPublicProfessionalByClinicIdFn = (
+  clinicId: number,
+) => Promise<PublicProfessionalRow | null | undefined>;
+
+type CreateSignedStorageUrlFn = (
+  path: string,
+) => Promise<string | null>;
+
+export type PublicProfessionalsNativeRoutesOptions = {
+  searchPublicProfessionals?: SearchPublicProfessionalsFn;
+  getPublicProfessionalByClinicId?: GetPublicProfessionalByClinicIdFn;
+  createSignedStorageUrl?: CreateSignedStorageUrlFn;
+  searchRateLimitWindowMs?: number;
+  searchRateLimitMaxAttempts?: number;
+  detailRateLimitWindowMs?: number;
+  detailRateLimitMaxAttempts?: number;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__publicProfessionalsRequestStartTimeNs";
+
+type PublicProfessionalsFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(origin: string) {
+  return origin.trim().toLowerCase();
+}
+
+function normalizeText(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parsePositiveInt(value: unknown, fallback: number, max?: number) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return typeof max === "number" ? Math.min(parsed, max) : parsed;
+}
+
+function parseOffset(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function parseClinicId(value: unknown) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+async function serializeProfessional(
+  row: PublicProfessionalRow,
+  createSignedStorageUrl: CreateSignedStorageUrlFn,
+) {
+  const avatarUrl = row.avatarStoragePath
+    ? await createSignedStorageUrl(row.avatarStoragePath)
+    : null;
+
+  return {
+    clinicId: row.clinicId,
+    displayName: row.displayName,
+    avatarUrl,
+    specialtyText: row.specialtyText,
+    servicesText: row.servicesText,
+    email: row.email,
+    phone: row.phone,
+    locality: row.locality,
+    country: row.country,
+    aboutText: row.aboutText,
+    updatedAt: row.updatedAt,
+    relevance: {
+      rank: row.rank ?? 0,
+      similarity: row.similarity ?? 0,
+      score: row.score ?? 0,
+    },
+    profileQualityScore: row.profileQualityScore ?? null,
+  };
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = request.headers.origin;
+
+  if (typeof rawOrigin !== "string" || !rawOrigin.trim()) {
+    return true;
+  }
+
+  const origin = rawOrigin.trim();
+
+  if (!allowedOrigins.has(normalizeOrigin(origin))) {
+    reply.code(500).send({
+      success: false,
+      error: "Error interno del servidor",
+      path: request.url,
+    });
+    return false;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", origin);
+  reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+  );
+
+  return true;
+}
+
+function setRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    remaining: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header("RateLimit-Remaining", String(Math.max(input.remaining, 0)));
+  reply.header(
+    "RateLimit-Reset",
+    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+  );
+}
+
+function createFixedWindowRateLimit(config: {
+  windowMs: number;
+  max: number;
+  errorMessage: string;
+  now?: () => number;
+}) {
+  const entries = new Map<string, { count: number; resetAt: number }>();
+  const now = config.now ?? (() => Date.now());
+
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const key = request.ip || "unknown";
+    const currentTime = now();
+    const currentEntry = entries.get(key);
+
+    let entry = currentEntry;
+
+    if (!entry || entry.resetAt <= currentTime) {
+      entry = {
+        count: 0,
+        resetAt: currentTime + config.windowMs,
+      };
+      entries.set(key, entry);
+    }
+
+    entry.count += 1;
+
+    setRateLimitHeaders(reply, {
+      max: config.max,
+      windowMs: config.windowMs,
+      remaining: config.max - entry.count,
+      resetAt: entry.resetAt,
+      now: currentTime,
+    });
+
+    if (entry.count > config.max) {
+      return reply.code(429).send({
+        success: false,
+        error: config.errorMessage,
+      });
+    }
+
+    return undefined;
+  };
+}
+
+async function loadDefaultSearchPublicProfessionals(): Promise<SearchPublicProfessionalsFn> {
+  const module = await import("../db-public-professionals.ts");
+  return module.searchPublicProfessionals;
+}
+
+async function loadDefaultGetPublicProfessionalByClinicId(): Promise<GetPublicProfessionalByClinicIdFn> {
+  const module = await import("../db-public-professionals.ts");
+  return module.getPublicProfessionalByClinicId;
+}
+
+async function loadDefaultCreateSignedStorageUrl(): Promise<CreateSignedStorageUrlFn> {
+  const module = await import("../lib/supabase.ts");
+  return module.createSignedStorageUrl;
+}
+
+export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
+  PublicProfessionalsNativeRoutesOptions
+> = async (app, options) => {
+  const searchPublicProfessionals =
+    options.searchPublicProfessionals ??
+    (await loadDefaultSearchPublicProfessionals());
+
+  const getPublicProfessionalByClinicId =
+    options.getPublicProfessionalByClinicId ??
+    (await loadDefaultGetPublicProfessionalByClinicId());
+
+  const createSignedStorageUrl =
+    options.createSignedStorageUrl ??
+    (await loadDefaultCreateSignedStorageUrl());
+
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  const searchRateLimit = createFixedWindowRateLimit({
+    windowMs:
+      options.searchRateLimitWindowMs ??
+      PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS,
+    max:
+      options.searchRateLimitMaxAttempts ??
+      PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS,
+    errorMessage: PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
+    now: options.now,
+  });
+
+  const detailRateLimit = createFixedWindowRateLimit({
+    windowMs:
+      options.detailRateLimitWindowMs ??
+      PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS,
+    max:
+      options.detailRateLimitMaxAttempts ??
+      PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS,
+    errorMessage: PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE,
+    now: options.now,
+  });
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as PublicProfessionalsFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    const corsAccepted = applyCorsHeaders(request, reply, allowedOrigins);
+
+    if (!corsAccepted) {
+      return reply;
+    }
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as PublicProfessionalsFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  app.get<{
+    Querystring: {
+      q?: string | number;
+      query?: string | number;
+      locality?: string | number;
+      country?: string | number;
+      limit?: string | number;
+      offset?: string | number;
+    };
+  }>(
+    "/search",
+    {
+      preHandler: searchRateLimit,
+    },
+    async (request, reply) => {
+      const query = normalizeText(request.query.q ?? request.query.query);
+      const locality = normalizeText(request.query.locality);
+      const country = normalizeText(request.query.country);
+      const limit = parsePositiveInt(request.query.limit, 20, 50);
+      const offset = parseOffset(request.query.offset, 0);
+
+      const result = await searchPublicProfessionals({
+        query,
+        locality,
+        country,
+        limit,
+        offset,
+      });
+
+      const professionals = await Promise.all(
+        result.rows.map((row) =>
+          serializeProfessional(row, createSignedStorageUrl),
+        ),
+      );
+
+      return reply.code(200).send({
+        success: true,
+        count: professionals.length,
+        total: result.total,
+        professionals,
+        filters: {
+          query: query ?? null,
+          locality: locality ?? null,
+          country: country ?? null,
+        },
+        pagination: {
+          limit: result.limit,
+          offset: result.offset,
+        },
+      });
+    },
+  );
+
+  app.get<{
+    Params: {
+      clinicId: string;
+    };
+  }>(
+    "/:clinicId",
+    {
+      preHandler: detailRateLimit,
+    },
+    async (request, reply) => {
+      const clinicId = parseClinicId(request.params.clinicId);
+
+      if (!clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "ID de clinica invalido",
+        });
+      }
+
+      const professional = await getPublicProfessionalByClinicId(clinicId);
+
+      if (!professional) {
+        return reply.code(404).send({
+          success: false,
+          error: "Perfil publico no encontrado",
+        });
+      }
+
+      return reply.code(200).send({
+        success: true,
+        professional: await serializeProfessional(
+          professional,
+          createSignedStorageUrl,
+        ),
+      });
+    },
+  );
+};

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import express from "express";
 
+process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
 process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
@@ -43,6 +44,16 @@ test(
           timestamp: "2026-04-22T00:00:00.000Z",
         },
       }),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
     });
 
     try {
@@ -82,4 +93,63 @@ test(
   },
 );
 
+test(
+  "createFastifyApp despacha /api/public/professionals al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
 
+        legacyApp.get("/public/professionals/search", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+
+      if (response.body) {
+        assert.deepEqual(JSON.parse(response.body), {
+          success: true,
+          count: 0,
+          total: 0,
+          professionals: [],
+          filters: {
+            query: null,
+            locality: null,
+            country: null,
+          },
+          pagination: {
+            limit: 20,
+            offset: 0,
+          },
+        });
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/public-professionals.fastify.test.ts
+++ b/test/public-professionals.fastify.test.ts
@@ -1,0 +1,225 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const {
+  publicProfessionalsNativeRoutes,
+} = await import("../server/routes/public-professionals.fastify.ts");
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(publicProfessionalsNativeRoutes as any, {
+    prefix: "/api/public/professionals",
+    searchPublicProfessionals: async () => ({
+      rows: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    }),
+    getPublicProfessionalByClinicId: async () => null,
+    createSignedStorageUrl: async (path: string) => `signed:${path}`,
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "publicProfessionalsNativeRoutes responde search con payload estable y CORS permitido",
+  async () => {
+    const app = await createTestApp({
+      searchPublicProfessionals: async ({
+        query,
+        locality,
+        country,
+        limit,
+        offset,
+      }: {
+        query?: string;
+        locality?: string;
+        country?: string;
+        limit: number;
+        offset: number;
+      }) => {
+        assert.equal(query, "cardio");
+        assert.equal(locality, "Rosario");
+        assert.equal(country, "AR");
+        assert.equal(limit, 5);
+        assert.equal(offset, 2);
+
+        return {
+          rows: [
+            {
+              clinicId: 7,
+              displayName: "Clinica Norte",
+              avatarStoragePath: "avatars/7.webp",
+              aboutText: "Cardiologia veterinaria",
+              specialtyText: "Cardiologia",
+              servicesText: "Ecocardiograma",
+              email: "norte@example.com",
+              phone: "3410000000",
+              locality: "Rosario",
+              country: "AR",
+              updatedAt: new Date("2026-04-23T00:00:00.000Z"),
+              profileQualityScore: 0.9,
+              rank: 0.75,
+              similarity: 0.65,
+              score: 1.4,
+            },
+          ],
+          total: 1,
+          limit,
+          offset,
+        };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search?q=cardio&locality=Rosario&country=AR&limit=5&offset=2",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+      assert.equal(response.headers["ratelimit-limit"], "10");
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        count: 1,
+        total: 1,
+        professionals: [
+          {
+            clinicId: 7,
+            displayName: "Clinica Norte",
+            avatarUrl: "signed:avatars/7.webp",
+            specialtyText: "Cardiologia",
+            servicesText: "Ecocardiograma",
+            email: "norte@example.com",
+            phone: "3410000000",
+            locality: "Rosario",
+            country: "AR",
+            aboutText: "Cardiologia veterinaria",
+            updatedAt: "2026-04-23T00:00:00.000Z",
+            relevance: {
+              rank: 0.75,
+              similarity: 0.65,
+              score: 1.4,
+            },
+            profileQualityScore: 0.9,
+          },
+        ],
+        filters: {
+          query: "cardio",
+          locality: "Rosario",
+          country: "AR",
+        },
+        pagination: {
+          limit: 5,
+          offset: 2,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "publicProfessionalsNativeRoutes devuelve 400 cuando clinicId es invalido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/abc",
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "ID de clinica invalido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "publicProfessionalsNativeRoutes aplica rate limit nativo fijo por IP",
+  async () => {
+    let now = 0;
+
+    const app = await createTestApp({
+      now: () => now,
+      searchRateLimitWindowMs: 60_000,
+      searchRateLimitMaxAttempts: 2,
+    });
+
+    try {
+      const first = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+        remoteAddress: "203.0.113.10",
+      });
+
+      const second = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+        remoteAddress: "203.0.113.10",
+      });
+
+      const third = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+        remoteAddress: "203.0.113.10",
+      });
+
+      assert.equal(first.statusCode, 200);
+      assert.equal(first.headers["ratelimit-limit"], "2");
+      assert.equal(first.headers["ratelimit-remaining"], "1");
+
+      assert.equal(second.statusCode, 200);
+      assert.equal(second.headers["ratelimit-limit"], "2");
+      assert.equal(second.headers["ratelimit-remaining"], "0");
+
+      assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["ratelimit-limit"], "2");
+      assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(third.body), {
+        success: false,
+        error: "Demasiadas consultas al directorio público. Intente más tarde.",
+      });
+
+      now = 61_000;
+
+      const fourth = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+        remoteAddress: "203.0.113.10",
+      });
+
+      assert.equal(fourth.statusCode, 200);
+      assert.equal(fourth.headers["ratelimit-remaining"], "1");
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- move `/api/public/professionals/search` and `/api/public/professionals/:clinicId` to native Fastify
- keep the legacy Express bridge for the rest of `/api`
- add native tests for routing, payloads, CORS and fixed-window rate limiting

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/fastify-app.test.ts test/public-professionals.fastify.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR peels the first read-only public API subtree out of Express while preserving the legacy bridge for all remaining `/api/*` routes.
