### PR TITLE
feat(particular-audit): add particular audit route

### DIFF
--- a/server/db-audit.ts
+++ b/server/db-audit.ts
@@ -329,3 +329,85 @@ export async function listAuditLog(filters: AdminAuditListFilters) {
     total: Number(countRows[0]?.count ?? 0),
   };
 }
+
+export async function listParticularAuditLog(
+  filters: AdminAuditListFilters,
+  particularTokenId: number,
+) {
+  const columnsPresent = await getAuditLogColumns();
+  const scopedFilters: AdminAuditListFilters = {
+    ...filters,
+    clinicId: undefined,
+    actorAdminUserId: undefined,
+    actorClinicUserId: undefined,
+    actorReportAccessTokenId: undefined,
+    targetReportAccessTokenId: undefined,
+  };
+  const { whereSql: baseWhereSql, values: baseValues } =
+    buildAuditLogWhere(scopedFilters);
+
+  const scopePlaceholder = baseValues.length + 1;
+  const scopeClause =
+    `("actor_report_access_token_id" = $${scopePlaceholder} or "target_report_access_token_id" = $${scopePlaceholder + 1})`;
+  const whereSql = baseWhereSql
+    ? `${baseWhereSql} and ${scopeClause}`
+    : `where ${scopeClause}`;
+  const values = [...baseValues, particularTokenId, particularTokenId];
+
+  const selectAction = buildOptionalSelect(columnsPresent, "action", "null::text");
+  const selectEntity = buildOptionalSelect(columnsPresent, "entity", "null::text");
+  const selectEntityId = buildOptionalSelect(
+    columnsPresent,
+    "entity_id",
+    "null::integer",
+  );
+
+  const rows = await pgClient.unsafe(
+    `
+      select
+        "id",
+        "event",
+        ${selectAction},
+        ${selectEntity},
+        ${selectEntityId},
+        "actor_type",
+        "actor_admin_user_id",
+        "actor_clinic_user_id",
+        "actor_report_access_token_id",
+        "clinic_id",
+        "report_id",
+        "target_admin_user_id",
+        "target_clinic_user_id",
+        "target_report_access_token_id",
+        "request_id",
+        "request_method",
+        "request_path",
+        "ip_address",
+        "user_agent",
+        "metadata",
+        "created_at"
+      from "audit_log"
+      ${whereSql}
+      order by "created_at" desc, "id" desc
+      limit $${values.length + 1}
+      offset $${values.length + 2}
+    `,
+    [...values, filters.limit, filters.offset],
+  );
+
+  const countRows = await pgClient.unsafe(
+    `
+      select count(*)::int as count
+      from "audit_log"
+      ${whereSql}
+    `,
+    values,
+  );
+
+  return {
+    items: rows.map((row) =>
+      serializeAuditLogListItem(row as Record<string, unknown>),
+    ),
+    total: Number(countRows[0]?.count ?? 0),
+  };
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -41,6 +41,10 @@ import {
   type ClinicPublicProfileNativeRoutesOptions,
 } from "./routes/clinic-public-profile.fastify.ts";
 import {
+  particularAuditNativeRoutes,
+  type ParticularAuditNativeRoutesOptions,
+} from "./routes/particular-audit.fastify.ts";
+import {
   particularAuthNativeRoutes,
   type ParticularAuthNativeRoutesOptions,
 } from "./routes/particular-auth.fastify.ts";
@@ -152,6 +156,7 @@ export type CreateFastifyAppOptions = {
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
+  particularAuditRoutes?: ParticularAuditNativeRoutesOptions;
   particularAuthRoutes?: ParticularAuthNativeRoutesOptions;
   particularStudyTrackingRoutes?: ParticularStudyTrackingNativeRoutesOptions;
   particularTokensRoutes?: ParticularTokensNativeRoutesOptions;
@@ -283,6 +288,11 @@ export async function createFastifyApp(
   await app.register(clinicPublicProfileNativeRoutes, {
     prefix: "/api/clinic/profile",
     ...(options.clinicPublicProfileRoutes ?? {}),
+  });
+
+  await app.register(particularAuditNativeRoutes, {
+    prefix: "/api/particular/audit-log",
+    ...(options.particularAuditRoutes ?? {}),
   });
 
   await app.register(particularAuthNativeRoutes, {

--- a/server/lib/admin-audit.ts
+++ b/server/lib/admin-audit.ts
@@ -378,6 +378,30 @@ export function buildClinicAuditListFilters(
   };
 }
 
+export function buildParticularAuditListFilters(
+  query: Record<string, unknown>,
+): AdminAuditListFilterBuildResult {
+  const { filters, errors } = buildAdminAuditListFilters(query);
+
+  return {
+    errors,
+    filters: {
+      event: filters.event,
+      actorType: filters.actorType,
+      reportId: filters.reportId,
+      from: filters.from,
+      to: filters.to,
+      limit: filters.limit,
+      offset: filters.offset,
+      clinicId: undefined,
+      actorAdminUserId: undefined,
+      actorClinicUserId: undefined,
+      actorReportAccessTokenId: undefined,
+      targetReportAccessTokenId: undefined,
+    },
+  };
+}
+
 export function buildAdminAuditCsv(items: AuditLogListItem[]): string {
   const headerRow = AUDIT_LOG_CSV_HEADERS.join(",");
   const rows = items.map((item) => {
@@ -414,4 +438,9 @@ export function buildAdminAuditCsv(items: AuditLogListItem[]): string {
 export function buildAdminAuditCsvFilename(now = new Date()): string {
   const timestamp = now.toISOString().replace(/[:.]/g, "-");
   return `admin-audit-log-${timestamp}.csv`;
+}
+
+export function buildParticularAuditCsvFilename(now = new Date()): string {
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  return `particular-audit-log-${timestamp}.csv`;
 }

--- a/server/routes/particular-audit.fastify.ts
+++ b/server/routes/particular-audit.fastify.ts
@@ -1,0 +1,458 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import {
+  buildAdminAuditCsv as defaultBuildAuditCsv,
+  buildParticularAuditCsvFilename as defaultBuildParticularAuditCsvFilename,
+  buildParticularAuditListFilters as defaultBuildParticularAuditListFilters,
+  type AdminAuditListFilters,
+  type AuditLogListItem,
+} from "../lib/admin-audit.ts";
+import { ENV } from "../lib/env.ts";
+import {
+  buildRequestLogLine,
+  sanitizeUrlForLogs,
+} from "../middlewares/request-logger.ts";
+
+type ParticularSessionRecord = {
+  particularTokenId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type ParticularTokenAuthRecord = {
+  id: number;
+  clinicId: number;
+  reportId: number | null;
+  isActive: boolean;
+};
+
+type AuthenticatedParticularUser = {
+  tokenId: number;
+  clinicId: number;
+  reportId: number | null;
+  sessionToken: string;
+};
+
+type AuditListResult = {
+  items: AuditLogListItem[];
+  total: number;
+};
+
+export type ParticularAuditNativeRoutesOptions = {
+  deleteParticularSession?: (tokenHash: string) => Promise<void>;
+  getParticularSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ParticularSessionRecord | null>;
+  getParticularTokenById?: (
+    id: number,
+  ) => Promise<ParticularTokenAuthRecord | null>;
+  updateParticularSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  listParticularAuditLog?: (
+    filters: AdminAuditListFilters,
+    particularTokenId: number,
+  ) => Promise<AuditListResult>;
+  buildParticularAuditListFilters?: (
+    query: Record<string, unknown>,
+  ) => {
+    filters: AdminAuditListFilters;
+    errors: string[];
+  };
+  buildAuditCsv?: (items: AuditLogListItem[]) => string;
+  buildParticularAuditCsvFilename?: (now?: Date) => string;
+  now?: () => number;
+};
+
+const REQUEST_START_TIME_KEY = "__particularAuditRequestStartTimeNs";
+const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+const PARTICULAR_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
+
+type ParticularAuditFastifyRequest = FastifyRequest & {
+  [REQUEST_START_TIME_KEY]?: bigint;
+};
+
+type NativeParticularAuditDeps = Required<
+  Pick<
+    ParticularAuditNativeRoutesOptions,
+    | "deleteParticularSession"
+    | "getParticularSessionByToken"
+    | "getParticularTokenById"
+    | "updateParticularSessionLastAccess"
+    | "hashSessionToken"
+    | "listParticularAuditLog"
+    | "buildParticularAuditListFilters"
+    | "buildAuditCsv"
+    | "buildParticularAuditCsvFilename"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeParticularAuditDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeParticularAuditDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const authSecurity = await import("../lib/auth-security.ts");
+      const dbParticular = await import("../db-particular.ts");
+      const dbAudit = await import("../db-audit.ts");
+
+      return {
+        deleteParticularSession: dbParticular.deleteParticularSession,
+        getParticularSessionByToken: dbParticular.getParticularSessionByToken,
+        getParticularTokenById: dbParticular.getParticularTokenById,
+        updateParticularSessionLastAccess:
+          dbParticular.updateParticularSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        listParticularAuditLog: dbAudit.listParticularAuditLog,
+        buildParticularAuditListFilters:
+          defaultBuildParticularAuditListFilters,
+        buildAuditCsv: defaultBuildAuditCsv,
+        buildParticularAuditCsvFilename:
+          defaultBuildParticularAuditCsvFilename,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getParticularSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.particularCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearParticularSessionCookie() {
+  return serializeCookie({
+    name: ENV.particularCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
+}
+
+async function authenticateParticularUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeParticularAuditDeps,
+  now: () => number,
+): Promise<AuthenticatedParticularUser | null> {
+  const token = getParticularSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Particular no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getParticularSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión particular inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteParticularSession(tokenHash);
+
+    reply.header("set-cookie", buildClearParticularSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión particular expirada",
+    });
+    return null;
+  }
+
+  const particularToken = await deps.getParticularTokenById(
+    session.particularTokenId,
+  );
+
+  if (!particularToken || !particularToken.isActive) {
+    await deps.deleteParticularSession(tokenHash);
+
+    reply.header("set-cookie", buildClearParticularSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Token particular inválido o inactivo",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateParticularSessionLastAccess(tokenHash);
+  }
+
+  return {
+    tokenId: particularToken.id,
+    clinicId: particularToken.clinicId,
+    reportId: particularToken.reportId ?? null,
+    sessionToken: token,
+  };
+}
+
+export const particularAuditNativeRoutes: FastifyPluginAsync<
+  ParticularAuditNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteParticularSession &&
+    !!options.getParticularSessionByToken &&
+    !!options.getParticularTokenById &&
+    !!options.updateParticularSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.listParticularAuditLog &&
+    !!options.buildParticularAuditListFilters &&
+    !!options.buildAuditCsv &&
+    !!options.buildParticularAuditCsvFilename;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeParticularAuditDeps = {
+    deleteParticularSession:
+      options.deleteParticularSession ??
+      defaultDeps!.deleteParticularSession,
+    getParticularSessionByToken:
+      options.getParticularSessionByToken ??
+      defaultDeps!.getParticularSessionByToken,
+    getParticularTokenById:
+      options.getParticularTokenById ?? defaultDeps!.getParticularTokenById,
+    updateParticularSessionLastAccess:
+      options.updateParticularSessionLastAccess ??
+      defaultDeps!.updateParticularSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    listParticularAuditLog:
+      options.listParticularAuditLog ?? defaultDeps!.listParticularAuditLog,
+    buildParticularAuditListFilters:
+      options.buildParticularAuditListFilters ??
+      defaultDeps!.buildParticularAuditListFilters,
+    buildAuditCsv: options.buildAuditCsv ?? defaultDeps!.buildAuditCsv,
+    buildParticularAuditCsvFilename:
+      options.buildParticularAuditCsvFilename ??
+      defaultDeps!.buildParticularAuditCsvFilename,
+  };
+
+  const now = options.now ?? (() => Date.now());
+
+  app.addHook("onRequest", async (request) => {
+    (request as ParticularAuditFastifyRequest)[REQUEST_START_TIME_KEY] =
+      process.hrtime.bigint();
+
+    return undefined;
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const startedAt =
+      (request as ParticularAuditFastifyRequest)[REQUEST_START_TIME_KEY] ??
+      process.hrtime.bigint();
+
+    const durationMs =
+      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const safeUrl = sanitizeUrlForLogs(request.url);
+
+    console.log(
+      buildRequestLogLine({
+        timestamp: new Date().toISOString(),
+        method: request.method,
+        url: safeUrl,
+        statusCode: reply.statusCode,
+        durationMs,
+      }),
+    );
+  });
+
+  app.get<{
+    Querystring: Record<string, unknown>;
+  }>("/export.csv", async (request, reply) => {
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const { filters, errors } = deps.buildParticularAuditListFilters(
+      request.query ?? {},
+    );
+
+    if (errors.length > 0) {
+      return reply.code(400).send({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const exportFilters: AdminAuditListFilters = {
+      ...filters,
+      limit: PARTICULAR_AUDIT_CSV_EXPORT_MAX_ROWS,
+      offset: 0,
+    };
+
+    const result = await deps.listParticularAuditLog(
+      exportFilters,
+      particular.tokenId,
+    );
+
+    if (result.total > PARTICULAR_AUDIT_CSV_EXPORT_MAX_ROWS) {
+      return reply.code(400).send({
+        success: false,
+        error: `Demasiados registros para exportar. Aplica filtros mas especificos (maximo ${PARTICULAR_AUDIT_CSV_EXPORT_MAX_ROWS}).`,
+      });
+    }
+
+    const csv = deps.buildAuditCsv(result.items);
+    const filename = deps.buildParticularAuditCsvFilename();
+
+    reply.header("content-type", "text/csv; charset=utf-8");
+    reply.header(
+      "content-disposition",
+      `attachment; filename="${filename}"`,
+    );
+
+    return reply.code(200).send(csv);
+  });
+
+  app.get<{
+    Querystring: Record<string, unknown>;
+  }>("/", async (request, reply) => {
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const { filters, errors } = deps.buildParticularAuditListFilters(
+      request.query ?? {},
+    );
+
+    if (errors.length > 0) {
+      return reply.code(400).send({
+        success: false,
+        error: errors[0],
+      });
+    }
+
+    const result = await deps.listParticularAuditLog(
+      filters,
+      particular.tokenId,
+    );
+
+    return reply.code(200).send({
+      success: true,
+      count: result.items.length,
+      items: result.items,
+      pagination: {
+        limit: filters.limit,
+        offset: filters.offset,
+        total: result.total,
+      },
+      filters: {
+        event: filters.event ?? null,
+        actorType: filters.actorType ?? null,
+        reportId: filters.reportId ?? null,
+        particularTokenId: particular.tokenId,
+        from: filters.from ?? null,
+        to: filters.to ?? null,
+      },
+    });
+  });
+};

--- a/test/audit-separated-surfaces.test.ts
+++ b/test/audit-separated-surfaces.test.ts
@@ -52,6 +52,8 @@ test("audit surfaces quedan montadas por dominio sin aliases cruzados", () => {
       'prefix: "/api/admin/audit-log"',
       'clinicAuditNativeRoutes, {',
       'prefix: "/api/clinic/audit-log"',
+      'particularAuditNativeRoutes, {',
+      'prefix: "/api/particular/audit-log"',
     ],
     "createFastifyApp audit surfaces",
   );
@@ -81,10 +83,16 @@ test("audit surfaces quedan montadas por dominio sin aliases cruzados", () => {
     /prefix: "\/api\/admin\/audit-log"/,
     "clinic audit no debe montarse en superficie admin",
   );
-  assert.doesNotMatch(
+  const particularAuditRegister = extractRegisterBlock(
     source,
-    /prefix: "\/api\/particular\/audit-log"/,
-    "particular audit aún no debe existir como alias accidental de admin o clinic",
+    "particularAuditNativeRoutes",
+  );
+
+  assert.match(particularAuditRegister, /prefix: "\/api\/particular\/audit-log"/);
+  assert.doesNotMatch(
+    particularAuditRegister,
+    /prefix: "\/api\/admin\/audit-log"|prefix: "\/api\/clinic\/audit-log"/,
+    "particular audit no debe montarse en superficie admin o clinic",
   );
 });
 
@@ -180,26 +188,19 @@ test("audit filter helpers separan admin global de clinic scoped", () => {
   );
 });
 
-test("particular audit queda reservado para una ruta propia no mezclada", () => {
+test("particular audit mantiene superficie propia y cookie particular exclusiva", () => {
   const fastifyApp = readSource("server/fastify-app.ts");
-  const adminAudit = readSource("server/routes/admin-audit.fastify.ts");
-  const clinicAudit = readSource("server/routes/clinic-audit.fastify.ts");
+  const source = readSource("server/routes/particular-audit.fastify.ts");
 
-  for (const [file, source] of [
-    ["server/fastify-app.ts", fastifyApp],
-    ["server/routes/admin-audit.fastify.ts", adminAudit],
-    ["server/routes/clinic-audit.fastify.ts", clinicAudit],
-  ] as const) {
-    assert.doesNotMatch(
-      source,
-      /particularAuditNativeRoutes|ParticularAuditNativeRoutesOptions/,
-      `${file} no debe declarar particular audit mezclado con admin/clinic`,
-    );
-  }
+  assert.match(fastifyApp, /particularAuditNativeRoutes/);
+  assert.match(fastifyApp, /prefix: "\/api\/particular\/audit-log"/);
+  assert.match(source, /export type ParticularAuditNativeRoutesOptions/);
+  assert.match(source, /cookies\[ENV\.particularCookieName\]/);
+  assert.match(source, /authenticateParticularUser\(\s*request,\s*reply,\s*deps,\s*now,?\s*\)/s);
+  assert.match(source, /listParticularAuditLog\(\s*filters,\s*particular\.tokenId/s);
+  assert.match(source, /listParticularAuditLog\(\s*exportFilters,\s*particular\.tokenId/s);
+  assert.match(source, /particularTokenId: particular\.tokenId/);
 
-  assert.doesNotMatch(
-    fastifyApp,
-    /\/api\/particular\/audit-log/,
-    "la ruta particular audit debe agregarse en PR separado",
-  );
+  assert.doesNotMatch(source, /cookies\[ENV\.adminCookieName\]/);
+  assert.doesNotMatch(source, /cookies\[ENV\.cookieName\]/);
 });

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 
 process.env.NODE_ENV ??= "development";
@@ -285,6 +285,30 @@ function buildClinicPublicProfileRouteStubs() {
   };
 }
 
+function buildParticularAuditRouteStubs() {
+  return {
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listParticularAuditLog: async () => ({
+      items: [],
+      total: 0,
+    }),
+    buildParticularAuditListFilters: (_query: Record<string, unknown>) => ({
+      filters: {
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAuditCsv: () => "id,event",
+    buildParticularAuditCsvFilename: () =>
+      "particular-audit-log-test.csv",
+  };
+}
+
 function buildParticularAuthRouteStubs() {
   return {
     createParticularSession: async () => {},
@@ -497,6 +521,7 @@ function buildFastifyDispatchRouteStubs() {
     clinicAuthRoutes: buildClinicAuthRouteStubs(),
     clinicAuditRoutes: buildClinicAuditRouteStubs(),
     clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+    particularAuditRoutes: buildParticularAuditRouteStubs(),
     particularAuthRoutes: buildParticularAuthRouteStubs(),
     particularStudyTrackingRoutes: buildParticularStudyTrackingRouteStubs(),
     particularTokensRoutes: buildParticularTokensRouteStubs(),
@@ -540,6 +565,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -646,6 +672,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -713,6 +740,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -785,6 +813,7 @@ test(
       },
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -903,6 +932,7 @@ test(
         }),
       },
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -996,6 +1026,7 @@ test(
           },
         }),
       },
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1052,6 +1083,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: {
         ...buildParticularAuthRouteStubs(),
         getParticularSessionByToken: async () => ({
@@ -1156,6 +1188,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1221,6 +1254,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1335,6 +1369,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1495,6 +1530,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1590,6 +1626,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1645,6 +1682,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1698,6 +1736,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1755,6 +1794,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
@@ -1872,6 +1912,7 @@ test(
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: buildParticularAuditRouteStubs(),
       particularAuthRoutes: buildParticularAuthRouteStubs(),
       particularTokensRoutes: buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {

--- a/test/particular-audit.fastify.test.ts
+++ b/test/particular-audit.fastify.test.ts
@@ -1,0 +1,358 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  particularAuditNativeRoutes,
+} = await import("../server/routes/particular-audit.fastify.ts");
+
+function createAuditItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    event: "report.public_accessed",
+    action: "report.public_accessed",
+    entity: "report_access_token",
+    entityId: 7,
+    actorType: "public_report_access_token",
+    actorAdminUserId: null,
+    actorClinicUserId: null,
+    actorReportAccessTokenId: 7,
+    clinicId: 3,
+    reportId: 55,
+    targetAdminUserId: null,
+    targetClinicUserId: null,
+    targetReportAccessTokenId: 7,
+    requestId: "req-1",
+    requestMethod: "GET",
+    requestPath: "/api/public/report-access/[REDACTED]",
+    ipAddress: "127.0.0.1",
+    userAgent: "node:test",
+    metadata: { source: "public-report-access" },
+    createdAt: new Date("2026-04-22T09:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createAuthStubs(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => ({
+      particularTokenId: 7,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getParticularTokenById: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: 55,
+      isActive: true,
+    }),
+    updateParticularSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    ...overrides,
+  };
+}
+
+async function createTestApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(particularAuditNativeRoutes as any, {
+    prefix: "/api/particular/audit-log",
+    ...createAuthStubs(),
+    listParticularAuditLog: async () => ({
+      items: [createAuditItem()],
+      total: 1,
+    }),
+    buildParticularAuditListFilters: async () => {
+      throw new Error("buildParticularAuditListFilters debe ser síncrono");
+    },
+    buildAuditCsv: () => "\uFEFFid,event\n101,report.public_accessed",
+    buildParticularAuditCsvFilename: () =>
+      "particular-audit-log-2026-04-22.csv",
+    now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
+    ...overrides,
+  });
+
+  return app;
+}
+
+function buildFilters(query: Record<string, unknown>) {
+  const limit = Number(query.limit ?? 50);
+  const offset = Number(query.offset ?? 0);
+
+  if (query.event === "bad") {
+    return {
+      errors: ["event invalido"],
+      filters: {
+        limit,
+        offset,
+      },
+    };
+  }
+
+  return {
+    errors: [],
+    filters: {
+      event:
+        typeof query.event === "string" && query.event.length > 0
+          ? query.event
+          : undefined,
+      actorType:
+        typeof query.actorType === "string" && query.actorType.length > 0
+          ? query.actorType
+          : undefined,
+      reportId: query.reportId ? Number(query.reportId) : undefined,
+      limit,
+      offset,
+    },
+  };
+}
+
+test("particularAuditNativeRoutes expone GET / con scope por token particular", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    buildParticularAuditListFilters: buildFilters,
+    listParticularAuditLog: async (
+      filters: Record<string, unknown>,
+      particularTokenId: number,
+    ) => {
+      calls.push({ filters, particularTokenId });
+      return {
+        items: [createAuditItem()],
+        total: 1,
+      };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/audit-log?event=report.public_accessed&reportId=55&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls, [
+      {
+        particularTokenId: 7,
+        filters: {
+          event: "report.public_accessed",
+          actorType: undefined,
+          reportId: 55,
+          limit: 5,
+          offset: 2,
+        },
+      },
+    ]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.items[0].actorReportAccessTokenId, 7);
+    assert.equal(body.items[0].targetReportAccessTokenId, 7);
+    assert.deepEqual(body.pagination, {
+      limit: 5,
+      offset: 2,
+      total: 1,
+    });
+    assert.deepEqual(body.filters, {
+      event: "report.public_accessed",
+      actorType: null,
+      reportId: 55,
+      particularTokenId: 7,
+      from: null,
+      to: null,
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularAuditNativeRoutes exporta GET /export.csv con scope por token particular", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    buildParticularAuditListFilters: buildFilters,
+    listParticularAuditLog: async (
+      filters: Record<string, unknown>,
+      particularTokenId: number,
+    ) => {
+      calls.push({ filters, particularTokenId });
+      return {
+        items: [createAuditItem()],
+        total: 1,
+      };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/audit-log/export.csv?reportId=55&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.headers["content-disposition"],
+      'attachment; filename="particular-audit-log-2026-04-22.csv"',
+    );
+    assert.match(String(response.headers["content-type"]), /text\/csv/);
+    assert.match(response.body, /^﻿id,event/);
+    assert.deepEqual(calls, [
+      {
+        particularTokenId: 7,
+        filters: {
+          event: undefined,
+          actorType: undefined,
+          reportId: 55,
+          limit: 10000,
+          offset: 0,
+        },
+      },
+    ]);
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularAuditNativeRoutes devuelve 400 cuando filtros son invalidos", async () => {
+  const app = await createTestApp({
+    buildParticularAuditListFilters: buildFilters,
+    listParticularAuditLog: async () => {
+      throw new Error("filtros invalidos no deben consultar audit log");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/audit-log?event=bad",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "event invalido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularAuditNativeRoutes bloquea GET / sin cookie particular", async () => {
+  const app = await createTestApp({
+    getParticularSessionByToken: async () => {
+      throw new Error("sin cookie particular no debe buscar sesion");
+    },
+    listParticularAuditLog: async () => {
+      throw new Error("sin cookie particular no debe consultar audit log");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/audit-log",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Particular no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularAuditNativeRoutes limpia cookie cuando la sesion expira", async () => {
+  let deletedHash: string | undefined;
+
+  const app = await createTestApp({
+    getParticularSessionByToken: async () => ({
+      particularTokenId: 7,
+      expiresAt: new Date("2026-04-23T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-22T00:00:00.000Z"),
+    }),
+    deleteParticularSession: async (tokenHash: string) => {
+      deletedHash = tokenHash;
+    },
+    listParticularAuditLog: async () => {
+      throw new Error("sesion expirada no debe consultar audit log");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/audit-log",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(deletedHash, "hash:particular-session-token");
+    assert.match(
+      String(response.headers["set-cookie"]),
+      new RegExp(`${ENV.particularCookieName}=;`),
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularAuditNativeRoutes bloquea token particular inactivo antes de listar", async () => {
+  let deletedHash: string | undefined;
+
+  const app = await createTestApp({
+    getParticularTokenById: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: 55,
+      isActive: false,
+    }),
+    deleteParticularSession: async (tokenHash: string) => {
+      deletedHash = tokenHash;
+    },
+    listParticularAuditLog: async () => {
+      throw new Error("token inactivo no debe consultar audit log");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/audit-log",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(deletedHash, "hash:particular-session-token");
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Token particular inválido o inactivo",
+    });
+  } finally {
+    await app.close();
+  }
+});

--- a/test/security-cross-auth-surface-boundaries.test.ts
+++ b/test/security-cross-auth-surface-boundaries.test.ts
@@ -27,6 +27,7 @@ const adminFiles = [
 ] as const;
 
 const particularFiles = [
+  "server/routes/particular-audit.fastify.ts",
   "server/routes/particular-auth.fastify.ts",
   "server/routes/particular-study-tracking.fastify.ts",
 ] as const;
@@ -124,6 +125,7 @@ test("cross auth surface registry keeps every protected route family explicit", 
       "server/routes/admin-particular-tokens.fastify.ts",
       "server/routes/admin-report-access-tokens.fastify.ts",
       "server/routes/admin-study-tracking.fastify.ts",
+      "server/routes/particular-audit.fastify.ts",
       "server/routes/particular-auth.fastify.ts",
       "server/routes/particular-study-tracking.fastify.ts",
       "server/routes/public-report-access.fastify.ts",


### PR DESCRIPTION
﻿## Summary

- Add particular audit route at /api/particular/audit-log.
- Add CSV export at /api/particular/audit-log/export.csv.
- Authenticate with the particular session cookie only.
- Scope audit reads by particular token ownership:
  - actorReportAccessTokenId = authenticated token
  - OR targetReportAccessTokenId = authenticated token
- Add DB listing helper for particular audit OR-scope.
- Add particular audit filters and CSV filename helper.
- Mount particular audit router in Fastify app.
- Update separated audit surface and cross-auth guardrails.
- Add route coverage for list, CSV export, invalid filters, missing session, expired session and inactive token.

## Validation

- pnpm typecheck: OK
- pnpm typecheck:test: OK
- pnpm test: OK — 545/545 passing
- focused block: OK — 46/46 passing
- git diff --check: OK
