### PR TITLE
feat(rate-limit): inject public professionals stores

### DIFF
--- a/server/routes/public-professionals.fastify.ts
+++ b/server/routes/public-professionals.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -13,6 +13,12 @@ import {
   PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS,
   PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS,
 } from "../lib/public-professionals-rate-limit.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
@@ -69,8 +75,10 @@ export type PublicProfessionalsNativeRoutesOptions = {
   createSignedStorageUrl?: CreateSignedStorageUrlFn;
   searchRateLimitWindowMs?: number;
   searchRateLimitMaxAttempts?: number;
+  searchRateLimitStore?: RateLimitStore;
   detailRateLimitWindowMs?: number;
   detailRateLimitMaxAttempts?: number;
+  detailRateLimitStore?: RateLimitStore;
   now?: () => number;
 };
 
@@ -224,27 +232,25 @@ function createFixedWindowRateLimit(config: {
   windowMs: number;
   max: number;
   errorMessage: string;
+  store?: RateLimitStore;
   now?: () => number;
 }) {
-  const entries = new Map<string, { count: number; resetAt: number }>();
+  const store = config.store ?? createMemoryRateLimitStore();
   const now = config.now ?? (() => Date.now());
 
   return async (request: FastifyRequest, reply: FastifyReply) => {
     const key = request.ip || "unknown";
     const currentTime = now();
-    const currentEntry = entries.get(key);
+    const entry = await getOrCreateRateLimitEntry(
+      store,
+      key,
+      config.windowMs,
+      currentTime,
+    );
+    const updatedEntry = await incrementRateLimitEntry(store, key, entry);
 
-    let entry = currentEntry;
-
-    if (!entry || entry.resetAt <= currentTime) {
-      entry = {
-        count: 0,
-        resetAt: currentTime + config.windowMs,
-      };
-      entries.set(key, entry);
-    }
-
-    entry.count += 1;
+    entry.count = updatedEntry.count;
+    entry.resetAt = updatedEntry.resetAt;
 
     setRateLimitHeaders(reply, {
       max: config.max,
@@ -305,6 +311,7 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
       options.searchRateLimitMaxAttempts ??
       PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS,
     errorMessage: PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE,
+    store: options.searchRateLimitStore,
     now: options.now,
   });
 
@@ -316,6 +323,7 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
       options.detailRateLimitMaxAttempts ??
       PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS,
     errorMessage: PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE,
+    store: options.detailRateLimitStore,
     now: options.now,
   });
 

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -288,8 +288,18 @@ test("public professionals search and detail keep independent fixed-window store
   );
   assertContains(
     source,
-    "const entries = new Map<string, { count: number; resetAt: number }>();",
-    "public professionals fixed window store",
+    "searchRateLimitStore?: RateLimitStore;",
+    "public professionals search injectable store option",
+  );
+  assertContains(
+    source,
+    "detailRateLimitStore?: RateLimitStore;",
+    "public professionals detail injectable store option",
+  );
+  assertContains(
+    source,
+    "config.store ?? createMemoryRateLimitStore();",
+    "public professionals memory fallback store",
   );
   assertContainsInOrder(
     source,
@@ -298,10 +308,12 @@ test("public professionals search and detail keep independent fixed-window store
       "PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_WINDOW_MS",
       "PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_MAX_ATTEMPTS",
       "PUBLIC_PROFESSIONALS_SEARCH_RATE_LIMIT_ERROR_MESSAGE",
+      "store: options.searchRateLimitStore",
       "const detailRateLimit = createFixedWindowRateLimit({",
       "PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_WINDOW_MS",
       "PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_MAX_ATTEMPTS",
       "PUBLIC_PROFESSIONAL_DETAIL_RATE_LIMIT_ERROR_MESSAGE",
+      "store: options.detailRateLimitStore",
     ],
     "public professionals separate limiter setup",
   );


### PR DESCRIPTION
## Summary
- Adds injectable rate limit stores to public professionals search.
- Adds injectable rate limit stores to public professionals detail.
- Keeps separate in-memory fallback stores for search and detail.
- Updates rate limit isolation guardrails for the public professionals store contract.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build