### PR TITLE
feat(frontend): read logistics data through API client

### DIFF
--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import Link from "next/link";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
-import { MOCK_FIELD_VISITS, MOCK_ROUTE_PLANS } from "@/lib/mock-data";
+import {
+  getLogisticsFieldVisits,
+  getRoutePlans,
+} from "@/lib/api";
 import {
   getFieldVisitStatusLabel,
   getFieldVisitStatusVariant,
@@ -19,11 +23,26 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function LogisticaPage() {
-  const activeVisits = MOCK_FIELD_VISITS.filter(
+async function getLogisticsRequestOptions(): Promise<RequestInit> {
+  const cookieHeader = (await cookies()).toString();
+
+  return {
+    cache: "no-store",
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+  };
+}
+
+export default async function LogisticaPage() {
+  const requestOptions = await getLogisticsRequestOptions();
+  const [fieldVisits, routePlans] = await Promise.all([
+    getLogisticsFieldVisits(requestOptions),
+    getRoutePlans(requestOptions),
+  ]);
+
+  const activeVisits = fieldVisits.filter(
     (v) => v.status === "in_progress" || v.status === "scheduled",
   );
-  const activePlans = MOCK_ROUTE_PLANS.filter(
+  const activePlans = routePlans.filter(
     (p) => p.status === "in_progress" || p.status === "released",
   );
 
@@ -34,7 +53,6 @@ export default function LogisticaPage() {
         subtitle="Visitas de campo y planes de ruta"
       />
       <main className="flex-1 p-6 space-y-6">
-        {/* Resumen */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <Card className="border-gray-100">
             <CardHeader className="pb-2">
@@ -68,13 +86,12 @@ export default function LogisticaPage() {
             </CardHeader>
             <CardContent>
               <p className="text-3xl font-bold text-gray-900">
-                {MOCK_FIELD_VISITS.length}
+                {fieldVisits.length}
               </p>
             </CardContent>
           </Card>
         </div>
 
-        {/* Módulos */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {[
             {
@@ -82,14 +99,14 @@ export default function LogisticaPage() {
               href: ROUTES.dashboardLogisticaVisitas,
               icon: "🚐",
               description: "Seguimiento de visitas programadas y en curso.",
-              count: MOCK_FIELD_VISITS.length,
+              count: fieldVisits.length,
             },
             {
               title: "Planes de ruta",
               href: ROUTES.dashboardLogisticaRutas,
               icon: "🗺️",
               description: "Planificación y gestión de rutas de entrega.",
-              count: MOCK_ROUTE_PLANS.length,
+              count: routePlans.length,
             },
             {
               title: "Métricas",
@@ -124,7 +141,6 @@ export default function LogisticaPage() {
           ))}
         </div>
 
-        {/* Visitas recientes */}
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-4">
             <CardTitle className="text-base">Visitas recientes</CardTitle>
@@ -133,7 +149,7 @@ export default function LogisticaPage() {
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
-            {MOCK_FIELD_VISITS.slice(0, 4).map((visit) => (
+            {fieldVisits.slice(0, 4).map((visit) => (
               <div
                 key={visit.id}
                 className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
@@ -158,7 +174,6 @@ export default function LogisticaPage() {
           </CardContent>
         </Card>
 
-        {/* Planes de ruta recientes */}
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-4">
             <CardTitle className="text-base">Planes de ruta</CardTitle>
@@ -167,7 +182,7 @@ export default function LogisticaPage() {
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
-            {MOCK_ROUTE_PLANS.map((plan) => (
+            {routePlans.map((plan) => (
               <div
                 key={plan.id}
                 className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -10,7 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { MOCK_ROUTE_PLANS } from "@/lib/mock-data";
+import { getRoutePlans } from "@/lib/api";
 import {
   getRoutePlanStatusLabel,
   getRoutePlanStatusVariant,
@@ -22,7 +23,18 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function RutasPage() {
+async function getLogisticsRequestOptions(): Promise<RequestInit> {
+  const cookieHeader = (await cookies()).toString();
+
+  return {
+    cache: "no-store",
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+  };
+}
+
+export default async function RutasPage() {
+  const routePlans = await getRoutePlans(await getLogisticsRequestOptions());
+
   return (
     <>
       <DashboardTopbar
@@ -30,12 +42,10 @@ export default function RutasPage() {
         subtitle="Planificación y gestión de rutas de entrega"
       />
       <main className="flex-1 p-6 space-y-6">
-        <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 text-xs text-amber-700">
-          <strong>Mock data:</strong> Se conectará con{" "}
-          <code>GET /api/logistics/route-plans</code>.
+        <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
+          Lectura conectada a <code>GET /api/logistics/route-plans</code>.
         </div>
 
-        {/* Resumen por estado */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           {(
             [
@@ -45,9 +55,7 @@ export default function RutasPage() {
               { status: "completed", label: "Completados" },
             ] as const
           ).map(({ status, label }) => {
-            const count = MOCK_ROUTE_PLANS.filter(
-              (p) => p.status === status,
-            ).length;
+            const count = routePlans.filter((p) => p.status === status).length;
             return (
               <Card key={status} className="border-gray-100">
                 <CardContent className="pt-4">
@@ -59,11 +67,10 @@ export default function RutasPage() {
           })}
         </div>
 
-        {/* Tabla */}
         <Card>
           <CardHeader>
             <CardTitle className="text-base">
-              Planes de ruta ({MOCK_ROUTE_PLANS.length})
+              Planes de ruta ({routePlans.length})
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
@@ -79,7 +86,7 @@ export default function RutasPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {MOCK_ROUTE_PLANS.map((plan) => {
+                {routePlans.map((plan) => {
                   const progress =
                     plan.totalStops > 0
                       ? Math.round(

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -10,11 +11,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { MOCK_FIELD_VISITS } from "@/lib/mock-data";
+import { getLogisticsFieldVisits } from "@/lib/api";
 import {
   getFieldVisitStatusLabel,
   getFieldVisitStatusVariant,
-  formatDate,
   formatDateTime,
 } from "@/lib/utils";
 
@@ -23,7 +23,20 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function VisitasPage() {
+async function getLogisticsRequestOptions(): Promise<RequestInit> {
+  const cookieHeader = (await cookies()).toString();
+
+  return {
+    cache: "no-store",
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+  };
+}
+
+export default async function VisitasPage() {
+  const visits = await getLogisticsFieldVisits(
+    await getLogisticsRequestOptions(),
+  );
+
   return (
     <>
       <DashboardTopbar
@@ -31,12 +44,10 @@ export default function VisitasPage() {
         subtitle="Seguimiento de visitas programadas y en curso"
       />
       <main className="flex-1 p-6 space-y-6">
-        <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 text-xs text-amber-700">
-          <strong>Mock data:</strong> Se conectará con{" "}
-          <code>GET /api/logistics/field-visits</code>.
+        <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
+          Lectura conectada a <code>GET /api/logistics/field-visits</code>.
         </div>
 
-        {/* Resumen por estado */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           {(
             [
@@ -46,9 +57,7 @@ export default function VisitasPage() {
               { status: "done", label: "Completadas" },
             ] as const
           ).map(({ status, label }) => {
-            const count = MOCK_FIELD_VISITS.filter(
-              (v) => v.status === status,
-            ).length;
+            const count = visits.filter((v) => v.status === status).length;
             return (
               <Card key={status} className="border-gray-100">
                 <CardContent className="pt-4">
@@ -60,11 +69,10 @@ export default function VisitasPage() {
           })}
         </div>
 
-        {/* Tabla */}
         <Card>
           <CardHeader>
             <CardTitle className="text-base">
-              Visitas ({MOCK_FIELD_VISITS.length})
+              Visitas ({visits.length})
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
@@ -81,7 +89,7 @@ export default function VisitasPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {MOCK_FIELD_VISITS.map((visit) => (
+                {visits.map((visit) => (
                   <TableRow key={visit.id}>
                     <TableCell className="font-mono text-xs text-gray-400">
                       #{visit.id}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,15 +39,18 @@ const API_BASE_URL =
 
 async function apiFetch<T>(
   path: string,
-  options?: RequestInit,
+  options: RequestInit = {},
 ): Promise<T> {
+  const headers = new Headers(options.headers);
+
+  if (options.body !== undefined && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
   const res = await fetch(`${API_BASE_URL}${path}`, {
-    credentials: "include",
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
     ...options,
+    credentials: options.credentials ?? "include",
+    headers,
   });
 
   if (!res.ok) {
@@ -55,6 +58,10 @@ async function apiFetch<T>(
     throw new Error(
       (body as { error?: string }).error ?? `HTTP ${res.status}`,
     );
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
   }
 
   return res.json() as Promise<T>;
@@ -155,44 +162,49 @@ export async function getReportDownloadUrl(
   }
 }
 
-// ─── Logística — Visitas de campo (@mock — endpoint pendiente de confirmación) ─
+// ─── Logística — Visitas de campo ─────────────────────────────────────────────
 
 /**
  * Obtener visitas de campo.
  * GET /api/logistics/field-visits
  *
- * @mock — El endpoint existe en el backend pero requiere autenticación admin.
- * Se usa mock data hasta confirmar el contrato de respuesta.
+ * Endpoint confirmado en backend. Acepta RequestInit para lectura server-side
+ * dinámica con cookies reenviadas desde Next.
  */
-export async function getLogisticsFieldVisits(): Promise<FieldVisit[]> {
+export async function getLogisticsFieldVisits(
+  options?: RequestInit,
+): Promise<FieldVisit[]> {
   try {
     const res = await apiFetch<{ visits: FieldVisit[] }>(
       "/api/logistics/field-visits",
+      options,
     );
     return res.visits ?? [];
   } catch {
-    // @mock
     console.warn("[API] getLogisticsFieldVisits: usando mock data");
     return MOCK_FIELD_VISITS;
   }
 }
 
-// ─── Logística — Planes de ruta (@mock — endpoint pendiente de confirmación) ──
+// ─── Logística — Planes de ruta ───────────────────────────────────────────────
 
 /**
  * Obtener planes de ruta.
  * GET /api/logistics/route-plans
  *
- * @mock — El endpoint existe en el backend pero requiere autenticación admin.
+ * Endpoint confirmado en backend. Acepta RequestInit para lectura server-side
+ * dinámica con cookies reenviadas desde Next.
  */
-export async function getRoutePlans(): Promise<RoutePlan[]> {
+export async function getRoutePlans(
+  options?: RequestInit,
+): Promise<RoutePlan[]> {
   try {
     const res = await apiFetch<{ plans: RoutePlan[] }>(
       "/api/logistics/route-plans",
+      options,
     );
     return res.plans ?? [];
   } catch {
-    // @mock
     console.warn("[API] getRoutePlans: usando mock data");
     return MOCK_ROUTE_PLANS;
   }


### PR DESCRIPTION
## Summary
- Connect logistics dashboard overview to the frontend API client.
- Connect field visits and route plans pages to logistics read wrappers.
- Forward request cookies for dynamic server-side logistics reads.
- Keep existing API fallback behavior while avoiding build-time logistics data resolution.

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
