### PR TITLE
feat(logistics-api): add route plan release lifecycle

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -134,6 +134,54 @@ export type UpdateRouteStopInput = Partial<
   }
 >;
 
+export const ROUTE_PLAN_LIFECYCLE_ACTIONS = [
+  "release",
+  "start",
+  "complete",
+  "cancel",
+] as const;
+
+export type RoutePlanLifecycleAction =
+  (typeof ROUTE_PLAN_LIFECYCLE_ACTIONS)[number];
+
+export type RoutePlanLifecycleTransition = {
+  from: RoutePlanStatus[];
+  to: RoutePlanStatus;
+};
+
+export const ROUTE_PLAN_LIFECYCLE_TRANSITIONS: Record<
+  RoutePlanLifecycleAction,
+  RoutePlanLifecycleTransition
+> = {
+  release: {
+    from: ["draft", "planned"],
+    to: "released",
+  },
+  start: {
+    from: ["released"],
+    to: "in_progress",
+  },
+  complete: {
+    from: ["in_progress"],
+    to: "completed",
+  },
+  cancel: {
+    from: ["draft", "planned", "released", "in_progress"],
+    to: "canceled",
+  },
+};
+
+export type RoutePlanLifecycleTransitionResult =
+  | {
+      routePlan: RoutePlan;
+      reason?: undefined;
+    }
+  | {
+      routePlan?: undefined;
+      reason: "not_found" | "invalid_transition";
+      currentStatus?: RoutePlanStatus;
+    };
+
 export function normalizeLogisticsLimit(
   value: number | null | undefined,
   defaultLimit = LOGISTICS_DEFAULT_LIMIT,
@@ -621,3 +669,68 @@ export async function updateClinicScopedRouteStop(
   });
 }
 
+
+
+export async function transitionClinicScopedRoutePlanStatus(
+  id: number,
+  clinicId: number,
+  action: RoutePlanLifecycleAction,
+): Promise<RoutePlanLifecycleTransitionResult> {
+  const transition = ROUTE_PLAN_LIFECYCLE_TRANSITIONS[action];
+
+  return db.transaction(async (tx) => {
+    const current = await tx
+      .select()
+      .from(routePlans)
+      .where(
+        and(
+          eq(routePlans.id, id),
+          eq(routePlans.clinicId, clinicId),
+        ),
+      )
+      .limit(1);
+
+    const routePlan = current[0];
+
+    if (!routePlan) {
+      return {
+        reason: "not_found",
+      };
+    }
+
+    if (!transition.from.includes(routePlan.status)) {
+      return {
+        reason: "invalid_transition",
+        currentStatus: routePlan.status,
+      };
+    }
+
+    const updated = await tx
+      .update(routePlans)
+      .set({
+        status: transition.to,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(routePlans.id, id),
+          eq(routePlans.clinicId, clinicId),
+          eq(routePlans.status, routePlan.status),
+        ),
+      )
+      .returning();
+
+    const updatedRoutePlan = updated[0];
+
+    if (!updatedRoutePlan) {
+      return {
+        reason: "invalid_transition",
+        currentStatus: routePlan.status,
+      };
+    }
+
+    return {
+      routePlan: updatedRoutePlan,
+    };
+  });
+}

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -19,6 +19,8 @@ import type {
   CreateRouteStopInput,
   ListRoutePlansParams,
   RoutePlan,
+  RoutePlanLifecycleAction,
+  RoutePlanLifecycleTransitionResult,
   RouteStop,
   UpdateRoutePlanInput,
   UpdateRouteStopInput,
@@ -83,6 +85,11 @@ export type LogisticsRoutePlansNativeRoutesOptions = {
     clinicId: number,
     input: UpdateRouteStopInput,
   ) => Promise<RouteStop | null | undefined>;
+  transitionClinicScopedRoutePlanStatus?: (
+    id: number,
+    clinicId: number,
+    action: RoutePlanLifecycleAction,
+  ) => Promise<RoutePlanLifecycleTransitionResult>;
   now?: () => number;
 };
 
@@ -101,6 +108,7 @@ type NativeLogisticsRoutePlansDeps = Required<
     | "createRouteStopForClinicRoutePlan"
     | "listRouteStopsForClinicRoutePlan"
     | "updateClinicScopedRouteStop"
+    | "transitionClinicScopedRoutePlanStatus"
   >
 >;
 
@@ -132,6 +140,8 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
           dbLogistics.listRouteStopsForClinicRoutePlan,
         updateClinicScopedRouteStop:
           dbLogistics.updateClinicScopedRouteStop,
