### PR TITLE
feat(logistics-api): add clinic visit location endpoints

### DIFF
--- a/server/routes/logistics-field-visits.fastify.ts
+++ b/server/routes/logistics-field-visits.fastify.ts
@@ -7,14 +7,18 @@ import type {
 import {
   FIELD_VISIT_SOURCE_TYPES,
   FIELD_VISIT_STATUSES,
+  VISIT_LOCATION_GEO_QUALITIES,
   type FieldVisitSourceType,
   type FieldVisitStatus,
+  type VisitLocationGeoQuality,
 } from "../../drizzle/schema.ts";
 import type {
   CreateFieldVisitInput,
   FieldVisit,
   ListFieldVisitsParams,
   UpdateFieldVisitInput,
+  UpsertVisitLocationInput,
+  VisitLocation,
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
 
@@ -60,6 +64,13 @@ export type LogisticsFieldVisitsNativeRoutesOptions = {
     clinicId: number,
     input: UpdateFieldVisitInput,
   ) => Promise<FieldVisit | null | undefined>;
+  getVisitLocationForClinicVisit?: (
+    fieldVisitId: number,
+    clinicId: number,
+  ) => Promise<VisitLocation | null | undefined>;
+  upsertVisitLocationForClinicVisit?: (
+    input: UpsertVisitLocationInput,
+  ) => Promise<VisitLocation | null | undefined>;
   now?: () => number;
 };
 
@@ -74,6 +85,8 @@ type NativeLogisticsFieldVisitsDeps = Required<
     | "createFieldVisit"
     | "listClinicFieldVisits"
     | "updateClinicScopedFieldVisit"
+    | "getVisitLocationForClinicVisit"
+    | "upsertVisitLocationForClinicVisit"
   >
 >;
 
@@ -99,6 +112,10 @@ async function loadDefaultDeps(): Promise<NativeLogisticsFieldVisitsDeps> {
         listClinicFieldVisits: dbLogistics.listClinicFieldVisits,
         updateClinicScopedFieldVisit:
           dbLogistics.updateClinicScopedFieldVisit,
+        getVisitLocationForClinicVisit:
+          dbLogistics.getVisitLocationForClinicVisit,
+        upsertVisitLocationForClinicVisit:
+          dbLogistics.upsertVisitLocationForClinicVisit,
       };
     })();
   }
@@ -704,6 +721,146 @@ function buildUpdateFieldVisitInput(
   return { input };
 }
 
