### PR TITLE
test(storage): guard upload and signed url boundaries

### DIFF
--- a/server/lib/supabase.ts
+++ b/server/lib/supabase.ts
@@ -21,16 +21,19 @@ export const supabase = createClient(
   ENV.supabaseServiceRoleKey,
 );
 
-function sanitizeFileName(fileName: string): string {
-  return fileName
+function sanitizeFileName(fileName: string, fallback: string): string {
+  const sanitized = fileName
     .normalize("NFKD")
     .replace(/[^\w.\-]+/g, "_")
+    .replace(/\.+/g, ".")
     .replace(/_+/g, "_")
-    .replace(/^_+|_+$/g, "");
+    .replace(/^[._-]+|[._-]+$/g, "");
+
+  return sanitized || fallback;
 }
 
 function buildReportStoragePath(clinicId: number, fileName: string): string {
-  const safeName = sanitizeFileName(fileName || "report");
+  const safeName = sanitizeFileName(fileName, "report");
   const timestamp = Date.now();
   const random = Math.random().toString(36).slice(2, 10);
 
@@ -38,7 +41,7 @@ function buildReportStoragePath(clinicId: number, fileName: string): string {
 }
 
 function buildClinicAvatarStoragePath(clinicId: number, fileName: string): string {
-  const safeName = sanitizeFileName(fileName || "avatar");
+  const safeName = sanitizeFileName(fileName, "avatar");
   const timestamp = Date.now();
   const random = Math.random().toString(36).slice(2, 10);
 

--- a/test/supabase-storage-boundaries.test.ts
+++ b/test/supabase-storage-boundaries.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SUPABASE_SOURCE_PATH = "server/lib/supabase.ts";
+const source = readFileSync(resolve(process.cwd(), SUPABASE_SOURCE_PATH), "utf8")
+  .replace(/\r\n/g, "\n");
+
+function extractExportedFunction(functionName: string): string {
+  const marker = `export async function ${functionName}`;
+  const start = source.indexOf(marker);
+
+  assert.notEqual(start, -1, `${functionName} debe existir en ${SUPABASE_SOURCE_PATH}`);
+
+  const next = source.indexOf("\nexport async function ", start + marker.length);
+
+  return source.slice(start, next === -1 ? source.length : next);
+}
+
+test("storage boundaries mantienen bucket privado y no exponen public URLs", () => {
+  assert.match(
+    source,
+    /createBucket\(ENV\.supabaseStorageBucket,\s*\{\s*public:\s*false,\s*\}\)/s,
+  );
+  assert.equal(source.includes("public: true"), false);
+  assert.equal(source.includes("getPublicUrl"), false);
+  assert.equal(source.includes("createPublicUrl"), false);
+});
+
+test("storage boundaries generan signed URLs sólo con TTL configurado por ENV", () => {
+  const createSignedStorageUrlSource = extractExportedFunction(
+    "createSignedStorageUrl",
+  );
+  const createSignedReportDownloadUrlSource = extractExportedFunction(
+    "createSignedReportDownloadUrl",
+  );
+
+  assert.match(
+    createSignedStorageUrlSource,
+    /\.createSignedUrl\(storagePath,\s*ENV\.signedUrlExpiresInSeconds\)/,
+  );
+  assert.match(
+    createSignedReportDownloadUrlSource,
+    /\.createSignedUrl\(storagePath,\s*ENV\.signedUrlExpiresInSeconds,\s*\{/,
+  );
+  assert.equal(createSignedStorageUrlSource.includes("getPublicUrl"), false);
+  assert.equal(createSignedReportDownloadUrlSource.includes("getPublicUrl"), false);
+});
+
+test("storage boundaries suben archivos con storage path privado y upsert deshabilitado", () => {
+  const uploadReportSource = extractExportedFunction("uploadReport");
+  const uploadClinicAvatarSource = extractExportedFunction("uploadClinicAvatar");
+
+  for (const functionSource of [uploadReportSource, uploadClinicAvatarSource]) {
+    assert.match(functionSource, /\.upload\(storagePath,\s*file,\s*\{/);
+    assert.match(functionSource, /contentType:\s*mimeType/);
+    assert.match(functionSource, /upsert:\s*false/);
+    assert.match(functionSource, /return storagePath;/);
+    assert.equal(functionSource.includes("signedUrl"), false);
+    assert.equal(functionSource.includes("getPublicUrl"), false);
+    assert.equal(functionSource.includes("return data"), false);
+  }
+});
+
+test("storage boundaries sanitizan nombres antes de construir paths persistibles", () => {
+  assert.match(source, /function sanitizeFileName\(fileName: string, fallback: string\)/);
+  assert.match(source, /\.replace\(\/\\\.\+\/g,\s*"\."\)/);
+  assert.match(source, /\.replace\(\/\^\[\._-\]\+\|\[\._-\]\+\$\/g,\s*""\)/);
+  assert.match(source, /return sanitized \|\| fallback;/);
+  assert.match(source, /sanitizeFileName\(fileName,\s*"report"\)/);
+  assert.match(source, /sanitizeFileName\(fileName,\s*"avatar"\)/);
+});

--- a/test/supabase-upload-success.test.ts
+++ b/test/supabase-upload-success.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -271,5 +271,96 @@ test("uploadClinicAvatar propaga error de upload cuando mimeType es válido", as
     );
   } finally {
     (supabase.storage as any).from = originalFrom;
+  }
+});
+test("uploadReport neutraliza path traversal y separadores de ruta en fileName", async () => {
+  const originalFrom = supabase.storage.from;
+  const originalDateNow = Date.now;
+  const originalMathRandom = Math.random;
+
+  let capturedPath: string | null = null;
+
+  Date.now = () => 1710000000100;
+  Math.random = () => 0.123456789;
+
+  (supabase.storage as any).from = () => ({
+    upload: async (path: string) => {
+      capturedPath = path;
+
+      return {
+        error: null,
+      };
+    },
+  });
+
+  try {
+    const result = await uploadReport({
+      file: Buffer.from("pdf-content"),
+      fileName: "..\\../Luna final #1.pdf",
+      clinicId: 17,
+      mimeType: "application/pdf",
+    });
+
+    assert.equal(
+      result,
+      "clinics/17/1710000000100-4fzzzxjy-Luna_final_1.pdf",
+    );
+    assert.equal(capturedPath, result);
+    assert.equal(result.split("/").length, 3);
+    assert.equal(result.includes(".."), false);
+    assert.equal(result.includes("\\"), false);
+    assert.equal(result.includes(" "), false);
+    assert.equal(result.startsWith("http://"), false);
+    assert.equal(result.startsWith("https://"), false);
+  } finally {
+    (supabase.storage as any).from = originalFrom;
+    Date.now = originalDateNow;
+    Math.random = originalMathRandom;
+  }
+});
+
+test("uploadClinicAvatar neutraliza path traversal y separadores de ruta en fileName", async () => {
+  const originalFrom = supabase.storage.from;
+  const originalDateNow = Date.now;
+  const originalMathRandom = Math.random;
+
+  let capturedPath: string | null = null;
+
+  Date.now = () => 1710000000101;
+  Math.random = () => 0.123456789;
+
+  (supabase.storage as any).from = () => ({
+    upload: async (path: string) => {
+      capturedPath = path;
+
+      return {
+        error: null,
+      };
+    },
+  });
+
+  try {
+    const result = await uploadClinicAvatar({
+      file: Buffer.from("avatar-content"),
+      fileName: "../avatar final.png",
+      clinicId: 21,
+      mimeType: "image/png",
+    });
+
+    assert.equal(
+      result,
+      "clinic-avatars/21/1710000000101-4fzzzxjy-avatar_final.png",
+    );
+    assert.equal(capturedPath, result);
+    assert.equal(result.split("/").length, 3);
+    assert.equal(result.includes(".."), false);
+    assert.equal(result.includes("\\"), false);
+    assert.equal(result.includes(" "), false);
+    assert.equal(result.startsWith("http://"), false);
+    assert.equal(result.startsWith("https://"), false);
+  } finally {
+    (supabase.storage as any).from = originalFrom;
+    Date.now = originalDateNow;
+    Math.random = originalMathRandom;
   }
 });


### PR DESCRIPTION
﻿## Resumen
Refuerza boundaries de storage/upload/signing para evitar path traversal, exposición pública accidental y drift de signed URLs.

## Cambios
- Endurece sanitización de nombres de archivo antes de construir storage paths persistibles.
- Neutraliza secuencias `..` y separadores de ruta en nombres de informes y avatars.
- Agrega cobertura de upload para evitar que el storage path sea una URL pública.
- Agrega invariant source-level para asegurar bucket privado (`public: false`).
- Bloquea uso accidental de `getPublicUrl` / public URLs en storage.
- Verifica que signed URLs usen `ENV.signedUrlExpiresInSeconds`.
- Verifica que uploads usen `upsert: false`, `contentType: mimeType` y devuelvan `storagePath`.

## Validación
- `git diff --check`
- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/supabase.test.ts test/supabase-upload-success.test.ts test/supabase-signed-url.test.ts test/supabase-recovery-edge.test.ts test/supabase-storage-boundaries.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm exec tsc -p ./test/tsconfig.json --noEmit`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

## Riesgo
Bajo-medio. Toca sanitización de storage paths, pero mantiene nombres normales existentes y agrega cobertura directa sobre casos de traversal.
