### PR TITLE
feat(logistics): add route stop compliance metrics

### DIFF
--- a/server/lib/logistics/metrics.ts
+++ b/server/lib/logistics/metrics.ts
@@ -660,3 +660,170 @@ export function calculateDurationBetweenRouteEvents(
     missingEvents,
   };
 }
+
+export interface RouteStopComplianceInput {
+  routeStopId?: number | null;
+  fieldVisitId: number;
+  sequence: number;
+  plannedKmFromPrev?: NumericMetricInput;
+  actualKmFromPrev?: NumericMetricInput;
+  plannedMinFromPrev?: NumericMetricInput;
+  actualArrival?: Date | null;
+  windowStart?: Date | null;
+  windowEnd?: Date | null;
+  toleranceMin?: NumericMetricInput;
+  distanceTolerancePercent?: NumericMetricInput;
+  timeToleranceMin?: NumericMetricInput;
+}
+
+export interface RouteStopComplianceMetric {
+  routeStopId: number | null;
+  fieldVisitId: number;
+  sequence: number;
+  distance: RouteDistanceComplianceMetrics;
+  actualMinFromPrev: number | null;
+  plannedMinFromPrev: number | null;
+  minDeltaFromPlan: number | null;
+  withinTimeTolerance: boolean | null;
+  window: TimeWindowComplianceResult;
+  isOutOfSequence: boolean;
+}
+
+export interface RouteStopComplianceSummary {
+  totalStops: number;
+  outOfSequenceCount: number;
+  distanceDeviationCount: number;
+  timeDeviationCount: number;
+  missingActualArrivalCount: number;
+  windowSummary: WindowComplianceSummary;
+  stopMetrics: RouteStopComplianceMetric[];
+}
+
+function normalizeRouteStopId(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function calculateActualMinutesFromPreviousArrival(
+  previousArrival: Date | null,
+  actualArrival: Date | null,
+): number | null {
+  const previousArrivalMs = getDateMs(previousArrival);
+  const actualArrivalMs = getDateMs(actualArrival);
+
+  if (previousArrivalMs === null || actualArrivalMs === null) {
+    return null;
+  }
+
+  return roundMetric((actualArrivalMs - previousArrivalMs) / 60000);
+}
+
+export function calculateRouteStopComplianceMetrics(
+  stops: readonly RouteStopComplianceInput[],
+): RouteStopComplianceSummary {
+  const sortedStops = stops
+    .slice()
+    .sort((left, right) => {
+      const sequenceDiff = left.sequence - right.sequence;
+
+      if (sequenceDiff !== 0) {
+        return sequenceDiff;
+      }
+
+      return left.fieldVisitId - right.fieldVisitId;
+    });
+
+  const stopMetrics: RouteStopComplianceMetric[] = [];
+  const windowStatuses: TimeWindowComplianceStatus[] = [];
+
+  let previousActualArrival: Date | null = null;
+  let outOfSequenceCount = 0;
+  let distanceDeviationCount = 0;
+  let timeDeviationCount = 0;
+  let missingActualArrivalCount = 0;
+
+  for (const stop of sortedStops) {
+    const actualArrivalMs = getDateMs(stop.actualArrival);
+    const actualArrival =
+      actualArrivalMs === null ? null : new Date(actualArrivalMs);
+    const plannedMinFromPrev = normalizeNonNegativeNumber(
+      stop.plannedMinFromPrev,
+    );
+    const actualMinFromPrev = calculateActualMinutesFromPreviousArrival(
+      previousActualArrival,
+      actualArrival,
+    );
+    const minDeltaFromPlan =
+      actualMinFromPrev !== null && plannedMinFromPrev !== null
+        ? roundMetric(actualMinFromPrev - plannedMinFromPrev)
+        : null;
+    const timeToleranceMin = normalizeNonNegativeNumber(stop.timeToleranceMin);
+    const withinTimeTolerance =
+      minDeltaFromPlan !== null && timeToleranceMin !== null
+        ? Math.abs(minDeltaFromPlan) <= timeToleranceMin
+        : null;
+    const window = classifyTimeWindowCompliance({
+      windowStart: stop.windowStart,
+      windowEnd: stop.windowEnd,
+      actualArrival,
+      toleranceMin: stop.toleranceMin,
+    });
+    const distance = calculateRouteDistanceCompliance({
+      plannedKm: stop.plannedKmFromPrev,
+      actualKm: stop.actualKmFromPrev,
+      tolerancePercent: stop.distanceTolerancePercent,
+    });
+    const isOutOfSequence =
+      previousActualArrival !== null &&
+      actualArrival !== null &&
+      actualArrival < previousActualArrival;
+
+    if (isOutOfSequence) {
+      outOfSequenceCount += 1;
+    }
+
+    if (distance.withinTolerance === false) {
+      distanceDeviationCount += 1;
+    }
+
+    if (withinTimeTolerance === false) {
+      timeDeviationCount += 1;
+    }
+
+    if (window.status === "missing_actual") {
+      missingActualArrivalCount += 1;
+    }
+
+    windowStatuses.push(window.status);
+
+    stopMetrics.push({
+      routeStopId: normalizeRouteStopId(stop.routeStopId),
+      fieldVisitId: stop.fieldVisitId,
+      sequence: stop.sequence,
+      distance,
+      actualMinFromPrev,
+      plannedMinFromPrev,
+      minDeltaFromPlan,
+      withinTimeTolerance,
+      window,
+      isOutOfSequence,
+    });
+
+    if (actualArrival !== null) {
+      previousActualArrival = actualArrival;
+    }
+  }
+
+  return {
+    totalStops: sortedStops.length,
+    outOfSequenceCount,
+    distanceDeviationCount,
+    timeDeviationCount,
+    missingActualArrivalCount,
+    windowSummary: summarizeWindowCompliance(windowStatuses),
+    stopMetrics,
+  };
+}

--- a/test/logistics-metrics.test.ts
+++ b/test/logistics-metrics.test.ts
@@ -4,6 +4,7 @@ import {
   calculateBasicRouteComplianceMetrics,
   calculateKmPerCompletedVisit,
   calculateRouteDistanceCompliance,
+  calculateRouteStopComplianceMetrics,
   classifyTimeWindowCompliance,
   summarizeWindowCompliance,
 } from "../server/lib/logistics/metrics.ts";
@@ -224,4 +225,84 @@ test("calculateBasicRouteComplianceMetrics combines distance stop and window sum
       },
     },
   );
