### PR TITLE
chore(fastify): remove remaining Express type leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PORTAL VETNEB Backend
 
-Backend auditado y endurecido para despliegue con **Supabase + Storage privado + Express + Drizzle**.
+Backend auditado y endurecido para despliegue con **Supabase + Storage privado + Fastify + Drizzle**.
 
 ## Qué quedó resuelto
 
@@ -18,7 +18,7 @@ Backend auditado y endurecido para despliegue con **Supabase + Storage privado +
 
 - Node.js
 - pnpm
-- Express
+- Fastify
 - TypeScript
 - Drizzle ORM
 - PostgreSQL / Supabase

--- a/server/routes/clinic-public-profile.fastify.ts
+++ b/server/routes/clinic-public-profile.fastify.ts
@@ -587,8 +587,14 @@ function requireClinicManagementPermission(
   return false;
 }
 
+type UploadedMultipartFile = {
+  buffer: Buffer;
+  originalname: string;
+  mimetype: string;
+};
+
 type RawRequestWithFile = FastifyRequest["raw"] & {
-  file?: Express.Multer.File;
+  file?: UploadedMultipartFile;
 };
 
 const upload = multer({
@@ -609,7 +615,7 @@ const upload = multer({
 function runAvatarUpload(
   request: FastifyRequest,
   reply: FastifyReply,
-): Promise<Express.Multer.File | undefined> {
+): Promise<UploadedMultipartFile | undefined> {
   return new Promise((resolve, reject) => {
     upload.single("avatar")(
       request.raw as any,
@@ -927,7 +933,7 @@ export const clinicPublicProfileNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    let file: Express.Multer.File | undefined;
+    let file: UploadedMultipartFile | undefined;
 
     try {
       file = await runAvatarUpload(request, reply);

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -59,8 +59,14 @@ type UpsertReportInput = {
   createdByClinicUserId?: number | null;
 };
 
+type UploadedMultipartFile = {
+  buffer: Buffer;
+  originalname: string;
+  mimetype: string;
+};
+
 type RawRequestWithFile = FastifyRequest["raw"] & {
-  file?: Express.Multer.File;
+  file?: UploadedMultipartFile;
   body?: Record<string, unknown>;
 };
 
@@ -463,7 +469,7 @@ function buildClearSessionCookie() {
 function runReportUpload(
   request: FastifyRequest,
   reply: FastifyReply,
-): Promise<Express.Multer.File | undefined> {
+): Promise<UploadedMultipartFile | undefined> {
   return new Promise((resolve, reject) => {
     upload.single("file")(
       request.raw as any,
@@ -718,7 +724,7 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      let file: Express.Multer.File | undefined;
+      let file: UploadedMultipartFile | undefined;
 
       try {
         file = await runReportUpload(request, reply);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 ﻿{
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "express"],
+    "types": ["node"],
     "noEmit": true,
     "rootDir": ".."
   },


### PR DESCRIPTION
## Summary

- Replace remaining Express.Multer.File references in Fastify routes with local uploaded file types.
- Remove explicit express test type loading from test/tsconfig.json.
- Update README stack references from Express to Fastify.
- Keep scope limited to post-migration cleanup; no route behavior changes.

## Validation

- pnpm typecheck
- pnpm test -- test/reports.fastify.test.ts test/clinic-public-profile.fastify.test.ts
- pnpm test