### PR TITLE
test(smoke): document required smoke env

### DIFF
--- a/docs/smoke-local.md
+++ b/docs/smoke-local.md
@@ -1,0 +1,54 @@
+﻿# Smoke local
+
+Los scripts de smoke validan el backend contra un servidor ya levantado.
+
+## Requisitos
+
+Terminal 1:
+
+```powershell
+cd C:\PORTAL-VETNEB
+pnpm build
+pnpm start
+```
+
+Alternativa para desarrollo:
+
+```powershell
+pnpm dev
+```
+
+## Variables requeridas
+
+Antes de ejecutar los smoke tests, configurar credenciales clinic validas para el entorno local:
+
+```powershell
+$env:SMOKE_BASE_URL = "http://localhost:3000"
+$env:SMOKE_USERNAME = "<clinic-user>"
+$env:SMOKE_PASSWORD = "<clinic-password>"
+```
+
+No usar los defaults internos `admin` / `admin123` salvo que existan explicitamente en la base local.
+
+## Smoke basico
+
+```powershell
+pnpm smoke:test
+```
+
+Valida health, login clinic, sesion, reports, study-types, logout y sesion invalidada.
+
+## Smoke upload
+
+```powershell
+$env:SMOKE_TMP_DIR = "C:\PORTAL-VETNEB\tmp"
+pnpm smoke:upload
+```
+
+Valida login clinic, creacion de PDF temporal, upload multipart, lectura de reports y logout.
+
+## Notas de seguridad
+
+Los scripts no deben registrar la password en consola.
+Solo muestran BASE URL y USUARIO.
+Las credenciales reales deben configurarse por entorno local y no commitearse.

--- a/test/smoke-env-contract.test.ts
+++ b/test/smoke-env-contract.test.ts
@@ -1,0 +1,47 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("smoke scripts document required runtime environment contract", () => {
+  const smokeTest = read("scripts/smoke/smoke-test.mjs");
+  const smokeUpload = read("scripts/smoke/smoke-upload.mjs");
+  const docs = read("docs/smoke-local.md");
+
+  for (const source of [smokeTest, smokeUpload]) {
+    assert.match(source, /process\.env\.SMOKE_BASE_URL/);
+    assert.match(source, /process\.env\.SMOKE_USERNAME/);
+    assert.match(source, /process\.env\.SMOKE_PASSWORD/);
+    assert.match(source, /BASE URL:/);
+    assert.match(source, /USUARIO:/);
+    const consoleLogLines = source
+      .split(/\r?\n/)
+      .filter((line) => line.includes("console.log"));
+
+    for (const line of consoleLogLines) {
+      assert.doesNotMatch(line, /PASSWORD|SMOKE_PASSWORD/);
+    }
+  }
+
+  assert.match(smokeUpload, /process\.env\.SMOKE_TMP_DIR/);
+
+  for (const marker of [
+    "SMOKE_BASE_URL",
+    "SMOKE_USERNAME",
+    "SMOKE_PASSWORD",
+    "SMOKE_TMP_DIR",
+    "pnpm smoke:test",
+    "pnpm smoke:upload",
+    "admin",
+    "admin123",
+  ]) {
+    assert.ok(docs.includes(marker), "docs/smoke-local.md missing " + marker);
+  }
+
+  assert.match(docs, /No usar los defaults internos `admin` \/ `admin123`/);
+  assert.match(docs, /no commitearse/i);
+});


### PR DESCRIPTION
﻿## Resumen

Documenta el contrato de entorno requerido para smoke tests locales y agrega guardrail source-level.

## Cambios

- Agrega `docs/smoke-local.md`.
- Documenta:
  - `SMOKE_BASE_URL`
  - `SMOKE_USERNAME`
  - `SMOKE_PASSWORD`
  - `SMOKE_TMP_DIR`
- Aclara que los defaults internos `admin` / `admin123` no deben usarse salvo que existan explícitamente en la base local.
- Agrega `test/smoke-env-contract.test.ts`.
- Verifica que:
  - `smoke-test.mjs` y `smoke-upload.mjs` lean las variables esperadas;
  - los scripts muestren `BASE URL` y `USUARIO`;
  - `smoke-upload.mjs` soporte `SMOKE_TMP_DIR`;
  - la documentación cubra ambos comandos smoke;
  - la password no se registre mediante `console.log`.

## Validación local

- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/smoke-env-contract.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`
- `pnpm validate:local`

Resultado: OK.