+});
+
+test("calculateRouteStopComplianceMetrics summarizes stop-level compliance deterministically", () => {
+  const result = calculateRouteStopComplianceMetrics([
+    {
+      routeStopId: 102,
+      fieldVisitId: 20,
+      sequence: 2,
+      plannedKmFromPrev: 8,
+      actualKmFromPrev: 11,
+      distanceTolerancePercent: 20,
+      plannedMinFromPrev: 30,
+      actualArrival: new Date("2026-05-03T10:50:00.000Z"),
+      windowStart: new Date("2026-05-03T10:30:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:00:00.000Z"),
+      toleranceMin: 5,
+      timeToleranceMin: 10,
+    },
+    {
+      routeStopId: 101,
+      fieldVisitId: 10,
+      sequence: 1,
+      plannedKmFromPrev: 4,
+      actualKmFromPrev: 4.2,
+      distanceTolerancePercent: 20,
+      plannedMinFromPrev: 0,
+      actualArrival: new Date("2026-05-03T10:00:00.000Z"),
+      windowStart: new Date("2026-05-03T09:45:00.000Z"),
+      windowEnd: new Date("2026-05-03T10:15:00.000Z"),
+      toleranceMin: 5,
+      timeToleranceMin: 10,
+    },
+  ]);
+
+  assert.equal(result.totalStops, 2);
+  assert.equal(result.distanceDeviationCount, 1);
+  assert.equal(result.timeDeviationCount, 1);
+  assert.equal(result.outOfSequenceCount, 0);
+  assert.equal(result.windowSummary.complianceRate, 100);
+  assert.deepEqual(
+    result.stopMetrics.map((metric) => metric.fieldVisitId),
+    [10, 20],
+  );
+  assert.equal(result.stopMetrics[1]?.distance.deltaPercent, 37.5);
+  assert.equal(result.stopMetrics[1]?.actualMinFromPrev, 50);
+  assert.equal(result.stopMetrics[1]?.minDeltaFromPlan, 20);
+  assert.equal(result.stopMetrics[1]?.withinTimeTolerance, false);
+});
+
+test("calculateRouteStopComplianceMetrics detects out-of-sequence and missing actual arrivals", () => {
+  const result = calculateRouteStopComplianceMetrics([
+    {
+      fieldVisitId: 10,
+      sequence: 1,
+      actualArrival: new Date("2026-05-03T11:00:00.000Z"),
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:30:00.000Z"),
+    },
+    {
+      fieldVisitId: 20,
+      sequence: 2,
+      actualArrival: new Date("2026-05-03T10:30:00.000Z"),
+      windowStart: new Date("2026-05-03T10:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T11:30:00.000Z"),
+    },
+    {
+      fieldVisitId: 30,
+      sequence: 3,
+      actualArrival: null,
+      windowStart: new Date("2026-05-03T12:00:00.000Z"),
+      windowEnd: new Date("2026-05-03T12:30:00.000Z"),
+    },
+  ]);
+
+  assert.equal(result.totalStops, 3);
+  assert.equal(result.outOfSequenceCount, 1);
+  assert.equal(result.missingActualArrivalCount, 1);
+  assert.equal(result.windowSummary.missingActualCount, 1);
+  assert.equal(result.stopMetrics[1]?.isOutOfSequence, true);
+  assert.equal(result.stopMetrics[2]?.window.status, "missing_actual");
 });


### PR DESCRIPTION
﻿Summary:
- Add route stop-level compliance metrics.
- Summarize distance deviations, time deviations, out-of-sequence arrivals, missing actual arrivals, and time-window compliance.
- Preserve deterministic ordering by sequence and fieldVisitId.
- Extend logistics metrics tests with stop-level compliance coverage.

Scope:
- Library/test only.
- No API changes.
- No DB changes.
- No schema changes.
- No migrations.

Validation:
- pnpm typecheck:test
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/logistics-metrics.test.ts
- pnpm test 838/838
- git diff --check
