### PR TITLE
feat(logistics): add SLA breach runtime service

### DIFF
--- a/server/lib/logistics/sla-breach.ts
+++ b/server/lib/logistics/sla-breach.ts
@@ -1,0 +1,70 @@
+import type {
+  MarkOverdueActiveClinicSlaInstancesBreachedParams,
+  SlaInstance,
+} from "../../db-logistics.ts";
+import type { SlaTargetType } from "../../../drizzle/schema.ts";
+
+export type MarkOverdueSlaBreachesDeps = {
+  markOverdueActiveClinicSlaInstancesBreached: (
+    params: MarkOverdueActiveClinicSlaInstancesBreachedParams,
+  ) => Promise<SlaInstance[]>;
+  now?: () => Date;
+};
+
+export type MarkOverdueSlaBreachesInput = {
+  clinicId: number;
+  dueAtOrBefore?: Date;
+  breachedAt?: Date;
+  targetType?: SlaTargetType;
+};
+
+export type MarkOverdueSlaBreachesResult = {
+  breachedCount: number;
+  breachedInstances: SlaInstance[];
+  dueAtOrBefore: Date;
+  breachedAt: Date;
+};
+
+function assertValidDate(value: Date, fieldName: string): void {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new Error(`${fieldName} invalido`);
+  }
+}
+
+function assertValidClinicId(clinicId: number): void {
+  if (!Number.isInteger(clinicId) || clinicId <= 0) {
+    throw new Error("clinicId debe ser un entero positivo");
+  }
+}
+
+export async function markOverdueSlaBreaches(
+  input: MarkOverdueSlaBreachesInput,
+  deps: MarkOverdueSlaBreachesDeps,
+): Promise<MarkOverdueSlaBreachesResult> {
+  assertValidClinicId(input.clinicId);
+
+  const now = deps.now ?? (() => new Date());
+  const defaultNow = now();
+  assertValidDate(defaultNow, "now");
+
+  const dueAtOrBefore = input.dueAtOrBefore ?? defaultNow;
+  const breachedAt = input.breachedAt ?? defaultNow;
+
+  assertValidDate(dueAtOrBefore, "dueAtOrBefore");
+  assertValidDate(breachedAt, "breachedAt");
+
+  const breachedInstances =
+    await deps.markOverdueActiveClinicSlaInstancesBreached({
+      clinicId: input.clinicId,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: input.targetType,
+    });
+
+  return {
+    breachedCount: breachedInstances.length,
+    breachedInstances,
+    dueAtOrBefore,
+    breachedAt,
+  };
+}

--- a/test/logistics-sla-breach-runtime.test.ts
+++ b/test/logistics-sla-breach-runtime.test.ts
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  markOverdueSlaBreaches,
+  type MarkOverdueSlaBreachesDeps,
+} from "../server/lib/logistics/sla-breach.ts";
+
+function createSlaInstanceFixture() {
+  return {
+    id: 1,
+    clinicId: 7,
+    policyId: 3,
+    targetType: "field_visit",
+    targetId: 11,
+    status: "breached",
+    startedAt: new Date("2026-05-01T10:00:00.000Z"),
+    dueAt: new Date("2026-05-01T12:00:00.000Z"),
+    breachedAt: new Date("2026-05-01T12:30:00.000Z"),
+    resolvedAt: null,
+    pausedAt: null,
+    metadata: null,
+    createdAt: new Date("2026-05-01T10:00:00.000Z"),
+    updatedAt: new Date("2026-05-01T12:30:00.000Z"),
+  };
+}
+
+test("SLA breach runtime marks overdue active instances with explicit cutoff and breach time", async () => {
+  const calls: unknown[] = [];
+  const fixture = createSlaInstanceFixture();
+
+  const deps: MarkOverdueSlaBreachesDeps = {
+    markOverdueActiveClinicSlaInstancesBreached: async (params) => {
+      calls.push(params);
+      return [fixture as any];
+    },
+  };
+
+  const dueAtOrBefore = new Date("2026-05-01T12:30:00.000Z");
+  const breachedAt = new Date("2026-05-01T12:45:00.000Z");
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 7,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+    deps,
+  );
+
+  assert.equal(result.breachedCount, 1);
+  assert.deepEqual(result.breachedInstances, [fixture]);
+  assert.equal(result.dueAtOrBefore, dueAtOrBefore);
+  assert.equal(result.breachedAt, breachedAt);
+  assert.deepEqual(calls, [
+    {
+      clinicId: 7,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+  ]);
+});
+
+test("SLA breach runtime defaults cutoff and breach time to injected now", async () => {
+  const calls: unknown[] = [];
+  const now = new Date("2026-05-05T00:00:00.000Z");
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 9,
+    },
+    {
+      now: () => now,
+      markOverdueActiveClinicSlaInstancesBreached: async (params) => {
+        calls.push(params);
+        return [];
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 0);
+  assert.deepEqual(result.breachedInstances, []);
+  assert.equal(result.dueAtOrBefore, now);
+  assert.equal(result.breachedAt, now);
+  assert.deepEqual(calls, [
+    {
+      clinicId: 9,
+      dueAtOrBefore: now,
+      breachedAt: now,
+      targetType: undefined,
+    },
+  ]);
+});
+
+test("SLA breach runtime rejects invalid clinic ids and invalid dates before DB writes", async () => {
+  let writes = 0;
+
+  const deps: MarkOverdueSlaBreachesDeps = {
+    now: () => new Date("2026-05-05T00:00:00.000Z"),
+    markOverdueActiveClinicSlaInstancesBreached: async () => {
+      writes += 1;
+      return [];
+    },
+  };
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches({ clinicId: 0 }, deps);
+  }, /clinicId debe ser un entero positivo/);
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches(
+      {
+        clinicId: 1,
+        dueAtOrBefore: new Date("invalid"),
+      },
+      deps,
+    );
+  }, /dueAtOrBefore invalido/);
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches(
+      {
+        clinicId: 1,
+        breachedAt: new Date("invalid"),
+      },
+      deps,
+    );
+  }, /breachedAt invalido/);
+
+  assert.equal(writes, 0);
+});


### PR DESCRIPTION
## Summary
- Adds an injectable SLA breach runtime service.
- Uses the DB helper to mark overdue active SLA instances as breached.
- Validates clinicId and date inputs before DB writes.

## Validation
- node --test ./test/logistics-sla-breach-runtime.test.ts
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Runtime service and test-only change.
- No routes, scheduler automation, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.