### PR TITLE
refactor(reports): restrict clinic reports routes to read-only

### DIFF
--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -3,26 +3,19 @@ import type {
   FastifyReply,
   FastifyRequest,
 } from "fastify";
-import multer from "multer";
 
 import type { Report, ReportStatus } from "../../drizzle/schema";
-import type { Multer } from "multer";
 import { ENV } from "../lib/env.ts";
-import { ALLOWED_MIME_TYPES } from "../lib/supabase.ts";
 import {
   getReadClinicScope,
   normalizeSearchText,
   parseOffset,
-  parseOptionalDate,
   parsePositiveInt,
   parseReportId,
   parseReportStatus,
 } from "../lib/reports.ts";
 import { REPORT_STATUSES } from "../lib/report-status.ts";
-import {
-  getClinicPermissions,
-  normalizeClinicUserRole,
-} from "../lib/permissions.ts";
+import { normalizeClinicUserRole } from "../lib/permissions.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
@@ -42,43 +35,12 @@ type ActiveSessionRecord = {
   lastAccess?: Date | null;
 };
 
-type ReportUploadInput = {
-  file: Buffer;
-  fileName: string;
-  clinicId: number;
-  mimeType: string;
-};
-
-type UpsertReportInput = {
-  clinicId: number;
-  patientName: string | null;
-  studyType: string | null;
-  uploadDate: Date | null;
-  fileName: string;
-  storagePath: string;
-  createdByClinicUserId?: number | null;
-};
-
-type UploadedMultipartFile = {
-  buffer: Buffer;
-  originalname: string;
-  mimetype: string;
-};
-
-type RawRequestWithFile = FastifyRequest["raw"] & {
-  file?: UploadedMultipartFile;
-  body?: Record<string, unknown>;
-};
-
 type AuthenticatedClinicUser = {
   id: number;
   clinicId: number;
   username: string;
   authProId: string | null;
   role: ReturnType<typeof normalizeClinicUserRole>;
-  permissions: ReturnType<typeof getClinicPermissions>;
-  canUploadReports: boolean;
-  canManageClinicUsers: boolean;
   sessionToken: string;
 };
 
