### PR TITLE
feat(audit): write audit log for admin report upload

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -33,6 +33,7 @@ export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
   "report.status.changed",
+  "report.uploaded",
   "report_access_token.created",
   "report_access_token.revoked",
   "report.public_accessed",

--- a/server/lib/audit-log.ts
+++ b/server/lib/audit-log.ts
@@ -11,6 +11,7 @@ export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
   "report.status.changed",
+  "report.uploaded",
   "report_access_token.created",
   "report_access_token.revoked",
   "report.public_accessed",

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -6,6 +6,7 @@ export const AUDIT_EVENTS = {
   ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
   CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
   REPORT_STATUS_CHANGED: "report.status.changed",
+  REPORT_UPLOADED: "report.uploaded",
   REPORT_ACCESS_TOKEN_CREATED: "report_access_token.created",
   REPORT_ACCESS_TOKEN_REVOKED: "report_access_token.revoked",
   REPORT_PUBLIC_ACCESSED: "report.public_accessed",

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -7,6 +7,7 @@ import multer from "multer";
 
 import type { Report } from "../../drizzle/schema";
 import type { Multer } from "multer";
+import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import { ALLOWED_MIME_TYPES } from "../lib/supabase.ts";
 import {
@@ -68,6 +69,17 @@ type AuthenticatedAdminUser = {
   sessionToken: string;
 };
 
+type AuditWriteInput = {
+  event: string;
+  clinicId?: number | null;
+  reportId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    adminUserId?: number | null;
+  };
+};
+
 export type AdminReportsNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
   getAdminSessionByToken?: (
@@ -84,6 +96,7 @@ export type AdminReportsNativeRoutesOptions = {
     storagePath: string,
     fileName?: string,
   ) => Promise<string>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   now?: () => number;
 };
 
@@ -129,6 +142,7 @@ type NativeAdminReportsDeps = Required<
     | "upsertReport"
     | "createSignedReportUrl"
     | "createSignedReportDownloadUrl"
+    | "writeAuditLog"
   >
 >;
 
@@ -140,6 +154,7 @@ async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const storage = await import("../lib/supabase.ts");
+      const audit = await import("../lib/audit.ts");
 
       return {
         deleteAdminSession: db.deleteAdminSession,
@@ -152,6 +167,10 @@ async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
         upsertReport: db.upsertReport,
         createSignedReportUrl: storage.createSignedReportUrl,
         createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
       };
     })();
   }
@@ -170,7 +189,8 @@ function hasAllInjectedDeps(options: AdminReportsNativeRoutesOptions) {
     !!options.uploadReport &&
     !!options.upsertReport &&
     !!options.createSignedReportUrl &&
-    !!options.createSignedReportDownloadUrl
+    !!options.createSignedReportDownloadUrl &&
+    !!options.writeAuditLog
   );
 }
 
@@ -199,6 +219,7 @@ async function resolveDeps(
     createSignedReportDownloadUrl:
       options.createSignedReportDownloadUrl ??
       defaultDeps!.createSignedReportDownloadUrl,
+    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
   };
 }
 
@@ -505,6 +526,22 @@ function getMultipartBody(request: FastifyRequest) {
   return body;
 }
 
+function createAuditRequestLike(
+  request: FastifyRequest,
+  admin: Pick<AuthenticatedAdminUser, "id" | "username">,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    adminAuth: {
+      id: admin.id,
+      username: admin.username,
+    },
+  };
+}
+
 async function serializeReport(report: Report, deps: NativeAdminReportsDeps) {
   const [previewUrl, downloadUrl] = await Promise.all([
     deps.createSignedReportUrl(report.storagePath),
@@ -659,6 +696,21 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
       fileName: file.originalname,
       storagePath,
       createdByAdminUserId: admin.id,
+    });
+
+    await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+      event: AUDIT_EVENTS.REPORT_UPLOADED,
+      clinicId: report.clinicId,
+      reportId: report.id,
+      metadata: {
+        fileName: file.originalname,
+        mimeType: file.mimetype,
+        storagePath,
+        patientName: patientName ?? null,
+        studyType: studyType ?? null,
+        uploadDate: uploadDate ?? null,
+        uploadedVia: "admin",
+      },
     });
 
     return reply.code(201).send({

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -64,6 +64,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       storagePath: string,
       fileName?: string,
     ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    writeAuditLog: async () => {},
     ...overrides,
   });
 
@@ -107,6 +108,7 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
   const uploadCalls: Array<Record<string, unknown>> = [];
   const upsertCalls: Array<Record<string, unknown>> = [];
   const clinicCalls: number[] = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
 
   const app = await createTestApp({
     getClinicById: async (clinicId: number) => {
@@ -138,6 +140,9 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
         fileName: input.fileName,
         storagePath: input.storagePath,
       });
+    },
+    writeAuditLog: async (req: unknown, input: Record<string, unknown>) => {
+      auditCalls.push({ req, input });
     },
   });
 
@@ -184,6 +189,63 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
       },
     );
 
