### PR TITLE
feat(logistics-schema): add route plans and stops

### DIFF
--- a/drizzle/migrations/0019_logistics_route_plans_stops.sql
+++ b/drizzle/migrations/0019_logistics_route_plans_stops.sql
@@ -1,0 +1,80 @@
+CREATE TABLE IF NOT EXISTS "route_plans" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "clinic_id" integer NOT NULL,
+  "service_date" timestamp NOT NULL,
+  "status" varchar(32) DEFAULT 'draft' NOT NULL,
+  "planning_mode" varchar(32) DEFAULT 'manual' NOT NULL,
+  "objective" varchar(32) DEFAULT 'distance' NOT NULL,
+  "total_planned_km" real DEFAULT 0 NOT NULL,
+  "total_planned_min" integer DEFAULT 0 NOT NULL,
+  "created_by_type" varchar(32) DEFAULT 'system' NOT NULL,
+  "created_by_id" integer,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "route_stops" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "route_plan_id" integer NOT NULL,
+  "field_visit_id" integer NOT NULL,
+  "sequence" integer NOT NULL,
+  "eta_start" timestamp,
+  "eta_end" timestamp,
+  "planned_km_from_prev" real DEFAULT 0 NOT NULL,
+  "planned_min_from_prev" integer DEFAULT 0 NOT NULL,
+  "actual_arrival" timestamp,
+  "actual_departure" timestamp,
+  "actual_km_from_prev" real,
+  "status" varchar(32) DEFAULT 'pending' NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "route_plans_clinic_id_idx" ON "route_plans" ("clinic_id");
+CREATE INDEX IF NOT EXISTS "route_plans_clinic_service_date_idx" ON "route_plans" ("clinic_id", "service_date");
+CREATE INDEX IF NOT EXISTS "route_plans_clinic_status_idx" ON "route_plans" ("clinic_id", "status");
+CREATE INDEX IF NOT EXISTS "route_plans_clinic_planning_mode_idx" ON "route_plans" ("clinic_id", "planning_mode");
+
+CREATE INDEX IF NOT EXISTS "route_stops_route_plan_id_idx" ON "route_stops" ("route_plan_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "route_stops_route_plan_sequence_idx" ON "route_stops" ("route_plan_id", "sequence");
+CREATE INDEX IF NOT EXISTS "route_stops_field_visit_id_idx" ON "route_stops" ("field_visit_id");
+CREATE INDEX IF NOT EXISTS "route_stops_route_plan_status_idx" ON "route_stops" ("route_plan_id", "status");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'route_plans_clinic_id_clinics_id_fk'
+  ) THEN
+    ALTER TABLE "route_plans"
+      ADD CONSTRAINT "route_plans_clinic_id_clinics_id_fk"
+      FOREIGN KEY ("clinic_id") REFERENCES "clinics"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'route_stops_route_plan_id_route_plans_id_fk'
+  ) THEN
+    ALTER TABLE "route_stops"
+      ADD CONSTRAINT "route_stops_route_plan_id_route_plans_id_fk"
+      FOREIGN KEY ("route_plan_id") REFERENCES "route_plans"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'route_stops_field_visit_id_field_visits_id_fk'
+  ) THEN
+    ALTER TABLE "route_stops"
+      ADD CONSTRAINT "route_stops_field_visit_id_field_visits_id_fk"
+      FOREIGN KEY ("field_visit_id") REFERENCES "field_visits"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
                         "when":  1776442203570,
                         "tag":  "0018_logistics_time_windows",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  19,
