### PR TITLE
feat(logistics): audit route lifecycle events

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -143,6 +143,8 @@ export const AUDIT_EVENTS = [
   "report_access_token.created",
   "report_access_token.revoked",
   "report.public_accessed",
+  "logistics.route_plan.lifecycle_changed",
+  "logistics.route_event.created",
 ] as const;
 export type AuditEvent = (typeof AUDIT_EVENTS)[number];
 

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -1,4 +1,4 @@
-﻿import type { Request } from "./http-types.ts";
+import type { Request } from "./http-types.ts";
 import type { AuditActorType, AuditEvent } from "../../drizzle/schema";
 import { sanitizeUrlForLogs } from "../middlewares/request-logger.ts";
 
@@ -13,6 +13,9 @@ export const AUDIT_EVENTS = {
   REPORT_ACCESS_TOKEN_CREATED: "report_access_token.created",
   REPORT_ACCESS_TOKEN_REVOKED: "report_access_token.revoked",
   REPORT_PUBLIC_ACCESSED: "report.public_accessed",
+  LOGISTICS_ROUTE_PLAN_LIFECYCLE_CHANGED:
+    "logistics.route_plan.lifecycle_changed",
+  LOGISTICS_ROUTE_EVENT_CREATED: "logistics.route_event.created",
 } as const satisfies Record<string, AuditEvent>;
 
 export type AuditActor = {

--- a/server/routes/logistics-route-events.fastify.ts
+++ b/server/routes/logistics-route-events.fastify.ts
@@ -18,6 +18,10 @@ import type {
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  AUDIT_EVENTS,
+  type AuditWriteInput,
+} from "../lib/audit.ts";
+import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
@@ -71,6 +75,7 @@ export type LogisticsRouteEventsNativeRoutesOptions = {
     afterId: number,
     limit?: number,
   ) => Promise<RouteEvent[]>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   now?: () => number;
 };
 
@@ -86,6 +91,7 @@ type NativeLogisticsRouteEventsDeps = Required<
     | "listClinicRouteEvents"
     | "listRouteEventsForClinicRoutePlan"
     | "listIncrementalClinicRouteEvents"
+    | "writeAuditLog"
   >
 >;
 
@@ -100,6 +106,7 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRouteEventsDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const dbLogistics = await import("../db-logistics.ts");
+      const audit = await import("../lib/audit.ts");
 
       return {
         deleteActiveSession: db.deleteActiveSession,
@@ -113,6 +120,10 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRouteEventsDeps> {
           dbLogistics.listRouteEventsForClinicRoutePlan,
         listIncrementalClinicRouteEvents:
           dbLogistics.listIncrementalClinicRouteEvents,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
       };
     })();
   }
@@ -738,6 +749,24 @@ function buildListRouteEventsParams(
   };
 }
 
+function createAuditRequestLike(
+  request: FastifyRequest,
+  auth: AuthenticatedClinicUser,
+): Record<string, unknown> {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    auth: {
+      id: auth.id,
+      clinicId: auth.clinicId,
+      username: auth.username,
+      role: auth.role,
+    },
+  };
+}
+
 function serializeDate(value: Date | null | undefined): string | null {
   if (!(value instanceof Date)) {
     return null;
@@ -774,7 +803,8 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
     !!options.createRouteEvent &&
     !!options.listClinicRouteEvents &&
     !!options.listRouteEventsForClinicRoutePlan &&
-    !!options.listIncrementalClinicRouteEvents;
+    !!options.listIncrementalClinicRouteEvents &&
+    true;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -799,6 +829,10 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
     listIncrementalClinicRouteEvents:
       options.listIncrementalClinicRouteEvents ??
       defaultDeps!.listIncrementalClinicRouteEvents,
+    writeAuditLog:
+      options.writeAuditLog ??
+      defaultDeps?.writeAuditLog ??
+      (async () => undefined),
   };
 
   const now = options.now ?? (() => Date.now());
@@ -1061,6 +1095,18 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
         error: "Plan de ruta o parada no encontrada",
       });
     }
