### PR TITLE
feat(logistics-sla): add SLA policies and instances

### DIFF
--- a/drizzle/migrations/0021_logistics_sla.sql
+++ b/drizzle/migrations/0021_logistics_sla.sql
@@ -1,0 +1,81 @@
+CREATE TABLE IF NOT EXISTS "sla_policies" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "clinic_id" integer,
+  "name" varchar(255) NOT NULL,
+  "scope" varchar(32) DEFAULT 'global' NOT NULL,
+  "target_type" varchar(64) NOT NULL,
+  "due_minutes" integer NOT NULL,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "sla_policies_due_minutes_positive_chk" CHECK ("due_minutes" > 0)
+);
+
+CREATE TABLE IF NOT EXISTS "sla_instances" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "clinic_id" integer NOT NULL,
+  "policy_id" integer,
+  "target_type" varchar(64) NOT NULL,
+  "target_id" integer NOT NULL,
+  "status" varchar(32) DEFAULT 'active' NOT NULL,
+  "started_at" timestamp NOT NULL,
+  "due_at" timestamp NOT NULL,
+  "paused_at" timestamp,
+  "breached_at" timestamp,
+  "resolved_at" timestamp,
+  "canceled_at" timestamp,
+  "metadata" jsonb,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "sla_instances_due_after_started_chk" CHECK ("due_at" > "started_at")
+);
+
+CREATE INDEX IF NOT EXISTS "sla_policies_clinic_id_idx" ON "sla_policies" ("clinic_id");
+CREATE INDEX IF NOT EXISTS "sla_policies_scope_target_type_idx" ON "sla_policies" ("scope", "target_type");
+CREATE INDEX IF NOT EXISTS "sla_policies_clinic_target_type_idx" ON "sla_policies" ("clinic_id", "target_type");
+CREATE INDEX IF NOT EXISTS "sla_policies_active_idx" ON "sla_policies" ("is_active");
+
+CREATE INDEX IF NOT EXISTS "sla_instances_clinic_id_idx" ON "sla_instances" ("clinic_id");
+CREATE INDEX IF NOT EXISTS "sla_instances_clinic_status_idx" ON "sla_instances" ("clinic_id", "status");
+CREATE INDEX IF NOT EXISTS "sla_instances_clinic_due_at_idx" ON "sla_instances" ("clinic_id", "due_at");
+CREATE INDEX IF NOT EXISTS "sla_instances_clinic_target_idx" ON "sla_instances" ("clinic_id", "target_type", "target_id");
+CREATE INDEX IF NOT EXISTS "sla_instances_policy_id_idx" ON "sla_instances" ("policy_id");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sla_policies_clinic_id_clinics_id_fk'
+  ) THEN
+    ALTER TABLE "sla_policies"
+      ADD CONSTRAINT "sla_policies_clinic_id_clinics_id_fk"
+      FOREIGN KEY ("clinic_id") REFERENCES "clinics"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sla_instances_clinic_id_clinics_id_fk'
+  ) THEN
+    ALTER TABLE "sla_instances"
+      ADD CONSTRAINT "sla_instances_clinic_id_clinics_id_fk"
+      FOREIGN KEY ("clinic_id") REFERENCES "clinics"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sla_instances_policy_id_sla_policies_id_fk'
+  ) THEN
+    ALTER TABLE "sla_instances"
+      ADD CONSTRAINT "sla_instances_policy_id_sla_policies_id_fk"
+      FOREIGN KEY ("policy_id") REFERENCES "sla_policies"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
                         "when":  1776442203572,
                         "tag":  "0020_logistics_route_events",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  21,
