### PR TITLE
fix(build): externalize packages for Render ESM runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.8.1",
   "scripts": {
     "dev": "tsx server/index.ts",
-    "build": "esbuild server/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js",
+    "build": "esbuild server/index.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/index.js",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "typecheck:test": "tsc -p ./test/tsconfig.json --noEmit",

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -17,7 +17,7 @@ const requiredScripts: Record<string, string> = {
   typecheck: "tsc --noEmit",
   "typecheck:test": "tsc -p ./test/tsconfig.json --noEmit",
   test: "node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts",
-  build: "esbuild server/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js",
+  build: "esbuild server/index.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/index.js",
   "validate:local": "pnpm typecheck && pnpm typecheck:test && pnpm test && pnpm build",
 };
 


### PR DESCRIPTION
## Resumen
Corrige el build de producción para Render externalizando dependencias npm en el bundle ESM.

## Problema
El build anterior empaquetaba dependencias CommonJS como `dotenv` dentro de `dist/index.js`. En runtime ESM, eso rompía con `Dynamic require of "fs" is not supported` al ejecutar `pnpm start`.

## Cambios
- Agrega `--packages=external` al script `build` de `package.json`.
- Actualiza el guardrail de `test/package-scripts.test.ts` para fijar el nuevo contrato estable del build.

## Validación local
- `pnpm build` OK; `dist/index.js` pasa de ~3.7mb a ~400kb.
- `pnpm start` ya no falla por dynamic require; llega a intentar conectar con DB.
- `pnpm validate:local` OK.
- Tests: `511/511` passing.
- `git diff --check` OK.

## Nota operativa
Después de mergear, Render debe redeployar desde `main`. Si el arranque falla luego, el siguiente bloqueo esperado ya no es packaging sino configuración de `DATABASE_URL`/Supabase DNS.