### PR TITLE
feat(rate-limit): inject token mutation stores

### DIFF
--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -12,6 +12,12 @@ import {
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
 } from "../lib/report-access-token-rate-limit.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 import {
   adminCreateReportAccessTokenSchema,
   buildPublicReportAccessPath,
@@ -101,6 +107,7 @@ export type AdminReportAccessTokensNativeRoutesOptions = {
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   mutationRateLimitWindowMs?: number;
   mutationRateLimitMaxAttempts?: number;
+  mutationRateLimitStore?: RateLimitStore;
   now?: () => number;
 };
 
@@ -398,25 +405,6 @@ function setMutationRateLimitHeaders(
   );
 }
 
-function getMutationEntry(
-  attempts: Map<string, { count: number; resetAt: number }>,
-  key: string,
-  windowMs: number,
-  now: number,
-) {
-  const current = attempts.get(key);
-
-  if (!current || current.resetAt <= now) {
-    const fresh = {
-      count: 0,
-      resetAt: now + windowMs,
-    };
-    attempts.set(key, fresh);
-    return fresh;
-  }
-
-  return current;
-}
 
 function shouldRefreshSessionLastAccess(
   lastAccess: Date | null | undefined,
@@ -565,7 +553,8 @@ export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
     options.mutationRateLimitMaxAttempts ??
     REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
-  const mutationAttempts = new Map<string, { count: number; resetAt: number }>();
+  const mutationRateLimitStore =
+    options.mutationRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as AdminReportAccessTokensFastifyRequest)[REQUEST_START_TIME_KEY] =
@@ -625,14 +614,14 @@ export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
   app.options("/:tokenId", optionsHandler);
   app.options("/:tokenId/revoke", optionsHandler);
 
