### PR TITLE
feat(logistics-events): add route event model

### DIFF
--- a/drizzle/migrations/0020_logistics_route_events.sql
+++ b/drizzle/migrations/0020_logistics_route_events.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS "route_events" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "clinic_id" integer NOT NULL,
+  "route_plan_id" integer,
+  "route_stop_id" integer,
+  "event_type" varchar(64) NOT NULL,
+  "event_time" timestamp NOT NULL,
+  "payload" jsonb,
+  "lat" real,
+  "lng" real,
+  "source" varchar(32) DEFAULT 'system' NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "route_events_clinic_id_idx" ON "route_events" ("clinic_id");
+CREATE INDEX IF NOT EXISTS "route_events_clinic_event_time_idx" ON "route_events" ("clinic_id", "event_time");
+CREATE INDEX IF NOT EXISTS "route_events_clinic_route_plan_event_time_idx" ON "route_events" ("clinic_id", "route_plan_id", "event_time");
+CREATE INDEX IF NOT EXISTS "route_events_route_stop_event_time_idx" ON "route_events" ("route_stop_id", "event_time");
+CREATE INDEX IF NOT EXISTS "route_events_event_type_idx" ON "route_events" ("event_type");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'route_events_clinic_id_clinics_id_fk'
+  ) THEN
+    ALTER TABLE "route_events"
+      ADD CONSTRAINT "route_events_clinic_id_clinics_id_fk"
+      FOREIGN KEY ("clinic_id") REFERENCES "clinics"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'route_events_route_plan_id_route_plans_id_fk'
+  ) THEN
+    ALTER TABLE "route_events"
+      ADD CONSTRAINT "route_events_route_plan_id_route_plans_id_fk"
+      FOREIGN KEY ("route_plan_id") REFERENCES "route_plans"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'route_events_route_stop_id_route_stops_id_fk'
+  ) THEN
+    ALTER TABLE "route_events"
+      ADD CONSTRAINT "route_events_route_stop_id_route_stops_id_fk"
+      FOREIGN KEY ("route_stop_id") REFERENCES "route_stops"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
                         "when":  1776442203571,
                         "tag":  "0019_logistics_route_plans_stops",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  20,
+                        "version":  "7",
+                        "when":  1776442203572,
+                        "tag":  "0020_logistics_route_events",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -82,6 +82,29 @@ export const ROUTE_STOP_STATUSES = [
   "canceled",
 ] as const;
 export type RouteStopStatus = (typeof ROUTE_STOP_STATUSES)[number];
+export const ROUTE_EVENT_TYPES = [
+  "route.created",
+  "route.released",
+  "route.started",
+  "stop.arrived",
+  "stop.departed",
+  "stop.skipped",
+  "stop.no_show",
+  "route.completed",
+  "route.canceled",
+  "route.replanned",
+] as const;
+export type RouteEventType = (typeof ROUTE_EVENT_TYPES)[number];
+
+export const ROUTE_EVENT_SOURCES = [
+  "system",
+  "admin",
+  "clinic",
+  "mobile",
+] as const;
+export type RouteEventSource = (typeof ROUTE_EVENT_SOURCES)[number];
+
+export type RouteEventPayload = Record<string, unknown>;
 export const AUDIT_ACTOR_TYPES = [
   "system",
   "admin_user",
@@ -810,6 +833,48 @@ export const routeStops = pgTable(
     ),
   }),
 );
