### PR TITLE
feat(http): move public report access routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -22,6 +22,10 @@ import {
   publicProfessionalsNativeRoutes,
   type PublicProfessionalsNativeRoutesOptions,
 } from "./routes/public-professionals.fastify.ts";
+import {
+  publicReportAccessNativeRoutes,
+  type PublicReportAccessNativeRoutesOptions,
+} from "./routes/public-report-access.fastify.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -47,6 +51,7 @@ export type CreateFastifyAppOptions = {
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   particularAuthRoutes?: ParticularAuthNativeRoutesOptions;
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
+  publicReportAccessRoutes?: PublicReportAccessNativeRoutesOptions;
 };
 
 const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
@@ -55,6 +60,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/auth",
   "/particular/auth",
   "/public/professionals",
+  "/public/report-access",
 ];
 
 function shouldBypassLegacyApi(url: unknown) {
@@ -135,6 +141,11 @@ export async function createFastifyApp(
   await app.register(publicProfessionalsNativeRoutes, {
     prefix: "/api/public/professionals",
     ...(options.publicProfessionalsRoutes ?? {}),
+  });
+
+  await app.register(publicReportAccessNativeRoutes, {
+    prefix: "/api/public/report-access",
+    ...(options.publicReportAccessRoutes ?? {}),
   });
 
   await app.register(fastifyExpress);

--- a/server/routes/public-report-access.fastify.ts
+++ b/server/routes/public-report-access.fastify.ts
@@ -1,0 +1,435 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+import type { Report, ReportAccessToken } from "../../drizzle/schema";
+
+import {
+  AUDIT_EVENTS,
+  buildPublicReportAccessTokenActor,
+} from "../lib/audit.ts";
+import { hashSessionToken as defaultHashSessionToken } from "../lib/auth-security.ts";
+import {
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_MAX_ATTEMPTS,
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_WINDOW_MS,
+} from "../lib/public-report-access-rate-limit.ts";
+import {
+  canAccessReportPublicly,
+  getReportAccessTokenState,
+  reportAccessTokenRawTokenSchema,
+  serializePublicReportAccess,
+} from "../lib/report-access-token.ts";
+import {
+  createSignedReportDownloadUrl as defaultCreateSignedReportDownloadUrl,
+  createSignedReportUrl as defaultCreateSignedReportUrl,
+} from "../lib/supabase.ts";
+import { ENV } from "../lib/env.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ReportAccessTokenWithReportRecord = {
+  token: ReportAccessToken;
+  report: Report;
+};
+
+type PublicReportAccessAuditInput = {
+  event: string;
+  clinicId?: number | null;
+  reportId?: number | null;
+  targetReportAccessTokenId?: number | null;
+  actor?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+};
+
+export type PublicReportAccessNativeRoutesOptions = {
+  getReportAccessTokenWithReportByTokenHash?: (
+    tokenHash: string,
+  ) => Promise<ReportAccessTokenWithReportRecord | null>;
+  recordReportAccessTokenAccess?: (
+    tokenId: number,
+  ) => Promise<ReportAccessToken | null>;
+  createSignedReportUrl?: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl?: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+  hashSessionToken?: (token: string) => string;
+  writeAuditLog?: (
+    req: unknown,
+    input: PublicReportAccessAuditInput,
+  ) => Promise<void>;
+  publicReportAccessRateLimitWindowMs?: number;
+  publicReportAccessRateLimitMaxAttempts?: number;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__publicReportAccessRequestStartTimeNs";
+
+type PublicReportAccessFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativePublicReportAccessDeps = Required<
+  Pick<
+    PublicReportAccessNativeRoutesOptions,
+    | "getReportAccessTokenWithReportByTokenHash"
+    | "recordReportAccessTokenAccess"
+    | "createSignedReportUrl"
+    | "createSignedReportDownloadUrl"
+    | "hashSessionToken"
+    | "writeAuditLog"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativePublicReportAccessDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativePublicReportAccessDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const dbReportAccess = await import("../db-report-access.ts");
+      const audit = await import("../lib/audit.ts");
+
+      return {
+        getReportAccessTokenWithReportByTokenHash:
+          dbReportAccess.getReportAccessTokenWithReportByTokenHash,
+        recordReportAccessTokenAccess:
+          dbReportAccess.recordReportAccessTokenAccess,
+        createSignedReportUrl: defaultCreateSignedReportUrl,
+        createSignedReportDownloadUrl: defaultCreateSignedReportDownloadUrl,
+        hashSessionToken: defaultHashSessionToken,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: PublicReportAccessAuditInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+  );
+}
+
+function setRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    count: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header(
+    "RateLimit-Remaining",
+    String(Math.max(input.max - input.count, 0)),
+  );
+  reply.header(
+    "RateLimit-Reset",
+    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+  );
+}
+
+function getAccessEntry(
+  attempts: Map<string, { count: number; resetAt: number }>,
+  key: string,
+  windowMs: number,
+  now: number,
+) {
+  const current = attempts.get(key);
+
+  if (!current || current.resetAt <= now) {
+    const fresh = {
+      count: 0,
+      resetAt: now + windowMs,
+    };
+    attempts.set(key, fresh);
+    return fresh;
+  }
+
+  return current;
+}
+
+export const publicReportAccessNativeRoutes: FastifyPluginAsync<
+  PublicReportAccessNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.getReportAccessTokenWithReportByTokenHash &&
+    !!options.recordReportAccessTokenAccess &&
+    !!options.createSignedReportUrl &&
+    !!options.createSignedReportDownloadUrl &&
+    !!options.hashSessionToken &&
+    !!options.writeAuditLog;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativePublicReportAccessDeps = {
+    getReportAccessTokenWithReportByTokenHash:
+      options.getReportAccessTokenWithReportByTokenHash ??
+      defaultDeps!.getReportAccessTokenWithReportByTokenHash,
+    recordReportAccessTokenAccess:
+      options.recordReportAccessTokenAccess ??
+      defaultDeps!.recordReportAccessTokenAccess,
+    createSignedReportUrl:
+      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
+    createSignedReportDownloadUrl:
+      options.createSignedReportDownloadUrl ??
+      defaultDeps!.createSignedReportDownloadUrl,
+    hashSessionToken: options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const publicReportAccessRateLimitWindowMs =
+    options.publicReportAccessRateLimitWindowMs ??
+    PUBLIC_REPORT_ACCESS_RATE_LIMIT_WINDOW_MS;
+  const publicReportAccessRateLimitMaxAttempts =
+    options.publicReportAccessRateLimitMaxAttempts ??
+    PUBLIC_REPORT_ACCESS_RATE_LIMIT_MAX_ATTEMPTS;
+  const allowedOrigins = new Set(getAllowedOrigins());
+  const accessAttempts = new Map<string, { count: number; resetAt: number }>();
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as PublicReportAccessFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as PublicReportAccessFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  app.options("/:token", async (request, reply) => {
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  });
+
+  app.get<{
+    Params: {
+      token: string;
+    };
+  }>("/:token", async (request, reply) => {
+    const rateLimitKey = request.ip || "unknown";
+    const currentTime = now();
+    const accessEntry = getAccessEntry(
+      accessAttempts,
+      rateLimitKey,
+      publicReportAccessRateLimitWindowMs,
+      currentTime,
+    );
+
+    if (accessEntry.count >= publicReportAccessRateLimitMaxAttempts) {
+      setRateLimitHeaders(reply, {
+        max: publicReportAccessRateLimitMaxAttempts,
+        windowMs: publicReportAccessRateLimitWindowMs,
+        count: accessEntry.count,
+        resetAt: accessEntry.resetAt,
+        now: currentTime,
+      });
+
+      return reply.code(429).send({
+        success: false,
+        error: PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    }
+
+    accessEntry.count += 1;
+
+    setRateLimitHeaders(reply, {
+      max: publicReportAccessRateLimitMaxAttempts,
+      windowMs: publicReportAccessRateLimitWindowMs,
+      count: accessEntry.count,
+      resetAt: accessEntry.resetAt,
+      now: currentTime,
+    });
+
+    const parsed = reportAccessTokenRawTokenSchema.safeParse(request.params.token);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: "Token de acceso inválido",
+      });
+    }
+
+    const tokenHash = deps.hashSessionToken(parsed.data);
+    const record = await deps.getReportAccessTokenWithReportByTokenHash(tokenHash);
+
+    if (!record) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    }
+
+    const tokenState = getReportAccessTokenState(record.token);
+
+    if (tokenState === "revoked") {
+      return reply.code(410).send({
+        success: false,
+        error: "El token público de informe fue revocado",
+      });
+    }
+
+    if (tokenState === "expired") {
+      return reply.code(410).send({
+        success: false,
+        error: "El token público de informe expiró",
+      });
+    }
+
+    if (!canAccessReportPublicly(record.report.currentStatus)) {
+      return reply.code(409).send({
+        success: false,
+        error: "El informe todavía no está disponible para acceso público",
+        currentStatus: record.report.currentStatus,
+      });
+    }
+
+    const updatedToken = await deps.recordReportAccessTokenAccess(record.token.id);
+    const [previewUrl, downloadUrl] = await Promise.all([
+      deps.createSignedReportUrl(record.report.storagePath),
+      deps.createSignedReportDownloadUrl(
+        record.report.storagePath,
+        record.report.fileName ?? undefined,
+      ),
+    ]);
+
+    await deps.writeAuditLog(request, {
+      event: AUDIT_EVENTS.REPORT_PUBLIC_ACCESSED,
+      clinicId: record.token.clinicId,
+      reportId: record.token.reportId,
+      targetReportAccessTokenId: record.token.id,
+      actor: buildPublicReportAccessTokenActor(record.token.id),
+      metadata: {
+        tokenLast4: record.token.tokenLast4,
+        accessCount: updatedToken?.accessCount ?? record.token.accessCount + 1,
+        lastAccessAt: updatedToken?.lastAccessAt ?? new Date(currentTime),
+      },
+    });
+
+    return reply.code(200).send({
+      success: true,
+      report: serializePublicReportAccess({
+        report: record.report,
+        previewUrl,
+        downloadUrl,
+      }),
+      token: {
+        accessCount: updatedToken?.accessCount ?? record.token.accessCount + 1,
+        lastAccessAt: updatedToken?.lastAccessAt ?? new Date(currentTime),
+        expiresAt: record.token.expiresAt,
+      },
+    });
+  });
+};

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -70,6 +70,20 @@ function buildParticularAuthRouteStubs() {
   };
 }
 