@@ -109,16 +71,6 @@ export type ReportsNativeRoutesOptions = {
   getStudyTypes?: (clinicId: number) => Promise<string[]>;
   getReportById?: (reportId: number) => Promise<Report | null>;
   getReportStatusHistory?: (reportId: number) => Promise<unknown[]>;
-  getClinicScopedStudyTrackingCase?: (
-    trackingCaseId: number,
-    clinicId: number,
-  ) => Promise<unknown | null>;
-  updateStudyTrackingCase?: (
-    trackingCaseId: number,
-    input: { reportId: number },
-  ) => Promise<unknown>;
-  uploadReport?: (input: ReportUploadInput) => Promise<string>;
-  upsertReport?: (input: UpsertReportInput) => Promise<Report>;
   createSignedReportUrl?: (storagePath: string) => Promise<string>;
   createSignedReportDownloadUrl?: (
     storagePath: string,
@@ -134,27 +86,6 @@ type ReportsFastifyRequest = FastifyRequest & {
   [REQUEST_START_TIME_KEY]?: bigint;
 };
 
-const allowedMimeTypes = new Set(ALLOWED_MIME_TYPES);
-
-const upload: Multer = multer({
-  storage: multer.memoryStorage(),
-  limits: {
-    fileSize: ENV.maxUploadFileSizeMb * 1024 * 1024,
-  },
-  fileFilter: (_req, file, cb) => {
-    if (
-      !allowedMimeTypes.has(
-        file.mimetype as (typeof ALLOWED_MIME_TYPES)[number],
-      )
-    ) {
-      cb(new Error("Tipo de archivo no permitido"));
-      return;
-    }
-
-    cb(null, true);
-  },
-});
-
 type NativeReportsDeps = Required<
   Pick<
     ReportsNativeRoutesOptions,
@@ -168,10 +99,6 @@ type NativeReportsDeps = Required<
     | "getStudyTypes"
     | "getReportById"
     | "getReportStatusHistory"
-    | "getClinicScopedStudyTrackingCase"
-    | "updateStudyTrackingCase"
-    | "uploadReport"
-    | "upsertReport"
     | "createSignedReportUrl"
     | "createSignedReportDownloadUrl"
   >
@@ -183,7 +110,6 @@ async function loadDefaultDeps(): Promise<NativeReportsDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
-      const studyTracking = await import("../db-study-tracking.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const storage = await import("../lib/supabase.ts");
 
@@ -198,11 +124,6 @@ async function loadDefaultDeps(): Promise<NativeReportsDeps> {
         getStudyTypes: db.getStudyTypes,
         getReportById: db.getReportById,
         getReportStatusHistory: db.getReportStatusHistory,
-        getClinicScopedStudyTrackingCase:
-          studyTracking.getClinicScopedStudyTrackingCase,
-        updateStudyTrackingCase: studyTracking.updateStudyTrackingCase,
-        uploadReport: storage.uploadReport,
-        upsertReport: db.upsertReport,
         createSignedReportUrl: storage.createSignedReportUrl,
         createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
       };
@@ -224,10 +145,6 @@ function hasAllInjectedDeps(options: ReportsNativeRoutesOptions) {
     !!options.getStudyTypes &&
     !!options.getReportById &&
     !!options.getReportStatusHistory &&
-    !!options.getClinicScopedStudyTrackingCase &&
-    !!options.updateStudyTrackingCase &&
-    !!options.uploadReport &&
-    !!options.upsertReport &&
     !!options.createSignedReportUrl &&
     !!options.createSignedReportDownloadUrl
   );
@@ -256,13 +173,6 @@ async function resolveDeps(
     getReportById: options.getReportById ?? defaultDeps!.getReportById,
     getReportStatusHistory:
       options.getReportStatusHistory ?? defaultDeps!.getReportStatusHistory,
-    getClinicScopedStudyTrackingCase:
-      options.getClinicScopedStudyTrackingCase ??
-      defaultDeps!.getClinicScopedStudyTrackingCase,
-    updateStudyTrackingCase:
-      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
-    uploadReport: options.uploadReport ?? defaultDeps!.uploadReport,
-    upsertReport: options.upsertReport ?? defaultDeps!.upsertReport,
     createSignedReportUrl:
       options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
     createSignedReportDownloadUrl:
@@ -362,24 +272,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
 }
 
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const requestOrigin = getRequestOrigin(request);
-
-  if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
-    reply.code(403).send({
-      success: false,
-      error: "Origen no permitido",
-    });
-    return false;
-  }
-
-  return true;
-}
-
 function parseCookies(cookieHeader: string | undefined) {
   const result: Record<string, string> = {};
 
@@ -466,36 +358,6 @@ function buildClearSessionCookie() {
   });
 }
 
-function runReportUpload(
-  request: FastifyRequest,
-  reply: FastifyReply,
-): Promise<UploadedMultipartFile | undefined> {
-  return new Promise((resolve, reject) => {
-    upload.single("file")(
-      request.raw as any,
-      reply.raw as any,
-      (error: unknown) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve((request.raw as RawRequestWithFile).file);
-      },
-    );
-  });
-}
-
-function getMultipartBody(request: FastifyRequest) {
-  const body = (request.raw as RawRequestWithFile).body;
-
-  if (!body || typeof body !== "object") {
-    return {};
-  }
-
-  return body;
-}
-
 function shouldRefreshSessionLastAccess(
   lastAccess: Date | null | undefined,
   nowMs: number,
@@ -563,17 +425,12 @@ async function authenticateClinicUser(
   }
 
   const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
-  const permissions = getClinicPermissions(role);
-
   return {
     id: clinicUser.id,
     clinicId: clinicUser.clinicId,
     username: clinicUser.username,
     authProId: clinicUser.authProId ?? null,
     role,
-    permissions,
-    canUploadReports: permissions.canUploadReports,
-    canManageClinicUsers: permissions.canManageClinicUsers,
     sessionToken: token,
   };
 }