+export const routeEvents = pgTable(
+  "route_events",
+  {
+    id: serial("id").primaryKey(),
+    clinicId: integer("clinic_id")
+      .notNull()
+      .references(() => clinics.id, { onDelete: "cascade" }),
+    routePlanId: integer("route_plan_id").references(() => routePlans.id, {
+      onDelete: "cascade",
+    }),
+    routeStopId: integer("route_stop_id").references(() => routeStops.id, {
+      onDelete: "cascade",
+    }),
+    eventType: varchar("event_type", { length: 64 })
+      .$type<RouteEventType>()
+      .notNull(),
+    eventTime: timestamp("event_time", { mode: "date" }).notNull(),
+    payload: jsonb("payload").$type<RouteEventPayload>(),
+    lat: real("lat"),
+    lng: real("lng"),
+    source: varchar("source", { length: 32 })
+      .$type<RouteEventSource>()
+      .notNull()
+      .default("system"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    clinicIdIdx: index("route_events_clinic_id_idx").on(table.clinicId),
+    clinicEventTimeIdx: index("route_events_clinic_event_time_idx").on(
+      table.clinicId,
+      table.eventTime,
+    ),
+    clinicRoutePlanEventTimeIdx: index(
+      "route_events_clinic_route_plan_event_time_idx",
+    ).on(table.clinicId, table.routePlanId, table.eventTime),
+    routeStopEventTimeIdx: index("route_events_route_stop_event_time_idx").on(
+      table.routeStopId,
+      table.eventTime,
+    ),
+    eventTypeIdx: index("route_events_event_type_idx").on(table.eventType),
+  }),
+);
 export const particularSessions = pgTable(
   "particular_sessions",
   {
@@ -873,6 +938,8 @@ export type NewRoutePlan = InferInsertModel<typeof routePlans>;
 
 export type RouteStop = InferSelectModel<typeof routeStops>;
 export type NewRouteStop = InferInsertModel<typeof routeStops>;
+export type RouteEvent = InferSelectModel<typeof routeEvents>;
+export type NewRouteEvent = InferInsertModel<typeof routeEvents>;
 
 export type ClinicPublicProfile = InferSelectModel<typeof clinicPublicProfiles>;
 export type NewClinicPublicProfile = InferInsertModel<typeof clinicPublicProfiles>;

--- a/pr191-body.md
+++ b/pr191-body.md
@@ -1,0 +1,33 @@
+## Summary
+
+- add route event type/source contracts to the schema
+- add `route_events` with required clinic scope
+- link route events optionally to route plans and route stops
+- support event payload, optional coordinates and source attribution
+- add tenant-first indexes for event querying
+- add migration `0020_logistics_route_events`
+- add schema/migration/contract guard tests
+
+## Scope
+
+Schema-only PR for logistics route event model.
+
+## Out of scope
+
+- no API endpoints
+- no polling endpoint
+- no WebSocket/SSE
+- no mobile telemetry batch ingestion
+- no SLA tables
+- no compliance metrics
+- no heuristic planning
+- no geocoding
+- no external map provider
+- no route optimization
+- no VRP/TSP/A*/Dijkstra/ACO
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/test/logistics-route-events-schema.test.ts
+++ b/test/logistics-route-events-schema.test.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  ROUTE_EVENT_SOURCES,
+  ROUTE_EVENT_TYPES,
+  routeEvents,
+} from "../drizzle/schema.ts";
+
+function assertUniqueValues(values: readonly string[], label: string) {
+  const unique = new Set(values);
+
+  assert.equal(unique.size, values.length, `${label} must not repeat values`);
+
+  for (const value of values) {
+    assert.equal(typeof value, "string");
+    assert.equal(value.trim(), value, `${label} must not contain edge spaces`);
+    assert.equal(value.length > 0, true, `${label} must not contain blanks`);
+  }
+}
+
+function assertRouteEventTypeValues(values: readonly string[]) {
+  assertUniqueValues(values, "ROUTE_EVENT_TYPES");
+
+  for (const value of values) {
+    assert.match(
+      value,
+      /^(route|stop)\.[a-z_]+$/,
+      "ROUTE_EVENT_TYPES must use domain.action format",
+    );
+  }
+}
+
+function assertSnakeCaseValues(values: readonly string[], label: string) {
+  assertUniqueValues(values, label);
+
+  for (const value of values) {
+    assert.match(value, /^[a-z_]+$/, `${label} must use snake_case values`);
+  }
+}
+
+test("route event types keep MVP operational event contract", () => {
+  assert.deepEqual(ROUTE_EVENT_TYPES, [
+    "route.created",
+    "route.released",
+    "route.started",
+    "stop.arrived",
+    "stop.departed",
+    "stop.skipped",
+    "stop.no_show",
+    "route.completed",
+    "route.canceled",
+    "route.replanned",
+  ]);
+
+  assertRouteEventTypeValues(ROUTE_EVENT_TYPES);
+});
+
+test("route event sources keep MVP source contract", () => {
+  assert.deepEqual(ROUTE_EVENT_SOURCES, [
+    "system",
+    "admin",
+    "clinic",
+    "mobile",
+  ]);
+
+  assertSnakeCaseValues(ROUTE_EVENT_SOURCES, "ROUTE_EVENT_SOURCES");
+});
+
+test("logistics schema exports route events table", () => {
+  assert.equal(typeof routeEvents, "object");
+});
+
+test("logistics route events migration creates base schema", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0020_logistics_route_events.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "route_events"/);
+  assert.match(migration, /"clinic_id" integer NOT NULL/);
+  assert.match(migration, /"route_plan_id" integer/);
+  assert.match(migration, /"route_stop_id" integer/);
+  assert.match(migration, /"event_type" varchar\(64\) NOT NULL/);
+  assert.match(migration, /"event_time" timestamp NOT NULL/);
+  assert.match(migration, /"payload" jsonb/);
+  assert.match(migration, /"lat" real/);
+  assert.match(migration, /"lng" real/);
+  assert.match(migration, /"source" varchar\(32\) DEFAULT 'system' NOT NULL/);
+});
+
+test("logistics route events migration creates tenant-first indexes", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0020_logistics_route_events.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /route_events_clinic_id_idx/);
+  assert.match(migration, /route_events_clinic_event_time_idx/);
+  assert.match(migration, /route_events_clinic_route_plan_event_time_idx/);
+  assert.match(migration, /route_events_route_stop_event_time_idx/);
+  assert.match(migration, /route_events_event_type_idx/);
+});
+
+test("logistics route events migration creates ownership foreign keys", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "0020_logistics_route_events.sql",
+    ),
+    "utf8",
+  );
+
+  assert.match(migration, /route_events_clinic_id_clinics_id_fk/);
+  assert.match(migration, /route_events_route_plan_id_route_plans_id_fk/);
+  assert.match(migration, /route_events_route_stop_id_route_stops_id_fk/);
+  assert.match(migration, /ON DELETE CASCADE ON UPDATE NO ACTION/);
+});
+
+test("logistics route events migration is registered in drizzle journal", () => {
+  const journal = readFileSync(
+    resolve(
+      process.cwd(),
+      "drizzle",
+      "migrations",
+      "meta",
+      "_journal.json",
+    ),
+    "utf8",
+  );
+
+  const parsed = JSON.parse(journal) as {
+    entries?: Array<{ idx?: number; tag?: string }>;
+  };
+
+  const entry = parsed.entries?.find(
+    (item) => item.tag === "0020_logistics_route_events",
+  );
+
+  assert.ok(entry, "journal must register 0020_logistics_route_events");
+  assert.equal(entry?.idx, 20);
+});


### PR DESCRIPTION
## Summary

- add route event type/source contracts to the schema
- add `route_events` with required clinic scope
- link route events optionally to route plans and route stops
- support event payload, optional coordinates and source attribution
- add tenant-first indexes for event querying
- add migration `0020_logistics_route_events`
- add schema/migration/contract guard tests

## Scope

Schema-only PR for logistics route event model.

## Out of scope

- no API endpoints
- no polling endpoint
- no WebSocket/SSE
- no mobile telemetry batch ingestion
- no SLA tables
- no compliance metrics
- no heuristic planning
- no geocoding
- no external map provider
- no route optimization
- no VRP/TSP/A*/Dijkstra/ACO

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
