### PR TITLE
feat(logistics): add clinic role gates

### DIFF
--- a/server/lib/permissions.ts
+++ b/server/lib/permissions.ts
@@ -24,6 +24,11 @@ export function normalizeClinicUserRole(
 export type ClinicPermissions = {
   canUploadReports: boolean;
   canManageClinicUsers: boolean;
+  canViewLogistics: boolean;
+  canManageLogisticsFieldVisits: boolean;
+  canManageLogisticsRoutePlans: boolean;
+  canManageLogisticsRouteEvents: boolean;
+  canViewLogisticsSla: boolean;
 };
 
 export function getClinicPermissions(role: ClinicUserRole): ClinicPermissions {
@@ -32,12 +37,22 @@ export function getClinicPermissions(role: ClinicUserRole): ClinicPermissions {
       return {
         canUploadReports: false,
         canManageClinicUsers: true,
+        canViewLogistics: true,
+        canManageLogisticsFieldVisits: true,
+        canManageLogisticsRoutePlans: true,
+        canManageLogisticsRouteEvents: true,
+        canViewLogisticsSla: true,
       };
     case "clinic_staff":
     default:
       return {
         canUploadReports: false,
         canManageClinicUsers: false,
+        canViewLogistics: true,
+        canManageLogisticsFieldVisits: false,
+        canManageLogisticsRoutePlans: false,
+        canManageLogisticsRouteEvents: false,
+        canViewLogisticsSla: true,
       };
   }
 }

--- a/server/routes/logistics-field-visits.fastify.ts
+++ b/server/routes/logistics-field-visits.fastify.ts
@@ -8,6 +8,7 @@ import {
   FIELD_VISIT_SOURCE_TYPES,
   FIELD_VISIT_STATUSES,
   VISIT_LOCATION_GEO_QUALITIES,
+  type ClinicUserRole,
   type FieldVisitSourceType,
   type FieldVisitStatus,
   type VisitLocationGeoQuality,
@@ -23,6 +24,10 @@ import type {
   VisitLocation,
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -35,6 +40,7 @@ type ClinicUserRecord = {
   clinicId: number;
   username: string;
   authProId?: string | null;
+  role?: ClinicUserRole | null;
 };
 
 type AuthenticatedClinicUser = {
@@ -42,6 +48,7 @@ type AuthenticatedClinicUser = {
   clinicId: number;
   username: string;
   authProId: string | null;
+  role: ClinicUserRole;
   sessionToken: string;
 };
 
@@ -262,6 +269,23 @@ function enforceTrustedOrigin(
   return false;
 }
 
+
+function enforceLogisticsPermission(
+  reply: FastifyReply,
+  allowed: boolean,
+): boolean {
+  if (allowed) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Permisos insuficientes para logistica",
+  });
+
+  return false;
+}
+
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {
   const result: Record<string, string> = {};
 
@@ -419,6 +443,7 @@ async function authenticateClinicUser(
     clinicId: clinicUser.clinicId,
     username: clinicUser.username,
     authProId: clinicUser.authProId ?? null,
+    role: normalizeClinicUserRole(clinicUser.role, "clinic_staff"),
     sessionToken: token,
   };
 }
@@ -1113,6 +1138,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
+      return reply;
+    }
+
     const status = parseFieldVisitStatus(request.query.status);
 
     if (status.error) {
@@ -1172,6 +1207,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
+      return reply;
+    }
+
     const parsed = buildCreateFieldVisitInput(request.body, auth.clinicId);
 
     if (!parsed.input) {
@@ -1210,6 +1255,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
       return reply;
     }
 
@@ -1262,6 +1317,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
+      return reply;
+    }
+
     const fieldVisitId = parseEntityId(request.params.fieldVisitId);
 
     if (!fieldVisitId) {
@@ -1302,6 +1367,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
       return reply;
     }
 
@@ -1355,6 +1430,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
+      return reply;
+    }
+
     const fieldVisitId = parseEntityId(request.params.fieldVisitId);
 
     if (!fieldVisitId) {
@@ -1391,6 +1476,16 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsFieldVisits,
+      )
+    ) {
       return reply;
     }
 

