### PR TITLE
test(security): guard sensitive token log redaction

### DIFF
--- a/test/request-logger-edge.test.ts
+++ b/test/request-logger-edge.test.ts
@@ -36,6 +36,29 @@ test("sanitizeUrlForLogs redacts path y query params sensibles de forma case-ins
   );
 });
 
+test("sanitizeUrlForLogs redacts public report path token and sensitive query tokens together", () => {
+  const rawPathToken = "a".repeat(64);
+  const rawQueryToken = "query-secret-token";
+  const rawReportAccessToken = "query-report-access-secret";
+
+  const sanitized = sanitizeUrlForLogs(
+    "/api/public/report-access/" +
+      rawPathToken +
+      "?token=" +
+      rawQueryToken +
+      "&reportAccessToken=" +
+      rawReportAccessToken +
+      "&safe=1",
+  );
+
+  assert.equal(
+    sanitized,
+    "/api/public/report-access/[REDACTED]?token=[REDACTED]&reportAccessToken=[REDACTED]&safe=1",
+  );
+  assert.doesNotMatch(sanitized, new RegExp(rawPathToken));
+  assert.doesNotMatch(sanitized, new RegExp(rawQueryToken));
+  assert.doesNotMatch(sanitized, new RegExp(rawReportAccessToken));
+});
 test("sanitizeUrlForLogs preserva fragments mientras redacts token query params", () => {
   const rawUrl = "/api/anything?token=abc123#section-2";
   const sanitized = sanitizeUrlForLogs(rawUrl);


### PR DESCRIPTION
## Resumen

Agrega cobertura explícita para redacción de tokens sensibles en logs.

## Cambios

- Agrega test en `request-logger-edge.test.ts` para validar redacción conjunta de:
  - token público de informe en path `/api/public/report-access/:token`;
  - query param `token`;
  - query param `reportAccessToken`.
- Verifica que parámetros no sensibles como `safe=1` se preserven.
- Verifica que los valores raw sensibles no aparezcan en la URL sanitizada.

## Validación local

- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/request-logger-edge.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

Resultado: OK.