### PR TITLE
feat(reports): move report upload route to native Fastify

### DIFF
--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -3,13 +3,17 @@ import type {
   FastifyReply,
   FastifyRequest,
 } from "fastify";
+import multer from "multer";
 
 import type { Report, ReportStatus } from "../../drizzle/schema";
+import type { Multer } from "multer";
 import { ENV } from "../lib/env.ts";
+import { ALLOWED_MIME_TYPES } from "../lib/supabase.ts";
 import {
   getReadClinicScope,
   normalizeSearchText,
   parseOffset,
+  parseOptionalDate,
   parsePositiveInt,
   parseReportId,
   parseReportStatus,
@@ -36,6 +40,28 @@ type ActiveSessionRecord = {
   clinicUserId: number;
   expiresAt: Date | null;
   lastAccess?: Date | null;
+};
+
+type ReportUploadInput = {
+  file: Buffer;
+  fileName: string;
+  clinicId: number;
+  mimeType: string;
+};
+
+type UpsertReportInput = {
+  clinicId: number;
+  patientName: string | null;
+  studyType: string | null;
+  uploadDate: Date | null;
+  fileName: string;
+  storagePath: string;
+  createdByClinicUserId?: number | null;
+};
+
+type RawRequestWithFile = FastifyRequest["raw"] & {
+  file?: Express.Multer.File;
+  body?: Record<string, unknown>;
 };
 
 type AuthenticatedClinicUser = {
@@ -77,6 +103,16 @@ export type ReportsNativeRoutesOptions = {
   getStudyTypes?: (clinicId: number) => Promise<string[]>;
   getReportById?: (reportId: number) => Promise<Report | null>;
   getReportStatusHistory?: (reportId: number) => Promise<unknown[]>;
+  getClinicScopedStudyTrackingCase?: (
+    trackingCaseId: number,
+    clinicId: number,
+  ) => Promise<unknown | null>;
+  updateStudyTrackingCase?: (
+    trackingCaseId: number,
+    input: { reportId: number },
+  ) => Promise<unknown>;
+  uploadReport?: (input: ReportUploadInput) => Promise<string>;
+  upsertReport?: (input: UpsertReportInput) => Promise<Report>;
   createSignedReportUrl?: (storagePath: string) => Promise<string>;
   createSignedReportDownloadUrl?: (
     storagePath: string,
@@ -92,6 +128,27 @@ type ReportsFastifyRequest = FastifyRequest & {
   [REQUEST_START_TIME_KEY]?: bigint;
 };
 
+const allowedMimeTypes = new Set(ALLOWED_MIME_TYPES);
+
+const upload: Multer = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: ENV.maxUploadFileSizeMb * 1024 * 1024,
+  },
+  fileFilter: (_req, file, cb) => {
+    if (
+      !allowedMimeTypes.has(
+        file.mimetype as (typeof ALLOWED_MIME_TYPES)[number],
+      )
+    ) {
+      cb(new Error("Tipo de archivo no permitido"));
+      return;
+    }
+
+    cb(null, true);
+  },
+});
+
 type NativeReportsDeps = Required<
   Pick<
     ReportsNativeRoutesOptions,
@@ -105,6 +162,10 @@ type NativeReportsDeps = Required<
     | "getStudyTypes"
     | "getReportById"
     | "getReportStatusHistory"
+    | "getClinicScopedStudyTrackingCase"
+    | "updateStudyTrackingCase"
+    | "uploadReport"
+    | "upsertReport"
     | "createSignedReportUrl"
     | "createSignedReportDownloadUrl"
   >
@@ -116,6 +177,7 @@ async function loadDefaultDeps(): Promise<NativeReportsDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
+      const studyTracking = await import("../db-study-tracking.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const storage = await import("../lib/supabase.ts");
 
@@ -130,6 +192,11 @@ async function loadDefaultDeps(): Promise<NativeReportsDeps> {
         getStudyTypes: db.getStudyTypes,
         getReportById: db.getReportById,
         getReportStatusHistory: db.getReportStatusHistory,
+        getClinicScopedStudyTrackingCase:
+          studyTracking.getClinicScopedStudyTrackingCase,
+        updateStudyTrackingCase: studyTracking.updateStudyTrackingCase,
+        uploadReport: storage.uploadReport,
+        upsertReport: db.upsertReport,
         createSignedReportUrl: storage.createSignedReportUrl,
         createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
       };
@@ -151,6 +218,10 @@ function hasAllInjectedDeps(options: ReportsNativeRoutesOptions) {
     !!options.getStudyTypes &&
     !!options.getReportById &&
     !!options.getReportStatusHistory &&
+    !!options.getClinicScopedStudyTrackingCase &&
+    !!options.updateStudyTrackingCase &&
+    !!options.uploadReport &&
+    !!options.upsertReport &&
     !!options.createSignedReportUrl &&
     !!options.createSignedReportDownloadUrl
   );
@@ -179,6 +250,13 @@ async function resolveDeps(
     getReportById: options.getReportById ?? defaultDeps!.getReportById,
     getReportStatusHistory:
       options.getReportStatusHistory ?? defaultDeps!.getReportStatusHistory,
+    getClinicScopedStudyTrackingCase:
+      options.getClinicScopedStudyTrackingCase ??
+      defaultDeps!.getClinicScopedStudyTrackingCase,
+    updateStudyTrackingCase:
+      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
+    uploadReport: options.uploadReport ?? defaultDeps!.uploadReport,
+    upsertReport: options.upsertReport ?? defaultDeps!.upsertReport,
     createSignedReportUrl:
       options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
     createSignedReportDownloadUrl:
@@ -278,6 +356,24 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
 }
 
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const requestOrigin = getRequestOrigin(request);
+
+  if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+    reply.code(403).send({
+      success: false,
+      error: "Origen no permitido",
+    });
+    return false;
+  }
+
+  return true;
+}
+
 function parseCookies(cookieHeader: string | undefined) {
   const result: Record<string, string> = {};
 
@@ -362,6 +458,36 @@ function buildClearSessionCookie() {
     maxAgeSeconds: 0,
     expires: "Thu, 01 Jan 1970 00:00:00 GMT",
   });