--- a/server/routes/logistics-route-events.fastify.ts
+++ b/server/routes/logistics-route-events.fastify.ts
@@ -7,6 +7,7 @@ import type {
 import {
   ROUTE_EVENT_SOURCES,
   ROUTE_EVENT_TYPES,
+  type ClinicUserRole,
   type RouteEventSource,
   type RouteEventType,
 } from "../../drizzle/schema.ts";
@@ -16,6 +17,10 @@ import type {
   RouteEvent,
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -28,6 +33,7 @@ type ClinicUserRecord = {
   clinicId: number;
   username: string;
   authProId?: string | null;
+  role?: ClinicUserRole | null;
 };
 
 type AuthenticatedClinicUser = {
@@ -35,6 +41,7 @@ type AuthenticatedClinicUser = {
   clinicId: number;
   username: string;
   authProId: string | null;
+  role: ClinicUserRole;
   sessionToken: string;
 };
 
@@ -237,6 +244,23 @@ function enforceTrustedOrigin(
   return false;
 }
 
+
+function enforceLogisticsPermission(
+  reply: FastifyReply,
+  allowed: boolean,
+): boolean {
+  if (allowed) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Permisos insuficientes para logistica",
+  });
+
+  return false;
+}
+
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {
   const result: Record<string, string> = {};
 
@@ -394,6 +418,7 @@ async function authenticateClinicUser(
     clinicId: clinicUser.clinicId,
     username: clinicUser.username,
     authProId: clinicUser.authProId ?? null,
+    role: normalizeClinicUserRole(clinicUser.role, "clinic_staff"),
     sessionToken: token,
   };
 }
@@ -829,6 +854,16 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRouteEvents,
+      )
+    ) {
+      return reply;
+    }
+
     const parsed = buildListRouteEventsParams(request.query, auth.clinicId);
 
     if (!parsed.params) {
@@ -863,6 +898,16 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRouteEvents,
+      )
+    ) {
       return reply;
     }
 
@@ -904,6 +949,16 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRouteEvents,
+      )
+    ) {
       return reply;
     }
 
@@ -976,6 +1031,16 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRouteEvents,
+      )
+    ) {
       return reply;
     }
 

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -9,6 +9,7 @@ import {
   ROUTE_PLANNING_MODES,
   ROUTE_PLAN_STATUSES,
   ROUTE_STOP_STATUSES,
+  type ClinicUserRole,
   type RoutePlanObjective,
   type RoutePlanningMode,
   type RoutePlanStatus,
@@ -29,6 +30,10 @@ import type {
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
+import {
   calculateRouteStopComplianceMetrics,
   type RouteStopComplianceInput,
 } from "../lib/logistics/metrics.ts";
@@ -44,6 +49,7 @@ type ClinicUserRecord = {
   clinicId: number;
   username: string;
   authProId?: string | null;
+  role?: ClinicUserRole | null;
 };
 
 type AuthenticatedClinicUser = {
@@ -51,6 +57,7 @@ type AuthenticatedClinicUser = {
   clinicId: number;
   username: string;
   authProId: string | null;
+  role: ClinicUserRole;
   sessionToken: string;
 };
 
@@ -285,6 +292,23 @@ function enforceTrustedOrigin(
   return false;
 }
 
+
+function enforceLogisticsPermission(
+  reply: FastifyReply,
+  allowed: boolean,
+): boolean {
+  if (allowed) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Permisos insuficientes para logistica",
+  });
+
+  return false;
+}
+
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {
   const result: Record<string, string> = {};
 
@@ -442,6 +466,7 @@ async function authenticateClinicUser(
     clinicId: clinicUser.clinicId,
     username: clinicUser.username,
     authProId: clinicUser.authProId ?? null,
+    role: normalizeClinicUserRole(clinicUser.role, "clinic_staff"),
     sessionToken: token,
   };
 }
@@ -1503,6 +1528,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
+      return reply;
+    }
+
     const parsed = buildGenerateHeuristicRoutePlanInput(
       request.body,
       auth.clinicId,
@@ -1554,6 +1589,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 
@@ -1624,6 +1669,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
+      return reply;
+    }
+
     const parsed = buildCreateRoutePlanInput(request.body, auth.clinicId);
 
     if (!parsed.input) {
@@ -1657,6 +1712,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 
@@ -1700,6 +1765,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 
@@ -1752,6 +1827,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 
@@ -1809,6 +1894,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
+      return reply;
+    }
+
     const routePlanId = parseEntityId(request.params.routePlanId);
 
     if (!routePlanId) {
@@ -1845,6 +1940,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 
@@ -1902,6 +2007,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 
@@ -1967,6 +2082,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      UNSAFE_METHODS.has(request.method.toUpperCase()) &&
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canManageLogisticsRoutePlans,
+      )
+    ) {
       return reply;
     }
 

--- a/server/routes/logistics-sla.fastify.ts
+++ b/server/routes/logistics-sla.fastify.ts
@@ -7,6 +7,7 @@ import type {
 import {
   SLA_INSTANCE_STATUSES,
   SLA_TARGET_TYPES,
+  type ClinicUserRole,
   type SlaInstanceStatus,
   type SlaTargetType,
 } from "../../drizzle/schema.ts";
@@ -19,6 +20,10 @@ import type {
   SlaPolicy,
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getClinicPermissions,
+  normalizeClinicUserRole,
+} from "../lib/permissions.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -31,6 +36,7 @@ type ClinicUserRecord = {
   clinicId: number;
   username: string;
   authProId?: string | null;
+  role?: ClinicUserRole | null;
 };
 
 type AuthenticatedClinicUser = {
@@ -38,6 +44,7 @@ type AuthenticatedClinicUser = {
   clinicId: number;
   username: string;
   authProId: string | null;
+  role: ClinicUserRole;
   sessionToken: string;
 };
 
@@ -205,6 +212,23 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
 }
 
