### PR TITLE
feat(logistics): expose route plan compliance metrics

### DIFF
--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -28,6 +28,10 @@ import type {
   UpdateRouteStopInput,
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  calculateRouteStopComplianceMetrics,
+  type RouteStopComplianceInput,
+} from "../lib/logistics/metrics.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -1245,6 +1249,60 @@ function getGenerateHeuristicRoutePlanError(
 }
 
 
+function buildRouteStopComplianceInputs(
+  routeStops: readonly RouteStop[],
+  query: {
+    distanceTolerancePercent?: unknown;
+    timeToleranceMin?: unknown;
+    toleranceMin?: unknown;
+  },
+): { inputs?: RouteStopComplianceInput[]; error?: string } {
+  const distanceTolerancePercent = parseOptionalPositiveNumberField(
+    query.distanceTolerancePercent,
+    "distanceTolerancePercent",
+  );
+
+  if (distanceTolerancePercent.error) {
+    return { error: distanceTolerancePercent.error };
+  }
+
+  const timeToleranceMin = parseOptionalPositiveNumberField(
+    query.timeToleranceMin,
+    "timeToleranceMin",
+  );
+
+  if (timeToleranceMin.error) {
+    return { error: timeToleranceMin.error };
+  }
+
+  const toleranceMin = parseOptionalPositiveNumberField(
+    query.toleranceMin,
+    "toleranceMin",
+  );
+
+  if (toleranceMin.error) {
+    return { error: toleranceMin.error };
+  }
+
+  return {
+    inputs: routeStops.map((routeStop) => ({
+      routeStopId: routeStop.id,
+      fieldVisitId: routeStop.fieldVisitId,
+      sequence: routeStop.sequence,
+      plannedKmFromPrev: routeStop.plannedKmFromPrev,
+      actualKmFromPrev: routeStop.actualKmFromPrev,
+      plannedMinFromPrev: routeStop.plannedMinFromPrev,
+      actualArrival: routeStop.actualArrival,
+      windowStart: routeStop.etaStart,
+      windowEnd: routeStop.etaEnd,
+      distanceTolerancePercent: distanceTolerancePercent.value,
+      timeToleranceMin: timeToleranceMin.value,
+      toleranceMin: toleranceMin.value,
+    })),
+  };
+}
+
+
 function getLifecycleActionError(
   result: RoutePlanLifecycleTransitionResult,
 ): { statusCode: number; error: string } {
@@ -1409,6 +1467,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
   app.options("/", optionsHandler);
   app.options("/heuristic", optionsHandler);
   app.options("/:routePlanId", optionsHandler);
+  app.options("/:routePlanId/metrics", optionsHandler);
   app.options("/:routePlanId/stops", optionsHandler);
   app.options("/:routePlanId/stops/:routeStopId", optionsHandler);
   app.options("/:routePlanId/release", optionsHandler);
@@ -1675,6 +1734,63 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     });
   });
 
