### PR TITLE
test(security): guard clinic-audit cookie session contract

### DIFF
--- a/server/routes/clinic-audit.fastify.ts
+++ b/server/routes/clinic-audit.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -10,6 +10,7 @@ import {
   type AdminAuditListFilters,
   type AuditLogListItem,
 } from "../lib/admin-audit.ts";
+import { ENV } from "../lib/env.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
@@ -163,8 +164,7 @@ function getSessionToken(request: FastifyRequest) {
       : undefined;
 
   const cookies = parseCookies(cookieHeader);
-  const envCookieName = process.env.COOKIE_NAME?.trim() || "vetneb_session";
-  const raw = cookies[envCookieName];
+  const raw = cookies[ENV.cookieName];
 
   if (typeof raw !== "string") {
     return undefined;
@@ -180,18 +180,14 @@ function serializeCookie(input: {
   maxAgeSeconds?: number;
   expires?: string;
 }) {
-  const sameSite = process.env.COOKIE_SAME_SITE?.trim() || "Lax";
-  const secure =
-    (process.env.COOKIE_SECURE?.trim() || "").toLowerCase() === "true";
-
   const parts = [
     `${input.name}=${encodeURIComponent(input.value)}`,
     "Path=/",
     "HttpOnly",
-    `SameSite=${sameSite}`,
+    `SameSite=${ENV.cookieSameSite}`,
   ];
 
-  if (secure) {
+  if (ENV.cookieSecure) {
     parts.push("Secure");
   }
 
@@ -207,10 +203,8 @@ function serializeCookie(input: {
 }
 
 function buildClearSessionCookie() {
-  const envCookieName = process.env.COOKIE_NAME?.trim() || "vetneb_session";
-
   return serializeCookie({
-    name: envCookieName,
+    name: ENV.cookieName,
     value: "",
     maxAgeSeconds: 0,
     expires: "Thu, 01 Jan 1970 00:00:00 GMT",

--- a/test/clinic-audit.fastify.test.ts
+++ b/test/clinic-audit.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -8,10 +8,9 @@ process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
-process.env.COOKIE_NAME ??= "vetneb_session";
-process.env.COOKIE_SAME_SITE ??= "Lax";
-process.env.COOKIE_SECURE ??= "false";
+process.env.COOKIE_NAME = "app_session_id";
 
+const { ENV } = await import("../server/lib/env.ts");
 const {
   clinicAuditNativeRoutes,
 } = await import("../server/routes/clinic-audit.fastify.ts");
@@ -141,7 +140,7 @@ test(
         method: "GET",
         url: "/api/clinic/audit-log?event=report.public_accessed&limit=25&offset=5",
         headers: {
-          cookie: "vetneb_session=session-token",
+          cookie: `${ENV.cookieName}=session-token`,
         },
       });
 
@@ -201,7 +200,7 @@ test(
         method: "GET",
         url: "/api/clinic/audit-log/export.csv",
         headers: {
-          cookie: "vetneb_session=session-token",
+          cookie: `${ENV.cookieName}=session-token`,
         },
       });
 
@@ -243,7 +242,7 @@ test(
         method: "GET",
         url: "/api/clinic/audit-log?event=bad",
         headers: {
-          cookie: "vetneb_session=session-token",
+          cookie: `${ENV.cookieName}=session-token`,
         },
       });
 
@@ -273,7 +272,7 @@ test(
         method: "GET",
         url: "/api/clinic/audit-log/export.csv",
         headers: {
-          cookie: "vetneb_session=session-token",
+          cookie: `${ENV.cookieName}=session-token`,
         },
       });
 
@@ -288,4 +287,91 @@ test(
     }
   },
 );
+test(
+  "clinicAuditNativeRoutes usa ENV.cookieName y rechaza cookie legacy vetneb_session",
+  async () => {
+    const hashCalls: string[] = [];
+    const app = await createTestApp({
+      hashSessionToken: (token: string) => {
+        hashCalls.push(token);
+        return `hash:${token}`;
+      },
+    });
 
+    try {
+      const legacyResponse = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log",
+        headers: {
+          cookie: "vetneb_session=session-token",
+        },
+      });
+
+      assert.equal(legacyResponse.statusCode, 401);
+      assert.deepEqual(JSON.parse(legacyResponse.body), {
+        success: false,
+        error: "No autenticado",
+      });
+      assert.deepEqual(hashCalls, []);
+
+      const envCookieResponse = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log",
+        headers: {
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(envCookieResponse.statusCode, 200);
+      assert.deepEqual(hashCalls, ["session-token"]);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuditNativeRoutes limpia cookie de sesión con contrato ENV cuando expira",
+  async () => {
+    const deletedSessions: string[] = [];
+    const app = await createTestApp({
+      getActiveSessionByToken: async () => ({
+        clinicUserId: 9,
+        expiresAt: new Date("2026-04-01T00:00:00.000Z"),
+        lastAccess: new Date("2026-03-31T00:00:00.000Z"),
+      }),
+      deleteActiveSession: async (tokenHash: string) => {
+        deletedSessions.push(tokenHash);
+      },
+      now: () => new Date("2026-04-29T00:00:00.000Z").getTime(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/clinic/audit-log",
+        headers: {
+          cookie: `${ENV.cookieName}=session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 401);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Sesión expirada",
+      });
+      assert.deepEqual(deletedSessions, ["hash:session-token"]);
+
+      const setCookie = String(response.headers["set-cookie"] ?? "");
+      assert.ok(setCookie.startsWith("app_session_id=;"));
+      assert.match(setCookie, /Path=\//);
+      assert.match(setCookie, /HttpOnly/);
+      assert.match(setCookie, /SameSite=lax/);
+      assert.match(setCookie, /Max-Age=0/);
+      assert.match(setCookie, /Expires=Thu, 01 Jan 1970 00:00:00 GMT/);
+      assert.equal(setCookie.includes("vetneb_session"), false);
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -25,6 +25,11 @@ const authRouteFiles = [
   "server/routes/auth.fastify.ts",
   "server/routes/admin-auth.fastify.ts",
   "server/routes/particular-auth.fastify.ts",
+] as const;
+
+const clinicSessionCookieRouteFiles = [
+  "server/routes/auth.fastify.ts",
+  "server/routes/clinic-audit.fastify.ts",
 ] as const;
 
 test("ENV mantiene cookies de sesión separadas y política productiva segura", () => {
@@ -80,6 +85,23 @@ test("las rutas de auth serializan cookies HttpOnly, Path=/, SameSite y Secure c
     );
   }
 });
+test("rutas clinic-scoped que limpian sesión usan contrato central ENV", () => {
+  for (const file of clinicSessionCookieRouteFiles) {
+    const source = read(file);
+
+    assertContains(source, 'import { ENV } from "../lib/env.ts";', file);
+    assertContains(source, "function serializeCookie(input:", file);
+    assertContains(source, '"Path=/"', file);
+    assertContains(source, '"HttpOnly"', file);
+    assertContains(source, "`SameSite=${ENV.cookieSameSite}`", file);
+    assertContains(source, "if (ENV.cookieSecure)", file);
+    assertContains(source, 'parts.push("Secure");', file);
+    assertContains(source, 'expires: "Thu, 01 Jan 1970 00:00:00 GMT"', file);
+    assertNotContains(source, "process.env.COOKIE_NAME", file);
+    assertNotContains(source, "process.env.COOKIE_SAME_SITE", file);
+    assertNotContains(source, "process.env.COOKIE_SECURE", file);
+  }
+});
 
 test("cada dominio de sesión lee y escribe únicamente su cookie correspondiente", () => {
   const clinicAuth = read("server/routes/auth.fastify.ts");
@@ -94,6 +116,33 @@ test("cada dominio de sesión lee y escribe únicamente su cookie correspondient
     clinicAuth,
     "cookies[ENV.particularCookieName]",
     "auth.fastify.ts",
+  );
+
+  const clinicAudit = read("server/routes/clinic-audit.fastify.ts");
+  assertContains(
+    clinicAudit,
+    "cookies[ENV.cookieName]",
+    "clinic-audit.fastify.ts",
+  );
+  assertContains(
+    clinicAudit,
+    "name: ENV.cookieName",
+    "clinic-audit.fastify.ts",
+  );
+  assertNotContains(
+    clinicAudit,
+    "cookies[ENV.adminCookieName]",
+    "clinic-audit.fastify.ts",
+  );
+  assertNotContains(
+    clinicAudit,
+    "cookies[ENV.particularCookieName]",
+    "clinic-audit.fastify.ts",
+  );
+  assertNotContains(
+    clinicAudit,
+    '"vetneb_session"',
+    "clinic-audit.fastify.ts",
   );
 
   const adminAuth = read("server/routes/admin-auth.fastify.ts");
@@ -225,4 +274,3 @@ test("logs de request sanitizan tokens y accesos públicos antes de escribir con
     assertContains(source, "buildRequestLogLine({", file);
   }
 });
-


### PR DESCRIPTION
﻿## Resumen
Alinea clinic-audit con el contrato central de sesión/cookies definido por ENV y agrega guardrails contra drift legacy.

## Cambios
- Cambia clinic-audit para leer la cookie de sesión desde `ENV.cookieName`.
- Cambia clear-cookie de clinic-audit para usar `ENV.cookieName`, `ENV.cookieSameSite` y `ENV.cookieSecure`.
- Elimina fallback legacy `vetneb_session` del runtime clinic-audit.
- Actualiza tests de clinic-audit para usar el default central `app_session_id`.
- Agrega cobertura que rechaza `vetneb_session` como cookie válida para clinic-audit.
- Agrega cobertura de clear-cookie con contrato ENV.
- Extiende invariants de seguridad para incluir clinic-audit en rutas clinic-scoped con sesión.

## Validación
- `git diff --check`
- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/clinic-audit.fastify.test.ts test/security-production-invariants.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

## Riesgo
Bajo-medio. Toca runtime de auth/cookies en clinic-audit, pero alinea con el contrato ENV ya usado por auth clinic y queda cubierto por tests directos e invariants.