+
+    await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+      event: AUDIT_EVENTS.LOGISTICS_ROUTE_EVENT_CREATED,
+      clinicId: auth.clinicId,
+      metadata: {
+        routeEventId: routeEvent.id,
+        routePlanId: routeEvent.routePlanId,
+        routeStopId: routeEvent.routeStopId,
+        eventType: routeEvent.eventType,
+        source: routeEvent.source,
+      },
+    });
 
     return reply.code(201).send({
       success: true,

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -30,6 +30,10 @@ import type {
 } from "../db-logistics.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  AUDIT_EVENTS,
+  type AuditWriteInput,
+} from "../lib/audit.ts";
+import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
@@ -106,6 +110,7 @@ export type LogisticsRoutePlansNativeRoutesOptions = {
   generateHeuristicRoutePlan?: (
     input: GenerateHeuristicRoutePlanInput,
   ) => Promise<GenerateHeuristicRoutePlanResult>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   now?: () => number;
 };
 
@@ -126,6 +131,7 @@ type NativeLogisticsRoutePlansDeps = Required<
     | "updateClinicScopedRouteStop"
     | "transitionClinicScopedRoutePlanStatus"
     | "generateHeuristicRoutePlan"
+    | "writeAuditLog"
   >
 >;
 
@@ -141,6 +147,7 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const dbLogistics = await import("../db-logistics.ts");
+      const audit = await import("../lib/audit.ts");
 
       return {
         deleteActiveSession: db.deleteActiveSession,
@@ -161,6 +168,10 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
         transitionClinicScopedRoutePlanStatus:
           dbLogistics.transitionClinicScopedRoutePlanStatus,
         generateHeuristicRoutePlan: dbLogistics.generateHeuristicRoutePlan,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
       };
     })();
   }
@@ -1359,6 +1370,24 @@ function getLifecycleActionError(
 }
 
 
+function createAuditRequestLike(
+  request: FastifyRequest,
+  auth: AuthenticatedClinicUser,
+): Record<string, unknown> {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    auth: {
+      id: auth.id,
+      clinicId: auth.clinicId,
+      username: auth.username,
+      role: auth.role,
+    },
+  };
+}
+
 function serializeDate(value: Date | null | undefined): string | null {
   if (!(value instanceof Date)) {
     return null;
@@ -2120,6 +2149,15 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+      event: AUDIT_EVENTS.LOGISTICS_ROUTE_PLAN_LIFECYCLE_CHANGED,
+      clinicId: auth.clinicId,
+      metadata: {
+        routePlanId,
+        action,
+        status: result.routePlan.status,
+      },
+    });
     return reply.code(200).send({
       success: true,
       message: "Estado del plan de ruta actualizado correctamente",

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -167,7 +167,11 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
           dbLogistics.updateClinicScopedRouteStop,
         transitionClinicScopedRoutePlanStatus:
           dbLogistics.transitionClinicScopedRoutePlanStatus,
-        generateHeuristicRoutePlan: dbLogistics.generateHeuristicRoutePlan,
+        writeAuditLog:
+      options.writeAuditLog ??
+      defaultDeps?.writeAuditLog ??
+      (async () => undefined),
+    generateHeuristicRoutePlan: dbLogistics.generateHeuristicRoutePlan,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
           input: AuditWriteInput,
@@ -1484,6 +1488,10 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     transitionClinicScopedRoutePlanStatus:
       options.transitionClinicScopedRoutePlanStatus ??
       defaultDeps!.transitionClinicScopedRoutePlanStatus,
+    writeAuditLog:
+      options.writeAuditLog ??
+      defaultDeps?.writeAuditLog ??
+      (async () => undefined),
     generateHeuristicRoutePlan:
       options.generateHeuristicRoutePlan ??
       defaultDeps?.generateHeuristicRoutePlan ??

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -167,11 +167,7 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
           dbLogistics.updateClinicScopedRouteStop,
         transitionClinicScopedRoutePlanStatus:
           dbLogistics.transitionClinicScopedRoutePlanStatus,
-        writeAuditLog:
-      options.writeAuditLog ??
-      defaultDeps?.writeAuditLog ??
-      (async () => undefined),
-    generateHeuristicRoutePlan: dbLogistics.generateHeuristicRoutePlan,
+        generateHeuristicRoutePlan: dbLogistics.generateHeuristicRoutePlan,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
           input: AuditWriteInput,

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   AUDIT_EVENTS,
@@ -20,6 +20,9 @@ test("AUDIT_EVENTS conserva los eventos públicos esperados", () => {
     REPORT_ACCESS_TOKEN_CREATED: "report_access_token.created",
     REPORT_ACCESS_TOKEN_REVOKED: "report_access_token.revoked",
     REPORT_PUBLIC_ACCESSED: "report.public_accessed",
+    LOGISTICS_ROUTE_PLAN_LIFECYCLE_CHANGED:
+      "logistics.route_plan.lifecycle_changed",
+    LOGISTICS_ROUTE_EVENT_CREATED: "logistics.route_event.created",
   });
 });
 

