### PR TITLE
feat(reports): move read-only report routes to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -63,6 +63,10 @@ import {
   type ReportAccessTokensNativeRoutesOptions,
 } from "./routes/report-access-tokens.fastify.ts";
 import {
+  reportsNativeRoutes,
+  type ReportsNativeRoutesOptions,
+} from "./routes/reports.fastify.ts";
+import {
   studyTrackingNativeRoutes,
   type StudyTrackingNativeRoutesOptions,
 } from "./routes/study-tracking.fastify.ts";
@@ -101,6 +105,7 @@ export type CreateFastifyAppOptions = {
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
   publicReportAccessRoutes?: PublicReportAccessNativeRoutesOptions;
   reportAccessTokensRoutes?: ReportAccessTokensNativeRoutesOptions;
+  reportsRoutes?: ReportsNativeRoutesOptions;
   studyTrackingRoutes?: StudyTrackingNativeRoutesOptions;
 };
 
@@ -122,6 +127,7 @@ const NATIVE_API_BRIDGE_BYPASS_PREFIXES = [
   "/public/professionals",
   "/public/report-access",
   "/report-access-tokens",
+  "/reports",
   "/study-tracking",
 ];
 
@@ -263,6 +269,11 @@ export async function createFastifyApp(
   await app.register(reportAccessTokensNativeRoutes, {
     prefix: "/api/report-access-tokens",
     ...(options.reportAccessTokensRoutes ?? {}),
+  });
+
+  await app.register(reportsNativeRoutes, {
+    prefix: "/api/reports",
+    ...(options.reportsRoutes ?? {}),
   });
 
   await app.register(studyTrackingNativeRoutes, {

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -1,0 +1,672 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type { Report, ReportStatus } from "../../drizzle/schema";
+import { ENV } from "../lib/env.ts";
+import {
+  getReadClinicScope,
+  normalizeSearchText,
+  parseOffset,
+  parsePositiveInt,
+  parseReportStatus,
+} from "../lib/reports.ts";
+import { REPORT_STATUSES } from "../lib/report-status.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuthenticatedClinicUser = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId: string | null;
+  role: ReturnType<typeof normalizeClinicUserRole>;
+  permissions: ReturnType<typeof getClinicPermissions>;
+  canUploadReports: boolean;
+  canManageClinicUsers: boolean;
+  sessionToken: string;
+};
+
+export type ReportsNativeRoutesOptions = {
+  deleteActiveSession?: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById?: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getReportsByClinicId?: (
+    clinicId: number,
+    limit: number,
+    offset: number,
+    currentStatus?: ReportStatus,
+  ) => Promise<Report[]>;
+  searchReports?: (
+    clinicId: number,
+    query: string | undefined,
+    studyType: string | undefined,
+    limit: number,
+    offset: number,
+    currentStatus?: ReportStatus,
+  ) => Promise<Report[]>;
+  getStudyTypes?: (clinicId: number) => Promise<string[]>;
+  createSignedReportUrl?: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl?: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__reportsRequestStartTimeNs";
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type ReportsFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeReportsDeps = Required<
+  Pick<
+    ReportsNativeRoutesOptions,
+    | "deleteActiveSession"
+    | "getActiveSessionByToken"
+    | "getClinicUserById"
+    | "updateSessionLastAccess"
+    | "hashSessionToken"
+    | "getReportsByClinicId"
+    | "searchReports"
+    | "getStudyTypes"
+    | "createSignedReportUrl"
+    | "createSignedReportDownloadUrl"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeReportsDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeReportsDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const storage = await import("../lib/supabase.ts");
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getReportsByClinicId: db.getReportsByClinicId,
+        searchReports: db.searchReports,
+        getStudyTypes: db.getStudyTypes,
+        createSignedReportUrl: storage.createSignedReportUrl,
+        createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function hasAllInjectedDeps(options: ReportsNativeRoutesOptions) {
+  return (
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getReportsByClinicId &&
+    !!options.searchReports &&
+    !!options.getStudyTypes &&
+    !!options.createSignedReportUrl &&
+    !!options.createSignedReportDownloadUrl
+  );
+}
+
+async function resolveDeps(
+  options: ReportsNativeRoutesOptions,
+): Promise<NativeReportsDeps> {
+  const defaultDeps = hasAllInjectedDeps(options) ? undefined : await loadDefaultDeps();
+
+  return {
+    deleteActiveSession:
+      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
+    getActiveSessionByToken:
+      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
+    getClinicUserById:
+      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
+    updateSessionLastAccess:
+      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getReportsByClinicId:
+      options.getReportsByClinicId ?? defaultDeps!.getReportsByClinicId,
+    searchReports: options.searchReports ?? defaultDeps!.searchReports,
+    getStudyTypes: options.getStudyTypes ?? defaultDeps!.getStudyTypes,
+    createSignedReportUrl:
+      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
+    createSignedReportDownloadUrl:
+      options.createSignedReportDownloadUrl ??
+      defaultDeps!.createSignedReportDownloadUrl,
+  };
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.cookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearSessionCookie() {
+  return serializeCookie({
+    name: ENV.cookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateClinicUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeReportsDeps,
+  now: () => number,
+): Promise<AuthenticatedClinicUser | null> {
+  const token = getSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "No autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getActiveSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión expirada",
+    });
+    return null;
+  }
+
+  const clinicUser = await deps.getClinicUserById(session.clinicUserId);
+
+  if (!clinicUser) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateSessionLastAccess(tokenHash);
+  }
+
+  const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+  const permissions = getClinicPermissions(role);
+
+  return {
+    id: clinicUser.id,
+    clinicId: clinicUser.clinicId,
+    username: clinicUser.username,
+    authProId: clinicUser.authProId ?? null,
+    role,
+    permissions,
+    canUploadReports: permissions.canUploadReports,
+    canManageClinicUsers: permissions.canManageClinicUsers,
+    sessionToken: token,
+  };
+}
+
+async function serializeReport(report: Report, deps: NativeReportsDeps) {
+  const [previewUrl, downloadUrl] = await Promise.all([
+    deps.createSignedReportUrl(report.storagePath),
+    deps.createSignedReportDownloadUrl(
+      report.storagePath,
+      report.fileName ?? undefined,
+    ),
+  ]);
+
+  return {
+    ...report,
+    previewUrl,
+    downloadUrl,
+  };
+}
+
+async function serializeReports(reports: Report[], deps: NativeReportsDeps) {
+  return Promise.all(reports.map((report) => serializeReport(report, deps)));
+}
+
+function validateStatusQuery(status: unknown, currentStatus: ReportStatus | undefined) {
+  return typeof status === "undefined" || !!currentStatus;
+}
+
+export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions> =
+  async (app, options) => {
+    const now = options.now ?? (() => Date.now());
+    const allowedOrigins = new Set(getAllowedOrigins());
+
+    app.addHook("onRequest", async (request, reply) => {
+      (request as ReportsFastifyRequest)[REQUEST_START_TIME_KEY] =
+        process.hrtime.bigint();
+
+      applyCorsHeaders(request, reply, allowedOrigins);
+
+      return undefined;
+    });
+
+    app.addHook("onResponse", async (request, reply) => {
+      const startedAt =
+        (request as ReportsFastifyRequest)[REQUEST_START_TIME_KEY] ??
+        process.hrtime.bigint();
+
+      const durationMs =
+        Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      const safeUrl = sanitizeUrlForLogs(request.url);
+
+      console.log(
+        buildRequestLogLine({
+          timestamp: new Date().toISOString(),
+          method: request.method,
+          url: safeUrl,
+          statusCode: reply.statusCode,
+          durationMs,
+        }),
+      );
+    });
+
+    const optionsHandler = async (
+      request: FastifyRequest,
+      reply: FastifyReply,
+    ) => {
+      const requestOrigin = getRequestOrigin(request);
+
+      if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+        return reply.code(403).send({
+          success: false,
+          error: "Origen no permitido",
+        });
+      }
+
+      applyCorsHeaders(request, reply, allowedOrigins);
+      reply.header("access-control-allow-methods", "GET,OPTIONS");
+
+      const requestedHeaders =
+        typeof request.headers["access-control-request-headers"] === "string"
+          ? request.headers["access-control-request-headers"]
+          : "content-type";
+
+      reply.header("access-control-allow-headers", requestedHeaders);
+      return reply.code(204).send();
+    };
+
+    app.options("/", optionsHandler);
+    app.options("/search", optionsHandler);
+    app.options("/study-types", optionsHandler);
+
+    app.get<{
+      Querystring: {
+        clinicId?: unknown;
+        status?: unknown;
+        limit?: unknown;
+        offset?: unknown;
+      };
+    }>("/", async (request, reply) => {
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      const scope = getReadClinicScope(request.query.clinicId, auth.clinicId);
+      const currentStatus = parseReportStatus(request.query.status);
+      const limit = parsePositiveInt(request.query.limit, 50, 100);
+      const offset = parseOffset(request.query.offset, 0);
+
+      if (scope.isForbidden) {
+        return reply.code(403).send({
+          success: false,
+          error: "No autorizado para consultar otra clinica",
+        });
+      }
+
+      if (!validateStatusQuery(request.query.status, currentStatus)) {
+        return reply.code(400).send({
+          success: false,
+          error: "Estado de informe invalido",
+          allowedStatuses: REPORT_STATUSES,
+        });
+      }
+
+      const reports = await deps.getReportsByClinicId(
+        scope.clinicId,
+        limit,
+        offset,
+        currentStatus,
+      );
+
+      return reply.code(200).send({
+        success: true,
+        count: reports.length,
+        reports: await serializeReports(reports, deps),
+        filters: {
+          status: currentStatus ?? null,
+        },
+        pagination: {
+          limit,
+          offset,
+        },
+      });
+    });
+
+    app.get<{
+      Querystring: {
+        clinicId?: unknown;
+        query?: unknown;
+        studyType?: unknown;
+        status?: unknown;
+        limit?: unknown;
+        offset?: unknown;
+      };
+    }>("/search", async (request, reply) => {
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      const scope = getReadClinicScope(request.query.clinicId, auth.clinicId);
+      const query = normalizeSearchText(request.query.query);
+      const studyType = normalizeSearchText(request.query.studyType);
+      const currentStatus = parseReportStatus(request.query.status);
+      const limit = parsePositiveInt(request.query.limit, 50, 100);
+      const offset = parseOffset(request.query.offset, 0);
+
+      if (scope.isForbidden) {
+        return reply.code(403).send({
+          success: false,
+          error: "No autorizado para consultar otra clinica",
+        });
+      }
+
+      if (!validateStatusQuery(request.query.status, currentStatus)) {
+        return reply.code(400).send({
+          success: false,
+          error: "Estado de informe invalido",
+          allowedStatuses: REPORT_STATUSES,
+        });
+      }
+
+      const reports = await deps.searchReports(
+        scope.clinicId,
+        query,
+        studyType,
+        limit,
+        offset,
+        currentStatus,
+      );
+
+      return reply.code(200).send({
+        success: true,
+        count: reports.length,
+        reports: await serializeReports(reports, deps),
+        filters: {
+          query: query ?? null,
+          studyType: studyType ?? null,
+          status: currentStatus ?? null,
+        },
+        pagination: {
+          limit,
+          offset,
+        },
+      });
+    });
+
+    app.get<{
+      Querystring: {
+        clinicId?: unknown;
+      };
+    }>("/study-types", async (request, reply) => {
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      const scope = getReadClinicScope(request.query.clinicId, auth.clinicId);
+
+      if (scope.isForbidden) {
+        return reply.code(403).send({
+          success: false,
+          error: "No autorizado para consultar otra clinica",
+        });
+      }
+
+      const studyTypes = await deps.getStudyTypes(scope.clinicId);
+
+      return reply.code(200).send({
+        success: true,
+        studyTypes,
+      });
+    });
+  };

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -1,0 +1,266 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { reportsNativeRoutes } = await import("../server/routes/reports.fastify.ts");
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    patientName: "Luna Gomez",
+    studyType: "Histopatología",
+    uploadDate: new Date("2026-04-20T00:00:00.000Z"),
+    fileName: "luna.pdf",
+    storagePath: "reports/3/luna.pdf",
+    previewUrl: null,
+    downloadUrl: null,
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-04-21T00:00:00.000Z"),
+    statusChangedByClinicUserId: 9,
+    statusChangedByAdminUserId: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => ({
+      clinicUserId: 9,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(reportsNativeRoutes as any, {
+    prefix: "/api/reports",
+    ...createAuthStubs(),
+    getReportsByClinicId: async () => [createReportFixture()],
+    searchReports: async () => [createReportFixture({ id: 56 })],
+    getStudyTypes: async () => ["Histopatología", "Citología"],
+    createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `download:${storagePath}:${fileName ?? ""}`,
+    now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
+    ...overrides,
+  });
+
+  return app;
+}
+
+test("reportsNativeRoutes expone GET / con lista clinic-scoped", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    getReportsByClinicId: async (
+      clinicId: number,
+      limit: number,
+      offset: number,
+      currentStatus?: string,
+    ) => {
+      calls.push({ clinicId, limit, offset, currentStatus });
+      return [createReportFixture()];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports?status=ready&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls, [
+      {
+        clinicId: 3,
+        limit: 5,
+        offset: 2,
+        currentStatus: "ready",
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.reports[0].id, 55);
+    assert.equal(body.reports[0].previewUrl, "preview:reports/3/luna.pdf");
+    assert.equal(
+      body.reports[0].downloadUrl,
+      "download:reports/3/luna.pdf:luna.pdf",
+    );
+    assert.equal(body.filters.status, "ready");
+    assert.equal(body.pagination.limit, 5);
+    assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes expone GET /search con filtros normalizados", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    searchReports: async (
+      clinicId: number,
+      query: string | undefined,
+      studyType: string | undefined,
+      limit: number,
+      offset: number,
+      currentStatus?: string,
+    ) => {
+      calls.push({ clinicId, query, studyType, limit, offset, currentStatus });
+      return [createReportFixture({ id: 56 })];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/search?query= Luna &studyType= Histo &status=ready&limit=10&offset=4",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls, [
+      {
+        clinicId: 3,
+        query: "Luna",
+        studyType: "Histo",
+        limit: 10,
+        offset: 4,
+        currentStatus: "ready",
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.reports[0].id, 56);
+    assert.equal(body.filters.query, "Luna");
+    assert.equal(body.filters.studyType, "Histo");
+    assert.equal(body.filters.status, "ready");
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes expone GET /study-types clinic-scoped", async () => {
+  const calls: number[] = [];
+  const app = await createTestApp({
+    getStudyTypes: async (clinicId: number) => {
+      calls.push(clinicId);
+      return ["Histopatología", "Citología"];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/study-types",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls, [3]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      studyTypes: ["Histopatología", "Citología"],
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes bloquea clinicId ajeno", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports?clinicId=5",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autorizado para consultar otra clinica",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes valida status inválido", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports?status=bad",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, false);
+    assert.equal(body.error, "Estado de informe invalido");
+    assert.ok(Array.isArray(body.allowedStatuses));
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes bloquea GET / sin sesión", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add native Fastify read-only reports routes
- register /api/reports before the legacy Express bridge
- cover reports list, search, study-types, scope, status validation, and auth

## Validation
- pnpm.cmd typecheck
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/reports.fastify.test.ts
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/fastify-app.test.ts
- pnpm.cmd test