### PR TITLE
feat(logistics): expose SLA summary route

### DIFF
--- a/server/routes/logistics-sla.fastify.ts
+++ b/server/routes/logistics-sla.fastify.ts
@@ -11,6 +11,7 @@ import {
   type SlaTargetType,
 } from "../../drizzle/schema.ts";
 import type {
+  ClinicSlaSummary,
   ListActiveClinicSlaPoliciesParams,
   ListClinicSlaInstancesParams,
   SlaInstance,
@@ -55,6 +56,7 @@ export type LogisticsSlaNativeRoutesOptions = {
   listClinicSlaInstances?: (
     params: ListClinicSlaInstancesParams,
   ) => Promise<SlaInstance[]>;
+  getClinicSlaSummary?: (clinicId: number) => Promise<ClinicSlaSummary>;
   now?: () => number;
 };
 
@@ -68,6 +70,7 @@ type NativeLogisticsSlaDeps = Required<
     | "hashSessionToken"
     | "listActiveClinicSlaPolicies"
     | "listClinicSlaInstances"
+    | "getClinicSlaSummary"
   >
 >;
 
@@ -90,6 +93,7 @@ async function loadDefaultDeps(): Promise<NativeLogisticsSlaDeps> {
         hashSessionToken: authSecurity.hashSessionToken,
         listActiveClinicSlaPolicies: dbLogistics.listActiveClinicSlaPolicies,
         listClinicSlaInstances: dbLogistics.listClinicSlaInstances,
+        getClinicSlaSummary: dbLogistics.getClinicSlaSummary,
       };
     })();
   }
@@ -545,7 +549,8 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
     !!options.updateSessionLastAccess &&
     !!options.hashSessionToken &&
     !!options.listActiveClinicSlaPolicies &&
-    !!options.listClinicSlaInstances;
+    !!options.listClinicSlaInstances &&
+    !!options.getClinicSlaSummary;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -565,6 +570,8 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
       defaultDeps!.listActiveClinicSlaPolicies,
     listClinicSlaInstances:
       options.listClinicSlaInstances ?? defaultDeps!.listClinicSlaInstances,
+    getClinicSlaSummary:
+      options.getClinicSlaSummary ?? defaultDeps!.getClinicSlaSummary,
   };
 
   const now = options.now ?? (() => Date.now());
@@ -602,6 +609,22 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
 
   app.options("/policies", optionsHandler);
   app.options("/instances", optionsHandler);
