### PR TITLE
feat(public-search): require recent histopathology activity

### DIFF
--- a/server/db-public-professionals.ts
+++ b/server/db-public-professionals.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { db, pgClient } from "./db";
 import {
@@ -13,6 +13,27 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
 export const MIN_PUBLIC_PROFILE_QUALITY_SCORE = 75;
 
+const RECENT_HISTOPATHOLOGY_REPORTS_SQL = `EXISTS (
+  SELECT 1
+  FROM reports recent_histopathology_reports
+  WHERE recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id
+    AND immutable_unaccent(COALESCE(recent_histopathology_reports.study_type, '')) ILIKE '%histopat%'
+    AND COALESCE(
+      recent_histopathology_reports.upload_date,
+      recent_histopathology_reports.created_at
+    ) >= NOW() - INTERVAL '3 months'
+)`;
+
+const RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL = sql`EXISTS (
+  SELECT 1
+  FROM reports recent_histopathology_reports
+  WHERE recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id
+    AND immutable_unaccent(COALESCE(recent_histopathology_reports.study_type, '')) ILIKE '%histopat%'
+    AND COALESCE(
+      recent_histopathology_reports.upload_date,
+      recent_histopathology_reports.created_at
+    ) >= NOW() - INTERVAL '3 months'
+)`;
 export type UpsertClinicPublicProfileInput = {
   displayName?: string | null;
   avatarStoragePath?: string | null;
@@ -467,6 +488,7 @@ export async function getPublicProfessionalByClinicId(clinicId: number) {
         eq(clinicPublicSearch.clinicId, clinicId),
         eq(clinicPublicSearch.isPublic, true),
         eq(clinicPublicSearch.isSearchEligible, true),
+        RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL,
       ),
     )
     .limit(1);
@@ -511,7 +533,11 @@ export async function searchPublicProfessionals(
   const offset = normalizeOffset(params.offset);
 
   const values: Array<string | number> = [];
-  const conditions = ["is_public = true", "is_search_eligible = true"];
+  const conditions = [
+    "is_public = true",
+    "is_search_eligible = true",
+    RECENT_HISTOPATHOLOGY_REPORTS_SQL,
+  ];
 
   let queryIndex: number | null = null;
   let localityIndex: number | null = null;

--- a/test/public-professionals-db-contract.test.ts
+++ b/test/public-professionals-db-contract.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function readDbPublicProfessionalsSource(): string {
+  return readFileSync(
+    resolve(process.cwd(), "server", "db-public-professionals.ts"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+}
+
+function assertContains(source: string, expected: string): void {
+  assert.ok(source.includes(expected), `expected source to contain: ${expected}`);
+}
+
+test("public professionals search requires recent histopathology activity", () => {
+  const source = readDbPublicProfessionalsSource();
+
+  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORTS_SQL");
+  assertContains(source, "FROM reports recent_histopathology_reports");
+  assertContains(
+    source,
+    "recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id",
+  );
+  assertContains(source, "recent_histopathology_reports.study_type");
+  assertContains(source, "ILIKE '%histopat%'");
+  assertContains(source, "recent_histopathology_reports.upload_date");
+  assertContains(source, "recent_histopathology_reports.created_at");
+  assertContains(source, "NOW() - INTERVAL '3 months'");
+});
+
+test("public professionals search keeps public profile eligibility filters", () => {
+  const source = readDbPublicProfessionalsSource();
+
+  assertContains(source, '"is_public = true"');
+  assertContains(source, '"is_search_eligible = true"');
+  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORTS_SQL,");
+});
+
+test("public professional detail lookup shares the recent histopathology gate", () => {
+  const source = readDbPublicProfessionalsSource();
+
+  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL");
+  assertContains(
+    source,
+    "RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL,\n      ),",
+  );
+});


### PR DESCRIPTION
Require clinics to have at least one recent histopathology report within the last 3 months to appear in the public professionals search and detail lookup. Other study types do not satisfy the eligibility gate. Validated locally with typecheck, test typecheck, direct contract test 3/3, pnpm test 379/379, build, and validate:local.