### PR TITLE
feat(http): move clinic study tracking routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -54,6 +54,10 @@ import {
   reportAccessTokensNativeRoutes,
   type ReportAccessTokensNativeRoutesOptions,
 } from "./routes/report-access-tokens.fastify.ts";
+import {
+  studyTrackingNativeRoutes,
+  type StudyTrackingNativeRoutesOptions,
+} from "./routes/study-tracking.fastify.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -87,6 +91,7 @@ export type CreateFastifyAppOptions = {
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
   publicReportAccessRoutes?: PublicReportAccessNativeRoutesOptions;
   reportAccessTokensRoutes?: ReportAccessTokensNativeRoutesOptions;
+  studyTrackingRoutes?: StudyTrackingNativeRoutesOptions;
 };
 
 const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
@@ -103,6 +108,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/public/professionals",
   "/public/report-access",
   "/report-access-tokens",
+  "/study-tracking",
 ];
 
 function shouldBypassLegacyApi(url: unknown) {
@@ -223,6 +229,11 @@ export async function createFastifyApp(
   await app.register(reportAccessTokensNativeRoutes, {
     prefix: "/api/report-access-tokens",
     ...(options.reportAccessTokensRoutes ?? {}),
+  });
+
+  await app.register(studyTrackingNativeRoutes, {
+    prefix: "/api/study-tracking",
+    ...(options.studyTrackingRoutes ?? {}),
   });
 
   await app.register(fastifyExpress);

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -1,0 +1,973 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type {
+  ParticularToken,
+  Report,
+  StudyTrackingCase,
+  StudyTrackingNotification,
+} from "../../drizzle/schema";
+import { ENV } from "../lib/env.ts";
+import {
+  applyEstimatedDeliveryRules,
+  buildValidationError,
+  clinicCreateStudyTrackingSchema,
+  parseBooleanQuery,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeStudyTrackingCase,
+  serializeStudyTrackingNotification,
+} from "../lib/study-tracking.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type ClinicRecord = {
+  id: number;
+  name: string;
+  contactEmail?: string | null;
+};
+
+type AuthenticatedClinicUser = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId: string | null;
+  role: ReturnType<typeof normalizeClinicUserRole>;
+  permissions: ReturnType<typeof getClinicPermissions>;
+  canUploadReports: boolean;
+  canManageClinicUsers: boolean;
+  sessionToken: string;
+};
+
+type StudyTrackingEmailInput = Pick<
+  StudyTrackingCase,
+  | "id"
+  | "clinicId"
+  | "receptionAt"
+  | "estimatedDeliveryAt"
+  | "currentStage"
+  | "paymentUrl"
+  | "adminContactEmail"
+  | "adminContactPhone"
+  | "notes"
+>;
+
+export type StudyTrackingNativeRoutesOptions = {
+  deleteActiveSession?: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById?: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  getParticularTokenById?: (
+    tokenId: number,
+  ) => Promise<ParticularToken | null | undefined>;
+  updateParticularTokenReport?: (
+    id: number,
+    reportId: number | null,
+  ) => Promise<ParticularToken | null | undefined>;
+  createStudyTrackingCase?: (input: {
+    clinicId: number;
+    reportId: number | null;
+    particularTokenId: number | null;
+    createdByAdminId: number | null;
+    createdByClinicUserId: number | null;
+    receptionAt: Date;
+    estimatedDeliveryAt: Date;
+    estimatedDeliveryAutoCalculatedAt: Date;
+    estimatedDeliveryWasManuallyAdjusted: boolean;
+    currentStage: string;
+    processingAt: Date | null;
+    evaluationAt: Date | null;
+    reportDevelopmentAt: Date | null;
+    deliveredAt: Date | null;
+    specialStainRequired: boolean;
+    specialStainNotifiedAt: Date | null;
+    paymentUrl: string | null;
+    adminContactEmail: string | null;
+    adminContactPhone: string | null;
+    notes: string | null;
+  }) => Promise<StudyTrackingCase>;
+  updateStudyTrackingCase?: (
+    id: number,
+    input: Partial<StudyTrackingCase>,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getClinicScopedStudyTrackingCase?: (
+    id: number,
+    clinicId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  listStudyTrackingCases?: (params: {
+    clinicId?: number;
+    reportId?: number;
+    particularTokenId?: number;
+    limit: number;
+    offset: number;
+  }) => Promise<StudyTrackingCase[]>;
+  createStudyTrackingNotification?: (input: {
+    studyTrackingCaseId: number;
+    clinicId: number;
+    reportId: number | null;
+    particularTokenId: number | null;
+    type: string;
+    title: string;
+    message: string;
+    isRead: boolean;
+    readAt: Date | null;
+  }) => Promise<StudyTrackingNotification>;
+  listStudyTrackingNotifications?: (params: {
+    clinicId?: number;
+    particularTokenId?: number;
+    studyTrackingCaseId?: number;
+    unreadOnly?: boolean;
+    limit: number;
+    offset: number;
+  }) => Promise<StudyTrackingNotification[]>;
+  sendSpecialStainRequiredEmail?: (input: {
+    to: Array<string | null | undefined>;
+    clinicName: string;
+    trackingCaseId: number;
+    receptionAt: Date;
+    estimatedDeliveryAt: Date;
+    currentStage: string;
+    paymentUrl: string | null;
+    adminContactEmail: string | null;
+    adminContactPhone: string | null;
+    notes: string | null;
+  }) => Promise<void>;
+  now?: () => number;
+  createDate?: () => Date;
+};
+
+const REQUEST_START_TIME_KEY = "__studyTrackingRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type StudyTrackingFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeStudyTrackingDeps = Required<
+  Pick<
+    StudyTrackingNativeRoutesOptions,
+    | "deleteActiveSession"
+    | "getActiveSessionByToken"
+    | "getClinicUserById"
+    | "updateSessionLastAccess"
+    | "hashSessionToken"
+    | "getClinicById"
+    | "getReportById"
+    | "getParticularTokenById"
+    | "updateParticularTokenReport"
+    | "createStudyTrackingCase"
+    | "updateStudyTrackingCase"
+    | "getClinicScopedStudyTrackingCase"
+    | "listStudyTrackingCases"
+    | "createStudyTrackingNotification"
+    | "listStudyTrackingNotifications"
+    | "sendSpecialStainRequiredEmail"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeStudyTrackingDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbStudyTracking = await import("../db-study-tracking.ts");
+      const dbParticular = await import("../db-particular.ts");
+      const email = await import("../lib/email.ts");
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getClinicById: db.getClinicById,
+        getReportById: db.getReportById,
+        getParticularTokenById: dbParticular.getParticularTokenById,
+        updateParticularTokenReport: dbParticular.updateParticularTokenReport,
+        createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
+        updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
+        getClinicScopedStudyTrackingCase:
+          dbStudyTracking.getClinicScopedStudyTrackingCase,
+        listStudyTrackingCases: dbStudyTracking.listStudyTrackingCases,
+        createStudyTrackingNotification:
+          dbStudyTracking.createStudyTrackingNotification,
+        listStudyTrackingNotifications:
+          dbStudyTracking.listStudyTrackingNotifications,
+        sendSpecialStainRequiredEmail: email.sendSpecialStainRequiredEmail,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.cookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearSessionCookie() {
+  return serializeCookie({
+    name: ENV.cookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateClinicUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeStudyTrackingDeps,
+  now: () => number,
+): Promise<AuthenticatedClinicUser | null> {
+  const token = getSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "No autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getActiveSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión expirada",
+    });
+    return null;
+  }
+
+  const clinicUser = await deps.getClinicUserById(session.clinicUserId);
+
+  if (!clinicUser) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateSessionLastAccess(tokenHash);
+  }
+
+  const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+  const permissions = getClinicPermissions(role);
+
+  return {
+    id: clinicUser.id,
+    clinicId: clinicUser.clinicId,
+    username: clinicUser.username,
+    authProId: clinicUser.authProId ?? null,
+    role,
+    permissions,
+    canUploadReports: permissions.canUploadReports,
+    canManageClinicUsers: permissions.canManageClinicUsers,
+    sessionToken: token,
+  };
+}
+
+function requireStudyTrackingManagementPermission(
+  auth: AuthenticatedClinicUser,
+  reply: FastifyReply,
+) {
+  if (auth.canManageClinicUsers) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "No autorizado para administrar recursos de la clinica",
+  });
+
+  return false;
+}
+
+async function notifySpecialStainByEmail(
+  trackingCase: StudyTrackingEmailInput,
+  deps: NativeStudyTrackingDeps,
+) {
+  const clinic = await deps.getClinicById(trackingCase.clinicId);
+
+  if (!clinic) {
+    console.warn("[EMAIL] special_stain_required skipped: clinic not found", {
+      trackingCaseId: trackingCase.id,
+      clinicId: trackingCase.clinicId,
+    });
+    return;
+  }
+
+  try {
+    await deps.sendSpecialStainRequiredEmail({
+      to: [clinic.contactEmail, trackingCase.adminContactEmail],
+      clinicName: clinic.name,
+      trackingCaseId: trackingCase.id,
+      receptionAt: trackingCase.receptionAt,
+      estimatedDeliveryAt: trackingCase.estimatedDeliveryAt,
+      currentStage: trackingCase.currentStage,
+      paymentUrl: trackingCase.paymentUrl,
+      adminContactEmail: trackingCase.adminContactEmail,
+      adminContactPhone: trackingCase.adminContactPhone,
+      notes: trackingCase.notes,
+    });
+  } catch (error) {
+    console.error("[EMAIL] special_stain_required failed", {
+      trackingCaseId: trackingCase.id,
+      clinicId: trackingCase.clinicId,
+      error,
+    });
+  }
+}
+
+export const studyTrackingNativeRoutes: FastifyPluginAsync<
+  StudyTrackingNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getClinicById &&
+    !!options.getReportById &&
+    !!options.getParticularTokenById &&
+    !!options.updateParticularTokenReport &&
+    !!options.createStudyTrackingCase &&
+    !!options.updateStudyTrackingCase &&
+    !!options.getClinicScopedStudyTrackingCase &&
+    !!options.listStudyTrackingCases &&
+    !!options.createStudyTrackingNotification &&
+    !!options.listStudyTrackingNotifications &&
+    !!options.sendSpecialStainRequiredEmail;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeStudyTrackingDeps = {
+    deleteActiveSession:
+      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
+    getActiveSessionByToken:
+      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
+    getClinicUserById:
+      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
+    updateSessionLastAccess:
+      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    getParticularTokenById:
+      options.getParticularTokenById ?? defaultDeps!.getParticularTokenById,
+    updateParticularTokenReport:
+      options.updateParticularTokenReport ??
+      defaultDeps!.updateParticularTokenReport,
+    createStudyTrackingCase:
+      options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
+    updateStudyTrackingCase:
+      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
+    getClinicScopedStudyTrackingCase:
+      options.getClinicScopedStudyTrackingCase ??
+      defaultDeps!.getClinicScopedStudyTrackingCase,
+    listStudyTrackingCases:
+      options.listStudyTrackingCases ?? defaultDeps!.listStudyTrackingCases,
+    createStudyTrackingNotification:
+      options.createStudyTrackingNotification ??
+      defaultDeps!.createStudyTrackingNotification,
+    listStudyTrackingNotifications:
+      options.listStudyTrackingNotifications ??
+      defaultDeps!.listStudyTrackingNotifications,
+    sendSpecialStainRequiredEmail:
+      options.sendSpecialStainRequiredEmail ??
+      defaultDeps!.sendSpecialStainRequiredEmail,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const createDate = options.createDate ?? (() => new Date());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as StudyTrackingFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as StudyTrackingFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/notifications", optionsHandler);
+  app.options("/:trackingCaseId", optionsHandler);
+
+  app.get<{
+    Querystring: {
+      unreadOnly?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/notifications", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const unreadOnly = parseBooleanQuery(request.query.unreadOnly) ?? false;
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const notifications = await deps.listStudyTrackingNotifications({
+      clinicId: auth.clinicId,
+      unreadOnly,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: notifications.length,
+      notifications: notifications.map((notification) =>
+        serializeStudyTrackingNotification(notification),
+      ),
+      pagination: {
+        limit,
+        offset,
+      },
+    });
+  });
+
+  app.post<{
+    Body: {
+      reportId?: unknown;
+      particularTokenId?: unknown;
+      receptionAt?: unknown;
+      currentStage?: unknown;
+      processingAt?: unknown;
+      evaluationAt?: unknown;
+      reportDevelopmentAt?: unknown;
+      deliveredAt?: unknown;
+      specialStainRequired?: unknown;
+      paymentUrl?: unknown;
+      adminContactEmail?: unknown;
+      adminContactPhone?: unknown;
+      notes?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    if (!requireStudyTrackingManagementPermission(auth, reply)) {
+      return reply;
+    }
+
+    const parsed = clinicCreateStudyTrackingSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    const clinic = await deps.getClinicById(auth.clinicId);
+
+    if (!clinic) {
+      return reply.code(404).send({
+        success: false,
+        error: "Clínica autenticada no encontrada",
+      });
+    }
+
+    if (typeof parsed.data.reportId === "number") {
+      const report = await deps.getReportById(parsed.data.reportId);
+
+      if (!report) {
+        return reply.code(404).send({
+          success: false,
+          error: "Informe no encontrado",
+        });
+      }
+
+      if (report.clinicId !== auth.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El informe no pertenece a la clínica autenticada",
+        });
+      }
+    }
+
+    if (typeof parsed.data.particularTokenId === "number") {
+      const particularToken = await deps.getParticularTokenById(
+        parsed.data.particularTokenId,
+      );
+
+      if (!particularToken) {
+        return reply.code(404).send({
+          success: false,
+          error: "Token particular no encontrado",
+        });
+      }
+
+      if (particularToken.clinicId !== auth.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El token particular no pertenece a la clínica autenticada",
+        });
+      }
+    }
+
+    const delivery = applyEstimatedDeliveryRules({
+      receptionAt: parsed.data.receptionAt,
+      manualEstimatedDeliveryAt: undefined,
+    });
+
+    const created = await deps.createStudyTrackingCase({
+      clinicId: auth.clinicId,
+      reportId: parsed.data.reportId ?? null,
+      particularTokenId: parsed.data.particularTokenId ?? null,
+      createdByAdminId: null,
+      createdByClinicUserId: auth.id,
+      receptionAt: parsed.data.receptionAt,
+      estimatedDeliveryAt: delivery.estimatedDeliveryAt,
+      estimatedDeliveryAutoCalculatedAt:
+        delivery.estimatedDeliveryAutoCalculatedAt,
+      estimatedDeliveryWasManuallyAdjusted:
+        delivery.estimatedDeliveryWasManuallyAdjusted,
+      currentStage: parsed.data.currentStage,
+      processingAt: parsed.data.processingAt ?? null,
+      evaluationAt: parsed.data.evaluationAt ?? null,
+      reportDevelopmentAt: parsed.data.reportDevelopmentAt ?? null,
+      deliveredAt: parsed.data.deliveredAt ?? null,
+      specialStainRequired: parsed.data.specialStainRequired,
+      specialStainNotifiedAt: null,
+      paymentUrl: parsed.data.paymentUrl ?? null,
+      adminContactEmail: parsed.data.adminContactEmail ?? null,
+      adminContactPhone: parsed.data.adminContactPhone ?? null,
+      notes: parsed.data.notes ?? null,
+    });
+
+    if (
+      typeof created.particularTokenId === "number" &&
+      typeof created.reportId === "number"
+    ) {
+      await deps.updateParticularTokenReport(
+        created.particularTokenId,
+        created.reportId,
+      );
+    }
+
+    let finalCase = created;
+
+    if (created.specialStainRequired) {
+      const notifiedAt = createDate();
+
+      await deps.createStudyTrackingNotification({
+        studyTrackingCaseId: created.id,
+        clinicId: created.clinicId,
+        reportId: created.reportId ?? null,
+        particularTokenId: created.particularTokenId ?? null,
+        type: "special_stain_required",
+        title: "Se requiere tinción especial",
+        message:
+          "El estudio requiere tinción especial. Se generó una notificación para seguimiento.",
+        isRead: false,
+        readAt: null,
+      });
+
+      finalCase =
+        (await deps.updateStudyTrackingCase(created.id, {
+          specialStainNotifiedAt: notifiedAt,
+        })) ?? created;
+
+      await notifySpecialStainByEmail(finalCase, deps);
+    }
+
+    return reply.code(201).send({
+      success: true,
+      message: "Seguimiento creado correctamente",
+      trackingCase: serializeStudyTrackingCase(finalCase),
+    });
+  });
+
+  app.get<{
+    Querystring: {
+      reportId?: unknown;
+      particularTokenId?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const reportId = parseEntityId(request.query.reportId);
+    const particularTokenId = parseEntityId(request.query.particularTokenId);
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const trackingCases = await deps.listStudyTrackingCases({
+      clinicId: auth.clinicId,
+      reportId,
+      particularTokenId,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: trackingCases.length,
+      trackingCases: trackingCases.map((trackingCase) =>
+        serializeStudyTrackingCase(trackingCase),
+      ),
+      pagination: {
+        limit,
+        offset,
+      },
+    });
+  });
+
+  app.get<{
+    Params: {
+      trackingCaseId: string;
+    };
+  }>("/:trackingCaseId", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const trackingCaseId = parseEntityId(request.params.trackingCaseId);
+
+    if (typeof trackingCaseId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de seguimiento inválido",
+      });
+    }
+
+    const trackingCase = await deps.getClinicScopedStudyTrackingCase(
+      trackingCaseId,
+      auth.clinicId,
+    );
+
+    if (!trackingCase) {
+      return reply.code(404).send({
+        success: false,
+        error: "Seguimiento no encontrado",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      trackingCase: serializeStudyTrackingCase(trackingCase),
+    });
+  });
+};

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -162,7 +162,7 @@ export type StudyTrackingNativeRoutesOptions = {
     adminContactEmail: string | null;
     adminContactPhone: string | null;
     notes: string | null;
-  }) => Promise<void>;
+  }) => Promise<unknown>;
   now?: () => number;
   createDate?: () => Date;
 };