+function buildPublicReportAccessRouteStubs() {
+  return {
+    getReportAccessTokenWithReportByTokenHash: async () => null,
+    recordReportAccessTokenAccess: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    hashSessionToken: (token: string) => `hash:${token}`,
+    writeAuditLog: async () => {},
+  };
+}
+
 test(
   "createFastifyApp expone root y health nativos y mantiene el bridge Express bajo /api",
   async () => {
@@ -116,6 +130,7 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
     });
 
     try {
@@ -196,6 +211,7 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
     });
 
     try {
@@ -269,6 +285,7 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
     });
 
     try {
@@ -377,6 +394,7 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
     });
 
     try {
@@ -434,6 +452,7 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
     });
 
     try {
@@ -468,3 +487,116 @@ test(
     }
   },
 );
+
+test(
+  "createFastifyApp despacha /api/public/report-access al router nativo antes del bridge Express",
+  async () => {
+    const rawToken = "a".repeat(64);
+
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/public/report-access/:token", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: {
+        ...buildPublicReportAccessRouteStubs(),
+        getReportAccessTokenWithReportByTokenHash: async () => ({
+          token: {
+            id: 9,
+            clinicId: 3,
+            reportId: 55,
+            tokenLast4: "ABCD",
+            accessCount: 2,
+            lastAccessAt: new Date("2026-04-22T10:00:00.000Z"),
+            expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+            revokedAt: null,
+            createdAt: new Date("2026-04-20T12:00:00.000Z"),
+            updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+            createdByClinicUserId: 5,
+            createdByAdminUserId: null,
+            revokedByClinicUserId: null,
+            revokedByAdminUserId: null,
+          },
+          report: {
+            id: 55,
+            clinicId: 3,
+            uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+            studyType: "Histopatología",
+            patientName: "Luna",
+            fileName: "luna-report.pdf",
+            currentStatus: "ready",
+            statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+            createdAt: new Date("2026-04-22T09:00:00.000Z"),
+            updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+            storagePath: "reports/report-55.pdf",
+          },
+        }),
+        recordReportAccessTokenAccess: async () => ({
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "ABCD",
+          accessCount: 3,
+          lastAccessAt: new Date("2026-04-24T00:00:00.000Z"),
+          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          revokedAt: null,
+          createdAt: new Date("2026-04-20T12:00:00.000Z"),
+          updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+          createdByClinicUserId: 5,
+          createdByAdminUserId: null,
+          revokedByClinicUserId: null,
+          revokedByAdminUserId: null,
+        }),
+        createSignedReportUrl: async () => "https://signed.example/preview",
+        createSignedReportDownloadUrl: async () =>
+          "https://signed.example/download",
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 404, 410, 409].includes(response.statusCode));
+
+      if (response.statusCode === 200 && response.body) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.report.id, 55);
+        assert.equal(body.report.previewUrl, "https://signed.example/preview");
+        assert.equal(
+          body.report.downloadUrl,
+          "https://signed.example/download",
+        );
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+

