### PR TITLE
feat(logistics): add overdue SLA DB helper

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, lte, or, sql } from "drizzle-orm";
 import { db } from "./db";
 import {
   fieldVisits,
@@ -197,6 +197,14 @@ export type ClinicSlaSummary = {
   breached: number;
   resolved: number;
   canceled: number;
+};
+
+export type ListOverdueActiveClinicSlaInstancesParams = {
+  clinicId: number;
+  dueAtOrBefore: Date;
+  targetType?: SlaTargetType;
+  limit?: number;
+  offset?: number;
 };
 
 export type GenerateHeuristicRoutePlanInput = {
@@ -1228,6 +1236,30 @@ export async function getClinicSlaSummary(
   }
 
   return summary;
+}
+
+export async function listOverdueActiveClinicSlaInstances(
+  params: ListOverdueActiveClinicSlaInstancesParams,
+): Promise<SlaInstance[]> {
+  const filters = [
+    eq(slaInstances.clinicId, params.clinicId),
+    eq(slaInstances.status, "active"),
+    lte(slaInstances.dueAt, params.dueAtOrBefore),
+  ];
+  const limit = normalizeLogisticsLimit(params.limit);
+  const offset = normalizeLogisticsOffset(params.offset);
+
+  if (params.targetType) {
+    filters.push(eq(slaInstances.targetType, params.targetType));
+  }
+
+  return db
+    .select()
+    .from(slaInstances)
+    .where(and(...filters))
+    .orderBy(asc(slaInstances.dueAt), asc(slaInstances.id))
+    .limit(limit)
+    .offset(offset);
 }
 
 export async function listClinicSlaInstances(

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -207,3 +207,18 @@ test("logistics DB SLA summary returns all known status buckets", () => {
   assert.ok(dbLogisticsSource.includes("summary.total += count"));
   assert.ok(dbLogisticsSource.includes("summary[row.status] = count"));
 });
+
+test("logistics DB helpers expose overdue active SLA instance reads", () => {
+  assert.ok(dbLogisticsSource.includes("export type ListOverdueActiveClinicSlaInstancesParams"));
+  assert.ok(dbLogisticsSource.includes("export async function listOverdueActiveClinicSlaInstances"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.clinicId, params.clinicId)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.status, \"active\")"));
+  assert.ok(dbLogisticsSource.includes("lte(slaInstances.dueAt, params.dueAtOrBefore)"));
+});
+
+test("logistics DB overdue SLA reads stay paginated, deterministic and optionally target-scoped", () => {
+  assert.ok(dbLogisticsSource.includes("normalizeLogisticsLimit(params.limit)"));
+  assert.ok(dbLogisticsSource.includes("normalizeLogisticsOffset(params.offset)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.targetType, params.targetType)"));
+  assert.ok(dbLogisticsSource.includes("orderBy(asc(slaInstances.dueAt), asc(slaInstances.id))"));
+});


### PR DESCRIPTION
## Summary
- Adds a clinic-scoped DB helper for overdue active SLA instances.
- Filters active SLA instances by dueAt cutoff.
- Keeps reads paginated, deterministic, and optionally target-type scoped.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- DB helper and test-only change.
- No routes, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.