### PR TITLE
feat(admin-reports): add admin report upload route

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -21,6 +21,10 @@ import {
   type AdminReportAccessTokensNativeRoutesOptions,
 } from "./routes/admin-report-access-tokens.fastify.ts";
 import {
+  adminReportsNativeRoutes,
+  type AdminReportsNativeRoutesOptions,
+} from "./routes/admin-reports.fastify.ts";
+import {
   adminStudyTrackingNativeRoutes,
   type AdminStudyTrackingNativeRoutesOptions,
 } from "./routes/admin-study-tracking.fastify.ts";
@@ -142,6 +146,7 @@ export type CreateFastifyAppOptions = {
   adminAuditRoutes?: AdminAuditNativeRoutesOptions;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   adminParticularTokensRoutes?: AdminParticularTokensNativeRoutesOptions;
+  adminReportsRoutes?: AdminReportsNativeRoutesOptions;
   adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
   adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
@@ -248,6 +253,11 @@ export async function createFastifyApp(
   await app.register(adminParticularTokensNativeRoutes, {
     prefix: "/api/admin/particular/tokens",
     ...(options.adminParticularTokensRoutes ?? {}),
+  });
+
+  await app.register(adminReportsNativeRoutes, {
+    prefix: "/api/admin/reports",
+    ...(options.adminReportsRoutes ?? {}),
   });
 
   await app.register(adminReportAccessTokensNativeRoutes, {

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -1,0 +1,670 @@
+﻿import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+import multer from "multer";
+
+import type { Report } from "../../drizzle/schema";
+import type { Multer } from "multer";
+import { ENV } from "../lib/env.ts";
+import { ALLOWED_MIME_TYPES } from "../lib/supabase.ts";
+import {
+  normalizeSearchText,
+  parseOptionalDate,
+  parseReportId,
+} from "../lib/reports.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type AdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type ClinicRecord = {
+  id: number;
+};
+
+type ReportUploadInput = {
+  file: Buffer;
+  fileName: string;
+  clinicId: number;
+  mimeType: string;
+};
+
+type UpsertReportInput = {
+  clinicId: number;
+  patientName: string | null;
+  studyType: string | null;
+  uploadDate: Date | null;
+  fileName: string;
+  storagePath: string;
+  createdByAdminUserId?: number | null;
+};
+
+type UploadedMultipartFile = {
+  buffer: Buffer;
+  originalname: string;
+  mimetype: string;
+};
+
+type RawRequestWithFile = FastifyRequest["raw"] & {
+  file?: UploadedMultipartFile;
+  body?: Record<string, unknown>;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+export type AdminReportsNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (adminUserId: number) => Promise<AdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
+  uploadReport?: (input: ReportUploadInput) => Promise<string>;
+  upsertReport?: (input: UpsertReportInput) => Promise<Report>;
+  createSignedReportUrl?: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl?: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__adminReportsRequestStartTimeNs";
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+type AdminReportsFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+const allowedMimeTypes = new Set(ALLOWED_MIME_TYPES);
+
+const upload: Multer = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: ENV.maxUploadFileSizeMb * 1024 * 1024,
+  },
+  fileFilter: (_req, file, cb) => {
+    if (
+      !allowedMimeTypes.has(
+        file.mimetype as (typeof ALLOWED_MIME_TYPES)[number],
+      )
+    ) {
+      cb(new Error("Tipo de archivo no permitido"));
+      return;
+    }
+
+    cb(null, true);
+  },
+});
+
+type NativeAdminReportsDeps = Required<
+  Pick<
+    AdminReportsNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getClinicById"
+    | "uploadReport"
+    | "upsertReport"
+    | "createSignedReportUrl"
+    | "createSignedReportDownloadUrl"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminReportsDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const storage = await import("../lib/supabase.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getClinicById: db.getClinicById,
+        uploadReport: storage.uploadReport,
+        upsertReport: db.upsertReport,
+        createSignedReportUrl: storage.createSignedReportUrl,
+        createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function hasAllInjectedDeps(options: AdminReportsNativeRoutesOptions) {
+  return (
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getClinicById &&
+    !!options.uploadReport &&
+    !!options.upsertReport &&
+    !!options.createSignedReportUrl &&
+    !!options.createSignedReportDownloadUrl
+  );
+}
+
+async function resolveDeps(
+  options: AdminReportsNativeRoutesOptions,
+): Promise<NativeAdminReportsDeps> {
+  const defaultDeps = hasAllInjectedDeps(options) ? undefined : await loadDefaultDeps();
+
+  return {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById:
+      options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
+    uploadReport: options.uploadReport ?? defaultDeps!.uploadReport,
+    upsertReport: options.upsertReport ?? defaultDeps!.upsertReport,
+    createSignedReportUrl:
+      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
+    createSignedReportDownloadUrl:
+      options.createSignedReportDownloadUrl ??
+      defaultDeps!.createSignedReportDownloadUrl,
+  };
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminReportsDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesion admin invalida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesion admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesion no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+function runReportUpload(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<UploadedMultipartFile | undefined> {
+  return new Promise((resolve, reject) => {
+    upload.single("file")(
+      request.raw as any,
+      reply.raw as any,
+      (error: unknown) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve((request.raw as RawRequestWithFile).file);
+      },
+    );
+  });
+}
+
+function getMultipartBody(request: FastifyRequest) {
+  const body = (request.raw as RawRequestWithFile).body;
+
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+
+  return body;
+}
+
+async function serializeReport(report: Report, deps: NativeAdminReportsDeps) {
+  const [previewUrl, downloadUrl] = await Promise.all([
+    deps.createSignedReportUrl(report.storagePath),
+    deps.createSignedReportDownloadUrl(
+      report.storagePath,
+      report.fileName ?? undefined,
+    ),
+  ]);
+
+  return {
+    ...report,
+    previewUrl,
+    downloadUrl,
+  };
+}
+
+export const adminReportsNativeRoutes: FastifyPluginAsync<
+  AdminReportsNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  if (!app.hasContentTypeParser("multipart/form-data")) {
+    app.addContentTypeParser("multipart/form-data", (_request, _payload, done) => {
+      done(null, undefined);
+    });
+  }
+
+  app.addHook("onRequest", async (request, reply) => {
+    (request as AdminReportsFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as AdminReportsFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "POST,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/upload", optionsHandler);
+
+  app.post("/upload", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const deps = await resolveDeps(options);
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    let file: UploadedMultipartFile | undefined;
+
+    try {
+      file = await runReportUpload(request, reply);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Error al procesar archivo";
+
+      return reply.code(400).send({
+        success: false,
+        error: message,
+      });
+    }
+
+    const body = getMultipartBody(request);
+    const clinicId = parseReportId(body.clinicId);
+
+    if (typeof clinicId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "clinicId es obligatorio",
+      });
+    }
+
+    const clinic = await deps.getClinicById(clinicId);
+
+    if (!clinic) {
+      return reply.code(404).send({
+        success: false,
+        error: "Clinica no encontrada",
+      });
+    }
+
+    if (!file) {
+      return reply.code(400).send({
+        success: false,
+        error: "No se proporciono ningun archivo",
+      });
+    }
+
+    const storagePath = await deps.uploadReport({
+      file: file.buffer,
+      fileName: file.originalname,
+      clinicId,
+      mimeType: file.mimetype,
+    });
+
+    const patientName = normalizeSearchText(body.patientName);
+    const studyType = normalizeSearchText(body.studyType);
+    const uploadDate = parseOptionalDate(body.uploadDate);
+
+    const report = await deps.upsertReport({
+      clinicId,
+      patientName: patientName ?? null,
+      studyType: studyType ?? null,
+      uploadDate: uploadDate ?? null,
+      fileName: file.originalname,
+      storagePath,
+      createdByAdminUserId: admin.id,
+    });
+
+    return reply.code(201).send({
+      success: true,
+      message: "Informe subido correctamente",
+      report: await serializeReport(report, deps),
+    });
+  });
+};

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -1,0 +1,385 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  adminReportsNativeRoutes,
+} = await import("../server/routes/admin-reports.fastify.ts");
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 88,
+    clinicId: 3,
+    uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+    studyType: "Histopatologia",
+    patientName: "Luna",
+    fileName: "luna-report.pdf",
+    currentStatus: "uploaded",
+    statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+    storagePath: "reports/3/luna-report.pdf",
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "ADMIN",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(adminReportsNativeRoutes as any, {
+    prefix: "/api/admin/reports",
+    ...createAuthStubs(),
+    getClinicById: async () => ({ id: 3 }),
+    uploadReport: async () => "reports/3/luna-report.pdf",
+    upsertReport: async () => createReportFixture(),
+    createSignedReportUrl: async (storagePath: string) =>
+      `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    ...overrides,
+  });
+
+  return app;
+}
+
+function buildMultipartReportPayload(
+  fields: Record<string, string> = {
+    clinicId: "3",
+    patientName: " Luna ",
+    studyType: " Histopatologia ",
+    uploadDate: "2026-04-22T09:00:00.000Z",
+  },
+) {
+  const boundary = "----vetneb-admin-report-boundary";
+  const chunks: string[] = [];
+
+  for (const [name, value] of Object.entries(fields)) {
+    chunks.push(`--${boundary}\r\n`);
+    chunks.push(`Content-Disposition: form-data; name="${name}"\r\n\r\n`);
+    chunks.push(value);
+    chunks.push("\r\n");
+  }
+
+  chunks.push(`--${boundary}\r\n`);
+  chunks.push(
+    'Content-Disposition: form-data; name="file"; filename="luna-report.pdf"\r\n',
+  );
+  chunks.push("Content-Type: application/pdf\r\n\r\n");
+  chunks.push("PDFDATA");
+  chunks.push(`\r\n--${boundary}--\r\n`);
+
+  return {
+    boundary,
+    payload: Buffer.from(chunks.join(""), "utf8"),
+  };
+}
+
+test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metadata", async () => {
+  const multipart = buildMultipartReportPayload();
+  const uploadCalls: Array<Record<string, unknown>> = [];
+  const upsertCalls: Array<Record<string, unknown>> = [];
+  const clinicCalls: number[] = [];
+
+  const app = await createTestApp({
+    getClinicById: async (clinicId: number) => {
+      clinicCalls.push(clinicId);
+      return { id: clinicId };
+    },
+    uploadReport: async (input: {
+      clinicId: number;
+      file: Buffer;
+      fileName: string;
+      mimeType: string;
+    }) => {
+      uploadCalls.push({
+        clinicId: input.clinicId,
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+        file: input.file.toString("utf8"),
+      });
+
+      return "reports/3/luna-report.pdf";
+    },
+    upsertReport: async (input: Record<string, unknown>) => {
+      upsertCalls.push(input);
+      return createReportFixture({
+        clinicId: input.clinicId,
+        patientName: input.patientName,
+        studyType: input.studyType,
+        uploadDate: input.uploadDate,
+        fileName: input.fileName,
+        storagePath: input.storagePath,
+      });
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(clinicCalls, [3]);
+    assert.deepEqual(uploadCalls, [
+      {
+        clinicId: 3,
+        fileName: "luna-report.pdf",
+        mimeType: "application/pdf",
+        file: "PDFDATA",
+      },
+    ]);
+
+    assert.equal(upsertCalls.length, 1);
+    assert.deepEqual(
+      {
+        ...upsertCalls[0],
+        uploadDate:
+          upsertCalls[0].uploadDate instanceof Date
+            ? upsertCalls[0].uploadDate.toISOString()
+            : upsertCalls[0].uploadDate,
+      },
+      {
+        clinicId: 3,
+        patientName: "Luna",
+        studyType: "Histopatologia",
+        uploadDate: "2026-04-22T09:00:00.000Z",
+        fileName: "luna-report.pdf",
+        storagePath: "reports/3/luna-report.pdf",
+        createdByAdminUserId: 1,
+      },
+    );
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Informe subido correctamente");
+    assert.equal(body.report.id, 88);
+    assert.equal(body.report.clinicId, 3);
+    assert.equal(body.report.patientName, "Luna");
+    assert.equal(body.report.studyType, "Histopatologia");
+    assert.equal(body.report.previewUrl, "signed-preview:reports/3/luna-report.pdf");
+    assert.equal(
+      body.report.downloadUrl,
+      "signed-download:reports/3/luna-report.pdf:luna-report.pdf",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes bloquea POST /upload con origin no permitido antes de auth", async () => {
+  const multipart = buildMultipartReportPayload();
+
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => {
+      throw new Error("origin no permitido no debe autenticar admin");
+    },
+    uploadReport: async () => {
+      throw new Error("origin no permitido no debe subir archivo");
+    },
+    upsertReport: async () => {
+      throw new Error("origin no permitido no debe persistir informe");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "https://evil.example",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes bloquea POST /upload sin sesion admin antes de storage", async () => {
+  const multipart = buildMultipartReportPayload();
+  let uploadCalls = 0;
+
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => null,
+    uploadReport: async () => {
+      uploadCalls += 1;
+      return "reports/3/luna-report.pdf";
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(uploadCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes requiere clinicId valido antes de storage", async () => {
+  const multipart = buildMultipartReportPayload({
+    patientName: "Luna",
+    studyType: "Histopatologia",
+  });
+  let uploadCalls = 0;
+  let upsertCalls = 0;
+
+  const app = await createTestApp({
+    uploadReport: async () => {
+      uploadCalls += 1;
+      return "reports/3/luna-report.pdf";
+    },
+    upsertReport: async () => {
+      upsertCalls += 1;
+      return createReportFixture();
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "clinicId es obligatorio",
+    });
+    assert.equal(uploadCalls, 0);
+    assert.equal(upsertCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes devuelve 404 cuando clinicId no existe", async () => {
+  const multipart = buildMultipartReportPayload();
+  let uploadCalls = 0;
+
+  const app = await createTestApp({
+    getClinicById: async () => null,
+    uploadReport: async () => {
+      uploadCalls += 1;
+      return "reports/3/luna-report.pdf";
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Clinica no encontrada",
+    });
+    assert.equal(uploadCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes responde preflight OPTIONS /upload sin autenticar", async () => {
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => {
+      throw new Error("preflight admin reports no debe autenticar");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        "access-control-request-headers": "content-type,x-requested-with",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.body, "");
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      "http://localhost:3000",
+    );
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+    assert.equal(
+      response.headers["access-control-allow-methods"],
+      "POST,OPTIONS",
+    );
+    assert.equal(
+      response.headers["access-control-allow-headers"],
+      "content-type,x-requested-with",
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -93,6 +93,37 @@ function buildAdminParticularTokensRouteStubs() {
     updateParticularTokenReport: async () => null,
   };
 }
+function buildAdminReportsRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    uploadReport: async () => "reports/admin-test.pdf",
+    upsertReport: async () => ({
+      id: 88,
+      clinicId: 3,
+      uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+      studyType: "Histopatologia",
+      patientName: "Luna",
+      fileName: "luna-report.pdf",
+      currentStatus: "uploaded",
+      statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+      createdAt: new Date("2026-04-22T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+      storagePath: "reports/admin-test.pdf",
+    } as any),
+    createSignedReportUrl: async (storagePath: string) =>
+      `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+  };
+}
+
 function buildAdminReportAccessTokensRouteStubs() {
   return {
     deleteAdminSession: async () => {},
@@ -460,6 +491,7 @@ function buildFastifyDispatchRouteStubs() {
     adminAuditRoutes: buildAdminAuditRouteStubs(),
     adminAuthRoutes: buildAdminAuthRouteStubs(),
     adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
+    adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
     adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
     clinicAuthRoutes: buildClinicAuthRouteStubs(),
@@ -502,7 +534,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -607,7 +640,8 @@ test(
       },
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -673,7 +707,8 @@ test(
         updateAdminSessionLastAccess: async () => {},
       },
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -730,7 +765,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
@@ -808,7 +844,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
@@ -916,7 +953,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1008,7 +1046,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1111,7 +1150,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1175,7 +1215,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1288,7 +1329,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1370,13 +1412,55 @@ test(
 );
 
 test(
+  "createFastifyApp despacha /api/admin/reports al router nativo",
+  async () => {
+    const app = await createFastifyApp({
+      ...buildFastifyDispatchRouteStubs(),
+      adminReportsRoutes: {
+        ...buildAdminReportsRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "ADMIN",
+        }),
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "OPTIONS",
+        url: "/api/admin/reports/upload",
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-headers": "content-type",
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.equal(response.statusCode, 204);
+      assert.equal(
+        response.headers["access-control-allow-methods"],
+        "POST,OPTIONS",
+      );
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "createFastifyApp despacha /api/admin/report-access-tokens al router nativo",
   async () => {
     const app = await createFastifyApp({
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: {
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: {
         ...buildAdminReportAccessTokensRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
@@ -1500,7 +1584,8 @@ test(
           },
         ],
       },
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1554,7 +1639,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1594,7 +1680,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: {
         ...buildAdminStudyTrackingRouteStubs(),
         getAdminSessionByToken: async () => ({
@@ -1662,7 +1749,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
@@ -1778,7 +1866,8 @@ test(
       adminAuditRoutes: buildAdminAuditRouteStubs(),
       adminAuthRoutes: buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),


### PR DESCRIPTION
﻿## Summary

- Add native admin report upload route at /api/admin/reports/upload.
- Require admin auth and trusted origin before storage/database writes.
- Require explicit clinicId in multipart payload.
- Validate clinic existence before uploading.
- Persist report metadata with createdByAdminUserId.
- Return signed preview/download URLs in the created report payload.
- Mount admin reports router in Fastify app.
- Add route and dispatch coverage.

## Validation

- pnpm typecheck: OK
- pnpm typecheck:test: OK
- pnpm test: OK — 529/529 passing
- git diff --check: OK
