### PR TITLE
docs(logistics): close phase 4 and 5 roadmap

### DIFF
--- a/docs/logistics/ROLLING_ROADMAP.md
+++ b/docs/logistics/ROLLING_ROADMAP.md
@@ -426,6 +426,22 @@ Required tests:
 
 ### PR 5.1 — Heuristic route ordering
 
+Status: completed in PR #213, PR #214, PR #215 and PR #216.
+
+Implemented scope:
+
+- Deterministic heuristic route planning baseline.
+- Clinic-scoped heuristic route plan generation API.
+- Runtime coverage for the heuristic API path.
+- Checklist update after heuristic validation.
+
+Current boundary:
+
+- No VRP/TSP/A*/Dijkstra/ACO implementation.
+- No external distance matrix or geocoding provider.
+- No heavy optimization in request handlers.
+- Advanced optimization remains gated by production volume and ROI evidence.
+
 Suggested title:
 
 `feat(logistics-planning): add deterministic route ordering heuristic`
@@ -463,6 +479,30 @@ Required tests:
 - Batch size limit.
 - No cross-tenant inputs.
 
+## Phase 4/5 closure status
+
+Phase 4 and Phase 5 are closed for the current MVP baseline.
+
+Completed Phase 4 scope:
+
+- SLA policies and instances schema.
+- SLA compliance helpers and coverage.
+- Basic route compliance metrics.
+- Clinic-scoped route plan compliance metrics API.
+
+Completed Phase 5 scope:
+
+- Deterministic heuristic route planning baseline.
+- Heuristic route plan generation API integration.
+- Runtime coverage for heuristic generation.
+- Checklist alignment after implementation.
+
+Remaining boundary:
+
+- SLA does not yet expose dedicated API routes.
+- SLA notifications and escalation runtime remain out of scope.
+- Advanced optimization remains discovery-only until production volume and ROI justify it.
+- External routing, distance matrix, geocoding and heavy optimization providers remain out of scope.
 ## Phase 6 — Advanced optimization evaluation
 
 Advanced optimization must remain gated until production data justifies it.

--- a/docs/notes/todo.md
+++ b/docs/notes/todo.md
@@ -92,4 +92,5 @@
 - [x] Implementar ciclo de release de planes de ruta
 - [x] Implementar API de eventos logísticos y polling incremental
 - [x] Evaluar heurística determinista simple
+- [x] Consolidar cierre documental de Phase 4/5 logística
 - [ ] Evaluar optimización avanzada solo con volumen/ROI justificado


### PR DESCRIPTION
﻿Summary:
- Mark logistics Phase 5.1 heuristic route ordering as completed after PRs 213 through 216.
- Add final Phase 4/5 closure status to the logistics rolling roadmap.
- Document completed Phase 4 SLA/compliance metrics scope and completed Phase 5 heuristic planning scope.
- Preserve remaining boundaries for SLA API routes, notifications/escalation runtime, external providers, and advanced optimization.
- Add checklist entry for Phase 4/5 documentation closure.

Scope:
- Documentation/checklist only.
- No runtime changes.
- No DB changes.
- No schema changes.
- No migrations.

Validation:
- git diff --check
- git diff --stat
