### PR TITLE
fix(public-professionals): return 403 for disallowed origin

### DIFF
--- a/server/routes/public-professionals.fastify.ts
+++ b/server/routes/public-professionals.fastify.ts
@@ -179,9 +179,9 @@ function applyCorsHeaders(
   const origin = rawOrigin.trim();
 
   if (!allowedOrigins.has(normalizeOrigin(origin))) {
-    reply.code(500).send({
+    reply.code(403).send({
       success: false,
-      error: "Error interno del servidor",
+      error: "Origin no permitido",
       path: request.url,
     });
     return false;
@@ -443,3 +443,4 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
     },
   );
 };
+

--- a/test/public-professionals.fastify.test.ts
+++ b/test/public-professionals.fastify.test.ts
@@ -223,3 +223,31 @@ test(
     }
   },
 );
+
+test(
+  "publicProfessionalsNativeRoutes devuelve 403 cuando origin no esta permitido",
+  async () => {
+    const app = await createTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/professionals/search",
+        headers: {
+          origin: "https://evil.example.com",
+        },
+      });
+
+      assert.equal(response.statusCode, 403);
+      assert.equal(response.headers["access-control-allow-origin"], undefined);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Origin no permitido",
+        path: "/api/public/professionals/search",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+


### PR DESCRIPTION
﻿## Summary
- Return 403 instead of 500 when public professionals receives a disallowed Origin.
- Keep blocked-origin responses out of CORS allow headers.
- Add regression coverage for disallowed Origin handling.

## Validation
- pnpm typecheck
- pnpm test -- test/public-professionals.fastify.test.ts
- pnpm test

## Scope
Only public professionals CORS/error semantics for disallowed Origin.