+                        "version":  "7",
+                        "when":  1776442203571,
+                        "tag":  "0019_logistics_route_plans_stops",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,6 +1,7 @@
 import {
   boolean,
   index,
+  uniqueIndex,
   integer,
   jsonb,
   pgTable,
@@ -47,6 +48,40 @@ export const VISIT_LOCATION_GEO_QUALITIES = [
 ] as const;
 export type VisitLocationGeoQuality =
   (typeof VISIT_LOCATION_GEO_QUALITIES)[number];
+export const ROUTE_PLAN_STATUSES = [
+  "draft",
+  "planned",
+  "released",
+  "in_progress",
+  "completed",
+  "canceled",
+] as const;
+export type RoutePlanStatus = (typeof ROUTE_PLAN_STATUSES)[number];
+
+export const ROUTE_PLANNING_MODES = ["manual", "heuristic"] as const;
+export type RoutePlanningMode = (typeof ROUTE_PLANNING_MODES)[number];
+
+export const ROUTE_PLAN_OBJECTIVES = ["distance", "time", "sla"] as const;
+export type RoutePlanObjective = (typeof ROUTE_PLAN_OBJECTIVES)[number];
+
+export const ROUTE_PLAN_CREATED_BY_TYPES = [
+  "system",
+  "admin",
+  "clinic",
+] as const;
+export type RoutePlanCreatedByType =
+  (typeof ROUTE_PLAN_CREATED_BY_TYPES)[number];
+
+export const ROUTE_STOP_STATUSES = [
+  "pending",
+  "arrived",
+  "departed",
+  "skipped",
+  "done",
+  "no_show",
+  "canceled",
+] as const;
+export type RouteStopStatus = (typeof ROUTE_STOP_STATUSES)[number];
 export const AUDIT_ACTOR_TYPES = [
   "system",
   "admin_user",
@@ -686,6 +721,95 @@ export const timeWindows = pgTable(
     ).on(table.fieldVisitId, table.windowStart),
   }),
 );
