### PR TITLE
ci(test): add test TypeScript gate

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Typecheck tests
+        run: pnpm typecheck:test
+
       - name: Test
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "esbuild server/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
+    "typecheck:test": "tsc -p ./test/tsconfig.json --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "smoke:test": "node scripts/smoke/smoke-test.mjs",


### PR DESCRIPTION
﻿## Resumen
Se agrega un gate explícito de TypeScript para tests en Backend CI.

## Cambios
- Agrega script `typecheck:test` para ejecutar `tsc -p ./test/tsconfig.json --noEmit`.
- Agrega step `Typecheck tests` en Backend CI después de `pnpm typecheck` y antes de `pnpm test`.

## Validación local
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test` — 368/368
- `pnpm build`

## Riesgo
Bajo. Solo CI/package script. No toca runtime ni contratos de API.