+
+function parseOptionalNumberField(
+  value: unknown,
+  fieldName: string,
+): { value?: number | null; error?: string } {
+  if (value == null || value === "") {
+    return { value: null };
+  }
+
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed)) {
+    return {
+      error: `${fieldName} debe ser numerico o null`,
+    };
+  }
+
+  return { value: parsed };
+}
+
+function parseVisitLocationGeoQuality(
+  value: unknown,
+): { value?: VisitLocationGeoQuality; error?: string } {
+  if (value == null || value === "") {
+    return {};
+  }
+
+  if (typeof value !== "string") {
+    return { error: "geoQuality invalido" };
+  }
+
+  const normalized = value.trim();
+
+  if (
+    VISIT_LOCATION_GEO_QUALITIES.includes(
+      normalized as VisitLocationGeoQuality,
+    )
+  ) {
+    return { value: normalized as VisitLocationGeoQuality };
+  }
+
+  return { error: "geoQuality invalido" };
+}
+
+function buildUpsertVisitLocationInput(
+  body: unknown,
+  fieldVisitId: number,
+  clinicId: number,
+): { input?: UpsertVisitLocationInput; error?: string } {
+  if (!isRecord(body)) {
+    return { error: "Body invalido" };
+  }
+
+  const addressRaw = normalizeOptionalText(body.addressRaw);
+
+  if (!addressRaw) {
+    return { error: "addressRaw es obligatorio" };
+  }
+
+  const addressNormalized = normalizeOptionalText(body.addressNormalized);
+
+  if (addressNormalized === undefined) {
+    return { error: "addressNormalized debe ser texto o null" };
+  }
+
+  const locality = normalizeOptionalText(body.locality);
+
+  if (locality === undefined) {
+    return { error: "locality debe ser texto o null" };
+  }
+
+  const country = normalizeOptionalText(body.country);
+
+  if (country === undefined) {
+    return { error: "country debe ser texto o null" };
+  }
+
+  const lat = parseOptionalNumberField(body.lat, "lat");
+
+  if (lat.error) {
+    return { error: lat.error };
+  }
+
+  const lng = parseOptionalNumberField(body.lng, "lng");
+
+  if (lng.error) {
+    return { error: lng.error };
+  }
+
+  const geoQuality = parseVisitLocationGeoQuality(body.geoQuality);
+
+  if (geoQuality.error) {
+    return { error: geoQuality.error };
+  }
+
+  const geocodeSource = normalizeOptionalText(body.geocodeSource);
+
+  if (geocodeSource === undefined) {
+    return { error: "geocodeSource debe ser texto o null" };
+  }
+
+  return {
+    input: {
+      fieldVisitId,
+      clinicId,
+      addressRaw,
+      addressNormalized,
+      locality,
+      country,
+      lat: lat.value,
+      lng: lng.value,
+      geoQuality: geoQuality.value,
+      geocodeSource,
+    },
+  };
+}
+
+function serializeVisitLocation(
+  location: VisitLocation,
+): Record<string, unknown> {
+  return {
+    id: location.id,
+    fieldVisitId: location.fieldVisitId,
+    addressRaw: location.addressRaw,
+    addressNormalized: location.addressNormalized,
+    locality: location.locality,
+    country: location.country,
+    lat: location.lat,
+    lng: location.lng,
+    geoQuality: location.geoQuality,
+    geocodeSource: location.geocodeSource,
+    updatedAt: serializeDate(location.updatedAt),
+  };
+}
+
 function serializeDate(value: Date | null | undefined): string | null {
   if (!(value instanceof Date)) {
     return null;
@@ -739,7 +896,9 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
     !!options.hashSessionToken &&
     !!options.createFieldVisit &&
     !!options.listClinicFieldVisits &&
-    !!options.updateClinicScopedFieldVisit;
+    !!options.updateClinicScopedFieldVisit &&
+    !!options.getVisitLocationForClinicVisit &&
+    !!options.upsertVisitLocationForClinicVisit;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -761,6 +920,12 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
     updateClinicScopedFieldVisit:
       options.updateClinicScopedFieldVisit ??
       defaultDeps!.updateClinicScopedFieldVisit,
+    getVisitLocationForClinicVisit:
+      options.getVisitLocationForClinicVisit ??
+      defaultDeps!.getVisitLocationForClinicVisit,
+    upsertVisitLocationForClinicVisit:
+      options.upsertVisitLocationForClinicVisit ??
+      defaultDeps!.upsertVisitLocationForClinicVisit,
   };
 
   const now = options.now ?? (() => Date.now());
@@ -785,7 +950,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
     }
 
     applyCorsHeaders(request, reply, allowedOrigins);
-    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
+    reply.header("access-control-allow-methods", "GET,POST,PUT,PATCH,OPTIONS");
 
     const requestedHeaders =
       typeof request.headers["access-control-request-headers"] === "string"
@@ -798,6 +963,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
 
   app.options("/", optionsHandler);
   app.options("/:fieldVisitId", optionsHandler);
+  app.options("/:fieldVisitId/location", optionsHandler);
 
   app.get<{
     Querystring: {
@@ -951,4 +1117,97 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       fieldVisit: serializeFieldVisit(updated),
     });
   });
+
+  app.get<{
+    Params: {
+      fieldVisitId: string;
+    };
+  }>("/:fieldVisitId/location", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const fieldVisitId = parseEntityId(request.params.fieldVisitId);
+
+    if (!fieldVisitId) {
+      return reply.code(400).send({
+        success: false,
+        error: "fieldVisitId invalido",
+      });
+    }
+
+    const location = await deps.getVisitLocationForClinicVisit(
+      fieldVisitId,
+      auth.clinicId,
+    );
+
+    if (!location) {
+      return reply.code(404).send({
+        success: false,
+        error: "Ubicacion de visita no encontrada",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      location: serializeVisitLocation(location),
+    });
+  });
+
+  app.put<{
+    Params: {
+      fieldVisitId: string;
+    };
+    Body: unknown;
+  }>("/:fieldVisitId/location", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const fieldVisitId = parseEntityId(request.params.fieldVisitId);
+
+    if (!fieldVisitId) {
+      return reply.code(400).send({
+        success: false,
+        error: "fieldVisitId invalido",
+      });
+    }
+
+    const parsed = buildUpsertVisitLocationInput(
+      request.body,
+      fieldVisitId,
+      auth.clinicId,
+    );
+
+    if (!parsed.input) {
+      return reply.code(400).send({
+        success: false,
+        error: parsed.error ?? "Body invalido",
+      });
+    }
+
+    const location = await deps.upsertVisitLocationForClinicVisit(parsed.input);
+
+    if (!location) {
+      return reply.code(404).send({
+        success: false,
+        error: "Visita de campo no encontrada",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      message: "Ubicacion de visita guardada correctamente",
+      location: serializeVisitLocation(location),
+    });
+  });
+
 };

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -522,6 +522,8 @@ function buildLogisticsFieldVisitsRouteStubs() {
     createFieldVisit: async () => null,
     listClinicFieldVisits: async () => [],
     updateClinicScopedFieldVisit: async () => null,
+    getVisitLocationForClinicVisit: async () => null,
+    upsertVisitLocationForClinicVisit: async () => null,
   };
 }
 function buildFastifyDispatchRouteStubs() {

--- a/test/logistics-field-visits-api.test.ts
+++ b/test/logistics-field-visits-api.test.ts
@@ -63,3 +63,43 @@ test("logistics field visit API keeps unsafe methods behind trusted-origin check
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /Origen no permitido/);
 });
