### PR TITLE
refactor(reports): add shared report route helpers

### DIFF
--- a/server/lib/reports.ts
+++ b/server/lib/reports.ts
@@ -1,0 +1,83 @@
+import type { ReportStatus } from "../../drizzle/schema";
+import { normalizeReportStatus } from "./report-status.ts";
+
+export function parsePositiveInt(value: unknown, fallback: number, max?: number) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  if (typeof max === "number") {
+    return Math.min(parsed, max);
+  }
+
+  return parsed;
+}
+
+export function parseOffset(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function normalizeSearchText(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function normalizeOptionalNote(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 2000) : null;
+}
+
+export function parseOptionalDate(value: unknown): Date | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+export function parseClinicId(value: unknown): number | undefined {
+  const parsed = Number(value);
+
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  return undefined;
+}
+
+export function parseReportStatus(value: unknown): ReportStatus | undefined {
+  return normalizeReportStatus(value);
+}
+
+export function getReadClinicScope(reqClinicId: unknown, authClinicId: number) {
+  const requestedClinicId = parseClinicId(reqClinicId);
+
+  if (requestedClinicId && requestedClinicId !== authClinicId) {
+    return {
+      clinicId: authClinicId,
+      isForbidden: true,
+    };
+  }
+
+  return {
+    clinicId: authClinicId,
+    isForbidden: false,
+  };
+}
+
+export function parseReportId(value: unknown): number | undefined {
+  const reportId = Number(value);
+  return Number.isInteger(reportId) && reportId > 0 ? reportId : undefined;
+}

--- a/test/reports.test.ts
+++ b/test/reports.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getReadClinicScope,
+  normalizeOptionalNote,
+  normalizeSearchText,
+  parseClinicId,
+  parseOffset,
+  parseOptionalDate,
+  parsePositiveInt,
+  parseReportId,
+  parseReportStatus,
+} from "../server/lib/reports.ts";
+
+test("reports helpers parsean enteros positivos con fallback y límite máximo", () => {
+  assert.equal(parsePositiveInt("25", 50, 100), 25);
+  assert.equal(parsePositiveInt("500", 50, 100), 100);
+  assert.equal(parsePositiveInt("0", 50, 100), 50);
+  assert.equal(parsePositiveInt("-1", 50, 100), 50);
+  assert.equal(parsePositiveInt("abc", 50, 100), 50);
+});
+
+test("reports helpers parsean offset y entity ids seguros", () => {
+  assert.equal(parseOffset("25"), 25);
+  assert.equal(parseOffset("0"), 0);
+  assert.equal(parseOffset("-1"), 0);
+  assert.equal(parseOffset("abc", 10), 10);
+
+  assert.equal(parseClinicId("3"), 3);
+  assert.equal(parseClinicId("0"), undefined);
+  assert.equal(parseClinicId("abc"), undefined);
+
+  assert.equal(parseReportId("55"), 55);
+  assert.equal(parseReportId("0"), undefined);
+  assert.equal(parseReportId("abc"), undefined);
+});
+
+test("reports helpers normalizan texto, notas y fechas opcionales", () => {
+  assert.equal(normalizeSearchText("  cardio  "), "cardio");
+  assert.equal(normalizeSearchText("   "), undefined);
+  assert.equal(normalizeSearchText(null), undefined);
+
+  assert.equal(normalizeOptionalNote("  nota  "), "nota");
+  assert.equal(normalizeOptionalNote("   "), null);
+  assert.equal(normalizeOptionalNote(null), null);
+  assert.equal(normalizeOptionalNote("a".repeat(2100)), "a".repeat(2000));
+
+  assert.equal(
+    parseOptionalDate("2026-04-20T00:00:00.000Z")?.toISOString(),
+    "2026-04-20T00:00:00.000Z",
+  );
+  assert.equal(parseOptionalDate("invalid"), undefined);
+  assert.equal(parseOptionalDate("   "), undefined);
+});
+
+test("reports helpers calculan scope de lectura clinic-scoped", () => {
+  assert.deepEqual(getReadClinicScope(undefined, 3), {
+    clinicId: 3,
+    isForbidden: false,
+  });
+
+  assert.deepEqual(getReadClinicScope("3", 3), {
+    clinicId: 3,
+    isForbidden: false,
+  });
+
+  assert.deepEqual(getReadClinicScope("5", 3), {
+    clinicId: 3,
+    isForbidden: true,
+  });
+
+  assert.deepEqual(getReadClinicScope("abc", 3), {
+    clinicId: 3,
+    isForbidden: false,
+  });
+});
+
+test("reports helpers normalizan estados de informe", () => {
+  assert.equal(parseReportStatus("ready"), "ready");
+  assert.equal(parseReportStatus(" READY "), "ready");
+  assert.equal(parseReportStatus("bad"), undefined);
+  assert.equal(parseReportStatus(undefined), undefined);
+});


### PR DESCRIPTION
﻿## Summary
- add shared pure helpers for report route parsing and clinic-scoped reads
- cover report helper parsing, optional values, clinic scope, and status normalization
- prepare /api/reports Fastify migration without changing production routing yet

## Validation
- pnpm.cmd typecheck
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/reports.test.ts
- pnpm.cmd test

## Notes
- No changes to reports.routes.ts, fastify-app.ts, or multipart upload behavior in this PR.