--- a/test/public-report-access.fastify.test.ts
+++ b/test/public-report-access.fastify.test.ts
@@ -1,0 +1,295 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const {
+  PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/public-report-access-rate-limit.ts");
+const {
+  publicReportAccessNativeRoutes,
+} = await import("../server/routes/public-report-access.fastify.ts");
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatología",
+    patientName: "Luna",
+    fileName: "luna-report.pdf",
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+    storagePath: "reports/report-55.pdf",
+    ...overrides,
+  };
+}
+
+function createReportAccessTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 9,
+    clinicId: 3,
+    reportId: 55,
+    tokenLast4: "ABCD",
+    accessCount: 2,
+    lastAccessAt: new Date("2026-04-22T10:00:00.000Z"),
+    expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+    revokedAt: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    createdByClinicUserId: 5,
+    createdByAdminUserId: null,
+    revokedByClinicUserId: null,
+    revokedByAdminUserId: null,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(publicReportAccessNativeRoutes as any, {
+    prefix: "/api/public/report-access",
+    getReportAccessTokenWithReportByTokenHash: async () => null,
+    recordReportAccessTokenAccess: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    hashSessionToken: (token: string) => `hash:${token}`,
+    writeAuditLog: async () => {},
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "publicReportAccessNativeRoutes responde acceso público con payload estable, urls firmadas y auditoria",
+  async () => {
+    const rawToken = "a".repeat(64);
+    const report = createReportFixture();
+    const token = createReportAccessTokenFixture();
+    const auditCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 3, 24, 0, 0, 0),
+      hashSessionToken: (value: string) => `hash:${value}`,
+      getReportAccessTokenWithReportByTokenHash: async (tokenHash: string) => {
+        assert.equal(tokenHash, `hash:${rawToken}`);
+        return { token, report };
+      },
+      recordReportAccessTokenAccess: async (tokenId: number) => {
+        assert.equal(tokenId, token.id);
+        return {
+          ...token,
+          accessCount: 3,
+          lastAccessAt: new Date("2026-04-24T00:00:00.000Z"),
+        };
+      },
+      createSignedReportUrl: async (storagePath: string) => {
+        assert.equal(storagePath, report.storagePath);
+        return "https://signed.example/preview";
+      },
+      createSignedReportDownloadUrl: async (
+        storagePath: string,
+        fileName?: string,
+      ) => {
+        assert.equal(storagePath, report.storagePath);
+        assert.equal(fileName, report.fileName);
+        return "https://signed.example/download";
+      },
+      writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+        auditCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+        headers: {
+          origin: "http://localhost:3000",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+      assert.equal(response.headers["ratelimit-limit"], "10");
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        report: {
+          id: report.id,
+          clinicId: report.clinicId,
+          uploadDate: report.uploadDate.toISOString(),
+          studyType: report.studyType,
+          patientName: report.patientName,
+          fileName: report.fileName,
+          currentStatus: report.currentStatus,
+          statusChangedAt: report.statusChangedAt.toISOString(),
+          createdAt: report.createdAt.toISOString(),
+          updatedAt: report.updatedAt.toISOString(),
+          previewUrl: "https://signed.example/preview",
+          downloadUrl: "https://signed.example/download",
+        },
+        token: {
+          accessCount: 3,
+          lastAccessAt: "2026-04-24T00:00:00.000Z",
+          expiresAt: token.expiresAt.toISOString(),
+        },
+      });
+
+      assert.equal(auditCalls.length, 1);
+      assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_PUBLIC_ACCESSED);
+      assert.equal(auditCalls[0].clinicId, token.clinicId);
+      assert.equal(auditCalls[0].reportId, token.reportId);
+      assert.equal(auditCalls[0].targetReportAccessTokenId, token.id);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "publicReportAccessNativeRoutes devuelve 400 cuando el token es invalido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/report-access/token-invalido",
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Token de acceso inválido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "publicReportAccessNativeRoutes devuelve 410 cuando el token fue revocado",
+  async () => {
+    const rawToken = "b".repeat(64);
+    const report = createReportFixture();
+    const token = createReportAccessTokenFixture({
+      revokedAt: new Date("2026-04-23T00:00:00.000Z"),
+    });
+
+    const app = await createTestApp({
+      getReportAccessTokenWithReportByTokenHash: async () => ({ token, report }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+      });
+
+      assert.equal(response.statusCode, 410);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "El token público de informe fue revocado",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "publicReportAccessNativeRoutes devuelve 409 cuando el informe no está disponible públicamente",
+  async () => {
+    const rawToken = "c".repeat(64);
+    const report = createReportFixture({
+      currentStatus: "draft",
+    });
+    const token = createReportAccessTokenFixture();
+
+    const app = await createTestApp({
+      getReportAccessTokenWithReportByTokenHash: async () => ({ token, report }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+      });
+
+      assert.equal(response.statusCode, 409);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "El informe todavía no está disponible para acceso público",
+        currentStatus: "draft",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "publicReportAccessNativeRoutes aplica rate limit nativo fijo por IP",
+  async () => {
+    const rawToken = "d".repeat(64);
+
+    const app = await createTestApp({
+      now: () => 0,
+      publicReportAccessRateLimitWindowMs: 60_000,
+      publicReportAccessRateLimitMaxAttempts: 2,
+      getReportAccessTokenWithReportByTokenHash: async () => null,
+    });
+
+    try {
+      const first = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+        remoteAddress: "203.0.113.40",
+      });
+
+      const second = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+        remoteAddress: "203.0.113.40",
+      });
+
+      const third = await app.inject({
+        method: "GET",
+        url: `/api/public/report-access/${rawToken}`,
+        remoteAddress: "203.0.113.40",
+      });
+
+      assert.equal(first.statusCode, 404);
+      assert.equal(second.statusCode, 404);
+      assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["ratelimit-limit"], "2");
+      assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(third.body), {
+        success: false,
+        error: PUBLIC_REPORT_ACCESS_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- move `/api/public/report-access/:token` to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for public report access routing, rate limit, signed URLs, audit logging and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/public-report-access.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the public report access subtree to Fastify while preserving the existing public-facing contract and leaving the Express bridge intact for the rest of the API.
