### PR TITLE
feat(http): move admin particular token routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -15,6 +15,10 @@ import {
   type AdminAuthNativeRoutesOptions,
 } from "./routes/admin-auth.fastify.ts";
 import {
+  adminParticularTokensNativeRoutes,
+  type AdminParticularTokensNativeRoutesOptions,
+} from "./routes/admin-particular-tokens.fastify.ts";
+import {
   adminReportAccessTokensNativeRoutes,
   type AdminReportAccessTokensNativeRoutesOptions,
 } from "./routes/admin-report-access-tokens.fastify.ts";
@@ -69,6 +73,7 @@ export type CreateFastifyAppOptions = {
   getServiceInfoPayload?: ServiceInfoFactory;
   adminAuditRoutes?: AdminAuditNativeRoutesOptions;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
+  adminParticularTokensRoutes?: AdminParticularTokensNativeRoutesOptions;
   adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
@@ -83,6 +88,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/health",
   "/admin/audit-log",
   "/admin/auth",
+  "/admin/particular-tokens",
   "/admin/report-access-tokens",
   "/auth",
   "/clinic/audit-log",
@@ -163,6 +169,11 @@ export async function createFastifyApp(
     ...(options.adminAuthRoutes ?? {}),
   });
 
+  await app.register(adminParticularTokensNativeRoutes, {
+    prefix: "/api/admin/particular-tokens",
+    ...(options.adminParticularTokensRoutes ?? {}),
+  });
+
   await app.register(adminReportAccessTokensNativeRoutes, {
     prefix: "/api/admin/report-access-tokens",
     ...(options.adminReportAccessTokensRoutes ?? {}),
@@ -224,3 +235,4 @@ export async function createFastifyApp(
 
   return app;
 }
+

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -1,0 +1,792 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type { ParticularToken, Report } from "../../drizzle/schema";
+import { ENV } from "../lib/env.ts";
+import {
+  adminCreateParticularTokenSchema,
+  buildValidationError,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeParticularToken,
+  serializeParticularTokenDetail,
+  updateParticularTokenReportSchema,
+} from "../lib/particular-token.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type AdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type ClinicRecord = {
+  id: number;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+export type AdminParticularTokensNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<AdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  generateSessionToken?: () => string;
+  hashSessionToken?: (token: string) => string;
+  getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  createParticularToken?: (input: {
+    clinicId: number;
+    reportId: number | null;
+    createdByAdminId: number | null;
+    createdByClinicUserId: number | null;
+    tokenHash: string;
+    tokenLast4: string;
+    tutorLastName: string;
+    petName: string;
+    petAge: string;
+    petBreed: string;
+    petSex: string;
+    petSpecies: string;
+    sampleLocation: string;
+    sampleEvolution: string;
+    detailsLesion: string | null;
+    extractionDate: Date;
+    shippingDate: Date;
+    isActive: boolean;
+    lastLoginAt: Date | null;
+  }) => Promise<ParticularToken>;
+  getParticularTokenById?: (
+    tokenId: number,
+  ) => Promise<ParticularToken | null | undefined>;
+  listParticularTokens?: (params: {
+    clinicId?: number;
+    limit: number;
+    offset: number;
+  }) => Promise<ParticularToken[]>;
+  updateParticularTokenReport?: (
+    id: number,
+    reportId: number | null,
+  ) => Promise<ParticularToken | null | undefined>;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__adminParticularTokensRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type AdminParticularTokensFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeAdminParticularTokensDeps = Required<
+  Pick<
+    AdminParticularTokensNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "generateSessionToken"
+    | "hashSessionToken"
+    | "getClinicById"
+    | "getReportById"
+    | "createParticularToken"
+    | "getParticularTokenById"
+    | "listParticularTokens"
+    | "updateParticularTokenReport"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminParticularTokensDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbParticular = await import("../db-particular.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        generateSessionToken: authSecurity.generateSessionToken,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getClinicById: db.getClinicById,
+        getReportById: db.getReportById,
+        createParticularToken: dbParticular.createParticularToken,
+        getParticularTokenById: dbParticular.getParticularTokenById,
+        listParticularTokens: dbParticular.listParticularTokens,
+        updateParticularTokenReport: dbParticular.updateParticularTokenReport,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminParticularTokensDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
+  AdminParticularTokensNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.generateSessionToken &&
+    !!options.hashSessionToken &&
+    !!options.getClinicById &&
+    !!options.getReportById &&
+    !!options.createParticularToken &&
+    !!options.getParticularTokenById &&
+    !!options.listParticularTokens &&
+    !!options.updateParticularTokenReport;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminParticularTokensDeps = {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById:
+      options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    generateSessionToken:
+      options.generateSessionToken ?? defaultDeps!.generateSessionToken,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    createParticularToken:
+      options.createParticularToken ?? defaultDeps!.createParticularToken,
+    getParticularTokenById:
+      options.getParticularTokenById ?? defaultDeps!.getParticularTokenById,
+    listParticularTokens:
+      options.listParticularTokens ?? defaultDeps!.listParticularTokens,
+    updateParticularTokenReport:
+      options.updateParticularTokenReport ??
+      defaultDeps!.updateParticularTokenReport,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as AdminParticularTokensFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as AdminParticularTokensFastifyRequest)[
+        REQUEST_START_TIME_KEY
+      ] ?? process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/:tokenId", optionsHandler);
+  app.options("/:tokenId/report", optionsHandler);
+
+  app.post<{
+    Body: {
+      clinicId?: unknown;
+      reportId?: unknown;
+      tutorLastName?: unknown;
+      petName?: unknown;
+      petAge?: unknown;
+      petBreed?: unknown;
+      petSex?: unknown;
+      petSpecies?: unknown;
+      sampleLocation?: unknown;
+      sampleEvolution?: unknown;
+      detailsLesion?: unknown;
+      extractionDate?: unknown;
+      shippingDate?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const parsed = adminCreateParticularTokenSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    const clinic = await deps.getClinicById(parsed.data.clinicId);
+
+    if (!clinic) {
+      return reply.code(404).send({
+        success: false,
+        error: "Clínica no encontrada",
+      });
+    }
+
+    if (typeof parsed.data.reportId === "number") {
+      const report = await deps.getReportById(parsed.data.reportId);
+
+      if (!report) {
+        return reply.code(404).send({
+          success: false,
+          error: "Informe no encontrado",
+        });
+      }
+
+      if (report.clinicId !== parsed.data.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El informe no pertenece a la clínica indicada",
+        });
+      }
+    }
+
+    const rawToken = deps.generateSessionToken();
+    const tokenHash = deps.hashSessionToken(rawToken);
+
+    const particularToken = await deps.createParticularToken({
+      clinicId: parsed.data.clinicId,
+      reportId:
+        typeof parsed.data.reportId === "number" ? parsed.data.reportId : null,
+      createdByAdminId: admin.id,
+      createdByClinicUserId: null,
+      tokenHash,
+      tokenLast4: rawToken.slice(-4),
+      tutorLastName: parsed.data.tutorLastName,
+      petName: parsed.data.petName,
+      petAge: parsed.data.petAge,
+      petBreed: parsed.data.petBreed,
+      petSex: parsed.data.petSex,
+      petSpecies: parsed.data.petSpecies,
+      sampleLocation: parsed.data.sampleLocation,
+      sampleEvolution: parsed.data.sampleEvolution,
+      detailsLesion: parsed.data.detailsLesion ?? null,
+      extractionDate: parsed.data.extractionDate,
+      shippingDate: parsed.data.shippingDate,
+      isActive: true,
+      lastLoginAt: null,
+    });
+
+    return reply.code(201).send({
+      success: true,
+      message: "Token particular creado correctamente",
+      token: rawToken,
+      particularToken: serializeParticularToken(particularToken),
+    });
+  });
+
+  app.get<{
+    Querystring: {
+      clinicId?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const clinicId = parseEntityId(request.query.clinicId);
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const tokens = await deps.listParticularTokens({
+      clinicId,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: tokens.length,
+      particularTokens: tokens.map((token) => serializeParticularToken(token)),
+      pagination: {
+        limit,
+        offset,
+      },
+      filters: {
+        clinicId: clinicId ?? null,
+      },
+    });
+  });
+
+  app.get<{
+    Params: {
+      tokenId: string;
+    };
+  }>("/:tokenId", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const token = await deps.getParticularTokenById(tokenId);
+
+    if (!token) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    }
+
+    const report =
+      typeof token.reportId === "number"
+        ? await deps.getReportById(token.reportId)
+        : null;
+
+    return reply.code(200).send({
+      success: true,
+      particularToken: serializeParticularTokenDetail(token, report),
+    });
+  });
+
+  app.patch<{
+    Params: {
+      tokenId: string;
+    };
+    Body: {
+      reportId?: unknown;
+    };
+  }>("/:tokenId/report", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const parsed = updateParticularTokenReportSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    const token = await deps.getParticularTokenById(tokenId);
+
+    if (!token) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    }
+
+    if (typeof parsed.data.reportId === "number") {
+      const report = await deps.getReportById(parsed.data.reportId);
+
+      if (!report) {
+        return reply.code(404).send({
+          success: false,
+          error: "Informe no encontrado",
+        });
+      }
+
+      if (report.clinicId !== token.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El informe no pertenece a la clínica del token",
+        });
+      }
+    }
+
+    const updated = await deps.updateParticularTokenReport(
+      tokenId,
+      parsed.data.reportId,
+    );
+
+    const report =
+      updated && typeof updated.reportId === "number"
+        ? await deps.getReportById(updated.reportId)
+        : null;
+
+    return reply.code(200).send({
+      success: true,
+      message:
+        typeof parsed.data.reportId === "number"
+          ? "Informe vinculado al token correctamente"
+          : "Informe desvinculado del token correctamente",
+      particularToken: updated
+        ? serializeParticularTokenDetail(updated, report)
+        : null,
+    });
+  });
+};

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -1,0 +1,436 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  adminParticularTokensNativeRoutes,
+} = await import("../server/routes/admin-particular-tokens.fastify.ts");
+
+function createClinicFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 3,
+    ...overrides,
+  };
+}
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatología",
+    patientName: "Luna",
+    fileName: "luna-report.pdf",
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+    storagePath: "reports/report-55.pdf",
+    ...overrides,
+  };
+}
+
+function createParticularTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    clinicId: 3,
+    reportId: 55,
+    tokenHash: "hash:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    tokenLast4: "aaaa",
+    tutorLastName: "Gomez",
+    petName: "Luna",
+    petAge: "8 años",
+    petBreed: "Caniche",
+    petSex: "Hembra",
+    petSpecies: "Canina",
+    sampleLocation: "Pabellón auricular",
+    sampleEvolution: "15 días",
+    detailsLesion: "Lesión nodular pequeña",
+    extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+    shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+    isActive: true,
+    lastLoginAt: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "ADMIN",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(adminParticularTokensNativeRoutes as any, {
+    prefix: "/api/admin/particular-tokens",
+    ...createAuthStubs(),
+    getClinicById: async () => createClinicFixture(),
+    getReportById: async () => createReportFixture(),
+    createParticularToken: async () => createParticularTokenFixture(),
+    getParticularTokenById: async () => createParticularTokenFixture(),
+    listParticularTokens: async () => [createParticularTokenFixture()],
+    updateParticularTokenReport: async () => createParticularTokenFixture(),
+    ...overrides,
+  });
+
+  return app;
+}
+
+test(
+  "adminParticularTokensNativeRoutes crea POST / con payload estable y token raw",
+  async () => {
+    const rawToken = "a".repeat(64);
+    const clinic = createClinicFixture();
+    const report = createReportFixture();
+    const createdToken = createParticularTokenFixture({
+      tokenHash: `hash:${rawToken}`,
+    });
+    const createCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      generateSessionToken: () => rawToken,
+      getClinicById: async (clinicId: number) => {
+        assert.equal(clinicId, 3);
+        return clinic;
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, 55);
+        return report;
+      },
+      createParticularToken: async (input: Record<string, unknown>) => {
+        createCalls.push(input);
+        return createdToken;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/particular-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 201);
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(createCalls.length, 1);
+      assert.equal(createCalls[0].clinicId, 3);
+      assert.equal(createCalls[0].reportId, 55);
+      assert.equal(createCalls[0].createdByAdminId, 1);
+      assert.equal(createCalls[0].createdByClinicUserId, null);
+      assert.equal(createCalls[0].tokenHash, `hash:${rawToken}`);
+      assert.equal(createCalls[0].tokenLast4, "aaaa");
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        message: "Token particular creado correctamente",
+        token: rawToken,
+        particularToken: {
+          id: 7,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+          isActive: true,
+          lastLoginAt: null,
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByAdminId: 1,
+          createdByClinicUserId: null,
+          hasLinkedReport: true,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes bloquea POST / con origin no permitido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/particular-tokens",
+        headers: {
+          origin: "https://evil.example",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Origen no permitido",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes expone GET / con lista, filtros y paginación",
+  async () => {
+    const listCalls: Array<Record<string, unknown>> = [];
+    const token = createParticularTokenFixture();
+
+    const app = await createTestApp({
+      listParticularTokens: async (params: Record<string, unknown>) => {
+        listCalls.push(params);
+        return [token];
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens?clinicId=3&limit=5&offset=2",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(listCalls.length, 1);
+      assert.equal(listCalls[0].clinicId, 3);
+      assert.equal(listCalls[0].limit, 5);
+      assert.equal(listCalls[0].offset, 2);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        count: 1,
+        particularTokens: [
+          {
+            id: 7,
+            clinicId: 3,
+            reportId: 55,
+            tokenLast4: "aaaa",
+            tutorLastName: "Gomez",
+            petName: "Luna",
+            petAge: "8 años",
+            petBreed: "Caniche",
+            petSex: "Hembra",
+            petSpecies: "Canina",
+            sampleLocation: "Pabellón auricular",
+            sampleEvolution: "15 días",
+            detailsLesion: "Lesión nodular pequeña",
+            extractionDate: "2026-04-20T00:00:00.000Z",
+            shippingDate: "2026-04-21T00:00:00.000Z",
+            isActive: true,
+            lastLoginAt: null,
+            createdAt: "2026-04-20T12:00:00.000Z",
+            updatedAt: "2026-04-22T12:00:00.000Z",
+            createdByAdminId: 1,
+            createdByClinicUserId: null,
+            hasLinkedReport: true,
+          },
+        ],
+        pagination: {
+          limit: 5,
+          offset: 2,
+        },
+        filters: {
+          clinicId: 3,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes expone GET /:tokenId con detalle y reporte vinculado",
+  async () => {
+    const token = createParticularTokenFixture();
+    const report = createReportFixture();
+
+    const app = await createTestApp({
+      getParticularTokenById: async (tokenId: number) => {
+        assert.equal(tokenId, 7);
+        return token;
+      },
+      getReportById: async (reportId: number) => {
+        assert.equal(reportId, 55);
+        return report;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens/7",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        particularToken: {
+          id: 7,
+          clinicId: 3,
+          reportId: 55,
+          tokenLast4: "aaaa",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+          isActive: true,
+          lastLoginAt: null,
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-22T12:00:00.000Z",
+          createdByAdminId: 1,
+          createdByClinicUserId: null,
+          hasLinkedReport: true,
+          report: {
+            id: 55,
+            clinicId: 3,
+            uploadDate: "2026-04-22T09:00:00.000Z",
+            studyType: "Histopatología",
+            patientName: "Luna",
+            fileName: "luna-report.pdf",
+            createdAt: "2026-04-22T09:00:00.000Z",
+            updatedAt: "2026-04-22T09:30:00.000Z",
+          },
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes vincula PATCH /:tokenId/report con trusted origin",
+  async () => {
+    const existing = createParticularTokenFixture({ reportId: null });
+    const updated = createParticularTokenFixture({ reportId: 55 });
+    const report = createReportFixture();
+    const updateCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      getParticularTokenById: async () => existing,
+      getReportById: async () => report,
+      updateParticularTokenReport: async (
+        tokenId: number,
+        reportId: number | null,
+      ) => {
+        updateCalls.push({ tokenId, reportId });
+        return updated;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/admin/particular-tokens/7/report",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          reportId: 55,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(updateCalls, [{ tokenId: 7, reportId: 55 }]);
+
+      const body = JSON.parse(response.body);
+      assert.equal(body.success, true);
+      assert.equal(body.message, "Informe vinculado al token correctamente");
+      assert.equal(body.particularToken.id, 7);
+      assert.equal(body.particularToken.reportId, 55);
+      assert.equal(body.particularToken.report.id, 55);
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -54,6 +54,46 @@ function buildAdminAuthRouteStubs() {
 }
 
 
+
+function buildAdminParticularTokensRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    createParticularToken: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: null,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      tutorLastName: "Gomez",
+      petName: "Luna",
+      petAge: "8 años",
+      petBreed: "Caniche",
+      petSex: "Hembra",
+      petSpecies: "Canina",
+      sampleLocation: "Pabellón auricular",
+      sampleEvolution: "15 días",
+      detailsLesion: null,
+      extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+      shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+      isActive: true,
+      lastLoginAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByAdminId: 1,
+      createdByClinicUserId: null,
+    }),
+    getParticularTokenById: async () => null,
+    listParticularTokens: async () => [],
+    updateParticularTokenReport: async () => null,
+  };
+}
 function buildAdminReportAccessTokensRouteStubs() {
   return {
     deleteAdminSession: async () => {},
@@ -301,6 +341,7 @@ test(
       }),
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -423,6 +464,7 @@ test(
         }),
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -497,6 +539,7 @@ test(
         }),
         updateAdminSessionLastAccess: async () => {},
       },
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -562,6 +605,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
@@ -648,6 +692,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
@@ -764,6 +809,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -864,6 +910,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -969,6 +1016,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1041,6 +1089,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1156,6 +1205,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1252,6 +1302,7 @@ test(
       },
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: {
         ...buildAdminReportAccessTokensRouteStubs(),
         getAdminSessionByToken: async () => ({
@@ -1327,4 +1378,101 @@ test(
     }
   },
 );
+
+
+test(
+  "createFastifyApp despacha /api/admin/particular-tokens al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/admin/particular-tokens", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: {
+        ...buildAdminParticularTokensRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "ADMIN",
+        }),
+        listParticularTokens: async () => [
+          {
+            id: 7,
+            clinicId: 3,
+            reportId: 55,
+            tokenHash: `hash:${"a".repeat(64)}`,
+            tokenLast4: "aaaa",
+            tutorLastName: "Gomez",
+            petName: "Luna",
+            petAge: "8 años",
+            petBreed: "Caniche",
+            petSex: "Hembra",
+            petSpecies: "Canina",
+            sampleLocation: "Pabellón auricular",
+            sampleEvolution: "15 días",
+            detailsLesion: null,
+            extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+            shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+            isActive: true,
+            lastLoginAt: null,
+            createdAt: new Date("2026-04-20T12:00:00.000Z"),
+            updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+            createdByAdminId: 1,
+            createdByClinicUserId: null,
+          },
+        ],
+      },
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens?clinicId=3&limit=5&offset=2",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.equal(response.statusCode, 200);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+
+
 


### PR DESCRIPTION
﻿## Summary
- add native Fastify admin particular token routes
- register /api/admin/particular-tokens before the legacy Express bridge
- cover native route behavior and Fastify bridge dispatch

## Validation
- pnpm.cmd typecheck
- pnpm.cmd test
