### PR TITLE
feat(logistics-metrics): add SLA compliance helpers

### DIFF
--- a/pr194-body.md
+++ b/pr194-body.md
@@ -1,0 +1,28 @@
+## Summary
+
+- add pure SLA compliance helpers to logistics metrics
+- classify SLA instances as active, paused, breached, resolved, canceled or missing_due_date
+- calculate overdue and remaining minutes
+- detect late resolutions against dueAt
+- aggregate SLA compliance status counts and breach rate
+- add unit tests for active, paused, breached, resolved, canceled and partial SLA cases
+
+## Scope
+
+Pure logic PR for SLA compliance metrics.
+
+## Out of scope
+
+- no API endpoints
+- no background jobs
+- no notifications
+- no escalation workflow
+- no dashboard/reporting UI
+- no database schema changes
+- no migrations
+
+## Validation
+
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test

--- a/server/lib/logistics/metrics.ts
+++ b/server/lib/logistics/metrics.ts
@@ -295,3 +295,175 @@ export function calculateBasicRouteComplianceMetrics(
     windows: summarizeWindowCompliance(input.windowStatuses ?? []),
   };
 }
+export type SlaComplianceStatus =
+  | "active"
+  | "paused"
+  | "breached"
+  | "resolved"
+  | "canceled"
+  | "missing_due_date";
+
+export interface SlaComplianceInput {
+  now?: Date | null;
+  dueAt?: Date | null;
+  pausedAt?: Date | null;
+  breachedAt?: Date | null;
+  resolvedAt?: Date | null;
+  canceledAt?: Date | null;
+}
+
+export interface SlaComplianceResult {
+  status: SlaComplianceStatus;
+  isBreached: boolean | null;
+  overdueMin: number | null;
+  remainingMin: number | null;
+  resolvedLateMin: number | null;
+}
+
+export interface SlaComplianceSummary {
+  totalCount: number;
+  evaluatedCount: number;
+  activeCount: number;
+  pausedCount: number;
+  breachedCount: number;
+  resolvedCount: number;
+  canceledCount: number;
+  missingDueDateCount: number;
+  breachRate: number | null;
+  resolvedLateCount: number;
+}
+
+function calculateMinuteDelta(fromMs: number, toMs: number): number {
+  return roundMetric((toMs - fromMs) / 60000);
+}
+
+export function classifySlaCompliance(
+  input: SlaComplianceInput,
+): SlaComplianceResult {
+  const nowMs = getDateMs(input.now) ?? Date.now();
+  const dueAtMs = getDateMs(input.dueAt);
+  const pausedAtMs = getDateMs(input.pausedAt);
+  const breachedAtMs = getDateMs(input.breachedAt);
+  const resolvedAtMs = getDateMs(input.resolvedAt);
+  const canceledAtMs = getDateMs(input.canceledAt);
+
+  if (dueAtMs === null) {
+    return {
+      status: "missing_due_date",
+      isBreached: null,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: null,
+    };
+  }
+
+  if (canceledAtMs !== null) {
+    return {
+      status: "canceled",
+      isBreached: false,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: null,
+    };
+  }
+
+  if (resolvedAtMs !== null) {
+    const resolvedLateMin = calculateMinuteDelta(dueAtMs, resolvedAtMs);
+    const isBreached = resolvedLateMin > 0 || breachedAtMs !== null;
+
+    return {
+      status: isBreached ? "breached" : "resolved",
+      isBreached,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: isBreached ? Math.max(resolvedLateMin, 0) : 0,
+    };
+  }
+
+  if (pausedAtMs !== null) {
+    const overdueMin = calculateMinuteDelta(dueAtMs, pausedAtMs);
+    const isBreached = overdueMin > 0 || breachedAtMs !== null;
+
+    return {
+      status: isBreached ? "breached" : "paused",
+      isBreached,
+      overdueMin: isBreached ? Math.max(overdueMin, 0) : null,
+      remainingMin: isBreached
+        ? null
+        : Math.max(calculateMinuteDelta(pausedAtMs, dueAtMs), 0),
+      resolvedLateMin: null,
+    };
+  }
+
+  const overdueMin = calculateMinuteDelta(dueAtMs, nowMs);
+  const isBreached = overdueMin > 0 || breachedAtMs !== null;
+
+  if (isBreached) {
+    return {
+      status: "breached",
+      isBreached: true,
+      overdueMin: Math.max(overdueMin, 0),
+      remainingMin: null,
+      resolvedLateMin: null,
+    };
+  }
+
+  return {
+    status: "active",
+    isBreached: false,
+    overdueMin: null,
+    remainingMin: Math.max(calculateMinuteDelta(nowMs, dueAtMs), 0),
+    resolvedLateMin: null,
+  };
+}
+
+export function summarizeSlaCompliance(
+  results: readonly SlaComplianceResult[],
+): SlaComplianceSummary {
+  let activeCount = 0;
+  let pausedCount = 0;
+  let breachedCount = 0;
+  let resolvedCount = 0;
+  let canceledCount = 0;
+  let missingDueDateCount = 0;
+  let resolvedLateCount = 0;
+
+  for (const result of results) {
+    if (result.status === "active") {
+      activeCount += 1;
+    } else if (result.status === "paused") {
+      pausedCount += 1;
+    } else if (result.status === "breached") {
+      breachedCount += 1;
+    } else if (result.status === "resolved") {
+      resolvedCount += 1;
+    } else if (result.status === "canceled") {
+      canceledCount += 1;
+    } else if (result.status === "missing_due_date") {
+      missingDueDateCount += 1;
+    }
+
+    if ((result.resolvedLateMin ?? 0) > 0) {
+      resolvedLateCount += 1;
+    }
+  }
+
+  const evaluatedCount =
+    activeCount + pausedCount + breachedCount + resolvedCount + canceledCount;
+
+  return {
+    totalCount: results.length,
+    evaluatedCount,
+    activeCount,
+    pausedCount,
+    breachedCount,
+    resolvedCount,
+    canceledCount,
+    missingDueDateCount,
+    breachRate:
+      evaluatedCount > 0
+        ? roundMetric((breachedCount / evaluatedCount) * 100)
+        : null,
+    resolvedLateCount,
+  };
+}

