### PR TITLE
feat(frontend): read dashboard summary through API client

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import Link from "next/link";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { StatsCards } from "@/components/dashboard/StatsCards";
@@ -6,37 +7,55 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
-import { MOCK_DASHBOARD_STATS, MOCK_REPORTS, MOCK_FIELD_VISITS } from "@/lib/mock-data";
-import { getReportStatusLabel, getReportStatusVariant, getFieldVisitStatusLabel, getFieldVisitStatusVariant, formatDate } from "@/lib/utils";
+import {
+  getDashboardStats,
+  getLogisticsFieldVisits,
+  getReports,
+} from "@/lib/api";
+import {
+  getReportStatusLabel,
+  getReportStatusVariant,
+  getFieldVisitStatusLabel,
+  getFieldVisitStatusVariant,
+  formatDate,
+} from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Dashboard — Portal VETNEB",
   robots: { index: false, follow: false },
 };
 
-export default function DashboardPage() {
-  const recentReports = MOCK_REPORTS.slice(0, 3);
-  const recentVisits = MOCK_FIELD_VISITS.slice(0, 3);
+async function getDashboardRequestOptions(): Promise<RequestInit> {
+  const cookieHeader = (await cookies()).toString();
+
+  return {
+    cache: "no-store",
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+  };
+}
+
+export default async function DashboardPage() {
+  const requestOptions = await getDashboardRequestOptions();
+  const [stats, reports, visits] = await Promise.all([
+    getDashboardStats(requestOptions),
+    getReports(requestOptions),
+    getLogisticsFieldVisits(requestOptions),
+  ]);
+
+  const recentReports = reports.slice(0, 3);
+  const recentVisits = visits.slice(0, 3);
 
   return (
     <>
-      <DashboardTopbar
-        title="Dashboard"
-        subtitle="Resumen operativo"
-      />
+      <DashboardTopbar title="Dashboard" subtitle="Resumen operativo" />
       <main className="flex-1 p-6 space-y-6">
-        {/* Banner de desarrollo */}
-        <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 text-sm text-amber-700">
-          <strong>Modo demo:</strong> Los datos mostrados son mock data. La
-          autenticación real se integrará en un próximo PR.
+        <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 text-sm text-blue-700">
+          Lectura conectada a datos operativos del backend.
         </div>
 
-        {/* Stats */}
-        <StatsCards stats={MOCK_DASHBOARD_STATS} />
+        <StatsCards stats={stats} />
 
-        {/* Actividad reciente */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* Informes recientes */}
           <Card>
             <CardHeader className="flex flex-row items-center justify-between pb-4">
               <CardTitle className="text-base">Informes recientes</CardTitle>
@@ -58,7 +77,10 @@ export default function DashboardPage() {
                       {report.studyType} · {formatDate(report.uploadDate)}
                     </p>
                   </div>
-                  <Badge variant={getReportStatusVariant(report.status)} className="ml-2 shrink-0">
+                  <Badge
+                    variant={getReportStatusVariant(report.status)}
+                    className="ml-2 shrink-0"
+                  >
                     {getReportStatusLabel(report.status)}
                   </Badge>
                 </div>
@@ -66,7 +88,6 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          {/* Visitas recientes */}
           <Card>
             <CardHeader className="flex flex-row items-center justify-between pb-4">
               <CardTitle className="text-base">Visitas de campo</CardTitle>
@@ -88,7 +109,10 @@ export default function DashboardPage() {
                       {formatDate(visit.scheduledAt)}
                     </p>
                   </div>
-                  <Badge variant={getFieldVisitStatusVariant(visit.status)} className="ml-2 shrink-0">
+                  <Badge
+                    variant={getFieldVisitStatusVariant(visit.status)}
+                    className="ml-2 shrink-0"
+                  >
                     {getFieldVisitStatusLabel(visit.status)}
                   </Badge>
                 </div>
@@ -97,7 +121,6 @@ export default function DashboardPage() {
           </Card>
         </div>
 
-        {/* Accesos rápidos */}
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Accesos rápidos</CardTitle>
@@ -106,8 +129,16 @@ export default function DashboardPage() {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
               {[
                 { label: "Informes", href: ROUTES.dashboardInformes, icon: "📋" },
-                { label: "Visitas", href: ROUTES.dashboardLogisticaVisitas, icon: "🚐" },
-                { label: "Rutas", href: ROUTES.dashboardLogisticaRutas, icon: "🗺️" },
+                {
+                  label: "Visitas",
+                  href: ROUTES.dashboardLogisticaVisitas,
+                  icon: "🚐",
+                },
+                {
+                  label: "Rutas",
+                  href: ROUTES.dashboardLogisticaRutas,
+                  icon: "🗺️",
+                },
                 { label: "Admin", href: ROUTES.dashboardAdmin, icon: "🔧" },
               ].map((item) => (
                 <Button
@@ -117,7 +148,9 @@ export default function DashboardPage() {
                   className="h-16 flex-col gap-1"
                 >
                   <Link href={item.href}>
-                    <span className="text-xl" aria-hidden="true">{item.icon}</span>
+                    <span className="text-xl" aria-hidden="true">
+                      {item.icon}
+                    </span>
                     <span className="text-xs">{item.label}</span>
                   </Link>
                 </Button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,8 +32,6 @@ import {
   MOCK_DASHBOARD_STATS,
 } from "@/lib/mock-data";
 
-// ─── Configuración base ───────────────────────────────────────────────────────
-
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
@@ -67,8 +65,6 @@ async function apiFetch<T>(
   return res.json() as Promise<T>;
 }
 
-// ─── Autenticación (endpoints confirmados en backend) ─────────────────────────
-
 export async function loginClinic(
   credentials: LoginCredentials,
 ): Promise<AuthUser> {
@@ -90,15 +86,6 @@ export async function logout(): Promise<void> {
   await apiFetch<void>("/api/auth/logout", { method: "POST" });
 }
 
-// ─── Informes ─────────────────────────────────────────────────────────────────
-
-/**
- * Obtener lista de informes de la clínica autenticada.
- * GET /api/reports
- *
- * Endpoint confirmado en backend. Acepta RequestInit para lectura server-side
- * dinámica con cookies reenviadas desde Next.
- */
 export async function getReports(options?: RequestInit): Promise<Report[]> {
   try {
     const res = await apiFetch<{ reports: Report[] }>("/api/reports", options);
@@ -109,13 +96,6 @@ export async function getReports(options?: RequestInit): Promise<Report[]> {
   }
 }
 
-/**
- * Buscar informes con filtros.
- * GET /api/reports/search
- *
- * Endpoint confirmado en backend. Acepta RequestInit para lectura server-side
- * dinámica con cookies reenviadas desde Next.
- */
 export async function searchReports(
   params: {
     query?: string;
@@ -154,8 +134,6 @@ export async function getReportDownloadUrl(
   }
 }
 
-// ─── Logística — Visitas de campo ─────────────────────────────────────────────
-
 export async function getLogisticsFieldVisits(
   options?: RequestInit,
 ): Promise<FieldVisit[]> {
@@ -170,8 +148,6 @@ export async function getLogisticsFieldVisits(
     return MOCK_FIELD_VISITS;
   }
 }
-
-// ─── Logística — Planes de ruta ───────────────────────────────────────────────
 
 export async function getRoutePlans(
   options?: RequestInit,
@@ -211,8 +187,6 @@ export async function getRoutePlanMetrics(
   return MOCK_ROUTE_METRICS;
 }
 
-// ─── Admin — Auditoría ────────────────────────────────────────────────────────
-
 export async function getAuditEntries(
   options?: RequestInit,
 ): Promise<AuditEntry[]> {
@@ -228,9 +202,28 @@ export async function getAuditEntries(
   }
 }
 
-// ─── Dashboard — Estadísticas resumen (@mock) ─────────────────────────────────
+export async function getDashboardStats(
+  options?: RequestInit,
+): Promise<DashboardStats> {
+  const [reports, visits, routePlans] = await Promise.all([
+    getReports(options),
+    getLogisticsFieldVisits(options),
+    getRoutePlans(options),
+  ]);
 
-export async function getDashboardStats(): Promise<DashboardStats> {
-  console.warn("[API] getDashboardStats: usando mock data");
+  return {
+    totalReports: reports.length,
+    pendingReports: reports.filter((report) => report.status !== "delivered")
+      .length,
+    activeVisits: visits.filter(
+      (visit) => visit.status === "scheduled" || visit.status === "in_progress",
+    ).length,
+    activePlans: routePlans.filter(
+      (plan) => plan.status === "released" || plan.status === "in_progress",
+    ).length,
+  };
+}
+
+export async function getFallbackDashboardStats(): Promise<DashboardStats> {
   return MOCK_DASHBOARD_STATS;
 }


### PR DESCRIPTION
## Summary
- Connect dashboard summary cards and recent activity to the frontend API client.
- Compute dashboard stats from reports, field visits and route plans read wrappers.
- Forward request cookies for dynamic server-side dashboard reads.
- Remove direct mock-data reads from the dashboard page and render it dynamically on demand.

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
