### PR TITLE
feat(reports): move report url and history routes to native Fastify

### DIFF
--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -11,6 +11,7 @@ import {
   normalizeSearchText,
   parseOffset,
   parsePositiveInt,
+  parseReportId,
   parseReportStatus,
 } from "../lib/reports.ts";
 import { REPORT_STATUSES } from "../lib/report-status.ts";
@@ -74,6 +75,8 @@ export type ReportsNativeRoutesOptions = {
     currentStatus?: ReportStatus,
   ) => Promise<Report[]>;
   getStudyTypes?: (clinicId: number) => Promise<string[]>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  getReportStatusHistory?: (reportId: number) => Promise<unknown[]>;
   createSignedReportUrl?: (storagePath: string) => Promise<string>;
   createSignedReportDownloadUrl?: (
     storagePath: string,
@@ -100,6 +103,8 @@ type NativeReportsDeps = Required<
     | "getReportsByClinicId"
     | "searchReports"
     | "getStudyTypes"
+    | "getReportById"
+    | "getReportStatusHistory"
     | "createSignedReportUrl"
     | "createSignedReportDownloadUrl"
   >
@@ -123,6 +128,8 @@ async function loadDefaultDeps(): Promise<NativeReportsDeps> {
         getReportsByClinicId: db.getReportsByClinicId,
         searchReports: db.searchReports,
         getStudyTypes: db.getStudyTypes,
+        getReportById: db.getReportById,
+        getReportStatusHistory: db.getReportStatusHistory,
         createSignedReportUrl: storage.createSignedReportUrl,
         createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
       };
@@ -142,6 +149,8 @@ function hasAllInjectedDeps(options: ReportsNativeRoutesOptions) {
     !!options.getReportsByClinicId &&
     !!options.searchReports &&
     !!options.getStudyTypes &&
+    !!options.getReportById &&
+    !!options.getReportStatusHistory &&
     !!options.createSignedReportUrl &&
     !!options.createSignedReportDownloadUrl
   );
@@ -167,6 +176,9 @@ async function resolveDeps(
       options.getReportsByClinicId ?? defaultDeps!.getReportsByClinicId,
     searchReports: options.searchReports ?? defaultDeps!.searchReports,
     getStudyTypes: options.getStudyTypes ?? defaultDeps!.getStudyTypes,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    getReportStatusHistory:
+      options.getReportStatusHistory ?? defaultDeps!.getReportStatusHistory,
     createSignedReportUrl:
       options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
     createSignedReportDownloadUrl:
@@ -454,6 +466,33 @@ async function serializeReports(reports: Report[], deps: NativeReportsDeps) {
   return Promise.all(reports.map((report) => serializeReport(report, deps)));
 }
 
+async function getAuthorizedReport(
+  reportId: number,
+  clinicId: number,
+  unauthorizedMessage: string,
+  deps: NativeReportsDeps,
+): Promise<{ report: Report } | { status: 403 | 404; error: string }> {
+  const report = await deps.getReportById(reportId);
+
+  if (!report) {
+    return {
+      status: 404,
+      error: "Informe no encontrado",
+    };
+  }
+
+  if (report.clinicId !== clinicId) {
+    return {
+      status: 403,
+      error: unauthorizedMessage,
+    };
+  }
+
+  return {
+    report,
+  };
+}
+
 function validateStatusQuery(status: unknown, currentStatus: ReportStatus | undefined) {
   return typeof status === "undefined" || !!currentStatus;
 }
@@ -520,6 +559,9 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     app.options("/", optionsHandler);
     app.options("/search", optionsHandler);
     app.options("/study-types", optionsHandler);
+    app.options("/:reportId/history", optionsHandler);
+    app.options("/:reportId/preview-url", optionsHandler);
+    app.options("/:reportId/download-url", optionsHandler);
 
     app.get<{
       Querystring: {
@@ -667,6 +709,143 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
       return reply.code(200).send({
         success: true,
         studyTypes,
+      });
+    });
+
+    app.get<{
+      Params: {
+        reportId?: unknown;
+      };
+    }>("/:reportId/history", async (request, reply) => {
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      const reportId = parseReportId(request.params.reportId);
+
+      if (typeof reportId !== "number") {
+        return reply.code(400).send({
+          success: false,
+          error: "ID de informe invalido",
+        });
+      }
+
+      const reportResult = await getAuthorizedReport(
+        reportId,
+        auth.clinicId,
+        "No autorizado para consultar el historial de este informe",
+        deps,
+      );
+
+      if (!("report" in reportResult)) {
+        return reply.code(reportResult.status).send({
+          success: false,
+          error: reportResult.error,
+        });
+      }
+
+      const history = await deps.getReportStatusHistory(reportId);
+
+      return reply.code(200).send({
+        success: true,
+        reportId,
+        currentStatus: reportResult.report.currentStatus,
+        count: history.length,
+        history,
+      });
+    });
+
+    app.get<{
+      Params: {
+        reportId?: unknown;
+      };
+    }>("/:reportId/preview-url", async (request, reply) => {
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      const reportId = parseReportId(request.params.reportId);
+
+      if (typeof reportId !== "number") {
+        return reply.code(400).send({
+          success: false,
+          error: "ID de informe invalido",
+        });
+      }
+
+      const reportResult = await getAuthorizedReport(
+        reportId,
+        auth.clinicId,
+        "No autorizado para previsualizar este informe",
+        deps,
+      );
+
+      if (!("report" in reportResult)) {
+        return reply.code(reportResult.status).send({
+          success: false,
+          error: reportResult.error,
+        });
+      }
+
+      const previewUrl = await deps.createSignedReportUrl(
+        reportResult.report.storagePath,
+      );
+
+      return reply.code(200).send({
+        success: true,
+        previewUrl,
+      });
+    });
+
+    app.get<{
+      Params: {
+        reportId?: unknown;
+      };
+    }>("/:reportId/download-url", async (request, reply) => {
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      const reportId = parseReportId(request.params.reportId);
+
+      if (typeof reportId !== "number") {
+        return reply.code(400).send({
+          success: false,
+          error: "ID de informe invalido",
+        });
+      }
+
+      const reportResult = await getAuthorizedReport(
+        reportId,
+        auth.clinicId,
+        "No autorizado para descargar este informe",
+        deps,
+      );
+
+      if (!("report" in reportResult)) {
+        return reply.code(reportResult.status).send({
+          success: false,
+          error: reportResult.error,
+        });
+      }
+
+      const downloadUrl = await deps.createSignedReportDownloadUrl(
+        reportResult.report.storagePath,
+        reportResult.report.fileName ?? undefined,
+      );
+
+      return reply.code(200).send({
+        success: true,
+        downloadUrl,
       });
     });
   };

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -33,6 +33,20 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createStatusHistoryFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    reportId: 55,
+    fromStatus: "processing",
+    toStatus: "ready",
+    note: "Informe listo",
+    changedByClinicUserId: 9,
+    changedByAdminUserId: null,
+    createdAt: new Date("2026-04-21T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 function createAuthStubs(overrides: Record<string, unknown> = {}) {
   return {
     deleteActiveSession: async () => {},
@@ -63,6 +77,8 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     getReportsByClinicId: async () => [createReportFixture()],
     searchReports: async () => [createReportFixture({ id: 56 })],
     getStudyTypes: async () => ["Histopatología", "Citología"],
+    getReportById: async () => createReportFixture(),
+    getReportStatusHistory: async () => [createStatusHistoryFixture()],
     createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
       storagePath: string,
@@ -196,6 +212,158 @@ test("reportsNativeRoutes expone GET /study-types clinic-scoped", async () => {
     assert.deepEqual(JSON.parse(response.body), {
       success: true,
       studyTypes: ["Histopatología", "Citología"],
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes expone GET /:reportId/history con historial clinic-scoped", async () => {
+  const getReportCalls: number[] = [];
+  const historyCalls: number[] = [];
+  const app = await createTestApp({
+    getReportById: async (reportId: number) => {
+      getReportCalls.push(reportId);
+      return createReportFixture({ id: reportId });
+    },
+    getReportStatusHistory: async (reportId: number) => {
+      historyCalls.push(reportId);
+      return [createStatusHistoryFixture({ reportId })];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/55/history",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(getReportCalls, [55]);
+    assert.deepEqual(historyCalls, [55]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.reportId, 55);
+    assert.equal(body.currentStatus, "ready");
+    assert.equal(body.count, 1);
+    assert.equal(body.history[0].toStatus, "ready");
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes expone GET /:reportId/preview-url clinic-scoped", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/55/preview-url",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      previewUrl: "preview:reports/3/luna.pdf",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes expone GET /:reportId/download-url clinic-scoped", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/55/download-url",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      downloadUrl: "download:reports/3/luna.pdf:luna.pdf",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes bloquea reportId inválido en rutas parametrizadas", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/abc/history",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "ID de informe invalido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes bloquea informe ajeno en rutas parametrizadas", async () => {
+  const app = await createTestApp({
+    getReportById: async () => createReportFixture({ clinicId: 99 }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/55/download-url",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autorizado para descargar este informe",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes devuelve 404 cuando el informe no existe en rutas parametrizadas", async () => {
+  const app = await createTestApp({
+    getReportById: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports/55/preview-url",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Informe no encontrado",
     });
   } finally {
     await app.close();


### PR DESCRIPTION
## Summary
- add native Fastify routes for report status history
- add native Fastify routes for report preview and download signed URLs
- cover reportId validation, clinic-scoped authorization, not found handling, and successful URL/history responses

## Validation
- pnpm.cmd typecheck
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/reports.fastify.test.ts
- pnpm.cmd test

## Notes
- PATCH /api/reports/:reportId/status remains out of scope for this PR.
- POST /api/reports/upload remains out of scope for this PR.