+                        "version":  "7",
+                        "when":  1776442203573,
+                        "tag":  "0021_logistics_sla",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -105,6 +105,25 @@ export const ROUTE_EVENT_SOURCES = [
 export type RouteEventSource = (typeof ROUTE_EVENT_SOURCES)[number];
 
 export type RouteEventPayload = Record<string, unknown>;
+export const SLA_POLICY_SCOPES = ["global", "clinic"] as const;
+export type SlaPolicyScope = (typeof SLA_POLICY_SCOPES)[number];
+
+export const SLA_TARGET_TYPES = [
+  "field_visit",
+  "route_plan",
+  "route_stop",
+  "study_tracking_case",
+] as const;
+export type SlaTargetType = (typeof SLA_TARGET_TYPES)[number];
+
+export const SLA_INSTANCE_STATUSES = [
+  "active",
+  "paused",
+  "breached",
+  "resolved",
+  "canceled",
+] as const;
+export type SlaInstanceStatus = (typeof SLA_INSTANCE_STATUSES)[number];
 export const AUDIT_ACTOR_TYPES = [
   "system",
   "admin_user",
@@ -875,6 +894,86 @@ export const routeEvents = pgTable(
     eventTypeIdx: index("route_events_event_type_idx").on(table.eventType),
   }),
 );
