### PR TITLE
fix(fastify): add global error and not-found handlers

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -81,6 +81,61 @@ type HealthCheckResponse = {
 type HealthCheckFactory = () => Promise<HealthCheckResponse>;
 type ServiceInfoFactory = () => Record<string, unknown>;
 
+function getFastifyErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unexpected error";
+}
+
+function getFastifyErrorStatus(error: unknown) {
+  if (
+    error &&
+    typeof error === "object" &&
+    "status" in error &&
+    typeof (error as { status?: number }).status === "number"
+  ) {
+    return normalizeFastifyErrorStatus((error as { status: number }).status);
+  }
+
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof (error as { statusCode?: number }).statusCode === "number"
+  ) {
+    return normalizeFastifyErrorStatus(
+      (error as { statusCode: number }).statusCode,
+    );
+  }
+
+  if (
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as { code?: string }).code === "string"
+  ) {
+    const code = (error as { code: string }).code;
+
+    if (["23505", "23503", "22P02", "42703"].includes(code)) {
+      return 400;
+    }
+  }
+
+  return 500;
+}
+
+function normalizeFastifyErrorStatus(status: number) {
+  return Number.isInteger(status) && status >= 400 && status <= 599
+    ? status
+    : 500;
+}
+
 export type CreateFastifyAppOptions = {
   getNativeHealthCheckResponse?: HealthCheckFactory;
   getServiceInfoPayload?: ServiceInfoFactory;
@@ -109,6 +164,34 @@ export async function createFastifyApp(
   const app = Fastify({
     logger: false,
     trustProxy: ENV.trustProxy,
+  });
+
+  app.setNotFoundHandler((request, reply) => {
+    return reply.code(404).send({
+      success: false,
+      error: "Ruta no encontrada",
+      path: request.url,
+    });
+  });
+
+  app.setErrorHandler((error, request, reply) => {
+    const status = getFastifyErrorStatus(error);
+    const message = getFastifyErrorMessage(error);
+
+    console.error("[API ERROR]", {
+      method: request.method,
+      path: request.url,
+      status,
+      message,
+      error,
+    });
+
+    return reply.code(status).send({
+      success: false,
+      error: status >= 500 ? "Error interno del servidor" : message,
+      details: status >= 500 ? undefined : message,
+      path: request.url,
+    });
   });
 
   const getNativeHealthCheckResponse =
@@ -244,4 +327,5 @@ export async function createFastifyApp(
 
   return app;
 }
+
 

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -1606,3 +1606,100 @@ test(
   },
 );
 
+
+test(
+  "createFastifyApp usa handlers globales para 404 y errores no capturados",
+  async () => {
+    const app = await createFastifyApp({
+      getServiceInfoPayload: () => ({
+        success: true,
+        service: "portal-vetneb-api",
+        environment: "test",
+      }),
+      getNativeHealthCheckResponse: async () => ({
+        statusCode: 200,
+        payload: {
+          success: true,
+          status: "ok",
+        },
+      }),
+      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
+      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuthRoutes: buildParticularAuthRouteStubs(),
+      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      publicProfessionalsRoutes: {
+        searchPublicProfessionals: async () => ({
+          rows: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+        getPublicProfessionalByClinicId: async () => null,
+        createSignedStorageUrl: async (path: string) => `signed:${path}`,
+      },
+      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
+    });
+
+    try {
+      app.get("/__test/internal-error", async () => {
+        throw new Error("detalle interno sensible");
+      });
+
+      app.get("/__test/bad-request", async () => {
+        const error = new Error("Payload invalido") as Error & {
+          statusCode: number;
+        };
+        error.statusCode = 400;
+        throw error;
+      });
+
+      const notFoundResponse = await app.inject({
+        method: "GET",
+        url: "/api/no-existe",
+      });
+
+      assert.equal(notFoundResponse.statusCode, 404);
+      assert.deepEqual(JSON.parse(notFoundResponse.body), {
+        success: false,
+        error: "Ruta no encontrada",
+        path: "/api/no-existe",
+      });
+
+      const internalResponse = await app.inject({
+        method: "GET",
+        url: "/__test/internal-error",
+      });
+
+      assert.equal(internalResponse.statusCode, 500);
+      assert.deepEqual(JSON.parse(internalResponse.body), {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/__test/internal-error",
+      });
+      assert.doesNotMatch(internalResponse.body, /detalle interno sensible/);
+
+      const badRequestResponse = await app.inject({
+        method: "GET",
+        url: "/__test/bad-request",
+      });
+
+      assert.equal(badRequestResponse.statusCode, 400);
+      assert.deepEqual(JSON.parse(badRequestResponse.body), {
+        success: false,
+        error: "Payload invalido",
+        details: "Payload invalido",
+        path: "/__test/bad-request",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- Add global Fastify not-found handler with the project API error shape.
- Add global Fastify error handler that normalizes status/statusCode and known Postgres errors.
- Keep 5xx responses generic to avoid leaking internal error details.
- Add integration coverage for 404, sanitized 500, and controlled 400 responses.

## Validation
- pnpm typecheck
- pnpm test -- test/fastify-app.test.ts
- pnpm test

## Scope
Only global Fastify 404/error handling and related tests.