+
+function enforceLogisticsPermission(
+  reply: FastifyReply,
+  allowed: boolean,
+): boolean {
+  if (allowed) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Permisos insuficientes para logistica",
+  });
+
+  return false;
+}
+
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {
   const result: Record<string, string> = {};
 
@@ -362,6 +386,7 @@ async function authenticateClinicUser(
     clinicId: clinicUser.clinicId,
     username: clinicUser.username,
     authProId: clinicUser.authProId ?? null,
+    role: normalizeClinicUserRole(clinicUser.role, "clinic_staff"),
     sessionToken: token,
   };
 }
@@ -694,6 +719,15 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canViewLogisticsSla,
+      )
+    ) {
+      return reply;
+    }
+
     const parsed = buildListOverdueSlaInstancesParams(
       request.query,
       auth.clinicId,
@@ -730,6 +764,15 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
+    if (
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canViewLogisticsSla,
+      )
+    ) {
+      return reply;
+    }
+
     const summary = await deps.getClinicSlaSummary(auth.clinicId);
 
     return reply.code(200).send({
@@ -748,6 +791,15 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canViewLogisticsSla,
+      )
+    ) {
       return reply;
     }
 
@@ -785,6 +837,15 @@ export const logisticsSlaNativeRoutes: FastifyPluginAsync<
     const auth = await authenticateClinicUser(request, reply, deps, now);
 
     if (!auth) {
+      return reply;
+    }
+
+    if (
+      !enforceLogisticsPermission(
+        reply,
+        getClinicPermissions(auth.role).canViewLogisticsSla,
+      )
+    ) {
       return reply;
     }
 

--- a/test/auth-middleware.test.ts
+++ b/test/auth-middleware.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -274,6 +274,11 @@ test("requireAuth autentica owner y actualiza lastAccess", async () => {
     permissions: {
       canUploadReports: false,
       canManageClinicUsers: true,
+      canViewLogistics: true,
+      canManageLogisticsFieldVisits: true,
+      canManageLogisticsRoutePlans: true,
+      canManageLogisticsRouteEvents: true,
+      canViewLogisticsSla: true,
     },
     canUploadReports: false,
     canManageClinicUsers: true,
@@ -332,6 +337,11 @@ test("requireAuth normaliza role inválido a clinic_staff", async () => {
     permissions: {
       canUploadReports: false,
       canManageClinicUsers: false,
+      canViewLogistics: true,
+      canManageLogisticsFieldVisits: false,
+      canManageLogisticsRoutePlans: false,
+      canManageLogisticsRouteEvents: false,
+      canViewLogisticsSla: true,
     },
     canUploadReports: false,
     canManageClinicUsers: false,

--- a/test/logistics-field-visits-api.test.ts
+++ b/test/logistics-field-visits-api.test.ts
@@ -145,3 +145,11 @@ test("logistics field visit API keeps time-window writes behind trusted-origin c
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /auth\.clinicId/);
 });
+
+test("logistics field visit API enforces role-aware logistics field visit permissions", () => {
+  assert.match(routeSource, /type ClinicUserRole/);
+  assert.match(routeSource, /normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\)/);
+  assert.match(routeSource, /getClinicPermissions\(auth\.role\)\.canManageLogisticsFieldVisits/);
+  assert.match(routeSource, /UNSAFE_METHODS\.has\(request\.method\.toUpperCase\(\)\)/);
+  assert.match(routeSource, /Permisos insuficientes para logistica/);
+});

--- a/test/logistics-route-events-api.test.ts
+++ b/test/logistics-route-events-api.test.ts
@@ -93,3 +93,11 @@ test("logistics route events API keeps event writes behind trusted-origin checks
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /Origen no permitido/);
 });
