### PR TITLE
test(logistics): cover SLA breach runtime invalid now

### DIFF
--- a/test/logistics-sla-breach-runtime.test.ts
+++ b/test/logistics-sla-breach-runtime.test.ts
@@ -94,6 +94,27 @@ test("SLA breach runtime defaults cutoff and breach time to injected now", async
   ]);
 });
 
+test("SLA breach runtime rejects invalid injected now before DB writes", async () => {
+  let writes = 0;
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches(
+      {
+        clinicId: 1,
+      },
+      {
+        now: () => new Date("invalid"),
+        markOverdueActiveClinicSlaInstancesBreached: async () => {
+          writes += 1;
+          return [];
+        },
+      },
+    );
+  }, /now invalido/);
+
+  assert.equal(writes, 0);
+});
+
 test("SLA breach runtime rejects invalid clinic ids and invalid dates before DB writes", async () => {
   let writes = 0;
 


### PR DESCRIPTION
## Summary
- Adds coverage for invalid injected now() in the SLA breach runtime.
- Verifies invalid now fails before DB writes.
- Keeps the SLA breach runtime validation explicit.

## Validation
- node --test ./test/logistics-sla-breach-runtime.test.ts
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Test-only change.
- No runtime, routes, scheduler automation, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.