### PR TITLE
feat(http): move admin audit routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -7,6 +7,10 @@ import fastifyExpress from "@fastify/express";
 
 import { ENV } from "./lib/env.ts";
 import {
+  adminAuditNativeRoutes,
+  type AdminAuditNativeRoutesOptions,
+} from "./routes/admin-audit.fastify.ts";
+import {
   adminAuthNativeRoutes,
   type AdminAuthNativeRoutesOptions,
 } from "./routes/admin-auth.fastify.ts";
@@ -55,6 +59,7 @@ export type CreateFastifyAppOptions = {
   createLegacyApp?: LegacyAppFactory;
   getNativeHealthCheckResponse?: HealthCheckFactory;
   getServiceInfoPayload?: ServiceInfoFactory;
+  adminAuditRoutes?: AdminAuditNativeRoutesOptions;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
@@ -66,6 +71,7 @@ export type CreateFastifyAppOptions = {
 
 const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/health",
+  "/admin/audit-log",
   "/admin/auth",
   "/auth",
   "/clinic/audit-log",
@@ -134,6 +140,11 @@ export async function createFastifyApp(
 
   app.get("/health", nativeHealthHandler);
   app.get("/api/health", nativeHealthHandler);
+
+  await app.register(adminAuditNativeRoutes, {
+    prefix: "/api/admin/audit-log",
+    ...(options.adminAuditRoutes ?? {}),
+  });
 
   await app.register(adminAuthNativeRoutes, {
     prefix: "/api/admin/auth",

--- a/server/routes/admin-audit.fastify.ts
+++ b/server/routes/admin-audit.fastify.ts
@@ -1,0 +1,430 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import {
+  buildAdminAuditCsv as defaultBuildAdminAuditCsv,
+  buildAdminAuditCsvFilename as defaultBuildAdminAuditCsvFilename,
+  buildAdminAuditListFilters as defaultBuildAdminAuditListFilters,
+  type AdminAuditListFilters,
+  type AuditLogListItem,
+} from "../lib/admin-audit.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type AdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type AuditListResult = {
+  items: AuditLogListItem[];
+  total: number;
+};
+
+export type AdminAuditNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (adminUserId: number) => Promise<AdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  listAuditLog?: (filters: AdminAuditListFilters) => Promise<AuditListResult>;
+  buildAdminAuditListFilters?: (
+    query: Record<string, unknown>,
+  ) => {
+    filters: AdminAuditListFilters;
+    errors: string[];
+  };
+  buildAdminAuditCsv?: (items: AuditLogListItem[]) => string;
+  buildAdminAuditCsvFilename?: (now?: Date) => string;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__adminAuditRequestStartTimeNs";
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+const ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
+
+type AdminAuditFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeAdminAuditDeps = Required<
+  Pick<
+    AdminAuditNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "listAuditLog"
+    | "buildAdminAuditListFilters"
+    | "buildAdminAuditCsv"
+    | "buildAdminAuditCsvFilename"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminAuditDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminAuditDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbAudit = await import("../db-audit.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        listAuditLog: dbAudit.listAuditLog,
+        buildAdminAuditListFilters: defaultBuildAdminAuditListFilters,
+        buildAdminAuditCsv: defaultBuildAdminAuditCsv,
+        buildAdminAuditCsvFilename: defaultBuildAdminAuditCsvFilename,
+      };
+    })();
+  }
+
+  return defaultDepsPromise!;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminAuditDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+export const adminAuditNativeRoutes: FastifyPluginAsync<
+  AdminAuditNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.listAuditLog &&
+    !!options.buildAdminAuditListFilters &&
+    !!options.buildAdminAuditCsv &&
+    !!options.buildAdminAuditCsvFilename;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminAuditDeps = {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById:
+      options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    listAuditLog: options.listAuditLog ?? defaultDeps!.listAuditLog,
+    buildAdminAuditListFilters:
+      options.buildAdminAuditListFilters ??
+      defaultDeps!.buildAdminAuditListFilters,
+    buildAdminAuditCsv:
+      options.buildAdminAuditCsv ?? defaultDeps!.buildAdminAuditCsv,
+    buildAdminAuditCsvFilename:
+      options.buildAdminAuditCsvFilename ??
+      defaultDeps!.buildAdminAuditCsvFilename,
+  };
+
+  const now = options.now ?? (() => Date.now());
+
+  app.addHook("onRequest", async (request) => {
+    (request as AdminAuditFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as AdminAuditFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  app.get<{
+    Querystring: Record<string, unknown>;
+  }>("/export.csv", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const { filters, errors } = deps.buildAdminAuditListFilters(
+      request.query ?? {},
+    );
+
+    if (errors.length > 0) {
+      return reply.code(400).send({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const exportFilters: AdminAuditListFilters = {
+      ...filters,
+      limit: ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS,
+      offset: 0,
+    };
+
+    const result = await deps.listAuditLog(exportFilters);
+
+    if (result.total > ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS) {
+      return reply.code(400).send({
+        success: false,
+        error: `Demasiados registros para exportar. Aplica filtros mas especificos (maximo ${ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS}).`,
+      });
+    }
+
+    const csv = deps.buildAdminAuditCsv(result.items);
+    const filename = deps.buildAdminAuditCsvFilename();
+
+    reply.header("content-type", "text/csv; charset=utf-8");
+    reply.header(
+      "content-disposition",
+      `attachment; filename="${filename}"`,
+    );
+
+    return reply.code(200).send(csv);
+  });
+
+  app.get<{
+    Querystring: Record<string, unknown>;
+  }>("/", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const { filters, errors } = deps.buildAdminAuditListFilters(
+      request.query ?? {},
+    );
+
+    if (errors.length > 0) {
+      return reply.code(400).send({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const result = await deps.listAuditLog(filters);
+
+    return reply.code(200).send({
+      success: true,
+      count: result.items.length,
+      items: result.items,
+      pagination: {
+        limit: filters.limit,
+        offset: filters.offset,
+        total: result.total,
+      },
+      filters: {
+        event: filters.event ?? null,
+        actorType: filters.actorType ?? null,
+        clinicId: filters.clinicId ?? null,
+        reportId: filters.reportId ?? null,
+        actorAdminUserId: filters.actorAdminUserId ?? null,
+        actorClinicUserId: filters.actorClinicUserId ?? null,
+        actorReportAccessTokenId: filters.actorReportAccessTokenId ?? null,
+        targetReportAccessTokenId: filters.targetReportAccessTokenId ?? null,
+        from: filters.from ?? null,
+        to: filters.to ?? null,
+      },
+    });
+  });
+};

--- a/test/admin-audit.fastify.test.ts
+++ b/test/admin-audit.fastify.test.ts
@@ -1,0 +1,283 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  adminAuditNativeRoutes,
+} = await import("../server/routes/admin-audit.fastify.ts");
+
+function createAuditItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 201,
+    event: "auth.admin.login.succeeded",
+    action: "auth.admin.login.succeeded",
+    entity: "admin_user",
+    entityId: 1,
+    actorType: "admin_user",
+    actorAdminUserId: 1,
+    actorClinicUserId: null,
+    actorReportAccessTokenId: null,
+    clinicId: 3,
+    reportId: null,
+    targetAdminUserId: 1,
+    targetClinicUserId: null,
+    targetReportAccessTokenId: null,
+    requestId: "req-admin-1",
+    requestMethod: "POST",
+    requestPath: "/api/admin/auth/login",
+    ipAddress: "127.0.0.1",
+    userAgent: "test-agent",
+    metadata: {
+      username: "ADMIN",
+    },
+    createdAt: new Date("2026-04-24T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "ADMIN",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(adminAuditNativeRoutes as any, {
+    prefix: "/api/admin/audit-log",
+    ...createAuthStubs(),
+    listAuditLog: async () => ({
+      items: [createAuditItem()],
+      total: 1,
+    }),
+    buildAdminAuditListFilters: (_query: Record<string, unknown>) => ({
+      filters: {
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAdminAuditCsv: (items: Array<Record<string, unknown>>) =>
+      `id,event\n${items[0].id},${items[0].event}`,
+    buildAdminAuditCsvFilename: () => "admin-audit-log-test.csv",
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "adminAuditNativeRoutes expone GET / con payload estable y filtros globales",
+  async () => {
+    const filterCalls: Array<Record<string, unknown>> = [];
+    const listCalls: Array<Record<string, unknown>> = [];
+    const item = createAuditItem();
+
+    const app = await createTestApp({
+      buildAdminAuditListFilters: (query: Record<string, unknown>) => {
+        filterCalls.push({ query });
+
+        return {
+          filters: {
+            event: "auth.admin.login.succeeded",
+            actorType: "admin_user",
+            clinicId: 3,
+            reportId: null,
+            actorAdminUserId: 1,
+            actorClinicUserId: null,
+            actorReportAccessTokenId: null,
+            targetReportAccessTokenId: null,
+            from: new Date("2026-04-01T00:00:00.000Z"),
+            to: new Date("2026-04-30T23:59:59.000Z"),
+            limit: 25,
+            offset: 5,
+          },
+          errors: [],
+        };
+      },
+      listAuditLog: async (filters: Record<string, unknown>) => {
+        listCalls.push(filters);
+
+        return {
+          items: [item],
+          total: 1,
+        };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/audit-log?event=auth.admin.login.succeeded&limit=25&offset=5",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(filterCalls.length, 1);
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].actorAdminUserId, 1);
+      assert.equal(listCalls[0].limit, 25);
+      assert.equal(listCalls[0].offset, 5);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        count: 1,
+        items: [
+          {
+            ...item,
+            createdAt: "2026-04-24T00:00:00.000Z",
+          },
+        ],
+        pagination: {
+          limit: 25,
+          offset: 5,
+          total: 1,
+        },
+        filters: {
+          event: "auth.admin.login.succeeded",
+          actorType: "admin_user",
+          clinicId: 3,
+          reportId: null,
+          actorAdminUserId: 1,
+          actorClinicUserId: null,
+          actorReportAccessTokenId: null,
+          targetReportAccessTokenId: null,
+          from: "2026-04-01T00:00:00.000Z",
+          to: "2026-04-30T23:59:59.000Z",
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuditNativeRoutes exporta GET /export.csv con headers y límite fijo",
+  async () => {
+    const listCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      listAuditLog: async (filters: Record<string, unknown>) => {
+        listCalls.push(filters);
+
+        return {
+          items: [createAuditItem()],
+          total: 1,
+        };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/audit-log/export.csv",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["content-type"], "text/csv; charset=utf-8");
+      assert.equal(
+        response.headers["content-disposition"],
+        'attachment; filename="admin-audit-log-test.csv"',
+      );
+
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].limit, 10000);
+      assert.equal(listCalls[0].offset, 0);
+
+      assert.equal(response.body, "id,event\n201,auth.admin.login.succeeded");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuditNativeRoutes devuelve 400 cuando los filtros son inválidos",
+  async () => {
+    const app = await createTestApp({
+      buildAdminAuditListFilters: () => ({
+        filters: {
+          limit: 50,
+          offset: 0,
+        },
+        errors: ["event invalido"],
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/audit-log?event=bad",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "event invalido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuditNativeRoutes devuelve 400 cuando export.csv supera el máximo permitido",
+  async () => {
+    const app = await createTestApp({
+      listAuditLog: async () => ({
+        items: [createAuditItem()],
+        total: 10001,
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/audit-log/export.csv",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error:
+          "Demasiados registros para exportar. Aplica filtros mas especificos (maximo 10000).",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -12,6 +12,29 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { ENV } = await import("../server/lib/env.ts");
 const { createFastifyApp } = await import("../server/fastify-app.ts");
 
+function buildAdminAuditRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAuditLog: async () => ({
+      items: [],
+      total: 0,
+    }),
+    buildAdminAuditListFilters: (_query: Record<string, unknown>) => ({
+      filters: {
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAdminAuditCsv: () => "id,event",
+    buildAdminAuditCsvFilename: () => "admin-audit-log-test.csv",
+  };
+}
+
 function buildAdminAuthRouteStubs() {
   return {
     createAdminSession: async () => {},
@@ -204,6 +227,7 @@ test(
           timestamp: "2026-04-22T00:00:00.000Z",
         },
       }),
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -260,6 +284,114 @@ test(
 );
 
 test(
+  "createFastifyApp despacha /api/admin/audit-log al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/admin/audit-log", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuditRoutes: {
+        ...buildAdminAuditRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "ADMIN",
+        }),
+        listAuditLog: async () => ({
+          items: [
+            {
+              id: 201,
+              event: "auth.admin.login.succeeded",
+              action: "auth.admin.login.succeeded",
+              entity: "admin_user",
+              entityId: 1,
+              actorType: "admin_user",
+              actorAdminUserId: 1,
+              actorClinicUserId: null,
+              actorReportAccessTokenId: null,
+              clinicId: 3,
+              reportId: null,
+              targetAdminUserId: 1,
+              targetClinicUserId: null,
+              targetReportAccessTokenId: null,
+              requestId: "req-admin-1",
+              requestMethod: "POST",
+              requestPath: "/api/admin/auth/login",
+              ipAddress: "127.0.0.1",
+              userAgent: "test-agent",
+              metadata: {
+                username: "ADMIN",
+              },
+              createdAt: new Date("2026-04-24T00:00:00.000Z"),
+            },
+          ],
+          total: 1,
+        }),
+        buildAdminAuditListFilters: (_query: Record<string, unknown>) => ({
+          filters: {
+            limit: 50,
+            offset: 0,
+          },
+          errors: [],
+        }),
+      },
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/audit-log",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
+
+      if (response.statusCode === 200 && response.body) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.count, 1);
+        assert.equal(body.pagination.total, 1);
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "createFastifyApp despacha /api/admin/auth al router nativo antes del bridge Express",
   async () => {
     const app = await createFastifyApp({
@@ -275,6 +407,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: {
         ...buildAdminAuthRouteStubs(),
         getAdminSessionByToken: async () => ({
@@ -349,6 +482,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
@@ -432,6 +566,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
@@ -545,6 +680,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -642,6 +778,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -744,6 +881,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -813,6 +951,7 @@ test(
 
         return legacyApp as any;
       },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),


### PR DESCRIPTION
## Summary
- move `/api/admin/audit-log/*` to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for admin audit listing, CSV export, filter validation and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-audit.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the admin audit subtree to Fastify while preserving the existing admin-facing contract and leaving the Express bridge intact for the rest of the API.
