### PR TITLE
feat(rate-limit): inject auth domain stores

### DIFF
--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -11,6 +11,12 @@ import {
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
@@ -80,6 +86,7 @@ export type AdminAuthNativeRoutesOptions = {
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   loginRateLimitWindowMs?: number;
   loginRateLimitMaxAttempts?: number;
+  loginRateLimitStore?: RateLimitStore;
   now?: () => number;
 };
 
@@ -378,25 +385,6 @@ function setLoginRateLimitHeaders(
   );
 }
 
-function getFailureEntry(
-  failures: Map<string, { count: number; resetAt: number }>,
-  key: string,
-  windowMs: number,
-  now: number,
-) {
-  const current = failures.get(key);
-
-  if (!current || current.resetAt <= now) {
-    const fresh = {
-      count: 0,
-      resetAt: now + windowMs,
-    };
-    failures.set(key, fresh);
-    return fresh;
-  }
-
-  return current;
-}
 
 function shouldRefreshSessionLastAccess(
   lastAccess: Date | null | undefined,
@@ -534,7 +522,8 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
   const loginRateLimitMaxAttempts =
     options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
-  const loginFailures = new Map<string, { count: number; resetAt: number }>();
+  const loginRateLimitStore =
+    options.loginRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as AdminAuthFastifyRequest)[REQUEST_START_TIME_KEY] =
@@ -606,8 +595,8 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
 
     const rateLimitKey = request.ip || "unknown";
     const currentTime = now();
-    const failureEntry = getFailureEntry(
-      loginFailures,
+    const failureEntry = await getOrCreateRateLimitEntry(
+      loginRateLimitStore,
       rateLimitKey,
       loginRateLimitWindowMs,
       currentTime,
@@ -628,8 +617,15 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const markFailure = () => {
-      failureEntry.count += 1;
+    const markFailure = async () => {
+      const updatedEntry = await incrementRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        failureEntry,
+      );
+
+      failureEntry.count = updatedEntry.count;
+      failureEntry.resetAt = updatedEntry.resetAt;
 
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -658,7 +654,7 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       typeof request.body?.password === "string" ? request.body.password : "";
 
     if (!username || !password) {
-      markFailure();
+      await markFailure();
 
       return reply.code(400).send({
         success: false,
@@ -669,7 +665,7 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     const admin = await deps.getAdminUserByUsername(username);
 
     if (!admin) {
-      markFailure();
+      await markFailure();
 
       return reply.code(401).send({
         success: false,
@@ -680,7 +676,7 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     const valid = await deps.verifyPassword(password, admin.passwordHash);
 
     if (!valid.valid) {
-      markFailure();
+      await markFailure();
 
       return reply.code(401).send({
         success: false,

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -11,6 +11,12 @@ import {
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 import { serializeParticularTokenDetail } from "../lib/particular-token.ts";
 import {
   buildRequestLogLine,
@@ -66,6 +72,7 @@ export type ParticularAuthNativeRoutesOptions = {
   hashSessionToken?: (token: string) => string;
   loginRateLimitWindowMs?: number;
   loginRateLimitMaxAttempts?: number;
+  loginRateLimitStore?: RateLimitStore;
   now?: () => number;
 };
 
@@ -370,25 +377,6 @@ function setLoginRateLimitHeaders(
   );
 }
 
-function getFailureEntry(
-  failures: Map<string, { count: number; resetAt: number }>,
-  key: string,
-  windowMs: number,
-  now: number,
-) {
-  const current = failures.get(key);
-
-  if (!current || current.resetAt <= now) {
-    const fresh = {
-      count: 0,
-      resetAt: now + windowMs,
-    };
-    failures.set(key, fresh);
-    return fresh;
-  }
-
-  return current;
-}
 
 function shouldRefreshSessionLastAccess(
   lastAccess: Date | null | undefined,
@@ -543,7 +531,8 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
   const loginRateLimitMaxAttempts =
     options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
-  const loginFailures = new Map<string, { count: number; resetAt: number }>();
+  const loginRateLimitStore =
+    options.loginRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as ParticularAuthFastifyRequest)[REQUEST_START_TIME_KEY] =
@@ -616,8 +605,8 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
 
     const rateLimitKey = request.ip || "unknown";
     const currentTime = now();
-    const failureEntry = getFailureEntry(
-      loginFailures,
+    const failureEntry = await getOrCreateRateLimitEntry(
+      loginRateLimitStore,
       rateLimitKey,
       loginRateLimitWindowMs,
       currentTime,
@@ -638,8 +627,15 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const markFailure = () => {
-      failureEntry.count += 1;
+    const markFailure = async () => {
+      const updatedEntry = await incrementRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        failureEntry,
+      );
+
+      failureEntry.count = updatedEntry.count;
+      failureEntry.resetAt = updatedEntry.resetAt;
 
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -664,7 +660,7 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       typeof request.body?.token === "string" ? request.body.token.trim() : "";
 
     if (!providedToken) {
-      markFailure();
+      await markFailure();
 
       return reply.code(400).send({
         success: false,
@@ -676,7 +672,7 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     const particularToken = await deps.getParticularTokenByTokenHash(tokenHash);
 
     if (!particularToken || !particularToken.isActive) {
-      markFailure();
+      await markFailure();
 
       return reply.code(401).send({
         success: false,

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -211,7 +211,11 @@ test("auth login rate limits keep separate in-memory stores per auth domain", ()
       'from "../lib/login-rate-limit.ts"',
       `${file} login rate limit import`,
     );
-    if (file === "server/routes/auth.fastify.ts") {
+    if (
+      file === "server/routes/auth.fastify.ts" ||
+      file === "server/routes/admin-auth.fastify.ts" ||
+      file === "server/routes/particular-auth.fastify.ts"
+    ) {
       assertContains(
         source,
         "loginRateLimitStore?: RateLimitStore;",


### PR DESCRIPTION
## Summary
- Adds injectable login rate limit stores to admin auth.
- Adds injectable login rate limit stores to particular auth.
- Keeps in-memory fallback behavior per auth domain.
- Updates rate limit isolation guardrails for all auth login domains.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build