### PR TITLE
test(public-search): guard public professionals fixture adoption

### DIFF
--- a/test/public-professionals-fixture-adoption-invariants.test.ts
+++ b/test/public-professionals-fixture-adoption-invariants.test.ts
@@ -1,0 +1,67 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("route surface tests usan fixtures compartidos sin stubs locales de profesionales públicos", () => {
+  const source = readSource(
+    "test/public-professionals-route-surface-invariants.test.ts",
+  );
+
+  assert.ok(
+    source.includes('from "./helpers/public-professionals-fixtures.ts"'),
+    "route surface debe importar fixtures compartidos",
+  );
+
+  assert.ok(
+    source.includes("buildPublicProfessionalsRouteFixtureStubs"),
+    "route surface debe usar buildPublicProfessionalsRouteFixtureStubs",
+  );
+
+  assert.equal(
+    source.includes("function buildPublicProfessionalsRouteStubs()"),
+    false,
+    "route surface no debe reintroducir stubs locales",
+  );
+
+  assert.equal(
+    source.includes("searchPublicProfessionals: async () => ({"),
+    false,
+    "route surface no debe duplicar searchPublicProfessionals local",
+  );
+
+  assert.equal(
+    source.includes("createSignedStorageUrl: async"),
+    false,
+    "route surface no debe duplicar signing fake local",
+  );
+});
+
+test("tests recientes de profesionales públicos comparten el helper de fixtures", () => {
+  const checkedFiles = [
+    "test/public-professionals-response-headers-invariants.test.ts",
+    "test/public-professionals-logging-invariants.test.ts",
+    "test/public-professionals-route-surface-invariants.test.ts",
+  ];
+
+  for (const file of checkedFiles) {
+    const source = readSource(file);
+
+    assert.ok(
+      source.includes('from "./helpers/public-professionals-fixtures.ts"'),
+      `${file} debe importar fixtures compartidos`,
+    );
+
+    assert.ok(
+      source.includes("buildPublicProfessionalsRouteFixtureStubs"),
+      `${file} debe usar buildPublicProfessionalsRouteFixtureStubs`,
+    );
+  }
+});

--- a/test/public-professionals-route-surface-invariants.test.ts
+++ b/test/public-professionals-route-surface-invariants.test.ts
@@ -3,6 +3,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import Fastify from "fastify";
+import {
+  buildPublicProfessionalFixtureRow,
+  buildPublicProfessionalsRouteFixtureStubs,
+} from "./helpers/public-professionals-fixtures.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -45,20 +49,6 @@ function extractRegisteredMethods(source: string): Array<{
   }));
 }
 
-function buildPublicProfessionalsRouteStubs() {
-  return {
-    searchPublicProfessionals: async () => ({
-      rows: [],
-      total: 0,
-      limit: 20,
-      offset: 0,
-    }),
-    getPublicProfessionalByClinicId: async () => null,
-    createSignedStorageUrl: async (path: string) => `signed:${path}`,
-    searchRateLimitMaxAttempts: 1_000,
-    detailRateLimitMaxAttempts: 1_000,
-  };
-}
 
 async function buildSurfaceApp() {
   const app = Fastify({
@@ -75,7 +65,14 @@ async function buildSurfaceApp() {
 
   await app.register(publicProfessionalsNativeRoutes, {
     prefix: "/api/public/professionals",
-    ...buildPublicProfessionalsRouteStubs(),
+    ...buildPublicProfessionalsRouteFixtureStubs({
+      row: buildPublicProfessionalFixtureRow({
+        clinicId: 999,
+      }),
+      searchRows: [],
+      searchRateLimitMaxAttempts: 1_000,
+      detailRateLimitMaxAttempts: 1_000,
+    }),
   });
 
   return app;


### PR DESCRIPTION
﻿## Resumen
Extiende la adopción de fixtures compartidos test-only en tests del directorio público de profesionales.

## Cambios
- Actualiza `public-professionals-route-surface-invariants.test.ts` para usar `buildPublicProfessionalsRouteFixtureStubs`.
- Elimina stubs locales duplicados de route-surface.
- Agrega guardrails para evitar reintroducir stubs locales en route-surface.
- Verifica que tests recientes de headers, logging y route-surface compartan el helper.
- Mantiene tests determinísticos sin DB/storage reales.

## Validación
- `git diff --check`
- `pnpm test -- test/public-professionals-fixture-adoption-invariants.test.ts test/public-professionals-route-surface-invariants.test.ts test/public-professionals-fixtures-invariants.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

## Riesgo
Bajo. Test-only; no modifica runtime ni contratos de API.
