### PR TITLE
chore(docs): align audit upload contract

### DIFF
--- a/docs/audit/IMPLEMENTACION_AUDITORIA.md
+++ b/docs/audit/IMPLEMENTACION_AUDITORIA.md
@@ -1,67 +1,67 @@
-﻿# AuditorÃ­a tÃ©cnica y plan de implementaciÃ³n â€” PORTAL VETNEB
+# Auditoría técnica y plan de implementación — PORTAL VETNEB
 
-## 1. DiagnÃ³stico principal
+## 1. Diagnóstico principal
 
 ### Bloqueante encontrado
 
-El backend estaba intentando leer `reports.storage_path`, pero la base real todavÃ­a podÃ­a venir con el esquema legado `drive_file_id`.
+El backend estaba intentando leer `reports.storage_path`, pero la base real todavía podía venir con el esquema legado `drive_file_id`.
 
-**SÃ­ntoma directo:**
+**Síntoma directo:**
 
 - error SQL `42703: column "storage_path" does not exist`
 
 ### Riesgos detectados
 
-1. endpoints de informes sin protecciÃ³n efectiva
+1. endpoints de informes sin protección efectiva
 2. bucket de Supabase asumido, pero no validado
-3. uso de URL pÃºblica para archivos clÃ­nicos
-4. ausencia de validaciÃ³n de tipos de archivo
-5. CORS sin configuraciÃ³n completa para cookies
+3. uso de URL pública para archivos clínicos
+4. ausencia de validación de tipos de archivo
+5. CORS sin configuración completa para cookies
 6. healthcheck sin validar Storage
 7. errores HTTP poco accionables
-8. repo con rastros de transiciÃ³n de Drive -> Supabase sin cierre completo
+8. repo con rastros de transición de Drive -> Supabase sin cierre completo
 
 ---
 
-## 2. SoluciÃ³n aplicada
+## 2. Solución aplicada
 
 ### Storage de Supabase
 
-Se reemplazÃ³ el flujo de URL pÃºblica por **signed URLs** sobre bucket privado.
+Se reemplazó el flujo de URL pública por **signed URLs** sobre bucket privado.
 
-### MigraciÃ³n de esquema
+### Migración de esquema
 
-Se dejÃ³ una migraciÃ³n idempotente para renombrar columnas legacy:
+Se dejó una migración idempotente para renombrar columnas legacy:
 
 - `clinics.drive_folder_id` -> `clinics.storage_folder_path`
 - `reports.drive_file_id` -> `reports.storage_path`
 
 ### Seguridad
 
-Se agregÃ³ middleware `requireAuth` y protecciÃ³n real para:
+Se agregó middleware `requireAuth` y protección real para:
 
 - listado de informes
-- bÃºsqueda
+- búsqueda
 - tipos de estudio
 - descarga
 - subida
 
-AdemÃ¡s, se restringe acceso cruzado entre clÃ­nicas.
+Además, se restringe acceso cruzado entre clínicas.
 
 ### Fluidez operativa
 
 Se agregaron:
 
-- paginaciÃ³n controlada
-- validaciÃ³n de lÃ­mites
+- paginación controlada
+- validación de límites
 - sorting consistente
 - healthcheck real
-- manejo mÃ¡s claro de errores
-- validaciÃ³n de MIME types
+- manejo más claro de errores
+- validación de MIME types
 
 ---
 
-## 3. Orden recomendado de implementaciÃ³n
+## 3. Orden recomendado de implementación
 
 ### Paso 1
 
@@ -91,7 +91,7 @@ Verificar salud:
 
 ### Paso 5
 
-Probar login y sesiÃ³n con cookies.
+Probar login y sesión con cookies.
 
 ### Paso 6
 
