### PR TITLE
feat(http): move admin study tracking routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -1,4 +1,4 @@
-import Fastify, {
+﻿import Fastify, {
   type FastifyInstance,
   type FastifyReply,
   type FastifyRequest,
@@ -22,6 +22,10 @@ import {
   adminReportAccessTokensNativeRoutes,
   type AdminReportAccessTokensNativeRoutesOptions,
 } from "./routes/admin-report-access-tokens.fastify.ts";
+import {
+  adminStudyTrackingNativeRoutes,
+  type AdminStudyTrackingNativeRoutesOptions,
+} from "./routes/admin-study-tracking.fastify.ts";
 import {
   clinicAuthNativeRoutes,
   type AuthNativeRoutesOptions,
@@ -83,6 +87,7 @@ export type CreateFastifyAppOptions = {
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   adminParticularTokensRoutes?: AdminParticularTokensNativeRoutesOptions;
   adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
+  adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
@@ -100,6 +105,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/admin/auth",
   "/admin/particular-tokens",
   "/admin/report-access-tokens",
+  "/admin/study-tracking",
   "/auth",
   "/clinic/audit-log",
   "/clinic/profile",
@@ -191,6 +197,11 @@ export async function createFastifyApp(
     ...(options.adminReportAccessTokensRoutes ?? {}),
   });
 
+  await app.register(adminStudyTrackingNativeRoutes, {
+    prefix: "/api/admin/study-tracking",
+    ...(options.adminStudyTrackingRoutes ?? {}),
+  });
+
   await app.register(clinicAuthNativeRoutes, {
     prefix: "/api/auth",
     ...(options.clinicAuthRoutes ?? {}),
@@ -257,3 +268,4 @@ export async function createFastifyApp(
 
   return app;
 }
+

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -1,0 +1,1157 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type {
+  ParticularToken,
+  Report,
+  StudyTrackingCase,
+  StudyTrackingNotification,
+} from "../../drizzle/schema";
+import { ENV } from "../lib/env.ts";
+import {
+  adminCreateStudyTrackingSchema,
+  applyEstimatedDeliveryRules,
+  applyStageTimestampDefaults,
+  buildValidationError,
+  parseBooleanQuery,
+  parseEntityId,
+  parseOffset,
+  parsePositiveInt,
+  serializeStudyTrackingCase,
+  serializeStudyTrackingNotification,
+  shouldCreateSpecialStainNotification,
+  updateStudyTrackingSchema,
+} from "../lib/study-tracking.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type AdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type ClinicRecord = {
+  id: number;
+  name: string;
+  contactEmail?: string | null;
+};
+
+type StudyTrackingEmailInput = Pick<
+  StudyTrackingCase,
+  | "id"
+  | "clinicId"
+  | "receptionAt"
+  | "estimatedDeliveryAt"
+  | "currentStage"
+  | "paymentUrl"
+  | "adminContactEmail"
+  | "adminContactPhone"
+  | "notes"
+>;
+
+export type AdminStudyTrackingNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (adminUserId: number) => Promise<AdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  getParticularTokenById?: (
+    tokenId: number,
+  ) => Promise<ParticularToken | null | undefined>;
+  updateParticularTokenReport?: (
+    id: number,
+    reportId: number | null,
+  ) => Promise<ParticularToken | null | undefined>;
+  createStudyTrackingCase?: (input: {
+    clinicId: number;
+    reportId: number | null;
+    particularTokenId: number | null;
+    createdByAdminId: number | null;
+    createdByClinicUserId: number | null;
+    receptionAt: Date;
+    estimatedDeliveryAt: Date;
+    estimatedDeliveryAutoCalculatedAt: Date;
+    estimatedDeliveryWasManuallyAdjusted: boolean;
+    currentStage: string;
+    processingAt: Date | null;
+    evaluationAt: Date | null;
+    reportDevelopmentAt: Date | null;
+    deliveredAt: Date | null;
+    specialStainRequired: boolean;
+    specialStainNotifiedAt: Date | null;
+    paymentUrl: string | null;
+    adminContactEmail: string | null;
+    adminContactPhone: string | null;
+    notes: string | null;
+  }) => Promise<StudyTrackingCase>;
+  updateStudyTrackingCase?: (
+    id: number,
+    input: Partial<StudyTrackingCase>,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getClinicScopedStudyTrackingCase?: (
+    id: number,
+    clinicId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getStudyTrackingCaseById?: (
+    id: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  listStudyTrackingCases?: (params: {
+    clinicId?: number;
+    reportId?: number;
+    particularTokenId?: number;
+    limit: number;
+    offset: number;
+  }) => Promise<StudyTrackingCase[]>;
+  createStudyTrackingNotification?: (input: {
+    studyTrackingCaseId: number;
+    clinicId: number;
+    reportId: number | null;
+    particularTokenId: number | null;
+    type: string;
+    title: string;
+    message: string;
+    isRead: boolean;
+    readAt: Date | null;
+  }) => Promise<StudyTrackingNotification>;
+  listStudyTrackingNotifications?: (params: {
+    clinicId?: number;
+    particularTokenId?: number;
+    studyTrackingCaseId?: number;
+    unreadOnly?: boolean;
+    limit: number;
+    offset: number;
+  }) => Promise<StudyTrackingNotification[]>;
+  sendSpecialStainRequiredEmail?: (input: {
+    to: Array<string | null | undefined>;
+    clinicName: string;
+    trackingCaseId: number;
+    receptionAt: Date;
+    estimatedDeliveryAt: Date;
+    currentStage: string;
+    paymentUrl: string | null;
+    adminContactEmail: string | null;
+    adminContactPhone: string | null;
+    notes: string | null;
+  }) => Promise<unknown>;
+  now?: () => number;
+  createDate?: () => Date;
+};
+
+const REQUEST_START_TIME_KEY = "__adminStudyTrackingRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type AdminStudyTrackingFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeAdminStudyTrackingDeps = Required<
+  Pick<
+    AdminStudyTrackingNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getClinicById"
+    | "getReportById"
+    | "getParticularTokenById"
+    | "updateParticularTokenReport"
+    | "createStudyTrackingCase"
+    | "updateStudyTrackingCase"
+    | "getClinicScopedStudyTrackingCase"
+    | "getStudyTrackingCaseById"
+    | "listStudyTrackingCases"
+    | "createStudyTrackingNotification"
+    | "listStudyTrackingNotifications"
+    | "sendSpecialStainRequiredEmail"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminStudyTrackingDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminStudyTrackingDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbStudyTracking = await import("../db-study-tracking.ts");
+      const dbParticular = await import("../db-particular.ts");
+      const email = await import("../lib/email.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getClinicById: db.getClinicById,
+        getReportById: db.getReportById,
+        getParticularTokenById: dbParticular.getParticularTokenById,
+        updateParticularTokenReport: dbParticular.updateParticularTokenReport,
+        createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
+        updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
+        getClinicScopedStudyTrackingCase:
+          dbStudyTracking.getClinicScopedStudyTrackingCase,
+        getStudyTrackingCaseById: dbStudyTracking.getStudyTrackingCaseById,
+        listStudyTrackingCases: dbStudyTracking.listStudyTrackingCases,
+        createStudyTrackingNotification:
+          dbStudyTracking.createStudyTrackingNotification,
+        listStudyTrackingNotifications:
+          dbStudyTracking.listStudyTrackingNotifications,
+        sendSpecialStainRequiredEmail: email.sendSpecialStainRequiredEmail,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminStudyTrackingDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+async function notifySpecialStainByEmail(
+  trackingCase: StudyTrackingEmailInput,
+  deps: NativeAdminStudyTrackingDeps,
+) {
+  const clinic = await deps.getClinicById(trackingCase.clinicId);
+
+  if (!clinic) {
+    console.warn("[EMAIL] special_stain_required skipped: clinic not found", {
+      trackingCaseId: trackingCase.id,
+      clinicId: trackingCase.clinicId,
+    });
+    return;
+  }
+
+  try {
+    await deps.sendSpecialStainRequiredEmail({
+      to: [clinic.contactEmail, trackingCase.adminContactEmail],
+      clinicName: clinic.name,
+      trackingCaseId: trackingCase.id,
+      receptionAt: trackingCase.receptionAt,
+      estimatedDeliveryAt: trackingCase.estimatedDeliveryAt,
+      currentStage: trackingCase.currentStage,
+      paymentUrl: trackingCase.paymentUrl,
+      adminContactEmail: trackingCase.adminContactEmail,
+      adminContactPhone: trackingCase.adminContactPhone,
+      notes: trackingCase.notes,
+    });
+  } catch (error) {
+    console.error("[EMAIL] special_stain_required failed", {
+      trackingCaseId: trackingCase.id,
+      clinicId: trackingCase.clinicId,
+      error,
+    });
+  }
+}
+
+export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
+  AdminStudyTrackingNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getClinicById &&
+    !!options.getReportById &&
+    !!options.getParticularTokenById &&
+    !!options.updateParticularTokenReport &&
+    !!options.createStudyTrackingCase &&
+    !!options.updateStudyTrackingCase &&
+    !!options.getClinicScopedStudyTrackingCase &&
+    !!options.getStudyTrackingCaseById &&
+    !!options.listStudyTrackingCases &&
+    !!options.createStudyTrackingNotification &&
+    !!options.listStudyTrackingNotifications &&
+    !!options.sendSpecialStainRequiredEmail;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminStudyTrackingDeps = {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById: options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    getParticularTokenById:
+      options.getParticularTokenById ?? defaultDeps!.getParticularTokenById,
+    updateParticularTokenReport:
+      options.updateParticularTokenReport ??
+      defaultDeps!.updateParticularTokenReport,
+    createStudyTrackingCase:
+      options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
+    updateStudyTrackingCase:
+      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
+    getClinicScopedStudyTrackingCase:
+      options.getClinicScopedStudyTrackingCase ??
+      defaultDeps!.getClinicScopedStudyTrackingCase,
+    getStudyTrackingCaseById:
+      options.getStudyTrackingCaseById ??
+      defaultDeps!.getStudyTrackingCaseById,
+    listStudyTrackingCases:
+      options.listStudyTrackingCases ?? defaultDeps!.listStudyTrackingCases,
+    createStudyTrackingNotification:
+      options.createStudyTrackingNotification ??
+      defaultDeps!.createStudyTrackingNotification,
+    listStudyTrackingNotifications:
+      options.listStudyTrackingNotifications ??
+      defaultDeps!.listStudyTrackingNotifications,
+    sendSpecialStainRequiredEmail:
+      options.sendSpecialStainRequiredEmail ??
+      defaultDeps!.sendSpecialStainRequiredEmail,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const createDate = options.createDate ?? (() => new Date());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as AdminStudyTrackingFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as AdminStudyTrackingFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/notifications", optionsHandler);
+  app.options("/:trackingCaseId", optionsHandler);
+
+  app.get<{
+    Querystring: {
+      clinicId?: unknown;
+      unreadOnly?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/notifications", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const clinicId = parseEntityId(request.query.clinicId);
+    const unreadOnly = parseBooleanQuery(request.query.unreadOnly) ?? false;
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const notifications = await deps.listStudyTrackingNotifications({
+      clinicId,
+      unreadOnly,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: notifications.length,
+      notifications: notifications.map((notification) =>
+        serializeStudyTrackingNotification(notification),
+      ),
+      pagination: {
+        limit,
+        offset,
+      },
+    });
+  });
+
+  app.post<{
+    Body: Record<string, unknown>;
+  }>("/", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const parsed = adminCreateStudyTrackingSchema.safeParse(request.body ?? {});
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    const clinic = await deps.getClinicById(parsed.data.clinicId);
+
+    if (!clinic) {
+      return reply.code(404).send({
+        success: false,
+        error: "Clínica no encontrada",
+      });
+    }
+
+    if (typeof parsed.data.reportId === "number") {
+      const report = await deps.getReportById(parsed.data.reportId);
+
+      if (!report) {
+        return reply.code(404).send({
+          success: false,
+          error: "Informe no encontrado",
+        });
+      }
+
+      if (report.clinicId !== parsed.data.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El informe no pertenece a la clínica indicada",
+        });
+      }
+    }
+
+    if (typeof parsed.data.particularTokenId === "number") {
+      const particularToken = await deps.getParticularTokenById(
+        parsed.data.particularTokenId,
+      );
+
+      if (!particularToken) {
+        return reply.code(404).send({
+          success: false,
+          error: "Token particular no encontrado",
+        });
+      }
+
+      if (particularToken.clinicId !== parsed.data.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El token particular no pertenece a la clínica indicada",
+        });
+      }
+    }
+
+    const delivery = applyEstimatedDeliveryRules({
+      receptionAt: parsed.data.receptionAt,
+      manualEstimatedDeliveryAt: parsed.data.estimatedDeliveryAt,
+    });
+
+    const created = await deps.createStudyTrackingCase({
+      clinicId: parsed.data.clinicId,
+      reportId: parsed.data.reportId ?? null,
+      particularTokenId: parsed.data.particularTokenId ?? null,
+      createdByAdminId: admin.id,
+      createdByClinicUserId: null,
+      receptionAt: parsed.data.receptionAt,
+      estimatedDeliveryAt: delivery.estimatedDeliveryAt,
+      estimatedDeliveryAutoCalculatedAt:
+        delivery.estimatedDeliveryAutoCalculatedAt,
+      estimatedDeliveryWasManuallyAdjusted:
+        delivery.estimatedDeliveryWasManuallyAdjusted,
+      currentStage: parsed.data.currentStage,
+      processingAt: parsed.data.processingAt ?? null,
+      evaluationAt: parsed.data.evaluationAt ?? null,
+      reportDevelopmentAt: parsed.data.reportDevelopmentAt ?? null,
+      deliveredAt: parsed.data.deliveredAt ?? null,
+      specialStainRequired: parsed.data.specialStainRequired,
+      specialStainNotifiedAt: null,
+      paymentUrl: parsed.data.paymentUrl ?? null,
+      adminContactEmail: parsed.data.adminContactEmail ?? null,
+      adminContactPhone: parsed.data.adminContactPhone ?? null,
+      notes: parsed.data.notes ?? null,
+    });
+
+    if (
+      typeof created.particularTokenId === "number" &&
+      typeof created.reportId === "number"
+    ) {
+      await deps.updateParticularTokenReport(
+        created.particularTokenId,
+        created.reportId,
+      );
+    }
+
+    let finalCase = created;
+
+    if (created.specialStainRequired) {
+      const notifiedAt = createDate();
+
+      await deps.createStudyTrackingNotification({
+        studyTrackingCaseId: created.id,
+        clinicId: created.clinicId,
+        reportId: created.reportId ?? null,
+        particularTokenId: created.particularTokenId ?? null,
+        type: "special_stain_required",
+        title: "Se requiere tinción especial",
+        message:
+          "El estudio ingresó a evaluación y requiere tinción especial para continuar.",
+        isRead: false,
+        readAt: null,
+      });
+
+      finalCase =
+        (await deps.updateStudyTrackingCase(created.id, {
+          specialStainNotifiedAt: notifiedAt,
+        })) ?? created;
+
+      await notifySpecialStainByEmail(finalCase, deps);
+    }
+
+    return reply.code(201).send({
+      success: true,
+      message: "Seguimiento creado correctamente",
+      trackingCase: serializeStudyTrackingCase(finalCase),
+    });
+  });
+
+  app.get<{
+    Querystring: {
+      clinicId?: unknown;
+      reportId?: unknown;
+      particularTokenId?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const clinicId = parseEntityId(request.query.clinicId);
+    const reportId = parseEntityId(request.query.reportId);
+    const particularTokenId = parseEntityId(request.query.particularTokenId);
+    const limit = parsePositiveInt(request.query.limit, 50, 100);
+    const offset = parseOffset(request.query.offset, 0);
+
+    const trackingCases = await deps.listStudyTrackingCases({
+      clinicId,
+      reportId,
+      particularTokenId,
+      limit,
+      offset,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      count: trackingCases.length,
+      trackingCases: trackingCases.map((trackingCase) =>
+        serializeStudyTrackingCase(trackingCase),
+      ),
+      pagination: {
+        limit,
+        offset,
+      },
+    });
+  });
+
+  app.get<{
+    Params: {
+      trackingCaseId: string;
+    };
+    Querystring: {
+      clinicId?: unknown;
+    };
+  }>("/:trackingCaseId", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const trackingCaseId = parseEntityId(request.params.trackingCaseId);
+
+    if (typeof trackingCaseId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de seguimiento inválido",
+      });
+    }
+
+    const clinicId = parseEntityId(request.query.clinicId);
+    const trackingCase =
+      typeof clinicId === "number"
+        ? await deps.getClinicScopedStudyTrackingCase(trackingCaseId, clinicId)
+        : await deps.getStudyTrackingCaseById(trackingCaseId);
+
+    if (!trackingCase) {
+      return reply.code(404).send({
+        success: false,
+        error: "Seguimiento no encontrado",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      trackingCase: serializeStudyTrackingCase(trackingCase),
+    });
+  });
+
+  app.patch<{
+    Params: {
+      trackingCaseId: string;
+    };
+    Querystring: {
+      clinicId?: unknown;
+    };
+    Body: Record<string, unknown>;
+  }>("/:trackingCaseId", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const trackingCaseId = parseEntityId(request.params.trackingCaseId);
+
+    if (typeof trackingCaseId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de seguimiento inválido",
+      });
+    }
+
+    const body = request.body ?? {};
+    const clinicId =
+      parseEntityId(body.clinicId) ?? parseEntityId(request.query.clinicId);
+
+    const current =
+      typeof clinicId === "number"
+        ? await deps.getClinicScopedStudyTrackingCase(trackingCaseId, clinicId)
+        : await deps.getStudyTrackingCaseById(trackingCaseId);
+
+    if (!current) {
+      return reply.code(404).send({
+        success: false,
+        error: "Seguimiento no encontrado",
+      });
+    }
+
+    const parsed = updateStudyTrackingSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: buildValidationError(parsed.error),
+      });
+    }
+
+    if (typeof parsed.data.reportId === "number") {
+      const report = await deps.getReportById(parsed.data.reportId);
+
+      if (!report) {
+        return reply.code(404).send({
+          success: false,
+          error: "Informe no encontrado",
+        });
+      }
+
+      if (report.clinicId !== current.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El informe no pertenece a la clínica del seguimiento",
+        });
+      }
+    }
+
+    if (typeof parsed.data.particularTokenId === "number") {
+      const particularToken = await deps.getParticularTokenById(
+        parsed.data.particularTokenId,
+      );
+
+      if (!particularToken) {
+        return reply.code(404).send({
+          success: false,
+          error: "Token particular no encontrado",
+        });
+      }
+
+      if (particularToken.clinicId !== current.clinicId) {
+        return reply.code(400).send({
+          success: false,
+          error: "El token particular no pertenece a la clínica del seguimiento",
+        });
+      }
+    }
+
+    const nextReceptionAt = parsed.data.receptionAt ?? current.receptionAt;
+    const deliveryRecalculationNeeded =
+      parsed.data.receptionAt instanceof Date ||
+      parsed.data.estimatedDeliveryAt instanceof Date;
+
+    const delivery = deliveryRecalculationNeeded
+      ? applyEstimatedDeliveryRules({
+          receptionAt: nextReceptionAt,
+          manualEstimatedDeliveryAt:
+            parsed.data.estimatedDeliveryAt instanceof Date
+              ? parsed.data.estimatedDeliveryAt
+              : undefined,
+        })
+      : null;
+
+    const stageDefaults = applyStageTimestampDefaults(current, {
+      currentStage: parsed.data.currentStage,
+      processingAt:
+        typeof parsed.data.processingAt === "undefined"
+          ? undefined
+          : parsed.data.processingAt,
+      evaluationAt:
+        typeof parsed.data.evaluationAt === "undefined"
+          ? undefined
+          : parsed.data.evaluationAt,
+      reportDevelopmentAt:
+        typeof parsed.data.reportDevelopmentAt === "undefined"
+          ? undefined
+          : parsed.data.reportDevelopmentAt,
+      deliveredAt:
+        typeof parsed.data.deliveredAt === "undefined"
+          ? undefined
+          : parsed.data.deliveredAt,
+    });
+
+    const updated = await deps.updateStudyTrackingCase(trackingCaseId, {
+      reportId:
+        typeof parsed.data.reportId === "undefined"
+          ? undefined
+          : parsed.data.reportId,
+      particularTokenId:
+        typeof parsed.data.particularTokenId === "undefined"
+          ? undefined
+          : parsed.data.particularTokenId,
+      receptionAt: parsed.data.receptionAt,
+      estimatedDeliveryAt: delivery?.estimatedDeliveryAt,
+      estimatedDeliveryAutoCalculatedAt:
+        delivery?.estimatedDeliveryAutoCalculatedAt,
+      estimatedDeliveryWasManuallyAdjusted:
+        delivery?.estimatedDeliveryWasManuallyAdjusted,
+      currentStage: parsed.data.currentStage,
+      processingAt:
+        typeof stageDefaults.processingAt === "undefined"
+          ? undefined
+          : stageDefaults.processingAt,
+      evaluationAt:
+        typeof stageDefaults.evaluationAt === "undefined"
+          ? undefined
+          : stageDefaults.evaluationAt,
+      reportDevelopmentAt:
+        typeof stageDefaults.reportDevelopmentAt === "undefined"
+          ? undefined
+          : stageDefaults.reportDevelopmentAt,
+      deliveredAt:
+        typeof stageDefaults.deliveredAt === "undefined"
+          ? undefined
+          : stageDefaults.deliveredAt,
+      specialStainRequired: parsed.data.specialStainRequired,
+      paymentUrl: parsed.data.paymentUrl,
+      adminContactEmail: parsed.data.adminContactEmail,
+      adminContactPhone: parsed.data.adminContactPhone,
+      notes: parsed.data.notes,
+    });
+
+    if (!updated) {
+      return reply.code(404).send({
+        success: false,
+        error: "Seguimiento no encontrado",
+      });
+    }
+
+    if (
+      typeof updated.particularTokenId === "number" &&
+      typeof updated.reportId === "number"
+    ) {
+      await deps.updateParticularTokenReport(
+        updated.particularTokenId,
+        updated.reportId,
+      );
+    }
+
+    let finalCase = updated;
+
+    if (
+      shouldCreateSpecialStainNotification({
+        previousRequired: current.specialStainRequired,
+        nextRequired: updated.specialStainRequired,
+        notifiedAt: updated.specialStainNotifiedAt,
+      })
+    ) {
+      const notifiedAt = createDate();
+
+      await deps.createStudyTrackingNotification({
+        studyTrackingCaseId: updated.id,
+        clinicId: updated.clinicId,
+        reportId: updated.reportId ?? null,
+        particularTokenId: updated.particularTokenId ?? null,
+        type: "special_stain_required",
+        title: "Se requiere tinción especial",
+        message:
+          "El estudio requiere tinción especial. Revisá el seguimiento para continuar la gestión.",
+        isRead: false,
+        readAt: null,
+      });
+
+      finalCase =
+        (await deps.updateStudyTrackingCase(updated.id, {
+          specialStainNotifiedAt: notifiedAt,
+        })) ?? updated;
+
+      await notifySpecialStainByEmail(finalCase, deps);
+    }
+
+    return reply.code(200).send({
+      success: true,
+      message: "Seguimiento actualizado correctamente",
+      trackingCase: serializeStudyTrackingCase(finalCase),
+    });
+  });
+};
+

