### PR TITLE
test(security): guard critical route preflight cors contract

### DIFF
--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -306,3 +306,65 @@ test(
     }
   },
 );
+test("clinicAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
+  const app = await createTestApp({
+    getActiveSessionByToken: async () => {
+      throw new Error("preflight OPTIONS no debe autenticar sesión clinic");
+    },
+  });
+
+  try {
+    for (const url of ["/api/auth/login", "/api/auth/me", "/api/auth/logout"]) {
+      const response = await app.inject({
+        method: "OPTIONS",
+        url,
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-headers": "content-type,x-requested-with",
+        },
+      });
+
+      assert.equal(response.statusCode, 204);
+      assert.equal(response.body, "");
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+      assert.equal(
+        response.headers["access-control-allow-methods"],
+        "GET,POST,OPTIONS",
+      );
+      assert.equal(
+        response.headers["access-control-allow-headers"],
+        "content-type,x-requested-with",
+      );
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/auth/login",
+      headers: {
+        origin: "https://evil.example",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});

--- a/test/report-access-tokens.fastify.test.ts
+++ b/test/report-access-tokens.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -551,3 +551,74 @@ test(
     }
   },
 );
+test("reportAccessTokensNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
+  const app = await createTestApp({
+    getActiveSessionByToken: async () => {
+      throw new Error("preflight OPTIONS no debe autenticar sesión clinic");
+    },
+  });
+
+  try {
+    for (const url of [
+      "/api/report-access-tokens",
+      "/api/report-access-tokens/9",
+      "/api/report-access-tokens/9/revoke",
+    ]) {
+      const response = await app.inject({
+        method: "OPTIONS",
+        url,
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-headers": "content-type,x-requested-with",
+        },
+      });
+
+      assert.equal(response.statusCode, 204);
+      assert.equal(response.body, "");
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+      assert.equal(
+        response.headers["access-control-allow-methods"],
+        "GET,POST,PATCH,OPTIONS",
+      );
+      assert.equal(
+        response.headers["access-control-allow-headers"],
+        "content-type,x-requested-with",
+      );
+      assert.equal(
+        response.headers["access-control-expose-headers"],
+        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+      );
+      assert.equal(response.headers["set-cookie"], undefined);
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportAccessTokensNativeRoutes bloquea preflight OPTIONS con origin no permitido", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/report-access-tokens/9/revoke",
+      headers: {
+        origin: "https://evil.example",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -637,3 +637,74 @@ test("reportsNativeRoutes bloquea GET / sin sesión", async () => {
     await app.close();
   }
 });
+test("reportsNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
+  const app = await createTestApp({
+    getActiveSessionByToken: async () => {
+      throw new Error("preflight OPTIONS no debe autenticar sesión clinic");
+    },
+  });
+
+  try {
+    for (const url of [
+      "/api/reports",
+      "/api/reports/upload",
+      "/api/reports/search",
+      "/api/reports/study-types",
+      "/api/reports/55/history",
+      "/api/reports/55/preview-url",
+      "/api/reports/55/download-url",
+    ]) {
+      const response = await app.inject({
+        method: "OPTIONS",
+        url,
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-headers": "content-type,x-requested-with",
+        },
+      });
+
+      assert.equal(response.statusCode, 204);
+      assert.equal(response.body, "");
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+      assert.equal(
+        response.headers["access-control-allow-methods"],
+        "GET,POST,OPTIONS",
+      );
+      assert.equal(
+        response.headers["access-control-allow-headers"],
+        "content-type,x-requested-with",
+      );
+      assert.equal(response.headers["set-cookie"], undefined);
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("reportsNativeRoutes bloquea preflight OPTIONS con origin no permitido", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/reports/upload",
+      headers: {
+        origin: "https://evil.example",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
﻿## Resumen
Agrega cobertura explícita del contrato preflight OPTIONS/CORS para rutas críticas.

## Cambios
- Cubre preflight permitido en auth clinic para `/login`, `/me` y `/logout`.
- Cubre preflight permitido en reports para lista, upload, search, study-types y rutas parametrizadas de historial/URLs firmadas.
- Cubre preflight permitido en report-access-tokens para lista, detalle y revoke.
- Verifica status 204, allow-origin, credentials, métodos permitidos y headers solicitados.
- Verifica que preflight no autentica sesión ni setea cookies.
- Cubre bloqueo de Origin no permitido con 403 en rutas críticas.

## Validación
- `git diff --check`
- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/auth.fastify.test.ts test/reports.fastify.test.ts test/report-access-tokens.fastify.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

## Riesgo
Bajo. Test-only; no modifica runtime ni contratos públicos existentes.
