### PR TITLE
test(permissions): guard clinic report surface is read-only

### DIFF
--- a/server/lib/permissions.ts
+++ b/server/lib/permissions.ts
@@ -30,13 +30,13 @@ export function getClinicPermissions(role: ClinicUserRole): ClinicPermissions {
   switch (role) {
     case "clinic_owner":
       return {
-        canUploadReports: true,
+        canUploadReports: false,
         canManageClinicUsers: true,
       };
     case "clinic_staff":
     default:
       return {
-        canUploadReports: true,
+        canUploadReports: false,
         canManageClinicUsers: false,
       };
   }

--- a/server/routes/public-report-access.fastify.ts
+++ b/server/routes/public-report-access.fastify.ts
@@ -372,7 +372,7 @@ export const publicReportAccessNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const tokenState = getReportAccessTokenState(record.token);
+    const tokenState = getReportAccessTokenState(record.token, new Date(currentTime));
 
     if (tokenState === "revoked") {
       return reply.code(410).send({

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -686,7 +686,7 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
       }
 
       applyCorsHeaders(request, reply, allowedOrigins);
-      reply.header("access-control-allow-methods", "GET,POST,OPTIONS");
+      reply.header("access-control-allow-methods", "GET,OPTIONS");
 
       const requestedHeaders =
         typeof request.headers["access-control-request-headers"] === "string"
@@ -698,7 +698,6 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     };
 
     app.options("/", optionsHandler);
-    app.options("/upload", optionsHandler);
     app.options("/search", optionsHandler);
     app.options("/study-types", optionsHandler);
     app.options("/:reportId/history", optionsHandler);

--- a/test/admin-audit.fastify.test.ts
+++ b/test/admin-audit.fastify.test.ts
@@ -48,7 +48,7 @@ function createAuthStubs(overrides: Record<string, unknown> = {}) {
     deleteAdminSession: async () => {},
     getAdminSessionByToken: async () => ({
       adminUserId: 1,
-      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
       lastAccess: new Date("2026-04-23T00:00:00.000Z"),
     }),
     getAdminUserById: async () => ({

--- a/test/auth-middleware.test.ts
+++ b/test/auth-middleware.test.ts
@@ -272,10 +272,10 @@ test("requireAuth autentica owner y actualiza lastAccess", async () => {
     authProId: "authpro-1",
     role: "clinic_owner",
     permissions: {
-      canUploadReports: true,
+      canUploadReports: false,
       canManageClinicUsers: true,
     },
-    canUploadReports: true,
+    canUploadReports: false,
     canManageClinicUsers: true,
     sessionToken: "token-valido",
   });
@@ -330,10 +330,10 @@ test("requireAuth normaliza role inválido a clinic_staff", async () => {
     authProId: null,
     role: "clinic_staff",
     permissions: {
-      canUploadReports: true,
+      canUploadReports: false,
       canManageClinicUsers: false,
     },
-    canUploadReports: true,
+    canUploadReports: false,
     canManageClinicUsers: false,
     sessionToken: "token-reciente",
   });

--- a/test/clinic-audit.fastify.test.ts
+++ b/test/clinic-audit.fastify.test.ts
@@ -49,7 +49,7 @@ function createAuthStubs(overrides: Record<string, unknown> = {}) {
     deleteActiveSession: async () => {},
     getActiveSessionByToken: async () => ({
       clinicUserId: 9,
-      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
       lastAccess: new Date("2026-04-23T00:00:00.000Z"),
     }),
     getClinicUserById: async () => ({

--- a/test/clinic-public-profile.fastify.test.ts
+++ b/test/clinic-public-profile.fastify.test.ts
@@ -60,7 +60,7 @@ function createAuthStubs(overrides: Record<string, unknown> = {}) {
     deleteActiveSession: async () => {},
     getActiveSessionByToken: async () => ({
       clinicUserId: 9,
-      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
       lastAccess: new Date("2026-04-23T00:00:00.000Z"),
     }),
     getClinicUserById: async () => ({

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -560,7 +560,7 @@ test(
         ...buildAdminAuditRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
-          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
           lastAccess: new Date("2026-04-23T00:00:00.000Z"),
         }),
         getAdminUserById: async () => ({
@@ -815,7 +815,7 @@ test(
         ...buildClinicAuditRouteStubs(),
         getActiveSessionByToken: async () => ({
           clinicUserId: 9,
-          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
           lastAccess: new Date("2026-04-23T00:00:00.000Z"),
         }),
         getClinicUserById: async () => ({
@@ -924,7 +924,7 @@ test(
         ...buildClinicPublicProfileRouteStubs(),
         getActiveSessionByToken: async () => ({
           clinicUserId: 9,
-          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
           lastAccess: new Date("2026-04-23T00:00:00.000Z"),
         }),
         getClinicUserById: async () => ({
@@ -1203,7 +1203,7 @@ test(
             tokenHash: "hash:ABCD",
             accessCount: 2,
             lastAccessAt: new Date("2026-04-22T10:00:00.000Z"),
-            expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
             revokedAt: null,
             createdAt: new Date("2026-04-20T12:00:00.000Z"),
             updatedAt: new Date("2026-04-22T12:00:00.000Z"),
@@ -1238,7 +1238,7 @@ test(
           tokenHash: "hash:ABCD",
           accessCount: 3,
           lastAccessAt: new Date("2026-04-24T00:00:00.000Z"),
-          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
           revokedAt: null,
           createdAt: new Date("2026-04-20T12:00:00.000Z"),
           updatedAt: new Date("2026-04-22T12:00:00.000Z"),
@@ -1466,7 +1466,7 @@ test(
         ...buildAdminParticularTokensRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
-          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
           lastAccess: new Date("2026-04-23T00:00:00.000Z"),
         }),
         getAdminUserById: async () => ({
@@ -1599,7 +1599,7 @@ test(
         ...buildAdminStudyTrackingRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
-          expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
           lastAccess: new Date("2026-04-23T00:00:00.000Z"),
         }),
         getAdminUserById: async () => ({

--- a/test/permissions-and-report-status.test.ts
+++ b/test/permissions-and-report-status.test.ts
@@ -28,12 +28,12 @@ test("normalizeClinicUserRole normaliza strings y aplica fallback", () => {
 
 test("getClinicPermissions devuelve permisos consistentes por rol", () => {
   assert.deepEqual(getClinicPermissions("clinic_owner"), {
-    canUploadReports: true,
+    canUploadReports: false,
     canManageClinicUsers: true,
   });
 
   assert.deepEqual(getClinicPermissions("clinic_staff"), {
-    canUploadReports: true,
+    canUploadReports: false,
     canManageClinicUsers: false,
   });
 });

--- a/test/public-report-access.fastify.test.ts
+++ b/test/public-report-access.fastify.test.ts
@@ -42,7 +42,7 @@ function createReportAccessTokenFixture(overrides: Record<string, unknown> = {})
     tokenLast4: "ABCD",
     accessCount: 2,
     lastAccessAt: new Date("2026-04-22T10:00:00.000Z"),
-    expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
     revokedAt: null,
     createdAt: new Date("2026-04-20T12:00:00.000Z"),
     updatedAt: new Date("2026-04-22T12:00:00.000Z"),

--- a/test/report-management-route-policy.test.ts
+++ b/test/report-management-route-policy.test.ts
@@ -32,7 +32,7 @@ test("reports protege PATCH /:reportId/status con management permission", () => 
   );
 });
 
-test("reports expone POST /upload nativo con permiso de upload, no management", () => {
+test("reports mantiene POST /upload nativo bloqueado por permiso de upload deshabilitado", () => {
   const nativeSource = readRouteSource("server/routes/reports.fastify.ts");
 
   assert.equal(
@@ -60,7 +60,7 @@ test("reports expone POST /upload nativo con permiso de upload, no management", 
   );
 });
 
-test("reports upload usa permisos persistentes derivados de role y no allowlist ENV legacy", () => {
+test("reports upload usa permisos persistentes read-only derivados de role y no allowlist ENV legacy", () => {
   const nativeSource = readRouteSource("server/routes/reports.fastify.ts");
   const permissionsSource = readRouteSource("server/lib/permissions.ts");
 
@@ -86,14 +86,14 @@ test("reports upload usa permisos persistentes derivados de role y no allowlist 
 
   assert.match(
     permissionsSource,
-    /case "clinic_owner":[\s\S]*canUploadReports: true,[\s\S]*canManageClinicUsers: true,/s,
-    "clinic_owner debe conservar permiso de upload y management",
+    /case "clinic_owner":[\s\S]*canUploadReports: false,[\s\S]*canManageClinicUsers: true,/s,
+    "clinic_owner debe conservar management sin permiso de upload",
   );
 
   assert.match(
     permissionsSource,
-    /case "clinic_staff":[\s\S]*canUploadReports: true,[\s\S]*canManageClinicUsers: false,/s,
-    "clinic_staff debe conservar permiso de upload sin management",
+    /case "clinic_staff":[\s\S]*canUploadReports: false,[\s\S]*canManageClinicUsers: false,/s,
+    "clinic_staff debe permanecer read-only sin upload ni management",
   );
 
   assert.match(

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -138,161 +138,78 @@ function buildMultipartReportPayload(options: { includeFile?: boolean } = {}) {
   };
 }
 
-test("reportsNativeRoutes expone POST /upload con multipart y tracking", async () => {
-  const uploadCalls: Array<Record<string, unknown>> = [];
-  const trackingCalls: Array<Record<string, unknown>> = [];
-  const updateTrackingCalls: Array<Record<string, unknown>> = [];
-  const upsertCalls: Array<Record<string, unknown>> = [];
-  const multipart = buildMultipartReportPayload();
+test("reportsNativeRoutes bloquea POST /upload para roles clinic", async () => {
+  for (const role of ["clinic_owner", "clinic_staff"] as const) {
+    const multipart = buildMultipartReportPayload();
+    const calls = {
+      uploadReport: 0,
+      upsertReport: 0,
+      getClinicScopedStudyTrackingCase: 0,
+      updateStudyTrackingCase: 0,
+    };
 
-  const app = await createTestApp({
-    uploadReport: async (input: {
-      file: Buffer;
-      fileName: string;
-      clinicId: number;
-      mimeType: string;
-    }) => {
-      uploadCalls.push({
-        clinicId: input.clinicId,
-        fileName: input.fileName,
-        mimeType: input.mimeType,
-        file: input.file.toString("utf8"),
-      });
-
-      return "reports/3/luna-new.pdf";
-    },
-    getClinicScopedStudyTrackingCase: async (
-      trackingCaseId: number,
-      clinicId: number,
-    ) => {
-      trackingCalls.push({ trackingCaseId, clinicId });
-      return {
-        id: trackingCaseId,
-        clinicId,
-      };
-    },
-    updateStudyTrackingCase: async (
-      trackingCaseId: number,
-      input: { reportId: number },
-    ) => {
-      updateTrackingCalls.push({ trackingCaseId, input });
-    },
-    upsertReport: async (input: Record<string, unknown>) => {
-      upsertCalls.push(input);
-
-      return createReportFixture({
-        id: 88,
-        clinicId: input.clinicId,
-        patientName: input.patientName,
-        studyType: input.studyType,
-        uploadDate: input.uploadDate,
-        fileName: input.fileName,
-        storagePath: input.storagePath,
-        currentStatus: "uploaded",
-        createdByClinicUserId: input.createdByClinicUserId,
-      });
-    },
-  });
-
-  try {
-    const response = await app.inject({
-      method: "POST",
-      url: "/api/reports/upload",
-      headers: {
-        origin: "http://localhost:3000",
-        cookie: `${ENV.cookieName}=session-token`,
-        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+    const app = await createTestApp({
+      getClinicUserById: async () => ({
+        id: 9,
+        clinicId: 3,
+        username: "doctor",
+        authProId: null,
+        role,
+      }),
+      uploadReport: async () => {
+        calls.uploadReport += 1;
+        return "reports/3/luna-new.pdf";
       },
-      payload: multipart.payload,
+      upsertReport: async () => {
+        calls.upsertReport += 1;
+        return createReportFixture({ id: 88 });
+      },
+      getClinicScopedStudyTrackingCase: async () => {
+        calls.getClinicScopedStudyTrackingCase += 1;
+        return {
+          id: 77,
+          clinicId: 3,
+        };
+      },
+      updateStudyTrackingCase: async () => {
+        calls.updateStudyTrackingCase += 1;
+      },
     });
 
-    assert.equal(response.statusCode, 201);
-    assert.deepEqual(uploadCalls, [
-      {
-        clinicId: 3,
-        fileName: "luna.pdf",
-        mimeType: "application/pdf",
-        file: "PDFDATA",
-      },
-    ]);
-    assert.deepEqual(trackingCalls, [
-      {
-        trackingCaseId: 77,
-        clinicId: 3,
-      },
-    ]);
-    assert.deepEqual(updateTrackingCalls, [
-      {
-        trackingCaseId: 77,
-        input: {
-          reportId: 88,
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/reports/upload",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
         },
-      },
-    ]);
+        payload: multipart.payload,
+      });
 
-    assert.equal(upsertCalls.length, 1);
-    assert.equal(upsertCalls[0].clinicId, 3);
-    assert.equal(upsertCalls[0].patientName, "Luna Gomez");
-    assert.equal(upsertCalls[0].studyType, "Histopatologia");
-    assert.equal(
-      (upsertCalls[0].uploadDate as Date).toISOString(),
-      "2026-04-25T10:30:00.000Z",
-    );
-    assert.equal(upsertCalls[0].fileName, "luna.pdf");
-    assert.equal(upsertCalls[0].storagePath, "reports/3/luna-new.pdf");
-    assert.equal(upsertCalls[0].createdByClinicUserId, 9);
-
-    const body = JSON.parse(response.body);
-    assert.equal(body.success, true);
-    assert.equal(body.message, "Archivo subido correctamente");
-    assert.equal(body.report.id, 88);
-    assert.equal(body.report.clinicId, 3);
-    assert.equal(body.report.patientName, "Luna Gomez");
-    assert.equal(body.report.studyType, "Histopatologia");
-    assert.equal(body.report.uploadDate, "2026-04-25T10:30:00.000Z");
-    assert.equal(body.report.fileName, "luna.pdf");
-    assert.equal(body.report.storagePath, "reports/3/luna-new.pdf");
-    assert.equal(body.report.previewUrl, "preview:reports/3/luna-new.pdf");
-    assert.equal(
-      body.report.downloadUrl,
-      "download:reports/3/luna-new.pdf:luna.pdf",
-    );
-  } finally {
-    await app.close();
-  }
-});
-
-test("reportsNativeRoutes bloquea POST /upload sin archivo", async () => {
-  const multipart = buildMultipartReportPayload({ includeFile: false });
-  let uploadCalled = false;
-
-  const app = await createTestApp({
-    uploadReport: async () => {
-      uploadCalled = true;
-      return "reports/3/luna-new.pdf";
-    },
-  });
-
-  try {
-    const response = await app.inject({
-      method: "POST",
-      url: "/api/reports/upload",
-      headers: {
-        origin: "http://localhost:3000",
-        cookie: `${ENV.cookieName}=session-token`,
-        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
-      },
-      payload: multipart.payload,
-    });
-
-    assert.equal(response.statusCode, 400);
-    assert.equal(uploadCalled, false);
-    assert.deepEqual(JSON.parse(response.body), {
-      success: false,
-      error: "No se proporciono ningun archivo",
-    });
-  } finally {
-    await app.close();
+      assert.equal(response.statusCode, 403, role);
+      assert.deepEqual(
+        JSON.parse(response.body),
+        {
+          success: false,
+          error: "No autorizado para subir informes",
+        },
+        role,
+      );
+      assert.deepEqual(
+        calls,
+        {
+          uploadReport: 0,
+          upsertReport: 0,
+          getClinicScopedStudyTrackingCase: 0,
+          updateStudyTrackingCase: 0,
+        },
+        role,
+      );
+    } finally {
+      await app.close();
+    }
   }
 });
 
@@ -637,17 +554,16 @@ test("reportsNativeRoutes bloquea GET / sin sesión", async () => {
     await app.close();
   }
 });
-test("reportsNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
+test("reportsNativeRoutes responde preflight OPTIONS para superficie clinic read-only sin autenticar", async () => {
   const app = await createTestApp({
     getActiveSessionByToken: async () => {
-      throw new Error("preflight OPTIONS no debe autenticar sesión clinic");
+      throw new Error("preflight OPTIONS no debe autenticar sesion clinic");
     },
   });
 
   try {
     for (const url of [
       "/api/reports",
-      "/api/reports/upload",
       "/api/reports/search",
       "/api/reports/study-types",
       "/api/reports/55/history",
@@ -672,7 +588,7 @@ test("reportsNativeRoutes responde preflight OPTIONS permitido sin autenticar", 
       assert.equal(response.headers["access-control-allow-credentials"], "true");
       assert.equal(
         response.headers["access-control-allow-methods"],
-        "GET,POST,OPTIONS",
+        "GET,OPTIONS",
       );
       assert.equal(
         response.headers["access-control-allow-headers"],
@@ -685,13 +601,38 @@ test("reportsNativeRoutes responde preflight OPTIONS permitido sin autenticar", 
   }
 });
 
+test("reportsNativeRoutes no anuncia POST /upload en preflight clinic", async () => {
+  const app = await createTestApp({
+    getActiveSessionByToken: async () => {
+      throw new Error("preflight OPTIONS /upload no debe autenticar sesion clinic");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        "access-control-request-headers": "content-type,x-requested-with",
+      },
+    });
+
+    assert.notEqual(response.statusCode, 204);
+    assert.equal(response.headers["access-control-allow-methods"], undefined);
+    assert.equal(response.headers["set-cookie"], undefined);
+  } finally {
+    await app.close();
+  }
+});
+
 test("reportsNativeRoutes bloquea preflight OPTIONS con origin no permitido", async () => {
   const app = await createTestApp();
 
   try {
     const response = await app.inject({
       method: "OPTIONS",
-      url: "/api/reports/upload",
+      url: "/api/reports/search",
       headers: {
         origin: "https://evil.example",
         "access-control-request-headers": "content-type",

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -89,7 +89,6 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         path: "server/routes/reports.fastify.ts",
         markers: [
           'app.options("/", optionsHandler)',
-          'app.options("/upload", optionsHandler)',
           'app.options("/search", optionsHandler)',
         ],
       },
@@ -120,7 +119,8 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
       {
         path: "test/reports.fastify.test.ts",
         markers: [
-          "reportsNativeRoutes responde preflight OPTIONS permitido sin autenticar",
+          "reportsNativeRoutes responde preflight OPTIONS para superficie clinic read-only sin autenticar",
+          "reportsNativeRoutes no anuncia POST /upload en preflight clinic",
           "reportsNativeRoutes bloquea preflight OPTIONS con origin no permitido",
         ],
       },


### PR DESCRIPTION
﻿## Summary

- Documenta y aplica la nueva regla de negocio: clinic_owner y clinic_staff no pueden subir informes desde la superficie clinic.
- Restringe la superficie clinic de reports a lectura, preview, download, history, search y study-types.
- Bloquea /api/reports/upload para roles clinic.
- Ajusta preflight CORS de reports clinic a GET,OPTIONS.
- Actualiza guardrails de permisos, auth middleware y registry crítico de superficies.
- Estabiliza fixtures temporales vencidos y hace que public report access use el now inyectado al evaluar expiración.

## Validation

- pnpm typecheck: OK
- pnpm typecheck:test: OK
- pnpm test: OK — 522/522 passing
- git diff --check: OK

## Commit

5c884db
