### PR TITLE
test(public-search): guard public professionals fixture factories

### DIFF
--- a/test/helpers/public-professionals-fixtures.ts
+++ b/test/helpers/public-professionals-fixtures.ts
@@ -1,0 +1,92 @@
+﻿export type PublicProfessionalFixtureRow = {
+  clinicId: number;
+  displayName: string;
+  avatarStoragePath: string | null;
+  aboutText: string | null;
+  specialtyText: string | null;
+  servicesText: string | null;
+  email: string | null;
+  phone: string | null;
+  locality: string | null;
+  country: string | null;
+  updatedAt: Date;
+  profileQualityScore: number;
+  rank: number;
+  similarity: number;
+  score: number;
+};
+
+export type PublicProfessionalsRouteFixtureStubs = {
+  searchPublicProfessionals: () => Promise<{
+    rows: PublicProfessionalFixtureRow[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>;
+  getPublicProfessionalByClinicId: (
+    clinicId: number,
+  ) => Promise<PublicProfessionalFixtureRow | null>;
+  createSignedStorageUrl: (path: string) => Promise<string>;
+  searchRateLimitWindowMs: number;
+  searchRateLimitMaxAttempts: number;
+  detailRateLimitWindowMs: number;
+  detailRateLimitMaxAttempts: number;
+  now: () => number;
+};
+
+export function buildPublicProfessionalFixtureRow(
+  overrides: Partial<PublicProfessionalFixtureRow> = {},
+): PublicProfessionalFixtureRow {
+  return {
+    clinicId: 123,
+    displayName: "Clinica Publica Fixture",
+    avatarStoragePath: null,
+    aboutText: "Perfil publico fixture",
+    specialtyText: "Histopatologia",
+    servicesText: "Biopsias",
+    email: "fixture@example.com",
+    phone: "3411234567",
+    locality: "Rosario",
+    country: "AR",
+    updatedAt: new Date("2026-04-29T20:00:00.000Z"),
+    profileQualityScore: 0.9,
+    rank: 0.4,
+    similarity: 0.3,
+    score: 0.7,
+    ...overrides,
+  };
+}
+
+export function buildPublicProfessionalsRouteFixtureStubs(
+  options: {
+    row?: PublicProfessionalFixtureRow;
+    searchRows?: PublicProfessionalFixtureRow[];
+    limit?: number;
+    offset?: number;
+    searchRateLimitMaxAttempts?: number;
+    detailRateLimitMaxAttempts?: number;
+    searchRateLimitWindowMs?: number;
+    detailRateLimitWindowMs?: number;
+    now?: () => number;
+  } = {},
+): PublicProfessionalsRouteFixtureStubs {
+  const row = options.row ?? buildPublicProfessionalFixtureRow();
+  const searchRows = options.searchRows ?? [row];
+
+  return {
+    searchPublicProfessionals: async () => ({
+      rows: searchRows,
+      total: searchRows.length,
+      limit: options.limit ?? 20,
+      offset: options.offset ?? 0,
+    }),
+    getPublicProfessionalByClinicId: async (clinicId: number) =>
+      clinicId === row.clinicId ? row : null,
+    createSignedStorageUrl: async (path: string) => `signed:${path}`,
+    searchRateLimitWindowMs: options.searchRateLimitWindowMs ?? 60_000,
+    searchRateLimitMaxAttempts: options.searchRateLimitMaxAttempts ?? 1,
+    detailRateLimitWindowMs: options.detailRateLimitWindowMs ?? 60_000,
+    detailRateLimitMaxAttempts: options.detailRateLimitMaxAttempts ?? 1,
+    now: options.now ?? (() => 10_000),
+  };
+}

--- a/test/public-professionals-fixtures-invariants.test.ts
+++ b/test/public-professionals-fixtures-invariants.test.ts
@@ -1,0 +1,76 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPublicProfessionalFixtureRow,
+  buildPublicProfessionalsRouteFixtureStubs,
+} from "./helpers/public-professionals-fixtures.ts";
+
+test("public professionals fixture row mantiene defaults públicos determinísticos", () => {
+  const row = buildPublicProfessionalFixtureRow();
+
+  assert.deepEqual(row, {
+    clinicId: 123,
+    displayName: "Clinica Publica Fixture",
+    avatarStoragePath: null,
+    aboutText: "Perfil publico fixture",
+    specialtyText: "Histopatologia",
+    servicesText: "Biopsias",
+    email: "fixture@example.com",
+    phone: "3411234567",
+    locality: "Rosario",
+    country: "AR",
+    updatedAt: new Date("2026-04-29T20:00:00.000Z"),
+    profileQualityScore: 0.9,
+    rank: 0.4,
+    similarity: 0.3,
+    score: 0.7,
+  });
+});
+
+test("public professionals fixture row permite overrides sin mutar defaults", () => {
+  const customized = buildPublicProfessionalFixtureRow({
+    clinicId: 777,
+    displayName: "Clinica Override",
+    email: "override@example.com",
+  });
+  const defaultRow = buildPublicProfessionalFixtureRow();
+
+  assert.equal(customized.clinicId, 777);
+  assert.equal(customized.displayName, "Clinica Override");
+  assert.equal(customized.email, "override@example.com");
+
+  assert.equal(defaultRow.clinicId, 123);
+  assert.equal(defaultRow.displayName, "Clinica Publica Fixture");
+  assert.equal(defaultRow.email, "fixture@example.com");
+});
+
+test("public professionals route stubs son determinísticos y sin DB ni storage reales", async () => {
+  const row = buildPublicProfessionalFixtureRow({
+    clinicId: 456,
+    avatarStoragePath: "avatars/456.webp",
+  });
+
+  const stubs = buildPublicProfessionalsRouteFixtureStubs({
+    row,
+    searchRateLimitMaxAttempts: 3,
+    detailRateLimitMaxAttempts: 4,
+    now: () => 25_000,
+  });
+
+  assert.deepEqual(await stubs.searchPublicProfessionals(), {
+    rows: [row],
+    total: 1,
+    limit: 20,
+    offset: 0,
+  });
+
+  assert.equal(await stubs.getPublicProfessionalByClinicId(456), row);
+  assert.equal(await stubs.getPublicProfessionalByClinicId(999), null);
+  assert.equal(await stubs.createSignedStorageUrl("avatars/456.webp"), "signed:avatars/456.webp");
+
+  assert.equal(stubs.searchRateLimitWindowMs, 60_000);
+  assert.equal(stubs.searchRateLimitMaxAttempts, 3);
+  assert.equal(stubs.detailRateLimitWindowMs, 60_000);
+  assert.equal(stubs.detailRateLimitMaxAttempts, 4);
+  assert.equal(stubs.now(), 25_000);
+});

--- a/test/public-professionals-logging-invariants.test.ts
+++ b/test/public-professionals-logging-invariants.test.ts
@@ -1,6 +1,11 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
+import {
+  buildPublicProfessionalFixtureRow,
+  buildPublicProfessionalsRouteFixtureStubs,
+  type PublicProfessionalsRouteFixtureStubs,
+} from "./helpers/public-professionals-fixtures.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -13,47 +18,8 @@ const { publicProfessionalsNativeRoutes } = await import(
   "../server/routes/public-professionals.fastify.ts"
 );
 
