### PR TITLE
feat(http): move clinic report access token routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -38,6 +38,10 @@ import {
   publicReportAccessNativeRoutes,
   type PublicReportAccessNativeRoutesOptions,
 } from "./routes/public-report-access.fastify.ts";
+import {
+  reportAccessTokensNativeRoutes,
+  type ReportAccessTokensNativeRoutesOptions,
+} from "./routes/report-access-tokens.fastify.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -67,6 +71,7 @@ export type CreateFastifyAppOptions = {
   particularAuthRoutes?: ParticularAuthNativeRoutesOptions;
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
   publicReportAccessRoutes?: PublicReportAccessNativeRoutesOptions;
+  reportAccessTokensRoutes?: ReportAccessTokensNativeRoutesOptions;
 };
 
 const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
@@ -79,6 +84,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/particular/auth",
   "/public/professionals",
   "/public/report-access",
+  "/report-access-tokens",
 ];
 
 function shouldBypassLegacyApi(url: unknown) {
@@ -179,6 +185,11 @@ export async function createFastifyApp(
   await app.register(publicReportAccessNativeRoutes, {
     prefix: "/api/public/report-access",
     ...(options.publicReportAccessRoutes ?? {}),
+  });
+
+  await app.register(reportAccessTokensNativeRoutes, {
+    prefix: "/api/report-access-tokens",
+    ...(options.reportAccessTokensRoutes ?? {}),
   });
 
   await app.register(fastifyExpress);

--- a/server/routes/report-access-tokens.fastify.ts
+++ b/server/routes/report-access-tokens.fastify.ts
@@ -1,0 +1,963 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type { Report, ReportAccessToken } from "../../drizzle/schema";
+import { AUDIT_EVENTS } from "../lib/audit.ts";
+import { ENV } from "../lib/env.ts";
+import {
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
+} from "../lib/report-access-token-rate-limit.ts";
+import {
+  buildPublicReportAccessPath,
+  buildValidationError,
+  clinicCreateReportAccessTokenSchema,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeReportAccessToken,
+  serializeReportAccessTokenDetail,
+} from "../lib/report-access-token.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type VerifyPasswordResult = {
+  valid: boolean;
+  needsRehash: boolean;
+};
+
+type AuthenticatedClinicUser = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId: string | null;
+  role: ReturnType<typeof normalizeClinicUserRole>;
+  permissions: ReturnType<typeof getClinicPermissions>;
+  canUploadReports: boolean;
+  canManageClinicUsers: boolean;
+  sessionToken: string;
+};
+
+type AuditWriteInput = {
+  event: string;
+  clinicId?: number | null;
+  reportId?: number | null;
+  targetReportAccessTokenId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    clinicUserId?: number | null;
+  };
+};
+
+export type ReportAccessTokensNativeRoutesOptions = {
+  createActiveSession?: (input: {
+    clinicUserId: number;
+    tokenHash: string;
+    expiresAt: Date;
+  }) => Promise<void>;
+  deleteActiveSession?: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById?: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  generateSessionToken?: () => string;
+  hashPassword?: (password: string) => Promise<string>;
+  hashSessionToken?: (token: string) => string;
+  verifyPassword?: (
+    password: string,
+    passwordHash: string,
+  ) => Promise<VerifyPasswordResult>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  createReportAccessToken?: (input: {
+    clinicId: number;
+    reportId: number;
+    tokenHash: string;
+    tokenLast4: string;
+    expiresAt: Date | null;
+    createdByClinicUserId: number | null;
+    createdByAdminUserId: number | null;
+    revokedByClinicUserId: number | null;
+    revokedByAdminUserId: number | null;
+  }) => Promise<ReportAccessToken>;
+  getClinicScopedReportAccessToken?: (
+    tokenId: number,
+    clinicId: number,
+  ) => Promise<ReportAccessToken | null | undefined>;
+  listReportAccessTokens?: (params: {
+    clinicId: number;
+    reportId?: number;
+    limit: number;
+    offset: number;
+  }) => Promise<ReportAccessToken[]>;
+  revokeReportAccessToken?: (input: {
+    id: number;
+    revokedByClinicUserId?: number | null;
+    revokedByAdminUserId?: number | null;
+  }) => Promise<ReportAccessToken | null | undefined>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  mutationRateLimitWindowMs?: number;
+  mutationRateLimitMaxAttempts?: number;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__reportAccessTokensRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type ReportAccessTokensFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeReportAccessTokensDeps = Required<
+  Pick<
+    ReportAccessTokensNativeRoutesOptions,
+    | "deleteActiveSession"
+    | "getActiveSessionByToken"
+    | "getClinicUserById"
+    | "updateSessionLastAccess"
+    | "generateSessionToken"
+    | "hashPassword"
+    | "hashSessionToken"
+    | "verifyPassword"
+    | "getReportById"
+    | "createReportAccessToken"
+    | "getClinicScopedReportAccessToken"
+    | "listReportAccessTokens"
+    | "revokeReportAccessToken"
+    | "writeAuditLog"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeReportAccessTokensDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeReportAccessTokensDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbReportAccess = await import("../db-report-access.ts");
+      const audit = await import("../lib/audit.ts");
+
+      return {
+        createActiveSession: db.createActiveSession,
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        generateSessionToken: authSecurity.generateSessionToken,
+        hashPassword: authSecurity.hashPassword,
+        hashSessionToken: authSecurity.hashSessionToken,
+        verifyPassword: authSecurity.verifyPassword,
+        getReportById: db.getReportById,
+        createReportAccessToken: dbReportAccess.createReportAccessToken,
+        getClinicScopedReportAccessToken:
+          dbReportAccess.getClinicScopedReportAccessToken,
+        listReportAccessTokens: dbReportAccess.listReportAccessTokens,
+        revokeReportAccessToken: dbReportAccess.revokeReportAccessToken,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise!;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+  );
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.cookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearSessionCookie() {
+  return serializeCookie({
+    name: ENV.cookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function setMutationRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    count: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header(
+    "RateLimit-Remaining",
+    String(Math.max(input.max - input.count, 0)),
+  );
+  reply.header(
+    "RateLimit-Reset",
+    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+  );
+}
+
+function getMutationEntry(
+  attempts: Map<string, { count: number; resetAt: number }>,
+  key: string,
+  windowMs: number,
+  now: number,
+) {
+  const current = attempts.get(key);
+
+  if (!current || current.resetAt <= now) {
+    const fresh = {
+      count: 0,
+      resetAt: now + windowMs,
+    };
+    attempts.set(key, fresh);
+    return fresh;
+  }
+
+  return current;
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+function createAuditRequestLike(
+  request: FastifyRequest,
+  auth?: Pick<
+    AuthenticatedClinicUser,
+    "id" | "clinicId" | "username" | "role" | "canManageClinicUsers" | "canUploadReports"
+  >,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    auth: auth
+      ? {
+          id: auth.id,
+          clinicId: auth.clinicId,
+          username: auth.username,
+          role: auth.role,
+          canManageClinicUsers: auth.canManageClinicUsers,
+          canUploadReports: auth.canUploadReports,
+        }
+      : undefined,
+  };
+}
+
+async function authenticateClinicUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeReportAccessTokensDeps,
+  now: () => number,
+): Promise<AuthenticatedClinicUser | null> {
+  const token = getSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "No autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getActiveSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión expirada",
+    });
+    return null;
+  }
+
+  const clinicUser = await deps.getClinicUserById(session.clinicUserId);
+
+  if (!clinicUser) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateSessionLastAccess(tokenHash);
+  }
+
+  const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+  const permissions = getClinicPermissions(role);
+
+  return {
+    id: clinicUser.id,
+    clinicId: clinicUser.clinicId,
+    username: clinicUser.username,
+    authProId: clinicUser.authProId ?? null,
+    role,
+    permissions,
+    canUploadReports: permissions.canUploadReports,
+    canManageClinicUsers: permissions.canManageClinicUsers,
+    sessionToken: token,
+  };
+}
+
+function requireReportAccessTokenManagementPermission(
+  auth: AuthenticatedClinicUser,
+  reply: FastifyReply,
+) {
+  if (auth.canManageClinicUsers) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "No autorizado para administrar tokens públicos de informes",
+  });
+
+  return false;
+}
+
+export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
+  ReportAccessTokensNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.generateSessionToken &&
+    !!options.hashPassword &&
+    !!options.hashSessionToken &&
+    !!options.verifyPassword &&
+    !!options.getReportById &&
+    !!options.createReportAccessToken &&
+    !!options.getClinicScopedReportAccessToken &&
+    !!options.listReportAccessTokens &&
+    !!options.revokeReportAccessToken &&
+    !!options.writeAuditLog;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeReportAccessTokensDeps = {
+    deleteActiveSession:
+      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
+    getActiveSessionByToken:
+      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
+    getClinicUserById:
+      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
+    updateSessionLastAccess:
+      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
+    generateSessionToken:
+      options.generateSessionToken ?? defaultDeps!.generateSessionToken,
+    hashPassword: options.hashPassword ?? defaultDeps!.hashPassword,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    verifyPassword: options.verifyPassword ?? defaultDeps!.verifyPassword,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    createReportAccessToken:
+      options.createReportAccessToken ?? defaultDeps!.createReportAccessToken,
+    getClinicScopedReportAccessToken:
+      options.getClinicScopedReportAccessToken ??
+      defaultDeps!.getClinicScopedReportAccessToken,
+    listReportAccessTokens:
+      options.listReportAccessTokens ?? defaultDeps!.listReportAccessTokens,
+    revokeReportAccessToken:
+      options.revokeReportAccessToken ?? defaultDeps!.revokeReportAccessToken,
+    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const mutationRateLimitWindowMs =
+    options.mutationRateLimitWindowMs ??
+    REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS;
+  const mutationRateLimitMaxAttempts =
+    options.mutationRateLimitMaxAttempts ??
+    REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS;
+  const allowedOrigins = new Set(getAllowedOrigins());
+  const mutationAttempts = new Map<string, { count: number; resetAt: number }>();
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as ReportAccessTokensFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as ReportAccessTokensFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/:tokenId", optionsHandler);
+  app.options("/:tokenId/revoke", optionsHandler);
+
+  const applyMutationRateLimit = (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const rateLimitKey = request.ip || "unknown";
+    const currentTime = now();
+    const entry = getMutationEntry(
+      mutationAttempts,
+      rateLimitKey,
+      mutationRateLimitWindowMs,
+      currentTime,
+    );
+
+    if (entry.count >= mutationRateLimitMaxAttempts) {
+      setMutationRateLimitHeaders(reply, {
+        max: mutationRateLimitMaxAttempts,
+        windowMs: mutationRateLimitWindowMs,
+        count: entry.count,
+        resetAt: entry.resetAt,
+        now: currentTime,
+      });
+
+      reply.code(429).send({
+        success: false,
+        error: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+      });
+
+      return null;
+    }
+
+    entry.count += 1;
+
+    setMutationRateLimitHeaders(reply, {
+      max: mutationRateLimitMaxAttempts,
+      windowMs: mutationRateLimitWindowMs,
+      count: entry.count,
+      resetAt: entry.resetAt,
+      now: currentTime,
+    });
+
+    return entry;
+  };
+
+  app.post<{
+    Body: {
+      reportId?: unknown;
+      expiresAt?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    if (!applyMutationRateLimit(request, reply)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    if (!requireReportAccessTokenManagementPermission(auth, reply)) {
+      return reply;
+    }
+
+    const parsed = clinicCreateReportAccessTokenSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    const report = await deps.getReportById(parsed.data.reportId);
+
+    if (!report || report.clinicId !== auth.clinicId) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado para la clínica autenticada",
+      });
+    }
+
+    const rawToken = deps.generateSessionToken();
+    const tokenHash = deps.hashSessionToken(rawToken);
+
+    const reportAccessToken = await deps.createReportAccessToken({
+      clinicId: auth.clinicId,
+      reportId: report.id,
+      tokenHash,
+      tokenLast4: rawToken.slice(-4),
+      expiresAt: parsed.data.expiresAt ?? null,
+      createdByClinicUserId: auth.id,
+      createdByAdminUserId: null,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: null,
+    });
+
+    await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+      event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED,
+      clinicId: reportAccessToken.clinicId,
+      reportId: reportAccessToken.reportId,
+      targetReportAccessTokenId: reportAccessToken.id,
+      metadata: {
+        tokenLast4: reportAccessToken.tokenLast4,
+        expiresAt: reportAccessToken.expiresAt,
+        createdVia: "clinic",
+      },
+    });
+
+    return reply.code(201).send({
+      success: true,
+      message: "Token público de informe creado correctamente",
+      token: rawToken,
+      publicAccessPath: buildPublicReportAccessPath(rawToken),
+      reportAccessToken: serializeReportAccessToken(reportAccessToken),
+    });
+  });
+
+  app.get<{
+    Querystring: {
+      reportId?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const reportId = parseEntityId(request.query.reportId);
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const tokens = await deps.listReportAccessTokens({
+      clinicId: auth.clinicId,
+      reportId,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: tokens.length,
+      reportAccessTokens: tokens.map((token) => serializeReportAccessToken(token)),
+      pagination: {
+        limit,
+        offset,
+      },
+      filters: {
+        reportId: reportId ?? null,
+      },
+    });
+  });
+
+  app.get<{
+    Params: {
+      tokenId: string;
+    };
+  }>("/:tokenId", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const token = await deps.getClinicScopedReportAccessToken(
+      tokenId,
+      auth.clinicId,
+    );
+
+    if (!token) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    }
+
+    const report = await deps.getReportById(token.reportId);
+
+    return reply.code(200).send({
+      success: true,
+      reportAccessToken: serializeReportAccessTokenDetail(token, report),
+    });
+  });
+
+  app.patch<{
+    Params: {
+      tokenId: string;
+    };
+  }>("/:tokenId/revoke", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    if (!applyMutationRateLimit(request, reply)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    if (!requireReportAccessTokenManagementPermission(auth, reply)) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const existing = await deps.getClinicScopedReportAccessToken(
+      tokenId,
+      auth.clinicId,
+    );
+
+    if (!existing) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    }
+
+    const revoked = await deps.revokeReportAccessToken({
+      id: tokenId,
+      revokedByClinicUserId: auth.id,
+      revokedByAdminUserId: null,
+    });
+
+    const report = revoked ? await deps.getReportById(revoked.reportId) : null;
+
+    if (revoked) {
+      await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+        event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED,
+        clinicId: revoked.clinicId,
+        reportId: revoked.reportId,
+        targetReportAccessTokenId: revoked.id,
+        metadata: {
+          tokenLast4: revoked.tokenLast4,
+          revokedAt: revoked.revokedAt,
+          revokedVia: "clinic",
+        },
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      message: "Token público de informe revocado correctamente",
+      reportAccessToken: revoked
+        ? serializeReportAccessTokenDetail(revoked, report)
+        : null,
+    });
+  });
+};
+

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -194,6 +194,44 @@ function buildPublicReportAccessRouteStubs() {
   };
 }
 