@@ -232,7 +232,13 @@ async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
     })();
   }
 
-  return defaultDepsPromise;
+  const depsPromise = defaultDepsPromise;
+
+  if (!depsPromise) {
+    throw new Error("No se pudieron cargar las dependencias de study tracking");
+  }
+
+  return depsPromise;
 }
 
 function getAllowedOrigins(): string[] {

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -293,6 +293,27 @@ function buildParticularTokensRouteStubs() {
     updateParticularTokenReport: async () => null,
   };
 }
+function buildStudyTrackingRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+    getClinicScopedStudyTrackingCase: async () => null,
+    listStudyTrackingCases: async () => [],
+    createStudyTrackingNotification: async () => ({} as any),
+    listStudyTrackingNotifications: async () => [],
+    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
+  };
+}
+
 function buildPublicReportAccessRouteStubs() {
   return {
     getReportAccessTokenWithReportByTokenHash: async () => null,
@@ -399,6 +420,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -523,6 +545,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -599,6 +622,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -680,6 +704,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -807,6 +832,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -909,6 +935,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -1016,6 +1043,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -1081,6 +1109,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -1207,6 +1236,7 @@ test(
           "https://signed.example/download",
       },
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -1271,6 +1301,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
       reportAccessTokensRoutes: {
         ...buildReportAccessTokensRouteStubs(),
         getActiveSessionByToken: async () => ({
@@ -1400,6 +1431,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -1504,6 +1536,7 @@ test(
       },
       publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
       reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
     });
 
     try {
@@ -1528,4 +1561,54 @@ test(
 
 
 
+
+
+
+test(
+  "createFastifyApp despacha /api/study-tracking al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/study-tracking", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({ success: false });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({ rows: [], total: 0, limit: 20, offset: 0 }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/study-tracking",
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.equal(response.statusCode, 401);
+    } finally {
+      await app.close();
+    }
+  },
+);
 

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -1,0 +1,386 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  studyTrackingNativeRoutes,
+} = await import("../server/routes/study-tracking.fastify.ts");
+
+function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    clinicId: 3,
+    reportId: 55,
+    particularTokenId: 7,
+    createdByAdminId: null,
+    createdByClinicUserId: 9,
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryWasManuallyAdjusted: false,
+    currentStage: "reception",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+    paymentUrl: "https://pay.example/study-11",
+    adminContactEmail: "admin@example.com",
+    adminContactPhone: "+5493410000000",
+    notes: "Caso clínico inicial",
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T12:30:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createNotificationFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 21,
+    studyTrackingCaseId: 11,
+    clinicId: 3,
+    reportId: 55,
+    particularTokenId: 7,
+    type: "special_stain_required",
+    title: "Se requiere tinción especial",
+    message:
+      "El estudio requiere tinción especial. Se generó una notificación para seguimiento.",
+    isRead: false,
+    readAt: null,
+    createdAt: new Date("2026-04-20T13:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => ({
+      clinicUserId: 9,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(studyTrackingNativeRoutes as any, {
+    prefix: "/api/study-tracking",
+    ...createAuthStubs(),
+    getClinicById: async () => ({
+      id: 3,
+      name: "Clínica Centro",
+      contactEmail: "clinic@example.com",
+    }),
+    getReportById: async () => ({
+      id: 55,
+      clinicId: 3,
+      uploadDate: new Date("2026-04-19T09:00:00.000Z"),
+      studyType: "Histopatología",
+      patientName: "Luna",
+      fileName: "luna.pdf",
+      currentStatus: "ready",
+      statusChangedAt: new Date("2026-04-19T10:00:00.000Z"),
+      storagePath: "reports/luna.pdf",
+      createdAt: new Date("2026-04-19T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-19T10:00:00.000Z"),
+    }),
+    getParticularTokenById: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: null,
+      tokenHash: "hash",
+      tokenLast4: "ABCD",
+      tutorLastName: "Gomez",
+      petName: "Luna",
+      petAge: "8 años",
+      petBreed: "Caniche",
+      petSex: "Hembra",
+      petSpecies: "Canina",
+      sampleLocation: "Pabellón auricular",
+      sampleEvolution: "15 días",
+      detailsLesion: null,
+      extractionDate: new Date("2026-04-18T00:00:00.000Z"),
+      shippingDate: new Date("2026-04-19T00:00:00.000Z"),
+      isActive: true,
+      lastLoginAt: null,
+      createdAt: new Date("2026-04-18T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T12:30:00.000Z"),
+      createdByAdminId: null,
+      createdByClinicUserId: 9,
+    }),
+    updateParticularTokenReport: async () => undefined,
+    createStudyTrackingCase: async () => createTrackingCaseFixture(),
+    updateStudyTrackingCase: async () => createTrackingCaseFixture(),
+    getClinicScopedStudyTrackingCase: async () => createTrackingCaseFixture(),
+    listStudyTrackingCases: async () => [createTrackingCaseFixture()],
+    createStudyTrackingNotification: async () => createNotificationFixture(),
+    listStudyTrackingNotifications: async () => [createNotificationFixture()],
+    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
+    now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
+    createDate: () => new Date("2026-04-20T13:30:00.000Z"),
+    ...overrides,
+  });
+
+  return app;
+}
+
+test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async () => {
+  const listCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    listStudyTrackingNotifications: async (params: Record<string, unknown>) => {
+      listCalls.push(params);
+      return [createNotificationFixture()];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/study-tracking/notifications?unreadOnly=true&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(listCalls, [
+      {
+        clinicId: 3,
+        unreadOnly: true,
+        limit: 5,
+        offset: 2,
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.notifications[0].id, 21);
+    assert.equal(body.notifications[0].clinicId, 3);
+    assert.equal(body.pagination.limit, 5);
+    assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes crea POST / con vínculos y notificación especial", async () => {
+  const createCalls: Array<Record<string, unknown>> = [];
+  const updateTokenCalls: Array<Record<string, unknown>> = [];
+  const notificationCalls: Array<Record<string, unknown>> = [];
+  const emailCalls: Array<Record<string, unknown>> = [];
+  const notifiedAt = new Date("2026-04-20T13:30:00.000Z");
+  const created = createTrackingCaseFixture({ specialStainRequired: true });
+  const updated = createTrackingCaseFixture({
+    specialStainRequired: true,
+    specialStainNotifiedAt: notifiedAt,
+  });
+
+  const app = await createTestApp({
+    createStudyTrackingCase: async (input: Record<string, unknown>) => {
+      createCalls.push(input);
+      return created;
+    },
+    updateParticularTokenReport: async (
+      particularTokenId: number,
+      reportId: number | null,
+    ) => {
+      updateTokenCalls.push({ particularTokenId, reportId });
+      return undefined;
+    },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture();
+    },
+    updateStudyTrackingCase: async (
+      trackingCaseId: number,
+      input: Record<string, unknown>,
+    ) => {
+      assert.equal(trackingCaseId, 11);
+      assert.deepEqual(input, { specialStainNotifiedAt: notifiedAt });
+      return updated;
+    },
+    sendSpecialStainRequiredEmail: async (input: Record<string, unknown>) => {
+      emailCalls.push(input);
+      return { sent: true };
+    },
+    createDate: () => notifiedAt,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/study-tracking",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        reportId: 55,
+        particularTokenId: 7,
+        receptionAt: "2026-04-20T00:00:00.000Z",
+        currentStage: "reception",
+        specialStainRequired: true,
+        paymentUrl: "https://pay.example/study-11",
+        adminContactEmail: "admin@example.com",
+        adminContactPhone: "+5493410000000",
+        notes: "Caso clínico inicial",
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      "http://localhost:3000",
+    );
+    assert.equal(createCalls.length, 1);
+    assert.equal(createCalls[0].clinicId, 3);
+    assert.equal(createCalls[0].reportId, 55);
+    assert.equal(createCalls[0].particularTokenId, 7);
+    assert.equal(createCalls[0].createdByAdminId, null);
+    assert.equal(createCalls[0].createdByClinicUserId, 9);
+    assert.equal(createCalls[0].specialStainRequired, true);
+    assert.equal(createCalls[0].estimatedDeliveryWasManuallyAdjusted, false);
+    assert.ok(createCalls[0].estimatedDeliveryAt instanceof Date);
+    assert.deepEqual(updateTokenCalls, [{ particularTokenId: 7, reportId: 55 }]);
+    assert.equal(notificationCalls.length, 1);
+    assert.equal(notificationCalls[0].studyTrackingCaseId, 11);
+    assert.equal(notificationCalls[0].clinicId, 3);
+    assert.equal(notificationCalls[0].type, "special_stain_required");
+    assert.equal(emailCalls.length, 1);
+    assert.deepEqual(emailCalls[0].to, ["clinic@example.com", "admin@example.com"]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Seguimiento creado correctamente");
+    assert.equal(body.trackingCase.id, 11);
+    assert.equal(body.trackingCase.clinicId, 3);
+    assert.equal(body.trackingCase.specialStainNotifiedAt, notifiedAt.toISOString());
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes bloquea POST / con origin no permitido", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/study-tracking",
+      headers: {
+        origin: "https://evil.example",
+        cookie: `${ENV.cookieName}=session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        receptionAt: "2026-04-20T00:00:00.000Z",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes expone GET / con lista clinic-scoped", async () => {
+  const listCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    listStudyTrackingCases: async (params: Record<string, unknown>) => {
+      listCalls.push(params);
+      return [createTrackingCaseFixture()];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/study-tracking?reportId=55&particularTokenId=7&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(listCalls, [
+      {
+        clinicId: 3,
+        reportId: 55,
+        particularTokenId: 7,
+        limit: 5,
+        offset: 2,
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.trackingCases[0].id, 11);
+    assert.equal(body.trackingCases[0].clinicId, 3);
+    assert.equal(body.pagination.limit, 5);
+    assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes expone GET /:trackingCaseId con detalle", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    getClinicScopedStudyTrackingCase: async (
+      trackingCaseId: number,
+      clinicId: number,
+    ) => {
+      calls.push({ trackingCaseId, clinicId });
+      return createTrackingCaseFixture();
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/study-tracking/11",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls, [{ trackingCaseId: 11, clinicId: 3 }]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.trackingCase.id, 11);
+    assert.equal(body.trackingCase.clinicId, 3);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
﻿## Summary
- add native Fastify clinic study tracking routes
- register /api/study-tracking before the legacy Express bridge
- cover native study tracking behavior and Fastify app bridge dispatch

## Validation
- pnpm.cmd typecheck
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/study-tracking.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd test
