### PR TITLE
chore(smoke): sync local smoke contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Copiar `.env.example` a `.env` y completar valores reales.
 - `POST /api/auth/login`
 - `GET /api/auth/me`
 - `POST /api/auth/logout`
-- `POST /api/reports/upload`
+- `POST /api/admin/reports/upload`
 - `GET /api/reports`
 - `GET /api/reports/search`
 - `GET /api/reports/study-types`
@@ -61,7 +61,7 @@ Copiar `.env.example` a `.env` y completar valores reales.
 3. pedir sesión con `GET /api/auth/me`
 4. listar informes con `GET /api/reports`
 5. buscar con `GET /api/reports/search`
-6. subir archivos con `POST /api/reports/upload`
+6. subir archivos con `POST /api/admin/reports/upload`
 7. descargar con `GET /api/reports/:reportId/download-url`
 
 ## Notas de implementación

--- a/docs/smoke-local.md
+++ b/docs/smoke-local.md
@@ -23,12 +23,14 @@ pnpm dev
 Antes de ejecutar los smoke tests, configurar credenciales clinic validas para el entorno local:
 
 ```powershell
-$env:SMOKE_BASE_URL = "http://localhost:3000"
+$env:SMOKE_BASE_URL = "http://127.0.0.1:3000"
 $env:SMOKE_USERNAME = "<clinic-user>"
 $env:SMOKE_PASSWORD = "<clinic-password>"
 ```
 
 No usar los defaults internos `admin` / `admin123` salvo que existan explicitamente en la base local.
+
+Usar `127.0.0.1` evita diferencias locales de resolucion IPv6 de `localhost`.
 
 ## Smoke basico
 
@@ -41,7 +43,7 @@ Valida health, login clinic, sesion, reports, study-types, logout y sesion inval
 ## Smoke upload
 
 ```powershell
-$env:SMOKE_TMP_DIR = "C:\PORTAL-VETNEB\tmp"
+$env:SMOKE_TMP_DIR = "$env:TEMP\portal-vetneb-smoke"
 pnpm smoke:upload
 ```
 

--- a/scripts/smoke/smoke-report-access-tokens.ps1
+++ b/scripts/smoke/smoke-report-access-tokens.ps1
@@ -1,5 +1,5 @@
 param(
-  [string]$BaseUrl = 'http://localhost:3000',
+  [string]$BaseUrl = 'http://127.0.0.1:3000',
   [pscredential]$Credential
 )
 

--- a/scripts/smoke/smoke-test-public-professionals.ps1
+++ b/scripts/smoke/smoke-test-public-professionals.ps1
@@ -1,5 +1,5 @@
 param(
-  [string]$BaseUrl = "http://localhost:3000",
+  [string]$BaseUrl = "http://127.0.0.1:3000",
   [pscredential]$Credential,
   [int]$ExpectedClinicId = 4
 )

--- a/scripts/smoke/smoke-test.mjs
+++ b/scripts/smoke/smoke-test.mjs
@@ -1,6 +1,6 @@
 import "dotenv/config";
 
-const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://localhost:3000";
+const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
 const USERNAME = process.env.SMOKE_USERNAME ?? "admin";
 const PASSWORD = process.env.SMOKE_PASSWORD ?? "admin123";
 

--- a/scripts/smoke/smoke-upload.mjs
+++ b/scripts/smoke/smoke-upload.mjs
@@ -1,11 +1,12 @@
 import "dotenv/config";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
-const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://localhost:3000";
+const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
 const USERNAME = process.env.SMOKE_USERNAME ?? "admin";
 const PASSWORD = process.env.SMOKE_PASSWORD ?? "admin123";
-const TMP_DIR = process.env.SMOKE_TMP_DIR ?? "C:\\PORTAL-VETNEB\\tmp";
+const TMP_DIR = process.env.SMOKE_TMP_DIR ?? path.join(os.tmpdir(), "portal-vetneb-smoke");
 const PDF_PATH = path.join(TMP_DIR, "smoke-test.pdf");
 
 function fail(message, error) {
@@ -131,7 +132,7 @@ async function run() {
   form.append("studyType", "PDF_PRUEBA");
   form.append("uploadDate", "2026-04-07");
 
-  const uploadRes = await fetchOrExplain(`${BASE_URL}/api/reports/upload`, {
+  const uploadRes = await fetchOrExplain(`${BASE_URL}/api/admin/reports/upload`, {
     method: "POST",
     headers: {
       Cookie: setCookie,
@@ -157,7 +158,7 @@ async function run() {
   assert(uploadJson?.report?.previewUrl, "UPLOAD NO DEVOLVIO previewUrl");
   assert(uploadJson?.report?.downloadUrl, "UPLOAD NO DEVOLVIO downloadUrl");
 
-  console.log("OK /api/reports/upload");
+  console.log("OK /api/admin/reports/upload");
   console.log(`REPORT ID: ${uploadJson.report.id}`);
 
   const reportsRes = await fetchOrExplain(`${BASE_URL}/api/reports`, {


### PR DESCRIPTION
﻿## Summary
- Updates local smoke defaults from localhost to 127.0.0.1.
- Aligns report upload smoke contract with /api/admin/reports/upload.
- Moves smoke upload temporary PDF default outside the repository.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Docs and smoke scripts only.
- No backend runtime, frontend, drizzle, package, lockfile, or environment changes.
