### PR TITLE
test(security): guard tenant isolation IDOR boundaries

### DIFF
--- a/test/report-access-tokens.fastify.test.ts
+++ b/test/report-access-tokens.fastify.test.ts
@@ -551,6 +551,95 @@ test(
     }
   },
 );
+
+test(
+  "reportAccessTokensNativeRoutes oculta detalle de token ajeno con 404",
+  async () => {
+    let getReportCalled = false;
+
+    const app = await createTestApp({
+      getClinicScopedReportAccessToken: async (
+        tokenId: number,
+        clinicId: number,
+      ) => {
+        assert.equal(tokenId, 9);
+        assert.equal(clinicId, 3);
+        return null;
+      },
+      getReportById: async () => {
+        getReportCalled = true;
+        return createReportFixture();
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/report-access-tokens/9",
+        headers: {
+          cookie: ENV.cookieName + "=session-token",
+        },
+      });
+
+      assert.equal(response.statusCode, 404);
+      assert.equal(getReportCalled, false);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "reportAccessTokensNativeRoutes oculta revocacion de token ajeno antes de mutar",
+  async () => {
+    let revokeCalled = false;
+    let auditCalled = false;
+
+    const app = await createTestApp({
+      getClinicScopedReportAccessToken: async (
+        tokenId: number,
+        clinicId: number,
+      ) => {
+        assert.equal(tokenId, 9);
+        assert.equal(clinicId, 3);
+        return null;
+      },
+      revokeReportAccessToken: async () => {
+        revokeCalled = true;
+        return null;
+      },
+      writeAuditLog: async () => {
+        auditCalled = true;
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/report-access-tokens/9/revoke",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: ENV.cookieName + "=session-token",
+        },
+      });
+
+      assert.equal(response.statusCode, 404);
+      assert.equal(revokeCalled, false);
+      assert.equal(auditCalled, false);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Token público de informe no encontrado",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
 test("reportAccessTokensNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
   const app = await createTestApp({
     getActiveSessionByToken: async () => {


### PR DESCRIPTION
﻿## Resumen

Agrega cobertura negativa para fronteras tenant/IDOR en tokens públicos de informe administrados por clínica.

## Cambios

- Agrega test para ocultar detalle de token ajeno con `404`.
- Verifica que, cuando el token no pertenece a la clínica autenticada:
  - no se consulta el informe vinculado;
  - no se filtra existencia del recurso.
- Agrega test para bloquear revocación de token ajeno antes de mutar.
- Verifica que, cuando el token no pertenece a la clínica autenticada:
  - no se ejecuta `revokeReportAccessToken`;
  - no se escribe auditoría;
  - se responde `404`.

## Validación local

- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/report-access-tokens.fastify.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

Resultado: OK.
