### PR TITLE
feat(http): move admin report access token routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -15,6 +15,10 @@ import {
   type AdminAuthNativeRoutesOptions,
 } from "./routes/admin-auth.fastify.ts";
 import {
+  adminReportAccessTokensNativeRoutes,
+  type AdminReportAccessTokensNativeRoutesOptions,
+} from "./routes/admin-report-access-tokens.fastify.ts";
+import {
   clinicAuthNativeRoutes,
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
@@ -65,6 +69,7 @@ export type CreateFastifyAppOptions = {
   getServiceInfoPayload?: ServiceInfoFactory;
   adminAuditRoutes?: AdminAuditNativeRoutesOptions;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
+  adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
@@ -78,6 +83,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/health",
   "/admin/audit-log",
   "/admin/auth",
+  "/admin/report-access-tokens",
   "/auth",
   "/clinic/audit-log",
   "/clinic/profile",
@@ -155,6 +161,11 @@ export async function createFastifyApp(
   await app.register(adminAuthNativeRoutes, {
     prefix: "/api/admin/auth",
     ...(options.adminAuthRoutes ?? {}),
+  });
+
+  await app.register(adminReportAccessTokensNativeRoutes, {
+    prefix: "/api/admin/report-access-tokens",
+    ...(options.adminReportAccessTokensRoutes ?? {}),
   });
 
   await app.register(clinicAuthNativeRoutes, {

--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -1,0 +1,907 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type { Report, ReportAccessToken } from "../../drizzle/schema";
+import { AUDIT_EVENTS } from "../lib/audit.ts";
+import { ENV } from "../lib/env.ts";
+import {
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
+} from "../lib/report-access-token-rate-limit.ts";
+import {
+  adminCreateReportAccessTokenSchema,
+  buildPublicReportAccessPath,
+  buildValidationError,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeReportAccessToken,
+  serializeReportAccessTokenDetail,
+} from "../lib/report-access-token.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type AdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type ClinicRecord = {
+  id: number;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type AuditWriteInput = {
+  event: string;
+  clinicId?: number | null;
+  reportId?: number | null;
+  targetReportAccessTokenId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    adminUserId?: number | null;
+  };
+};
+
+export type AdminReportAccessTokensNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<AdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  generateSessionToken?: () => string;
+  hashSessionToken?: (token: string) => string;
+  getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  createReportAccessToken?: (input: {
+    clinicId: number;
+    reportId: number;
+    tokenHash: string;
+    tokenLast4: string;
+    expiresAt: Date | null;
+    createdByClinicUserId: number | null;
+    createdByAdminUserId: number | null;
+    revokedByClinicUserId: number | null;
+    revokedByAdminUserId: number | null;
+  }) => Promise<ReportAccessToken>;
+  getReportAccessTokenById?: (
+    tokenId: number,
+  ) => Promise<ReportAccessToken | null | undefined>;
+  listReportAccessTokens?: (params: {
+    clinicId?: number;
+    reportId?: number;
+    limit: number;
+    offset: number;
+  }) => Promise<ReportAccessToken[]>;
+  revokeReportAccessToken?: (input: {
+    id: number;
+    revokedByClinicUserId?: number | null;
+    revokedByAdminUserId?: number | null;
+  }) => Promise<ReportAccessToken | null | undefined>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  mutationRateLimitWindowMs?: number;
+  mutationRateLimitMaxAttempts?: number;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__adminReportAccessTokensRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type AdminReportAccessTokensFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeAdminReportAccessTokensDeps = Required<
+  Pick<
+    AdminReportAccessTokensNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "generateSessionToken"
+    | "hashSessionToken"
+    | "getClinicById"
+    | "getReportById"
+    | "createReportAccessToken"
+    | "getReportAccessTokenById"
+    | "listReportAccessTokens"
+    | "revokeReportAccessToken"
+    | "writeAuditLog"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminReportAccessTokensDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminReportAccessTokensDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbReportAccess = await import("../db-report-access.ts");
+      const audit = await import("../lib/audit.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        generateSessionToken: authSecurity.generateSessionToken,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getClinicById: db.getClinicById,
+        getReportById: db.getReportById,
+        createReportAccessToken: dbReportAccess.createReportAccessToken,
+        getReportAccessTokenById: dbReportAccess.getReportAccessTokenById,
+        listReportAccessTokens: dbReportAccess.listReportAccessTokens,
+        revokeReportAccessToken: dbReportAccess.revokeReportAccessToken,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise!;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+  );
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function setMutationRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    count: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header(
+    "RateLimit-Remaining",
+    String(Math.max(input.max - input.count, 0)),
+  );
+  reply.header(
+    "RateLimit-Reset",
+    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+  );
+}
+
+function getMutationEntry(
+  attempts: Map<string, { count: number; resetAt: number }>,
+  key: string,
+  windowMs: number,
+  now: number,
+) {
+  const current = attempts.get(key);
+
+  if (!current || current.resetAt <= now) {
+    const fresh = {
+      count: 0,
+      resetAt: now + windowMs,
+    };
+    attempts.set(key, fresh);
+    return fresh;
+  }
+
+  return current;
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+function createAuditRequestLike(
+  request: FastifyRequest,
+  admin?: Pick<AuthenticatedAdminUser, "id" | "username">,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    adminAuth: admin
+      ? {
+          id: admin.id,
+          username: admin.username,
+        }
+      : undefined,
+  };
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminReportAccessTokensDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
+  AdminReportAccessTokensNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.generateSessionToken &&
+    !!options.hashSessionToken &&
+    !!options.getClinicById &&
+    !!options.getReportById &&
+    !!options.createReportAccessToken &&
+    !!options.getReportAccessTokenById &&
+    !!options.listReportAccessTokens &&
+    !!options.revokeReportAccessToken &&
+    !!options.writeAuditLog;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminReportAccessTokensDeps = {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById:
+      options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    generateSessionToken:
+      options.generateSessionToken ?? defaultDeps!.generateSessionToken,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    createReportAccessToken:
+      options.createReportAccessToken ?? defaultDeps!.createReportAccessToken,
+    getReportAccessTokenById:
+      options.getReportAccessTokenById ??
+      defaultDeps!.getReportAccessTokenById,
+    listReportAccessTokens:
+      options.listReportAccessTokens ?? defaultDeps!.listReportAccessTokens,
+    revokeReportAccessToken:
+      options.revokeReportAccessToken ?? defaultDeps!.revokeReportAccessToken,
+    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const mutationRateLimitWindowMs =
+    options.mutationRateLimitWindowMs ??
+    REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS;
+  const mutationRateLimitMaxAttempts =
+    options.mutationRateLimitMaxAttempts ??
+    REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS;
+  const allowedOrigins = new Set(getAllowedOrigins());
+  const mutationAttempts = new Map<string, { count: number; resetAt: number }>();
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as AdminReportAccessTokensFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as AdminReportAccessTokensFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/:tokenId", optionsHandler);
+  app.options("/:tokenId/revoke", optionsHandler);
+
+  const applyMutationRateLimit = (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const rateLimitKey = request.ip || "unknown";
+    const currentTime = now();
+    const entry = getMutationEntry(
+      mutationAttempts,
+      rateLimitKey,
+      mutationRateLimitWindowMs,
+      currentTime,
+    );
+
+    if (entry.count >= mutationRateLimitMaxAttempts) {
+      setMutationRateLimitHeaders(reply, {
+        max: mutationRateLimitMaxAttempts,
+        windowMs: mutationRateLimitWindowMs,
+        count: entry.count,
+        resetAt: entry.resetAt,
+        now: currentTime,
+      });
+
+      reply.code(429).send({
+        success: false,
+        error: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+      });
+
+      return null;
+    }
+
+    entry.count += 1;
+
+    setMutationRateLimitHeaders(reply, {
+      max: mutationRateLimitMaxAttempts,
+      windowMs: mutationRateLimitWindowMs,
+      count: entry.count,
+      resetAt: entry.resetAt,
+      now: currentTime,
+    });
+
+    return entry;
+  };
+
+  app.post<{
+    Body: {
+      clinicId?: unknown;
+      reportId?: unknown;
+      expiresAt?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    if (!applyMutationRateLimit(request, reply)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const parsed = adminCreateReportAccessTokenSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    const clinic = await deps.getClinicById(parsed.data.clinicId);
+
+    if (!clinic) {
+      return reply.code(404).send({
+        success: false,
+        error: "Clínica no encontrada",
+      });
+    }
+
+    const report = await deps.getReportById(parsed.data.reportId);
+
+    if (!report) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    if (report.clinicId !== parsed.data.clinicId) {
+      return reply.code(400).send({
+        success: false,
+        error: "El informe no pertenece a la clínica indicada",
+      });
+    }
+
+    const rawToken = deps.generateSessionToken();
+    const tokenHash = deps.hashSessionToken(rawToken);
+
+    const reportAccessToken = await deps.createReportAccessToken({
+      clinicId: parsed.data.clinicId,
+      reportId: report.id,
+      tokenHash,
+      tokenLast4: rawToken.slice(-4),
+      expiresAt: parsed.data.expiresAt ?? null,
+      createdByClinicUserId: null,
+      createdByAdminUserId: admin.id,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: null,
+    });
+
+    await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+      event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED,
+      clinicId: reportAccessToken.clinicId,
+      reportId: reportAccessToken.reportId,
+      targetReportAccessTokenId: reportAccessToken.id,
+      metadata: {
+        tokenLast4: reportAccessToken.tokenLast4,
+        expiresAt: reportAccessToken.expiresAt,
+        createdVia: "admin",
+      },
+    });
+
+    return reply.code(201).send({
+      success: true,
+      message: "Token público de informe creado correctamente",
+      token: rawToken,
+      publicAccessPath: buildPublicReportAccessPath(rawToken),
+      reportAccessToken: serializeReportAccessToken(reportAccessToken),
+    });
+  });
+
+  app.get<{
+    Querystring: {
+      clinicId?: unknown;
+      reportId?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const clinicId = parseEntityId(request.query.clinicId);
+    const reportId = parseEntityId(request.query.reportId);
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const tokens = await deps.listReportAccessTokens({
+      clinicId,
+      reportId,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: tokens.length,
+      reportAccessTokens: tokens.map((token) => serializeReportAccessToken(token)),
+      pagination: {
+        limit,
+        offset,
+      },
+      filters: {
+        clinicId: clinicId ?? null,
+        reportId: reportId ?? null,
+      },
+    });
+  });
+
+  app.get<{
+    Params: {
+      tokenId: string;
+    };
+  }>("/:tokenId", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const token = await deps.getReportAccessTokenById(tokenId);
+
+    if (!token) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    }
+
+    const report = await deps.getReportById(token.reportId);
+
+    return reply.code(200).send({
+      success: true,
+      reportAccessToken: serializeReportAccessTokenDetail(token, report),
+    });
+  });
+
+  app.patch<{
+    Params: {
+      tokenId: string;
+    };
+  }>("/:tokenId/revoke", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    if (!applyMutationRateLimit(request, reply)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const existing = await deps.getReportAccessTokenById(tokenId);
+
+    if (!existing) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    }
+
+    const revoked = await deps.revokeReportAccessToken({
+      id: tokenId,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: admin.id,
+    });
+
+    const report = revoked ? await deps.getReportById(revoked.reportId) : null;
+
+    if (revoked) {
+      await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+        event: AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED,
+        clinicId: revoked.clinicId,
+        reportId: revoked.reportId,
+        targetReportAccessTokenId: revoked.id,
+        metadata: {
+          tokenLast4: revoked.tokenLast4,
+          revokedAt: revoked.revokedAt,
+          revokedVia: "admin",
+        },
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      message: "Token público de informe revocado correctamente",
+      reportAccessToken: revoked
+        ? serializeReportAccessTokenDetail(revoked, report)
+        : null,
+    });
+  });
+};

