### PR TITLE
feat(logistics-metrics): add route event aggregation helpers

### DIFF
--- a/pr195-body.md
+++ b/pr195-body.md
@@ -1,0 +1,21 @@
+﻿## Summary
+
+- add pure route event aggregation helpers
+- count route events by event type and source
+- extract first/last event boundaries by route plan and route stop
+- calculate route and stop durations from event pairs
+- report missing event types for incomplete operational timelines
+- add unit tests for route event aggregation and duration helpers
+
+## Scope
+
+Pure logic PR for route event aggregation metrics.
+
+## Out of scope
+
+- no API endpoints
+- no background jobs
+- no notifications
+- no dashboard/reporting UI
+- no database schema changes
+- no migrations

--- a/server/lib/logistics/metrics.ts
+++ b/server/lib/logistics/metrics.ts
@@ -467,3 +467,196 @@ export function summarizeSlaCompliance(
     resolvedLateCount,
   };
 }
+
+export interface RouteEventMetricInput {
+  routePlanId?: number | null;
+  routeStopId?: number | null;
+  eventType: string;
+  source?: string | null;
+  eventTime: Date;
+}
+
+export interface RouteEventBoundary {
+  eventType: string;
+  eventTime: Date;
+  routePlanId: number | null;
+  routeStopId: number | null;
+}
+
+export interface RouteEventAggregationSummary {
+  totalCount: number;
+  byEventType: Record<string, number>;
+  bySource: Record<string, number>;
+  firstEvent: RouteEventBoundary | null;
+  lastEvent: RouteEventBoundary | null;
+}
+
+export interface RouteEventDurationResult {
+  durationMin: number | null;
+  missingEvents: string[];
+}
+
+function isValidRouteEvent(event: RouteEventMetricInput): boolean {
+  return (
+    typeof event.eventType === "string" &&
+    event.eventType.trim().length > 0 &&
+    event.eventTime instanceof Date &&
+    Number.isFinite(event.eventTime.getTime())
+  );
+}
+
+function toRouteEventBoundary(
+  event: RouteEventMetricInput,
+): RouteEventBoundary {
+  return {
+    eventType: event.eventType,
+    eventTime: event.eventTime,
+    routePlanId:
+      typeof event.routePlanId === "number" && Number.isInteger(event.routePlanId)
+        ? event.routePlanId
+        : null,
+    routeStopId:
+      typeof event.routeStopId === "number" && Number.isInteger(event.routeStopId)
+        ? event.routeStopId
+        : null,
+  };
+}
+
+function sortRouteEvents(
+  events: readonly RouteEventMetricInput[],
+): RouteEventMetricInput[] {
+  return events
+    .filter(isValidRouteEvent)
+    .slice()
+    .sort((left, right) => left.eventTime.getTime() - right.eventTime.getTime());
+}
+
+export function summarizeRouteEvents(
+  events: readonly RouteEventMetricInput[],
+): RouteEventAggregationSummary {
+  const sortedEvents = sortRouteEvents(events);
+  const byEventType: Record<string, number> = {};
+  const bySource: Record<string, number> = {};
+
+  for (const event of sortedEvents) {
+    byEventType[event.eventType] = (byEventType[event.eventType] ?? 0) + 1;
+
+    const source = event.source?.trim() || "unknown";
+    bySource[source] = (bySource[source] ?? 0) + 1;
+  }
+
+  const first = sortedEvents[0] ?? null;
+  const last = sortedEvents.length > 0 ? sortedEvents[sortedEvents.length - 1] : null;
+
+  return {
+    totalCount: sortedEvents.length,
+    byEventType,
+    bySource,
+    firstEvent: first ? toRouteEventBoundary(first) : null,
+    lastEvent: last ? toRouteEventBoundary(last) : null,
+  };
+}
+
+export function getRouteEventBoundariesByRoutePlan(
+  events: readonly RouteEventMetricInput[],
+): Record<number, { firstEvent: RouteEventBoundary; lastEvent: RouteEventBoundary }> {
+  const grouped: Record<number, RouteEventMetricInput[]> = {};
+
+  for (const event of sortRouteEvents(events)) {
+    if (typeof event.routePlanId !== "number" || !Number.isInteger(event.routePlanId)) {
+      continue;
+    }
+
+    grouped[event.routePlanId] = grouped[event.routePlanId] ?? [];
+    grouped[event.routePlanId].push(event);
+  }
+
+  const result: Record<
+    number,
+    { firstEvent: RouteEventBoundary; lastEvent: RouteEventBoundary }
+  > = {};
+
+  for (const [routePlanId, routeEvents] of Object.entries(grouped)) {
+    const first = routeEvents[0];
+    const last = routeEvents.length > 0 ? routeEvents[routeEvents.length - 1] : undefined;
+
+    if (first && last) {
+      result[Number(routePlanId)] = {
+        firstEvent: toRouteEventBoundary(first),
+        lastEvent: toRouteEventBoundary(last),
+      };
+    }
+  }
+
+  return result;
+}
+
+export function getRouteEventBoundariesByRouteStop(
+  events: readonly RouteEventMetricInput[],
+): Record<number, { firstEvent: RouteEventBoundary; lastEvent: RouteEventBoundary }> {
+  const grouped: Record<number, RouteEventMetricInput[]> = {};
+
+  for (const event of sortRouteEvents(events)) {
+    if (typeof event.routeStopId !== "number" || !Number.isInteger(event.routeStopId)) {
+      continue;
+    }
+
+    grouped[event.routeStopId] = grouped[event.routeStopId] ?? [];
+    grouped[event.routeStopId].push(event);
+  }
+
+  const result: Record<
+    number,
+    { firstEvent: RouteEventBoundary; lastEvent: RouteEventBoundary }
+  > = {};
+
+  for (const [routeStopId, routeEvents] of Object.entries(grouped)) {
+    const first = routeEvents[0];
+    const last = routeEvents.length > 0 ? routeEvents[routeEvents.length - 1] : undefined;
+
+    if (first && last) {
+      result[Number(routeStopId)] = {
+        firstEvent: toRouteEventBoundary(first),
+        lastEvent: toRouteEventBoundary(last),
+      };
+    }
+  }
+
+  return result;
+}
+
+export function calculateDurationBetweenRouteEvents(
+  events: readonly RouteEventMetricInput[],
+  startEventType: string,
+  endEventType: string,
+): RouteEventDurationResult {
+  const sortedEvents = sortRouteEvents(events);
+  const start = sortedEvents.find((event) => event.eventType === startEventType);
+  const end = sortedEvents.find(
+    (event) =>
+      event.eventType === endEventType &&
+      (!start || event.eventTime.getTime() >= start.eventTime.getTime()),
+  );
+
+  const missingEvents: string[] = [];
+
+  if (!start) {
+    missingEvents.push(startEventType);
+  }
+
+  if (!end) {
+    missingEvents.push(endEventType);
+  }
+
+  if (!start || !end) {
+    return { durationMin: null, missingEvents };
+  }
+
+  return {
+    durationMin: calculateMinuteDelta(
+      start.eventTime.getTime(),
+      end.eventTime.getTime(),
+    ),
+    missingEvents,
+  };
+}

