### PR TITLE
feat(logistics): wire SLA breach runtime DB deps

### DIFF
--- a/server/lib/logistics/sla-breach.ts
+++ b/server/lib/logistics/sla-breach.ts
@@ -25,6 +25,10 @@ export type MarkOverdueSlaBreachesResult = {
   breachedAt: Date;
 };
 
+export type MarkOverdueSlaBreachesWithDbOptions = {
+  now?: () => Date;
+};
+
 function assertValidDate(value: Date, fieldName: string): void {
   if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
     throw new Error(`${fieldName} invalido`);
@@ -67,4 +71,18 @@ export async function markOverdueSlaBreaches(
     dueAtOrBefore,
     breachedAt,
   };
+}
+
+export async function markOverdueSlaBreachesWithDb(
+  input: MarkOverdueSlaBreachesInput,
+  options: MarkOverdueSlaBreachesWithDbOptions = {},
+): Promise<MarkOverdueSlaBreachesResult> {
+  const { markOverdueActiveClinicSlaInstancesBreached } = await import(
+    "../../db-logistics.ts"
+  );
+
+  return markOverdueSlaBreaches(input, {
+    markOverdueActiveClinicSlaInstancesBreached,
+    now: options.now,
+  });
 }

--- a/test/logistics-sla-breach-runtime.test.ts
+++ b/test/logistics-sla-breach-runtime.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   markOverdueSlaBreaches,
+  markOverdueSlaBreachesWithDb,
   type MarkOverdueSlaBreachesDeps,
 } from "../server/lib/logistics/sla-breach.ts";
 
@@ -151,4 +152,8 @@ test("SLA breach runtime rejects invalid clinic ids and invalid dates before DB 
   }, /breachedAt invalido/);
 
   assert.equal(writes, 0);
+});
+
+test("SLA breach runtime exposes DB-wired entrypoint", () => {
+  assert.equal(typeof markOverdueSlaBreachesWithDb, "function");
 });


### PR DESCRIPTION
## Summary
- Adds a DB-wired SLA breach runtime entrypoint.
- Keeps DB imports lazy to avoid loading DB dependencies in unit tests.
- Preserves explicit dependency injection for testability.

## Validation
- node --test ./test/logistics-sla-breach-runtime.test.ts
- pnpm typecheck:test
- pnpm test
- pnpm typecheck
- pnpm build

## Notes
- Runtime wiring and test-only change.
- No routes, scheduler automation, frontend, drizzle, docs, legacy, package, lockfile, or environment changes.