+        transitionClinicScopedRoutePlanStatus:
+          dbLogistics.transitionClinicScopedRoutePlanStatus,
       };
     })();
   }
@@ -1019,6 +1029,32 @@ function buildUpdateRouteStopInput(
   return { input };
 }
 
+
+
+function getLifecycleActionError(
+  result: RoutePlanLifecycleTransitionResult,
+): { statusCode: number; error: string } {
+  if (result.reason === "not_found") {
+    return {
+      statusCode: 404,
+      error: "Plan de ruta no encontrado",
+    };
+  }
+
+  if (result.reason === "invalid_transition") {
+    return {
+      statusCode: 409,
+      error: "Transicion de estado no permitida",
+    };
+  }
+
+  return {
+    statusCode: 500,
+    error: "No se pudo cambiar el estado del plan de ruta",
+  };
+}
+
+
 function serializeDate(value: Date | null | undefined): string | null {
   if (!(value instanceof Date)) {
     return null;
@@ -1078,7 +1114,8 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     !!options.updateClinicScopedRoutePlan &&
     !!options.createRouteStopForClinicRoutePlan &&
     !!options.listRouteStopsForClinicRoutePlan &&
-    !!options.updateClinicScopedRouteStop;
+    !!options.updateClinicScopedRouteStop &&
+    !!options.transitionClinicScopedRoutePlanStatus;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -1111,6 +1148,9 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     updateClinicScopedRouteStop:
       options.updateClinicScopedRouteStop ??
       defaultDeps!.updateClinicScopedRouteStop,
+    transitionClinicScopedRoutePlanStatus:
+      options.transitionClinicScopedRoutePlanStatus ??
+      defaultDeps!.transitionClinicScopedRoutePlanStatus,
   };
 
   const now = options.now ?? (() => Date.now());
@@ -1150,6 +1190,10 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
   app.options("/:routePlanId", optionsHandler);
   app.options("/:routePlanId/stops", optionsHandler);
   app.options("/:routePlanId/stops/:routeStopId", optionsHandler);
+  app.options("/:routePlanId/release", optionsHandler);
+  app.options("/:routePlanId/start", optionsHandler);
+  app.options("/:routePlanId/complete", optionsHandler);
+  app.options("/:routePlanId/cancel", optionsHandler);
 
   app.get<{
     Querystring: {
@@ -1502,4 +1546,89 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       routeStop: serializeRouteStop(routeStop),
     });
   });
+
+  async function handleRoutePlanLifecycleAction(
+    action: RoutePlanLifecycleAction,
+    request: FastifyRequest<{
+      Params: {
+        routePlanId: string;
+      };
+    }>,
+    reply: FastifyReply,
+  ) {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const routePlanId = parseEntityId(request.params.routePlanId);
+
+    if (!routePlanId) {
+      return reply.code(400).send({
+        success: false,
+        error: "routePlanId invalido",
+      });
+    }
+
+    const result = await deps.transitionClinicScopedRoutePlanStatus(
+      routePlanId,
+      auth.clinicId,
+      action,
+    );
+
+    if (!result.routePlan) {
+      const error = getLifecycleActionError(result);
+
+      return reply.code(error.statusCode).send({
+        success: false,
+        error: error.error,
+        currentStatus: result.currentStatus,
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      message: "Estado del plan de ruta actualizado correctamente",
+      action,
+      routePlan: serializeRoutePlan(result.routePlan),
+    });
+  }
+
+  app.post<{
+    Params: {
+      routePlanId: string;
+    };
+  }>("/:routePlanId/release", async (request, reply) =>
+    handleRoutePlanLifecycleAction("release", request, reply),
+  );
+
+  app.post<{
+    Params: {
+      routePlanId: string;
+    };
+  }>("/:routePlanId/start", async (request, reply) =>
+    handleRoutePlanLifecycleAction("start", request, reply),
+  );
+
+  app.post<{
+    Params: {
+      routePlanId: string;
+    };
+  }>("/:routePlanId/complete", async (request, reply) =>
+    handleRoutePlanLifecycleAction("complete", request, reply),
+  );
+
+  app.post<{
+    Params: {
+      routePlanId: string;
+    };
+  }>("/:routePlanId/cancel", async (request, reply) =>
+    handleRoutePlanLifecycleAction("cancel", request, reply),
+  );
+
 };

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -526,6 +526,9 @@ function buildLogisticsRoutePlansRouteStubs() {
     createRouteStopForClinicRoutePlan: async () => null,
     listRouteStopsForClinicRoutePlan: async () => [],
     updateClinicScopedRouteStop: async () => null,
+    transitionClinicScopedRoutePlanStatus: async () => ({
+      reason: "not_found" as const,
+    }),
   };
 }
 

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -92,3 +92,23 @@ test("logistics DB helpers keep route stops clinic scoped through route plans", 
   assert.match(dbLogisticsSource, /eq\(routePlans\.clinicId, clinicId\)/);
   assert.match(dbLogisticsSource, /eq\(routeStops\.id, id\)/);
 });