+export const routePlans = pgTable(
+  "route_plans",
+  {
+    id: serial("id").primaryKey(),
+    clinicId: integer("clinic_id")
+      .notNull()
+      .references(() => clinics.id, { onDelete: "cascade" }),
+    serviceDate: timestamp("service_date", { mode: "date" }).notNull(),
+    status: varchar("status", { length: 32 })
+      .$type<RoutePlanStatus>()
+      .notNull()
+      .default("draft"),
+    planningMode: varchar("planning_mode", { length: 32 })
+      .$type<RoutePlanningMode>()
+      .notNull()
+      .default("manual"),
+    objective: varchar("objective", { length: 32 })
+      .$type<RoutePlanObjective>()
+      .notNull()
+      .default("distance"),
+    totalPlannedKm: real("total_planned_km").default(0).notNull(),
+    totalPlannedMin: integer("total_planned_min").default(0).notNull(),
+    createdByType: varchar("created_by_type", { length: 32 })
+      .$type<RoutePlanCreatedByType>()
+      .notNull()
+      .default("system"),
+    createdById: integer("created_by_id"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    clinicIdIdx: index("route_plans_clinic_id_idx").on(table.clinicId),
+    clinicServiceDateIdx: index("route_plans_clinic_service_date_idx").on(
+      table.clinicId,
+      table.serviceDate,
+    ),
+    clinicStatusIdx: index("route_plans_clinic_status_idx").on(
+      table.clinicId,
+      table.status,
+    ),
+    clinicPlanningModeIdx: index("route_plans_clinic_planning_mode_idx").on(
+      table.clinicId,
+      table.planningMode,
+    ),
+  }),
+);
+
+export const routeStops = pgTable(
+  "route_stops",
+  {
+    id: serial("id").primaryKey(),
+    routePlanId: integer("route_plan_id")
+      .notNull()
+      .references(() => routePlans.id, { onDelete: "cascade" }),
+    fieldVisitId: integer("field_visit_id")
+      .notNull()
+      .references(() => fieldVisits.id, { onDelete: "cascade" }),
+    sequence: integer("sequence").notNull(),
+    etaStart: timestamp("eta_start", { mode: "date" }),
+    etaEnd: timestamp("eta_end", { mode: "date" }),
+    plannedKmFromPrev: real("planned_km_from_prev").default(0).notNull(),
+    plannedMinFromPrev: integer("planned_min_from_prev").default(0).notNull(),
+    actualArrival: timestamp("actual_arrival", { mode: "date" }),
+    actualDeparture: timestamp("actual_departure", { mode: "date" }),
+    actualKmFromPrev: real("actual_km_from_prev"),
+    status: varchar("status", { length: 32 })
+      .$type<RouteStopStatus>()
+      .notNull()
+      .default("pending"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    routePlanIdIdx: index("route_stops_route_plan_id_idx").on(
+      table.routePlanId,
+    ),
+    routePlanSequenceIdx: uniqueIndex("route_stops_route_plan_sequence_idx").on(
+      table.routePlanId,
+      table.sequence,
+    ),
+    fieldVisitIdIdx: index("route_stops_field_visit_id_idx").on(
+      table.fieldVisitId,
+    ),
+    routePlanStatusIdx: index("route_stops_route_plan_status_idx").on(
+      table.routePlanId,
+      table.status,
+    ),
+  }),
+);
 export const particularSessions = pgTable(
   "particular_sessions",
   {
@@ -744,6 +868,11 @@ export type VisitLocation = InferSelectModel<typeof visitLocations>;
 export type NewVisitLocation = InferInsertModel<typeof visitLocations>;
 export type TimeWindow = InferSelectModel<typeof timeWindows>;
 export type NewTimeWindow = InferInsertModel<typeof timeWindows>;
+export type RoutePlan = InferSelectModel<typeof routePlans>;
+export type NewRoutePlan = InferInsertModel<typeof routePlans>;
+
+export type RouteStop = InferSelectModel<typeof routeStops>;
+export type NewRouteStop = InferInsertModel<typeof routeStops>;
 
 export type ClinicPublicProfile = InferSelectModel<typeof clinicPublicProfiles>;
 export type NewClinicPublicProfile = InferInsertModel<typeof clinicPublicProfiles>;

--- a/pr190-body.md
+++ b/pr190-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+- add route plan lifecycle/status contracts to the schema
+- add `route_plans` linked to clinics with tenant-first indexes
+- add `route_stops` linked to route plans and field visits
+- enforce unique stop sequence per route plan
+- add migration `0019_logistics_route_plans_stops`
+- add schema/migration/contract guard tests
+
+## Scope
+
+Schema-only PR for logistics Phase 1 route plans and route stops.
+
+## Out of scope
+
+- no API endpoints
+- no route events
+- no polling
+- no SLA tables
+- no compliance metrics
+- no heuristic planning
+- no geocoding
+- no external map provider
+- no route optimization
+- no VRP/TSP/A*/Dijkstra/ACO
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/test/logistics-route-plans-stops-schema.test.ts
+++ b/test/logistics-route-plans-stops-schema.test.ts
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  ROUTE_PLAN_CREATED_BY_TYPES,
+  ROUTE_PLAN_OBJECTIVES,
+  ROUTE_PLAN_STATUSES,
+  ROUTE_PLANNING_MODES,
+  ROUTE_STOP_STATUSES,
+  routePlans,
+  routeStops,
+} from "../drizzle/schema.ts";
+
+function assertNormalizedUniqueValues(
+  values: readonly string[],
+  label: string,
+) {
+  const unique = new Set(values);
+
+  assert.equal(unique.size, values.length, `${label} no debe repetir valores`);
+
+  for (const value of values) {
+    assert.equal(typeof value, "string");
+    assert.equal(value.trim(), value, `${label} no debe contener espacios`);
+    assert.equal(value.length > 0, true, `${label} no debe contener vacíos`);
+    assert.match(
+      value,
+      /^[a-z_]+$/,
+      `${label} debe usar valores snake_case normalizados`,
+    );
+  }
+}
+
+test("route plan statuses conserva el lifecycle base MVP", () => {
+  assert.deepEqual(ROUTE_PLAN_STATUSES, [
+    "draft",
+    "planned",
+    "released",
+    "in_progress",
+    "completed",
+    "canceled",
+  ]);
+
+  assertNormalizedUniqueValues(ROUTE_PLAN_STATUSES, "ROUTE_PLAN_STATUSES");
+});
+
+test("route planning modes conserva los modos MVP permitidos", () => {
+  assert.deepEqual(ROUTE_PLANNING_MODES, ["manual", "heuristic"]);
+
+  assertNormalizedUniqueValues(ROUTE_PLANNING_MODES, "ROUTE_PLANNING_MODES");
+});
+
+test("route plan objectives conserva los objetivos MVP permitidos", () => {
+  assert.deepEqual(ROUTE_PLAN_OBJECTIVES, ["distance", "time", "sla"]);
+
+  assertNormalizedUniqueValues(ROUTE_PLAN_OBJECTIVES, "ROUTE_PLAN_OBJECTIVES");
+});
+
+test("route plan created by types conserva actores internos permitidos", () => {
+  assert.deepEqual(ROUTE_PLAN_CREATED_BY_TYPES, [
+    "system",
+    "admin",
+    "clinic",
+  ]);
+
+  assertNormalizedUniqueValues(
+    ROUTE_PLAN_CREATED_BY_TYPES,
+    "ROUTE_PLAN_CREATED_BY_TYPES",
+  );
+});
+
+test("route stop statuses conserva estados operativos base", () => {
+  assert.deepEqual(ROUTE_STOP_STATUSES, [
+    "pending",
+    "arrived",
+    "departed",
+    "skipped",
+    "done",
+    "no_show",
+    "canceled",
+  ]);
+
+  assertNormalizedUniqueValues(ROUTE_STOP_STATUSES, "ROUTE_STOP_STATUSES");
+});
+
+test("logistics schema exports route plans and route stops tables", () => {
+  assert.equal(typeof routePlans, "object");
+  assert.equal(typeof routeStops, "object");
+});
+
+test("logistics route plans and stops migration creates base schema", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0019_logistics_route_plans_stops.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "route_plans"/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "route_stops"/);
+  assert.match(migration, /"clinic_id" integer NOT NULL/);
+  assert.match(migration, /"service_date" timestamp NOT NULL/);
+  assert.match(migration, /"status" varchar\(32\) DEFAULT 'draft' NOT NULL/);
+  assert.match(migration, /"planning_mode" varchar\(32\) DEFAULT 'manual' NOT NULL/);
+  assert.match(migration, /"objective" varchar\(32\) DEFAULT 'distance' NOT NULL/);
+  assert.match(migration, /"total_planned_km" real DEFAULT 0 NOT NULL/);
+  assert.match(migration, /"total_planned_min" integer DEFAULT 0 NOT NULL/);
+  assert.match(migration, /"created_by_type" varchar\(32\) DEFAULT 'system' NOT NULL/);
+  assert.match(migration, /"route_plan_id" integer NOT NULL/);
+  assert.match(migration, /"field_visit_id" integer NOT NULL/);
+  assert.match(migration, /"sequence" integer NOT NULL/);
+  assert.match(migration, /"planned_km_from_prev" real DEFAULT 0 NOT NULL/);
+  assert.match(migration, /"planned_min_from_prev" integer DEFAULT 0 NOT NULL/);
+  assert.match(migration, /"status" varchar\(32\) DEFAULT 'pending' NOT NULL/);
+});
+
+test("logistics route plans and stops migration creates tenant and sequence indexes", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0019_logistics_route_plans_stops.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /route_plans_clinic_id_idx/);
+  assert.match(migration, /route_plans_clinic_service_date_idx/);
+  assert.match(migration, /route_plans_clinic_status_idx/);
+  assert.match(migration, /route_plans_clinic_planning_mode_idx/);
+  assert.match(migration, /route_stops_route_plan_id_idx/);
+  assert.match(migration, /CREATE UNIQUE INDEX IF NOT EXISTS "route_stops_route_plan_sequence_idx"/);
+  assert.match(migration, /route_stops_field_visit_id_idx/);
+  assert.match(migration, /route_stops_route_plan_status_idx/);
+});
+
+test("logistics route plans and stops migration creates ownership foreign keys", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0019_logistics_route_plans_stops.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /route_plans_clinic_id_clinics_id_fk/);
+  assert.match(migration, /route_stops_route_plan_id_route_plans_id_fk/);
+  assert.match(migration, /route_stops_field_visit_id_field_visits_id_fk/);
+  assert.match(migration, /ON DELETE CASCADE ON UPDATE NO ACTION/);
+});
+
+test("logistics route plans and stops migration is registered in drizzle journal", () => {
+  const journal = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "meta",
+      "_journal.json",
+    ),
+    "utf8",
+  );
+
+  const parsed = JSON.parse(journal) as {
+    entries?: Array<{ idx?: number; tag?: string }>;
+  };
+
+  const entry = parsed.entries?.find(
+    (item) => item.tag === "0019_logistics_route_plans_stops",
+  );
+
+  assert.ok(entry, "journal debe registrar 0019_logistics_route_plans_stops");
+  assert.equal(entry?.idx, 19);
+});


### PR DESCRIPTION
## Summary

- add route plan lifecycle/status contracts to the schema
- add `route_plans` linked to clinics with tenant-first indexes
- add `route_stops` linked to route plans and field visits
- enforce unique stop sequence per route plan
- add migration `0019_logistics_route_plans_stops`
- add schema/migration/contract guard tests

## Scope

Schema-only PR for logistics Phase 1 route plans and route stops.

## Out of scope

- no API endpoints
- no route events
- no polling
- no SLA tables
- no compliance metrics
- no heuristic planning
- no geocoding
- no external map provider
- no route optimization
- no VRP/TSP/A*/Dijkstra/ACO

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