--- a/test/admin-report-access-tokens.fastify.test.ts
+++ b/test/admin-report-access-tokens.fastify.test.ts
@@ -1,0 +1,527 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/report-access-token-rate-limit.ts");
+const {
+  adminReportAccessTokensNativeRoutes,
+} = await import("../server/routes/admin-report-access-tokens.fastify.ts");
+
+function createClinicFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 3,
+    ...overrides,
+  };
+}
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatología",
+    patientName: "Luna",
+    fileName: "luna-report.pdf",
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+    storagePath: "reports/report-55.pdf",
+    ...overrides,
+  };
+}
+
+function createReportAccessTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 9,
+    clinicId: 3,
+    reportId: 55,
+    tokenHash: "hash:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    tokenLast4: "aaaa",
+    accessCount: 0,
+    lastAccessAt: null,
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    revokedAt: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    createdByClinicUserId: null,
+    createdByAdminUserId: 1,
+    revokedByClinicUserId: null,
+    revokedByAdminUserId: null,
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "ADMIN",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(adminReportAccessTokensNativeRoutes as any, {
+    prefix: "/api/admin/report-access-tokens",
+    ...createAuthStubs(),
+    getClinicById: async () => createClinicFixture(),
+    getReportById: async () => createReportFixture(),
+    createReportAccessToken: async () => createReportAccessTokenFixture(),
+    getReportAccessTokenById: async () => createReportAccessTokenFixture(),
+    listReportAccessTokens: async () => [createReportAccessTokenFixture()],
+    revokeReportAccessToken: async () =>
+      createReportAccessTokenFixture({
+        revokedAt: new Date("2026-04-24T00:00:00.000Z"),
+        revokedByAdminUserId: 1,
+      }),
+    writeAuditLog: async () => {},
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "adminReportAccessTokensNativeRoutes crea POST / con payload estable, path público y auditoria",
+  async () => {
+    const rawToken = "a".repeat(64);
+    const clinic = createClinicFixture();
+    const report = createReportFixture();
+    const createdToken = createReportAccessTokenFixture({
+      tokenHash: `hash:${rawToken}`,
+    });
+    const auditCalls: Array<Record<string, unknown>> = [];
+    const createCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      generateSessionToken: () => rawToken,
+      getClinicById: async (clinicId: number) => {
+        assert.equal(clinicId, 3);
+        return clinic;
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, 55);
+        return report;
+      },
+      createReportAccessToken: async (input: Record<string, unknown>) => {
+        createCalls.push(input);
+        return createdToken;
+      },
+      writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+        auditCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 201);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["ratelimit-limit"], "10");
+      assert.equal(createCalls.length, 1);
+      assert.equal(createCalls[0].clinicId, 3);
+      assert.equal(createCalls[0].reportId, 55);
+      assert.equal(createCalls[0].tokenHash, `hash:${rawToken}`);
+      assert.equal(createCalls[0].tokenLast4, "aaaa");
+      assert.equal(createCalls[0].createdByAdminUserId, 1);
+      assert.equal(createCalls[0].createdByClinicUserId, null);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Token público de informe creado correctamente",
+        token: rawToken,
+        publicAccessPath: `/api/public/report-access/${rawToken}`,
+        reportAccessToken: {
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          accessCount: 0,
+          lastAccessAt: null,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          revokedAt: null,
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByClinicUserId: null,
+          createdByAdminUserId: 1,
+          revokedByClinicUserId: null,
+          revokedByAdminUserId: null,
+          state: "active",
+          isExpired: false,
+          isRevoked: false,
+        },
+      });
+
+      assert.equal(auditCalls.length, 1);
+      assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_CREATED);
+      assert.equal(auditCalls[0].clinicId, 3);
+      assert.equal(auditCalls[0].reportId, 55);
+      assert.equal(auditCalls[0].targetReportAccessTokenId, 9);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminReportAccessTokensNativeRoutes bloquea POST / con origin no permitido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/report-access-tokens",
+        headers: {
+          origin: "https://evil.example",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Origen no permitido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminReportAccessTokensNativeRoutes expone GET / con lista, filtros y paginación",
+  async () => {
+    const listCalls: Array<Record<string, unknown>> = [];
+    const token = createReportAccessTokenFixture();
+
+    const app = await createTestApp({
+      listReportAccessTokens: async (params: Record<string, unknown>) => {
+        listCalls.push(params);
+        return [token];
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/report-access-tokens?clinicId=3&reportId=55&limit=5&offset=2",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].clinicId, 3);
+      assert.equal(listCalls[0].reportId, 55);
+      assert.equal(listCalls[0].limit, 5);
+      assert.equal(listCalls[0].offset, 2);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        count: 1,
+        reportAccessTokens: [
+          {
+            id: 9,
+            clinicId: 3,
+            reportId: 55,
+            tokenLast4: "aaaa",
+            accessCount: 0,
+            lastAccessAt: null,
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            revokedAt: null,
+            createdAt: "2026-04-20T12:00:00.000Z",
+            updatedAt: "2026-04-22T12:00:00.000Z",
+            createdByClinicUserId: null,
+            createdByAdminUserId: 1,
+            revokedByClinicUserId: null,
+            revokedByAdminUserId: null,
+            state: "active",
+            isExpired: false,
+            isRevoked: false,
+          },
+        ],
+        pagination: {
+          limit: 5,
+          offset: 2,
+        },
+        filters: {
+          clinicId: 3,
+          reportId: 55,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminReportAccessTokensNativeRoutes expone GET /:tokenId con detalle y reporte vinculado",
+  async () => {
+    const token = createReportAccessTokenFixture();
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      getReportAccessTokenById: async (tokenId: number) => {
+        assert.equal(tokenId, 9);
+        return token;
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, 55);
+        return report;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/report-access-tokens/9",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        reportAccessToken: {
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          accessCount: 0,
+          lastAccessAt: null,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          revokedAt: null,
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByClinicUserId: null,
+          createdByAdminUserId: 1,
+          revokedByClinicUserId: null,
+          revokedByAdminUserId: null,
+          state: "active",
+          isExpired: false,
+          isRevoked: false,
+          report: {
+            id: 55,
+            clinicId: 3,
+            uploadDate: "2026-04-22T09:00:00.000Z",
+            studyType: "Histopatología",
+            patientName: "Luna",
+            fileName: "luna-report.pdf",
+            currentStatus: "ready",
+            statusChangedAt: "2026-04-22T09:30:00.000Z",
+            createdAt: "2026-04-22T09:00:00.000Z",
+            updatedAt: "2026-04-22T09:30:00.000Z",
+          },
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminReportAccessTokensNativeRoutes revoca PATCH /:tokenId/revoke y escribe auditoria",
+  async () => {
+    const existing = createReportAccessTokenFixture();
+    const revoked = createReportAccessTokenFixture({
+      revokedAt: new Date("2026-04-24T00:00:00.000Z"),
+      revokedByAdminUserId: 1,
+    });
+    const report = createReportFixture();
+    const auditCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      getReportAccessTokenById: async () => existing,
+      revokeReportAccessToken: async (input: Record<string, unknown>) => {
+        assert.equal(input.id, 9);
+        assert.equal(input.revokedByAdminUserId, 1);
+        return revoked;
+      },
+      getReportById: async () => report,
+      writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+        auditCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/admin/report-access-tokens/9/revoke",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["ratelimit-limit"], "10");
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Token público de informe revocado correctamente",
+        reportAccessToken: {
+          id: 9,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          accessCount: 0,
+          lastAccessAt: null,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          revokedAt: "2026-04-24T00:00:00.000Z",
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByClinicUserId: null,
+          createdByAdminUserId: 1,
+          revokedByClinicUserId: null,
+          revokedByAdminUserId: 1,
+          state: "revoked",
+          isExpired: false,
+          isRevoked: true,
+          report: {
+            id: 55,
+            clinicId: 3,
+            uploadDate: "2026-04-22T09:00:00.000Z",
+            studyType: "Histopatología",
+            patientName: "Luna",
+            fileName: "luna-report.pdf",
+            currentStatus: "ready",
+            statusChangedAt: "2026-04-22T09:30:00.000Z",
+            createdAt: "2026-04-22T09:00:00.000Z",
+            updatedAt: "2026-04-22T09:30:00.000Z",
+          },
+        },
+      });
+
+      assert.equal(auditCalls.length, 1);
+      assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED);
+      assert.equal(auditCalls[0].clinicId, 3);
+      assert.equal(auditCalls[0].reportId, 55);
+      assert.equal(auditCalls[0].targetReportAccessTokenId, 9);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminReportAccessTokensNativeRoutes aplica rate limit nativo fijo sobre mutaciones",
+  async () => {
+    const app = await createTestApp({
+      now: () => 0,
+      mutationRateLimitWindowMs: 60_000,
+      mutationRateLimitMaxAttempts: 2,
+      getClinicById: async () => createClinicFixture(),
+      getReportById: async () => null,
+    });
+
+    try {
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/admin/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+        },
+        remoteAddress: "203.0.113.40",
+      });
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/api/admin/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+        },
+        remoteAddress: "203.0.113.40",
+      });
+
+      const third = await app.inject({
+        method: "POST",
+        url: "/api/admin/report-access-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+        },
+        remoteAddress: "203.0.113.40",
+      });
+
+      assert.equal(first.statusCode, 404);
+      assert.equal(second.statusCode, 404);
+      assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["ratelimit-limit"], "2");
+      assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(third.body), {
+        success: false,
+        error: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -53,6 +53,40 @@ function buildAdminAuthRouteStubs() {
   };
 }
 
