### PR TITLE
feat(rate-limit): add injectable login store

### DIFF
--- a/server/lib/rate-limit-store.ts
+++ b/server/lib/rate-limit-store.ts
@@ -1,0 +1,57 @@
+export type RateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+export type RateLimitStore = {
+  get: (key: string) => RateLimitEntry | undefined | Promise<RateLimitEntry | undefined>;
+  set: (key: string, entry: RateLimitEntry) => void | Promise<void>;
+};
+
+export function createMemoryRateLimitStore(): RateLimitStore {
+  const entries = new Map<string, RateLimitEntry>();
+
+  return {
+    get: (key) => entries.get(key),
+    set: (key, entry) => {
+      entries.set(key, entry);
+    },
+  };
+}
+
+export async function getOrCreateRateLimitEntry(
+  store: RateLimitStore,
+  key: string,
+  windowMs: number,
+  now: number,
+): Promise<RateLimitEntry> {
+  const current = await store.get(key);
+
+  if (!current || current.resetAt <= now) {
+    const fresh = {
+      count: 0,
+      resetAt: now + windowMs,
+    };
+
+    await store.set(key, fresh);
+
+    return fresh;
+  }
+
+  return current;
+}
+
+export async function incrementRateLimitEntry(
+  store: RateLimitStore,
+  key: string,
+  entry: RateLimitEntry,
+): Promise<RateLimitEntry> {
+  const updated = {
+    count: entry.count + 1,
+    resetAt: entry.resetAt,
+  };
+
+  await store.set(key, updated);
+
+  return updated;
+}

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -11,6 +11,12 @@ import {
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 import {
   getClinicPermissions,
   normalizeClinicUserRole,
@@ -104,6 +110,7 @@ export type AuthNativeRoutesOptions = {
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   loginRateLimitWindowMs?: number;
   loginRateLimitMaxAttempts?: number;
+  loginRateLimitStore?: RateLimitStore;
   now?: () => number;
 };
 
@@ -403,25 +410,6 @@ function setLoginRateLimitHeaders(
   );
 }
 
-function getFailureEntry(
-  failures: Map<string, { count: number; resetAt: number }>,
-  key: string,
-  windowMs: number,
-  now: number,
-) {
-  const current = failures.get(key);
-
-  if (!current || current.resetAt <= now) {
-    const fresh = {
-      count: 0,
-      resetAt: now + windowMs,
-    };
-    failures.set(key, fresh);
-    return fresh;
-  }
-
-  return current;
-}
 
 function createAuditRequestLike(
   request: FastifyRequest,
@@ -554,7 +542,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
   const loginRateLimitMaxAttempts =
     options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
-  const loginFailures = new Map<string, { count: number; resetAt: number }>();
+  const loginRateLimitStore =
+    options.loginRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as AuthFastifyRequest)[REQUEST_START_TIME_KEY] =
@@ -623,8 +612,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
 
     const rateLimitKey = request.ip || "unknown";
     const currentTime = now();
-    const failureEntry = getFailureEntry(
-      loginFailures,
+    const failureEntry = await getOrCreateRateLimitEntry(
+      loginRateLimitStore,
       rateLimitKey,
       loginRateLimitWindowMs,
       currentTime,
@@ -645,8 +634,15 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const markFailure = () => {
-      failureEntry.count += 1;
+    const markFailure = async () => {
+      const updatedEntry = await incrementRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        failureEntry,
+      );
+
+      failureEntry.count = updatedEntry.count;
+      failureEntry.resetAt = updatedEntry.resetAt;
 
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -675,7 +671,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       typeof request.body?.password === "string" ? request.body.password : "";
 
     if (!username || !password) {
-      markFailure();
+      await markFailure();
 
       return reply.code(400).send({
         success: false,
@@ -686,7 +682,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     const clinicUser = await deps.getClinicUserByUsername(username);
 
     if (!clinicUser) {
-      markFailure();
+      await markFailure();
 
       return reply.code(401).send({
         success: false,
@@ -700,7 +696,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     );
 
     if (!passwordCheck.valid) {
-      markFailure();
+      await markFailure();
 
       return reply.code(401).send({
         success: false,

--- a/test/auth-middleware.test.ts
+++ b/test/auth-middleware.test.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { readFileSync } from "node:fs";
 import assert from "node:assert/strict";
 
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -379,4 +380,16 @@ test("requireAuth propaga errores inesperados a next", async () => {
   assert.equal(res.statusCode, 200);
   assert.equal(res.jsonPayload, undefined);
   assert.deepEqual(nextCalls, [expectedError]);
+});
+
+test("clinic auth route exposes injectable login rate limit store contract", async () => {
+  const source = readFileSync(
+    new URL("../server/routes/auth.fastify.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /loginRateLimitStore\?: RateLimitStore/);
+  assert.match(source, /options\.loginRateLimitStore \?\? createMemoryRateLimitStore\(\)/);
+  assert.match(source, /await getOrCreateRateLimitEntry\(/);
+  assert.match(source, /await incrementRateLimitEntry\(/);
 });

--- a/test/rate-limit-store.test.ts
+++ b/test/rate-limit-store.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../server/lib/rate-limit-store.ts";
+
+test("rate limit memory store creates and reuses active entries", async () => {
+  const store = createMemoryRateLimitStore();
+
+  const first = await getOrCreateRateLimitEntry(store, "ip:1", 1000, 10);
+  const second = await getOrCreateRateLimitEntry(store, "ip:1", 1000, 20);
+
+  assert.deepEqual(first, {
+    count: 0,
+    resetAt: 1010,
+  });
+  assert.equal(second, first);
+});
+
+test("rate limit memory store resets expired entries", async () => {
+  const store = createMemoryRateLimitStore();
+
+  const first = await getOrCreateRateLimitEntry(store, "ip:1", 1000, 10);
+  const updated = await incrementRateLimitEntry(store, "ip:1", first);
+
+  assert.deepEqual(updated, {
+    count: 1,
+    resetAt: 1010,
+  });
+
+  const reset = await getOrCreateRateLimitEntry(store, "ip:1", 1000, 1011);
+
+  assert.deepEqual(reset, {
+    count: 0,
+    resetAt: 2011,
+  });
+});
+
+test("rate limit helpers support injected async stores", async () => {
+  const entries = new Map<string, { count: number; resetAt: number }>();
+  const calls: string[] = [];
+
+  const store: RateLimitStore = {
+    get: async (key) => {
+      calls.push(`get:${key}`);
+      return entries.get(key);
+    },
+    set: async (key, entry) => {
+      calls.push(`set:${key}:${entry.count}:${entry.resetAt}`);
+      entries.set(key, entry);
+    },
+  };
+
+  const entry = await getOrCreateRateLimitEntry(store, "ip:async", 500, 100);
+  const updated = await incrementRateLimitEntry(store, "ip:async", entry);
+  const reused = await getOrCreateRateLimitEntry(store, "ip:async", 500, 101);
+
+  assert.deepEqual(updated, {
+    count: 1,
+    resetAt: 600,
+  });
+  assert.deepEqual(reused, updated);
+  assert.deepEqual(calls, [
+    "get:ip:async",
+    "set:ip:async:0:600",
+    "set:ip:async:1:600",
+    "get:ip:async",
+  ]);
+});

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -211,11 +211,34 @@ test("auth login rate limits keep separate in-memory stores per auth domain", ()
       'from "../lib/login-rate-limit.ts"',
       `${file} login rate limit import`,
     );
-    assertContains(
-      source,
-      "const loginFailures = new Map<string, { count: number; resetAt: number }>();",
-      `${file} login store`,
-    );
+    if (file === "server/routes/auth.fastify.ts") {
+      assertContains(
+        source,
+        "loginRateLimitStore?: RateLimitStore;",
+        `${file} injectable login rate limit store option`,
+      );
+      assertContains(
+        source,
+        "options.loginRateLimitStore ?? createMemoryRateLimitStore();",
+        `${file} memory fallback login rate limit store`,
+      );
+      assertContains(
+        source,
+        "await getOrCreateRateLimitEntry(",
+        `${file} login rate limit store read`,
+      );
+      assertContains(
+        source,
+        "await incrementRateLimitEntry(",
+        `${file} login rate limit store increment`,
+      );
+    } else {
+      assertContains(
+        source,
+        "const loginFailures = new Map<string, { count: number; resetAt: number }>();",
+        `${file} login store`,
+      );
+    }
     assertContains(
       source,
       "options.loginRateLimitWindowMs ?? LOGIN_RATE_LIMIT_WINDOW_MS",


### PR DESCRIPTION
## Summary
- Adds a reusable injectable rate limit store contract.
- Keeps clinic auth login fallback on an in-memory store.
- Updates guardrails for the new injectable store contract.
- Adds store unit coverage for memory and async injected stores.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build