### PR TITLE
feat(logistics): add route event DB helpers

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -1,13 +1,17 @@
-﻿import { and, desc, eq } from "drizzle-orm";
+﻿import { and, asc, desc, eq, gt } from "drizzle-orm";
 import { db } from "./db";
 import {
   fieldVisits,
+  routeEvents,
   routePlans,
   routeStops,
   timeWindows,
   visitLocations,
   type FieldVisitSourceType,
   type FieldVisitStatus,
+  type RouteEventPayload,
+  type RouteEventSource,
+  type RouteEventType,
   type RoutePlanCreatedByType,
   type RoutePlanObjective,
   type RoutePlanningMode,
@@ -33,6 +37,8 @@ export type RoutePlan = typeof routePlans.$inferSelect;
 export type NewRoutePlan = typeof routePlans.$inferInsert;
 export type RouteStop = typeof routeStops.$inferSelect;
 export type NewRouteStop = typeof routeStops.$inferInsert;
+export type RouteEvent = typeof routeEvents.$inferSelect;
+export type NewRouteEvent = typeof routeEvents.$inferInsert;
 
 export type CreateFieldVisitInput = {
   clinicId: number;
@@ -133,6 +139,28 @@ export type UpdateRouteStopInput = Partial<
     actualKmFromPrev: number | null;
   }
 >;
+
+export type CreateRouteEventInput = {
+  clinicId: number;
+  routePlanId?: number | null;
+  routeStopId?: number | null;
+  eventType: RouteEventType;
+  eventTime?: Date;
+  payload?: RouteEventPayload | null;
+  lat?: number | null;
+  lng?: number | null;
+  source?: RouteEventSource;
+};
+
+export type ListRouteEventsParams = {
+  clinicId: number;
+  routePlanId?: number;
+  routeStopId?: number;
+  eventType?: RouteEventType;
+  afterId?: number;
+  limit?: number;
+  offset?: number;
+};
 
 export const ROUTE_PLAN_LIFECYCLE_ACTIONS = [
   "release",
@@ -732,5 +760,133 @@ export async function transitionClinicScopedRoutePlanStatus(
     return {
       routePlan: updatedRoutePlan,
     };
+  });
+}
+
+
+export async function createRouteEvent(
+  input: CreateRouteEventInput,
+): Promise<RouteEvent | undefined> {
+  const now = new Date();
+
+  return db.transaction(async (tx) => {
+    if (typeof input.routePlanId === "number") {
+      const routePlan = await tx
+        .select()
+        .from(routePlans)
+        .where(
+          and(
+            eq(routePlans.id, input.routePlanId),
+            eq(routePlans.clinicId, input.clinicId),
+          ),
+        )
+        .limit(1);
+
+      if (!routePlan[0]) {
+        return undefined;
+      }
+    }
+
+    if (typeof input.routeStopId === "number") {
+      const routeStop = await tx
+        .select({ routeStop: routeStops })
+        .from(routeStops)
+        .innerJoin(
+          routePlans,
+          eq(routeStops.routePlanId, routePlans.id),
+        )
+        .where(
+          and(
+            eq(routeStops.id, input.routeStopId),
+            eq(routePlans.clinicId, input.clinicId),
+          ),
+        )
+        .limit(1);
+
+      if (!routeStop[0]) {
+        return undefined;
+      }
+    }
+
+    const result = await tx
+      .insert(routeEvents)
+      .values({
+        clinicId: input.clinicId,
+        routePlanId: input.routePlanId ?? null,
+        routeStopId: input.routeStopId ?? null,
+        eventType: input.eventType,
+        eventTime: input.eventTime ?? now,
+        payload: input.payload ?? null,
+        lat: input.lat ?? null,
+        lng: input.lng ?? null,
+        source: input.source ?? "system",
+        createdAt: now,
+      })
+      .returning();
+
+    return result[0];
+  });
+}
+
+export async function listClinicRouteEvents(
+  params: ListRouteEventsParams,
+): Promise<RouteEvent[]> {
+  const filters = [eq(routeEvents.clinicId, params.clinicId)];
+  const limit = normalizeLogisticsLimit(params.limit);
+  const offset = normalizeLogisticsOffset(params.offset);
+
+  if (typeof params.routePlanId === "number") {
+    filters.push(eq(routeEvents.routePlanId, params.routePlanId));
+  }
+
+  if (typeof params.routeStopId === "number") {
+    filters.push(eq(routeEvents.routeStopId, params.routeStopId));
+  }
+
+  if (params.eventType) {
+    filters.push(eq(routeEvents.eventType, params.eventType));
+  }
+
+  if (typeof params.afterId === "number") {
+    filters.push(gt(routeEvents.id, params.afterId));
+  }
+
+  return db
+    .select()
+    .from(routeEvents)
+    .where(and(...filters))
+    .orderBy(asc(routeEvents.id))
+    .limit(limit)
+    .offset(offset);
+}
+
+export async function listRouteEventsForClinicRoutePlan(
+  routePlanId: number,
+  clinicId: number,
+  params: Omit<ListRouteEventsParams, "clinicId" | "routePlanId"> = {},
+): Promise<RouteEvent[]> {
+  const routePlan = await getClinicScopedRoutePlan(routePlanId, clinicId);
+
+  if (!routePlan) {
+    return [];
+  }
+
+  return listClinicRouteEvents({
+    ...params,
+    clinicId,
+    routePlanId,
+  });
+}
+
+export async function listIncrementalClinicRouteEvents(
+  clinicId: number,
+  afterId: number,
+  limit?: number,
+): Promise<RouteEvent[]> {
+  return listClinicRouteEvents({
+    clinicId,
+    afterId,
+    limit,
+    offset: 0,
   });
 }

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -112,3 +112,36 @@ test("logistics DB helpers transition route plan status only inside clinic scope
   assert.match(dbLogisticsSource, /reason: "invalid_transition"/);
   assert.match(dbLogisticsSource, /reason: "not_found"/);
 });