-  const applyMutationRateLimit = (
+  const applyMutationRateLimit = async (
     request: FastifyRequest,
     reply: FastifyReply,
   ) => {
     const rateLimitKey = request.ip || "unknown";
     const currentTime = now();
-    const entry = getMutationEntry(
-      mutationAttempts,
+    const entry = await getOrCreateRateLimitEntry(
+      mutationRateLimitStore,
       rateLimitKey,
       mutationRateLimitWindowMs,
       currentTime,
@@ -655,7 +644,14 @@ export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
       return null;
     }
 
-    entry.count += 1;
+    const updatedEntry = await incrementRateLimitEntry(
+      mutationRateLimitStore,
+      rateLimitKey,
+      entry,
+    );
+
+    entry.count = updatedEntry.count;
+    entry.resetAt = updatedEntry.resetAt;
 
     setMutationRateLimitHeaders(reply, {
       max: mutationRateLimitMaxAttempts,
@@ -679,7 +675,7 @@ export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    if (!applyMutationRateLimit(request, reply)) {
+    if (!(await applyMutationRateLimit(request, reply))) {
       return reply;
     }
 
@@ -846,7 +842,7 @@ export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    if (!applyMutationRateLimit(request, reply)) {
+    if (!(await applyMutationRateLimit(request, reply))) {
       return reply;
     }
 

--- a/server/routes/report-access-tokens.fastify.ts
+++ b/server/routes/report-access-tokens.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -12,6 +12,12 @@ import {
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
 } from "../lib/report-access-token-rate-limit.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 import {
   buildPublicReportAccessPath,
   buildValidationError,
@@ -125,6 +131,7 @@ export type ReportAccessTokensNativeRoutesOptions = {
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   mutationRateLimitWindowMs?: number;
   mutationRateLimitMaxAttempts?: number;
+  mutationRateLimitStore?: RateLimitStore;
   now?: () => number;
 };
 
@@ -426,25 +433,6 @@ function setMutationRateLimitHeaders(
   );
 }
 
-function getMutationEntry(
-  attempts: Map<string, { count: number; resetAt: number }>,
-  key: string,
-  windowMs: number,
-  now: number,
-) {
-  const current = attempts.get(key);
-
-  if (!current || current.resetAt <= now) {
-    const fresh = {
-      count: 0,
-      resetAt: now + windowMs,
-    };
-    attempts.set(key, fresh);
-    return fresh;
-  }
-
-  return current;
-}
 
 function shouldRefreshSessionLastAccess(
   lastAccess: Date | null | undefined,
@@ -626,7 +614,8 @@ export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
     options.mutationRateLimitMaxAttempts ??
     REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
-  const mutationAttempts = new Map<string, { count: number; resetAt: number }>();
+  const mutationRateLimitStore =
+    options.mutationRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as ReportAccessTokensFastifyRequest)[REQUEST_START_TIME_KEY] =
@@ -686,14 +675,14 @@ export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
   app.options("/:tokenId", optionsHandler);
   app.options("/:tokenId/revoke", optionsHandler);
 
-  const applyMutationRateLimit = (
+  const applyMutationRateLimit = async (
     request: FastifyRequest,
     reply: FastifyReply,
   ) => {
     const rateLimitKey = request.ip || "unknown";
     const currentTime = now();
-    const entry = getMutationEntry(
-      mutationAttempts,
+    const entry = await getOrCreateRateLimitEntry(
+      mutationRateLimitStore,
       rateLimitKey,
       mutationRateLimitWindowMs,
       currentTime,
@@ -716,7 +705,14 @@ export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
       return null;
     }
 
-    entry.count += 1;
+    const updatedEntry = await incrementRateLimitEntry(
+      mutationRateLimitStore,
+      rateLimitKey,
+      entry,
+    );
+
+    entry.count = updatedEntry.count;
+    entry.resetAt = updatedEntry.resetAt;
 
     setMutationRateLimitHeaders(reply, {
       max: mutationRateLimitMaxAttempts,
@@ -739,7 +735,7 @@ export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    if (!applyMutationRateLimit(request, reply)) {
+    if (!(await applyMutationRateLimit(request, reply))) {
       return reply;
     }
 
@@ -894,7 +890,7 @@ export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    if (!applyMutationRateLimit(request, reply)) {
+    if (!(await applyMutationRateLimit(request, reply))) {
       return reply;
     }
 

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -405,12 +405,17 @@ test("report access token mutation rate limits cut off before auth and writes", 
     );
     assertContains(
       source,
-      "const mutationAttempts = new Map<string, { count: number; resetAt: number }>();",
-      `${scenario.file} mutation store`,
+      "mutationRateLimitStore?: RateLimitStore;",
+      `${scenario.file} injectable mutation store option`,
     );
     assertContains(
       source,
-      "const applyMutationRateLimit = (",
+      "options.mutationRateLimitStore ?? createMemoryRateLimitStore();",
+      `${scenario.file} memory fallback mutation store`,
+    );
+    assertContains(
+      source,
+      "const applyMutationRateLimit = async (",
       `${scenario.file} mutation limiter function`,
     );
     assertContainsInOrder(
@@ -421,14 +426,14 @@ test("report access token mutation rate limits cut off before auth and writes", 
         "reply.code(429).send({",
         "error: REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE",
         "return null;",
-        "entry.count += 1;",
+        "const updatedEntry = await incrementRateLimitEntry(",
       ],
       `${scenario.file} mutation limiter cut-off`,
     );
     assertContainsInOrder(
       source,
       [
-        "if (!applyMutationRateLimit(request, reply)) {",
+        "if (!(await applyMutationRateLimit(request, reply))) {",
         "return reply;",
         scenario.authMarker,
       ],
@@ -437,7 +442,7 @@ test("report access token mutation rate limits cut off before auth and writes", 
     assertContainsInOrder(
       source,
       [
-        "if (!applyMutationRateLimit(request, reply)) {",
+        "if (!(await applyMutationRateLimit(request, reply))) {",
         scenario.authMarker,
         "await deps.writeAuditLog(",
       ],


### PR DESCRIPTION
## Summary
- Adds injectable rate limit stores to clinic report access token mutations.
- Adds injectable rate limit stores to admin report access token mutations.
- Keeps in-memory fallback behavior for mutation rate limits.
- Updates rate limit isolation guardrails for async mutation store usage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build