### PR TITLE
feat(logistics-schema): add field visits base model

### DIFF
--- a/drizzle/migrations/0017_logistics_field_visits.sql
+++ b/drizzle/migrations/0017_logistics_field_visits.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS "field_visits" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "clinic_id" integer NOT NULL,
+  "source_type" varchar(40) DEFAULT 'manual' NOT NULL,
+  "source_id" integer,
+  "status" varchar(32) DEFAULT 'pending' NOT NULL,
+  "priority" integer DEFAULT 0 NOT NULL,
+  "criticality" varchar(32),
+  "service_duration_min" integer DEFAULT 0 NOT NULL,
+  "notes" text,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "visit_locations" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "field_visit_id" integer NOT NULL,
+  "address_raw" text NOT NULL,
+  "address_normalized" text,
+  "locality" varchar(255),
+  "country" varchar(255),
+  "lat" real,
+  "lng" real,
+  "geo_quality" varchar(32) DEFAULT 'missing' NOT NULL,
+  "geocode_source" varchar(100),
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "field_visits_clinic_id_idx" ON "field_visits" ("clinic_id");
+CREATE INDEX IF NOT EXISTS "field_visits_clinic_status_idx" ON "field_visits" ("clinic_id", "status");
+CREATE INDEX IF NOT EXISTS "field_visits_clinic_priority_created_at_idx" ON "field_visits" ("clinic_id", "priority", "created_at");
+CREATE INDEX IF NOT EXISTS "field_visits_clinic_source_idx" ON "field_visits" ("clinic_id", "source_type", "source_id");
+CREATE INDEX IF NOT EXISTS "field_visits_created_at_idx" ON "field_visits" ("created_at");
+
+CREATE INDEX IF NOT EXISTS "visit_locations_field_visit_id_idx" ON "visit_locations" ("field_visit_id");
+CREATE INDEX IF NOT EXISTS "visit_locations_geo_quality_idx" ON "visit_locations" ("geo_quality");
+CREATE INDEX IF NOT EXISTS "visit_locations_locality_country_idx" ON "visit_locations" ("locality", "country");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'field_visits_clinic_id_clinics_id_fk'
+  ) THEN
+    ALTER TABLE "field_visits"
+      ADD CONSTRAINT "field_visits_clinic_id_clinics_id_fk"
+      FOREIGN KEY ("clinic_id") REFERENCES "clinics"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'visit_locations_field_visit_id_field_visits_id_fk'
+  ) THEN
+    ALTER TABLE "visit_locations"
+      ADD CONSTRAINT "visit_locations_field_visit_id_field_visits_id_fk"
+      FOREIGN KEY ("field_visit_id") REFERENCES "field_visits"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
                         "when":  1776442203568,
                         "tag":  "0016_audit_log",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  17,
+                        "version":  "7",
+                        "when":  1776442203569,
+                        "tag":  "0017_logistics_field_visits",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -4,12 +4,13 @@ import {
   integer,
   jsonb,
   pgTable,
+  real,
   serial,
   text,
   timestamp,
   varchar,
 } from "drizzle-orm/pg-core";
-import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const CLINIC_USER_ROLES = ["clinic_owner", "clinic_staff"] as const;
 export type ClinicUserRole = (typeof CLINIC_USER_ROLES)[number];
@@ -21,6 +22,31 @@ export const REPORT_STATUSES = [
   "delivered",
 ] as const;
 export type ReportStatus = (typeof REPORT_STATUSES)[number];
+export const FIELD_VISIT_SOURCE_TYPES = [
+  "report",
+  "study_tracking_case",
+  "manual",
+] as const;
+export type FieldVisitSourceType = (typeof FIELD_VISIT_SOURCE_TYPES)[number];
+
+export const FIELD_VISIT_STATUSES = [
+  "pending",
+  "scheduled",
+  "in_progress",
+  "done",
+  "canceled",
+  "no_show",
+] as const;
+export type FieldVisitStatus = (typeof FIELD_VISIT_STATUSES)[number];
+
+export const VISIT_LOCATION_GEO_QUALITIES = [
+  "exact",
+  "approx",
+  "missing",
+  "ambiguous",
+] as const;
+export type VisitLocationGeoQuality =
+  (typeof VISIT_LOCATION_GEO_QUALITIES)[number];
 export const AUDIT_ACTOR_TYPES = [
   "system",
   "admin_user",
@@ -559,6 +585,80 @@ export const studyTrackingNotifications = pgTable(
   }),
 );
 
