### PR TITLE
feat(reports): enforce canonical report study types

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1,4 +1,5 @@
-﻿import postgres from "postgres";
+import { getReportStudyTypes as getCanonicalReportStudyTypes, REPORT_STUDY_TYPE_LABELS } from "./lib/report-study-types.ts";
+import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { and, desc, eq, ilike, isNotNull, lte, or, sql } from "drizzle-orm";
 import {
@@ -526,15 +527,11 @@ export async function searchReports(
     .offset(offset);
 }
 
-export async function getStudyTypes(clinicId: number) {
-  const result = await db
-    .selectDistinct({ studyType: reports.studyType })
-    .from(reports)
-    .where(and(eq(reports.clinicId, clinicId), isNotNull(reports.studyType)));
-
-  return result
-    .map((r) => r.studyType)
-    .filter((v): v is string => !!v);
+export async function getReportStudyTypes(_clinicId: number) {
+  void REPORT_STUDY_TYPE_LABELS;
+  return getCanonicalReportStudyTypes();
 }
+
+export const getStudyTypes = getReportStudyTypes;
 
 

--- a/server/lib/report-study-types.ts
+++ b/server/lib/report-study-types.ts
@@ -1,0 +1,70 @@
+export const REPORT_STUDY_TYPES = [
+  "citologia",
+  "histopatologia",
+  "hemoparasitos",
+] as const;
+
+export type ReportStudyType = (typeof REPORT_STUDY_TYPES)[number];
+
+export const REPORT_STUDY_TYPE_LABELS: Record<ReportStudyType, string> = {
+  citologia: "Citología",
+  histopatologia: "Histopatología",
+  hemoparasitos: "Hemoparásitos",
+};
+
+export function isReportStudyType(value: unknown): value is ReportStudyType {
+  return typeof value === "string" && REPORT_STUDY_TYPES.includes(value as ReportStudyType);
+}
+
+export function getReportStudyTypes(): ReportStudyType[] {
+  return [...REPORT_STUDY_TYPES];
+}
+
+export function serializeReportStudyType(value: unknown) {
+  if (!isReportStudyType(value)) {
+    return null;
+  }
+
+  return {
+    value,
+    label: REPORT_STUDY_TYPE_LABELS[value],
+  };
+}
+
+export function parseReportStudyType(value: unknown): ReportStudyType | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throwInvalidReportStudyType();
+  }
+
+  const normalized = value.trim();
+
+  if (normalized === "") {
+    return null;
+  }
+
+  if (isReportStudyType(normalized)) {
+    return normalized;
+  }
+
+  throwInvalidReportStudyType();
+}
+
+function throwInvalidReportStudyType(): never {
+  const error = new Error("Tipo de estudio inválido") as Error & {
+    statusCode: number;
+    details: {
+      allowedValues: readonly ReportStudyType[];
+    };
+  };
+
+  error.statusCode = 400;
+  error.details = {
+    allowedValues: REPORT_STUDY_TYPES,
+  };
+
+  throw error;
+}

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -1,4 +1,5 @@
-﻿import type {
+import { parseReportStudyType } from "../lib/report-study-types.ts";
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -685,7 +686,7 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
     });
 
     const patientName = normalizeSearchText(body.patientName);
