### PR TITLE
feat(logistics-metrics): add basic route compliance metrics

### DIFF
--- a/pr193-body.md
+++ b/pr193-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+- add pure logistics compliance metric helpers
+- calculate planned vs actual distance deltas
+- calculate distance deviation percentage and tolerance compliance
+- calculate kilometers per completed visit
+- classify time window compliance as early/on_time/late/no_window/missing_actual
+- summarize partial window compliance metrics when operational data is incomplete
+- add unit tests for distance, stop completion and time-window compliance metrics
+
+## Scope
+
+Pure logic PR for basic logistics compliance metrics.
+
+## Out of scope
+
+- no API endpoints
+- no dashboard/reporting UI
+- no database schema changes
+- no migrations
+- no route event ingestion
+- no geocoding
+- no external map provider
+- no route optimization
+- no VRP/TSP/A*/Dijkstra/ACO
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/server/lib/logistics/metrics.ts
+++ b/server/lib/logistics/metrics.ts
@@ -1,0 +1,297 @@
+export type NumericMetricInput = number | null | undefined;
+
+export type TimeWindowComplianceStatus =
+  | "early"
+  | "on_time"
+  | "late"
+  | "no_window"
+  | "missing_actual";
+
+export interface RouteDistanceComplianceInput {
+  plannedKm?: NumericMetricInput;
+  actualKm?: NumericMetricInput;
+  tolerancePercent?: NumericMetricInput;
+}
+
+export interface RouteDistanceComplianceMetrics {
+  plannedKm: number | null;
+  actualKm: number | null;
+  deltaKm: number | null;
+  absoluteDeltaKm: number | null;
+  deltaPercent: number | null;
+  efficiencyRatio: number | null;
+  withinTolerance: boolean | null;
+}
+
+export interface TimeWindowComplianceInput {
+  windowStart?: Date | null;
+  windowEnd?: Date | null;
+  actualArrival?: Date | null;
+  toleranceMin?: NumericMetricInput;
+}
+
+export interface TimeWindowComplianceResult {
+  status: TimeWindowComplianceStatus;
+  toleranceMin: number;
+  deltaFromWindowMin: number | null;
+  earlyByMin: number | null;
+  lateByMin: number | null;
+}
+
+export interface WindowComplianceSummary {
+  totalCount: number;
+  evaluatedCount: number;
+  earlyCount: number;
+  onTimeCount: number;
+  lateCount: number;
+  noWindowCount: number;
+  missingActualCount: number;
+  complianceRate: number | null;
+}
+
+export interface BasicRouteComplianceInput {
+  plannedKm?: NumericMetricInput;
+  actualKm?: NumericMetricInput;
+  totalStops?: NumericMetricInput;
+  completedStops?: NumericMetricInput;
+  distanceTolerancePercent?: NumericMetricInput;
+  windowStatuses?: readonly TimeWindowComplianceStatus[];
+}
+
+export interface BasicRouteComplianceMetrics {
+  distance: RouteDistanceComplianceMetrics;
+  totalStops: number | null;
+  completedStops: number | null;
+  completionRate: number | null;
+  kmPerCompletedVisit: number | null;
+  windows: WindowComplianceSummary;
+}
+
+const METRIC_DECIMALS = 6;
+
+function roundMetric(value: number): number {
+  const rounded = Number(value.toFixed(METRIC_DECIMALS));
+
+  if (Object.is(rounded, -0)) {
+    return 0;
+  }
+
+  return rounded;
+}
+
+function normalizeNonNegativeNumber(value: NumericMetricInput): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function normalizeNonNegativeInteger(value: NumericMetricInput): number | null {
+  const normalized = normalizeNonNegativeNumber(value);
+
+  if (normalized === null || !Number.isInteger(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function getDateMs(date: Date | null | undefined): number | null {
+  if (!(date instanceof Date)) {
+    return null;
+  }
+
+  const time = date.getTime();
+
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+
+  return time;
+}
+
+export function calculateRouteDistanceCompliance(
+  input: RouteDistanceComplianceInput,
+): RouteDistanceComplianceMetrics {
+  const plannedKm = normalizeNonNegativeNumber(input.plannedKm);
+  const actualKm = normalizeNonNegativeNumber(input.actualKm);
+  const tolerancePercent = normalizeNonNegativeNumber(input.tolerancePercent);
+
+  const hasBothDistances = plannedKm !== null && actualKm !== null;
+  const deltaKm = hasBothDistances ? roundMetric(actualKm - plannedKm) : null;
+  const absoluteDeltaKm = deltaKm === null ? null : roundMetric(Math.abs(deltaKm));
+  const deltaPercent =
+    hasBothDistances && plannedKm > 0
+      ? roundMetric(((actualKm - plannedKm) / plannedKm) * 100)
+      : null;
+  const efficiencyRatio =
+    hasBothDistances && plannedKm > 0 ? roundMetric(actualKm / plannedKm) : null;
+
+  let withinTolerance: boolean | null = null;
+
+  if (hasBothDistances && tolerancePercent !== null) {
+    if (plannedKm === 0) {
+      withinTolerance = actualKm === 0;
+    } else if (deltaPercent !== null) {
+      withinTolerance = Math.abs(deltaPercent) <= tolerancePercent;
+    }
+  }
+
+  return {
+    plannedKm,
+    actualKm,
+    deltaKm,
+    absoluteDeltaKm,
+    deltaPercent,
+    efficiencyRatio,
+    withinTolerance,
+  };
+}
+
+export function calculateKmPerCompletedVisit(
+  actualKm: NumericMetricInput,
+  completedVisits: NumericMetricInput,
+): number | null {
+  const normalizedActualKm = normalizeNonNegativeNumber(actualKm);
+  const normalizedCompletedVisits = normalizeNonNegativeInteger(completedVisits);
+
+  if (
+    normalizedActualKm === null ||
+    normalizedCompletedVisits === null ||
+    normalizedCompletedVisits === 0
+  ) {
+    return null;
+  }
+
+  return roundMetric(normalizedActualKm / normalizedCompletedVisits);
+}
+
+export function classifyTimeWindowCompliance(
+  input: TimeWindowComplianceInput,
+): TimeWindowComplianceResult {
+  const windowStartMs = getDateMs(input.windowStart);
+  const windowEndMs = getDateMs(input.windowEnd);
+  const actualArrivalMs = getDateMs(input.actualArrival);
+  const toleranceMin = normalizeNonNegativeNumber(input.toleranceMin) ?? 0;
+
+  if (
+    windowStartMs === null ||
+    windowEndMs === null ||
+    windowStartMs >= windowEndMs
+  ) {
+    return {
+      status: "no_window",
+      toleranceMin,
+      deltaFromWindowMin: null,
+      earlyByMin: null,
+      lateByMin: null,
+    };
+  }
+
+  if (actualArrivalMs === null) {
+    return {
+      status: "missing_actual",
+      toleranceMin,
+      deltaFromWindowMin: null,
+      earlyByMin: null,
+      lateByMin: null,
+    };
+  }
+
+  const earlyByMin = roundMetric((windowStartMs - actualArrivalMs) / 60000);
+  const lateByMin = roundMetric((actualArrivalMs - windowEndMs) / 60000);
+
+  if (earlyByMin > toleranceMin) {
+    return {
+      status: "early",
+      toleranceMin,
+      deltaFromWindowMin: -earlyByMin,
+      earlyByMin,
+      lateByMin: null,
+    };
+  }
+
+  if (lateByMin > toleranceMin) {
+    return {
+      status: "late",
+      toleranceMin,
+      deltaFromWindowMin: lateByMin,
+      earlyByMin: null,
+      lateByMin,
+    };
+  }
+
+  return {
+    status: "on_time",
+    toleranceMin,
+    deltaFromWindowMin: 0,
+    earlyByMin: null,
+    lateByMin: null,
+  };
+}
+
+export function summarizeWindowCompliance(
+  statuses: readonly TimeWindowComplianceStatus[],
+): WindowComplianceSummary {
+  let earlyCount = 0;
+  let onTimeCount = 0;
+  let lateCount = 0;
+  let noWindowCount = 0;
+  let missingActualCount = 0;
+
+  for (const status of statuses) {
+    if (status === "early") {
+      earlyCount += 1;
+    } else if (status === "on_time") {
+      onTimeCount += 1;
+    } else if (status === "late") {
+      lateCount += 1;
+    } else if (status === "no_window") {
+      noWindowCount += 1;
+    } else if (status === "missing_actual") {
+      missingActualCount += 1;
+    }
+  }
+
+  const evaluatedCount = earlyCount + onTimeCount + lateCount;
+
+  return {
+    totalCount: statuses.length,
+    evaluatedCount,
+    earlyCount,
+    onTimeCount,
+    lateCount,
+    noWindowCount,
+    missingActualCount,
+    complianceRate:
+      evaluatedCount > 0 ? roundMetric((onTimeCount / evaluatedCount) * 100) : null,
+  };
+}
+
+export function calculateBasicRouteComplianceMetrics(
+  input: BasicRouteComplianceInput,
+): BasicRouteComplianceMetrics {
+  const totalStops = normalizeNonNegativeInteger(input.totalStops);
+  const completedStops = normalizeNonNegativeInteger(input.completedStops);
+  const completionRate =
+    totalStops !== null && totalStops > 0 && completedStops !== null
+      ? roundMetric((completedStops / totalStops) * 100)
+      : null;
+
+  return {
+    distance: calculateRouteDistanceCompliance({
+      plannedKm: input.plannedKm,
+      actualKm: input.actualKm,
+      tolerancePercent: input.distanceTolerancePercent,
+    }),
+    totalStops,
+    completedStops,
+    completionRate,
+    kmPerCompletedVisit: calculateKmPerCompletedVisit(
+      input.actualKm,
+      completedStops,
+    ),
+    windows: summarizeWindowCompliance(input.windowStatuses ?? []),
+  };
+}

--- a/test/logistics-metrics.test.ts
+++ b/test/logistics-metrics.test.ts
@@ -1,0 +1,227 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  calculateBasicRouteComplianceMetrics,
+  calculateKmPerCompletedVisit,
+  calculateRouteDistanceCompliance,
+  classifyTimeWindowCompliance,
+  summarizeWindowCompliance,
+} from "../server/lib/logistics/metrics.ts";
+
+test("calculateRouteDistanceCompliance returns planned vs actual distance metrics", () => {
+  assert.deepEqual(
+    calculateRouteDistanceCompliance({
+      plannedKm: 100,
+      actualKm: 112.5,
+      tolerancePercent: 15,
+    }),
+    {
+      plannedKm: 100,
+      actualKm: 112.5,
+      deltaKm: 12.5,
+      absoluteDeltaKm: 12.5,
+      deltaPercent: 12.5,
+      efficiencyRatio: 1.125,
+      withinTolerance: true,
+    },
+  );
+});
+
+test("calculateRouteDistanceCompliance detects distance deviations beyond tolerance", () => {
+  const metrics = calculateRouteDistanceCompliance({
+    plannedKm: 100,
+    actualKm: 112.5,
+    tolerancePercent: 10,
+  });
+
+  assert.equal(metrics.withinTolerance, false);
+  assert.equal(metrics.deltaPercent, 12.5);
+});
+
+test("calculateRouteDistanceCompliance supports partial metrics when data is missing", () => {
+  assert.deepEqual(
+    calculateRouteDistanceCompliance({
+      plannedKm: undefined,
+      actualKm: 42,
+      tolerancePercent: 10,
+    }),
+    {
+      plannedKm: null,
+      actualKm: 42,
+      deltaKm: null,
+      absoluteDeltaKm: null,
+      deltaPercent: null,
+      efficiencyRatio: null,
+      withinTolerance: null,
+    },
+  );
+});
+
+test("calculateRouteDistanceCompliance handles zero planned kilometers deterministically", () => {
+  assert.equal(
+    calculateRouteDistanceCompliance({
+      plannedKm: 0,
+      actualKm: 0,
+      tolerancePercent: 5,
+    }).withinTolerance,
+    true,
+  );
+
+  assert.equal(
+    calculateRouteDistanceCompliance({
+      plannedKm: 0,
+      actualKm: 1,
+      tolerancePercent: 5,
+    }).withinTolerance,
+    false,
+  );
+});
+
+test("calculateKmPerCompletedVisit returns null for incomplete denominator", () => {
+  assert.equal(calculateKmPerCompletedVisit(25, 5), 5);
+  assert.equal(calculateKmPerCompletedVisit(25, 0), null);
+  assert.equal(calculateKmPerCompletedVisit(null, 5), null);
+  assert.equal(calculateKmPerCompletedVisit(25, 2.5), null);
+});
+
+test("classifyTimeWindowCompliance classifies on-time arrivals", () => {
+  assert.deepEqual(
+    classifyTimeWindowCompliance({
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:00:00.000Z"),
+      actualArrival: new Date("2026-05-03T10:30:00.000Z"),
+    }),
+    {
+      status: "on_time",
+      toleranceMin: 0,
+      deltaFromWindowMin: 0,
+      earlyByMin: null,
+      lateByMin: null,
+    },
+  );
+});
+
+test("classifyTimeWindowCompliance applies tolerance to early and late arrivals", () => {
+  assert.equal(
+    classifyTimeWindowCompliance({
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:00:00.000Z"),
+      actualArrival: new Date("2026-05-03T09:56:00.000Z"),
+      toleranceMin: 5,
+    }).status,
+    "on_time",
+  );
+
+  assert.deepEqual(
+    classifyTimeWindowCompliance({
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:00:00.000Z"),
+      actualArrival: new Date("2026-05-03T09:50:00.000Z"),
+      toleranceMin: 5,
+    }),
+    {
+      status: "early",
+      toleranceMin: 5,
+      deltaFromWindowMin: -10,
+      earlyByMin: 10,
+      lateByMin: null,
+    },
+  );
+
+  assert.deepEqual(
+    classifyTimeWindowCompliance({
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:00:00.000Z"),
+      actualArrival: new Date("2026-05-03T11:10:00.000Z"),
+      toleranceMin: 5,
+    }),
+    {
+      status: "late",
+      toleranceMin: 5,
+      deltaFromWindowMin: 10,
+      earlyByMin: null,
+      lateByMin: 10,
+    },
+  );
+});
+
+test("classifyTimeWindowCompliance handles missing actuals and invalid windows", () => {
+  assert.equal(
+    classifyTimeWindowCompliance({
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:00:00.000Z"),
+      actualArrival: null,
+    }).status,
+    "missing_actual",
+  );
+
+  assert.equal(
+    classifyTimeWindowCompliance({
+      windowStart: new Date("2026-05-03T11:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T10:00:00.000Z"),
+      actualArrival: new Date("2026-05-03T10:30:00.000Z"),
+    }).status,
+    "no_window",
+  );
+});
+
+test("summarizeWindowCompliance returns evaluated and partial compliance metrics", () => {
+  assert.deepEqual(
+    summarizeWindowCompliance([
+      "on_time",
+      "on_time",
+      "early",
+      "late",
+      "missing_actual",
+      "no_window",
+    ]),
+    {
+      totalCount: 6,
+      evaluatedCount: 4,
+      earlyCount: 1,
+      onTimeCount: 2,
+      lateCount: 1,
+      noWindowCount: 1,
+      missingActualCount: 1,
+      complianceRate: 50,
+    },
+  );
+});
+
+test("calculateBasicRouteComplianceMetrics combines distance stop and window summaries", () => {
+  assert.deepEqual(
+    calculateBasicRouteComplianceMetrics({
+      plannedKm: 90,
+      actualKm: 99,
+      totalStops: 5,
+      completedStops: 3,
+      distanceTolerancePercent: 10,
+      windowStatuses: ["on_time", "late", "missing_actual"],
+    }),
+    {
+      distance: {
+        plannedKm: 90,
+        actualKm: 99,
+        deltaKm: 9,
+        absoluteDeltaKm: 9,
+        deltaPercent: 10,
+        efficiencyRatio: 1.1,
+        withinTolerance: true,
+      },
+      totalStops: 5,
+      completedStops: 3,
+      completionRate: 60,
+      kmPerCompletedVisit: 33,
+      windows: {
+        totalCount: 3,
+        evaluatedCount: 2,
+        earlyCount: 0,
+        onTimeCount: 1,
+        lateCount: 1,
+        noWindowCount: 0,
+        missingActualCount: 1,
+        complianceRate: 50,
+      },
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- add pure logistics compliance metric helpers
- calculate planned vs actual distance deltas
- calculate distance deviation percentage and tolerance compliance
- calculate kilometers per completed visit
- classify time window compliance as early/on_time/late/no_window/missing_actual
- summarize partial window compliance metrics when operational data is incomplete
- add unit tests for distance, stop completion and time-window compliance metrics

## Scope

Pure logic PR for basic logistics compliance metrics.

## Out of scope

- no API endpoints
- no dashboard/reporting UI
- no database schema changes
- no migrations
- no route event ingestion
- no geocoding
- no external map provider
- no route optimization
- no VRP/TSP/A*/Dijkstra/ACO

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