+export const fieldVisits = pgTable(
+  "field_visits",
+  {
+    id: serial("id").primaryKey(),
+    clinicId: integer("clinic_id")
+      .notNull()
+      .references(() => clinics.id, { onDelete: "cascade" }),
+    sourceType: varchar("source_type", { length: 40 })
+      .$type<FieldVisitSourceType>()
+      .notNull()
+      .default("manual"),
+    sourceId: integer("source_id"),
+    status: varchar("status", { length: 32 })
+      .$type<FieldVisitStatus>()
+      .notNull()
+      .default("pending"),
+    priority: integer("priority").default(0).notNull(),
+    criticality: varchar("criticality", { length: 32 }),
+    serviceDurationMin: integer("service_duration_min").default(0).notNull(),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    clinicIdIdx: index("field_visits_clinic_id_idx").on(table.clinicId),
+    clinicStatusIdx: index("field_visits_clinic_status_idx").on(
+      table.clinicId,
+      table.status,
+    ),
+    clinicPriorityCreatedAtIdx: index(
+      "field_visits_clinic_priority_created_at_idx",
+    ).on(table.clinicId, table.priority, table.createdAt),
+    clinicSourceIdx: index("field_visits_clinic_source_idx").on(
+      table.clinicId,
+      table.sourceType,
+      table.sourceId,
+    ),
+    createdAtIdx: index("field_visits_created_at_idx").on(table.createdAt),
+  }),
+);
+
+export const visitLocations = pgTable(
+  "visit_locations",
+  {
+    id: serial("id").primaryKey(),
+    fieldVisitId: integer("field_visit_id")
+      .notNull()
+      .references(() => fieldVisits.id, { onDelete: "cascade" }),
+    addressRaw: text("address_raw").notNull(),
+    addressNormalized: text("address_normalized"),
+    locality: varchar("locality", { length: 255 }),
+    country: varchar("country", { length: 255 }),
+    lat: real("lat"),
+    lng: real("lng"),
+    geoQuality: varchar("geo_quality", { length: 32 })
+      .$type<VisitLocationGeoQuality>()
+      .notNull()
+      .default("missing"),
+    geocodeSource: varchar("geocode_source", { length: 100 }),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    fieldVisitIdIdx: index("visit_locations_field_visit_id_idx").on(
+      table.fieldVisitId,
+    ),
+    geoQualityIdx: index("visit_locations_geo_quality_idx").on(
+      table.geoQuality,
+    ),
+    localityCountryIdx: index("visit_locations_locality_country_idx").on(
+      table.locality,
+      table.country,
+    ),
+  }),
+);
 export const particularSessions = pgTable(
   "particular_sessions",
   {
@@ -610,6 +710,11 @@ export type NewAdminSession = InferInsertModel<typeof adminSessions>;
 
 export type ParticularToken = InferSelectModel<typeof particularTokens>;
 export type NewParticularToken = InferInsertModel<typeof particularTokens>;
+export type FieldVisit = InferSelectModel<typeof fieldVisits>;
+export type NewFieldVisit = InferInsertModel<typeof fieldVisits>;
+
+export type VisitLocation = InferSelectModel<typeof visitLocations>;
+export type NewVisitLocation = InferInsertModel<typeof visitLocations>;
 
 export type ClinicPublicProfile = InferSelectModel<typeof clinicPublicProfiles>;
 export type NewClinicPublicProfile = InferInsertModel<typeof clinicPublicProfiles>;

--- a/pr188-body.md
+++ b/pr188-body.md
@@ -1,0 +1,29 @@
+﻿## Summary
+
+- add logistics field visit source/status contracts to the schema
+- add `field_visits` with tenant-first indexes
+- add `visit_locations` with optional coordinates and explicit geo quality
+- add migration `0017_logistics_field_visits`
+- add schema/migration guard tests for the logistics base model
+
+## Scope
+
+Schema-only PR for logistics Phase 1 base model.
+
+## Out of scope
+
+- no API endpoints
+- no route plans
+- no route stops
+- no route events
+- no SLA tables
+- no geocoding
+- no external map provider
+- no route optimization
+- no VRP/TSP/A*/Dijkstra/ACO
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/test/logistics-field-visits-schema.test.ts
+++ b/test/logistics-field-visits-schema.test.ts
@@ -1,0 +1,127 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  FIELD_VISIT_SOURCE_TYPES,
+  FIELD_VISIT_STATUSES,
+  VISIT_LOCATION_GEO_QUALITIES,
+  fieldVisits,
+  visitLocations,
+} from "../drizzle/schema.ts";
+
+function assertNormalizedUniqueValues(
+  values: readonly string[],
+  label: string,
+) {
+  const unique = new Set(values);
+
+  assert.equal(unique.size, values.length, `${label} no debe repetir valores`);
+
+  for (const value of values) {
+    assert.equal(typeof value, "string");
+    assert.equal(value.trim(), value, `${label} no debe contener espacios`);
+    assert.equal(value.length > 0, true, `${label} no debe contener vacíos`);
+    assert.match(
+      value,
+      /^[a-z_]+$/,
+      `${label} debe usar valores snake_case normalizados`,
+    );
+  }
+}
+
+test("logistics field visit source types conserva el contrato MVP", () => {
+  assert.deepEqual(FIELD_VISIT_SOURCE_TYPES, [
+    "report",
+    "study_tracking_case",
+    "manual",
+  ]);
+
+  assertNormalizedUniqueValues(
+    FIELD_VISIT_SOURCE_TYPES,
+    "FIELD_VISIT_SOURCE_TYPES",
+  );
+});
+
+test("logistics field visit statuses conserva el contrato MVP", () => {
+  assert.deepEqual(FIELD_VISIT_STATUSES, [
+    "pending",
+    "scheduled",
+    "in_progress",
+    "done",
+    "canceled",
+    "no_show",
+  ]);
+
+  assertNormalizedUniqueValues(FIELD_VISIT_STATUSES, "FIELD_VISIT_STATUSES");
+});
+
+test("visit location geo qualities conserva el contrato MVP", () => {
+  assert.deepEqual(VISIT_LOCATION_GEO_QUALITIES, [
+    "exact",
+    "approx",
+    "missing",
+    "ambiguous",
+  ]);
+
+  assertNormalizedUniqueValues(
+    VISIT_LOCATION_GEO_QUALITIES,
+    "VISIT_LOCATION_GEO_QUALITIES",
+  );
+});
+
+test("logistics schema exports field visits and visit locations tables", () => {
+  assert.equal(typeof fieldVisits, "object");
+  assert.equal(typeof visitLocations, "object");
+});
+
+test("logistics field visits migration creates tenant-first schema", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0017_logistics_field_visits.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "field_visits"/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "visit_locations"/);
+  assert.match(migration, /"clinic_id" integer NOT NULL/);
+  assert.match(migration, /"source_type" varchar\(40\) DEFAULT 'manual' NOT NULL/);
+  assert.match(migration, /"status" varchar\(32\) DEFAULT 'pending' NOT NULL/);
+  assert.match(migration, /"geo_quality" varchar\(32\) DEFAULT 'missing' NOT NULL/);
+  assert.match(migration, /"lat" real/);
+  assert.match(migration, /"lng" real/);
+  assert.match(migration, /ON DELETE CASCADE ON UPDATE NO ACTION/);
+  assert.match(migration, /field_visits_clinic_id_idx/);
+  assert.match(migration, /field_visits_clinic_status_idx/);
+  assert.match(migration, /field_visits_clinic_priority_created_at_idx/);
+  assert.match(migration, /field_visits_clinic_source_idx/);
+  assert.match(migration, /visit_locations_field_visit_id_idx/);
+});
+
+test("logistics migration is registered in drizzle journal", () => {
+  const journal = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "meta",
+      "_journal.json",
+    ),
+    "utf8",
+  );
+
+  const parsed = JSON.parse(journal) as {
+    entries?: Array<{ idx?: number; tag?: string }>;
+  };
+
+  const entry = parsed.entries?.find(
+    (item) => item.tag === "0017_logistics_field_visits",
+  );
+
+  assert.ok(entry, "journal debe registrar 0017_logistics_field_visits");
+  assert.equal(entry?.idx, 17);
+});


### PR DESCRIPTION
﻿## Summary

- add logistics field visit source/status contracts to the schema
- add `field_visits` with tenant-first indexes
- add `visit_locations` with optional coordinates and explicit geo quality
- add migration `0017_logistics_field_visits`
- add schema/migration guard tests for the logistics base model

## Scope

Schema-only PR for logistics Phase 1 base model.

## Out of scope

- no API endpoints
- no route plans
- no route stops
- no route events
- no SLA tables
- no geocoding
- no external map provider
- no route optimization
- no VRP/TSP/A*/Dijkstra/ACO

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
