### PR TITLE
feat(logistics): add SLA DB read helpers

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -1,10 +1,12 @@
-import { and, asc, desc, eq, gt, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, or } from "drizzle-orm";
 import { db } from "./db";
 import {
   fieldVisits,
   routeEvents,
   routePlans,
   routeStops,
+  slaInstances,
+  slaPolicies,
   timeWindows,
   visitLocations,
   type FieldVisitSourceType,
@@ -17,6 +19,8 @@ import {
   type RoutePlanningMode,
   type RoutePlanStatus,
   type RouteStopStatus,
+  type SlaInstanceStatus,
+  type SlaTargetType,
   type VisitLocationGeoQuality,
 } from "../drizzle/schema";
 import {
@@ -44,6 +48,8 @@ export type RouteStop = typeof routeStops.$inferSelect;
 export type NewRouteStop = typeof routeStops.$inferInsert;
 export type RouteEvent = typeof routeEvents.$inferSelect;
 export type NewRouteEvent = typeof routeEvents.$inferInsert;
+export type SlaPolicy = typeof slaPolicies.$inferSelect;
+export type SlaInstance = typeof slaInstances.$inferSelect;
 
 export type CreateFieldVisitInput = {
   clinicId: number;
@@ -163,6 +169,22 @@ export type ListRouteEventsParams = {
   routeStopId?: number;
   eventType?: RouteEventType;
   afterId?: number;
+  limit?: number;
+  offset?: number;
+};
+
+export type ListActiveClinicSlaPoliciesParams = {
+  clinicId: number;
+  targetType?: SlaTargetType;
+  limit?: number;
+  offset?: number;
+};
+
+export type ListClinicSlaInstancesParams = {
+  clinicId: number;
+  status?: SlaInstanceStatus;
+  targetType?: SlaTargetType;
+  targetId?: number;
   limit?: number;
   offset?: number;
 };
@@ -1141,4 +1163,55 @@ export async function listIncrementalClinicRouteEvents(
     limit,
     offset: 0,
   });
+}
+
+export async function listActiveClinicSlaPolicies(
+  params: ListActiveClinicSlaPoliciesParams,
+): Promise<SlaPolicy[]> {
+  const filters = [
+    eq(slaPolicies.isActive, true),
+    or(eq(slaPolicies.scope, "global"), eq(slaPolicies.clinicId, params.clinicId))!,
+  ];
+  const limit = normalizeLogisticsLimit(params.limit);
+  const offset = normalizeLogisticsOffset(params.offset);
+
+  if (params.targetType) {
+    filters.push(eq(slaPolicies.targetType, params.targetType));
+  }
+
+  return db
+    .select()
+    .from(slaPolicies)
+    .where(and(...filters))
+    .orderBy(asc(slaPolicies.targetType), asc(slaPolicies.scope), desc(slaPolicies.id))
+    .limit(limit)
+    .offset(offset);
+}
+
+export async function listClinicSlaInstances(
+  params: ListClinicSlaInstancesParams,
+): Promise<SlaInstance[]> {
+  const filters = [eq(slaInstances.clinicId, params.clinicId)];
+  const limit = normalizeLogisticsLimit(params.limit);
+  const offset = normalizeLogisticsOffset(params.offset);
+
+  if (params.status) {
+    filters.push(eq(slaInstances.status, params.status));
+  }
+
+  if (params.targetType) {
+    filters.push(eq(slaInstances.targetType, params.targetType));
+  }
+
+  if (typeof params.targetId === "number") {
+    filters.push(eq(slaInstances.targetId, params.targetId));
+  }
+
+  return db
+    .select()
+    .from(slaInstances)
+    .where(and(...filters))
+    .orderBy(asc(slaInstances.dueAt), asc(slaInstances.id))
+    .limit(limit)
+    .offset(offset);
 }

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -167,3 +167,24 @@ test("logistics DB heuristic generation reports invalid clinic-scoped inputs wit
   assert.match(dbLogisticsSource, /missingFieldVisitIds/);
   assert.match(dbLogisticsSource, /reason: "route_plan_not_created"/);
 });
+
+test("logistics DB helpers expose tenant-scoped SLA read helpers", () => {
+  assert.ok(dbLogisticsSource.includes("export type ListActiveClinicSlaPoliciesParams"));
+  assert.ok(dbLogisticsSource.includes("export type ListClinicSlaInstancesParams"));
+  assert.ok(dbLogisticsSource.includes("export type SlaPolicy = typeof slaPolicies.$inferSelect"));
+  assert.ok(dbLogisticsSource.includes("export type SlaInstance = typeof slaInstances.$inferSelect"));
+  assert.ok(dbLogisticsSource.includes("export async function listActiveClinicSlaPolicies"));
+  assert.ok(dbLogisticsSource.includes("export async function listClinicSlaInstances"));
+});
+
+test("logistics DB SLA reads stay clinic scoped, active and paginated", () => {
+  assert.ok(dbLogisticsSource.includes("eq(slaPolicies.isActive, true)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaPolicies.clinicId, params.clinicId)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.clinicId, params.clinicId)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.status, params.status)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.targetType, params.targetType)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.targetId, params.targetId)"));
+  assert.ok(dbLogisticsSource.includes("normalizeLogisticsLimit(params.limit)"));
+  assert.ok(dbLogisticsSource.includes("normalizeLogisticsOffset(params.offset)"));
+  assert.ok(dbLogisticsSource.includes("orderBy(asc(slaInstances.dueAt), asc(slaInstances.id))"));
+});


### PR DESCRIPTION
## Summary
- Adds tenant-scoped read helpers for active SLA policies.
- Adds tenant-scoped read helpers for SLA instances.
- Keeps SLA DB reads paginated and deterministic.

## Validation
- pnpm typecheck:test
- pnpm test

## Notes
- DB helper and test-only change.
- No routes, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.