### PR TITLE
test(logistics): cover SLA invalid session boundary

### DIFF
--- a/test/logistics-sla-routes-integration.fastify.test.ts
+++ b/test/logistics-sla-routes-integration.fastify.test.ts
@@ -220,6 +220,33 @@ test("logistics SLA integration rejects unauthenticated reads before DB helpers"
 });
 
 
+test("logistics SLA integration rejects invalid sessions before DB helpers", async () => {
+  const { app, policyCalls, instanceCalls, overdueCalls, summaryCalls } = await createIntegrationApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/logistics/sla/summary",
+      headers: {
+        cookie: `${ENV.cookieName}=invalid-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Sesion invalida",
+    });
+
+    assert.deepEqual(policyCalls, []);
+    assert.deepEqual(instanceCalls, []);
+    assert.deepEqual(overdueCalls, []);
+    assert.deepEqual(summaryCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
 test("logistics SLA integration handles CORS preflight without DB helpers", async () => {
   const { app, policyCalls, instanceCalls, overdueCalls, summaryCalls } = await createIntegrationApp();
 


### PR DESCRIPTION
## Summary
- Adds runtime integration coverage for invalid SLA route sessions.
- Verifies invalid session cookies return 401.
- Verifies SLA DB helpers are not called for invalid sessions.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build