### PR TITLE
test(frontend): run Playwright smoke tests in CI

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -53,3 +53,17 @@ jobs:
 
       - name: Build frontend
         run: pnpm --dir frontend build
+
+      - name: Install Playwright browsers
+        run: pnpm --dir frontend exec playwright install --with-deps chromium
+
+      - name: Run frontend E2E smoke tests
+        run: pnpm --dir frontend e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-playwright-report
+          path: frontend/playwright-report/
+          if-no-files-found: ignore

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,7 @@
+import { createRequire } from "node:module";
 import type { Config } from "tailwindcss";
+
+const require = createRequire(import.meta.url);
 
 const config: Config = {
   darkMode: "class",


### PR DESCRIPTION
## Summary
- Run frontend Playwright smoke tests in the existing Frontend CI workflow.
- Install Chromium with Playwright dependencies before running E2E.
- Upload the Playwright report as an artifact on CI failure.
- Make `tailwind.config.ts` compatible with ESM loading by using `createRequire` for the existing `tailwindcss-animate` plugin.

## Validation
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`
- `pnpm --dir frontend e2e`