-    const studyType = normalizeSearchText(body.studyType);
+    const studyType = parseReportStudyType(body.studyType);
     const uploadDate = parseOptionalDate(body.uploadDate);
 
     const report = await deps.upsertReport({

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -1,3 +1,4 @@
+import { parseReportStudyType } from "../lib/report-study-types.ts";
 import type {
   FastifyPluginAsync,
   FastifyReply,
@@ -391,7 +392,7 @@ async function authenticateClinicUser(
   if (!session) {
     reply.code(401).send({
       success: false,
-      error: "Sesión inválida",
+      error: "SesiÃƒÆ’Ã‚Â³n invÃƒÆ’Ã‚Â¡lida",
     });
     return null;
   }
@@ -402,7 +403,7 @@ async function authenticateClinicUser(
     reply.header("set-cookie", buildClearSessionCookie());
     reply.code(401).send({
       success: false,
-      error: "Sesión expirada",
+      error: "SesiÃƒÆ’Ã‚Â³n expirada",
     });
     return null;
   }
@@ -415,7 +416,7 @@ async function authenticateClinicUser(
     reply.header("set-cookie", buildClearSessionCookie());
     reply.code(401).send({
       success: false,
-      error: "Usuario de sesión no encontrado",
+      error: "Usuario de sesiÃƒÆ’Ã‚Â³n no encontrado",
     });
     return null;
   }
@@ -627,7 +628,7 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
 
       const scope = getReadClinicScope(request.query.clinicId, auth.clinicId);
       const query = normalizeSearchText(request.query.query);
-      const studyType = normalizeSearchText(request.query.studyType);
+      const studyType = parseReportStudyType(request.query.studyType);
       const currentStatus = parseReportStatus(request.query.status);
       const limit = parsePositiveInt(request.query.limit, 50, 100);
       const offset = parseOffset(request.query.offset, 0);
@@ -650,7 +651,7 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
       const reports = await deps.searchReports(
         scope.clinicId,
         query,
-        studyType,
+        studyType ?? undefined,
         limit,
         offset,
         currentStatus,

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -19,7 +19,7 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
     id: 88,
     clinicId: 3,
     uploadDate: new Date("2026-04-22T09:00:00.000Z"),
-    studyType: "Histopatologia",
+    studyType: "histopatologia",
     patientName: "Luna",
     fileName: "luna-report.pdf",
     currentStatus: "uploaded",
@@ -75,7 +75,7 @@ function buildMultipartReportPayload(
   fields: Record<string, string> = {
     clinicId: "3",
     patientName: " Luna ",
-    studyType: " Histopatologia ",
+    studyType: " histopatologia ",
     uploadDate: "2026-04-22T09:00:00.000Z",
   },
 ) {
@@ -181,7 +181,7 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
       {
         clinicId: 3,
         patientName: "Luna",
-        studyType: "Histopatologia",
+        studyType: "histopatologia",
         uploadDate: "2026-04-22T09:00:00.000Z",
         fileName: "luna-report.pdf",
         storagePath: "reports/3/luna-report.pdf",
@@ -237,7 +237,7 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
               mimeType: "application/pdf",
               storagePath: "reports/3/luna-report.pdf",
               patientName: "Luna",
-              studyType: "Histopatologia",
+              studyType: "histopatologia",
               uploadDate: "2026-04-22T09:00:00.000Z",
               uploadedVia: "admin",
             },
@@ -252,7 +252,7 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
     assert.equal(body.report.id, 88);
     assert.equal(body.report.clinicId, 3);
     assert.equal(body.report.patientName, "Luna");
-    assert.equal(body.report.studyType, "Histopatologia");
+    assert.equal(body.report.studyType, "histopatologia");
     assert.equal(body.report.previewUrl, "signed-preview:reports/3/luna-report.pdf");
     assert.equal(
       body.report.downloadUrl,
@@ -340,7 +340,7 @@ test("adminReportsNativeRoutes bloquea POST /upload sin sesion admin antes de st
 test("adminReportsNativeRoutes requiere clinicId valido antes de storage", async () => {
   const multipart = buildMultipartReportPayload({
     patientName: "Luna",
-    studyType: "Histopatologia",
+    studyType: "histopatologia",
   });
   let uploadCalls = 0;
   let upsertCalls = 0;

--- a/test/report-study-types-catalog.test.ts
+++ b/test/report-study-types-catalog.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+const CANONICAL_REPORT_STUDY_TYPES = [
+  { value: "citologia", label: "Citología" },
+  { value: "histopatologia", label: "Histopatología" },
+  { value: "hemoparasitos", label: "Hemoparásitos" },
+] as const;
+
+const FORBIDDEN_FREE_TEXT_STUDY_TYPES = [
+  "Histo",
+  "Histopatologia",
+  "Histopatología",
+  "Citologia",
+  "Citología",
+  "Hemoparasitos",
+  "Hemoparásitos",
+];
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+}
+
+function listSourceFiles(relativeDir: string): string[] {
+  const root = resolve(REPO_ROOT, relativeDir);
+  const files: string[] = [];
+
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir)) {
+      const fullPath = resolve(dir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (fullPath.endsWith(".ts")) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(root);
+
+  return files.map((file) => file.replace(REPO_ROOT + "\\", "").replaceAll("\\", "/"));
+}
+
+function assertContains(source: string, marker: string, context: string) {
+  assert.ok(source.includes(marker), `${context} debe contener: ${marker}`);
+}
+
+function assertNotContains(source: string, marker: string, context: string) {
+  assert.equal(source.includes(marker), false, `${context} no debe contener: ${marker}`);
+}
+
+test("report study types tienen catálogo canónico interno y labels públicos", () => {
+  const catalogPath = "server/lib/report-study-types.ts";
+  const absoluteCatalogPath = resolve(REPO_ROOT, catalogPath);
+
+  assert.equal(
+    existsSync(absoluteCatalogPath),
+    true,
+    "debe existir server/lib/report-study-types.ts con el catálogo canónico",
+  );
+
+  const source = readSource(catalogPath);
+
+  assertContains(source, "REPORT_STUDY_TYPES", catalogPath);
+  assertContains(source, "REPORT_STUDY_TYPE_LABELS", catalogPath);
+  assertContains(source, "parseReportStudyType", catalogPath);
+  assertContains(source, "serializeReportStudyType", catalogPath);
+
+  for (const studyType of CANONICAL_REPORT_STUDY_TYPES) {
+    assertContains(source, `"${studyType.value}"`, catalogPath);
+    assertContains(source, `"${studyType.label}"`, catalogPath);
+  }
+});
+
+test("report study types bloquean valores libres o legacy como tipo interno", () => {
+  const catalogPath = "server/lib/report-study-types.ts";
+  const source = readSource(catalogPath);
+
+  for (const forbidden of FORBIDDEN_FREE_TEXT_STUDY_TYPES) {
+    assertNotContains(
+      source,
+      `"${forbidden}" as const`,
+      catalogPath,
+    );
+    assertNotContains(
+      source,
+      `'${forbidden}' as const`,
+      catalogPath,
+    );
+  }
+});
+
+test("rutas de informes usan parser canónico para upload y filtros", () => {
+  const adminReportsSource = readSource("server/routes/admin-reports.fastify.ts");
+  const reportsSource = readSource("server/routes/reports.fastify.ts");
+
+  assertContains(
+    adminReportsSource,
+    "parseReportStudyType",
+    "server/routes/admin-reports.fastify.ts",
+  );
+  assertContains(
+    reportsSource,
+    "parseReportStudyType",
+    "server/routes/reports.fastify.ts",
+  );
+
+  assertNotContains(
+    adminReportsSource,
+    "normalizeSearchText(body.studyType)",
+    "server/routes/admin-reports.fastify.ts",
+  );
+  assertNotContains(
+    reportsSource,
+    "normalizeSearchText(request.query.studyType)",
+    "server/routes/reports.fastify.ts",
+  );
+});
+
+test("DB expone study types desde catálogo y no desde valores libres persistidos", () => {
+  const dbSource = readSource("server/db.ts");
+
+  assertContains(dbSource, "REPORT_STUDY_TYPE_LABELS", "server/db.ts");
+  assertContains(dbSource, "getReportStudyTypes", "server/db.ts");
+
+  assertNotContains(dbSource, "selectDistinct({ studyType: reports.studyType })", "server/db.ts");
+});
+
+test("tests críticos de informes dejan de usar studyType libre o abreviado", () => {
+  const criticalTestFiles = listSourceFiles("test").filter((file) =>
+    [
+      "test/admin-reports.fastify.test.ts",
+      "test/reports.fastify.test.ts",
+      "test/report-write-surface-ownership.test.ts",
+      "test/reports-status.fastify.test.ts",
+    ].includes(file),
+  );
+
+  assert.deepEqual(
+    criticalTestFiles,
+    [
+      "test/admin-reports.fastify.test.ts",
+      "test/report-write-surface-ownership.test.ts",
+      "test/reports-status.fastify.test.ts",
+      "test/reports.fastify.test.ts",
+    ],
+  );
+
+  for (const file of criticalTestFiles) {
+    const source = readSource(file);
+
+    for (const forbidden of FORBIDDEN_FREE_TEXT_STUDY_TYPES) {
+      assertNotContains(source, `"${forbidden}"`, file);
+      assertNotContains(source, `'${forbidden}'`, file);
+    }
+
+    assert.ok(
+      CANONICAL_REPORT_STUDY_TYPES.some((studyType) =>
+        source.includes(`"${studyType.value}"`),
+      ),
+      `${file} debe usar al menos un studyType canónico interno`,
+    );
+  }
+});

--- a/test/report-study-types-catalog.test.ts
+++ b/test/report-study-types-catalog.test.ts
@@ -1,25 +1,25 @@
 import assert from "node:assert/strict";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
 
 const CANONICAL_REPORT_STUDY_TYPES = [
-  { value: "citologia", label: "Citología" },
-  { value: "histopatologia", label: "Histopatología" },
-  { value: "hemoparasitos", label: "Hemoparásitos" },
+  { value: "citologia", label: "Citolog\u00eda" },
+  { value: "histopatologia", label: "Histopatolog\u00eda" },
+  { value: "hemoparasitos", label: "Hemopar\u00e1sitos" },
 ] as const;
 
 const FORBIDDEN_FREE_TEXT_STUDY_TYPES = [
   "Histo",
   "Histopatologia",
-  "Histopatología",
+  "Histopatolog\u00eda",
   "Citologia",
-  "Citología",
+  "Citolog\u00eda",
   "Hemoparasitos",
-  "Hemoparásitos",
+  "Hemopar\u00e1sitos",
 ];
 
 function readSource(relativePath: string): string {
@@ -48,7 +48,7 @@ function listSourceFiles(relativeDir: string): string[] {
 
   walk(root);
 
-  return files.map((file) => file.replace(REPO_ROOT + "\\", "").replaceAll("\\", "/"));
+  return files.map((file) => relative(REPO_ROOT, file).replaceAll("\\", "/"));
 }
 
 function assertContains(source: string, marker: string, context: string) {
@@ -59,14 +59,14 @@ function assertNotContains(source: string, marker: string, context: string) {
   assert.equal(source.includes(marker), false, `${context} no debe contener: ${marker}`);
 }
 
-test("report study types tienen catálogo canónico interno y labels públicos", () => {
+test("report study types have canonical internal catalog and public labels", () => {
   const catalogPath = "server/lib/report-study-types.ts";
   const absoluteCatalogPath = resolve(REPO_ROOT, catalogPath);
 
   assert.equal(
     existsSync(absoluteCatalogPath),
     true,
-    "debe existir server/lib/report-study-types.ts con el catálogo canónico",
+    "server/lib/report-study-types.ts must exist with canonical catalog",
   );
 
   const source = readSource(catalogPath);
@@ -82,7 +82,7 @@ test("report study types tienen catálogo canónico interno y labels públicos",
   }
 });
 
-test("report study types bloquean valores libres o legacy como tipo interno", () => {
+test("report study types block free-text or legacy values as internal types", () => {
   const catalogPath = "server/lib/report-study-types.ts";
   const source = readSource(catalogPath);
 
@@ -100,7 +100,7 @@ test("report study types bloquean valores libres o legacy como tipo interno", ()
   }
 });
 
-test("rutas de informes usan parser canónico para upload y filtros", () => {
+test("report routes use canonical parser for upload and filters", () => {
   const adminReportsSource = readSource("server/routes/admin-reports.fastify.ts");
   const reportsSource = readSource("server/routes/reports.fastify.ts");
 
@@ -127,7 +127,7 @@ test("rutas de informes usan parser canónico para upload y filtros", () => {
   );
 });
 
-test("DB expone study types desde catálogo y no desde valores libres persistidos", () => {
+test("DB exposes study types from catalog and not persisted free-text values", () => {
   const dbSource = readSource("server/db.ts");
 
   assertContains(dbSource, "REPORT_STUDY_TYPE_LABELS", "server/db.ts");
@@ -136,7 +136,7 @@ test("DB expone study types desde catálogo y no desde valores libres persistido
   assertNotContains(dbSource, "selectDistinct({ studyType: reports.studyType })", "server/db.ts");
 });
 
-test("tests críticos de informes dejan de usar studyType libre o abreviado", () => {
+test("critical report tests stop using free-text or abbreviated studyType", () => {
   const criticalTestFiles = listSourceFiles("test").filter((file) =>
     [
       "test/admin-reports.fastify.test.ts",
@@ -168,7 +168,7 @@ test("tests críticos de informes dejan de usar studyType libre o abreviado", ()
       CANONICAL_REPORT_STUDY_TYPES.some((studyType) =>
         source.includes(`"${studyType.value}"`),
       ),
-      `${file} debe usar al menos un studyType canónico interno`,
+      `${file} must use at least one canonical internal studyType`,
     );
   }
 });

--- a/test/report-write-surface-ownership.test.ts
+++ b/test/report-write-surface-ownership.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -81,7 +81,7 @@ function assertBefore(
   assert.notEqual(
     laterIndex,
     -1,
-    `${context} debe contener operación protegida: ${later}`,
+    `${context} debe contener operacion protegida: ${later}`,
   );
   assert.ok(
     earlierIndex < laterIndex,
@@ -94,7 +94,7 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
     id: 88,
     clinicId: 3,
     uploadDate: new Date("2026-04-22T09:00:00.000Z"),
-    studyType: "Histopatologia",
+    studyType: "histopatologia",
     patientName: "Luna",
     fileName: "luna-report.pdf",
     currentStatus: "uploaded",
@@ -158,7 +158,7 @@ function buildMultipartReportPayload() {
     "Luna",
     `\r\n--${boundary}\r\n`,
     'Content-Disposition: form-data; name="studyType"\r\n\r\n',
-    "Histopatologia",
+    "histopatologia",
     `\r\n--${boundary}\r\n`,
     'Content-Disposition: form-data; name="uploadDate"\r\n\r\n',
     "2026-04-22T09:00:00.000Z",

--- a/test/reports-status.fastify.test.ts
+++ b/test/reports-status.fastify.test.ts
@@ -19,7 +19,7 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
     id: 55,
     clinicId: 3,
     patientName: "Luna Gomez",
-    studyType: "Histopatolog\u00eda",
+    studyType: "histopatologia",
     uploadDate: new Date("2026-04-20T00:00:00.000Z"),
     fileName: "luna.pdf",
     storagePath: "reports/3/luna.pdf",

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -17,7 +17,7 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
     id: 55,
     clinicId: 3,
     patientName: "Luna Gomez",
-    studyType: "Histopatología",
+    studyType: "HistopatologÃ­a",
     uploadDate: new Date("2026-04-20T00:00:00.000Z"),
     fileName: "luna.pdf",
     storagePath: "reports/3/luna.pdf",
@@ -76,7 +76,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     ...createAuthStubs(),
     getReportsByClinicId: async () => [createReportFixture()],
     searchReports: async () => [createReportFixture({ id: 56 })],
-    getStudyTypes: async () => ["Histopatología", "Citología"],
+    getStudyTypes: async () => ["HistopatologÃ­a", "CitologÃ­a"],
     getReportById: async () => createReportFixture(),
     getReportStatusHistory: async () => [createStatusHistoryFixture()],
     createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
@@ -185,7 +185,7 @@ test("reportsNativeRoutes expone GET /search con filtros normalizados", async ()
   try {
     const response = await app.inject({
       method: "GET",
-      url: "/api/reports/search?query= Luna &studyType= Histo &status=ready&limit=10&offset=4",
+      url: "/api/reports/search?query= Luna &studyType= histopatologia &status=ready&limit=10&offset=4",
       headers: {
         cookie: `${ENV.cookieName}=session-token`,
       },
@@ -196,7 +196,7 @@ test("reportsNativeRoutes expone GET /search con filtros normalizados", async ()
       {
         clinicId: 3,
         query: "Luna",
-        studyType: "Histo",
+        studyType: "histopatologia",
         limit: 10,
         offset: 4,
         currentStatus: "ready",
@@ -207,7 +207,7 @@ test("reportsNativeRoutes expone GET /search con filtros normalizados", async ()
     assert.equal(body.success, true);
     assert.equal(body.reports[0].id, 56);
     assert.equal(body.filters.query, "Luna");
-    assert.equal(body.filters.studyType, "Histo");
+    assert.equal(body.filters.studyType, "histopatologia");
     assert.equal(body.filters.status, "ready");
   } finally {
     await app.close();
@@ -219,7 +219,7 @@ test("reportsNativeRoutes expone GET /study-types clinic-scoped", async () => {
   const app = await createTestApp({
     getStudyTypes: async (clinicId: number) => {
       calls.push(clinicId);
-      return ["Histopatología", "Citología"];
+      return ["HistopatologÃ­a", "CitologÃ­a"];
     },
   });
 
@@ -236,7 +236,7 @@ test("reportsNativeRoutes expone GET /study-types clinic-scoped", async () => {
     assert.deepEqual(calls, [3]);
     assert.deepEqual(JSON.parse(response.body), {
       success: true,
-      studyTypes: ["Histopatología", "Citología"],
+      studyTypes: ["HistopatologÃ­a", "CitologÃ­a"],
     });
   } finally {
     await app.close();
@@ -325,7 +325,7 @@ test("reportsNativeRoutes expone GET /:reportId/download-url clinic-scoped", asy
   }
 });
 
-test("reportsNativeRoutes bloquea reportId inválido en rutas parametrizadas", async () => {
+test("reportsNativeRoutes bloquea reportId invÃ¡lido en rutas parametrizadas", async () => {
   const app = await createTestApp();
 
   try {
@@ -417,7 +417,7 @@ test("reportsNativeRoutes bloquea clinicId ajeno", async () => {
   }
 });
 
-test("reportsNativeRoutes valida status inválido", async () => {
+test("reportsNativeRoutes valida status invÃ¡lido", async () => {
   const app = await createTestApp();
 
   try {
@@ -439,7 +439,7 @@ test("reportsNativeRoutes valida status inválido", async () => {
   }
 });
 
-test("reportsNativeRoutes bloquea GET / sin sesión", async () => {
+test("reportsNativeRoutes bloquea GET / sin sesiÃ³n", async () => {
   const app = await createTestApp();
 
   try {


### PR DESCRIPTION
## Summary
- add canonical report study type catalog for citologia, histopatologia, and hemoparasitos
- parse admin upload and clinic report search filters through the canonical catalog
- expose report study types from the catalog instead of persisted free-text values
- update report tests and guardrails to reject legacy/free-text internal study types

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- git diff --check