### PR TITLE
test(ci): fix frontend workflow typecheck guard

### DIFF
--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -57,9 +57,12 @@ function getEventBlock(source: string, eventName: string): string {
 
   const afterEventHeader = eventStart + eventHeader.length;
   const nextEventMatch = source.slice(afterEventHeader).match(/\n  [a-z_]+:\n/);
-  const eventEnd = nextEventMatch
-    ? afterEventHeader + nextEventMatch.index + 1
-    : source.length;
+  const nextEventIndex =
+    nextEventMatch && typeof nextEventMatch.index === "number"
+      ? nextEventMatch.index
+      : -1;
+  const eventEnd =
+    nextEventIndex >= 0 ? afterEventHeader + nextEventIndex + 1 : source.length;
 
   return source.slice(eventStart, eventEnd);
 }


### PR DESCRIPTION
## Summary
- Fixes TypeScript narrowing for frontend CI workflow event block parsing.
- Adds an explicit guard for RegExpMatchArray.index before using it.
- Preserves the existing workflow guardrail behavior.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Does not touch frontend, server, docs, drizzle, package files, or lockfiles.
- Logistics stash remains preserved for the next PR.