### PR TITLE
feat(logistics): integrate heuristic route plan generation API

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -1,4 +1,4 @@
-﻿import { and, asc, desc, eq, gt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray } from "drizzle-orm";
 import { db } from "./db";
 import {
   fieldVisits,
@@ -23,6 +23,11 @@ import {
   assertValidTimeWindowRange,
   normalizeTimeWindowTimezone,
 } from "./lib/logistics/time-window.ts";
+import {
+  buildHeuristicRoutePlan,
+  type RoutePlanningPoint,
+  type RoutePlanningVisit,
+} from "./lib/logistics/route-planning.ts";
 
 export const LOGISTICS_DEFAULT_LIMIT = 50;
 export const LOGISTICS_MAX_LIMIT = 100;
@@ -161,6 +166,38 @@ export type ListRouteEventsParams = {
   limit?: number;
   offset?: number;
 };
+
+export type GenerateHeuristicRoutePlanInput = {
+  clinicId: number;
+  serviceDate: Date;
+  fieldVisitIds: number[];
+  routeStart?: Date;
+  startLocation?: RoutePlanningPoint | null;
+  objective?: RoutePlanObjective;
+  travelSpeedKmh?: number;
+  fallbackLegMinutes?: number;
+  createdByType?: RoutePlanCreatedByType;
+  createdById?: number | null;
+};
+
+export type GenerateHeuristicRoutePlanResult =
+  | {
+      routePlan: RoutePlan;
+      routeStops: RouteStop[];
+      warnings: string[];
+      reason?: undefined;
+      missingFieldVisitIds?: undefined;
+    }
+  | {
+      routePlan?: undefined;
+      routeStops?: undefined;
+      warnings?: undefined;
+      reason:
+        | "no_visits"
+        | "field_visits_not_found"
+        | "route_plan_not_created";
+      missingFieldVisitIds?: number[];
+    };
 
 export const ROUTE_PLAN_LIFECYCLE_ACTIONS = [
   "release",
@@ -759,6 +796,221 @@ export async function transitionClinicScopedRoutePlanStatus(
 
     return {
       routePlan: updatedRoutePlan,
+    };
+  });
+}
+
+
+function normalizeGenerateHeuristicFieldVisitIds(ids: number[]): number[] {
+  const result: number[] = [];
+  const seen = new Set<number>();
+
+  for (const id of ids) {
+    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    result.push(id);
+  }
+
+  return result;
+}
+
+function toRoutePlanningPoint(
+  location: VisitLocation | null | undefined,
+): RoutePlanningPoint | null {
+  if (
+    !location ||
+    typeof location.lat !== "number" ||
+    typeof location.lng !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    lat: location.lat,
+    lng: location.lng,
+  };
+}
+
+export async function generateHeuristicRoutePlan(
+  input: GenerateHeuristicRoutePlanInput,
+): Promise<GenerateHeuristicRoutePlanResult> {
+  const fieldVisitIds = normalizeGenerateHeuristicFieldVisitIds(
+    input.fieldVisitIds,
+  );
+
+  if (fieldVisitIds.length === 0) {
+    return {
+      reason: "no_visits",
+    };
+  }
+
+  return db.transaction(async (tx) => {
+    const visitRows = await tx
+      .select({
+        fieldVisit: fieldVisits,
+        location: visitLocations,
+      })
+      .from(fieldVisits)
+      .leftJoin(
+        visitLocations,
+        eq(visitLocations.fieldVisitId, fieldVisits.id),
+      )
+      .where(
+        and(
+          eq(fieldVisits.clinicId, input.clinicId),
+          inArray(fieldVisits.id, fieldVisitIds),
+        ),
+      );
+
+    const visitById = new Map<
+      number,
+      {
+        fieldVisit: FieldVisit;
+        location: VisitLocation | null;
+      }
+    >();
+
+    for (const row of visitRows) {
+      visitById.set(row.fieldVisit.id, {
+        fieldVisit: row.fieldVisit,
+        location: row.location,
+      });
+    }
+
+    const missingFieldVisitIds = fieldVisitIds.filter(
+      (fieldVisitId) => !visitById.has(fieldVisitId),
+    );
+
+    if (missingFieldVisitIds.length > 0) {
+      return {
+        reason: "field_visits_not_found",
+        missingFieldVisitIds,
+      };
+    }
+
+    const timeWindowRows = await tx
+      .select({
+        timeWindow: timeWindows,
+      })
+      .from(timeWindows)
+      .innerJoin(
+        fieldVisits,
+        eq(timeWindows.fieldVisitId, fieldVisits.id),
+      )
+      .where(
+        and(
+          eq(fieldVisits.clinicId, input.clinicId),
+          inArray(timeWindows.fieldVisitId, fieldVisitIds),
+        ),
+      )
+      .orderBy(timeWindows.windowStart, timeWindows.id);
+
+    const timeWindowsByVisitId = new Map<number, TimeWindow[]>();
+
+    for (const row of timeWindowRows) {
+      const existing = timeWindowsByVisitId.get(row.timeWindow.fieldVisitId);
+
+      if (existing) {
+        existing.push(row.timeWindow);
+      } else {
+        timeWindowsByVisitId.set(row.timeWindow.fieldVisitId, [
+          row.timeWindow,
+        ]);
+      }
+    }
+
+    const planningVisits: RoutePlanningVisit[] = fieldVisitIds.map(
+      (fieldVisitId) => {
+        const visitRow = visitById.get(fieldVisitId);
+
+        if (!visitRow) {
+          throw new Error("field visit ownership check drifted");
+        }
+
+        return {
+          fieldVisitId,
+          priority: visitRow.fieldVisit.priority,
+          serviceDurationMin: visitRow.fieldVisit.serviceDurationMin,
+          location: toRoutePlanningPoint(visitRow.location),
+          timeWindows: (timeWindowsByVisitId.get(fieldVisitId) ?? []).map(
+            (timeWindow) => ({
+              windowStart: timeWindow.windowStart,
+              windowEnd: timeWindow.windowEnd,
+              isHard: timeWindow.isHard,
+            }),
+          ),
+        };
+      },
+    );
+
+    const heuristicPlan = buildHeuristicRoutePlan(planningVisits, {
+      routeStart: input.routeStart ?? input.serviceDate,
+      startLocation: input.startLocation,
+      objective: input.objective ?? "distance",
+      travelSpeedKmh: input.travelSpeedKmh,
+      fallbackLegMinutes: input.fallbackLegMinutes,
+    });
+
+    const now = new Date();
+
+    const routePlanResult = await tx
+      .insert(routePlans)
+      .values({
+        clinicId: input.clinicId,
+        serviceDate: input.serviceDate,
+        status: "planned",
+        planningMode: "heuristic",
+        objective: heuristicPlan.objective,
+        totalPlannedKm: heuristicPlan.totalPlannedKm,
+        totalPlannedMin: heuristicPlan.totalPlannedMin,
+        createdByType: input.createdByType ?? "system",
+        createdById: input.createdById ?? null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    const routePlan = routePlanResult[0];
+
+    if (!routePlan) {
+      return {
+        reason: "route_plan_not_created",
+      };
+    }
+
+    const routeStopResults: RouteStop[] = [];
+
+    for (const plannedStop of heuristicPlan.stops) {
+      const routeStopResult = await tx
+        .insert(routeStops)
+        .values({
+          routePlanId: routePlan.id,
+          fieldVisitId: plannedStop.fieldVisitId,
+          sequence: plannedStop.sequence,
+          etaStart: plannedStop.etaStart,
+          etaEnd: plannedStop.etaEnd,
+          plannedKmFromPrev: plannedStop.plannedKmFromPrev,
+          plannedMinFromPrev: plannedStop.plannedMinFromPrev,
+          status: "pending",
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+
+      const routeStop = routeStopResult[0];
+
+      if (routeStop) {
+        routeStopResults.push(routeStop);
+      }
+    }
+
+    return {
+      routePlan,
+      routeStops: routeStopResults,
+      warnings: heuristicPlan.warnings,
     };
   });
 }

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -17,6 +17,8 @@ import {
 import type {
   CreateRoutePlanInput,
   CreateRouteStopInput,
+  GenerateHeuristicRoutePlanInput,
+  GenerateHeuristicRoutePlanResult,
   ListRoutePlansParams,
   RoutePlan,
   RoutePlanLifecycleAction,
@@ -90,6 +92,9 @@ export type LogisticsRoutePlansNativeRoutesOptions = {
     clinicId: number,
     action: RoutePlanLifecycleAction,
   ) => Promise<RoutePlanLifecycleTransitionResult>;
+  generateHeuristicRoutePlan?: (
+    input: GenerateHeuristicRoutePlanInput,
+  ) => Promise<GenerateHeuristicRoutePlanResult>;
   now?: () => number;
 };
 
@@ -109,6 +114,7 @@ type NativeLogisticsRoutePlansDeps = Required<
     | "listRouteStopsForClinicRoutePlan"
     | "updateClinicScopedRouteStop"
     | "transitionClinicScopedRoutePlanStatus"
+    | "generateHeuristicRoutePlan"
   >
 >;
 
@@ -142,6 +148,7 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
           dbLogistics.updateClinicScopedRouteStop,
         transitionClinicScopedRoutePlanStatus:
           dbLogistics.transitionClinicScopedRoutePlanStatus,
+        generateHeuristicRoutePlan: dbLogistics.generateHeuristicRoutePlan,
       };
     })();
   }
@@ -1031,6 +1038,213 @@ function buildUpdateRouteStopInput(
 
 
 
+function parsePositiveNumberField(
+  value: unknown,
+  fieldName: string,
+): { value?: number; error?: string } {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return { error: `${fieldName} debe ser numerico mayor a cero` };
+  }
+
+  return { value: parsed };
+}
+
+function parseOptionalPositiveNumberField(
+  value: unknown,
+  fieldName: string,
+): { value?: number; error?: string } {
+  if (value == null || value === "") {
+    return {};
+  }
+
+  return parsePositiveNumberField(value, fieldName);
+}
+
+function parseFieldVisitIds(value: unknown): {
+  value?: number[];
+  error?: string;
+} {
+  if (!Array.isArray(value)) {
+    return { error: "fieldVisitIds debe ser un array" };
+  }
+
+  const result: number[] = [];
+  const seen = new Set<number>();
+
+  for (const rawId of value) {
+    const parsed =
+      typeof rawId === "number"
+        ? rawId
+        : typeof rawId === "string"
+          ? Number(rawId)
+          : Number.NaN;
+
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return { error: "fieldVisitIds debe contener enteros positivos" };
+    }
+
+    if (!seen.has(parsed)) {
+      seen.add(parsed);
+      result.push(parsed);
+    }
+  }
+
+  if (result.length === 0) {
+    return { error: "fieldVisitIds debe incluir al menos una visita" };
+  }
+
+  return { value: result };
+}
+
+function parseOptionalRoutePlanningPoint(value: unknown): {
+  value?: GenerateHeuristicRoutePlanInput["startLocation"];
+  error?: string;
+} {
+  if (value == null || value === "") {
+    return {};
+  }
+
+  if (!isRecord(value)) {
+    return { error: "startLocation debe ser objeto o null" };
+  }
+
+  const lat =
+    typeof value.lat === "number"
+      ? value.lat
+      : typeof value.lat === "string"
+        ? Number(value.lat)
+        : Number.NaN;
+  const lng =
+    typeof value.lng === "number"
+      ? value.lng
+      : typeof value.lng === "string"
+        ? Number(value.lng)
+        : Number.NaN;
+
+  if (
+    !Number.isFinite(lat) ||
+    !Number.isFinite(lng) ||
+    lat < -90 ||
+    lat > 90 ||
+    lng < -180 ||
+    lng > 180
+  ) {
+    return { error: "startLocation debe incluir lat/lng validos" };
+  }
+
+  return {
+    value: {
+      lat,
+      lng,
+    },
+  };
+}
+
+function buildGenerateHeuristicRoutePlanInput(
+  body: unknown,
+  clinicId: number,
+  createdById: number,
+): { input?: GenerateHeuristicRoutePlanInput; error?: string } {
+  if (!isRecord(body)) {
+    return { error: "Body invalido" };
+  }
+
+  const serviceDate = parseDateField(body.serviceDate, "serviceDate");
+
+  if (serviceDate.error || !serviceDate.value) {
+    return { error: serviceDate.error ?? "serviceDate invalido" };
+  }
+
+  const fieldVisitIds = parseFieldVisitIds(body.fieldVisitIds);
+
+  if (fieldVisitIds.error || !fieldVisitIds.value) {
+    return { error: fieldVisitIds.error ?? "fieldVisitIds invalido" };
+  }
+
+  const routeStart = parseOptionalDateField(body.routeStart, "routeStart");
+
+  if (routeStart.error) {
+    return { error: routeStart.error };
+  }
+
+  const startLocation = parseOptionalRoutePlanningPoint(body.startLocation);
+
+  if (startLocation.error) {
+    return { error: startLocation.error };
+  }
+
+  const objective = parseRoutePlanObjective(body.objective);
+
+  if (objective.error) {
+    return { error: objective.error };
+  }
+
+  const travelSpeedKmh = parseOptionalPositiveNumberField(
+    body.travelSpeedKmh,
+    "travelSpeedKmh",
+  );
+
+  if (travelSpeedKmh.error) {
+    return { error: travelSpeedKmh.error };
+  }
+
+  const fallbackLegMinutes = parseOptionalPositiveNumberField(
+    body.fallbackLegMinutes,
+    "fallbackLegMinutes",
+  );
+
+  if (fallbackLegMinutes.error) {
+    return { error: fallbackLegMinutes.error };
+  }
+
+  return {
+    input: {
+      clinicId,
+      serviceDate: serviceDate.value,
+      fieldVisitIds: fieldVisitIds.value,
+      routeStart: routeStart.value ?? undefined,
+      startLocation: startLocation.value,
+      objective: objective.value,
+      travelSpeedKmh: travelSpeedKmh.value,
+      fallbackLegMinutes: fallbackLegMinutes.value,
+      createdByType: "clinic",
+      createdById,
+    },
+  };
+}
+
+function getGenerateHeuristicRoutePlanError(
+  result: GenerateHeuristicRoutePlanResult,
+): { statusCode: number; error: string; missingFieldVisitIds?: number[] } {
+  if (result.reason === "no_visits") {
+    return {
+      statusCode: 400,
+      error: "Debe incluir al menos una visita para planificar",
+    };
+  }
+
+  if (result.reason === "field_visits_not_found") {
+    return {
+      statusCode: 404,
+      error: "Una o mas visitas no existen para la clinica",
+      missingFieldVisitIds: result.missingFieldVisitIds,
+    };
+  }
+
+  return {
+    statusCode: 500,
+    error: "No se pudo generar el plan heuristico",
+  };
+}
+
+
 function getLifecycleActionError(
   result: RoutePlanLifecycleTransitionResult,
 ): { statusCode: number; error: string } {
@@ -1151,6 +1365,12 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     transitionClinicScopedRoutePlanStatus:
       options.transitionClinicScopedRoutePlanStatus ??
       defaultDeps!.transitionClinicScopedRoutePlanStatus,
+    generateHeuristicRoutePlan:
+      options.generateHeuristicRoutePlan ??
+      defaultDeps?.generateHeuristicRoutePlan ??
+      (async () => ({
+        reason: "route_plan_not_created" as const,
+      })),
   };
 
   const now = options.now ?? (() => Date.now());