+
+function buildAdminReportAccessTokensRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    createReportAccessToken: async () => ({
+      id: 9,
+      clinicId: 3,
+      reportId: 55,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      accessCount: 0,
+      lastAccessAt: null,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      revokedAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByClinicUserId: null,
+      createdByAdminUserId: 1,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: null,
+    }),
+    getReportAccessTokenById: async () => null,
+    listReportAccessTokens: async () => [],
+    revokeReportAccessToken: async () => null,
+    writeAuditLog: async () => {},
+  };
+}
 function buildClinicAuthRouteStubs() {
   return {
     createActiveSession: async () => {},
@@ -267,6 +301,7 @@ test(
       }),
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -388,6 +423,7 @@ test(
         }),
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -461,6 +497,7 @@ test(
         }),
         updateAdminSessionLastAccess: async () => {},
       },
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -525,6 +562,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
         getActiveSessionByToken: async () => ({
@@ -610,6 +648,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
         ...buildClinicAuditRouteStubs(),
@@ -725,6 +764,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: {
@@ -824,6 +864,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -928,6 +969,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -999,6 +1041,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1113,6 +1156,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1189,3 +1233,98 @@ test(
     }
   },
 );
+
+test(
+  "createFastifyApp despacha /api/admin/report-access-tokens al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/admin/report-access-tokens", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminReportAccessTokensRoutes: {
+        ...buildAdminReportAccessTokensRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "ADMIN",
+        }),
+        listReportAccessTokens: async () => [
+          {
+            id: 9,
+            clinicId: 3,
+            reportId: 55,
+            tokenHash: `hash:${"a".repeat(64)}`,
+            tokenLast4: "aaaa",
+            accessCount: 0,
+            lastAccessAt: null,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            revokedAt: null,
+            createdAt: new Date("2026-04-20T12:00:00.000Z"),
+            updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+            createdByClinicUserId: null,
+            createdByAdminUserId: 1,
+            revokedByClinicUserId: null,
+            revokedByAdminUserId: null,
+          },
+        ],
+      },
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/report-access-tokens?clinicId=3&reportId=55",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
+
+      if (response.statusCode === 200 && response.body) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.count, 1);
+        assert.equal(body.filters.clinicId, 3);
+        assert.equal(body.filters.reportId, 55);
+        assert.equal(body.reportAccessTokens[0].id, 9);
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+


### PR DESCRIPTION
## Summary
- move `/api/admin/report-access-tokens/*` to native Fastify
- keep the legacy Express bridge for the remaining `/api/*` routes
- add native tests for admin report access token creation, listing, detail, revoke, rate limit and bridge bypass coverage

## Testing
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-report-access-tokens.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd typecheck
- pnpm.cmd test

## Risk
Low. This PR migrates the admin report access token subtree to Fastify while preserving the existing admin-facing contract and leaving the Express bridge intact for the rest of the API.
