### PR TITLE
test(security): guard admin route preflight cors contract

### DIFF
--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -358,3 +358,85 @@ test(
     }
   },
 );
+test("adminAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => {
+      throw new Error("preflight OPTIONS no debe autenticar sesión admin");
+    },
+    getAdminUserByUsername: async () => {
+      throw new Error("preflight OPTIONS no debe consultar usuario admin");
+    },
+  });
+
+  try {
+    for (const url of [
+      "/api/admin/auth/login",
+      "/api/admin/auth/me",
+      "/api/admin/auth/logout",
+    ]) {
+      const response = await app.inject({
+        method: "OPTIONS",
+        url,
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-headers": "content-type,x-requested-with",
+        },
+      });
+
+      assert.equal(response.statusCode, 204);
+      assert.equal(response.body, "");
+      assert.equal(
+        response.headers["access-control-allow-origin"],
+        "http://localhost:3000",
+      );
+      assert.equal(response.headers["access-control-allow-credentials"], "true");
+      assert.equal(
+        response.headers["access-control-allow-methods"],
+        "GET,POST,OPTIONS",
+      );
+      assert.equal(
+        response.headers["access-control-allow-headers"],
+        "content-type,x-requested-with",
+      );
+      assert.equal(
+        response.headers["access-control-expose-headers"],
+        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+      );
+      assert.equal(response.headers["set-cookie"], undefined);
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido", async () => {
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => {
+      throw new Error("preflight OPTIONS bloqueado no debe autenticar sesión admin");
+    },
+    getAdminUserByUsername: async () => {
+      throw new Error("preflight OPTIONS bloqueado no debe consultar usuario admin");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/admin/auth/login",
+      headers: {
+        origin: "https://evil.example",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+    assert.equal(response.headers["set-cookie"], undefined);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
﻿## Resumen
Agrega cobertura explícita del contrato preflight OPTIONS/CORS para rutas críticas de admin auth.

## Cambios
- Cubre preflight permitido en admin auth para `/login`, `/me` y `/logout`.
- Verifica status 204, allow-origin, credentials, métodos permitidos y headers solicitados.
- Verifica expose headers de rate limit en preflight admin.
- Verifica que preflight no autentica sesión admin ni consulta usuario admin.
- Verifica que preflight no setea cookies.
- Cubre bloqueo de Origin no permitido con 403.

## Validación
- `git diff --check`
- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-auth.fastify.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

## Riesgo
Bajo. Test-only; no modifica runtime ni contratos públicos existentes.