+  app.options("/summary", optionsHandler);
+
+  app.get("/summary", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const summary = await deps.getClinicSlaSummary(auth.clinicId);
+
+    return reply.code(200).send({
+      success: true,
+      summary,
+    });
+  });
 
   app.get<{
     Querystring: {

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -572,6 +572,15 @@ function buildLogisticsSlaRouteStubs() {
     hashSessionToken: (token: string) => `hash:${token}`,
     listActiveClinicSlaPolicies: async () => [],
     listClinicSlaInstances: async () => [],
+    getClinicSlaSummary: async () => ({
+      clinicId: 1,
+      total: 0,
+      active: 0,
+      paused: 0,
+      breached: 0,
+      resolved: 0,
+      canceled: 0,
+    }),
   };
 }
 function buildFastifyDispatchRouteStubs() {

--- a/test/logistics-sla-routes-api.test.ts
+++ b/test/logistics-sla-routes-api.test.ts
@@ -13,10 +13,12 @@ const appSource = readFileSync(
   "utf8",
 );
 
-test("logistics SLA API exposes read-only policy and instance endpoints", () => {
+test("logistics SLA API exposes read-only policy, instance and summary endpoints", () => {
   assert.match(routeSource, /export const logisticsSlaNativeRoutes/);
+  assert.match(routeSource, /app\.get\("\/summary", async/);
   assert.match(routeSource, /app\.get<[\s\S]*>\("\/policies", async/);
   assert.match(routeSource, /app\.get<[\s\S]*>\("\/instances", async/);
+  assert.match(routeSource, /app\.options\("\/summary", optionsHandler\)/);
   assert.match(routeSource, /app\.options\("\/policies", optionsHandler\)/);
   assert.match(routeSource, /app\.options\("\/instances", optionsHandler\)/);
   assert.match(routeSource, /GET,OPTIONS/);
@@ -25,15 +27,19 @@ test("logistics SLA API exposes read-only policy and instance endpoints", () => 
 test("logistics SLA API wires DB helpers through injectable deps", () => {
   assert.match(routeSource, /listActiveClinicSlaPolicies\?:/);
   assert.match(routeSource, /listClinicSlaInstances\?:/);
+  assert.match(routeSource, /getClinicSlaSummary\?:/);
   assert.match(routeSource, /dbLogistics\.listActiveClinicSlaPolicies/);
   assert.match(routeSource, /dbLogistics\.listClinicSlaInstances/);
+  assert.match(routeSource, /dbLogistics\.getClinicSlaSummary/);
   assert.match(routeSource, /deps\.listActiveClinicSlaPolicies\(parsed\.params\)/);
   assert.match(routeSource, /deps\.listClinicSlaInstances\(parsed\.params\)/);
+  assert.match(routeSource, /deps\.getClinicSlaSummary\(auth\.clinicId\)/);
 });
 
 test("logistics SLA API keeps reads clinic scoped and paginated", () => {
   assert.match(routeSource, /buildListSlaPoliciesParams\(request\.query, auth\.clinicId\)/);
   assert.match(routeSource, /buildListSlaInstancesParams\(request\.query, auth\.clinicId\)/);
+  assert.match(routeSource, /getClinicSlaSummary\(auth\.clinicId\)/);
   assert.match(routeSource, /clinicId,/);
   assert.match(routeSource, /parsePositiveInt\(query\.limit, 50, 100\)/);
   assert.match(routeSource, /parseOffset\(query\.offset\)/);

--- a/test/logistics-sla-routes-integration.fastify.test.ts
+++ b/test/logistics-sla-routes-integration.fastify.test.ts
@@ -75,6 +75,7 @@ async function createIntegrationApp() {
   const app = Fastify();
   const policyCalls: SlaPolicyCall[] = [];
   const instanceCalls: SlaInstanceCall[] = [];
+  const summaryCalls: number[] = [];
   const deletedSessionHashes: string[] = [];
   const updatedSessionHashes: string[] = [];
 
@@ -119,21 +120,45 @@ async function createIntegrationApp() {
       instanceCalls.push(params);
       return [createSlaInstanceFixture() as any];
     },
+    getClinicSlaSummary: async (clinicId: number) => {
+      summaryCalls.push(clinicId);
+      return {
+        clinicId,
+        total: 5,
+        active: 2,
+        paused: 1,
+        breached: 1,
+        resolved: 1,
+        canceled: 0,
+      };
+    },
   });
 
   return {
     app,
     policyCalls,
     instanceCalls,
+    summaryCalls,
     deletedSessionHashes,
     updatedSessionHashes,
   };
 }
 
 test("logistics SLA integration rejects unauthenticated reads before DB helpers", async () => {
-  const { app, policyCalls, instanceCalls } = await createIntegrationApp();
+  const { app, policyCalls, instanceCalls, summaryCalls } = await createIntegrationApp();
 
   try {
+    const summaryResponse = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/summary",
+    });
+
+    assert.equal(summaryResponse.statusCode, 401);
+    assert.deepEqual(JSON.parse(summaryResponse.body), {
+      success: false,
+      error: "No autenticado",
+    });
+
     const policiesResponse = await app.inject({
       method: "GET",
       url: "/api/logistics/sla/policies",
@@ -158,6 +183,42 @@ test("logistics SLA integration rejects unauthenticated reads before DB helpers"
 
     assert.deepEqual(policyCalls, []);
     assert.deepEqual(instanceCalls, []);
+    assert.deepEqual(summaryCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
+
+test("logistics SLA integration returns clinic-scoped summary", async () => {
+  const { app, summaryCalls } = await createIntegrationApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/summary",
+      headers: {
+        cookie: createCookie(),
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+    assert.deepEqual(body, {
+      success: true,
+      summary: {
+        clinicId: 3,
+        total: 5,
+        active: 2,
+        paused: 1,
+        breached: 1,
+        resolved: 1,
+        canceled: 0,
+      },
+    });
+
+    assert.deepEqual(summaryCalls, [3]);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary
- Adds GET /api/logistics/sla/summary.
- Wires the route through dependency-injected getClinicSlaSummary.
- Extends SLA route contract and Fastify inject integration coverage.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Read-only route surface.
- No drizzle, frontend, docs, legacy, package, lockfile, or environment changes.