+export const slaPolicies = pgTable(
+  "sla_policies",
+  {
+    id: serial("id").primaryKey(),
+    clinicId: integer("clinic_id").references(() => clinics.id, {
+      onDelete: "cascade",
+    }),
+    name: varchar("name", { length: 255 }).notNull(),
+    scope: varchar("scope", { length: 32 })
+      .$type<SlaPolicyScope>()
+      .notNull()
+      .default("global"),
+    targetType: varchar("target_type", { length: 64 })
+      .$type<SlaTargetType>()
+      .notNull(),
+    dueMinutes: integer("due_minutes").notNull(),
+    isActive: boolean("is_active").default(true).notNull(),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    clinicIdIdx: index("sla_policies_clinic_id_idx").on(table.clinicId),
+    scopeTargetTypeIdx: index("sla_policies_scope_target_type_idx").on(
+      table.scope,
+      table.targetType,
+    ),
+    clinicTargetTypeIdx: index("sla_policies_clinic_target_type_idx").on(
+      table.clinicId,
+      table.targetType,
+    ),
+    activeIdx: index("sla_policies_active_idx").on(table.isActive),
+  }),
+);
+
+export const slaInstances = pgTable(
+  "sla_instances",
+  {
+    id: serial("id").primaryKey(),
+    clinicId: integer("clinic_id")
+      .notNull()
+      .references(() => clinics.id, { onDelete: "cascade" }),
+    policyId: integer("policy_id").references(() => slaPolicies.id, {
+      onDelete: "set null",
+    }),
+    targetType: varchar("target_type", { length: 64 })
+      .$type<SlaTargetType>()
+      .notNull(),
+    targetId: integer("target_id").notNull(),
+    status: varchar("status", { length: 32 })
+      .$type<SlaInstanceStatus>()
+      .notNull()
+      .default("active"),
+    startedAt: timestamp("started_at", { mode: "date" }).notNull(),
+    dueAt: timestamp("due_at", { mode: "date" }).notNull(),
+    pausedAt: timestamp("paused_at", { mode: "date" }),
+    breachedAt: timestamp("breached_at", { mode: "date" }),
+    resolvedAt: timestamp("resolved_at", { mode: "date" }),
+    canceledAt: timestamp("canceled_at", { mode: "date" }),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    clinicIdIdx: index("sla_instances_clinic_id_idx").on(table.clinicId),
+    clinicStatusIdx: index("sla_instances_clinic_status_idx").on(
+      table.clinicId,
+      table.status,
+    ),
+    clinicDueAtIdx: index("sla_instances_clinic_due_at_idx").on(
+      table.clinicId,
+      table.dueAt,
+    ),
+    clinicTargetIdx: index("sla_instances_clinic_target_idx").on(
+      table.clinicId,
+      table.targetType,
+      table.targetId,
+    ),
+    policyIdIdx: index("sla_instances_policy_id_idx").on(table.policyId),
+  }),
+);
 export const particularSessions = pgTable(
   "particular_sessions",
   {
@@ -940,6 +1039,11 @@ export type RouteStop = InferSelectModel<typeof routeStops>;
 export type NewRouteStop = InferInsertModel<typeof routeStops>;
 export type RouteEvent = InferSelectModel<typeof routeEvents>;
 export type NewRouteEvent = InferInsertModel<typeof routeEvents>;
+export type SlaPolicy = InferSelectModel<typeof slaPolicies>;
+export type NewSlaPolicy = InferInsertModel<typeof slaPolicies>;
+
+export type SlaInstance = InferSelectModel<typeof slaInstances>;
+export type NewSlaInstance = InferInsertModel<typeof slaInstances>;
 
 export type ClinicPublicProfile = InferSelectModel<typeof clinicPublicProfiles>;
 export type NewClinicPublicProfile = InferInsertModel<typeof clinicPublicProfiles>;

--- a/pr192-body.md
+++ b/pr192-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+- add SLA policy scope and target contracts to the schema
+- add SLA instance lifecycle/status contracts
+- add `sla_policies` with optional clinic scoping
+- add `sla_instances` with required clinic scope and generic target references
+- add due-time validation checks
+- add tenant-first indexes for SLA querying
+- add migration `0021_logistics_sla`
+- add schema/migration/contract guard tests
+
+## Scope
+
+Schema-only PR for logistics SLA policies and instances.
+
+## Out of scope
+
+- no API endpoints
+- no notifications
+- no escalations
+- no dashboard metrics
+- no business-hours calendar
+- no background jobs
+- no route optimization
+- no VRP/TSP/A*/Dijkstra/ACO
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/test/logistics-sla-schema.test.ts
+++ b/test/logistics-sla-schema.test.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  SLA_INSTANCE_STATUSES,
+  SLA_POLICY_SCOPES,
+  SLA_TARGET_TYPES,
+  slaInstances,
+  slaPolicies,
+} from "../drizzle/schema.ts";
+
+function assertNormalizedUniqueValues(
+  values: readonly string[],
+  label: string,
+) {
+  const unique = new Set(values);
+
+  assert.equal(unique.size, values.length, `${label} must not repeat values`);
+
+  for (const value of values) {
+    assert.equal(typeof value, "string");
+    assert.equal(value.trim(), value, `${label} must not contain edge spaces`);
+    assert.equal(value.length > 0, true, `${label} must not contain blanks`);
+    assert.match(value, /^[a-z_]+$/, `${label} must use snake_case values`);
+  }
+}
+
+test("SLA policy scopes keep MVP scope contract", () => {
+  assert.deepEqual(SLA_POLICY_SCOPES, ["global", "clinic"]);
+
+  assertNormalizedUniqueValues(SLA_POLICY_SCOPES, "SLA_POLICY_SCOPES");
+});
+
+test("SLA target types keep MVP target contract", () => {
+  assert.deepEqual(SLA_TARGET_TYPES, [
+    "field_visit",
+    "route_plan",
+    "route_stop",
+    "study_tracking_case",
+  ]);
+
+  assertNormalizedUniqueValues(SLA_TARGET_TYPES, "SLA_TARGET_TYPES");
+});
+
+test("SLA instance statuses keep MVP lifecycle contract", () => {
+  assert.deepEqual(SLA_INSTANCE_STATUSES, [
+    "active",
+    "paused",
+    "breached",
+    "resolved",
+    "canceled",
+  ]);
+
+  assertNormalizedUniqueValues(
+    SLA_INSTANCE_STATUSES,
+    "SLA_INSTANCE_STATUSES",
+  );
+});
+
+test("logistics schema exports SLA policies and instances tables", () => {
+  assert.equal(typeof slaPolicies, "object");
+  assert.equal(typeof slaInstances, "object");
+});
+
+test("logistics SLA migration creates policies and instances base schema", () => {
+  const migration = readFileSync(
+    resolve(process.cwd(), "drizzle", "migrations", "0021_logistics_sla.sql"),
+    "utf8",
+  );
+
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "sla_policies"/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS "sla_instances"/);
+  assert.match(migration, /"clinic_id" integer/);
+  assert.match(migration, /"name" varchar\(255\) NOT NULL/);
+  assert.match(migration, /"scope" varchar\(32\) DEFAULT 'global' NOT NULL/);
+  assert.match(migration, /"target_type" varchar\(64\) NOT NULL/);
+  assert.match(migration, /"due_minutes" integer NOT NULL/);
+  assert.match(migration, /"is_active" boolean DEFAULT true NOT NULL/);
+  assert.match(migration, /"status" varchar\(32\) DEFAULT 'active' NOT NULL/);
+  assert.match(migration, /"target_id" integer NOT NULL/);
+  assert.match(migration, /"started_at" timestamp NOT NULL/);
+  assert.match(migration, /"due_at" timestamp NOT NULL/);
+  assert.match(migration, /"paused_at" timestamp/);
+  assert.match(migration, /"breached_at" timestamp/);
+  assert.match(migration, /"resolved_at" timestamp/);
+  assert.match(migration, /"canceled_at" timestamp/);
+  assert.match(migration, /"metadata" jsonb/);
+});
+
+test("logistics SLA migration creates validation checks in the correct tables", () => {
+  const migration = readFileSync(
+    resolve(process.cwd(), "drizzle", "migrations", "0021_logistics_sla.sql"),
+    "utf8",
+  );
+
+  const policiesStart = migration.indexOf('CREATE TABLE IF NOT EXISTS "sla_policies"');
+  const instancesStart = migration.indexOf('CREATE TABLE IF NOT EXISTS "sla_instances"');
+  const dueMinutesCheck = migration.indexOf('CHECK ("due_minutes" > 0)');
+  const dueAfterStartedCheck = migration.indexOf('CHECK ("due_at" > "started_at")');
+
+  assert.ok(policiesStart >= 0);
+  assert.ok(instancesStart > policiesStart);
+  assert.ok(dueMinutesCheck > policiesStart);
+  assert.ok(dueMinutesCheck < instancesStart);
+  assert.ok(dueAfterStartedCheck > instancesStart);
+});
+
+test("logistics SLA migration creates tenant-first indexes", () => {
+  const migration = readFileSync(
+    resolve(process.cwd(), "drizzle", "migrations", "0021_logistics_sla.sql"),
+    "utf8",
+  );
+
+  assert.match(migration, /sla_policies_clinic_id_idx/);
+  assert.match(migration, /sla_policies_scope_target_type_idx/);
+  assert.match(migration, /sla_policies_clinic_target_type_idx/);
+  assert.match(migration, /sla_policies_active_idx/);
+  assert.match(migration, /sla_instances_clinic_id_idx/);
+  assert.match(migration, /sla_instances_clinic_status_idx/);
+  assert.match(migration, /sla_instances_clinic_due_at_idx/);
+  assert.match(migration, /sla_instances_clinic_target_idx/);
+  assert.match(migration, /sla_instances_policy_id_idx/);
+});
+
+test("logistics SLA migration creates ownership foreign keys", () => {
+  const migration = readFileSync(
+    resolve(process.cwd(), "drizzle", "migrations", "0021_logistics_sla.sql"),
+    "utf8",
+  );
+
+  assert.match(migration, /sla_policies_clinic_id_clinics_id_fk/);
+  assert.match(migration, /sla_instances_clinic_id_clinics_id_fk/);
+  assert.match(migration, /sla_instances_policy_id_sla_policies_id_fk/);
+  assert.match(migration, /ON DELETE CASCADE ON UPDATE NO ACTION/);
+  assert.match(migration, /ON DELETE SET NULL ON UPDATE NO ACTION/);
+});
+
+test("logistics SLA migration is registered in drizzle journal", () => {
+  const journal = readFileSync(
+    resolve(process.cwd(), "drizzle", "migrations", "meta", "_journal.json"),
+    "utf8",
+  );
+
+  const parsed = JSON.parse(journal) as {
+    entries?: Array<{ idx?: number; tag?: string }>;
+  };
+
+  const entry = parsed.entries?.find(
+    (item) => item.tag === "0021_logistics_sla",
+  );
+
+  assert.ok(entry, "journal must register 0021_logistics_sla");
+  assert.equal(entry?.idx, 21);
+});


### PR DESCRIPTION
## Summary

- add SLA policy scope and target contracts to the schema
- add SLA instance lifecycle/status contracts
- add `sla_policies` with optional clinic scoping
- add `sla_instances` with required clinic scope and generic target references
- add due-time validation checks
- add tenant-first indexes for SLA querying
- add migration `0021_logistics_sla`
- add schema/migration/contract guard tests

## Scope

Schema-only PR for logistics SLA policies and instances.

## Out of scope

- no API endpoints
- no notifications
- no escalations
- no dashboard metrics
- no business-hours calendar
- no background jobs
- no route optimization
- no VRP/TSP/A*/Dijkstra/ACO

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