+    assert.equal(auditCalls.length, 1);
+    assert.deepEqual(
+      auditCalls.map((call) => {
+        const input = call.input as Record<string, unknown>;
+        const metadata = input.metadata as Record<string, unknown> | undefined;
+
+        return {
+          req: call.req,
+          input: {
+            ...input,
+            metadata: {
+            ...(metadata ?? {}),
+            uploadDate:
+              metadata?.uploadDate instanceof Date
+                ? metadata.uploadDate.toISOString()
+                : metadata?.uploadDate,
+          },
+        },
+      };
+      }),
+      [
+        {
+          req: {
+            method: "POST",
+            originalUrl: "/api/admin/reports/upload",
+            ip: "127.0.0.1",
+            headers: {
+              origin: "http://localhost:3000",
+              cookie: `${ENV.adminCookieName}=admin-session-token`,
+              "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+              "user-agent": "lightMyRequest",
+              host: "localhost:80",
+              "content-length": String(multipart.payload.length),
+            },
+            adminAuth: {
+              id: 1,
+              username: "ADMIN",
+            },
+          },
+          input: {
+            event: "report.uploaded",
+            clinicId: 3,
+            reportId: 88,
+            metadata: {
+              fileName: "luna-report.pdf",
+              mimeType: "application/pdf",
+              storagePath: "reports/3/luna-report.pdf",
+              patientName: "Luna",
+              studyType: "Histopatologia",
+              uploadDate: "2026-04-22T09:00:00.000Z",
+              uploadedVia: "admin",
+            },
+          },
+        },
+      ],
+    );
+
     const body = JSON.parse(response.body);
     assert.equal(body.success, true);
     assert.equal(body.message, "Informe subido correctamente");
@@ -210,6 +272,9 @@ test("adminReportsNativeRoutes bloquea POST /upload con origin no permitido ante
     },
     uploadReport: async () => {
       throw new Error("origin no permitido no debe subir archivo");
+    },
+    writeAuditLog: async () => {
+      throw new Error("origin no permitido no debe auditar upload");
     },
     upsertReport: async () => {
       throw new Error("origin no permitido no debe persistir informe");
@@ -248,6 +313,9 @@ test("adminReportsNativeRoutes bloquea POST /upload sin sesion admin antes de st
       uploadCalls += 1;
       return "reports/3/luna-report.pdf";
     },
+    writeAuditLog: async () => {
+      throw new Error("sin sesion admin no debe auditar upload");
+    },
   });
 
   try {
@@ -285,6 +353,9 @@ test("adminReportsNativeRoutes requiere clinicId valido antes de storage", async
     upsertReport: async () => {
       upsertCalls += 1;
       return createReportFixture();
+    },
+    writeAuditLog: async () => {
+      throw new Error("clinicId invalido no debe auditar upload");
     },
   });
 

--- a/test/audit-critical-flow-writes.test.ts
+++ b/test/audit-critical-flow-writes.test.ts
@@ -267,10 +267,35 @@ test("rutas críticas auditadas mantienen writeAuditLog inyectable y default rea
   }
 });
 
-test("admin report upload aún no declara evento auditado dedicado", () => {
+test("admin report upload audita creación exitosa de informe por admin", () => {
   const source = readSource("server/routes/admin-reports.fastify.ts");
 
-  assert.match(source, /createdByAdminUserId: admin\.id/);
-  assert.doesNotMatch(source, /AUDIT_EVENTS/);
-  assert.doesNotMatch(source, /writeAuditLog/);
+  assertContainsAll(
+    source,
+    [
+      "writeAuditLog?:",
+      "writeAuditLog: audit.writeAuditLog",
+      "createdByAdminUserId: admin.id",
+      "await deps.writeAuditLog(createAuditRequestLike(request, admin), {",
+      "event: AUDIT_EVENTS.REPORT_UPLOADED",
+      "clinicId: report.clinicId",
+      "reportId: report.id",
+      "fileName: file.originalname",
+      "mimeType: file.mimetype",
+      "storagePath,",
+      "uploadedVia: \"admin\"",
+    ],
+    "admin report upload audit payload",
+  );
+
+  assertContainsInOrder(
+    source,
+    [
+      "const storagePath = await deps.uploadReport({",
+      "const report = await deps.upsertReport({",
+      "await deps.writeAuditLog(createAuditRequestLike(request, admin), {",
+      "return reply.code(201).send({",
+    ],
+    "admin report upload audit order",
+  );
 });

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -13,6 +13,7 @@ test("AUDIT_EVENTS conserva los eventos públicos esperados", () => {
     ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
     CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
     REPORT_STATUS_CHANGED: "report.status.changed",
+    REPORT_UPLOADED: "report.uploaded",
     REPORT_ACCESS_TOKEN_CREATED: "report_access_token.created",
     REPORT_ACCESS_TOKEN_REVOKED: "report_access_token.revoked",
     REPORT_PUBLIC_ACCESSED: "report.public_accessed",

--- a/test/report-write-surface-ownership.test.ts
+++ b/test/report-write-surface-ownership.test.ts
@@ -139,6 +139,7 @@ async function createAdminReportUploadApp(overrides: Record<string, unknown> = {
       storagePath: string,
       fileName?: string,
     ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    writeAuditLog: async () => {},
     now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
     ...overrides,
   });


### PR DESCRIPTION
﻿## Summary

- Add dedicated audit event for admin report uploads:
  - report.uploaded
  - AUDIT_EVENTS.REPORT_UPLOADED
- Wire writeAuditLog into /api/admin/reports/upload.
- Write audit log after successful storage upload and report upsert.
- Preserve admin actor context through adminAuth.
- Include upload metadata:
  - fileName
  - mimeType
  - storagePath
  - patientName
  - studyType
  - uploadDate
  - uploadedVia: admin
- Keep report write ownership guardrails updated.
- Allow audit filters/exports to recognize report.uploaded.

## Validation

- pnpm typecheck: OK
- pnpm typecheck:test: OK
- pnpm test: OK — 563/563 passing
- git diff --check: OK