--- a/test/logistics-route-event-aggregation.test.ts
+++ b/test/logistics-route-event-aggregation.test.ts
@@ -1,0 +1,162 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  calculateDurationBetweenRouteEvents,
+  getRouteEventBoundariesByRoutePlan,
+  getRouteEventBoundariesByRouteStop,
+  summarizeRouteEvents,
+} from "../server/lib/logistics/metrics.ts";
+
+const events = [
+  {
+    routePlanId: 10,
+    eventType: "route.completed",
+    source: "system",
+    eventTime: new Date("2026-05-03T12:00:00.000Z"),
+  },
+  {
+    routePlanId: 10,
+    eventType: "route.started",
+    source: "mobile",
+    eventTime: new Date("2026-05-03T10:00:00.000Z"),
+  },
+  {
+    routePlanId: 10,
+    routeStopId: 100,
+    eventType: "stop.arrived",
+    source: "mobile",
+    eventTime: new Date("2026-05-03T10:30:00.000Z"),
+  },
+  {
+    routePlanId: 10,
+    routeStopId: 100,
+    eventType: "stop.departed",
+    source: "mobile",
+    eventTime: new Date("2026-05-03T10:50:00.000Z"),
+  },
+] as const;
+
+test("summarizeRouteEvents counts by event type and source", () => {
+  assert.deepEqual(summarizeRouteEvents(events), {
+    totalCount: 4,
+    byEventType: {
+      "route.started": 1,
+      "stop.arrived": 1,
+      "stop.departed": 1,
+      "route.completed": 1,
+    },
+    bySource: {
+      mobile: 3,
+      system: 1,
+    },
+    firstEvent: {
+      eventType: "route.started",
+      eventTime: new Date("2026-05-03T10:00:00.000Z"),
+      routePlanId: 10,
+      routeStopId: null,
+    },
+    lastEvent: {
+      eventType: "route.completed",
+      eventTime: new Date("2026-05-03T12:00:00.000Z"),
+      routePlanId: 10,
+      routeStopId: null,
+    },
+  });
+});
+
+test("getRouteEventBoundariesByRoutePlan returns first and last events per route", () => {
+  assert.deepEqual(getRouteEventBoundariesByRoutePlan(events), {
+    10: {
+      firstEvent: {
+        eventType: "route.started",
+        eventTime: new Date("2026-05-03T10:00:00.000Z"),
+        routePlanId: 10,
+        routeStopId: null,
+      },
+      lastEvent: {
+        eventType: "route.completed",
+        eventTime: new Date("2026-05-03T12:00:00.000Z"),
+        routePlanId: 10,
+        routeStopId: null,
+      },
+    },
+  });
+});
+
+test("getRouteEventBoundariesByRouteStop returns first and last events per stop", () => {
+  assert.deepEqual(getRouteEventBoundariesByRouteStop(events), {
+    100: {
+      firstEvent: {
+        eventType: "stop.arrived",
+        eventTime: new Date("2026-05-03T10:30:00.000Z"),
+        routePlanId: 10,
+        routeStopId: 100,
+      },
+      lastEvent: {
+        eventType: "stop.departed",
+        eventTime: new Date("2026-05-03T10:50:00.000Z"),
+        routePlanId: 10,
+        routeStopId: 100,
+      },
+    },
+  });
+});
+
+test("calculateDurationBetweenRouteEvents returns route duration", () => {
+  assert.deepEqual(
+    calculateDurationBetweenRouteEvents(
+      events,
+      "route.started",
+      "route.completed",
+    ),
+    {
+      durationMin: 120,
+      missingEvents: [],
+    },
+  );
+});
+
+test("calculateDurationBetweenRouteEvents returns stop service duration", () => {
+  assert.deepEqual(
+    calculateDurationBetweenRouteEvents(
+      events,
+      "stop.arrived",
+      "stop.departed",
+    ),
+    {
+      durationMin: 20,
+      missingEvents: [],
+    },
+  );
+});
+
+test("calculateDurationBetweenRouteEvents reports missing event types", () => {
+  assert.deepEqual(
+    calculateDurationBetweenRouteEvents(events, "route.started", "route.canceled"),
+    {
+      durationMin: null,
+      missingEvents: ["route.canceled"],
+    },
+  );
+});
+
+test("summarizeRouteEvents ignores invalid events safely", () => {
+  assert.equal(
+    summarizeRouteEvents([
+      ...events,
+      {
+        routePlanId: 20,
+        eventType: "",
+        source: "mobile",
+        eventTime: new Date("2026-05-03T09:00:00.000Z"),
+      },
+      {
+        routePlanId: 20,
+        eventType: "route.started",
+        source: "mobile",
+        eventTime: new Date("invalid"),
+      },
+    ]).totalCount,
+    4,
+  );
+});


### PR DESCRIPTION
﻿## Summary

- add pure route event aggregation helpers
- count route events by event type and source
- extract first/last event boundaries by route plan and route stop
- calculate route and stop durations from event pairs
- report missing event types for incomplete operational timelines
- add unit tests for route event aggregation and duration helpers

## Scope

Pure logic PR for route event aggregation metrics.

## Out of scope

- no API endpoints
- no background jobs
- no notifications
- no dashboard/reporting UI
- no database schema changes
- no migrations