-function buildProfessionalRow() {
-  return {
-    clinicId: 130,
-    displayName: "Clinica Logging",
-    avatarStoragePath: null,
-    aboutText: "Perfil publico para logging",
-    specialtyText: "Histopatologia",
-    servicesText: "Biopsias",
-    email: "logging@example.com",
-    phone: "3411300130",
-    locality: "Rosario",
-    country: "AR",
-    updatedAt: new Date("2026-04-29T21:00:00.000Z"),
-    profileQualityScore: 0.91,
-    rank: 0.4,
-    similarity: 0.3,
-    score: 0.7,
-  };
-}
-
-function buildPublicProfessionalsRouteStubs() {
-  return {
-    searchPublicProfessionals: async () => ({
-      rows: [buildProfessionalRow()],
-      total: 1,
-      limit: 20,
-      offset: 0,
-    }),
-    getPublicProfessionalByClinicId: async (clinicId: number) =>
-      clinicId === 130 ? buildProfessionalRow() : null,
-    createSignedStorageUrl: async (path: string) => `signed:${path}`,
-    searchRateLimitWindowMs: 60_000,
-    searchRateLimitMaxAttempts: 1,
-    detailRateLimitWindowMs: 60_000,
-    detailRateLimitMaxAttempts: 1,
-    now: () => 10_000,
-  };
-}
-
 async function buildLoggingApp(
-  overrides: Partial<ReturnType<typeof buildPublicProfessionalsRouteStubs>> = {},
+  overrides: Partial<PublicProfessionalsRouteFixtureStubs> = {},
 ) {
   const app = Fastify({
     logger: false,
@@ -61,7 +27,17 @@ async function buildLoggingApp(
 
   await app.register(publicProfessionalsNativeRoutes, {
     prefix: "/api/public/professionals",
-    ...buildPublicProfessionalsRouteStubs(),
+    ...buildPublicProfessionalsRouteFixtureStubs({
+      row: buildPublicProfessionalFixtureRow({
+        clinicId: 130,
+        displayName: "Clinica Logging",
+        aboutText: "Perfil publico para logging",
+        email: "logging@example.com",
+        phone: "3411300130",
+        updatedAt: new Date("2026-04-29T21:00:00.000Z"),
+        profileQualityScore: 0.91,
+      }),
+    }),
     ...overrides,
   });
 
@@ -298,3 +274,4 @@ test("public professionals logging registra CORS bloqueado sin headers ni payloa
     await app.close();
   }
 });
+

--- a/test/public-professionals-response-headers-invariants.test.ts
+++ b/test/public-professionals-response-headers-invariants.test.ts
@@ -1,6 +1,9 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
+import {
+  buildPublicProfessionalsRouteFixtureStubs,
+} from "./helpers/public-professionals-fixtures.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -14,45 +17,6 @@ const { publicProfessionalsNativeRoutes } = await import(
 );
 
 const allowedOrigin = "http://localhost:3000";
-
-function buildProfessionalRow() {
-  return {
-    clinicId: 123,
-    displayName: "Clinica Headers",
-    avatarStoragePath: null,
-    aboutText: "Perfil publico para headers",
-    specialtyText: "Histopatologia",
-    servicesText: "Biopsias",
-    email: "headers@example.com",
-    phone: "3411234567",
-    locality: "Rosario",
-    country: "AR",
-    updatedAt: new Date("2026-04-29T20:00:00.000Z"),
-    profileQualityScore: 0.9,
-    rank: 0.4,
-    similarity: 0.3,
-    score: 0.7,
-  };
-}
-
-function buildPublicProfessionalsRouteStubs() {
-  return {
-    searchPublicProfessionals: async () => ({
-      rows: [buildProfessionalRow()],
-      total: 1,
-      limit: 20,
-      offset: 0,
-    }),
-    getPublicProfessionalByClinicId: async (clinicId: number) =>
-      clinicId === 123 ? buildProfessionalRow() : null,
-    createSignedStorageUrl: async (path: string) => `signed:${path}`,
-    searchRateLimitWindowMs: 60_000,
-    searchRateLimitMaxAttempts: 1,
-    detailRateLimitWindowMs: 60_000,
-    detailRateLimitMaxAttempts: 1,
-    now: () => 10_000,
-  };
-}
 
 async function buildHeaderApp() {
   const app = Fastify({
@@ -69,7 +33,7 @@ async function buildHeaderApp() {
 
   await app.register(publicProfessionalsNativeRoutes, {
     prefix: "/api/public/professionals",
-    ...buildPublicProfessionalsRouteStubs(),
+    ...buildPublicProfessionalsRouteFixtureStubs(),
   });
 
   return app;
@@ -391,3 +355,4 @@ test("profesionales públicos no setea cookies en 429 ni aliases 404", async () 
     await app.close();
   }
 });
+


### PR DESCRIPTION
﻿## Resumen
Agrega factories compartidas test-only para fixtures del directorio público de profesionales.

## Cambios
- Crea `test/helpers/public-professionals-fixtures.ts`.
- Centraliza `buildPublicProfessionalFixtureRow`.
- Centraliza `buildPublicProfessionalsRouteFixtureStubs`.
- Agrega guardrails del helper de fixtures.
- Actualiza tests de headers y logging para usar fixtures compartidos.
- Mantiene tests determinísticos sin DB/storage reales.

## Validación
- `git diff --check`
- `pnpm test -- test/public-professionals-fixtures-invariants.test.ts test/public-professionals-response-headers-invariants.test.ts test/public-professionals-logging-invariants.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

## Riesgo
Bajo. Test-only; no modifica runtime ni contratos de API.