--- a/test/admin-study-tracking.fastify.test.ts
+++ b/test/admin-study-tracking.fastify.test.ts
@@ -1,0 +1,469 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  adminStudyTrackingNativeRoutes,
+} = await import("../server/routes/admin-study-tracking.fastify.ts");
+
+function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    clinicId: 3,
+    reportId: 55,
+    particularTokenId: 7,
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryWasManuallyAdjusted: false,
+    currentStage: "reception",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+    paymentUrl: "https://pay.example/study-11",
+    adminContactEmail: "admin@example.com",
+    adminContactPhone: "+5493410000000",
+    notes: "Caso clínico inicial",
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T12:30:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createNotificationFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 21,
+    studyTrackingCaseId: 11,
+    clinicId: 3,
+    reportId: 55,
+    particularTokenId: 7,
+    type: "special_stain_required",
+    title: "Se requiere tinción especial",
+    message:
+      "El estudio ingresó a evaluación y requiere tinción especial para continuar.",
+    isRead: false,
+    readAt: null,
+    createdAt: new Date("2026-04-20T13:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAdminAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(adminStudyTrackingNativeRoutes as any, {
+    prefix: "/api/admin/study-tracking",
+    ...createAdminAuthStubs(),
+    getClinicById: async () => ({
+      id: 3,
+      name: "Clínica Centro",
+      contactEmail: "clinic@example.com",
+    }),
+    getReportById: async () => ({
+      id: 55,
+      clinicId: 3,
+      uploadDate: new Date("2026-04-19T09:00:00.000Z"),
+      studyType: "Histopatología",
+      patientName: "Luna",
+      fileName: "luna.pdf",
+      currentStatus: "ready",
+      statusChangedAt: new Date("2026-04-19T10:00:00.000Z"),
+      storagePath: "reports/luna.pdf",
+      createdAt: new Date("2026-04-19T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-19T10:00:00.000Z"),
+    }),
+    getParticularTokenById: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: null,
+      tokenHash: "hash",
+      tokenLast4: "ABCD",
+      tutorLastName: "Gomez",
+      petName: "Luna",
+      petAge: "8 años",
+      petBreed: "Caniche",
+      petSex: "Hembra",
+      petSpecies: "Canina",
+      sampleLocation: "Pabellón auricular",
+      sampleEvolution: "15 días",
+      detailsLesion: null,
+      extractionDate: new Date("2026-04-18T00:00:00.000Z"),
+      shippingDate: new Date("2026-04-19T00:00:00.000Z"),
+      isActive: true,
+      lastLoginAt: null,
+      createdAt: new Date("2026-04-18T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T12:30:00.000Z"),
+      createdByAdminId: null,
+      createdByClinicUserId: 9,
+    }),
+    updateParticularTokenReport: async () => undefined,
+    createStudyTrackingCase: async () => createTrackingCaseFixture(),
+    updateStudyTrackingCase: async () => createTrackingCaseFixture(),
+    getClinicScopedStudyTrackingCase: async () => createTrackingCaseFixture(),
+    getStudyTrackingCaseById: async () => createTrackingCaseFixture(),
+    listStudyTrackingCases: async () => [createTrackingCaseFixture()],
+    createStudyTrackingNotification: async () => createNotificationFixture(),
+    listStudyTrackingNotifications: async () => [createNotificationFixture()],
+    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
+    now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
+    createDate: () => new Date("2026-04-20T13:30:00.000Z"),
+    ...overrides,
+  });
+
+  return app;
+}
+
+test("adminStudyTrackingNativeRoutes expone GET /notifications con filtros admin", async () => {
+  const listCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    listStudyTrackingNotifications: async (params: Record<string, unknown>) => {
+      listCalls.push(params);
+      return [createNotificationFixture()];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/study-tracking/notifications?clinicId=3&unreadOnly=true&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(listCalls, [
+      {
+        clinicId: 3,
+        unreadOnly: true,
+        limit: 5,
+        offset: 2,
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.notifications[0].id, 21);
+    assert.equal(body.notifications[0].clinicId, 3);
+    assert.equal(body.pagination.limit, 5);
+    assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes crea POST / con admin, vínculos y notificación especial", async () => {
+  const createCalls: Array<Record<string, unknown>> = [];
+  const updateTokenCalls: Array<Record<string, unknown>> = [];
+  const notificationCalls: Array<Record<string, unknown>> = [];
+  const emailCalls: Array<Record<string, unknown>> = [];
+  const notifiedAt = new Date("2026-04-20T13:30:00.000Z");
+  const created = createTrackingCaseFixture({ specialStainRequired: true });
+  const updated = createTrackingCaseFixture({
+    specialStainRequired: true,
+    specialStainNotifiedAt: notifiedAt,
+  });
+
+  const app = await createTestApp({
+    createStudyTrackingCase: async (input: Record<string, unknown>) => {
+      createCalls.push(input);
+      return created;
+    },
+    updateParticularTokenReport: async (
+      particularTokenId: number,
+      reportId: number | null,
+    ) => {
+      updateTokenCalls.push({ particularTokenId, reportId });
+      return undefined;
+    },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture();
+    },
+    updateStudyTrackingCase: async (
+      trackingCaseId: number,
+      input: Record<string, unknown>,
+    ) => {
+      assert.equal(trackingCaseId, 11);
+      assert.deepEqual(input, { specialStainNotifiedAt: notifiedAt });
+      return updated;
+    },
+    sendSpecialStainRequiredEmail: async (input: Record<string, unknown>) => {
+      emailCalls.push(input);
+      return { sent: true };
+    },
+    createDate: () => notifiedAt,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/study-tracking",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        reportId: 55,
+        particularTokenId: 7,
+        receptionAt: "2026-04-20T00:00:00.000Z",
+        currentStage: "evaluation",
+        specialStainRequired: true,
+        paymentUrl: "https://pay.example/study-11",
+        adminContactEmail: "admin@example.com",
+        adminContactPhone: "+5493410000000",
+        notes: "Caso clínico inicial",
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      "http://localhost:3000",
+    );
+    assert.equal(createCalls.length, 1);
+    assert.equal(createCalls[0].clinicId, 3);
+    assert.equal(createCalls[0].reportId, 55);
+    assert.equal(createCalls[0].particularTokenId, 7);
+    assert.equal(createCalls[0].createdByAdminId, 1);
+    assert.equal(createCalls[0].createdByClinicUserId, null);
+    assert.equal(createCalls[0].specialStainRequired, true);
+    assert.ok(createCalls[0].estimatedDeliveryAt instanceof Date);
+    assert.deepEqual(updateTokenCalls, [{ particularTokenId: 7, reportId: 55 }]);
+    assert.equal(notificationCalls.length, 1);
+    assert.equal(notificationCalls[0].studyTrackingCaseId, 11);
+    assert.equal(notificationCalls[0].clinicId, 3);
+    assert.equal(notificationCalls[0].type, "special_stain_required");
+    assert.equal(emailCalls.length, 1);
+    assert.deepEqual(emailCalls[0].to, ["clinic@example.com", "admin@example.com"]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Seguimiento creado correctamente");
+    assert.equal(body.trackingCase.id, 11);
+    assert.equal(body.trackingCase.clinicId, 3);
+    assert.equal(body.trackingCase.specialStainNotifiedAt, notifiedAt.toISOString());
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes bloquea POST / con origin no permitido", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/study-tracking",
+      headers: {
+        origin: "https://evil.example",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        receptionAt: "2026-04-20T00:00:00.000Z",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes expone GET / con lista admin-scoped", async () => {
+  const listCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    listStudyTrackingCases: async (params: Record<string, unknown>) => {
+      listCalls.push(params);
+      return [createTrackingCaseFixture()];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/study-tracking?clinicId=3&reportId=55&particularTokenId=7&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(listCalls, [
+      {
+        clinicId: 3,
+        reportId: 55,
+        particularTokenId: 7,
+        limit: 5,
+        offset: 2,
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.trackingCases[0].id, 11);
+    assert.equal(body.trackingCases[0].clinicId, 3);
+    assert.equal(body.pagination.limit, 5);
+    assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes expone GET /:trackingCaseId con detalle global o clinic-scoped", async () => {
+  const scopedCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    getClinicScopedStudyTrackingCase: async (
+      trackingCaseId: number,
+      clinicId: number,
+    ) => {
+      scopedCalls.push({ trackingCaseId, clinicId });
+      return createTrackingCaseFixture();
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/study-tracking/11?clinicId=3",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(scopedCalls, [{ trackingCaseId: 11, clinicId: 3 }]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.trackingCase.id, 11);
+    assert.equal(body.trackingCase.clinicId, 3);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes actualiza PATCH /:trackingCaseId y notifica tinción especial", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const notificationCalls: Array<Record<string, unknown>> = [];
+  const emailCalls: Array<Record<string, unknown>> = [];
+  const notifiedAt = new Date("2026-04-20T13:30:00.000Z");
+  const current = createTrackingCaseFixture({
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+  });
+  const updated = createTrackingCaseFixture({
+    currentStage: "evaluation",
+    specialStainRequired: true,
+    specialStainNotifiedAt: null,
+  });
+  const finalCase = createTrackingCaseFixture({
+    currentStage: "evaluation",
+    specialStainRequired: true,
+    specialStainNotifiedAt: notifiedAt,
+  });
+
+  const app = await createTestApp({
+    getClinicScopedStudyTrackingCase: async () => current,
+    updateStudyTrackingCase: async (
+      trackingCaseId: number,
+      input: Record<string, unknown>,
+    ) => {
+      assert.equal(trackingCaseId, 11);
+      updateCalls.push(input);
+
+      if ("specialStainNotifiedAt" in input) {
+        return finalCase;
+      }
+
+      return updated;
+    },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture();
+    },
+    sendSpecialStainRequiredEmail: async (input: Record<string, unknown>) => {
+      emailCalls.push(input);
+      return { sent: true };
+    },
+    createDate: () => notifiedAt,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/11",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        currentStage: "evaluation",
+        specialStainRequired: true,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(updateCalls.length, 2);
+    assert.equal(updateCalls[0].currentStage, "evaluation");
+    assert.equal(updateCalls[0].specialStainRequired, true);
+    assert.deepEqual(updateCalls[1], { specialStainNotifiedAt: notifiedAt });
+    assert.equal(notificationCalls.length, 1);
+    assert.equal(notificationCalls[0].type, "special_stain_required");
+    assert.equal(emailCalls.length, 1);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Seguimiento actualizado correctamente");
+    assert.equal(body.trackingCase.id, 11);
+    assert.equal(body.trackingCase.specialStainNotifiedAt, notifiedAt.toISOString());
+  } finally {
+    await app.close();
+  }
+});
+
+
+

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -73,12 +73,12 @@ function buildAdminParticularTokensRouteStubs() {
       tokenLast4: "aaaa",
       tutorLastName: "Gomez",
       petName: "Luna",
-      petAge: "8 años",
+      petAge: "8 aÃ±os",
       petBreed: "Caniche",
       petSex: "Hembra",
       petSpecies: "Canina",
-      sampleLocation: "Pabellón auricular",
-      sampleEvolution: "15 días",
+      sampleLocation: "PabellÃ³n auricular",
+      sampleEvolution: "15 dÃ­as",
       detailsLesion: null,
       extractionDate: new Date("2026-04-20T00:00:00.000Z"),
       shippingDate: new Date("2026-04-21T00:00:00.000Z"),
@@ -125,6 +125,27 @@ function buildAdminReportAccessTokensRouteStubs() {
     listReportAccessTokens: async () => [],
     revokeReportAccessToken: async () => null,
     writeAuditLog: async () => {},
+  };
+}
+function buildAdminStudyTrackingRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+    getClinicScopedStudyTrackingCase: async () => null,
+    getStudyTrackingCaseById: async () => null,
+    listStudyTrackingCases: async () => [],
+    createStudyTrackingNotification: async () => ({} as any),
+    listStudyTrackingNotifications: async () => [],
+    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
   };
 }
 function buildClinicAuthRouteStubs() {
@@ -272,12 +293,12 @@ function buildParticularTokensRouteStubs() {
       tokenLast4: "aaaa",
       tutorLastName: "Gomez",
       petName: "Luna",
-      petAge: "8 años",
+      petAge: "8 aÃ±os",
       petBreed: "Caniche",
       petSex: "Hembra",
       petSpecies: "Canina",
-      sampleLocation: "Pabellón auricular",
-      sampleEvolution: "15 días",
+      sampleLocation: "PabellÃ³n auricular",
+      sampleEvolution: "15 dÃ­as",
       detailsLesion: null,
       extractionDate: new Date("2026-04-20T00:00:00.000Z"),
       shippingDate: new Date("2026-04-21T00:00:00.000Z"),
@@ -403,6 +424,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -528,6 +550,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -605,6 +628,7 @@ test(
       },
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -673,6 +697,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
         getActiveSessionByToken: async () => ({
@@ -762,6 +787,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
         ...buildClinicAuditRouteStubs(),
@@ -881,6 +907,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: {
@@ -984,6 +1011,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1001,13 +1029,13 @@ test(
           tokenLast4: "ABCD",
           tutorLastName: "Gomez",
           petName: "Luna",
-          petAge: "8 años",
+          petAge: "8 aÃ±os",
           petBreed: "Caniche",
           petSex: "Hembra",
           petSpecies: "Canina",
-          sampleLocation: "Pabellón auricular",
-          sampleEvolution: "15 días",
-          detailsLesion: "Lesión nodular pequeña",
+          sampleLocation: "PabellÃ³n auricular",
+          sampleEvolution: "15 dÃ­as",
+          detailsLesion: "LesiÃ³n nodular pequeÃ±a",
           extractionDate: new Date("2026-04-20T00:00:00.000Z"),
           shippingDate: new Date("2026-04-21T00:00:00.000Z"),
           isActive: true,
@@ -1023,7 +1051,7 @@ test(
           clinicId: 3,
           storagePath: "reports/report-55.pdf",
           uploadDate: new Date("2026-04-22T09:00:00.000Z"),
-          studyType: "Histopatología",
+          studyType: "HistopatologÃ­a",
           patientName: "Luna",
           fileName: "luna-report.pdf",
           createdAt: new Date("2026-04-22T09:00:00.000Z"),
@@ -1092,6 +1120,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1167,6 +1196,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1205,7 +1235,7 @@ test(
             id: 55,
             clinicId: 3,
             uploadDate: new Date("2026-04-22T09:00:00.000Z"),
-            studyType: "Histopatología",
+            studyType: "HistopatologÃ­a",
             patientName: "Luna",
             fileName: "luna-report.pdf",
             currentStatus: "ready",
@@ -1285,6 +1315,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1414,6 +1445,7 @@ test(
           },
         ],
       },
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1500,12 +1532,12 @@ test(
             tokenLast4: "aaaa",
             tutorLastName: "Gomez",
             petName: "Luna",
-            petAge: "8 años",
+            petAge: "8 aÃ±os",
             petBreed: "Caniche",
             petSex: "Hembra",
             petSpecies: "Canina",
-            sampleLocation: "Pabellón auricular",
-            sampleEvolution: "15 días",
+            sampleLocation: "PabellÃ³n auricular",
+            sampleEvolution: "15 dÃ­as",
             detailsLesion: null,
             extractionDate: new Date("2026-04-20T00:00:00.000Z"),
             shippingDate: new Date("2026-04-21T00:00:00.000Z"),
@@ -1519,6 +1551,7 @@ test(
         ],
       },
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1582,6 +1615,7 @@ test(
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
       adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1611,4 +1645,84 @@ test(
     }
   },
 );
+
+
+test(
+  "createFastifyApp despacha /api/admin/study-tracking al router nativo antes del bridge Express",
+  async () => {
+    const app = await createFastifyApp({
+      createLegacyApp: () => {
+        const legacyApp = express();
+
+        legacyApp.get("/admin/study-tracking", (_req, res) => {
+          res.setHeader("x-legacy-bridge", "should-not-run");
+          res.status(418).json({
+            success: false,
+          });
+        });
+
+        return legacyApp as any;
+      },
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: {
+        ...buildAdminStudyTrackingRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "VETNEB",
+        }),
+        listStudyTrackingCases: async () => [],
+      },
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/study-tracking?clinicId=3",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.notEqual(response.statusCode, 418);
+      assert.ok([200, 401].includes(response.statusCode));
+
+      if (response.statusCode === 200 && response.body) {
+        const body = JSON.parse(response.body);
+        assert.equal(body.success, true);
+        assert.equal(body.count, 0);
+      }
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+
 


### PR DESCRIPTION
﻿## Summary
- add native Fastify admin study tracking routes
- register /api/admin/study-tracking before the legacy Express bridge
- cover native admin study tracking behavior and Fastify app bridge dispatch

## Validation
- pnpm.cmd typecheck
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-study-tracking.fastify.test.ts test/fastify-app.test.ts
- pnpm.cmd test
