### PR TITLE
test(permissions): guard persistent role upload semantics

### DIFF
--- a/test/report-management-route-policy.test.ts
+++ b/test/report-management-route-policy.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -60,6 +60,54 @@ test("reports expone POST /upload nativo con permiso de upload, no management", 
   );
 });
 
+test("reports upload usa permisos persistentes derivados de role y no allowlist ENV legacy", () => {
+  const nativeSource = readRouteSource("server/routes/reports.fastify.ts");
+  const permissionsSource = readRouteSource("server/lib/permissions.ts");
+
+  const uploadRouteStart = nativeSource.indexOf('app.post("/upload"');
+  const uploadRouteEnd = nativeSource.indexOf('app.get<{', uploadRouteStart);
+
+  assert.notEqual(uploadRouteStart, -1, "POST /upload debe existir");
+  assert.notEqual(uploadRouteEnd, -1, "Debe existir una ruta posterior a POST /upload");
+
+  const uploadRouteBlock = nativeSource.slice(uploadRouteStart, uploadRouteEnd);
+
+  assert.match(
+    nativeSource,
+    /const role = normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\);[\s\S]*const permissions = getClinicPermissions\(role\);[\s\S]*canUploadReports: permissions\.canUploadReports/s,
+    "La autenticacion de reports debe derivar canUploadReports desde el role persistente",
+  );
+
+  assert.match(
+    permissionsSource,
+    /export function getClinicPermissions\(role: ClinicUserRole\): ClinicPermissions/,
+    "Debe existir un resolver central de permisos por role persistente",
+  );
+
+  assert.match(
+    permissionsSource,
+    /case "clinic_owner":[\s\S]*canUploadReports: true,[\s\S]*canManageClinicUsers: true,/s,
+    "clinic_owner debe conservar permiso de upload y management",
+  );
+
+  assert.match(
+    permissionsSource,
+    /case "clinic_staff":[\s\S]*canUploadReports: true,[\s\S]*canManageClinicUsers: false,/s,
+    "clinic_staff debe conservar permiso de upload sin management",
+  );
+
+  assert.match(
+    uploadRouteBlock,
+    /if \(!auth\.canUploadReports\)/,
+    "POST /upload debe depender de auth.canUploadReports",
+  );
+
+  assert.doesNotMatch(
+    uploadRouteBlock,
+    /LAB_UPLOAD_USERNAMES|labUploadUsernames|ENV\.labUploadUsernames/,
+    "POST /upload no debe depender de allowlists ENV legacy para autorizar uploads",
+  );
+});
 test("report-access-tokens protege mutaciones nativas con management permission", () => {
   const source = readRouteSource("server/routes/report-access-tokens.fastify.ts");
 


### PR DESCRIPTION
﻿## Resumen

Reconciliación de #3 con el modelo actual de roles persistentes `clinic_owner` / `clinic_staff`.

## Contexto

#3 fue creado cuando el sistema todavía no tenía `clinic_users.role` persistente y planteaba roles `lab` / `clinic`.

En `main` actual, el modelo ya evolucionó:

- `clinic_users.role` existe y es persistente.
- Los roles vigentes son `clinic_owner` y `clinic_staff`.
- Login y `/me` ya exponen `role` y `permissions`.
- El upload de reports ya depende de `auth.canUploadReports`.

## Cambios

- Agrega guardrail source-level en `test/report-management-route-policy.test.ts`.
- Verifica que reports upload deriva permisos desde `clinicUser.role`.
- Verifica que `getClinicPermissions(role)` sea el resolver central.
- Verifica la semántica actual:
  - `clinic_owner`: upload + management.
  - `clinic_staff`: upload sin management.
- Verifica que `POST /upload` depende de `auth.canUploadReports`.
- Bloquea reintroducción de allowlists ENV legacy para autorizar upload.

## Validación local

- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/report-management-route-policy.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `git diff --check`

Resultado:

- Test focalizado OK.
- Typecheck OK.
- Typecheck tests OK.
- Suite completa OK: `512/512` passing.
- `git diff --check` OK.

Closes #3
