### PR TITLE
feat(logistics): bound heuristic field visit input

### DIFF
--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -124,6 +124,7 @@ type NativeLogisticsRoutePlansDeps = Required<
 
 const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const MAX_ROUTE_PLAN_FIELD_VISIT_IDS = 100;
 
 let defaultDepsPromise: Promise<NativeLogisticsRoutePlansDeps> | undefined;
 
@@ -1077,6 +1078,12 @@ function parseFieldVisitIds(value: unknown): {
 } {
   if (!Array.isArray(value)) {
     return { error: "fieldVisitIds debe ser un array" };
+  }
+
+  if (value.length > MAX_ROUTE_PLAN_FIELD_VISIT_IDS) {
+    return {
+      error: `fieldVisitIds no puede incluir mas de ${MAX_ROUTE_PLAN_FIELD_VISIT_IDS} visitas`,
+    };
   }
 
   const result: number[] = [];

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -152,12 +152,25 @@ test("logistics route plans API wires heuristic generation through injectable de
 
 test("logistics route plans API validates heuristic generation input before DB calls", () => {
   assert.match(routeSource, /parseFieldVisitIds/);
+  assert.match(routeSource, /const MAX_ROUTE_PLAN_FIELD_VISIT_IDS = 100/);
+  assert.match(routeSource, /if \(value\.length > MAX_ROUTE_PLAN_FIELD_VISIT_IDS\)/);
+  assert.match(
+    routeSource,
+    /fieldVisitIds no puede incluir mas de \$\{MAX_ROUTE_PLAN_FIELD_VISIT_IDS\} visitas/,
+  );
   assert.match(routeSource, /fieldVisitIds debe incluir al menos una visita/);
   assert.match(routeSource, /parseOptionalRoutePlanningPoint/);
   assert.match(routeSource, /startLocation debe incluir lat\/lng validos/);
   assert.match(routeSource, /parseOptionalPositiveNumberField/);
   assert.match(routeSource, /travelSpeedKmh/);
   assert.match(routeSource, /fallbackLegMinutes/);
+});
+
+test("logistics route plans API keeps heuristic planning call behind 400 validation cut-off", () => {
+  assert.match(
+    routeSource,
+    /const parsed = buildGenerateHeuristicRoutePlanInput\([\s\S]*?if \(!parsed\.input\) {[\s\S]*?return reply\.code\(400\)\.send\({[\s\S]*?}\);\s*}\s*const result = await deps\.generateHeuristicRoutePlan\(parsed\.input\);/,
+  );
 });
 
 test("logistics route plans API keeps heuristic generation clinic scoped and trusted-origin protected", () => {

--- a/test/security-validation-cutoff-boundaries.test.ts
+++ b/test/security-validation-cutoff-boundaries.test.ts
@@ -264,6 +264,32 @@ test("clinic study tracking create validates body before linked lookups writes n
   );
 });
 
+test("logistics heuristic route validates fieldVisitIds bound before planning execution", () => {
+  const source = readSource("server/routes/logistics-route-plans.fastify.ts");
+  const heuristicRoute = sliceFrom(
+    source,
+    'app.post<{\n    Body: {\n      serviceDate?: unknown;',
+    "logistics heuristic route",
+  );
+
+  assertContainsInOrder(
+    heuristicRoute,
+    [
+      "const parsed = buildGenerateHeuristicRoutePlanInput(",
+      "if (!parsed.input) {",
+      "return reply.code(400).send({",
+      "const result = await deps.generateHeuristicRoutePlan(parsed.input);",
+    ],
+    "logistics heuristic validation cut-off",
+  );
+
+  assertContains(
+    source,
+    "fieldVisitIds no puede incluir mas de",
+    "logistics heuristic fieldVisitIds bound validation",
+  );
+});
+
 test("audit list and export filters return 400 before listing or exporting data", () => {
   for (const scenario of [
     {


### PR DESCRIPTION
## Summary
- Adds a hard limit for heuristic route planning fieldVisitIds.
- Rejects oversized fieldVisitIds payloads before route planning execution.
- Adds regression coverage for the validation cut-off.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Notes
- Only touches logistics route validation and related tests.
- Does not touch frontend, docs, drizzle, package files, lockfiles, or environment files.