### PR TITLE
feat(logistics): expose overdue SLA route

### DIFF
--- a/server/routes/logistics-sla.fastify.ts
+++ b/server/routes/logistics-sla.fastify.ts
@@ -14,6 +14,7 @@ import type {
   ClinicSlaSummary,
   ListActiveClinicSlaPoliciesParams,
   ListClinicSlaInstancesParams,
+  ListOverdueActiveClinicSlaInstancesParams,
   SlaInstance,
   SlaPolicy,
 } from "../db-logistics.ts";
@@ -56,6 +57,9 @@ export type LogisticsSlaNativeRoutesOptions = {
   listClinicSlaInstances?: (
     params: ListClinicSlaInstancesParams,
   ) => Promise<SlaInstance[]>;
+  listOverdueActiveClinicSlaInstances?: (
+    params: ListOverdueActiveClinicSlaInstancesParams,
+  ) => Promise<SlaInstance[]>;
   getClinicSlaSummary?: (clinicId: number) => Promise<ClinicSlaSummary>;
   now?: () => number;
 };
@@ -70,6 +74,7 @@ type NativeLogisticsSlaDeps = Required<
     | "hashSessionToken"
     | "listActiveClinicSlaPolicies"
     | "listClinicSlaInstances"
+    | "listOverdueActiveClinicSlaInstances"
     | "getClinicSlaSummary"
   >
 >;
@@ -93,6 +98,8 @@ async function loadDefaultDeps(): Promise<NativeLogisticsSlaDeps> {
         hashSessionToken: authSecurity.hashSessionToken,
         listActiveClinicSlaPolicies: dbLogistics.listActiveClinicSlaPolicies,
         listClinicSlaInstances: dbLogistics.listClinicSlaInstances,
+        listOverdueActiveClinicSlaInstances:
+          dbLogistics.listOverdueActiveClinicSlaInstances,
         getClinicSlaSummary: dbLogistics.getClinicSlaSummary,
       };
     })();
@@ -481,6 +488,63 @@ function buildListSlaPoliciesParams(
   };
 }
 