+function buildReportAccessTokensRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashPassword: async () => "unused",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    getReportById: async () => null,
+    createReportAccessToken: async () => ({
+      id: 9,
+      clinicId: 3,
+      reportId: 55,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      accessCount: 0,
+      lastAccessAt: null,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      revokedAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByClinicUserId: 9,
+      createdByAdminUserId: null,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: null,
+    }),
+    getClinicScopedReportAccessToken: async () => null,
+    listReportAccessTokens: async () => [],
+    revokeReportAccessToken: async () => null,
+    writeAuditLog: async () => {},
+  };
+}
+
 test(
   "createFastifyApp expone root y health nativos y mantiene el bridge Express bajo /api",
   async () => {
@@ -244,6 +282,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -364,6 +403,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -436,6 +476,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -513,6 +554,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -636,6 +678,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -734,6 +777,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -837,6 +881,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -898,6 +943,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -1020,6 +1066,7 @@ test(
         createSignedReportDownloadUrl: async () =>
           "https://signed.example/download",
       },
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     });
 
     try {
@@ -1041,6 +1088,101 @@ test(
           body.report.downloadUrl,
           "https://signed.example/download",
         );
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp despacha /api/report-access-tokens al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/report-access-tokens", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: {
+        ...buildReportAccessTokensRouteStubs(),
+        getActiveSessionByToken: async () => ({
+          clinicUserId: 9,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getClinicUserById: async () => ({
+          id: 9,
+          clinicId: 3,
+          username: "doctor",
+          authProId: null,
+          role: "clinic_owner",
+        }),
+        listReportAccessTokens: async () => [
+          {
+            id: 9,
+            clinicId: 3,
+            reportId: 55,
+            tokenHash: `hash:${"a".repeat(64)}`,
+            tokenLast4: "aaaa",
+            accessCount: 0,
+            lastAccessAt: null,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            revokedAt: null,
+            createdAt: new Date("2026-04-20T12:00:00.000Z"),
+            updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+            createdByClinicUserId: 9,
+            createdByAdminUserId: null,
+            revokedByClinicUserId: null,
+            revokedByAdminUserId: null,
+          },
+        ],
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/report-access-tokens?reportId=55",
+        headers: {
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
+
+      if (response.statusCode === 200 && response.body) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.count, 1);
+        assert.equal(body.filters.reportId, 55);
+        assert.equal(body.reportAccessTokens[0].id, 9);
       }
     } finally {
       await app.close();

--- a/test/report-access-tokens.fastify.test.ts
+++ b/test/report-access-tokens.fastify.test.ts
@@ -1,0 +1,553 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/report-access-token-rate-limit.ts");
+const {
+  reportAccessTokensNativeRoutes,
+} = await import("../server/routes/report-access-tokens.fastify.ts");
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatología",
+    patientName: "Luna",
+    fileName: "luna-report.pdf",
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+    storagePath: "reports/report-55.pdf",
+    ...overrides,
+  };
+}
+
+function createReportAccessTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 9,
+    clinicId: 3,
+    reportId: 55,
+    tokenHash: "hash:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    tokenLast4: "aaaa",
+    accessCount: 0,
+    lastAccessAt: null,
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    revokedAt: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    createdByClinicUserId: 9,
+    createdByAdminUserId: null,
+    revokedByClinicUserId: null,
+    revokedByAdminUserId: null,
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => ({
+      clinicUserId: 9,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashPassword: async () => "unused",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(reportAccessTokensNativeRoutes as any, {
+    prefix: "/api/report-access-tokens",
+    ...createAuthStubs(),
+    getReportById: async () => createReportFixture(),
+    createReportAccessToken: async () => createReportAccessTokenFixture(),
+    getClinicScopedReportAccessToken: async () => createReportAccessTokenFixture(),
+    listReportAccessTokens: async () => [createReportAccessTokenFixture()],
+    revokeReportAccessToken: async () =>
+      createReportAccessTokenFixture({
+        revokedAt: new Date("2026-04-24T00:00:00.000Z"),
+        revokedByClinicUserId: 9,
+      }),
+    writeAuditLog: async () => {},
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "reportAccessTokensNativeRoutes crea POST / con payload estable, path público y auditoria",
+  async () => {
+    const rawToken = "a".repeat(64);
+    const report = createReportFixture();
+    const createdToken = createReportAccessTokenFixture({
+      tokenHash: `hash:${rawToken}`,
+    });
+    const auditCalls: Array<Record<string, unknown>> = [];
+    const createCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      generateSessionToken: () => rawToken,
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, 55);
+        return report;
+      },
+      createReportAccessToken: async (input: Record<string, unknown>) => {
+        createCalls.push(input);
+        return createdToken;
+      },
+      writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+        auditCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 201);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["ratelimit-limit"], "10");
+      assert.equal(createCalls.length, 1);
+      assert.equal(createCalls[0].clinicId, 3);
+      assert.equal(createCalls[0].reportId, 55);
+      assert.equal(createCalls[0].tokenHash, `hash:${rawToken}`);
+      assert.equal(createCalls[0].tokenLast4, "aaaa");
+      assert.equal(createCalls[0].createdByClinicUserId, 9);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Token público de informe creado correctamente",
+        token: rawToken,
+        publicAccessPath: `/api/public/report-access/${rawToken}`,
+        reportAccessToken: {
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          accessCount: 0,
+          lastAccessAt: null,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          revokedAt: null,
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByClinicUserId: 9,
+          createdByAdminUserId: null,
+          revokedByClinicUserId: null,
+          revokedByAdminUserId: null,
+          state: "active",
+          isExpired: false,
+          isRevoked: false,
+        },
+      });
+
+      assert.equal(auditCalls.length, 1);
+      assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED);
+      assert.equal(auditCalls[0].clinicId, 3);
+      assert.equal(auditCalls[0].reportId, 55);
+      assert.equal(auditCalls[0].targetReportAccessTokenId, 9);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes bloquea POST / con origin no permitido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/report-access-tokens",
+        headers: {
+          origin: "https://evil.example",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Origen no permitido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes expone GET / con lista, filtros y paginación",
+  async () => {
+    const listCalls: Array<Record<string, unknown>> = [];
+    const token = createReportAccessTokenFixture();
+
+    const app = await createTestApp({
+      listReportAccessTokens: async (params: Record<string, unknown>) => {
+        listCalls.push(params);
+        return [token];
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/report-access-tokens?reportId=55&limit=5&offset=2",
+        headers: {
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].clinicId, 3);
+      assert.equal(listCalls[0].reportId, 55);
+      assert.equal(listCalls[0].limit, 5);
+      assert.equal(listCalls[0].offset, 2);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        count: 1,
+        reportAccessTokens: [
+          {
+            id: 9,
+            clinicId: 3,
+            reportId: 55,
+            tokenLast4: "aaaa",
+            accessCount: 0,
+            lastAccessAt: null,
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            revokedAt: null,
+            createdAt: "2026-04-20T12:00:00.000Z",
+            updatedAt: "2026-04-22T12:00:00.000Z",
+            createdByClinicUserId: 9,
+            createdByAdminUserId: null,
+            revokedByClinicUserId: null,
+            revokedByAdminUserId: null,
+            state: "active",
+            isExpired: false,
+            isRevoked: false,
+          },
+        ],
+        pagination: {
+          limit: 5,
+          offset: 2,
+        },
+        filters: {
+          reportId: 55,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes expone GET /:tokenId con detalle y reporte vinculado",
+  async () => {
+    const token = createReportAccessTokenFixture();
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      getClinicScopedReportAccessToken: async (tokenId: number, clinicId: number) => {
+        assert.equal(tokenId, 9);
+        assert.equal(clinicId, 3);
+        return token;
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, 55);
+        return report;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/report-access-tokens/9",
+        headers: {
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        reportAccessToken: {
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          accessCount: 0,
+          lastAccessAt: null,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          revokedAt: null,
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByClinicUserId: 9,
+          createdByAdminUserId: null,
+          revokedByClinicUserId: null,
+          revokedByAdminUserId: null,
+          state: "active",
+          isExpired: false,
+          isRevoked: false,
+          report: {
+            id: 55,
+            clinicId: 3,
+            uploadDate: "2026-04-22T09:00:00.000Z",
+            studyType: "Histopatología",
+            patientName: "Luna",
+            fileName: "luna-report.pdf",
+            currentStatus: "ready",
+            statusChangedAt: "2026-04-22T09:30:00.000Z",
+            createdAt: "2026-04-22T09:00:00.000Z",
+            updatedAt: "2026-04-22T09:30:00.000Z",
+          },
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes revoca PATCH /:tokenId/revoke y escribe auditoria",
+  async () => {
+    const existing = createReportAccessTokenFixture();
+    const revoked = createReportAccessTokenFixture({
+      revokedAt: new Date("2026-04-24T00:00:00.000Z"),
+      revokedByClinicUserId: 9,
+    });
+    const report = createReportFixture();
+    const auditCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      getClinicScopedReportAccessToken: async () => existing,
+      revokeReportAccessToken: async (input: Record<string, unknown>) => {
+        assert.equal(input.id, 9);
+        assert.equal(input.revokedByClinicUserId, 9);
+        return revoked;
+      },
+      getReportById: async () => report,
+      writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+        auditCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/report-access-tokens/9/revoke",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["ratelimit-limit"], "10");
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Token público de informe revocado correctamente",
+        reportAccessToken: {
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          accessCount: 0,
+          lastAccessAt: null,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          revokedAt: "2026-04-24T00:00:00.000Z",
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByClinicUserId: 9,
+          createdByAdminUserId: null,
+          revokedByClinicUserId: 9,
+          revokedByAdminUserId: null,
+          state: "revoked",
+          isExpired: false,
+          isRevoked: true,
+          report: {
+            id: 55,
+            clinicId: 3,
+            uploadDate: "2026-04-22T09:00:00.000Z",
+            studyType: "Histopatología",
+            patientName: "Luna",
+            fileName: "luna-report.pdf",
+            currentStatus: "ready",
+            statusChangedAt: "2026-04-22T09:30:00.000Z",
+            createdAt: "2026-04-22T09:00:00.000Z",
+            updatedAt: "2026-04-22T09:30:00.000Z",
+          },
+        },
+      });
+
+      assert.equal(auditCalls.length, 1);
+      assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED);
+      assert.equal(auditCalls[0].clinicId, 3);
+      assert.equal(auditCalls[0].reportId, 55);
+      assert.equal(auditCalls[0].targetReportAccessTokenId, 9);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes bloquea mutaciones sin management permission",
+  async () => {
+    const app = await createTestApp({
+      getClinicUserById: async () => ({
+        id: 9,
+        clinicId: 3,
+        username: "staff",
+        authProId: null,
+        role: "clinic_staff",
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "No autorizado para administrar tokens públicos de informes",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes aplica rate limit nativo fijo sobre mutaciones",
+  async () => {
+    const app = await createTestApp({
+      now: () => 0,
+      mutationRateLimitWindowMs: 60_000,
+      mutationRateLimitMaxAttempts: 2,
+      getReportById: async () => null,
+    });
+
+    try {
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+        },
+        remoteAddress: "203.0.113.40",
+      });
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/api/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+        },
+        remoteAddress: "203.0.113.40",
+      });
+
+      const third = await app.inject({
+        method: "POST",
+        url: "/api/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+        },
+        remoteAddress: "203.0.113.40",
+      });
+
+      assert.equal(first.statusCode, 404);
+      assert.equal(second.statusCode, 404);
+      assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["ratelimit-limit"], "2");
+      assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(third.body), {
+        success: false,
+        error: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- move `/api/report-access-tokens/*` to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for clinic report access token creation, listing, detail, revoke, rate limit and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/report-access-tokens.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the clinic report access token subtree to Fastify while preserving the existing clinic-facing contract and leaving the Express bridge intact for the rest of the API.