@@ -633,15 +490,6 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
   async (app, options) => {
     const now = options.now ?? (() => Date.now());
     const allowedOrigins = new Set(getAllowedOrigins());
-
-    if (!app.hasContentTypeParser("multipart/form-data")) {
-      app.addContentTypeParser(
-        "multipart/form-data",
-        (_request, _payload, done) => {
-          done(null, undefined);
-        },
-      );
-    }
 
     app.addHook("onRequest", async (request, reply) => {
       (request as ReportsFastifyRequest)[REQUEST_START_TIME_KEY] =
@@ -703,97 +551,6 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     app.options("/:reportId/history", optionsHandler);
     app.options("/:reportId/preview-url", optionsHandler);
     app.options("/:reportId/download-url", optionsHandler);
-
-    app.post("/upload", async (request, reply) => {
-      if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
-        return reply;
-      }
-
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
-
-      if (!auth) {
-        return reply;
-      }
-
-      if (!auth.canUploadReports) {
-        return reply.code(403).send({
-          success: false,
-          error: "No autorizado para subir informes",
-        });
-      }
-
-      let file: UploadedMultipartFile | undefined;
-
-      try {
-        file = await runReportUpload(request, reply);
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Error al procesar archivo";
-
-        return reply.code(400).send({
-          success: false,
-          error: message,
-        });
-      }
-
-      if (!file) {
-        return reply.code(400).send({
-          success: false,
-          error: "No se proporciono ningun archivo",
-        });
-      }
-
-      const clinicId = auth.clinicId;
-      const body = getMultipartBody(request);
-      const storagePath = await deps.uploadReport({
-        file: file.buffer,
-        fileName: file.originalname,
-        clinicId,
-        mimeType: file.mimetype,
-      });
-
-      const patientName = normalizeSearchText(body.patientName);
-      const studyType = normalizeSearchText(body.studyType);
-      const uploadDate = parseOptionalDate(body.uploadDate);
-      const trackingCaseId = parseReportId(body.trackingCaseId);
-
-      if (typeof trackingCaseId === "number") {
-        const trackingCase = await deps.getClinicScopedStudyTrackingCase(
-          trackingCaseId,
-          clinicId,
-        );
-
-        if (!trackingCase) {
-          return reply.code(404).send({
-            success: false,
-            error: "Seguimiento no encontrado para la clinica autenticada",
-          });
-        }
-      }
-
-      const report = await deps.upsertReport({
-        clinicId,
-        patientName: patientName ?? null,
-        studyType: studyType ?? null,
-        uploadDate: uploadDate ?? null,
-        fileName: file.originalname,
-        storagePath,
-        createdByClinicUserId: auth.id,
-      });
-
-      if (typeof trackingCaseId === "number") {
-        await deps.updateStudyTrackingCase(trackingCaseId, {
-          reportId: report.id,
-        });
-      }
-
-      return reply.code(201).send({
-        success: true,
-        message: "Archivo subido correctamente",
-        report: await serializeReport(report, deps),
-      });
-    });
 
     app.get<{
       Querystring: {

--- a/test/report-management-route-policy.test.ts
+++ b/test/report-management-route-policy.test.ts
@@ -32,7 +32,7 @@ test("reports protege PATCH /:reportId/status con management permission", () => 
   );
 });
 
-test("reports mantiene POST /upload nativo bloqueado por permiso de upload deshabilitado", () => {
+test("reports clinic read-only no registra POST /upload nativo", () => {
   const nativeSource = readRouteSource("server/routes/reports.fastify.ts");
 
   assert.equal(
@@ -41,41 +41,23 @@ test("reports mantiene POST /upload nativo bloqueado por permiso de upload desha
     "server/routes/reports.routes.ts ya no debe existir",
   );
 
-  assert.match(
-    nativeSource,
-    /app\.post\(\s*"\/upload"/s,
-  );
-  assert.match(
-    nativeSource,
-    /if \(!auth\.canUploadReports\)/,
-  );
-  assert.match(
-    nativeSource,
-    /error: "No autorizado para subir informes"/,
-  );
   assert.doesNotMatch(
     nativeSource,
-    /app\.post\(\s*"\/upload"[\s\S]*?canManageClinicUsers/s,
-    "POST /upload no debe exigir permiso de management de clinica",
+    /app\.post\(\s*"\/upload"/s,
+    "reports clinic no debe registrar POST /upload",
   );
+  assert.doesNotMatch(nativeSource, /runReportUpload|multer|deps\.uploadReport|deps\.upsertReport/);
+  assert.doesNotMatch(nativeSource, /createdByClinicUserId:\s*auth\.id/);
 });
 
-test("reports upload usa permisos persistentes read-only derivados de role y no allowlist ENV legacy", () => {
+test("reports clinic read-only conserva permisos persistentes sin allowlist ENV legacy", () => {
   const nativeSource = readRouteSource("server/routes/reports.fastify.ts");
   const permissionsSource = readRouteSource("server/lib/permissions.ts");
 
-  const uploadRouteStart = nativeSource.indexOf('app.post("/upload"');
-  const uploadRouteEnd = nativeSource.indexOf('app.get<{', uploadRouteStart);
-
-  assert.notEqual(uploadRouteStart, -1, "POST /upload debe existir");
-  assert.notEqual(uploadRouteEnd, -1, "Debe existir una ruta posterior a POST /upload");
-
-  const uploadRouteBlock = nativeSource.slice(uploadRouteStart, uploadRouteEnd);
-
   assert.match(
     nativeSource,
-    /const role = normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\);[\s\S]*const permissions = getClinicPermissions\(role\);[\s\S]*canUploadReports: permissions\.canUploadReports/s,
-    "La autenticacion de reports debe derivar canUploadReports desde el role persistente",
+    /const role = normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\);/s,
+    "La autenticacion de reports debe conservar normalizacion del role persistente",
   );
 
   assert.match(
@@ -96,18 +78,13 @@ test("reports upload usa permisos persistentes read-only derivados de role y no 
     "clinic_staff debe permanecer read-only sin upload ni management",
   );
 
-  assert.match(
-    uploadRouteBlock,
-    /if \(!auth\.canUploadReports\)/,
-    "POST /upload debe depender de auth.canUploadReports",
-  );
-
   assert.doesNotMatch(
-    uploadRouteBlock,
+    nativeSource,
     /LAB_UPLOAD_USERNAMES|labUploadUsernames|ENV\.labUploadUsernames/,
-    "POST /upload no debe depender de allowlists ENV legacy para autorizar uploads",
+    "reports clinic no debe depender de allowlists ENV legacy para autorizar uploads",
   );
 });
+
 test("report-access-tokens protege mutaciones nativas con management permission", () => {
   const source = readRouteSource("server/routes/report-access-tokens.fastify.ts");
 

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -79,18 +79,6 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     getStudyTypes: async () => ["Histopatología", "Citología"],
     getReportById: async () => createReportFixture(),
     getReportStatusHistory: async () => [createStatusHistoryFixture()],
-    getClinicScopedStudyTrackingCase: async () => ({
-      id: 77,
-      clinicId: 3,
-    }),
-    updateStudyTrackingCase: async () => {},
-    uploadReport: async () => "reports/3/luna-new.pdf",
-    upsertReport: async () =>
-      createReportFixture({
-        id: 88,
-        currentStatus: "uploaded",
-        storagePath: "reports/3/luna-new.pdf",
-      }),
     createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
       storagePath: string,
@@ -103,113 +91,28 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
   return app;
 }
 
-function buildMultipartReportPayload(options: { includeFile?: boolean } = {}) {
-  const boundary = "----vetneb-report-boundary";
-  const includeFile = options.includeFile ?? true;
-  const chunks = [
-    `--${boundary}\r\n`,
-    'Content-Disposition: form-data; name="patientName"\r\n\r\n',
-    "Luna Gomez",
-    `\r\n--${boundary}\r\n`,
-    'Content-Disposition: form-data; name="studyType"\r\n\r\n',
-    "Histopatologia",
-    `\r\n--${boundary}\r\n`,
-    'Content-Disposition: form-data; name="uploadDate"\r\n\r\n',
-    "2026-04-25T10:30:00.000Z",
-    `\r\n--${boundary}\r\n`,
-    'Content-Disposition: form-data; name="trackingCaseId"\r\n\r\n',
-    "77",
-  ];
+test("reportsNativeRoutes no registra POST /upload en superficie clinic read-only", async () => {
+  const app = await createTestApp({
+    getActiveSessionByToken: async () => {
+      throw new Error("POST /upload clinic no debe autenticar sesion");
+    },
+  });
 
-  if (includeFile) {
-    chunks.push(
-      `\r\n--${boundary}\r\n`,
-      'Content-Disposition: form-data; name="file"; filename="luna.pdf"\r\n',
-      "Content-Type: application/pdf\r\n\r\n",
-      "PDFDATA",
-    );
-  }
-
-  chunks.push(`\r\n--${boundary}--\r\n`);
-
-  return {
-    boundary,
-    payload: Buffer.from(chunks.join(""), "utf8"),
-  };
-}
-
-test("reportsNativeRoutes bloquea POST /upload para roles clinic", async () => {
-  for (const role of ["clinic_owner", "clinic_staff"] as const) {
-    const multipart = buildMultipartReportPayload();
-    const calls = {
-      uploadReport: 0,
-      upsertReport: 0,
-      getClinicScopedStudyTrackingCase: 0,
-      updateStudyTrackingCase: 0,
-    };
-
-    const app = await createTestApp({
-      getClinicUserById: async () => ({
-        id: 9,
-        clinicId: 3,
-        username: "doctor",
-        authProId: null,
-        role,
-      }),
-      uploadReport: async () => {
-        calls.uploadReport += 1;
-        return "reports/3/luna-new.pdf";
-      },
-      upsertReport: async () => {
-        calls.upsertReport += 1;
-        return createReportFixture({ id: 88 });
-      },
-      getClinicScopedStudyTrackingCase: async () => {
-        calls.getClinicScopedStudyTrackingCase += 1;
-        return {
-          id: 77,
-          clinicId: 3,
-        };
-      },
-      updateStudyTrackingCase: async () => {
-        calls.updateStudyTrackingCase += 1;
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
       },
     });
 
-    try {
-      const response = await app.inject({
-        method: "POST",
-        url: "/api/reports/upload",
-        headers: {
-          origin: "http://localhost:3000",
-          cookie: `${ENV.cookieName}=session-token`,
-          "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
-        },
-        payload: multipart.payload,
-      });
-
-      assert.equal(response.statusCode, 403, role);
-      assert.deepEqual(
-        JSON.parse(response.body),
-        {
-          success: false,
-          error: "No autorizado para subir informes",
-        },
-        role,
-      );
-      assert.deepEqual(
-        calls,
-        {
-          uploadReport: 0,
-          upsertReport: 0,
-          getClinicScopedStudyTrackingCase: 0,
-          updateStudyTrackingCase: 0,
-        },
-        role,
-      );
-    } finally {
-      await app.close();
-    }
+    assert.equal(response.statusCode, 404);
+    assert.equal(response.headers["set-cookie"], undefined);
+    assert.match(response.body, /POST:\/api\/reports\/upload|Route/);
+  } finally {
+    await app.close();
   }
 });
 

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -140,10 +140,6 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
       "Mutaciones clinic-scoped sensibles preservan origin, sesión y permiso antes de DB/storage/audit.",
     runtimeFiles: [
       {
-        path: "server/routes/reports.fastify.ts",
-        markers: ["auth.canUploadReports", "deps.uploadReport"],
-      },
-      {
         path: "server/routes/reports-status.fastify.ts",
         markers: ["requireReportStatusWritePermission", "deps.updateReportStatus"],
       },

--- a/test/security-mutation-permission-surface.test.ts
+++ b/test/security-mutation-permission-surface.test.ts
@@ -13,18 +13,6 @@ type SensitiveMutationRoute = {
 
 const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
   {
-    file: "server/routes/reports.fastify.ts",
-    method: "post",
-    path: "/upload",
-    permissionGuard: "auth.canUploadReports",
-    protectedCalls: [
-      "runReportUpload",
-      "deps.uploadReport",
-      "deps.upsertReport",
-      "deps.updateStudyTrackingCase",
-    ],
-  },
-  {
     file: "server/routes/reports-status.fastify.ts",
     method: "patch",
     path: "/:reportId/status",
@@ -269,22 +257,27 @@ test("permission helpers devuelven 403 estable antes de mutaciones sensibles", (
   }
 });
 
-test("reports upload conserva permiso de carga antes de storage y DB", () => {
-  const route = SENSITIVE_MUTATION_ROUTES.find(
-    (candidate) =>
-      candidate.file === "server/routes/reports.fastify.ts" &&
-      candidate.method === "post" &&
-      candidate.path === "/upload",
+test("reports clinic read-only no declara rutas mutantes ni storage upload", () => {
+  const source = readSource("server/routes/reports.fastify.ts");
+
+  assert.deepEqual(
+    extractActualMutatingRoutes("server/routes/reports.fastify.ts"),
+    [],
+    "reports clinic debe quedar limitado a rutas read-only",
   );
 
-  assert.ok(route);
-
-  const block = extractRouteBlock(route);
-
-  assertContains(block, "if (!auth.canUploadReports)", "reports upload");
-  assertContains(block, "No autorizado para subir informes", "reports upload");
-
-  for (const protectedCall of route.protectedCalls) {
-    assertBefore(block, "if (!auth.canUploadReports)", protectedCall, "reports upload");
+  for (const forbiddenMarker of [
+    "app.post(\"/upload\"",
+    "runReportUpload",
+    "auth.canUploadReports",
+    "deps.uploadReport",
+    "deps.upsertReport",
+    "deps.updateStudyTrackingCase",
+  ]) {
+    assert.equal(
+      source.includes(forbiddenMarker),
+      false,
+      `reports clinic read-only no debe contener marker: ${forbiddenMarker}`,
+    );
   }
 });

--- a/test/trusted-origin-router-policy.test.ts
+++ b/test/trusted-origin-router-policy.test.ts
@@ -24,15 +24,16 @@ test("clinic-public-profile nativo valida origin antes de auth en mutaciones", (
   );
 });
 
-test("reports nativos validan origin antes de auth en mutaciones", () => {
+test("reports clinic read-only no declara mutaciones y status valida origin antes de auth", () => {
   const reportsSource = readRouteSource("server/routes/reports.fastify.ts");
   const reportsStatusSource = readRouteSource(
     "server/routes/reports-status.fastify.ts",
   );
 
-  assert.match(
+  assert.doesNotMatch(
     reportsSource,
-    /app\.post\(\s*"\/upload"[\s\S]*?enforceTrustedOrigin\(request, reply, allowedOrigins\)[\s\S]*?authenticateClinicUser/s,
+    /app\.(post|patch|delete)(?:<[\s\S]*?>)?\(/,
+    "reports clinic debe quedar sin rutas mutantes",
   );
   assert.match(
     reportsStatusSource,


### PR DESCRIPTION
﻿## Summary

- Remove legacy clinic POST /api/reports/upload route from reports router.
- Keep clinic reports surface read-only: list, search, study-types, history, preview-url, download-url.
- Remove clinic upload storage/database dependencies from reports.fastify.ts.
- Preserve admin upload ownership through /api/admin/reports/upload from PR2.
- Update route policy, mutation registry, critical surface registry, trusted-origin guardrails and reports route tests.

## Validation

- pnpm typecheck: OK
- pnpm typecheck:test: OK
- pnpm test: OK — 529/529 passing
- PR3 focused block: OK — 57/57 passing
- git diff --check: OK