+
+
+test("logistics DB helpers define guarded route plan lifecycle transitions", () => {
+  assert.match(dbLogisticsSource, /export const ROUTE_PLAN_LIFECYCLE_ACTIONS/);
+  assert.match(dbLogisticsSource, /export const ROUTE_PLAN_LIFECYCLE_TRANSITIONS/);
+  assert.match(dbLogisticsSource, /release:\s*{\s*from: \["draft", "planned"\],\s*to: "released"/);
+  assert.match(dbLogisticsSource, /start:\s*{\s*from: \["released"\],\s*to: "in_progress"/);
+  assert.match(dbLogisticsSource, /complete:\s*{\s*from: \["in_progress"\],\s*to: "completed"/);
+  assert.match(dbLogisticsSource, /cancel:\s*{\s*from: \["draft", "planned", "released", "in_progress"\],\s*to: "canceled"/);
+});
+
+test("logistics DB helpers transition route plan status only inside clinic scope", () => {
+  assert.match(dbLogisticsSource, /export async function transitionClinicScopedRoutePlanStatus/);
+  assert.match(dbLogisticsSource, /db\.transaction\(async \(tx\) =>/);
+  assert.match(dbLogisticsSource, /eq\(routePlans\.id, id\)/);
+  assert.match(dbLogisticsSource, /eq\(routePlans\.clinicId, clinicId\)/);
+  assert.match(dbLogisticsSource, /eq\(routePlans\.status, routePlan\.status\)/);
+  assert.match(dbLogisticsSource, /reason: "invalid_transition"/);
+  assert.match(dbLogisticsSource, /reason: "not_found"/);
+});

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -106,3 +106,30 @@ test("logistics route plans API keeps unsafe methods behind trusted-origin check
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /Origen no permitido/);
 });
+
+
+test("logistics route plans API exposes release lifecycle endpoints", () => {
+  assert.match(routeSource, /app\.post<[\s\S]*>\("\/:routePlanId\/release", async/);
+  assert.match(routeSource, /app\.post<[\s\S]*>\("\/:routePlanId\/start", async/);
+  assert.match(routeSource, /app\.post<[\s\S]*>\("\/:routePlanId\/complete", async/);
+  assert.match(routeSource, /app\.post<[\s\S]*>\("\/:routePlanId\/cancel", async/);
+  assert.match(routeSource, /app\.options\("\/:routePlanId\/release", optionsHandler\)/);
+  assert.match(routeSource, /app\.options\("\/:routePlanId\/cancel", optionsHandler\)/);
+});
+
+test("logistics route plans API wires lifecycle transition helper through injectable deps", () => {
+  assert.match(routeSource, /transitionClinicScopedRoutePlanStatus\?:/);
+  assert.match(routeSource, /RoutePlanLifecycleAction/);
+  assert.match(routeSource, /RoutePlanLifecycleTransitionResult/);
+  assert.match(routeSource, /dbLogistics\.transitionClinicScopedRoutePlanStatus/);
+  assert.match(routeSource, /deps\.transitionClinicScopedRoutePlanStatus\(\s*routePlanId,\s*auth\.clinicId,\s*action,\s*\)/);
+});
+
+test("logistics route plans API keeps lifecycle writes clinic scoped and trusted-origin protected", () => {
+  assert.match(routeSource, /function getLifecycleActionError/);
+  assert.match(routeSource, /async function handleRoutePlanLifecycleAction/);
+  assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
+  assert.match(routeSource, /auth\.clinicId/);
+  assert.match(routeSource, /currentStatus: result\.currentStatus/);
+  assert.match(routeSource, /Transicion de estado no permitida/);
+});


### PR DESCRIPTION
Add route plan release lifecycle. Scope: clinic-scoped release, start, complete, and cancel transitions; no route events, no polling, no schema changes, no migrations. Validation: pnpm typecheck:test, pnpm test 806/806, pnpm validate:local.