--- a/test/logistics-route-events-api.test.ts
+++ b/test/logistics-route-events-api.test.ts
@@ -101,3 +101,12 @@ test("logistics route events API enforces role-aware logistics route event permi
   assert.match(routeSource, /UNSAFE_METHODS\.has\(request\.method\.toUpperCase\(\)\)/);
   assert.match(routeSource, /Permisos insuficientes para logistica/);
 });
+
+test("logistics route events API audits route event creation", () => {
+  assert.match(routeSource, /writeAuditLog\?:/);
+  assert.match(routeSource, /writeAuditLog: audit\.writeAuditLog/);
+  assert.match(routeSource, /AUDIT_EVENTS\.LOGISTICS_ROUTE_EVENT_CREATED/);
+  assert.match(routeSource, /await deps\.writeAuditLog\(createAuditRequestLike\(request, auth\),/);
+  assert.match(routeSource, /routeEventId: routeEvent\.id/);
+  assert.match(routeSource, /eventType: routeEvent\.eventType/);
+});

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -207,3 +207,12 @@ test("logistics route plans API enforces role-aware logistics route plan permiss
   assert.match(routeSource, /UNSAFE_METHODS\.has\(request\.method\.toUpperCase\(\)\)/);
   assert.match(routeSource, /Permisos insuficientes para logistica/);
 });
+
+test("logistics route plans API audits lifecycle transitions", () => {
+  assert.match(routeSource, /writeAuditLog\?:/);
+  assert.match(routeSource, /writeAuditLog: audit\.writeAuditLog/);
+  assert.match(routeSource, /AUDIT_EVENTS\.LOGISTICS_ROUTE_PLAN_LIFECYCLE_CHANGED/);
+  assert.match(routeSource, /await deps\.writeAuditLog\(createAuditRequestLike\(request, auth\),/);
+  assert.match(routeSource, /routePlanId,/);
+  assert.match(routeSource, /action,/);
+});

--- a/test/logistics-schema-suite-completeness.test.ts
+++ b/test/logistics-schema-suite-completeness.test.ts
@@ -1,4 +1,4 @@
-﻿import assert from "node:assert/strict";
+import assert from "node:assert/strict";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -250,4 +250,9 @@ test("pre-existing native logistics schema tests remain in the suite", async () 
   for (const { exportName } of expectedTableExports) {
     assertSourceIncludes(combinedTestSource, exportName);
   }
+});
+
+test("logistics audit events remain registered in audit schema", () => {
+  assert.ok(schema.AUDIT_EVENTS.includes("logistics.route_plan.lifecycle_changed"));
+  assert.ok(schema.AUDIT_EVENTS.includes("logistics.route_event.created"));
 });


### PR DESCRIPTION
## Summary
- Adds logistics audit events to the shared audit catalog.
- Audits successful route plan lifecycle transitions.
- Audits successful logistics route event creation.
- Keeps audit writes injectable and non-blocking for route defaults.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build