### PR TITLE
feat(logistics): add SLA breach notification hook

### DIFF
--- a/server/lib/logistics/sla-breach.ts
+++ b/server/lib/logistics/sla-breach.ts
@@ -4,10 +4,22 @@ import type {
 } from "../../db-logistics.ts";
 import type { SlaTargetType } from "../../../drizzle/schema.ts";
 
+export type MarkOverdueSlaBreachesNotification = {
+  clinicId: number;
+  breachedCount: number;
+  breachedInstances: SlaInstance[];
+  dueAtOrBefore: Date;
+  breachedAt: Date;
+  targetType?: SlaTargetType;
+};
+
 export type MarkOverdueSlaBreachesDeps = {
   markOverdueActiveClinicSlaInstancesBreached: (
     params: MarkOverdueActiveClinicSlaInstancesBreachedParams,
   ) => Promise<SlaInstance[]>;
+  notifySlaBreaches?: (
+    notification: MarkOverdueSlaBreachesNotification,
+  ) => Promise<void>;
   now?: () => Date;
 };
 
@@ -64,6 +76,17 @@ export async function markOverdueSlaBreaches(
       breachedAt,
       targetType: input.targetType,
     });
+
+  if (breachedInstances.length > 0 && deps.notifySlaBreaches) {
+    await deps.notifySlaBreaches({
+      clinicId: input.clinicId,
+      breachedCount: breachedInstances.length,
+      breachedInstances,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: input.targetType,
+    });
+  }
 
   return {
     breachedCount: breachedInstances.length,

--- a/test/logistics-sla-breach-runtime.test.ts
+++ b/test/logistics-sla-breach-runtime.test.ts
@@ -173,3 +173,62 @@ test("SLA breach runtime DB-wired entrypoint imports DB helper lazily and delega
     /return\s+markOverdueSlaBreaches\(\s*input,\s*\{\s*markOverdueActiveClinicSlaInstancesBreached,\s*now:\s*options\.now,\s*\}\s*\)/,
   );
 });
+
+test("SLA breach runtime notifies marked breaches with escalation payload", async () => {
+  const fixture = createSlaInstanceFixture();
+  const dueAtOrBefore = new Date("2026-05-01T12:30:00.000Z");
+  const breachedAt = new Date("2026-05-01T12:45:00.000Z");
+  const notifications: unknown[] = [];
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 7,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+    {
+      markOverdueActiveClinicSlaInstancesBreached: async () => [
+        fixture as any,
+      ],
+      notifySlaBreaches: async (notification) => {
+        notifications.push(notification);
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 1);
+  assert.deepEqual(notifications, [
+    {
+      clinicId: 7,
+      breachedCount: 1,
+      breachedInstances: [fixture],
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+  ]);
+});
+
+test("SLA breach runtime skips notification hook when no breaches are marked", async () => {
+  let notifications = 0;
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 7,
+      dueAtOrBefore: new Date("2026-05-01T12:30:00.000Z"),
+      breachedAt: new Date("2026-05-01T12:45:00.000Z"),
+      targetType: "route_plan",
+    },
+    {
+      markOverdueActiveClinicSlaInstancesBreached: async () => [],
+      notifySlaBreaches: async () => {
+        notifications += 1;
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 0);
+  assert.deepEqual(result.breachedInstances, []);
+  assert.equal(notifications, 0);
+});


### PR DESCRIPTION
## Summary
- Adds an injectable SLA breach notification hook.
- Emits notification payloads only when overdue SLA instances are marked as breached.
- Covers notification payload and no-breach skip behavior.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build