+function parseOptionalDate(
+  value: unknown,
+  fieldName: string,
+): { value?: Date; error?: string } {
+  if (value == null || value === "") {
+    return {};
+  }
+
+  if (typeof value !== "string") {
+    return { error: `${fieldName} invalido` };
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return { error: `${fieldName} invalido` };
+  }
+
+  return { value: date };
+}
+
+function buildListOverdueSlaInstancesParams(
+  query: {
+    dueAtOrBefore?: unknown;
+    targetType?: unknown;
+    limit?: unknown;
+    offset?: unknown;
+  },
+  clinicId: number,
+  now: () => number,
+): { params?: ListOverdueActiveClinicSlaInstancesParams; error?: string } {
+  const dueAtOrBefore = parseOptionalDate(
+    query.dueAtOrBefore,
+    "dueAtOrBefore",
+  );
+
+  if (dueAtOrBefore.error) {
+    return { error: dueAtOrBefore.error };
+  }
+
+  const targetType = parseSlaTargetType(query.targetType);
+
+  if (targetType.error) {
+    return { error: targetType.error };
+  }
+
+  return {
+    params: {
+      clinicId,
+      dueAtOrBefore: dueAtOrBefore.value ?? new Date(now()),
+      targetType: targetType.value,
+      limit: parsePositiveInt(query.limit, 50, 100),
+      offset: parseOffset(query.offset),
+    },
+  };
+}
+
 function buildListSlaInstancesParams(
   query: {
     status?: unknown;
@@ -550,6 +614,7 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
     !!options.hashSessionToken &&
     !!options.listActiveClinicSlaPolicies &&
     !!options.listClinicSlaInstances &&
+    !!options.listOverdueActiveClinicSlaInstances &&
     !!options.getClinicSlaSummary;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
@@ -570,6 +635,9 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
       defaultDeps!.listActiveClinicSlaPolicies,
     listClinicSlaInstances:
       options.listClinicSlaInstances ?? defaultDeps!.listClinicSlaInstances,
+    listOverdueActiveClinicSlaInstances:
+      options.listOverdueActiveClinicSlaInstances ??
+      defaultDeps!.listOverdueActiveClinicSlaInstances,
     getClinicSlaSummary:
       options.getClinicSlaSummary ?? defaultDeps!.getClinicSlaSummary,
   };
@@ -610,6 +678,50 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
   app.options("/policies", optionsHandler);
   app.options("/instances", optionsHandler);
   app.options("/summary", optionsHandler);
+  app.options("/overdue", optionsHandler);
+
+  app.get<{
+    Querystring: {
+      dueAtOrBefore?: unknown;
+      targetType?: unknown;
+      limit?: unknown;
+      offset?: unknown;
+    };
+  }>("/overdue", async (request, reply) => {
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const parsed = buildListOverdueSlaInstancesParams(
+      request.query,
+      auth.clinicId,
+      now,
+    );
+
+    if (!parsed.params) {
+      return reply.code(400).send({
+        success: false,
+        error: parsed.error ?? "Parametros invalidos",
+      });
+    }
+
+    const instances = await deps.listOverdueActiveClinicSlaInstances(
+      parsed.params,
+    );
+
+    return reply.code(200).send({
+      success: true,
+      count: instances.length,
+      instances: instances.map((instance) => serializeSlaInstance(instance)),
+      pagination: {
+        limit: parsed.params.limit,
+        offset: parsed.params.offset,
+      },
+      dueAtOrBefore: parsed.params.dueAtOrBefore.toISOString(),
+    });
+  });
 
   app.get("/summary", async (request, reply) => {
     const auth = await authenticateClinicUser(request, reply, deps, now);

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -572,6 +572,7 @@ function buildLogisticsSlaRouteStubs() {
     hashSessionToken: (token: string) => `hash:${token}`,
     listActiveClinicSlaPolicies: async () => [],
     listClinicSlaInstances: async () => [],
+    listOverdueActiveClinicSlaInstances: async () => [],
     getClinicSlaSummary: async () => ({
       clinicId: 1,
       total: 0,

--- a/test/logistics-sla-routes-api.test.ts
+++ b/test/logistics-sla-routes-api.test.ts
@@ -13,12 +13,14 @@ const appSource = readFileSync(
   "utf8",
 );
 
-test("logistics SLA API exposes read-only policy, instance and summary endpoints", () => {
+test("logistics SLA API exposes read-only policy, instance, overdue and summary endpoints", () => {
   assert.match(routeSource, /export const logisticsSlaNativeRoutes/);
   assert.match(routeSource, /app\.get\("\/summary", async/);
+  assert.match(routeSource, /app\.get<[\s\S]*>\("\/overdue", async/);
   assert.match(routeSource, /app\.get<[\s\S]*>\("\/policies", async/);
   assert.match(routeSource, /app\.get<[\s\S]*>\("\/instances", async/);
   assert.match(routeSource, /app\.options\("\/summary", optionsHandler\)/);
+  assert.match(routeSource, /app\.options\("\/overdue", optionsHandler\)/);
   assert.match(routeSource, /app\.options\("\/policies", optionsHandler\)/);
   assert.match(routeSource, /app\.options\("\/instances", optionsHandler\)/);
   assert.match(routeSource, /GET,OPTIONS/);
@@ -28,12 +30,15 @@ test("logistics SLA API wires DB helpers through injectable deps", () => {
   assert.match(routeSource, /listActiveClinicSlaPolicies\?:/);
   assert.match(routeSource, /listClinicSlaInstances\?:/);
   assert.match(routeSource, /getClinicSlaSummary\?:/);
+  assert.match(routeSource, /listOverdueActiveClinicSlaInstances\?:/);
   assert.match(routeSource, /dbLogistics\.listActiveClinicSlaPolicies/);
   assert.match(routeSource, /dbLogistics\.listClinicSlaInstances/);
   assert.match(routeSource, /dbLogistics\.getClinicSlaSummary/);
+  assert.match(routeSource, /dbLogistics\.listOverdueActiveClinicSlaInstances/);
   assert.match(routeSource, /deps\.listActiveClinicSlaPolicies\(parsed\.params\)/);
   assert.match(routeSource, /deps\.listClinicSlaInstances\(parsed\.params\)/);
   assert.match(routeSource, /deps\.getClinicSlaSummary\(auth\.clinicId\)/);
+  assert.match(routeSource, /deps\.listOverdueActiveClinicSlaInstances\(\s*parsed\.params,\s*\)/);
 });
 
 test("logistics SLA API keeps reads clinic scoped and paginated", () => {
@@ -59,4 +64,11 @@ test("fastify app registers logistics SLA routes under dedicated prefix", () => 
   assert.match(appSource, /type LogisticsSlaNativeRoutesOptions/);
   assert.match(appSource, /logisticsSlaRoutes\?: LogisticsSlaNativeRoutesOptions/);
   assert.match(appSource, /prefix: "\/api\/logistics\/sla"/);
+});
+
+test("logistics SLA API validates overdue route filters before DB reads", () => {
+  assert.match(routeSource, /buildListOverdueSlaInstancesParams/);
+  assert.match(routeSource, /parseOptionalDate\(\s*query\.dueAtOrBefore,\s*"dueAtOrBefore",\s*\)/);
+  assert.match(routeSource, /parseSlaTargetType\(query\.targetType\)/);
+  assert.match(routeSource, /dueAtOrBefore: dueAtOrBefore\.value \?\? new Date\(now\(\)\)/);
 });

--- a/test/logistics-sla-routes-integration.fastify.test.ts
+++ b/test/logistics-sla-routes-integration.fastify.test.ts
@@ -75,6 +75,13 @@ async function createIntegrationApp() {
   const app = Fastify();
   const policyCalls: SlaPolicyCall[] = [];
   const instanceCalls: SlaInstanceCall[] = [];
+  const overdueCalls: Array<{
+    clinicId: number;
+    dueAtOrBefore: Date;
+    targetType?: string;
+    limit?: number;
+    offset?: number;
+  }> = [];
   const summaryCalls: number[] = [];
   const deletedSessionHashes: string[] = [];
   const updatedSessionHashes: string[] = [];
@@ -120,6 +127,16 @@ async function createIntegrationApp() {
       instanceCalls.push(params);
       return [createSlaInstanceFixture() as any];
     },
+    listOverdueActiveClinicSlaInstances: async (params: {
+      clinicId: number;
+      dueAtOrBefore: Date;
+      targetType?: string;
+      limit?: number;
+      offset?: number;
+    }) => {
+      overdueCalls.push(params);
+      return [createSlaInstanceFixture() as any];
+    },
     getClinicSlaSummary: async (clinicId: number) => {
       summaryCalls.push(clinicId);
       return {
@@ -138,6 +155,7 @@ async function createIntegrationApp() {
     app,
     policyCalls,
     instanceCalls,
+    overdueCalls,
     summaryCalls,
     deletedSessionHashes,
     updatedSessionHashes,
@@ -145,9 +163,20 @@ async function createIntegrationApp() {
 }
 
 test("logistics SLA integration rejects unauthenticated reads before DB helpers", async () => {
-  const { app, policyCalls, instanceCalls, summaryCalls } = await createIntegrationApp();
+  const { app, policyCalls, instanceCalls, overdueCalls, summaryCalls } = await createIntegrationApp();
 
   try {
+    const overdueResponse = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/overdue",
+    });
+
+    assert.equal(overdueResponse.statusCode, 401);
+    assert.deepEqual(JSON.parse(overdueResponse.body), {
+      success: false,
+      error: "No autenticado",
+    });
+
     const summaryResponse = await app.inject({
       method: "GET",
       url: "/api/logistics/sla/summary",
@@ -183,12 +212,87 @@ test("logistics SLA integration rejects unauthenticated reads before DB helpers"
 
     assert.deepEqual(policyCalls, []);
     assert.deepEqual(instanceCalls, []);
+    assert.deepEqual(overdueCalls, []);
     assert.deepEqual(summaryCalls, []);
   } finally {
     await app.close();
   }
 });
 
+
+test("logistics SLA integration lists overdue active instances with clinic scope and cutoff", async () => {
+  const { app, overdueCalls } = await createIntegrationApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/overdue?dueAtOrBefore=2026-05-01T12:30:00.000Z&targetType=field_visit&limit=4&offset=1",
+      headers: {
+        cookie: createCookie(),
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.equal(body.dueAtOrBefore, "2026-05-01T12:30:00.000Z");
+    assert.deepEqual(body.pagination, {
+      limit: 4,
+      offset: 1,
+    });
+    assert.equal(body.instances[0].id, 21);
+    assert.equal(body.instances[0].dueAt, "2026-05-01T12:00:00.000Z");
+
+    assert.equal(overdueCalls.length, 1);
+    assert.equal(overdueCalls[0].clinicId, 3);
+    assert.equal(overdueCalls[0].dueAtOrBefore.toISOString(), "2026-05-01T12:30:00.000Z");
+    assert.equal(overdueCalls[0].targetType, "field_visit");
+    assert.equal(overdueCalls[0].limit, 4);
+    assert.equal(overdueCalls[0].offset, 1);
+  } finally {
+    await app.close();
+  }
+});
+
+test("logistics SLA integration rejects invalid overdue filters before DB reads", async () => {
+  const { app, overdueCalls } = await createIntegrationApp();
+
+  try {
+    const invalidDateResponse = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/overdue?dueAtOrBefore=not-a-date",
+      headers: {
+        cookie: createCookie(),
+      },
+    });
+
+    assert.equal(invalidDateResponse.statusCode, 400);
+    assert.deepEqual(JSON.parse(invalidDateResponse.body), {
+      success: false,
+      error: "dueAtOrBefore invalido",
+    });
+
+    const invalidTargetTypeResponse = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/overdue?targetType=unknown",
+      headers: {
+        cookie: createCookie(),
+      },
+    });
+
+    assert.equal(invalidTargetTypeResponse.statusCode, 400);
+    assert.deepEqual(JSON.parse(invalidTargetTypeResponse.body), {
+      success: false,
+      error: "targetType invalido",
+    });
+
+    assert.deepEqual(overdueCalls, []);
+  } finally {
+    await app.close();
+  }
+});
 
 test("logistics SLA integration returns clinic-scoped summary", async () => {
   const { app, summaryCalls } = await createIntegrationApp();


### PR DESCRIPTION
## Summary
- Adds GET /api/logistics/sla/overdue.
- Wires the route through dependency-injected listOverdueActiveClinicSlaInstances.
- Adds cutoff, target type, pagination, and invalid filter coverage.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Read-only route surface.
- No drizzle, frontend, docs, legacy, package, lockfile, or environment changes.