### PR TITLE
feat(reports): move report status updates to native Fastify

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -67,6 +67,10 @@ import {
   type ReportsNativeRoutesOptions,
 } from "./routes/reports.fastify.ts";
 import {
+  reportsStatusNativeRoutes,
+  type ReportsStatusNativeRoutesOptions,
+} from "./routes/reports-status.fastify.ts";
+import {
   studyTrackingNativeRoutes,
   type StudyTrackingNativeRoutesOptions,
 } from "./routes/study-tracking.fastify.ts";
@@ -106,6 +110,7 @@ export type CreateFastifyAppOptions = {
   publicReportAccessRoutes?: PublicReportAccessNativeRoutesOptions;
   reportAccessTokensRoutes?: ReportAccessTokensNativeRoutesOptions;
   reportsRoutes?: ReportsNativeRoutesOptions;
+  reportsStatusRoutes?: ReportsStatusNativeRoutesOptions;
   studyTrackingRoutes?: StudyTrackingNativeRoutesOptions;
 };
 
@@ -274,6 +279,11 @@ export async function createFastifyApp(
   await app.register(reportsNativeRoutes, {
     prefix: "/api/reports",
     ...(options.reportsRoutes ?? {}),
+  });
+
+  await app.register(reportsStatusNativeRoutes, {
+    prefix: "/api/reports",
+    ...(options.reportsStatusRoutes ?? {}),
   });
 
   await app.register(studyTrackingNativeRoutes, {

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -79,7 +79,7 @@ export type ReportsStatusNativeRoutesOptions = {
     note: string | null;
     changedByClinicUserId?: number | null;
     changedByAdminUserId?: number | null;
-  }) => Promise<Report | null>;
+  }) => Promise<Report | null | undefined>;
   createSignedReportUrl?: (storagePath: string) => Promise<string>;
   createSignedReportDownloadUrl?: (
     storagePath: string,
@@ -141,7 +141,7 @@ async function loadDefaultDeps(): Promise<NativeReportsStatusDeps> {
     })();
   }
 