@@ -1187,6 +1407,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
   };
 
   app.options("/", optionsHandler);
+  app.options("/heuristic", optionsHandler);
   app.options("/:routePlanId", optionsHandler);
   app.options("/:routePlanId/stops", optionsHandler);
   app.options("/:routePlanId/stops/:routeStopId", optionsHandler);
@@ -1195,6 +1416,66 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
   app.options("/:routePlanId/complete", optionsHandler);
   app.options("/:routePlanId/cancel", optionsHandler);
 
+  app.post<{
+    Body: {
+      serviceDate?: unknown;
+      fieldVisitIds?: unknown;
+      routeStart?: unknown;
+      startLocation?: unknown;
+      objective?: unknown;
+      travelSpeedKmh?: unknown;
+      fallbackLegMinutes?: unknown;
+    };
+  }>("/heuristic", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const parsed = buildGenerateHeuristicRoutePlanInput(
+      request.body,
+      auth.clinicId,
+      auth.id,
+    );
+
+    if (!parsed.input) {
+      return reply.code(400).send({
+        success: false,
+        error: parsed.error ?? "Body invalido",
+      });
+    }
+
+    const result = await deps.generateHeuristicRoutePlan(parsed.input);
+
+    if (result.reason) {
+      const error = getGenerateHeuristicRoutePlanError(result);
+
+      return reply.code(error.statusCode).send({
+        success: false,
+        error: error.error,
+        missingFieldVisitIds: error.missingFieldVisitIds,
+      });
+    }
+
+    return reply.code(201).send({
+      success: true,
+      routePlan: serializeRoutePlan(result.routePlan),
+      routeStops: result.routeStops.map((routeStop) =>
+        serializeRouteStop(routeStop),
+      ),
+      planning: {
+        mode: "heuristic",
+        objective: result.routePlan.objective,
+        fieldVisitCount: result.routeStops.length,
+        warnings: result.warnings,
+      },
+    });
+  });
   app.get<{
     Querystring: {
       status?: unknown;

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -145,3 +145,25 @@ test("logistics DB helpers support route event route-plan scoped reads", () => {
   assert.match(dbLogisticsSource, /if \(!routePlan\) \{\s*return \[\];\s*\}/);
   assert.match(dbLogisticsSource, /routePlanId,/);
 });
+
+test("logistics DB helpers generate heuristic route plans transactionally", () => {
+  assert.match(dbLogisticsSource, /buildHeuristicRoutePlan/);
+  assert.match(dbLogisticsSource, /export type GenerateHeuristicRoutePlanInput/);
+  assert.match(dbLogisticsSource, /export type GenerateHeuristicRoutePlanResult/);
+  assert.match(dbLogisticsSource, /export async function generateHeuristicRoutePlan/);
+  assert.match(dbLogisticsSource, /normalizeGenerateHeuristicFieldVisitIds/);
+  assert.match(dbLogisticsSource, /inArray\(fieldVisits\.id, fieldVisitIds\)/);
+  assert.match(dbLogisticsSource, /leftJoin\(\s*visitLocations,\s*eq\(visitLocations\.fieldVisitId, fieldVisits\.id\),\s*\)/);
+  assert.match(dbLogisticsSource, /inArray\(timeWindows\.fieldVisitId, fieldVisitIds\)/);
+  assert.match(dbLogisticsSource, /planningMode: "heuristic"/);
+  assert.match(dbLogisticsSource, /status: "planned"/);
+  assert.match(dbLogisticsSource, /tx\s*\.\s*insert\(routePlans\)/);
+  assert.match(dbLogisticsSource, /tx\s*\.\s*insert\(routeStops\)/);
+});
+
+test("logistics DB heuristic generation reports invalid clinic-scoped inputs without partial writes", () => {
+  assert.match(dbLogisticsSource, /reason: "no_visits"/);
+  assert.match(dbLogisticsSource, /reason: "field_visits_not_found"/);
+  assert.match(dbLogisticsSource, /missingFieldVisitIds/);
+  assert.match(dbLogisticsSource, /reason: "route_plan_not_created"/);
+});

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -133,3 +133,37 @@ test("logistics route plans API keeps lifecycle writes clinic scoped and trusted
   assert.match(routeSource, /currentStatus: result\.currentStatus/);
   assert.match(routeSource, /Transicion de estado no permitida/);
 });
+
+test("logistics route plans API exposes heuristic generation endpoint", () => {
+  assert.match(routeSource, /app\.options\("\/heuristic", optionsHandler\)/);
+  assert.match(routeSource, /app\.post<[\s\S]*>\("\/heuristic", async/);
+  assert.match(routeSource, /buildGenerateHeuristicRoutePlanInput/);
+  assert.match(routeSource, /deps\.generateHeuristicRoutePlan\(parsed\.input\)/);
+  assert.match(routeSource, /planning:\s*{\s*mode: "heuristic"/);
+});
+
+test("logistics route plans API wires heuristic generation through injectable deps", () => {
+  assert.match(routeSource, /GenerateHeuristicRoutePlanInput/);
+  assert.match(routeSource, /GenerateHeuristicRoutePlanResult/);
+  assert.match(routeSource, /generateHeuristicRoutePlan\?:/);
+  assert.match(routeSource, /dbLogistics\.generateHeuristicRoutePlan/);
+  assert.match(routeSource, /options\.generateHeuristicRoutePlan/);
+});
+
+test("logistics route plans API validates heuristic generation input before DB calls", () => {
+  assert.match(routeSource, /parseFieldVisitIds/);
+  assert.match(routeSource, /fieldVisitIds debe incluir al menos una visita/);
+  assert.match(routeSource, /parseOptionalRoutePlanningPoint/);
+  assert.match(routeSource, /startLocation debe incluir lat\/lng validos/);
+  assert.match(routeSource, /parseOptionalPositiveNumberField/);
+  assert.match(routeSource, /travelSpeedKmh/);
+  assert.match(routeSource, /fallbackLegMinutes/);
+});
+
+test("logistics route plans API keeps heuristic generation clinic scoped and trusted-origin protected", () => {
+  assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
+  assert.match(routeSource, /auth\.clinicId/);
+  assert.match(routeSource, /createdByType: "clinic"/);
+  assert.match(routeSource, /createdById,/);
+  assert.match(routeSource, /missingFieldVisitIds/);
+});


### PR DESCRIPTION
﻿Summary:
- Add transactional heuristic route plan generation helper.
- Add clinic-scoped route plan API endpoint for heuristic generation.
- Persist heuristic route plan and generated route stops.
- Validate fieldVisitIds, serviceDate, routeStart, startLocation, objective, travelSpeedKmh, and fallbackLegMinutes.
- Keep default-dependency loading safe for existing injected route tests.
- Add DB/API source-coverage tests for heuristic generation integration.

Scope:
- API + DB helper integration.
- Uses existing heuristic baseline from PR 213.
- No schema changes.
- No migrations.

Validation:
- pnpm typecheck
- pnpm typecheck:test
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/logistics-db.test.ts test/logistics-route-plans-api.test.ts test/fastify-app.test.ts
- pnpm test 832/832
- git diff --check