+
+test("logistics route events API enforces role-aware logistics route event permissions", () => {
+  assert.match(routeSource, /type ClinicUserRole/);
+  assert.match(routeSource, /normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\)/);
+  assert.match(routeSource, /getClinicPermissions\(auth\.role\)\.canManageLogisticsRouteEvents/);
+  assert.match(routeSource, /UNSAFE_METHODS\.has\(request\.method\.toUpperCase\(\)\)/);
+  assert.match(routeSource, /Permisos insuficientes para logistica/);
+});

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -199,3 +199,11 @@ test("logistics route plans API validates route compliance metrics tolerances", 
   assert.match(routeSource, /parseOptionalPositiveNumberField\(\s*query\.timeToleranceMin/);
   assert.match(routeSource, /parseOptionalPositiveNumberField\(\s*query\.toleranceMin/);
 });
+
+test("logistics route plans API enforces role-aware logistics route plan permissions", () => {
+  assert.match(routeSource, /type ClinicUserRole/);
+  assert.match(routeSource, /normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\)/);
+  assert.match(routeSource, /getClinicPermissions\(auth\.role\)\.canManageLogisticsRoutePlans/);
+  assert.match(routeSource, /UNSAFE_METHODS\.has\(request\.method\.toUpperCase\(\)\)/);
+  assert.match(routeSource, /Permisos insuficientes para logistica/);
+});

--- a/test/logistics-route-plans-heuristic-runtime.test.ts
+++ b/test/logistics-route-plans-heuristic-runtime.test.ts
@@ -92,6 +92,7 @@ async function buildRoutePlansRuntimeApp(input?: {
             id: 9,
             clinicId: 7,
             username: "clinic-user",
+            role: "clinic_owner",
             authProId: null,
           }
         : null,

--- a/test/logistics-route-plans-metrics-runtime.test.ts
+++ b/test/logistics-route-plans-metrics-runtime.test.ts
@@ -87,6 +87,7 @@ async function buildRoutePlansMetricsRuntimeApp(input?: {
             id: 9,
             clinicId: 7,
             username: "clinic-user",
+            role: "clinic_owner",
             authProId: null,
           }
         : null,

--- a/test/logistics-sla-routes-api.test.ts
+++ b/test/logistics-sla-routes-api.test.ts
@@ -72,3 +72,10 @@ test("logistics SLA API validates overdue route filters before DB reads", () => 
   assert.match(routeSource, /parseSlaTargetType\(query\.targetType\)/);
   assert.match(routeSource, /dueAtOrBefore: dueAtOrBefore\.value \?\? new Date\(now\(\)\)/);
 });
+
+test("logistics SLA API enforces role-aware logistics SLA read permissions", () => {
+  assert.match(routeSource, /type ClinicUserRole/);
+  assert.match(routeSource, /normalizeClinicUserRole\(clinicUser\.role, "clinic_staff"\)/);
+  assert.match(routeSource, /getClinicPermissions\(auth\.role\)\.canViewLogisticsSla/);
+  assert.match(routeSource, /Permisos insuficientes para logistica/);
+});

--- a/test/permissions-and-report-status.test.ts
+++ b/test/permissions-and-report-status.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   getClinicPermissions,
@@ -30,11 +30,21 @@ test("getClinicPermissions devuelve permisos consistentes por rol", () => {
   assert.deepEqual(getClinicPermissions("clinic_owner"), {
     canUploadReports: false,
     canManageClinicUsers: true,
+    canViewLogistics: true,
+    canManageLogisticsFieldVisits: true,
+    canManageLogisticsRoutePlans: true,
+    canManageLogisticsRouteEvents: true,
+    canViewLogisticsSla: true,
   });
 
   assert.deepEqual(getClinicPermissions("clinic_staff"), {
     canUploadReports: false,
     canManageClinicUsers: false,
+    canViewLogistics: true,
+    canManageLogisticsFieldVisits: false,
+    canManageLogisticsRoutePlans: false,
+    canManageLogisticsRouteEvents: false,
+    canViewLogisticsSla: true,
   });
 });
 

--- a/test/security-mutation-permission-surface.test.ts
+++ b/test/security-mutation-permission-surface.test.ts
@@ -281,3 +281,23 @@ test("reports clinic read-only no declara rutas mutantes ni storage upload", () 
     );
   }
 });
+
+test("clinic permissions expose logistics role gates", () => {
+  const source = readSource("server/lib/permissions.ts");
+
+  for (const marker of [
+    "canViewLogistics: boolean",
+    "canManageLogisticsFieldVisits: boolean",
+    "canManageLogisticsRoutePlans: boolean",
+    "canManageLogisticsRouteEvents: boolean",
+    "canViewLogisticsSla: boolean",
+    "canManageLogisticsFieldVisits: true",
+    "canManageLogisticsRoutePlans: true",
+    "canManageLogisticsRouteEvents: true",
+    "canManageLogisticsFieldVisits: false",
+    "canManageLogisticsRoutePlans: false",
+    "canManageLogisticsRouteEvents: false",
+  ]) {
+    assertContains(source, marker, "server/lib/permissions.ts");
+  }
+});


### PR DESCRIPTION
## Summary
- Adds logistics-specific clinic role permissions.
- Allows logistics reads for clinic users while gating logistics mutations by role.
- Updates backend tests and runtime fixtures for the expanded permission contract.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build