### PR TITLE
feat(http): move admin auth routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -7,6 +7,10 @@ import fastifyExpress from "@fastify/express";
 
 import { ENV } from "./lib/env.ts";
 import {
+  adminAuthNativeRoutes,
+  type AdminAuthNativeRoutesOptions,
+} from "./routes/admin-auth.fastify.ts";
+import {
   clinicAuthNativeRoutes,
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
@@ -35,12 +39,14 @@ export type CreateFastifyAppOptions = {
   createLegacyApp?: LegacyAppFactory;
   getNativeHealthCheckResponse?: HealthCheckFactory;
   getServiceInfoPayload?: ServiceInfoFactory;
+  adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
 };
 
 const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/health",
+  "/admin/auth",
   "/auth",
   "/public/professionals",
 ];
@@ -68,6 +74,7 @@ export async function createFastifyApp(
     logger: false,
     trustProxy: ENV.trustProxy,
   });
+
   const getNativeHealthCheckResponse =
     options.getNativeHealthCheckResponse ??
     (async () =>
@@ -103,6 +110,11 @@ export async function createFastifyApp(
 
   app.get("/health", nativeHealthHandler);
   app.get("/api/health", nativeHealthHandler);
+
+  await app.register(adminAuthNativeRoutes, {
+    prefix: "/api/admin/auth",
+    ...(options.adminAuthRoutes ?? {}),
+  });
 
   await app.register(clinicAuthNativeRoutes, {
     prefix: "/api/auth",

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -1,0 +1,765 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { AUDIT_EVENTS } from "../lib/audit.ts";
+import { ENV } from "../lib/env.ts";
+import {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+  LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
+  LOGIN_RATE_LIMIT_WINDOW_MS,
+} from "../lib/login-rate-limit.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type VerifyPasswordResult = {
+  valid: boolean;
+  needsRehash: boolean;
+};
+
+type AdminUserRecord = {
+  id: number;
+  username: string;
+  passwordHash: string;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type AuditWriteInput = {
+  event: string;
+  targetAdminUserId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    adminUserId?: number | null;
+  };
+};
+
+export type AdminAuthNativeRoutesOptions = {
+  createAdminSession?: (input: {
+    adminUserId: number;
+    tokenHash: string;
+    expiresAt: Date;
+  }) => Promise<unknown>;
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  getAdminUserByUsername?: (
+    username: string,
+  ) => Promise<AdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  generateSessionToken?: () => string;
+  hashSessionToken?: (token: string) => string;
+  verifyPassword?: (
+    password: string,
+    passwordHash: string,
+  ) => Promise<VerifyPasswordResult>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  loginRateLimitWindowMs?: number;
+  loginRateLimitMaxAttempts?: number;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__adminAuthRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type AdminAuthFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeAdminAuthDeps = Required<
+  Pick<
+    AdminAuthNativeRoutesOptions,
+    | "createAdminSession"
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "getAdminUserByUsername"
+    | "updateAdminSessionLastAccess"
+    | "generateSessionToken"
+    | "hashSessionToken"
+    | "verifyPassword"
+    | "writeAuditLog"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminAuthDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminAuthDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const audit = await import("../lib/audit.ts");
+
+      return {
+        createAdminSession: db.createAdminSession,
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        getAdminUserByUsername: db.getAdminUserByUsername,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        generateSessionToken: authSecurity.generateSessionToken,
+        hashSessionToken: authSecurity.hashSessionToken,
+        verifyPassword: authSecurity.verifyPassword,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+  );
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildAdminSessionCookie(token: string) {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: token,
+    maxAgeSeconds: ENV.sessionTtlHours * 60 * 60,
+  });
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function setLoginRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    failedCount: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header(
+    "RateLimit-Remaining",
+    String(Math.max(input.max - input.failedCount, 0)),
+  );
+  reply.header(
+    "RateLimit-Reset",
+    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+  );
+}
+
+function getFailureEntry(
+  failures: Map<string, { count: number; resetAt: number }>,
+  key: string,
+  windowMs: number,
+  now: number,
+) {
+  const current = failures.get(key);
+
+  if (!current || current.resetAt <= now) {
+    const fresh = {
+      count: 0,
+      resetAt: now + windowMs,
+    };
+    failures.set(key, fresh);
+    return fresh;
+  }
+
+  return current;
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+function createAuditRequestLike(
+  request: FastifyRequest,
+  admin?: Pick<AuthenticatedAdminUser, "id" | "username">,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    adminAuth: admin
+      ? {
+          id: admin.id,
+          username: admin.username,
+        }
+      : undefined,
+  };
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminAuthDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+export const adminAuthNativeRoutes: FastifyPluginAsync<
+  AdminAuthNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.createAdminSession &&
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.getAdminUserByUsername &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.generateSessionToken &&
+    !!options.hashSessionToken &&
+    !!options.verifyPassword &&
+    !!options.writeAuditLog;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminAuthDeps = {
+    createAdminSession:
+      options.createAdminSession ?? defaultDeps!.createAdminSession,
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById:
+      options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    getAdminUserByUsername:
+      options.getAdminUserByUsername ?? defaultDeps!.getAdminUserByUsername,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    generateSessionToken:
+      options.generateSessionToken ?? defaultDeps!.generateSessionToken,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    verifyPassword: options.verifyPassword ?? defaultDeps!.verifyPassword,
+    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const loginRateLimitWindowMs =
+    options.loginRateLimitWindowMs ?? LOGIN_RATE_LIMIT_WINDOW_MS;
+  const loginRateLimitMaxAttempts =
+    options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
+  const allowedOrigins = new Set(getAllowedOrigins());
+  const loginFailures = new Map<string, { count: number; resetAt: number }>();
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as AdminAuthFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as AdminAuthFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/login", optionsHandler);
+  app.options("/me", optionsHandler);
+  app.options("/logout", optionsHandler);
+
+  app.post<{
+    Body: {
+      username?: unknown;
+      password?: unknown;
+    };
+  }>("/login", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const rateLimitKey = request.ip || "unknown";
+    const currentTime = now();
+    const failureEntry = getFailureEntry(
+      loginFailures,
+      rateLimitKey,
+      loginRateLimitWindowMs,
+      currentTime,
+    );
+
+    if (failureEntry.count >= loginRateLimitMaxAttempts) {
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
+
+      return reply.code(429).send({
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    }
+
+    const markFailure = () => {
+      failureEntry.count += 1;
+
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
+    };
+
+    const markSuccess = () => {
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
+    };
+
+    const username =
+      typeof request.body?.username === "string"
+        ? request.body.username.trim()
+        : "";
+    const password =
+      typeof request.body?.password === "string" ? request.body.password : "";
+
+    if (!username || !password) {
+      markFailure();
+
+      return reply.code(400).send({
+        success: false,
+        error: "Usuario y contraseña requeridos",
+      });
+    }
+
+    const admin = await deps.getAdminUserByUsername(username);
+
+    if (!admin) {
+      markFailure();
+
+      return reply.code(401).send({
+        success: false,
+        error: "Credenciales inválidas",
+      });
+    }
+
+    const valid = await deps.verifyPassword(password, admin.passwordHash);
+
+    if (!valid.valid) {
+      markFailure();
+
+      return reply.code(401).send({
+        success: false,
+        error: "Credenciales inválidas",
+      });
+    }
+
+    const token = deps.generateSessionToken();
+    const tokenHash = deps.hashSessionToken(token);
+    const expiresAt = new Date(
+      currentTime + ENV.sessionTtlHours * 60 * 60 * 1000,
+    );
+
+    await deps.createAdminSession({
+      adminUserId: admin.id,
+      tokenHash,
+      expiresAt,
+    });
+
+    await deps.writeAuditLog(createAuditRequestLike(request), {
+      event: AUDIT_EVENTS.ADMIN_LOGIN_SUCCEEDED,
+      targetAdminUserId: admin.id,
+      metadata: {
+        username: admin.username,
+        sessionExpiresAt: expiresAt,
+      },
+      actor: {
+        type: "admin_user",
+        adminUserId: admin.id,
+      },
+    });
+
+    reply.header("set-cookie", buildAdminSessionCookie(token));
+    markSuccess();
+
+    return reply.code(200).send({
+      success: true,
+      admin: {
+        id: admin.id,
+        username: admin.username,
+      },
+    });
+  });
+
+  app.get("/me", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    return reply.code(200).send({
+      success: true,
+      admin: {
+        id: admin.id,
+        username: admin.username,
+      },
+    });
+  });
+
+  app.post("/logout", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const tokenHash = deps.hashSessionToken(admin.sessionToken);
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+
+    return reply.code(200).send({
+      success: true,
+      message: "Sesión admin cerrada correctamente",
+    });
+  });
+};

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -1,0 +1,360 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/login-rate-limit.ts");
+const {
+  adminAuthNativeRoutes,
+} = await import("../server/routes/admin-auth.fastify.ts");
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(adminAuthNativeRoutes as any, {
+    prefix: "/api/admin/auth",
+    createAdminSession: async () => {},
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    getAdminUserByUsername: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "admin-session-token",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    writeAuditLog: async () => {},
+    ...overrides,
+  });
+
+  return app;
+}
+
+function getSetCookieHeader(response: { headers: Record<string, unknown> }) {
+  const raw = response.headers["set-cookie"];
+
+  if (Array.isArray(raw)) {
+    return raw.join("\n");
+  }
+
+  return typeof raw === "string" ? raw : "";
+}
+
+test(
+  "adminAuthNativeRoutes login exitoso conserva payload, cookie y auditoria",
+  async () => {
+    const sessionCalls: Array<{
+      adminUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+    const auditCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async (username: string) => {
+        assert.equal(username, "VETNEB");
+
+        return {
+          id: 1,
+          username: "VETNEB",
+          passwordHash: "stored-hash",
+        };
+      },
+      verifyPassword: async (password: string, passwordHash: string) => {
+        assert.equal(password, "31731490Neb");
+        assert.equal(passwordHash, "stored-hash");
+
+        return {
+          valid: true,
+          needsRehash: false,
+        };
+      },
+      generateSessionToken: () => "admin-token-123",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createAdminSession: async (input: {
+        adminUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        sessionCalls.push(input);
+      },
+      writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+        auditCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          username: " VETNEB ",
+          password: "31731490Neb",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.adminCookieName}=admin-token-123`));
+      assert.ok(setCookie.includes("Path=/"));
+      assert.ok(setCookie.includes("HttpOnly"));
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        admin: {
+          id: 1,
+          username: "VETNEB",
+        },
+      });
+
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(sessionCalls[0].adminUserId, 1);
+      assert.equal(sessionCalls[0].tokenHash, "hash:admin-token-123");
+      assert.equal(
+        sessionCalls[0].expiresAt.getTime(),
+        ENV.sessionTtlHours * 60 * 60 * 1000,
+      );
+
+      assert.equal(auditCalls.length, 1);
+      assert.equal(auditCalls[0].event, AUDIT_EVENTS.ADMIN_LOGIN_SUCCEEDED);
+      assert.equal(auditCalls[0].targetAdminUserId, 1);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuthNativeRoutes bloquea login con origin no permitido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "https://evil.example",
+        },
+        payload: {
+          username: "VETNEB",
+          password: "31731490Neb",
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Origen no permitido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuthNativeRoutes expone /me con sesión admin válida por cookie",
+  async () => {
+    const lastAccessCalls: string[] = [];
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getAdminSessionByToken: async (tokenHash: string) => {
+        assert.equal(tokenHash, "hash:admin-session-token");
+
+        return {
+          adminUserId: 7,
+          expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+          lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+        };
+      },
+      getAdminUserById: async (adminUserId: number) => {
+        assert.equal(adminUserId, 7);
+
+        return {
+          id: 7,
+          username: "ADMIN",
+        };
+      },
+      updateAdminSessionLastAccess: async (tokenHash: string) => {
+        lastAccessCalls.push(tokenHash);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/auth/me",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        admin: {
+          id: 7,
+          username: "ADMIN",
+        },
+      });
+
+      assert.deepEqual(lastAccessCalls, ["hash:admin-session-token"]);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuthNativeRoutes logout elimina sesión y limpia cookie",
+  async () => {
+    const deletedHashes: string[] = [];
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getAdminSessionByToken: async () => ({
+        adminUserId: 3,
+        expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+        lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+      }),
+      getAdminUserById: async () => ({
+        id: 3,
+        username: "VETNEB",
+      }),
+      updateAdminSessionLastAccess: async () => {},
+      deleteAdminSession: async (tokenHash: string) => {
+        deletedHashes.push(tokenHash);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/logout",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Sesión admin cerrada correctamente",
+      });
+
+      assert.deepEqual(deletedHashes, ["hash:admin-session-token"]);
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.adminCookieName}=`));
+      assert.ok(setCookie.includes("Max-Age=0"));
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuthNativeRoutes aplica rate limit de login sobre intentos fallidos",
+  async () => {
+    const app = await createTestApp({
+      now: () => 0,
+      loginRateLimitWindowMs: 60_000,
+      loginRateLimitMaxAttempts: 2,
+      getAdminUserByUsername: async () => ({
+        id: 1,
+        username: "VETNEB",
+        passwordHash: "stored-hash",
+      }),
+      verifyPassword: async () => ({
+        valid: false,
+        needsRehash: false,
+      }),
+    });
+
+    try {
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.20",
+        payload: {
+          username: "VETNEB",
+          password: "bad-1",
+        },
+      });
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.20",
+        payload: {
+          username: "VETNEB",
+          password: "bad-2",
+        },
+      });
+
+      const third = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.20",
+        payload: {
+          username: "VETNEB",
+          password: "bad-3",
+        },
+      });
+
+      assert.equal(first.statusCode, 401);
+      assert.equal(second.statusCode, 401);
+      assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["ratelimit-limit"], "2");
+      assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(third.body), {
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -12,6 +12,24 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { ENV } = await import("../server/lib/env.ts");
 const { createFastifyApp } = await import("../server/fastify-app.ts");
 
+function buildAdminAuthRouteStubs() {
+  return {
+    createAdminSession: async () => {},
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    getAdminUserByUsername: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "admin-session-token",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    writeAuditLog: async () => {},
+  };
+}
+
 function buildClinicAuthRouteStubs() {
   return {
     createActiveSession: async () => {},
@@ -65,6 +83,7 @@ test(
           timestamp: "2026-04-22T00:00:00.000Z",
         },
       }),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
@@ -116,13 +135,13 @@ test(
 );
 
 test(
-  "createFastifyApp despacha /api/public/professionals al router nativo antes del bridge Express",
+  "createFastifyApp despacha /api/admin/auth al router nativo antes del bridge Express",
   async () => {
     const app = await createFastifyApp({
       createLegacyApp: () => {
         const legacyApp = express();
 
-        legacyApp.get("/public/professionals/search", (_req, res) => {
+        legacyApp.get("/admin/auth/me", (_req, res) => {
           res.setHeader("x-legacy-bridge", "should-not-run");
           res.status(418).json({
             success: false,
@@ -130,6 +149,19 @@ test(
         });
 
         return legacyApp as any;
+      },
+      adminAuthRoutes: {
+        ...buildAdminAuthRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 7,
+          expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+          lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+        }),
+        getAdminUserById: async () => ({
+          id: 7,
+          username: "ADMIN",
+        }),
+        updateAdminSessionLastAccess: async () => {},
       },
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       publicProfessionalsRoutes: {
@@ -147,27 +179,22 @@ test(
     try {
       const response = await app.inject({
         method: "GET",
-        url: "/api/public/professionals/search",
+        url: "/api/admin/auth/me",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
       });
 
-      assert.equal(response.statusCode, 200);
       assert.equal(response.headers["x-legacy-bridge"], undefined);
       assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
 
-      if (response.body) {
+      if (response.statusCode === 200) {
         assert.deepEqual(JSON.parse(response.body), {
           success: true,
-          count: 0,
-          total: 0,
-          professionals: [],
-          filters: {
-            query: null,
-            locality: null,
-            country: null,
-          },
-          pagination: {
-            limit: 20,
-            offset: 0,
+          admin: {
+            id: 7,
+            username: "ADMIN",
           },
         });
       }
@@ -176,9 +203,6 @@ test(
     }
   },
 );
-
-
-
 
 test(
   "createFastifyApp despacha /api/auth al router nativo antes del bridge Express",
@@ -196,6 +220,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
         getActiveSessionByToken: async () => ({
@@ -258,3 +283,65 @@ test(
   },
 );
 
+test(
+  "createFastifyApp despacha /api/public/professionals al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/public/professionals/search", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+
+      if (response.body) {
+        assert.deepEqual(JSON.parse(response.body), {
+          success: true,
+          count: 0,
+          total: 0,
+          professionals: [],
+          filters: {
+            query: null,
+            locality: null,
+            country: null,
+          },
+          pagination: {
+            limit: 20,
+            offset: 0,
+          },
+        });
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- move `/api/admin/auth/login`, `/api/admin/auth/me` and `/api/admin/auth/logout` to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for admin auth routing, cookie/session behavior and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-auth.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the admin auth subtree to Fastify while preserving the existing admin-facing contract and leaving the Express bridge intact for the rest of the API.