+}
+
+function runReportUpload(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<Express.Multer.File | undefined> {
+  return new Promise((resolve, reject) => {
+    upload.single("file")(
+      request.raw as any,
+      reply.raw as any,
+      (error: unknown) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve((request.raw as RawRequestWithFile).file);
+      },
+    );
+  });
+}
+
+function getMultipartBody(request: FastifyRequest) {
+  const body = (request.raw as RawRequestWithFile).body;
+
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+
+  return body;
 }
 
 function shouldRefreshSessionLastAccess(
@@ -502,6 +628,15 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     const now = options.now ?? (() => Date.now());
     const allowedOrigins = new Set(getAllowedOrigins());
 
+    if (!app.hasContentTypeParser("multipart/form-data")) {
+      app.addContentTypeParser(
+        "multipart/form-data",
+        (_request, _payload, done) => {
+          done(null, undefined);
+        },
+      );
+    }
+
     app.addHook("onRequest", async (request, reply) => {
       (request as ReportsFastifyRequest)[REQUEST_START_TIME_KEY] =
         process.hrtime.bigint();
@@ -545,7 +680,7 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
       }
 
       applyCorsHeaders(request, reply, allowedOrigins);
-      reply.header("access-control-allow-methods", "GET,OPTIONS");
+      reply.header("access-control-allow-methods", "GET,POST,OPTIONS");
 
       const requestedHeaders =
         typeof request.headers["access-control-request-headers"] === "string"
@@ -557,11 +692,103 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     };
 
     app.options("/", optionsHandler);
+    app.options("/upload", optionsHandler);
     app.options("/search", optionsHandler);
     app.options("/study-types", optionsHandler);
     app.options("/:reportId/history", optionsHandler);
     app.options("/:reportId/preview-url", optionsHandler);
     app.options("/:reportId/download-url", optionsHandler);
+
+    app.post("/upload", async (request, reply) => {
+      if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+        return reply;
+      }
+
+      const deps = await resolveDeps(options);
+      const auth = await authenticateClinicUser(request, reply, deps, now);
+
+      if (!auth) {
+        return reply;
+      }
+
+      if (!auth.canUploadReports) {
+        return reply.code(403).send({
+          success: false,
+          error: "No autorizado para subir informes",
+        });
+      }
+
+      let file: Express.Multer.File | undefined;
+
+      try {
+        file = await runReportUpload(request, reply);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Error al procesar archivo";
+
+        return reply.code(400).send({
+          success: false,
+          error: message,
+        });
+      }
+
+      if (!file) {
+        return reply.code(400).send({
+          success: false,
+          error: "No se proporciono ningun archivo",
+        });
+      }
+
+      const clinicId = auth.clinicId;
+      const body = getMultipartBody(request);
+      const storagePath = await deps.uploadReport({
+        file: file.buffer,
+        fileName: file.originalname,
+        clinicId,
+        mimeType: file.mimetype,
+      });
+
+      const patientName = normalizeSearchText(body.patientName);
+      const studyType = normalizeSearchText(body.studyType);
+      const uploadDate = parseOptionalDate(body.uploadDate);
+      const trackingCaseId = parseReportId(body.trackingCaseId);
+
+      if (typeof trackingCaseId === "number") {
+        const trackingCase = await deps.getClinicScopedStudyTrackingCase(
+          trackingCaseId,
+          clinicId,
+        );
+
+        if (!trackingCase) {
+          return reply.code(404).send({
+            success: false,
+            error: "Seguimiento no encontrado para la clinica autenticada",
+          });
+        }
+      }
+
+      const report = await deps.upsertReport({
+        clinicId,
+        patientName: patientName ?? null,
+        studyType: studyType ?? null,
+        uploadDate: uploadDate ?? null,
+        fileName: file.originalname,
+        storagePath,
+        createdByClinicUserId: auth.id,
+      });
+
+      if (typeof trackingCaseId === "number") {
+        await deps.updateStudyTrackingCase(trackingCaseId, {
+          reportId: report.id,
+        });
+      }
+
+      return reply.code(201).send({
+        success: true,
+        message: "Archivo subido correctamente",
+        report: await serializeReport(report, deps),
+      });
+    });
 
     app.get<{
       Querystring: {

--- a/server/routes/reports.routes.ts
+++ b/server/routes/reports.routes.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import multer from "multer";
 import type { Report, ReportStatus } from "../../drizzle/schema";
 import {
   getReportById,
@@ -8,51 +7,22 @@ import {
   getStudyTypes,
   searchReports,
   updateReportStatus,
-  upsertReport,
 } from "../db";
-import {
-  getClinicScopedStudyTrackingCase,
-  updateStudyTrackingCase,
-} from "../db-study-tracking";
 import {
   REPORT_STATUSES,
   canTransitionReportStatus,
   normalizeReportStatus,
 } from "../lib/report-status";
 import { AUDIT_EVENTS, writeAuditLog } from "../lib/audit";
-import { ENV } from "../lib/env";
 import {
-  ALLOWED_MIME_TYPES,
   createSignedReportDownloadUrl,
   createSignedReportUrl,
-  uploadReport,
 } from "../lib/supabase";
 import { requireAuth } from "../middlewares/auth";
 import { requireTrustedOrigin } from "../middlewares/trusted-origin";
 import { asyncHandler } from "../utils/async-handler";
 
 const router = Router();
-
-const allowedMimeTypes = new Set(ALLOWED_MIME_TYPES);
-
-const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: {
-    fileSize: ENV.maxUploadFileSizeMb * 1024 * 1024,
-  },
-  fileFilter: (_req, file, cb) => {
-    if (
-      !allowedMimeTypes.has(
-        file.mimetype as (typeof ALLOWED_MIME_TYPES)[number],
-      )
-    ) {
-      cb(new Error("Tipo de archivo no permitido"));
-      return;
-    }
-
-    cb(null, true);
-  },
-});
 
 function parsePositiveInt(value: unknown, fallback: number, max?: number) {
   const parsed = Number(value);
@@ -89,15 +59,6 @@ function normalizeOptionalNote(value: unknown) {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed.slice(0, 2000) : null;
-}
-
-function parseOptionalDate(value: unknown): Date | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? undefined : date;
 }
 
 function parseClinicId(value: unknown): number | undefined {
@@ -184,17 +145,6 @@ async function serializeReports(reports: Report[]) {
 router.use(requireTrustedOrigin);
 router.use(requireAuth);
 
-const requireUploadPermission = asyncHandler(async (req, res, next) => {
-  if (!req.auth?.canUploadReports) {
-    return res.status(403).json({
-      success: false,
-      error: "No autorizado para subir informes",
-    });
-  }
-
-  next();
-});
-
 const requireReportStatusWritePermission = asyncHandler(async (req, res, next) => {
   if (!req.auth?.canManageClinicUsers) {
     return res.status(403).json({
@@ -205,70 +155,6 @@ const requireReportStatusWritePermission = asyncHandler(async (req, res, next) =
 
   next();
 });
-
-router.post(
-  "/upload",
-  requireUploadPermission,
-  upload.single("file"),
-  asyncHandler(async (req, res) => {
-    if (!req.file) {
-      return res.status(400).json({
-        success: false,
-        error: "No se proporciono ningun archivo",
-      });
-    }
-
-    const clinicId = req.auth!.clinicId;
-
-    const storagePath = await uploadReport({
-      file: req.file.buffer,
-      fileName: req.file.originalname,
-      clinicId,
-      mimeType: req.file.mimetype,
-    });
-
-    const patientName = normalizeSearchText(req.body?.patientName);
-    const studyType = normalizeSearchText(req.body?.studyType);
-    const uploadDate = parseOptionalDate(req.body?.uploadDate);
-    const trackingCaseId = parseReportId(req.body?.trackingCaseId);
-
-    if (typeof trackingCaseId === "number") {
-      const trackingCase = await getClinicScopedStudyTrackingCase(
-        trackingCaseId,
-        clinicId,
-      );
-
-      if (!trackingCase) {
-        return res.status(404).json({
-          success: false,
-          error: "Seguimiento no encontrado para la clínica autenticada",
-        });
-      }
-    }
-
-    const report = await upsertReport({
-      clinicId,
-      patientName: patientName ?? null,
-      studyType: studyType ?? null,
-      uploadDate: uploadDate ?? null,
-      fileName: req.file.originalname,
-      storagePath,
-      createdByClinicUserId: req.auth!.id,
-    });
-
-    if (typeof trackingCaseId === "number") {
-      await updateStudyTrackingCase(trackingCaseId, {
-        reportId: report.id,
-      });
-    }
-
-    return res.status(201).json({
-      success: true,
-      message: "Archivo subido correctamente",
-      report: await serializeReport(report),
-    });
-  }),
-);
 
 router.get(
   "/",

--- a/test/report-management-route-policy.test.ts
+++ b/test/report-management-route-policy.test.ts
@@ -34,6 +34,35 @@ test("reports protege PATCH /:reportId/status con management permission", () => 
   );
 });
 
+test("reports expone POST /upload nativo con permiso de upload, no management", () => {
+  const legacySource = readRouteSource("server/routes/reports.routes.ts");
+  const nativeSource = readRouteSource("server/routes/reports.fastify.ts");
+
+  assert.doesNotMatch(
+    legacySource,
+    /router\.post\(\s*"\/upload"/s,
+    "POST /upload ya no debe existir en el router Express legacy",
+  );
+
+  assert.match(
+    nativeSource,
+    /app\.post\(\s*"\/upload"/s,
+  );
+  assert.match(
+    nativeSource,
+    /if \(!auth\.canUploadReports\)/,
+  );
+  assert.match(
+    nativeSource,
+    /error: "No autorizado para subir informes"/,
+  );
+  assert.doesNotMatch(
+    nativeSource,
+    /app\.post\(\s*"\/upload"[\s\S]*?canManageClinicUsers/s,
+    "POST /upload no debe exigir permiso de management de clinica",
+  );
+});
+
 test("report-access-tokens protege mutaciones con management permission", () => {
   const source = readRouteSource("server/routes/report-access-tokens.routes.ts");
 

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -79,6 +79,18 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     getStudyTypes: async () => ["Histopatología", "Citología"],
     getReportById: async () => createReportFixture(),
     getReportStatusHistory: async () => [createStatusHistoryFixture()],
+    getClinicScopedStudyTrackingCase: async () => ({
+      id: 77,
+      clinicId: 3,
+    }),
+    updateStudyTrackingCase: async () => {},
+    uploadReport: async () => "reports/3/luna-new.pdf",
+    upsertReport: async () =>
+      createReportFixture({
+        id: 88,
+        currentStatus: "uploaded",
+        storagePath: "reports/3/luna-new.pdf",
+      }),
     createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
       storagePath: string,
@@ -90,6 +102,199 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
 
   return app;
 }
+
+function buildMultipartReportPayload(options: { includeFile?: boolean } = {}) {
+  const boundary = "----vetneb-report-boundary";
+  const includeFile = options.includeFile ?? true;
+  const chunks = [
+    `--${boundary}\r\n`,
+    'Content-Disposition: form-data; name="patientName"\r\n\r\n',
+    "Luna Gomez",
+    `\r\n--${boundary}\r\n`,
+    'Content-Disposition: form-data; name="studyType"\r\n\r\n',
+    "Histopatologia",
+    `\r\n--${boundary}\r\n`,
+    'Content-Disposition: form-data; name="uploadDate"\r\n\r\n',
+    "2026-04-25T10:30:00.000Z",
+    `\r\n--${boundary}\r\n`,
+    'Content-Disposition: form-data; name="trackingCaseId"\r\n\r\n',
+    "77",
+  ];
+
+  if (includeFile) {
+    chunks.push(
+      `\r\n--${boundary}\r\n`,
+      'Content-Disposition: form-data; name="file"; filename="luna.pdf"\r\n',
+      "Content-Type: application/pdf\r\n\r\n",
+      "PDFDATA",
+    );
+  }
+
+  chunks.push(`\r\n--${boundary}--\r\n`);
+
+  return {
+    boundary,
+    payload: Buffer.from(chunks.join(""), "utf8"),
+  };
+}
+
+test("reportsNativeRoutes expone POST /upload con multipart y tracking", async () => {
+  const uploadCalls: Array<Record<string, unknown>> = [];
+  const trackingCalls: Array<Record<string, unknown>> = [];
+  const updateTrackingCalls: Array<Record<string, unknown>> = [];
+  const upsertCalls: Array<Record<string, unknown>> = [];
+  const multipart = buildMultipartReportPayload();
+
+  const app = await createTestApp({
+    uploadReport: async (input: {
+      file: Buffer;
+      fileName: string;
+      clinicId: number;
+      mimeType: string;
+    }) => {
+      uploadCalls.push({
+        clinicId: input.clinicId,
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+        file: input.file.toString("utf8"),
+      });
+
+      return "reports/3/luna-new.pdf";
+    },
+    getClinicScopedStudyTrackingCase: async (
+      trackingCaseId: number,
+      clinicId: number,
+    ) => {
+      trackingCalls.push({ trackingCaseId, clinicId });
+      return {
+        id: trackingCaseId,
+        clinicId,
+      };
+    },
+    updateStudyTrackingCase: async (
+      trackingCaseId: number,
+      input: { reportId: number },
+    ) => {
+      updateTrackingCalls.push({ trackingCaseId, input });
+    },
+    upsertReport: async (input: Record<string, unknown>) => {
+      upsertCalls.push(input);
+
+      return createReportFixture({
+        id: 88,
+        clinicId: input.clinicId,
+        patientName: input.patientName,
+        studyType: input.studyType,
+        uploadDate: input.uploadDate,
+        fileName: input.fileName,
+        storagePath: input.storagePath,
+        currentStatus: "uploaded",
+        createdByClinicUserId: input.createdByClinicUserId,
+      });
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(uploadCalls, [
+      {
+        clinicId: 3,
+        fileName: "luna.pdf",
+        mimeType: "application/pdf",
+        file: "PDFDATA",
+      },
+    ]);
+    assert.deepEqual(trackingCalls, [
+      {
+        trackingCaseId: 77,
+        clinicId: 3,
+      },
+    ]);
+    assert.deepEqual(updateTrackingCalls, [
+      {
+        trackingCaseId: 77,
+        input: {
+          reportId: 88,
+        },
+      },
+    ]);
+
+    assert.equal(upsertCalls.length, 1);
+    assert.equal(upsertCalls[0].clinicId, 3);
+    assert.equal(upsertCalls[0].patientName, "Luna Gomez");
+    assert.equal(upsertCalls[0].studyType, "Histopatologia");
+    assert.equal(
+      (upsertCalls[0].uploadDate as Date).toISOString(),
+      "2026-04-25T10:30:00.000Z",
+    );
+    assert.equal(upsertCalls[0].fileName, "luna.pdf");
+    assert.equal(upsertCalls[0].storagePath, "reports/3/luna-new.pdf");
+    assert.equal(upsertCalls[0].createdByClinicUserId, 9);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Archivo subido correctamente");
+    assert.equal(body.report.id, 88);
+    assert.equal(body.report.clinicId, 3);
+    assert.equal(body.report.patientName, "Luna Gomez");
+    assert.equal(body.report.studyType, "Histopatologia");
+    assert.equal(body.report.uploadDate, "2026-04-25T10:30:00.000Z");
+    assert.equal(body.report.fileName, "luna.pdf");
+    assert.equal(body.report.storagePath, "reports/3/luna-new.pdf");
+    assert.equal(body.report.previewUrl, "preview:reports/3/luna-new.pdf");
+    assert.equal(
+      body.report.downloadUrl,
+      "download:reports/3/luna-new.pdf:luna.pdf",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes bloquea POST /upload sin archivo", async () => {
+  const multipart = buildMultipartReportPayload({ includeFile: false });
+  let uploadCalled = false;
+
+  const app = await createTestApp({
+    uploadReport: async () => {
+      uploadCalled = true;
+      return "reports/3/luna-new.pdf";
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(uploadCalled, false);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No se proporciono ningun archivo",
+    });
+  } finally {
+    await app.close();
+  }
+});
 
 test("reportsNativeRoutes expone GET / con lista clinic-scoped", async () => {
   const calls: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Move `POST /api/reports/upload` to the native Fastify reports route.
- Keep multipart upload handling with the existing Multer-on-raw-request pattern used by native Fastify avatar upload.
- Remove the legacy Express `POST /upload` implementation from `reports.routes.ts`.
- Add route tests for successful multipart upload and missing file handling.
- Add policy coverage confirming upload uses `canUploadReports`, not clinic management permission.

## Validation
- `pnpm typecheck`
- `pnpm test` — 364/364 passing

## Scope
Only `POST /api/reports/upload`. No read routes, status/history, URL, audit, rate-limit, role, or unrelated cleanup changes.