### PR TITLE
feat(logistics-schema): add time windows

### DIFF
--- a/drizzle/migrations/0018_logistics_time_windows.sql
+++ b/drizzle/migrations/0018_logistics_time_windows.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS "time_windows" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "field_visit_id" integer NOT NULL,
+  "window_start" timestamp NOT NULL,
+  "window_end" timestamp NOT NULL,
+  "timezone" varchar(64) DEFAULT 'UTC' NOT NULL,
+  "is_hard" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "time_windows_window_range_chk" CHECK ("window_start" < "window_end")
+);
+
+CREATE INDEX IF NOT EXISTS "time_windows_field_visit_id_idx" ON "time_windows" ("field_visit_id");
+CREATE INDEX IF NOT EXISTS "time_windows_window_start_idx" ON "time_windows" ("window_start");
+CREATE INDEX IF NOT EXISTS "time_windows_window_end_idx" ON "time_windows" ("window_end");
+CREATE INDEX IF NOT EXISTS "time_windows_field_visit_window_start_idx" ON "time_windows" ("field_visit_id", "window_start");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'time_windows_field_visit_id_field_visits_id_fk'
+  ) THEN
+    ALTER TABLE "time_windows"
+      ADD CONSTRAINT "time_windows_field_visit_id_field_visits_id_fk"
+      FOREIGN KEY ("field_visit_id") REFERENCES "field_visits"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
                         "when":  1776442203569,
                         "tag":  "0017_logistics_field_visits",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  18,
+                        "version":  "7",
+                        "when":  1776442203570,
+                        "tag":  "0018_logistics_time_windows",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -659,6 +659,33 @@ export const visitLocations = pgTable(
     ),
   }),
 );