+  app.get<{
+    Params: { routePlanId: string };
+    Querystring: {
+      distanceTolerancePercent?: unknown;
+      timeToleranceMin?: unknown;
+      toleranceMin?: unknown;
+    };
+  }>("/:routePlanId/metrics", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const routePlanId = parseEntityId(request.params.routePlanId);
+
+    if (!routePlanId) {
+      return reply.code(400).send({
+        success: false,
+        error: "routePlanId invalido",
+      });
+    }
+
+    const routePlan = await deps.getClinicScopedRoutePlan(
+      routePlanId,
+      auth.clinicId,
+    );
+
+    if (!routePlan) {
+      return reply.code(404).send({
+        success: false,
+        error: "Plan de ruta no encontrado",
+      });
+    }
+
+    const routeStops = await deps.listRouteStopsForClinicRoutePlan(
+      routePlanId,
+      auth.clinicId,
+    );
+    const metricInputs = buildRouteStopComplianceInputs(
+      routeStops,
+      request.query,
+    );
+
+    if (!metricInputs.inputs) {
+      return reply.code(400).send({
+        success: false,
+        error: metricInputs.error ?? "Query invalida",
+      });
+    }
+
+    return reply.send({
+      success: true,
+      routePlan: serializeRoutePlan(routePlan),
+      metrics: calculateRouteStopComplianceMetrics(metricInputs.inputs),
+    });
+  });
   app.get<{
     Params: {
       routePlanId: string;

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -167,3 +167,22 @@ test("logistics route plans API keeps heuristic generation clinic scoped and tru
   assert.match(routeSource, /createdById,/);
   assert.match(routeSource, /missingFieldVisitIds/);
 });
+
+test("logistics route plans API exposes route compliance metrics endpoint", () => {
+  assert.match(routeSource, /calculateRouteStopComplianceMetrics/);
+  assert.match(routeSource, /RouteStopComplianceInput/);
+  assert.match(routeSource, /buildRouteStopComplianceInputs/);
+  assert.match(routeSource, /"\/:routePlanId\/metrics"/);
+  assert.match(routeSource, /deps\.getClinicScopedRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /deps\.listRouteStopsForClinicRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /metrics: calculateRouteStopComplianceMetrics\(metricInputs\.inputs\)/);
+});
+
+test("logistics route plans API validates route compliance metrics tolerances", () => {
+  assert.match(routeSource, /distanceTolerancePercent/);
+  assert.match(routeSource, /timeToleranceMin/);
+  assert.match(routeSource, /toleranceMin/);
+  assert.match(routeSource, /parseOptionalPositiveNumberField\(\s*query\.distanceTolerancePercent/);
+  assert.match(routeSource, /parseOptionalPositiveNumberField\(\s*query\.timeToleranceMin/);
+  assert.match(routeSource, /parseOptionalPositiveNumberField\(\s*query\.toleranceMin/);
+});

--- a/test/logistics-route-plans-metrics-runtime.test.ts
+++ b/test/logistics-route-plans-metrics-runtime.test.ts
@@ -1,0 +1,218 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import type { InjectOptions } from "light-my-request";
+
+import type {
+  GenerateHeuristicRoutePlanInput,
+  GenerateHeuristicRoutePlanResult,
+  RoutePlan,
+  RouteStop,
+} from "../server/db-logistics.ts";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { logisticsRoutePlansNativeRoutes } = await import(
+  "../server/routes/logistics-route-plans.fastify.ts"
+);
+
+const VALID_ORIGIN = "http://localhost:3000";
+const SESSION_TOKEN = "clinic-session-token";
+const SESSION_COOKIE = `${ENV.cookieName}=${SESSION_TOKEN}`;
+
+function buildRoutePlan(overrides: Partial<RoutePlan> = {}): RoutePlan {
+  return {
+    id: 501,
+    clinicId: 7,
+    serviceDate: new Date("2026-05-05T00:00:00.000Z"),
+    status: "planned",
+    planningMode: "heuristic",
+    objective: "distance",
+    totalPlannedKm: 12,
+    totalPlannedMin: 70,
+    createdByType: "clinic",
+    createdById: 9,
+    createdAt: new Date("2026-05-04T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-04T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function buildRouteStop(overrides: Partial<RouteStop> = {}): RouteStop {
+  return {
+    id: 701,
+    routePlanId: 501,
+    fieldVisitId: 10,
+    sequence: 1,
+    etaStart: new Date("2026-05-05T10:00:00.000Z"),
+    etaEnd: new Date("2026-05-05T10:30:00.000Z"),
+    plannedKmFromPrev: 4,
+    plannedMinFromPrev: 0,
+    actualArrival: new Date("2026-05-05T10:05:00.000Z"),
+    actualDeparture: new Date("2026-05-05T10:20:00.000Z"),
+    actualKmFromPrev: 4.2,
+    status: "done",
+    createdAt: new Date("2026-05-04T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-04T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+async function buildRoutePlansMetricsRuntimeApp(input?: {
+  routePlan?: RoutePlan | null;
+  routeStops?: RouteStop[];
+}): Promise<FastifyInstance> {
+  const app = Fastify();
+
+  await app.register(logisticsRoutePlansNativeRoutes, {
+    prefix: "/api/logistics/route-plans",
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async (tokenHash: string) =>
+      tokenHash === `hash:${SESSION_TOKEN}`
+        ? {
+            clinicUserId: 9,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            lastAccess: new Date("2026-05-04T00:00:00.000Z"),
+          }
+        : null,
+    getClinicUserById: async (clinicUserId: number) =>
+      clinicUserId === 9
+        ? {
+            id: 9,
+            clinicId: 7,
+            username: "clinic-user",
+            authProId: null,
+          }
+        : null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createRoutePlan: async () => null,
+    getClinicScopedRoutePlan: async (_routePlanId, clinicId) => {
+      if (clinicId !== 7) {
+        return null;
+      }
+
+      return input && "routePlan" in input ? input.routePlan : buildRoutePlan();
+    },
+    listClinicRoutePlans: async () => [],
+    updateClinicScopedRoutePlan: async () => null,
+    createRouteStopForClinicRoutePlan: async () => null,
+    listRouteStopsForClinicRoutePlan: async () =>
+      input?.routeStops ?? [
+        buildRouteStop(),
+        buildRouteStop({
+          id: 702,
+          fieldVisitId: 20,
+          sequence: 2,
+          etaStart: new Date("2026-05-05T10:40:00.000Z"),
+          etaEnd: new Date("2026-05-05T11:00:00.000Z"),
+          plannedKmFromPrev: 8,
+          plannedMinFromPrev: 30,
+          actualArrival: new Date("2026-05-05T11:00:00.000Z"),
+          actualDeparture: new Date("2026-05-05T11:15:00.000Z"),
+          actualKmFromPrev: 11,
+          status: "done",
+        }),
+      ],
+    updateClinicScopedRouteStop: async () => null,
+    transitionClinicScopedRoutePlanStatus: async () => ({
+      reason: "not_found" as const,
+    }),
+    generateHeuristicRoutePlan: async (
+      _routePlanInput: GenerateHeuristicRoutePlanInput,
+    ): Promise<GenerateHeuristicRoutePlanResult> => ({
+      reason: "route_plan_not_created",
+    }),
+  });
+
+  return app;
+}
+
+function getInput(path: string): InjectOptions {
+  return {
+    method: "GET",
+    url: path,
+    headers: {
+      cookie: SESSION_COOKIE,
+      origin: VALID_ORIGIN,
+    },
+  };
+}
+
+test("logistics route plan metrics endpoint returns clinic-scoped compliance metrics", async () => {
+  const app = await buildRoutePlansMetricsRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      getInput(
+        "/api/logistics/route-plans/501/metrics?distanceTolerancePercent=20&timeToleranceMin=10&toleranceMin=5",
+      ),
+    );
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.routePlan.id, 501);
+    assert.equal(body.metrics.totalStops, 2);
+    assert.equal(body.metrics.distanceDeviationCount, 1);
+    assert.equal(body.metrics.timeDeviationCount, 1);
+    assert.equal(body.metrics.outOfSequenceCount, 0);
+    assert.equal(body.metrics.windowSummary.complianceRate, 100);
+    assert.deepEqual(
+      body.metrics.stopMetrics.map((metric: { fieldVisitId: number }) => metric.fieldVisitId),
+      [10, 20],
+    );
+    assert.equal(body.metrics.stopMetrics[1].distance.deltaPercent, 37.5);
+    assert.equal(body.metrics.stopMetrics[1].actualMinFromPrev, 55);
+    assert.equal(body.metrics.stopMetrics[1].minDeltaFromPlan, 25);
+    assert.equal(body.metrics.stopMetrics[1].withinTimeTolerance, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("logistics route plan metrics endpoint returns 404 for non clinic-scoped route plans", async () => {
+  const app = await buildRoutePlansMetricsRuntimeApp({
+    routePlan: null,
+  });
+
+  try {
+    const response = await app.inject(getInput("/api/logistics/route-plans/999/metrics"));
+
+    assert.equal(response.statusCode, 404);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, false);
+    assert.equal(body.error, "Plan de ruta no encontrado");
+  } finally {
+    await app.close();
+  }
+});
+
+test("logistics route plan metrics endpoint validates tolerance query params", async () => {
+  const app = await buildRoutePlansMetricsRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      getInput("/api/logistics/route-plans/501/metrics?distanceTolerancePercent=-1"),
+    );
+
+    assert.equal(response.statusCode, 400);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, false);
+    assert.equal(body.error, "distanceTolerancePercent debe ser numerico mayor a cero");
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
﻿Summary:
- Add clinic-scoped route plan compliance metrics endpoint.
- Expose GET /api/logistics/route-plans/:routePlanId/metrics.
- Reuse route stop compliance metrics from server/lib/logistics/metrics.ts.
- Support optional tolerance query parameters for distance, leg time, and time-window compliance.
- Add source and runtime coverage for success, not-found, and query validation paths.

Scope:
- API integration and tests only.
- No DB changes.
- No schema changes.
- No migrations.
- No provider integrations.

Validation:
- pnpm typecheck:test
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/logistics-route-plans-metrics-runtime.test.ts test/logistics-route-plans-api.test.ts
- pnpm test 843/843
- git diff --check
