### PR TITLE
test(logistics): cover overdue SLA default cutoff

### DIFF
--- a/test/logistics-sla-routes-integration.fastify.test.ts
+++ b/test/logistics-sla-routes-integration.fastify.test.ts
@@ -256,6 +256,39 @@ test("logistics SLA integration lists overdue active instances with clinic scope
   }
 });
 
+test("logistics SLA integration defaults overdue cutoff to now", async () => {
+  const { app, overdueCalls } = await createIntegrationApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/overdue?targetType=field_visit&limit=3&offset=2",
+      headers: {
+        cookie: createCookie(),
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.dueAtOrBefore, "2026-05-05T00:00:00.000Z");
+    assert.deepEqual(body.pagination, {
+      limit: 3,
+      offset: 2,
+    });
+
+    assert.equal(overdueCalls.length, 1);
+    assert.equal(overdueCalls[0].clinicId, 3);
+    assert.equal(overdueCalls[0].dueAtOrBefore.toISOString(), "2026-05-05T00:00:00.000Z");
+    assert.equal(overdueCalls[0].targetType, "field_visit");
+    assert.equal(overdueCalls[0].limit, 3);
+    assert.equal(overdueCalls[0].offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
 test("logistics SLA integration rejects invalid overdue filters before DB reads", async () => {
   const { app, overdueCalls } = await createIntegrationApp();
 


### PR DESCRIPTION
## Summary
- Adds Fastify inject coverage for the overdue SLA route default cutoff.
- Verifies dueAtOrBefore defaults to the injected now() value.
- Keeps target type, pagination, and clinic scope assertions explicit.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Test-only change.
- No runtime, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.