### PR TITLE
feat(logistics): add SLA summary DB helper

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, or } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, or, sql } from "drizzle-orm";
 import { db } from "./db";
 import {
   fieldVisits,
@@ -187,6 +187,16 @@ export type ListClinicSlaInstancesParams = {
   targetId?: number;
   limit?: number;
   offset?: number;
+};
+
+export type ClinicSlaSummary = {
+  clinicId: number;
+  total: number;
+  active: number;
+  paused: number;
+  breached: number;
+  resolved: number;
+  canceled: number;
 };
 
 export type GenerateHeuristicRoutePlanInput = {
@@ -1186,6 +1196,38 @@ export async function listActiveClinicSlaPolicies(
     .orderBy(asc(slaPolicies.targetType), asc(slaPolicies.scope), desc(slaPolicies.id))
     .limit(limit)
     .offset(offset);
+}
+
+export async function getClinicSlaSummary(
+  clinicId: number,
+): Promise<ClinicSlaSummary> {
+  const rows = await db
+    .select({
+      status: slaInstances.status,
+      count: sql<number>`cast(count(*) as int)`,
+    })
+    .from(slaInstances)
+    .where(eq(slaInstances.clinicId, clinicId))
+    .groupBy(slaInstances.status);
+
+  const summary: ClinicSlaSummary = {
+    clinicId,
+    total: 0,
+    active: 0,
+    paused: 0,
+    breached: 0,
+    resolved: 0,
+    canceled: 0,
+  };
+
+  for (const row of rows) {
+    const count = Number(row.count) || 0;
+
+    summary.total += count;
+    summary[row.status] = count;
+  }
+
+  return summary;
 }
 
 export async function listClinicSlaInstances(

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -187,4 +187,23 @@ test("logistics DB SLA reads stay clinic scoped, active and paginated", () => {
   assert.ok(dbLogisticsSource.includes("normalizeLogisticsLimit(params.limit)"));
   assert.ok(dbLogisticsSource.includes("normalizeLogisticsOffset(params.offset)"));
   assert.ok(dbLogisticsSource.includes("orderBy(asc(slaInstances.dueAt), asc(slaInstances.id))"));
+});
+
+test("logistics DB helpers expose tenant-scoped SLA summary helper", () => {
+  assert.ok(dbLogisticsSource.includes("export type ClinicSlaSummary = {"));
+  assert.ok(dbLogisticsSource.includes("export async function getClinicSlaSummary"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.clinicId, clinicId)"));
+  assert.ok(dbLogisticsSource.includes("groupBy(slaInstances.status)"));
+  assert.ok(dbLogisticsSource.includes("sql<number>\`cast(count(*) as int)\`"));
+});
+
+test("logistics DB SLA summary returns all known status buckets", () => {
+  assert.ok(dbLogisticsSource.includes("total: 0"));
+  assert.ok(dbLogisticsSource.includes("active: 0"));
+  assert.ok(dbLogisticsSource.includes("paused: 0"));
+  assert.ok(dbLogisticsSource.includes("breached: 0"));
+  assert.ok(dbLogisticsSource.includes("resolved: 0"));
+  assert.ok(dbLogisticsSource.includes("canceled: 0"));
+  assert.ok(dbLogisticsSource.includes("summary.total += count"));
+  assert.ok(dbLogisticsSource.includes("summary[row.status] = count"));
 });


### PR DESCRIPTION
## Summary
- Adds a clinic-scoped SLA summary DB helper.
- Aggregates SLA instance counts by status.
- Returns stable buckets for total, active, paused, breached, resolved, and canceled.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- DB helper and test-only change.
- No routes, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.