--- a/test/logistics-sla-compliance.test.ts
+++ b/test/logistics-sla-compliance.test.ts
@@ -1,0 +1,237 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifySlaCompliance,
+  summarizeSlaCompliance,
+} from "../server/lib/logistics/metrics.ts";
+
+const now = new Date("2026-05-03T12:00:00.000Z");
+
+test("classifySlaCompliance returns active with remaining minutes before dueAt", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T12:45:00.000Z"),
+    }),
+    {
+      status: "active",
+      isBreached: false,
+      overdueMin: null,
+      remainingMin: 45,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("classifySlaCompliance returns breached with overdue minutes after dueAt", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T11:30:00.000Z"),
+    }),
+    {
+      status: "breached",
+      isBreached: true,
+      overdueMin: 30,
+      remainingMin: null,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("classifySlaCompliance respects explicit breachedAt even before dueAt", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T12:45:00.000Z"),
+      breachedAt: new Date("2026-05-03T11:50:00.000Z"),
+    }),
+    {
+      status: "breached",
+      isBreached: true,
+      overdueMin: 0,
+      remainingMin: null,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("classifySlaCompliance returns paused when paused before dueAt", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T12:45:00.000Z"),
+      pausedAt: new Date("2026-05-03T12:15:00.000Z"),
+    }),
+    {
+      status: "paused",
+      isBreached: false,
+      overdueMin: null,
+      remainingMin: 30,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("classifySlaCompliance returns breached when paused after dueAt", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T11:30:00.000Z"),
+      pausedAt: new Date("2026-05-03T11:45:00.000Z"),
+    }),
+    {
+      status: "breached",
+      isBreached: true,
+      overdueMin: 15,
+      remainingMin: null,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("classifySlaCompliance returns resolved when resolved before dueAt", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T12:45:00.000Z"),
+      resolvedAt: new Date("2026-05-03T12:15:00.000Z"),
+    }),
+    {
+      status: "resolved",
+      isBreached: false,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: 0,
+    },
+  );
+});
+
+test("classifySlaCompliance returns breached for late resolution", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T11:30:00.000Z"),
+      resolvedAt: new Date("2026-05-03T12:10:00.000Z"),
+    }),
+    {
+      status: "breached",
+      isBreached: true,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: 40,
+    },
+  );
+});
+
+test("classifySlaCompliance returns canceled before breach math", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: new Date("2026-05-03T11:30:00.000Z"),
+      canceledAt: new Date("2026-05-03T11:45:00.000Z"),
+    }),
+    {
+      status: "canceled",
+      isBreached: false,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("classifySlaCompliance handles missing due date as partial metric", () => {
+  assert.deepEqual(
+    classifySlaCompliance({
+      now,
+      dueAt: null,
+    }),
+    {
+      status: "missing_due_date",
+      isBreached: null,
+      overdueMin: null,
+      remainingMin: null,
+      resolvedLateMin: null,
+    },
+  );
+});
+
+test("summarizeSlaCompliance aggregates status counts and breach rate", () => {
+  const active = classifySlaCompliance({
+    now,
+    dueAt: new Date("2026-05-03T12:45:00.000Z"),
+  });
+  const paused = classifySlaCompliance({
+    now,
+    dueAt: new Date("2026-05-03T12:45:00.000Z"),
+    pausedAt: new Date("2026-05-03T12:15:00.000Z"),
+  });
+  const breached = classifySlaCompliance({
+    now,
+    dueAt: new Date("2026-05-03T11:30:00.000Z"),
+  });
+  const resolved = classifySlaCompliance({
+    now,
+    dueAt: new Date("2026-05-03T12:45:00.000Z"),
+    resolvedAt: new Date("2026-05-03T12:15:00.000Z"),
+  });
+  const lateResolved = classifySlaCompliance({
+    now,
+    dueAt: new Date("2026-05-03T11:30:00.000Z"),
+    resolvedAt: new Date("2026-05-03T12:10:00.000Z"),
+  });
+  const canceled = classifySlaCompliance({
+    now,
+    dueAt: new Date("2026-05-03T12:45:00.000Z"),
+    canceledAt: new Date("2026-05-03T12:10:00.000Z"),
+  });
+  const missingDueDate = classifySlaCompliance({ now, dueAt: null });
+
+  assert.deepEqual(
+    summarizeSlaCompliance([
+      active,
+      paused,
+      breached,
+      resolved,
+      lateResolved,
+      canceled,
+      missingDueDate,
+    ]),
+    {
+      totalCount: 7,
+      evaluatedCount: 6,
+      activeCount: 1,
+      pausedCount: 1,
+      breachedCount: 2,
+      resolvedCount: 1,
+      canceledCount: 1,
+      missingDueDateCount: 1,
+      breachRate: 33.333333,
+      resolvedLateCount: 1,
+    },
+  );
+});
+
+test("summarizeSlaCompliance returns null breach rate for empty evaluated set", () => {
+  assert.deepEqual(
+    summarizeSlaCompliance([
+      classifySlaCompliance({
+        now,
+        dueAt: null,
+      }),
+    ]),
+    {
+      totalCount: 1,
+      evaluatedCount: 0,
+      activeCount: 0,
+      pausedCount: 0,
+      breachedCount: 0,
+      resolvedCount: 0,
+      canceledCount: 0,
+      missingDueDateCount: 1,
+      breachRate: null,
+      resolvedLateCount: 0,
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- add pure SLA compliance helpers to logistics metrics
- classify SLA instances as active, paused, breached, resolved, canceled or missing_due_date
- calculate overdue and remaining minutes
- detect late resolutions against dueAt
- aggregate SLA compliance status counts and breach rate
- add unit tests for active, paused, breached, resolved, canceled and partial SLA cases

## Scope

Pure logic PR for SLA compliance metrics.

## Out of scope

- no API endpoints
- no background jobs
- no notifications
- no escalation workflow
- no dashboard/reporting UI
- no database schema changes
- no migrations

## Validation

- pnpm typecheck
- pnpm typecheck:test
- pnpm test