+export const timeWindows = pgTable(
+  "time_windows",
+  {
+    id: serial("id").primaryKey(),
+    fieldVisitId: integer("field_visit_id")
+      .notNull()
+      .references(() => fieldVisits.id, { onDelete: "cascade" }),
+    windowStart: timestamp("window_start", { mode: "date" }).notNull(),
+    windowEnd: timestamp("window_end", { mode: "date" }).notNull(),
+    timezone: varchar("timezone", { length: 64 }).notNull().default("UTC"),
+    isHard: boolean("is_hard").default(true).notNull(),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    fieldVisitIdIdx: index("time_windows_field_visit_id_idx").on(
+      table.fieldVisitId,
+    ),
+    windowStartIdx: index("time_windows_window_start_idx").on(
+      table.windowStart,
+    ),
+    windowEndIdx: index("time_windows_window_end_idx").on(table.windowEnd),
+    fieldVisitWindowStartIdx: index(
+      "time_windows_field_visit_window_start_idx",
+    ).on(table.fieldVisitId, table.windowStart),
+  }),
+);
 export const particularSessions = pgTable(
   "particular_sessions",
   {
@@ -715,6 +742,8 @@ export type NewFieldVisit = InferInsertModel<typeof fieldVisits>;
 
 export type VisitLocation = InferSelectModel<typeof visitLocations>;
 export type NewVisitLocation = InferInsertModel<typeof visitLocations>;
+export type TimeWindow = InferSelectModel<typeof timeWindows>;
+export type NewTimeWindow = InferInsertModel<typeof timeWindows>;
 
 export type ClinicPublicProfile = InferSelectModel<typeof clinicPublicProfiles>;
 export type NewClinicPublicProfile = InferInsertModel<typeof clinicPublicProfiles>;

--- a/pr189-body.md
+++ b/pr189-body.md
@@ -1,0 +1,30 @@
+## Summary
+
+- add `time_windows` linked to `field_visits`
+- enforce `window_start < window_end` in the SQL migration
+- add explicit timezone and hard/soft window fields
+- add deterministic time window validation helpers
+- add schema/migration/validation guard tests
+
+## Scope
+
+Schema-only PR for logistics Phase 1 time windows.
+
+## Out of scope
+
+- no API endpoints
+- no route plans
+- no route stops
+- no route events
+- no SLA tables
+- no time-window compliance metrics
+- no geocoding
+- no external map provider
+- no route optimization
+- no VRP/TSP/A*/Dijkstra/ACO
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/server/lib/logistics/time-window.ts
+++ b/server/lib/logistics/time-window.ts
@@ -1,0 +1,40 @@
+export const DEFAULT_TIME_WINDOW_TIMEZONE = "UTC";
+export const TIME_WINDOW_TIMEZONE_MAX_LENGTH = 64;
+
+export function isValidTimeWindowRange(
+  windowStart: Date,
+  windowEnd: Date,
+): boolean {
+  return (
+    windowStart instanceof Date &&
+    windowEnd instanceof Date &&
+    Number.isFinite(windowStart.getTime()) &&
+    Number.isFinite(windowEnd.getTime()) &&
+    windowStart.getTime() < windowEnd.getTime()
+  );
+}
+
+export function normalizeTimeWindowTimezone(
+  timezone: string | null | undefined,
+): string {
+  const normalized = timezone?.trim();
+
+  if (!normalized) {
+    return DEFAULT_TIME_WINDOW_TIMEZONE;
+  }
+
+  if (normalized.length > TIME_WINDOW_TIMEZONE_MAX_LENGTH) {
+    return normalized.slice(0, TIME_WINDOW_TIMEZONE_MAX_LENGTH);
+  }
+
+  return normalized;
+}
+
+export function assertValidTimeWindowRange(
+  windowStart: Date,
+  windowEnd: Date,
+): void {
+  if (!isValidTimeWindowRange(windowStart, windowEnd)) {
+    throw new Error("windowStart must be earlier than windowEnd");
+  }
+}

--- a/test/logistics-time-windows-schema.test.ts
+++ b/test/logistics-time-windows-schema.test.ts
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { timeWindows } from "../drizzle/schema.ts";
+import {
+  DEFAULT_TIME_WINDOW_TIMEZONE,
+  TIME_WINDOW_TIMEZONE_MAX_LENGTH,
+  assertValidTimeWindowRange,
+  isValidTimeWindowRange,
+  normalizeTimeWindowTimezone,
+} from "../server/lib/logistics/time-window.ts";
+
+test("logistics schema exports time windows table", () => {
+  assert.equal(typeof timeWindows, "object");
+});
+
+test("isValidTimeWindowRange accepts start before end", () => {
+  assert.equal(
+    isValidTimeWindowRange(
+      new Date("2026-05-03T10:00:00.000Z"),
+      new Date("2026-05-03T11:00:00.000Z"),
+    ),
+    true,
+  );
+});
+
+test("isValidTimeWindowRange rejects equal inverted or invalid dates", () => {
+  assert.equal(
+    isValidTimeWindowRange(
+      new Date("2026-05-03T10:00:00.000Z"),
+      new Date("2026-05-03T10:00:00.000Z"),
+    ),
+    false,
+  );
+
+  assert.equal(
+    isValidTimeWindowRange(
+      new Date("2026-05-03T11:00:00.000Z"),
+      new Date("2026-05-03T10:00:00.000Z"),
+    ),
+    false,
+  );
+
+  assert.equal(
+    isValidTimeWindowRange(
+      new Date("invalid"),
+      new Date("2026-05-03T10:00:00.000Z"),
+    ),
+    false,
+  );
+});
+
+test("assertValidTimeWindowRange throws for invalid ranges", () => {
+  assert.doesNotThrow(() => {
+    assertValidTimeWindowRange(
+      new Date("2026-05-03T10:00:00.000Z"),
+      new Date("2026-05-03T11:00:00.000Z"),
+    );
+  });
+
+  assert.throws(
+    () => {
+      assertValidTimeWindowRange(
+        new Date("2026-05-03T10:00:00.000Z"),
+        new Date("2026-05-03T10:00:00.000Z"),
+      );
+    },
+    /windowStart must be earlier than windowEnd/,
+  );
+});
+
+test("normalizeTimeWindowTimezone applies explicit UTC default and trims", () => {
+  assert.equal(DEFAULT_TIME_WINDOW_TIMEZONE, "UTC");
+  assert.equal(normalizeTimeWindowTimezone(undefined), "UTC");
+  assert.equal(normalizeTimeWindowTimezone(null), "UTC");
+  assert.equal(normalizeTimeWindowTimezone("   "), "UTC");
+  assert.equal(normalizeTimeWindowTimezone(" America/Argentina/Cordoba "), "America/Argentina/Cordoba");
+});
+
+test("normalizeTimeWindowTimezone caps timezone length", () => {
+  const longTimezone = "A".repeat(TIME_WINDOW_TIMEZONE_MAX_LENGTH + 20);
+  const normalized = normalizeTimeWindowTimezone(longTimezone);
+
+  assert.equal(normalized.length, TIME_WINDOW_TIMEZONE_MAX_LENGTH);
+});
+
+test("logistics time windows migration creates validation and indexes", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0018_logistics_time_windows.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "time_windows"/);
+  assert.match(migration, /"field_visit_id" integer NOT NULL/);
+  assert.match(migration, /"window_start" timestamp NOT NULL/);
+  assert.match(migration, /"window_end" timestamp NOT NULL/);
+  assert.match(migration, /"timezone" varchar\(64\) DEFAULT 'UTC' NOT NULL/);
+  assert.match(migration, /"is_hard" boolean DEFAULT true NOT NULL/);
+  assert.match(migration, /CHECK \("window_start" < "window_end"\)/);
+  assert.match(migration, /time_windows_field_visit_id_idx/);
+  assert.match(migration, /time_windows_window_start_idx/);
+  assert.match(migration, /time_windows_window_end_idx/);
+  assert.match(migration, /time_windows_field_visit_window_start_idx/);
+  assert.match(migration, /ON DELETE CASCADE ON UPDATE NO ACTION/);
+});
+
+test("logistics time windows migration is registered in drizzle journal", () => {
+  const journal = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "meta",
+      "_journal.json",
+    ),
+    "utf8",
+  );
+
+  const parsed = JSON.parse(journal) as {
+    entries?: Array<{ idx?: number; tag?: string }>;
+  };
+
+  const entry = parsed.entries?.find(
+    (item) => item.tag === "0018_logistics_time_windows",
+  );
+
+  assert.ok(entry, "journal debe registrar 0018_logistics_time_windows");
+  assert.equal(entry?.idx, 18);
+});


### PR DESCRIPTION
## Summary

- add `time_windows` linked to `field_visits`
- enforce `window_start < window_end` in the SQL migration
- add explicit timezone and hard/soft window fields
- add deterministic time window validation helpers
- add schema/migration/validation guard tests

## Scope

Schema-only PR for logistics Phase 1 time windows.

## Out of scope

- no API endpoints
- no route plans
- no route stops
- no route events
- no SLA tables
- no time-window compliance metrics
- no geocoding
- no external map provider
- no route optimization
- no VRP/TSP/A*/Dijkstra/ACO

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