+
+
+test("logistics DB helpers expose route event append-only operations", () => {
+  assert.match(dbLogisticsSource, /export type CreateRouteEventInput/);
+  assert.match(dbLogisticsSource, /export type ListRouteEventsParams/);
+  assert.match(dbLogisticsSource, /export async function createRouteEvent/);
+  assert.match(dbLogisticsSource, /export async function listClinicRouteEvents/);
+  assert.match(dbLogisticsSource, /export async function listRouteEventsForClinicRoutePlan/);
+  assert.match(dbLogisticsSource, /export async function listIncrementalClinicRouteEvents/);
+});
+
+test("logistics DB helpers verify clinic ownership before route event writes", () => {
+  assert.match(dbLogisticsSource, /eq\(routePlans\.id, input\.routePlanId\)/);
+  assert.match(dbLogisticsSource, /eq\(routePlans\.clinicId, input\.clinicId\)/);
+  assert.match(dbLogisticsSource, /innerJoin\(\s*routePlans,\s*eq\(routeStops\.routePlanId, routePlans\.id\),\s*\)/);
+  assert.match(dbLogisticsSource, /eq\(routeStops\.id, input\.routeStopId\)/);
+  assert.match(dbLogisticsSource, /eq\(routePlans\.clinicId, input\.clinicId\)/);
+  assert.match(dbLogisticsSource, /return undefined/);
+});
+
+test("logistics DB helpers keep route event reads clinic scoped and incremental", () => {
+  assert.match(dbLogisticsSource, /eq\(routeEvents\.clinicId, params\.clinicId\)/);
+  assert.match(dbLogisticsSource, /gt\(routeEvents\.id, params\.afterId\)/);
+  assert.match(dbLogisticsSource, /orderBy\(asc\(routeEvents\.id\)\)/);
+  assert.match(dbLogisticsSource, /normalizeLogisticsLimit\(params\.limit\)/);
+  assert.match(dbLogisticsSource, /listClinicRouteEvents\(\{\s*clinicId,\s*afterId,\s*limit,\s*offset: 0,\s*\}\)/);
+});
+
+test("logistics DB helpers support route event route-plan scoped reads", () => {
+  assert.match(dbLogisticsSource, /const routePlan = await getClinicScopedRoutePlan\(routePlanId, clinicId\)/);
+  assert.match(dbLogisticsSource, /if \(!routePlan\) \{\s*return \[\];\s*\}/);
+  assert.match(dbLogisticsSource, /routePlanId,/);
+});


### PR DESCRIPTION
Add route event DB helpers. Scope: DB helpers only, no API endpoints, no polling HTTP, no schema changes, no migrations. Validation: pnpm typecheck:test, pnpm test 810/810, pnpm validate:local.