-  return defaultDepsPromise;
+  return defaultDepsPromise!;
 }
 
 function hasAllInjectedDeps(options: ReportsStatusNativeRoutesOptions) {

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -1,0 +1,722 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import type { Report, ReportStatus } from "../../drizzle/schema";
+import { AUDIT_EVENTS } from "../lib/audit.ts";
+import { ENV } from "../lib/env.ts";
+import {
+  normalizeOptionalNote,
+  parseReportId,
+  parseReportStatus,
+} from "../lib/reports.ts";
+import {
+  REPORT_STATUSES,
+  canTransitionReportStatus,
+} from "../lib/report-status.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuthenticatedClinicUser = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId: string | null;
+  role: ReturnType<typeof normalizeClinicUserRole>;
+  permissions: ReturnType<typeof getClinicPermissions>;
+  canUploadReports: boolean;
+  canManageClinicUsers: boolean;
+  sessionToken: string;
+};
+
+type AuditWriteInput = {
+  event: string;
+  clinicId?: number | null;
+  reportId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    clinicUserId?: number | null;
+  };
+};
+
+export type ReportsStatusNativeRoutesOptions = {
+  deleteActiveSession?: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById?: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getReportById?: (reportId: number) => Promise<Report | null>;
+  updateReportStatus?: (input: {
+    reportId: number;
+    toStatus: ReportStatus;
+    note: string | null;
+    changedByClinicUserId?: number | null;
+    changedByAdminUserId?: number | null;
+  }) => Promise<Report | null>;
+  createSignedReportUrl?: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl?: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__reportsStatusRequestStartTimeNs";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+type ReportsStatusFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeReportsStatusDeps = Required<
+  Pick<
+    ReportsStatusNativeRoutesOptions,
+    | "deleteActiveSession"
+    | "getActiveSessionByToken"
+    | "getClinicUserById"
+    | "updateSessionLastAccess"
+    | "hashSessionToken"
+    | "getReportById"
+    | "updateReportStatus"
+    | "createSignedReportUrl"
+    | "createSignedReportDownloadUrl"
+    | "writeAuditLog"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeReportsStatusDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeReportsStatusDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const storage = await import("../lib/supabase.ts");
+      const audit = await import("../lib/audit.ts");
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getReportById: db.getReportById,
+        updateReportStatus: db.updateReportStatus,
+        createSignedReportUrl: storage.createSignedReportUrl,
+        createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function hasAllInjectedDeps(options: ReportsStatusNativeRoutesOptions) {
+  return (
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getReportById &&
+    !!options.updateReportStatus &&
+    !!options.createSignedReportUrl &&
+    !!options.createSignedReportDownloadUrl &&
+    !!options.writeAuditLog
+  );
+}
+
+async function resolveDeps(
+  options: ReportsStatusNativeRoutesOptions,
+): Promise<NativeReportsStatusDeps> {
+  const defaultDeps = hasAllInjectedDeps(options) ? undefined : await loadDefaultDeps();
+
+  return {
+    deleteActiveSession:
+      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
+    getActiveSessionByToken:
+      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
+    getClinicUserById:
+      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
+    updateSessionLastAccess:
+      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
+    updateReportStatus:
+      options.updateReportStatus ?? defaultDeps!.updateReportStatus,
+    createSignedReportUrl:
+      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
+    createSignedReportDownloadUrl:
+      options.createSignedReportDownloadUrl ??
+      defaultDeps!.createSignedReportDownloadUrl,
+    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+  };
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.cookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearSessionCookie() {
+  return serializeCookie({
+    name: ENV.cookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+function createAuditRequestLike(
+  request: FastifyRequest,
+  auth: AuthenticatedClinicUser,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    auth: {
+      id: auth.id,
+      clinicId: auth.clinicId,
+      username: auth.username,
+      role: auth.role,
+      canManageClinicUsers: auth.canManageClinicUsers,
+      canUploadReports: auth.canUploadReports,
+    },
+  };
+}
+
+async function authenticateClinicUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeReportsStatusDeps,
+  now: () => number,
+): Promise<AuthenticatedClinicUser | null> {
+  const token = getSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "No autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getActiveSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión expirada",
+    });
+    return null;
+  }
+
+  const clinicUser = await deps.getClinicUserById(session.clinicUserId);
+
+  if (!clinicUser) {
+    await deps.deleteActiveSession(tokenHash);
+
+    reply.header("set-cookie", buildClearSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateSessionLastAccess(tokenHash);
+  }
+
+  const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+  const permissions = getClinicPermissions(role);
+
+  return {
+    id: clinicUser.id,
+    clinicId: clinicUser.clinicId,
+    username: clinicUser.username,
+    authProId: clinicUser.authProId ?? null,
+    role,
+    permissions,
+    canUploadReports: permissions.canUploadReports,
+    canManageClinicUsers: permissions.canManageClinicUsers,
+    sessionToken: token,
+  };
+}
+
+function requireReportStatusWritePermission(
+  auth: AuthenticatedClinicUser,
+  reply: FastifyReply,
+) {
+  if (auth.canManageClinicUsers) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "No autorizado para cambiar el estado de informes",
+  });
+
+  return false;
+}
+
+async function getAuthorizedReport(
+  reportId: number,
+  clinicId: number,
+  unauthorizedMessage: string,
+  deps: NativeReportsStatusDeps,
+): Promise<{ report: Report } | { status: 403 | 404; error: string }> {
+  const report = await deps.getReportById(reportId);
+
+  if (!report) {
+    return {
+      status: 404,
+      error: "Informe no encontrado",
+    };
+  }
+
+  if (report.clinicId !== clinicId) {
+    return {
+      status: 403,
+      error: unauthorizedMessage,
+    };
+  }
+
+  return {
+    report,
+  };
+}
+
+async function serializeReport(report: Report, deps: NativeReportsStatusDeps) {
+  const [previewUrl, downloadUrl] = await Promise.all([
+    deps.createSignedReportUrl(report.storagePath),
+    deps.createSignedReportDownloadUrl(
+      report.storagePath,
+      report.fileName ?? undefined,
+    ),
+  ]);
+
+  return {
+    ...report,
+    previewUrl,
+    downloadUrl,
+  };
+}
+
+export const reportsStatusNativeRoutes: FastifyPluginAsync<
+  ReportsStatusNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as ReportsStatusFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as ReportsStatusFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "PATCH,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/:reportId/status", optionsHandler);
+
+  app.patch<{
+    Params: {
+      reportId?: unknown;
+    };
+    Body: {
+      status?: unknown;
+      note?: unknown;
+    };
+  }>("/:reportId/status", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const deps = await resolveDeps(options);
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    if (!requireReportStatusWritePermission(auth, reply)) {
+      return reply;
+    }
+
+    const reportId = parseReportId(request.params.reportId);
+    const nextStatus = parseReportStatus(request.body?.status);
+    const note = normalizeOptionalNote(request.body?.note);
+
+    if (typeof reportId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de informe invalido",
+      });
+    }
+
+    if (!nextStatus) {
+      return reply.code(400).send({
+        success: false,
+        error: "Estado de informe invalido",
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
+    const reportResult = await getAuthorizedReport(
+      reportId,
+      auth.clinicId,
+      "No autorizado para cambiar el estado de este informe",
+      deps,
+    );
+
+    if (!("report" in reportResult)) {
+      return reply.code(reportResult.status).send({
+        success: false,
+        error: reportResult.error,
+      });
+    }
+
+    if (reportResult.report.currentStatus === nextStatus) {
+      return reply.code(400).send({
+        success: false,
+        error: "El informe ya se encuentra en ese estado",
+      });
+    }
+
+    if (!canTransitionReportStatus(reportResult.report.currentStatus, nextStatus)) {
+      return reply.code(400).send({
+        success: false,
+        error: "La transición de estado no está permitida",
+        currentStatus: reportResult.report.currentStatus,
+        requestedStatus: nextStatus,
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
+    const updated = await deps.updateReportStatus({
+      reportId,
+      toStatus: nextStatus,
+      note,
+      changedByClinicUserId: auth.id,
+      changedByAdminUserId: null,
+    });
+
+    if (!updated) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+      event: AUDIT_EVENTS.REPORT_STATUS_CHANGED,
+      clinicId: updated.clinicId,
+      reportId: updated.id,
+      metadata: {
+        fromStatus: reportResult.report.currentStatus,
+        toStatus: nextStatus,
+        note,
+      },
+    });
+
+    return reply.code(200).send({
+      success: true,
+      message: "Estado de informe actualizado correctamente",
+      report: await serializeReport(updated, deps),
+    });
+  });
+};

--- a/test/reports-status.fastify.test.ts
+++ b/test/reports-status.fastify.test.ts
@@ -19,7 +19,7 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
     id: 55,
     clinicId: 3,
     patientName: "Luna Gomez",
-    studyType: "Histopatología",
+    studyType: "Histopatolog\u00eda",
     uploadDate: new Date("2026-04-20T00:00:00.000Z"),
     fileName: "luna.pdf",
     storagePath: "reports/3/luna.pdf",
@@ -117,7 +117,7 @@ test("reportsStatusNativeRoutes actualiza PATCH /:reportId/status y escribe audi
     ]);
 
     assert.equal(auditCalls.length, 1);
