### PR TITLE
feat(logistics): add SLA breach DB helper

### DIFF
--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -207,6 +207,13 @@ export type ListOverdueActiveClinicSlaInstancesParams = {
   offset?: number;
 };
 
+export type MarkOverdueActiveClinicSlaInstancesBreachedParams = {
+  clinicId: number;
+  dueAtOrBefore: Date;
+  breachedAt: Date;
+  targetType?: SlaTargetType;
+};
+
 export type GenerateHeuristicRoutePlanInput = {
   clinicId: number;
   serviceDate: Date;
@@ -1236,6 +1243,30 @@ export async function getClinicSlaSummary(
   }
 
   return summary;
+}
+
+export async function markOverdueActiveClinicSlaInstancesBreached(
+  params: MarkOverdueActiveClinicSlaInstancesBreachedParams,
+): Promise<SlaInstance[]> {
+  const filters = [
+    eq(slaInstances.clinicId, params.clinicId),
+    eq(slaInstances.status, "active"),
+    lte(slaInstances.dueAt, params.dueAtOrBefore),
+  ];
+
+  if (params.targetType) {
+    filters.push(eq(slaInstances.targetType, params.targetType));
+  }
+
+  return db
+    .update(slaInstances)
+    .set({
+      status: "breached",
+      breachedAt: params.breachedAt,
+      updatedAt: params.breachedAt,
+    })
+    .where(and(...filters))
+    .returning();
 }
 
 export async function listOverdueActiveClinicSlaInstances(

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -222,3 +222,20 @@ test("logistics DB overdue SLA reads stay paginated, deterministic and optionall
   assert.ok(dbLogisticsSource.includes("eq(slaInstances.targetType, params.targetType)"));
   assert.ok(dbLogisticsSource.includes("orderBy(asc(slaInstances.dueAt), asc(slaInstances.id))"));
 });
+
+test("logistics DB helpers expose SLA breach marking helper", () => {
+  assert.ok(dbLogisticsSource.includes("export type MarkOverdueActiveClinicSlaInstancesBreachedParams"));
+  assert.ok(dbLogisticsSource.includes("export async function markOverdueActiveClinicSlaInstancesBreached"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.clinicId, params.clinicId)"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.status, \"active\")"));
+  assert.ok(dbLogisticsSource.includes("lte(slaInstances.dueAt, params.dueAtOrBefore)"));
+});
+
+test("logistics DB SLA breach marking updates only overdue active instances", () => {
+  assert.ok(dbLogisticsSource.includes("status: \"breached\""));
+  assert.ok(dbLogisticsSource.includes("breachedAt: params.breachedAt"));
+  assert.ok(dbLogisticsSource.includes("updatedAt: params.breachedAt"));
+  assert.ok(dbLogisticsSource.includes("eq(slaInstances.targetType, params.targetType)"));
+  assert.ok(dbLogisticsSource.includes(".update(slaInstances)"));
+  assert.ok(dbLogisticsSource.includes(".returning()"));
+});


### PR DESCRIPTION
## Summary
- Adds a clinic-scoped DB helper to mark overdue active SLA instances as breached.
- Updates breachedAt and updatedAt atomically with the breach timestamp.
- Keeps target type scoping optional and returns updated SLA instances.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- DB helper and test-only change.
- No routes, scheduler/runtime automation, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.