### PR TITLE
chore(legacy): document old drizzle sql

### DIFF
--- a/legacy/drizzle-old/README.md
+++ b/legacy/drizzle-old/README.md
@@ -1,0 +1,12 @@
+﻿# Legacy Drizzle SQL
+
+This directory contains historical Drizzle SQL artifacts kept for repository archaeology only.
+
+These files are not part of the active migration chain and must not be used for new database changes.
+
+Active database changes must be added under `drizzle/migrations/` and validated through the project migration workflow.
+
+## Files
+
+- `big_zuras.sql`
+- `loving_boom_boom.sql`


### PR DESCRIPTION
﻿## Summary
- Adds a deprecation note for historical Drizzle SQL artifacts.
- Clarifies that legacy/drizzle-old is not part of the active migration chain.
- Points active database changes to drizzle/migrations and the migration workflow.

## Validation
- pnpm typecheck:test
- pnpm test

## Notes
- Documentation-only change under legacy/drizzle-old.
- No runtime, active migrations, frontend, package, lockfile, or environment changes.