-    assert.equal(auditCalls[0].event, "report.status_changed");
+    assert.equal(auditCalls[0].event, "report.status.changed");
     assert.equal(auditCalls[0].clinicId, 3);
     assert.equal(auditCalls[0].reportId, 55);
     assert.deepEqual(auditCalls[0].metadata, {
@@ -173,7 +173,7 @@ test("reportsStatusNativeRoutes bloquea PATCH /:reportId/status sin management p
   }
 });
 
-test("reportsStatusNativeRoutes valida reportId y status inválidos", async () => {
+test("reportsStatusNativeRoutes valida reportId y status invalidos", async () => {
   const app = await createTestApp();
 
   try {
@@ -267,7 +267,7 @@ test("reportsStatusNativeRoutes bloquea informe ajeno o inexistente", async () =
   }
 });
 
-test("reportsStatusNativeRoutes rechaza status repetido o transición inválida", async () => {
+test("reportsStatusNativeRoutes rechaza status repetido o transicion invalida", async () => {
   const sameStatusApp = await createTestApp({
     getReportById: async () => createReportFixture({ currentStatus: "ready" }),
   });
@@ -312,7 +312,7 @@ test("reportsStatusNativeRoutes rechaza status repetido o transición inválida"
     assert.equal(response.statusCode, 400);
     const body = JSON.parse(response.body);
     assert.equal(body.success, false);
-    assert.equal(body.error, "La transición de estado no está permitida");
+    assert.equal(body.error, "La transici\u00f3n de estado no est\u00e1 permitida");
     assert.equal(body.currentStatus, "delivered");
     assert.equal(body.requestedStatus, "processing");
   } finally {

--- a/test/reports-status.fastify.test.ts
+++ b/test/reports-status.fastify.test.ts
@@ -1,0 +1,350 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { reportsStatusNativeRoutes } = await import(
+  "../server/routes/reports-status.fastify.ts"
+);
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    patientName: "Luna Gomez",
+    studyType: "Histopatología",
+    uploadDate: new Date("2026-04-20T00:00:00.000Z"),
+    fileName: "luna.pdf",
+    storagePath: "reports/3/luna.pdf",
+    previewUrl: null,
+    downloadUrl: null,
+    currentStatus: "processing",
+    statusChangedAt: new Date("2026-04-21T00:00:00.000Z"),
+    statusChangedByClinicUserId: 9,
+    statusChangedByAdminUserId: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => ({
+      clinicUserId: 9,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(reportsStatusNativeRoutes as any, {
+    prefix: "/api/reports",
+    ...createAuthStubs(),
+    getReportById: async () => createReportFixture(),
+    updateReportStatus: async (input: { toStatus: string }) =>
+      createReportFixture({ currentStatus: input.toStatus }),
+    createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `download:${storagePath}:${fileName ?? ""}`,
+    writeAuditLog: async () => {},
+    now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
+    ...overrides,
+  });
+
+  return app;
+}
+
+test("reportsStatusNativeRoutes actualiza PATCH /:reportId/status y escribe auditoria", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    updateReportStatus: async (input: Record<string, unknown>) => {
+      updateCalls.push(input);
+      return createReportFixture({ currentStatus: input.toStatus });
+    },
+    writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+      auditCalls.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        status: "ready",
+        note: " Informe listo ",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(updateCalls, [
+      {
+        reportId: 55,
+        toStatus: "ready",
+        note: "Informe listo",
+        changedByClinicUserId: 9,
+        changedByAdminUserId: null,
+      },
+    ]);
+
+    assert.equal(auditCalls.length, 1);
+    assert.equal(auditCalls[0].event, "report.status_changed");
+    assert.equal(auditCalls[0].clinicId, 3);
+    assert.equal(auditCalls[0].reportId, 55);
+    assert.deepEqual(auditCalls[0].metadata, {
+      fromStatus: "processing",
+      toStatus: "ready",
+      note: "Informe listo",
+    });
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Estado de informe actualizado correctamente");
+    assert.equal(body.report.currentStatus, "ready");
+    assert.equal(body.report.previewUrl, "preview:reports/3/luna.pdf");
+    assert.equal(
+      body.report.downloadUrl,
+      "download:reports/3/luna.pdf:luna.pdf",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsStatusNativeRoutes bloquea PATCH /:reportId/status sin management permission", async () => {
+  const app = await createTestApp({
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_staff",
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "ready",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autorizado para cambiar el estado de informes",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsStatusNativeRoutes valida reportId y status inválidos", async () => {
+  const app = await createTestApp();
+
+  try {
+    const invalidReportId = await app.inject({
+      method: "PATCH",
+      url: "/api/reports/abc/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "ready",
+      },
+    });
+
+    assert.equal(invalidReportId.statusCode, 400);
+    assert.deepEqual(JSON.parse(invalidReportId.body), {
+      success: false,
+      error: "ID de informe invalido",
+    });
+
+    const invalidStatus = await app.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "bad",
+      },
+    });
+
+    assert.equal(invalidStatus.statusCode, 400);
+    const body = JSON.parse(invalidStatus.body);
+    assert.equal(body.success, false);
+    assert.equal(body.error, "Estado de informe invalido");
+    assert.ok(Array.isArray(body.allowedStatuses));
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsStatusNativeRoutes bloquea informe ajeno o inexistente", async () => {
+  const foreignReportApp = await createTestApp({
+    getReportById: async () => createReportFixture({ clinicId: 99 }),
+  });
+
+  try {
+    const response = await foreignReportApp.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "ready",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autorizado para cambiar el estado de este informe",
+    });
+  } finally {
+    await foreignReportApp.close();
+  }
+
+  const missingReportApp = await createTestApp({
+    getReportById: async () => null,
+  });
+
+  try {
+    const response = await missingReportApp.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "ready",
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Informe no encontrado",
+    });
+  } finally {
+    await missingReportApp.close();
+  }
+});
+
+test("reportsStatusNativeRoutes rechaza status repetido o transición inválida", async () => {
+  const sameStatusApp = await createTestApp({
+    getReportById: async () => createReportFixture({ currentStatus: "ready" }),
+  });
+
+  try {
+    const response = await sameStatusApp.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "ready",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "El informe ya se encuentra en ese estado",
+    });
+  } finally {
+    await sameStatusApp.close();
+  }
+
+  const invalidTransitionApp = await createTestApp({
+    getReportById: async () => createReportFixture({ currentStatus: "delivered" }),
+  });
+
+  try {
+    const response = await invalidTransitionApp.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+      payload: {
+        status: "processing",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, false);
+    assert.equal(body.error, "La transición de estado no está permitida");
+    assert.equal(body.currentStatus, "delivered");
+    assert.equal(body.requestedStatus, "processing");
+  } finally {
+    await invalidTransitionApp.close();
+  }
+});
+
+test("reportsStatusNativeRoutes bloquea origin no permitido antes de auth", async () => {
+  const app = await createTestApp({
+    getActiveSessionByToken: async () => {
+      throw new Error("auth should not run");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/reports/55/status",
+      headers: {
+        origin: "http://evil.example",
+      },
+      payload: {
+        status: "ready",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
﻿## Summary
- add native Fastify PATCH /api/reports/:reportId/status support
- register the native report status route before the legacy Express bridge
- cover management permission, validation, clinic-scoped authorization, transitions, audit log, and trusted-origin behavior

## Validation
- pnpm.cmd typecheck
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/reports-status.fastify.test.ts
- pnpm.cmd exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/fastify-app.test.ts
- pnpm.cmd test

## Notes
- POST /api/reports/upload remains out of scope for this PR.