@@ -120,7 +120,7 @@ await fetch("/api/reports?limit=50&offset=0", {
 });
 ```
 
-### BÃºsqueda
+### Búsqueda
 
 ```ts
 await fetch("/api/reports/search?query=juan&studyType=rx", {
@@ -155,17 +155,16 @@ window.open(downloadUrl, "_blank");
 
 ## 5. Pendientes recomendados para siguiente fase
 
-1. hash de contraseÃ±as con `bcrypt` en vez de `sha256`
+1. hash de contraseñas con `bcrypt` en vez de `sha256`
 2. rate limiting de login
 3. refresh de signed URLs desde frontend al expirar
-4. extracciÃ³n automÃ¡tica de metadatos de informes
-5. tests de integraciÃ³n para auth + upload + search
+4. extracción automática de metadatos de informes
+5. tests de integración para auth + upload + search
 6. soft delete de reportes
-7. auditorÃ­a de accesos por usuario
+7. auditoría de accesos por usuario
 
 ---
 
 ## 6. Resultado
 
-El backend queda listo para uso real con Supabase Storage privado, sesiones por cookie y migraciÃ³n ordenada del storage legado.
-
+El backend queda listo para uso real con Supabase Storage privado, sesiones por cookie y migración ordenada del storage legado.

--- a/docs/audit/IMPLEMENTACION_AUDITORIA.md
+++ b/docs/audit/IMPLEMENTACION_AUDITORIA.md
@@ -1,67 +1,67 @@
-# Auditoría técnica y plan de implementación — PORTAL VETNEB
+﻿# AuditorÃ­a tÃ©cnica y plan de implementaciÃ³n â€” PORTAL VETNEB
 
-## 1. Diagnóstico principal
+## 1. DiagnÃ³stico principal
 
 ### Bloqueante encontrado
 
-El backend estaba intentando leer `reports.storage_path`, pero la base real todavía podía venir con el esquema legado `drive_file_id`.
+El backend estaba intentando leer `reports.storage_path`, pero la base real todavÃ­a podÃ­a venir con el esquema legado `drive_file_id`.
 
-**Síntoma directo:**
+**SÃ­ntoma directo:**
 
 - error SQL `42703: column "storage_path" does not exist`
 
 ### Riesgos detectados
 
-1. endpoints de informes sin protección efectiva
+1. endpoints de informes sin protecciÃ³n efectiva
 2. bucket de Supabase asumido, pero no validado
-3. uso de URL pública para archivos clínicos
-4. ausencia de validación de tipos de archivo
-5. CORS sin configuración completa para cookies
+3. uso de URL pÃºblica para archivos clÃ­nicos
+4. ausencia de validaciÃ³n de tipos de archivo
+5. CORS sin configuraciÃ³n completa para cookies
 6. healthcheck sin validar Storage
 7. errores HTTP poco accionables
-8. repo con rastros de transición de Drive -> Supabase sin cierre completo
+8. repo con rastros de transiciÃ³n de Drive -> Supabase sin cierre completo
 
 ---
 
-## 2. Solución aplicada
+## 2. SoluciÃ³n aplicada
 
 ### Storage de Supabase
 
-Se reemplazó el flujo de URL pública por **signed URLs** sobre bucket privado.
+Se reemplazÃ³ el flujo de URL pÃºblica por **signed URLs** sobre bucket privado.
 
-### Migración de esquema
+### MigraciÃ³n de esquema
 
-Se dejó una migración idempotente para renombrar columnas legacy:
+Se dejÃ³ una migraciÃ³n idempotente para renombrar columnas legacy:
 
 - `clinics.drive_folder_id` -> `clinics.storage_folder_path`
 - `reports.drive_file_id` -> `reports.storage_path`
 
 ### Seguridad
 
-Se agregó middleware `requireAuth` y protección real para:
+Se agregÃ³ middleware `requireAuth` y protecciÃ³n real para:
 
 - listado de informes
-- búsqueda
+- bÃºsqueda
 - tipos de estudio
 - descarga
 - subida
 
-Además, se restringe acceso cruzado entre clínicas.
+AdemÃ¡s, se restringe acceso cruzado entre clÃ­nicas.
 
 ### Fluidez operativa
 
 Se agregaron:
 
-- paginación controlada
-- validación de límites
+- paginaciÃ³n controlada
+- validaciÃ³n de lÃ­mites
 - sorting consistente
 - healthcheck real
-- manejo más claro de errores
-- validación de MIME types
+- manejo mÃ¡s claro de errores
+- validaciÃ³n de MIME types
 
 ---
 
-## 3. Orden recomendado de implementación
+## 3. Orden recomendado de implementaciÃ³n
 
 ### Paso 1
 
@@ -91,7 +91,7 @@ Verificar salud:
 
 ### Paso 5
 
-Probar login y sesión con cookies.
+Probar login y sesiÃ³n con cookies.
 
 ### Paso 6
 
@@ -120,7 +120,7 @@ await fetch("/api/reports?limit=50&offset=0", {
 });
 ```
 
-### Búsqueda
+### BÃºsqueda
 
 ```ts
 await fetch("/api/reports/search?query=juan&studyType=rx", {
@@ -134,7 +134,7 @@ await fetch("/api/reports/search?query=juan&studyType=rx", {
 const formData = new FormData();
 formData.append("file", file);
 
-await fetch("/api/reports/upload", {
+await fetch("/api/admin/reports/upload", {
   method: "POST",
   credentials: "include",
   body: formData,
@@ -155,16 +155,17 @@ window.open(downloadUrl, "_blank");
 
 ## 5. Pendientes recomendados para siguiente fase
 
-1. hash de contraseñas con `bcrypt` en vez de `sha256`
+1. hash de contraseÃ±as con `bcrypt` en vez de `sha256`
 2. rate limiting de login
 3. refresh de signed URLs desde frontend al expirar
-4. extracción automática de metadatos de informes
-5. tests de integración para auth + upload + search
+4. extracciÃ³n automÃ¡tica de metadatos de informes
+5. tests de integraciÃ³n para auth + upload + search
 6. soft delete de reportes
-7. auditoría de accesos por usuario
+7. auditorÃ­a de accesos por usuario
 
 ---
 
 ## 6. Resultado
 
-El backend queda listo para uso real con Supabase Storage privado, sesiones por cookie y migración ordenada del storage legado.
+El backend queda listo para uso real con Supabase Storage privado, sesiones por cookie y migraciÃ³n ordenada del storage legado.
+


### PR DESCRIPTION
## Summary
- Aligns the audit implementation upload example with the current admin upload endpoint.
- Replaces legacy /api/reports/upload with /api/admin/reports/upload.

## Validation
- pnpm typecheck:test
- pnpm test

## Notes
- Documentation-only change.
- No runtime, tests, frontend, drizzle, legacy, package, lockfile, or environment changes.