### PR TITLE
feat(http): move clinic audit routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -15,6 +15,10 @@ import {
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
 import {
+  clinicAuditNativeRoutes,
+  type ClinicAuditNativeRoutesOptions,
+} from "./routes/clinic-audit.fastify.ts";
+import {
   clinicPublicProfileNativeRoutes,
   type ClinicPublicProfileNativeRoutesOptions,
 } from "./routes/clinic-public-profile.fastify.ts";
@@ -53,6 +57,7 @@ export type CreateFastifyAppOptions = {
   getServiceInfoPayload?: ServiceInfoFactory;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
+  clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
   particularAuthRoutes?: ParticularAuthNativeRoutesOptions;
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
@@ -63,6 +68,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/health",
   "/admin/auth",
   "/auth",
+  "/clinic/audit-log",
   "/clinic/profile",
   "/particular/auth",
   "/public/professionals",
@@ -137,6 +143,11 @@ export async function createFastifyApp(
   await app.register(clinicAuthNativeRoutes, {
     prefix: "/api/auth",
     ...(options.clinicAuthRoutes ?? {}),
+  });
+
+  await app.register(clinicAuditNativeRoutes, {
+    prefix: "/api/clinic/audit-log",
+    ...(options.clinicAuditRoutes ?? {}),
   });
 
   await app.register(clinicPublicProfileNativeRoutes, {

--- a/server/routes/clinic-audit.fastify.ts
+++ b/server/routes/clinic-audit.fastify.ts
@@ -1,0 +1,458 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import {
+  buildAdminAuditCsv as defaultBuildAdminAuditCsv,
+  buildClinicAuditListFilters as defaultBuildClinicAuditListFilters,
+  type AdminAuditListFilters,
+  type AuditLogListItem,
+} from "../lib/admin-audit.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuditListResult = {
+  items: AuditLogListItem[];
+  total: number;
+};
+
+type AuthenticatedClinicUser = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId: string | null;
+  role: ReturnType<typeof normalizeClinicUserRole>;
+  permissions: ReturnType<typeof getClinicPermissions>;
+  canUploadReports: boolean;
+  canManageClinicUsers: boolean;
+  sessionToken: string;
+};
+
+export type ClinicAuditNativeRoutesOptions = {
+  deleteActiveSession?: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById?: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  listAuditLog?: (filters: AdminAuditListFilters) => Promise<AuditListResult>;
+  buildClinicAuditListFilters?: (
+    query: Record<string, unknown>,
+    clinicId: number,
+  ) => {
+    filters: AdminAuditListFilters;
+    errors: string[];
+  };
+  buildAdminAuditCsv?: (items: AuditLogListItem[]) => string;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__clinicAuditRequestStartTimeNs";
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+const CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
+
+type ClinicAuditFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeClinicAuditDeps = Required<
+  Pick<
+    ClinicAuditNativeRoutesOptions,
+    | "deleteActiveSession"
+    | "getActiveSessionByToken"
+    | "getClinicUserById"
+    | "updateSessionLastAccess"
+    | "hashSessionToken"
+    | "listAuditLog"
+    | "buildClinicAuditListFilters"
+    | "buildAdminAuditCsv"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeClinicAuditDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeClinicAuditDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbAudit = await import("../db-audit.ts");
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        listAuditLog: dbAudit.listAuditLog,
+        buildClinicAuditListFilters: defaultBuildClinicAuditListFilters,
+        buildAdminAuditCsv: defaultBuildAdminAuditCsv,
+      };
+    })();
+  }
+
+  return defaultDepsPromise!;
+}
+
+function buildClinicAuditCsvFilename(now = new Date()): string {
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  return `clinic-audit-log-${timestamp}.csv`;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const envCookieName = process.env.COOKIE_NAME?.trim() || "vetneb_session";
+  const raw = cookies[envCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const sameSite = process.env.COOKIE_SAME_SITE?.trim() || "Lax";
+  const secure =
+    (process.env.COOKIE_SECURE?.trim() || "").toLowerCase() === "true";
+
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${sameSite}`,
+  ];
+
+  if (secure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearSessionCookie() {
+  const envCookieName = process.env.COOKIE_NAME?.trim() || "vetneb_session";
+
+  return serializeCookie({
+    name: envCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateClinicUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeClinicAuditDeps,
+  now: () => number,
+): Promise<AuthenticatedClinicUser | null> {
+  const token = getSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "No autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getActiveSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión expirada",
+    });
+    return null;
+  }
+
+  const clinicUser = await deps.getClinicUserById(session.clinicUserId);
+
+  if (!clinicUser) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateSessionLastAccess(tokenHash);
+  }
+
+  const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+  const permissions = getClinicPermissions(role);
+
+  return {
+    id: clinicUser.id,
+    clinicId: clinicUser.clinicId,
+    username: clinicUser.username,
+    authProId: clinicUser.authProId ?? null,
+    role,
+    permissions,
+    canUploadReports: permissions.canUploadReports,
+    canManageClinicUsers: permissions.canManageClinicUsers,
+    sessionToken: token,
+  };
+}
+
+export const clinicAuditNativeRoutes: FastifyPluginAsync<
+  ClinicAuditNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.listAuditLog &&
+    !!options.buildClinicAuditListFilters &&
+    !!options.buildAdminAuditCsv;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeClinicAuditDeps = {
+    deleteActiveSession:
+      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
+    getActiveSessionByToken:
+      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
+    getClinicUserById:
+      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
+    updateSessionLastAccess:
+      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    listAuditLog: options.listAuditLog ?? defaultDeps!.listAuditLog,
+    buildClinicAuditListFilters:
+      options.buildClinicAuditListFilters ??
+      defaultDeps!.buildClinicAuditListFilters,
+    buildAdminAuditCsv:
+      options.buildAdminAuditCsv ?? defaultDeps!.buildAdminAuditCsv,
+  };
+
+  const now = options.now ?? (() => Date.now());
+
+  app.addHook("onRequest", async (request) => {
+    (request as ClinicAuditFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as ClinicAuditFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  app.get<{
+    Querystring: Record<string, unknown>;
+  }>("/export.csv", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const { filters, errors } = deps.buildClinicAuditListFilters(
+      request.query ?? {},
+      auth.clinicId,
+    );
+
+    if (errors.length > 0) {
+      return reply.code(400).send({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const exportFilters: AdminAuditListFilters = {
+      ...filters,
+      limit: CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS,
+      offset: 0,
+    };
+
+    const result = await deps.listAuditLog(exportFilters);
+
+    if (result.total > CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS) {
+      return reply.code(400).send({
+        success: false,
+        error: `Demasiados registros para exportar. Aplica filtros mas especificos (maximo ${CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS}).`,
+      });
+    }
+
+    const csv = deps.buildAdminAuditCsv(result.items);
+    const filename = buildClinicAuditCsvFilename();
+
+    reply.header("content-type", "text/csv; charset=utf-8");
+    reply.header(
+      "content-disposition",
+      `attachment; filename="${filename}"`,
+    );
+
+    return reply.code(200).send(csv);
+  });
+
+  app.get<{
+    Querystring: Record<string, unknown>;
+  }>("/", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const { filters, errors } = deps.buildClinicAuditListFilters(
+      request.query ?? {},
+      auth.clinicId,
+    );
+
+    if (errors.length > 0) {
+      return reply.code(400).send({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const result = await deps.listAuditLog(filters);
+
+    return reply.code(200).send({
+      success: true,
+      count: result.items.length,
+      items: result.items,
+      pagination: {
+        limit: filters.limit,
+        offset: filters.offset,
+        total: result.total,
+      },
+      filters: {
+        event: filters.event ?? null,
+        actorType: filters.actorType ?? null,
+        clinicId: auth.clinicId,
+        reportId: filters.reportId ?? null,
+        actorClinicUserId: filters.actorClinicUserId ?? null,
+        actorReportAccessTokenId: filters.actorReportAccessTokenId ?? null,
+        targetReportAccessTokenId: filters.targetReportAccessTokenId ?? null,
+        from: filters.from ?? null,
+        to: filters.to ?? null,
+      },
+    });
+  });
+};

--- a/test/clinic-audit.fastify.test.ts
+++ b/test/clinic-audit.fastify.test.ts
@@ -1,0 +1,291 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.COOKIE_NAME ??= "vetneb_session";
+process.env.COOKIE_SAME_SITE ??= "Lax";
+process.env.COOKIE_SECURE ??= "false";
+
+const {
+  clinicAuditNativeRoutes,
+} = await import("../server/routes/clinic-audit.fastify.ts");
+
+function createAuditItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    event: "report.public_accessed",
+    action: "report.public_accessed",
+    entity: "report_access_token",
+    entityId: 55,
+    actorType: "public_report_access_token",
+    actorAdminUserId: null,
+    actorClinicUserId: null,
+    actorReportAccessTokenId: 9,
+    clinicId: 3,
+    reportId: 55,
+    targetAdminUserId: null,
+    targetClinicUserId: null,
+    targetReportAccessTokenId: 9,
+    requestId: "req-1",
+    requestMethod: "GET",
+    requestPath: "/api/public/report-access/[REDACTED]",
+    ipAddress: "127.0.0.1",
+    userAgent: "test-agent",
+    metadata: {
+      tokenLast4: "ABCD",
+    },
+    createdAt: new Date("2026-04-24T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => ({
+      clinicUserId: 9,
+      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(clinicAuditNativeRoutes as any, {
+    prefix: "/api/clinic/audit-log",
+    ...createAuthStubs(),
+    listAuditLog: async () => ({
+      items: [createAuditItem()],
+      total: 1,
+    }),
+    buildClinicAuditListFilters: (
+      _query: Record<string, unknown>,
+      clinicId: number,
+    ) => ({
+      filters: {
+        clinicId,
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAdminAuditCsv: (items: Array<Record<string, unknown>>) =>
+      `id,event\n${items[0].id},${items[0].event}`,
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "clinicAuditNativeRoutes expone GET / con payload estable y filtros clinic-scoped",
+  async () => {
+    const filterCalls: Array<Record<string, unknown>> = [];
+    const listCalls: Array<Record<string, unknown>> = [];
+    const item = createAuditItem();
+
+    const app = await createTestApp({
+      buildClinicAuditListFilters: (
+        query: Record<string, unknown>,
+        clinicId: number,
+      ) => {
+        filterCalls.push({ query, clinicId });
+
+        return {
+          filters: {
+            clinicId,
+            event: "report.public_accessed",
+            actorType: "public_report_access_token",
+            reportId: 55,
+            actorClinicUserId: undefined,
+            actorReportAccessTokenId: 9,
+            targetReportAccessTokenId: 9,
+            from: new Date("2026-04-01T00:00:00.000Z"),
+            to: new Date("2026-04-30T23:59:59.000Z"),
+            limit: 25,
+            offset: 5,
+          },
+          errors: [],
+        };
+      },
+      listAuditLog: async (filters: Record<string, unknown>) => {
+        listCalls.push(filters);
+
+        return {
+          items: [{ ...item, createdAt: "2026-04-24T00:00:00.000Z" }],
+          total: 1,
+        };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log?event=report.public_accessed&limit=25&offset=5",
+        headers: {
+          cookie: "vetneb_session=session-token",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(filterCalls.length, 1);
+      assert.equal(filterCalls[0].clinicId, 3);
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].clinicId, 3);
+      assert.equal(listCalls[0].limit, 25);
+      assert.equal(listCalls[0].offset, 5);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        count: 1,
+        items: [{ ...item, createdAt: "2026-04-24T00:00:00.000Z" }],
+        pagination: {
+          limit: 25,
+          offset: 5,
+          total: 1,
+        },
+        filters: {
+          event: "report.public_accessed",
+          actorType: "public_report_access_token",
+          clinicId: 3,
+          reportId: 55,
+          actorClinicUserId: null,
+          actorReportAccessTokenId: 9,
+          targetReportAccessTokenId: 9,
+          from: "2026-04-01T00:00:00.000Z",
+          to: "2026-04-30T23:59:59.000Z",
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuditNativeRoutes exporta GET /export.csv con headers y límite fijo",
+  async () => {
+    const listCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      listAuditLog: async (filters: Record<string, unknown>) => {
+        listCalls.push(filters);
+
+        return {
+          items: [createAuditItem()],
+          total: 1,
+        };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log/export.csv",
+        headers: {
+          cookie: "vetneb_session=session-token",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["content-type"], "text/csv; charset=utf-8");
+      assert.match(
+        String(response.headers["content-disposition"] ?? ""),
+        /^attachment; filename="clinic-audit-log-/,
+      );
+
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].clinicId, 3);
+      assert.equal(listCalls[0].limit, 10000);
+      assert.equal(listCalls[0].offset, 0);
+
+      assert.equal(response.body, "id,event\n101,report.public_accessed");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuditNativeRoutes devuelve 400 cuando los filtros son inválidos",
+  async () => {
+    const app = await createTestApp({
+      buildClinicAuditListFilters: () => ({
+        filters: {
+          clinicId: 3,
+          limit: 50,
+          offset: 0,
+        },
+        errors: ["event invalido"],
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log?event=bad",
+        headers: {
+          cookie: "vetneb_session=session-token",
+        },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "event invalido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuditNativeRoutes devuelve 400 cuando export.csv supera el máximo permitido",
+  async () => {
+    const app = await createTestApp({
+      listAuditLog: async () => ({
+        items: [createAuditItem()],
+        total: 10001,
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log/export.csv",
+        headers: {
+          cookie: "vetneb_session=session-token",
+        },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error:
+          "Demasiados registros para exportar. Aplica filtros mas especificos (maximo 10000).",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -50,6 +50,32 @@ function buildClinicAuthRouteStubs() {
   };
 }
 
+function buildClinicAuditRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAuditLog: async () => ({
+      items: [],
+      total: 0,
+    }),
+    buildClinicAuditListFilters: (
+      _query: Record<string, unknown>,
+      clinicId: number,
+    ) => ({
+      filters: {
+        clinicId,
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAdminAuditCsv: () => "id,event",
+  };
+}
+
 function buildClinicPublicProfileRouteStubs() {
   return {
     deleteActiveSession: async () => {},
@@ -180,6 +206,7 @@ test(
       }),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
@@ -262,6 +289,7 @@ test(
         updateAdminSessionLastAccess: async () => {},
       },
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
@@ -337,6 +365,7 @@ test(
         }),
         updateSessionLastAccess: async () => {},
       },
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
@@ -388,6 +417,119 @@ test(
 );
 
 test(
+  "createFastifyApp despacha /api/clinic/audit-log al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/clinic/audit-log", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: {
+        ...buildClinicAuditRouteStubs(),
+        getActiveSessionByToken: async () => ({
+          clinicUserId: 9,
+          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getClinicUserById: async () => ({
+          id: 9,
+          clinicId: 3,
+          username: "doctor",
+          authProId: null,
+          role: "clinic_owner",
+        }),
+        listAuditLog: async () => ({
+          items: [
+            {
+              id: 101,
+              event: "report.public_accessed",
+              action: "report.public_accessed",
+              entity: "report_access_token",
+              entityId: 55,
+              actorType: "public_report_access_token",
+              actorAdminUserId: null,
+              actorClinicUserId: null,
+              actorReportAccessTokenId: 9,
+              clinicId: 3,
+              reportId: 55,
+              targetAdminUserId: null,
+              targetClinicUserId: null,
+              targetReportAccessTokenId: 9,
+              requestId: "req-1",
+              requestMethod: "GET",
+              requestPath: "/api/public/report-access/[REDACTED]",
+              ipAddress: "127.0.0.1",
+              userAgent: "test-agent",
+              metadata: { tokenLast4: "ABCD" },
+              createdAt: new Date("2026-04-24T00:00:00.000Z"),
+            },
+          ],
+          total: 1,
+        }),
+        buildClinicAuditListFilters: (
+          _query: Record<string, unknown>,
+          clinicId: number,
+        ) => ({
+          filters: {
+            clinicId,
+            limit: 50,
+            offset: 0,
+          },
+          errors: [],
+        }),
+      },
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log",
+        headers: {
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
+
+      if (response.statusCode === 200 && response.body) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.count, 1);
+        assert.equal(body.pagination.total, 1);
+        assert.equal(body.filters.clinicId, 3);
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "createFastifyApp despacha /api/clinic/profile al router nativo antes del bridge Express",
   async () => {
     const app = await createFastifyApp({
@@ -405,6 +547,7 @@ test(
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: {
         ...buildClinicPublicProfileRouteStubs(),
         getActiveSessionByToken: async () => ({
@@ -501,6 +644,7 @@ test(
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
       particularAuthRoutes: {
         ...buildParticularAuthRouteStubs(),
@@ -602,6 +746,7 @@ test(
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {
@@ -670,6 +815,7 @@ test(
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       publicProfessionalsRoutes: {


### PR DESCRIPTION
## Summary
- move `/api/clinic/audit-log/*` to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for clinic audit listing, CSV export, filter validation and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/clinic-audit.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the clinic audit subtree to Fastify while preserving the existing clinic-facing contract and leaving the Express bridge intact for the rest of the API.
