### PR TITLE
chore(docs): clarify audit upload admin surface

### DIFF
--- a/docs/audit/IMPLEMENTACION_AUDITORIA.md
+++ b/docs/audit/IMPLEMENTACION_AUDITORIA.md
@@ -130,6 +130,8 @@ await fetch("/api/reports/search?query=juan&studyType=rx", {
 
 ### Upload
 
+Este endpoint pertenece a la superficie admin.
+
 ```ts
 const formData = new FormData();
 formData.append("file", file);


### PR DESCRIPTION
## Summary
- Clarifies that the audit upload example belongs to the admin surface.
- Keeps the existing /api/admin/reports/upload endpoint contract unchanged.

## Validation
- pnpm typecheck:test
- pnpm test

## Notes
- Documentation-only change.
- No runtime, tests, frontend, drizzle, legacy, package, lockfile, or environment changes.