### PR TITLE
feat(http): move particular auth routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -15,6 +15,10 @@ import {
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
 import {
+  particularAuthNativeRoutes,
+  type ParticularAuthNativeRoutesOptions,
+} from "./routes/particular-auth.fastify.ts";
+import {
   publicProfessionalsNativeRoutes,
   type PublicProfessionalsNativeRoutesOptions,
 } from "./routes/public-professionals.fastify.ts";
@@ -41,6 +45,7 @@ export type CreateFastifyAppOptions = {
   getServiceInfoPayload?: ServiceInfoFactory;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
+  particularAuthRoutes?: ParticularAuthNativeRoutesOptions;
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
 };
 
@@ -48,6 +53,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/health",
   "/admin/auth",
   "/auth",
+  "/particular/auth",
   "/public/professionals",
 ];
 
@@ -119,6 +125,11 @@ export async function createFastifyApp(
   await app.register(clinicAuthNativeRoutes, {
     prefix: "/api/auth",
     ...(options.clinicAuthRoutes ?? {}),
+  });
+
+  await app.register(particularAuthNativeRoutes, {
+    prefix: "/api/particular/auth",
+    ...(options.particularAuthRoutes ?? {}),
   });
 
   await app.register(publicProfessionalsNativeRoutes, {

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -1,0 +1,839 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+import type { ParticularToken, Report } from "../../drizzle/schema";
+
+import { ENV } from "../lib/env.ts";
+import {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+  LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
+  LOGIN_RATE_LIMIT_WINDOW_MS,
+} from "../lib/login-rate-limit.ts";
+import { serializeParticularTokenDetail } from "../lib/particular-token.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ParticularSessionRecord = {
+  particularTokenId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type ParticularTokenAuthRecord = {
+  id: number;
+  clinicId: number;
+  reportId: number | null;
+  isActive: boolean;
+};
+
+type AuthenticatedParticularUser = {
+  tokenId: number;
+  clinicId: number;
+  reportId: number | null;
+  sessionToken: string;
+};
+
+export type ParticularAuthNativeRoutesOptions = {
+  createParticularSession?: (input: {
+    particularTokenId: number;
+    tokenHash: string;
+    lastAccess: Date;
+    expiresAt: Date;
+  }) => Promise<unknown>;
+  deleteParticularSession?: (tokenHash: string) => Promise<void>;
+  getParticularSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ParticularSessionRecord | null>;
+  getParticularTokenById?: (
+    id: number,
+  ) => Promise<ParticularToken | ParticularTokenAuthRecord | null>;
+  getParticularTokenByTokenHash?: (
+    tokenHash: string,
+  ) => Promise<(ParticularToken & { isActive: boolean }) | null>;
+  updateParticularSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  updateParticularTokenLastLogin?: (tokenId: number) => Promise<void>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  createSignedReportUrl?: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl?: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+  generateSessionToken?: () => string;
+  hashSessionToken?: (token: string) => string;
+  loginRateLimitWindowMs?: number;
+  loginRateLimitMaxAttempts?: number;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__particularAuthRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type ParticularAuthFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeParticularAuthDeps = Required<
+  Pick<
+    ParticularAuthNativeRoutesOptions,
+    | "createParticularSession"
+    | "deleteParticularSession"
+    | "getParticularSessionByToken"
+    | "getParticularTokenById"
+    | "getParticularTokenByTokenHash"
+    | "updateParticularSessionLastAccess"
+    | "updateParticularTokenLastLogin"
+    | "getReportById"
+    | "createSignedReportUrl"
+    | "createSignedReportDownloadUrl"
+    | "generateSessionToken"
+    | "hashSessionToken"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeParticularAuthDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeParticularAuthDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const dbParticular = await import("../db-particular.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const supabase = await import("../lib/supabase.ts");
+
+      return {
+        createParticularSession: dbParticular.createParticularSession,
+        deleteParticularSession: dbParticular.deleteParticularSession,
+        getParticularSessionByToken: dbParticular.getParticularSessionByToken,
+        getParticularTokenById: dbParticular.getParticularTokenById,
+        getParticularTokenByTokenHash:
+          dbParticular.getParticularTokenByTokenHash,
+        updateParticularSessionLastAccess:
+          dbParticular.updateParticularSessionLastAccess,
+        updateParticularTokenLastLogin:
+          dbParticular.updateParticularTokenLastLogin,
+        getReportById: db.getReportById,
+        createSignedReportUrl: supabase.createSignedReportUrl,
+        createSignedReportDownloadUrl:
+          supabase.createSignedReportDownloadUrl,
+        generateSessionToken: authSecurity.generateSessionToken,
+        hashSessionToken: authSecurity.hashSessionToken,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+  );
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getParticularSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.particularCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildParticularSessionCookie(token: string) {
+  return serializeCookie({
+    name: ENV.particularCookieName,
+    value: token,
+    maxAgeSeconds: ENV.sessionTtlHours * 60 * 60,
+  });
+}
+
+function buildClearParticularSessionCookie() {
+  return serializeCookie({
+    name: ENV.particularCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function setLoginRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    failedCount: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header(
+    "RateLimit-Remaining",
+    String(Math.max(input.max - input.failedCount, 0)),
+  );
+  reply.header(
+    "RateLimit-Reset",
+    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+  );
+}
+
+function getFailureEntry(
+  failures: Map<string, { count: number; resetAt: number }>,
+  key: string,
+  windowMs: number,
+  now: number,
+) {
+  const current = failures.get(key);
+
+  if (!current || current.resetAt <= now) {
+    const fresh = {
+      count: 0,
+      resetAt: now + windowMs,
+    };
+    failures.set(key, fresh);
+    return fresh;
+  }
+
+  return current;
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function buildParticularResponse(
+  deps: NativeParticularAuthDeps,
+  tokenId: number,
+) {
+  const particularToken = await deps.getParticularTokenById(tokenId);
+
+  if (!particularToken) {
+    return null;
+  }
+
+  const report =
+    typeof particularToken.reportId === "number"
+      ? await deps.getReportById(particularToken.reportId)
+      : null;
+
+  return serializeParticularTokenDetail(
+    particularToken as ParticularToken,
+    report,
+  );
+}
+
+async function authenticateParticularUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeParticularAuthDeps,
+  now: () => number,
+): Promise<AuthenticatedParticularUser | null> {
+  const token = getParticularSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Particular no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getParticularSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión particular inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteParticularSession(tokenHash);
+
+    reply.header("set-cookie", buildClearParticularSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión particular expirada",
+    });
+    return null;
+  }
+
+  const particularToken = await deps.getParticularTokenById(
+    session.particularTokenId,
+  );
+
+  if (!particularToken || !particularToken.isActive) {
+    await deps.deleteParticularSession(tokenHash);
+
+    reply.header("set-cookie", buildClearParticularSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Token particular inválido o inactivo",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateParticularSessionLastAccess(tokenHash);
+  }
+
+  return {
+    tokenId: particularToken.id,
+    clinicId: particularToken.clinicId,
+    reportId: particularToken.reportId ?? null,
+    sessionToken: token,
+  };
+}
+
+export const particularAuthNativeRoutes: FastifyPluginAsync<
+  ParticularAuthNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.createParticularSession &&
+    !!options.deleteParticularSession &&
+    !!options.getParticularSessionByToken &&
+    !!options.getParticularTokenById &&
+    !!options.getParticularTokenByTokenHash &&
+    !!options.updateParticularSessionLastAccess &&
+    !!options.updateParticularTokenLastLogin &&
+    !!options.getReportById &&
+    !!options.createSignedReportUrl &&
+    !!options.createSignedReportDownloadUrl &&
+    !!options.generateSessionToken &&
+    !!options.hashSessionToken;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeParticularAuthDeps = {
+    createParticularSession:
+      options.createParticularSession ?? defaultDeps!.createParticularSession,
+    deleteParticularSession:
+      options.deleteParticularSession ?? defaultDeps!.deleteParticularSession,
+    getParticularSessionByToken:
+      options.getParticularSessionByToken ??
+      defaultDeps!.getParticularSessionByToken,
+    getParticularTokenById:
+      options.getParticularTokenById ?? defaultDeps!.getParticularTokenById,
+    getParticularTokenByTokenHash:
+      options.getParticularTokenByTokenHash ??
+      defaultDeps!.getParticularTokenByTokenHash,
+    updateParticularSessionLastAccess:
+      options.updateParticularSessionLastAccess ??
+      defaultDeps!.updateParticularSessionLastAccess,
+    updateParticularTokenLastLogin:
+      options.updateParticularTokenLastLogin ??
+      defaultDeps!.updateParticularTokenLastLogin,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    createSignedReportUrl:
+      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
+    createSignedReportDownloadUrl:
+      options.createSignedReportDownloadUrl ??
+      defaultDeps!.createSignedReportDownloadUrl,
+    generateSessionToken:
+      options.generateSessionToken ?? defaultDeps!.generateSessionToken,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const loginRateLimitWindowMs =
+    options.loginRateLimitWindowMs ?? LOGIN_RATE_LIMIT_WINDOW_MS;
+  const loginRateLimitMaxAttempts =
+    options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
+  const allowedOrigins = new Set(getAllowedOrigins());
+  const loginFailures = new Map<string, { count: number; resetAt: number }>();
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as ParticularAuthFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as ParticularAuthFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/login", optionsHandler);
+  app.options("/me", optionsHandler);
+  app.options("/logout", optionsHandler);
+  app.options("/report/preview-url", optionsHandler);
+  app.options("/report/download-url", optionsHandler);
+
+  app.post<{
+    Body: {
+      token?: unknown;
+    };
+  }>("/login", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const rateLimitKey = request.ip || "unknown";
+    const currentTime = now();
+    const failureEntry = getFailureEntry(
+      loginFailures,
+      rateLimitKey,
+      loginRateLimitWindowMs,
+      currentTime,
+    );
+
+    if (failureEntry.count >= loginRateLimitMaxAttempts) {
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
+
+      return reply.code(429).send({
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    }
+
+    const markFailure = () => {
+      failureEntry.count += 1;
+
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
+    };
+
+    const markSuccess = () => {
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
+    };
+
+    const providedToken =
+      typeof request.body?.token === "string" ? request.body.token.trim() : "";
+
+    if (!providedToken) {
+      markFailure();
+
+      return reply.code(400).send({
+        success: false,
+        error: "Token obligatorio",
+      });
+    }
+
+    const tokenHash = deps.hashSessionToken(providedToken);
+    const particularToken = await deps.getParticularTokenByTokenHash(tokenHash);
+
+    if (!particularToken || !particularToken.isActive) {
+      markFailure();
+
+      return reply.code(401).send({
+        success: false,
+        error: "Token inválido",
+      });
+    }
+
+    const sessionToken = deps.generateSessionToken();
+    const sessionTokenHash = deps.hashSessionToken(sessionToken);
+    const expiresAt = new Date(
+      currentTime + ENV.sessionTtlHours * 60 * 60 * 1000,
+    );
+
+    await deps.createParticularSession({
+      particularTokenId: particularToken.id,
+      tokenHash: sessionTokenHash,
+      lastAccess: new Date(currentTime),
+      expiresAt,
+    });
+
+    await deps.updateParticularTokenLastLogin(particularToken.id);
+
+    reply.header("set-cookie", buildParticularSessionCookie(sessionToken));
+    markSuccess();
+
+    return reply.code(200).send({
+      success: true,
+      particular: await buildParticularResponse(deps, particularToken.id),
+    });
+  });
+
+  app.get("/me", async (request, reply) => {
+    const particular = await authenticateParticularUser(request, reply, deps, now);
+
+    if (!particular) {
+      return reply;
+    }
+
+    const response = await buildParticularResponse(deps, particular.tokenId);
+
+    if (!response) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      particular: response,
+    });
+  });
+
+  app.post("/logout", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const tokenHash = deps.hashSessionToken(particular.sessionToken);
+    await deps.deleteParticularSession(tokenHash);
+
+    reply.header("set-cookie", buildClearParticularSessionCookie());
+
+    return reply.code(200).send({
+      success: true,
+      message: "Sesión particular cerrada correctamente",
+    });
+  });
+
+  app.get("/report/preview-url", async (request, reply) => {
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const reportId = particular.reportId;
+
+    if (typeof reportId !== "number") {
+      return reply.code(409).send({
+        success: false,
+        error: "El token particular no tiene un informe vinculado",
+      });
+    }
+
+    const report = await deps.getReportById(reportId);
+
+    if (!report || report.clinicId !== particular.clinicId) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    const previewUrl = await deps.createSignedReportUrl(report.storagePath);
+
+    return reply.code(200).send({
+      success: true,
+      previewUrl,
+    });
+  });
+
+  app.get("/report/download-url", async (request, reply) => {
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const reportId = particular.reportId;
+
+    if (typeof reportId !== "number") {
+      return reply.code(409).send({
+        success: false,
+        error: "El token particular no tiene un informe vinculado",
+      });
+    }
+
+    const report = await deps.getReportById(reportId);
+
+    if (!report || report.clinicId !== particular.clinicId) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    const downloadUrl = await deps.createSignedReportDownloadUrl(
+      report.storagePath,
+      report.fileName ?? undefined,
+    );
+
+    return reply.code(200).send({
+      success: true,
+      downloadUrl,
+    });
+  });
+};
+

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -50,6 +50,26 @@ function buildClinicAuthRouteStubs() {
   };
 }
 
+function buildParticularAuthRouteStubs() {
+  return {
+    createParticularSession: async () => {},
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    updateParticularTokenLastLogin: async () => {},
+    getReportById: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    generateSessionToken: () => "particular-session-token",
+    hashSessionToken: (token: string) => `hash:${token}`,
+  };
+}
+
 test(
   "createFastifyApp expone root y health nativos y mantiene el bridge Express bajo /api",
   async () => {
@@ -85,6 +105,7 @@ test(
       }),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -164,6 +185,7 @@ test(
         updateAdminSessionLastAccess: async () => {},
       },
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -236,6 +258,7 @@ test(
         }),
         updateSessionLastAccess: async () => {},
       },
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -284,6 +307,105 @@ test(
 );
 
 test(
+  "createFastifyApp despacha /api/particular/auth al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/particular/auth/me", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      particularAuthRoutes: {
+        ...buildParticularAuthRouteStubs(),
+        getParticularSessionByToken: async () => ({
+          particularTokenId: 7,
+          expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+          lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+        }),
+        getParticularTokenById: async () => ({
+          id: 7,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "ABCD",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+          shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+          isActive: true,
+          lastLoginAt: new Date("2026-04-22T10:00:00.000Z"),
+          createdAt: new Date("2026-04-20T12:00:00.000Z"),
+          updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+          createdByAdminId: 1,
+          createdByClinicUserId: null,
+        }),
+        updateParticularSessionLastAccess: async () => {},
+        getReportById: async () => ({
+          id: 55,
+          clinicId: 3,
+          storagePath: "reports/report-55.pdf",
+          uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+          studyType: "Histopatología",
+          patientName: "Luna",
+          fileName: "luna-report.pdf",
+          createdAt: new Date("2026-04-22T09:00:00.000Z"),
+          updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+        }),
+      },
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/particular/auth/me",
+        headers: {
+          cookie: `${ENV.particularCookieName}=particular-session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
+
+      if (response.statusCode === 200) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.particular.id, 7);
+        assert.equal(body.particular.clinicId, 3);
+        assert.equal(body.particular.report.id, 55);
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "createFastifyApp despacha /api/public/professionals al router nativo antes del bridge Express",
   async () => {
     const app = await createFastifyApp({
@@ -301,6 +423,7 @@ test(
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -1,0 +1,519 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/login-rate-limit.ts");
+const {
+  particularAuthNativeRoutes,
+} = await import("../server/routes/particular-auth.fastify.ts");
+
+function createParticularTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    clinicId: 3,
+    reportId: 55,
+    tokenLast4: "ABCD",
+    tutorLastName: "Gomez",
+    petName: "Luna",
+    petAge: "8 años",
+    petBreed: "Caniche",
+    petSex: "Hembra",
+    petSpecies: "Canina",
+    sampleLocation: "Pabellón auricular",
+    sampleEvolution: "15 días",
+    detailsLesion: "Lesión nodular pequeña",
+    extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+    shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+    isActive: true,
+    lastLoginAt: new Date("2026-04-22T10:00:00.000Z"),
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    ...overrides,
+  };
+}
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    storagePath: "reports/report-55.pdf",
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatología",
+    patientName: "Luna",
+    fileName: "luna-report.pdf",
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(particularAuthNativeRoutes as any, {
+    prefix: "/api/particular/auth",
+    createParticularSession: async () => {},
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    updateParticularTokenLastLogin: async () => {},
+    getReportById: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    generateSessionToken: () => "particular-session-token",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  });
+
+  return app;
+}
+
+function getSetCookieHeader(response: { headers: Record<string, unknown> }) {
+  const raw = response.headers["set-cookie"];
+
+  if (Array.isArray(raw)) {
+    return raw.join("\n");
+  }
+
+  return typeof raw === "string" ? raw : "";
+}
+
+test(
+  "particularAuthNativeRoutes login exitoso conserva payload, cookie y lastLogin",
+  async () => {
+    const sessionCalls: Array<{
+      particularTokenId: number;
+      tokenHash: string;
+      lastAccess: Date;
+      expiresAt: Date;
+    }> = [];
+    const lastLoginCalls: number[] = [];
+    const particularToken = createParticularTokenFixture();
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      now: () => 0,
+      getParticularTokenByTokenHash: async (tokenHash: string) => {
+        assert.equal(tokenHash, "hash:PARTICULAR-RAW-TOKEN");
+        return particularToken;
+      },
+      createParticularSession: async (input: {
+        particularTokenId: number;
+        tokenHash: string;
+        lastAccess: Date;
+        expiresAt: Date;
+      }) => {
+        sessionCalls.push(input);
+      },
+      updateParticularTokenLastLogin: async (tokenId: number) => {
+        lastLoginCalls.push(tokenId);
+      },
+      getParticularTokenById: async (tokenId: number) => {
+        assert.equal(tokenId, particularToken.id);
+        return particularToken;
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, report.id);
+        return report;
+      },
+      generateSessionToken: () => "particular-session-123",
+      hashSessionToken: (token: string) => `hash:${token}`,
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          token: " PARTICULAR-RAW-TOKEN ",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(
+        setCookie.includes(
+          `${ENV.particularCookieName}=particular-session-123`,
+        ),
+      );
+      assert.ok(setCookie.includes("Path=/"));
+      assert.ok(setCookie.includes("HttpOnly"));
+
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(sessionCalls[0].particularTokenId, particularToken.id);
+      assert.equal(sessionCalls[0].tokenHash, "hash:particular-session-123");
+      assert.equal(
+        sessionCalls[0].expiresAt.getTime(),
+        ENV.sessionTtlHours * 60 * 60 * 1000,
+      );
+      assert.equal(sessionCalls[0].lastAccess.getTime(), 0);
+      assert.deepEqual(lastLoginCalls, [particularToken.id]);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        particular: {
+          id: particularToken.id,
+          clinicId: particularToken.clinicId,
+          reportId: particularToken.reportId,
+          tokenLast4: particularToken.tokenLast4,
+          tutorLastName: particularToken.tutorLastName,
+          petName: particularToken.petName,
+          petAge: particularToken.petAge,
+          petBreed: particularToken.petBreed,
+          petSex: particularToken.petSex,
+          petSpecies: particularToken.petSpecies,
+          sampleLocation: particularToken.sampleLocation,
+          sampleEvolution: particularToken.sampleEvolution,
+          detailsLesion: particularToken.detailsLesion,
+          extractionDate: particularToken.extractionDate.toISOString(),
+          shippingDate: particularToken.shippingDate.toISOString(),
+          isActive: particularToken.isActive,
+          lastLoginAt: particularToken.lastLoginAt.toISOString(),
+          createdAt: particularToken.createdAt.toISOString(),
+          updatedAt: particularToken.updatedAt.toISOString(),
+          createdByAdminId: particularToken.createdByAdminId,
+          createdByClinicUserId: particularToken.createdByClinicUserId,
+          hasLinkedReport: true,
+          report: {
+            id: report.id,
+            clinicId: report.clinicId,
+            uploadDate: report.uploadDate.toISOString(),
+            studyType: report.studyType,
+            patientName: report.patientName,
+            fileName: report.fileName,
+            createdAt: report.createdAt.toISOString(),
+            updatedAt: report.updatedAt.toISOString(),
+          },
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes bloquea login con origin no permitido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "https://evil.example",
+        },
+        payload: {
+          token: "PARTICULAR-RAW-TOKEN",
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Origen no permitido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes expone /me con sesión particular válida por cookie",
+  async () => {
+    const lastAccessCalls: string[] = [];
+    const particularToken = createParticularTokenFixture();
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getParticularSessionByToken: async (tokenHash: string) => {
+        assert.equal(tokenHash, "hash:particular-session-token");
+
+        return {
+          particularTokenId: particularToken.id,
+          expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+          lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+        };
+      },
+      getParticularTokenById: async (tokenId: number) => {
+        assert.equal(tokenId, particularToken.id);
+        return particularToken;
+      },
+      updateParticularSessionLastAccess: async (tokenHash: string) => {
+        lastAccessCalls.push(tokenHash);
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, report.id);
+        return report;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/particular/auth/me",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.particularCookieName}=particular-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.deepEqual(lastAccessCalls, ["hash:particular-session-token"]);
+
+      const body = JSON.parse(response.body);
+      assert.equal(body.success, true);
+      assert.equal(body.particular.id, particularToken.id);
+      assert.equal(body.particular.report.id, report.id);
+      assert.equal(body.particular.hasLinkedReport, true);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes logout elimina sesión y limpia cookie",
+  async () => {
+    const deletedHashes: string[] = [];
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getParticularSessionByToken: async () => ({
+        particularTokenId: 7,
+        expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+        lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+      }),
+      getParticularTokenById: async () => ({
+        id: 7,
+        clinicId: 3,
+        reportId: 55,
+        isActive: true,
+      }),
+      updateParticularSessionLastAccess: async () => {},
+      deleteParticularSession: async (tokenHash: string) => {
+        deletedHashes.push(tokenHash);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/logout",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.particularCookieName}=particular-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Sesión particular cerrada correctamente",
+      });
+
+      assert.deepEqual(deletedHashes, ["hash:particular-session-token"]);
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.particularCookieName}=`));
+      assert.ok(setCookie.includes("Max-Age=0"));
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes expone preview-url cuando hay informe vinculado",
+  async () => {
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getParticularSessionByToken: async () => ({
+        particularTokenId: 7,
+        expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+        lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+      }),
+      getParticularTokenById: async () => ({
+        id: 7,
+        clinicId: 3,
+        reportId: 55,
+        isActive: true,
+      }),
+      updateParticularSessionLastAccess: async () => {},
+      getReportById: async () => report,
+      createSignedReportUrl: async (storagePath: string) => {
+        assert.equal(storagePath, report.storagePath);
+        return "https://signed.example/preview";
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/particular/auth/report/preview-url",
+        headers: {
+          cookie: `${ENV.particularCookieName}=particular-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        previewUrl: "https://signed.example/preview",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes expone download-url cuando hay informe vinculado",
+  async () => {
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getParticularSessionByToken: async () => ({
+        particularTokenId: 7,
+        expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
+        lastAccess: new Date(Date.UTC(2026, 3, 23, 23, 0, 0)),
+      }),
+      getParticularTokenById: async () => ({
+        id: 7,
+        clinicId: 3,
+        reportId: 55,
+        isActive: true,
+      }),
+      updateParticularSessionLastAccess: async () => {},
+      getReportById: async () => report,
+      createSignedReportDownloadUrl: async (
+        storagePath: string,
+        fileName?: string,
+      ) => {
+        assert.equal(storagePath, report.storagePath);
+        assert.equal(fileName, report.fileName);
+        return "https://signed.example/download";
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/particular/auth/report/download-url",
+        headers: {
+          cookie: `${ENV.particularCookieName}=particular-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        downloadUrl: "https://signed.example/download",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes aplica rate limit de login sobre intentos fallidos",
+  async () => {
+    const app = await createTestApp({
+      now: () => 0,
+      loginRateLimitWindowMs: 60_000,
+      loginRateLimitMaxAttempts: 2,
+      getParticularTokenByTokenHash: async () => null,
+    });
+
+    try {
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.30",
+        payload: {
+          token: "bad-1",
+        },
+      });
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.30",
+        payload: {
+          token: "bad-2",
+        },
+      });
+
+      const third = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.30",
+        payload: {
+          token: "bad-3",
+        },
+      });
+
+      assert.equal(first.statusCode, 401);
+      assert.equal(second.statusCode, 401);
+      assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["ratelimit-limit"], "2");
+      assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(third.body), {
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- move the full `/api/particular/auth/*` subtree to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for particular auth routing, cookie/session behavior, linked report URLs and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/particular-auth.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the full particular auth subtree to Fastify while preserving the existing particular-facing contract and leaving the Express bridge intact for the rest of the API.