+
+
+test("logistics field visit API exposes clinic-scoped location endpoints", () => {
+  assert.match(routeSource, /app\.get<[\s\S]*>\("\/:fieldVisitId\/location", async/);
+  assert.match(routeSource, /app\.put<[\s\S]*>\("\/:fieldVisitId\/location", async/);
+  assert.match(routeSource, /app\.options\("\/:fieldVisitId\/location", optionsHandler\)/);
+  assert.match(routeSource, /GET,POST,PUT,PATCH,OPTIONS/);
+});
+
+test("logistics field visit API wires visit location DB helpers through injectable deps", () => {
+  assert.match(routeSource, /getVisitLocationForClinicVisit\?:/);
+  assert.match(routeSource, /upsertVisitLocationForClinicVisit\?:/);
+  assert.match(routeSource, /dbLogistics\.getVisitLocationForClinicVisit/);
+  assert.match(routeSource, /dbLogistics\.upsertVisitLocationForClinicVisit/);
+  assert.match(routeSource, /deps\.getVisitLocationForClinicVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /deps\.upsertVisitLocationForClinicVisit\(parsed\.input\)/);
+});
+
+test("logistics field visit API validates visit location payload before upsert", () => {
+  assert.match(routeSource, /function buildUpsertVisitLocationInput/);
+  assert.match(routeSource, /addressRaw es obligatorio/);
+  assert.match(routeSource, /parseOptionalNumberField\(body\.lat, "lat"\)/);
+  assert.match(routeSource, /parseOptionalNumberField\(body\.lng, "lng"\)/);
+  assert.match(routeSource, /VISIT_LOCATION_GEO_QUALITIES/);
+  assert.match(routeSource, /parseVisitLocationGeoQuality\(body\.geoQuality\)/);
+});
+
+test("logistics field visit API serializes visit location without exposing non-schema fields", () => {
+  assert.match(routeSource, /function serializeVisitLocation/);
+  assert.match(routeSource, /addressRaw: location\.addressRaw/);
+  assert.match(routeSource, /geoQuality: location\.geoQuality/);
+  assert.match(routeSource, /updatedAt: serializeDate\(location\.updatedAt\)/);
+  assert.doesNotMatch(routeSource, /createdAt: serializeDate\(location\.createdAt\)/);
+});
+
+test("logistics field visit API keeps location writes behind trusted-origin checks", () => {
+  assert.match(routeSource, /app\.put<[\s\S]*>\("\/:fieldVisitId\/location", async/);
+  assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
+  assert.match(routeSource, /auth\.clinicId/);
+});


### PR DESCRIPTION
﻿## Summary
- Add clinic-scoped visit location endpoints under `/api/logistics/field-visits/:fieldVisitId/location`.
- Support `GET` for reading an existing location and `PUT` for upserting a location.
- Reuse existing logistics DB helpers.
- Keep reads and writes scoped to the authenticated clinic session.
- Add guardrail tests for route registration, helper wiring, validation, serialization, and trusted-origin protection.

## Scope
- Clinic visit location API only.
- No time-window endpoints.
- No route plan endpoints.
- No admin logistics API.
- No schema changes.
- No migrations.

## Validation
- `pnpm typecheck:test`
- `pnpm test` — 781/781
- `pnpm validate:local`
