### PR TITLE
test(frontend): cover dashboard live-read contract

### DIFF
--- a/test/frontend-dashboard-live-read-contract.test.ts
+++ b/test/frontend-dashboard-live-read-contract.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+function assertIncludes(source: string, expected: string, context: string): void {
+  assert.ok(source.includes(expected), `${context} missing ${expected}`);
+}
+
+function assertNotIncludes(
+  source: string,
+  unexpected: string,
+  context: string,
+): void {
+  assert.ok(
+    !source.includes(unexpected),
+    `${context} must not include ${unexpected}`,
+  );
+}
+
+const dashboardPage = "frontend/src/app/dashboard/page.tsx";
+const frontendApiClient = "frontend/src/lib/api.ts";
+
+test("frontend dashboard page does not read mock data directly", () => {
+  const source = read(dashboardPage);
+
+  assertNotIncludes(source, "@/lib/mock-data", dashboardPage);
+  assertNotIncludes(source, "MOCK_DASHBOARD_STATS", dashboardPage);
+  assertNotIncludes(source, "MOCK_REPORTS", dashboardPage);
+  assertNotIncludes(source, "MOCK_FIELD_VISITS", dashboardPage);
+  assertNotIncludes(source, "Modo demo", dashboardPage);
+  assertNotIncludes(source, "mock data", dashboardPage);
+});
+
+test("frontend dashboard page uses API client wrappers", () => {
+  const source = read(dashboardPage);
+
+  assertIncludes(source, 'from "@/lib/api"', dashboardPage);
+  assertIncludes(source, "getDashboardStats", dashboardPage);
+  assertIncludes(source, "getReports", dashboardPage);
+  assertIncludes(source, "getLogisticsFieldVisits", dashboardPage);
+  assertIncludes(source, "Promise.all", dashboardPage);
+  assertIncludes(source, "getDashboardStats(requestOptions)", dashboardPage);
+  assertIncludes(source, "getReports(requestOptions)", dashboardPage);
+  assertIncludes(
+    source,
+    "getLogisticsFieldVisits(requestOptions)",
+    dashboardPage,
+  );
+});
+
+test("frontend dashboard page forces dynamic server reads with forwarded cookies", () => {
+  const source = read(dashboardPage);
+
+  assertIncludes(source, 'import { cookies } from "next/headers";', dashboardPage);
+  assertIncludes(source, "async function getDashboardRequestOptions()", dashboardPage);
+  assertIncludes(source, "(await cookies()).toString()", dashboardPage);
+  assertIncludes(source, 'cache: "no-store"', dashboardPage);
+  assertIncludes(source, "Cookie: cookieHeader", dashboardPage);
+  assertIncludes(source, "export default async function", dashboardPage);
+});
+
+test("frontend dashboard stats are computed from live-read wrappers", () => {
+  const source = read(frontendApiClient);
+
+  assertIncludes(
+    source,
+    "export async function getDashboardStats(",
+    frontendApiClient,
+  );
+  assertIncludes(source, "options?: RequestInit", frontendApiClient);
+  assertIncludes(source, "getReports(options)", frontendApiClient);
+  assertIncludes(source, "getLogisticsFieldVisits(options)", frontendApiClient);
+  assertIncludes(source, "getRoutePlans(options)", frontendApiClient);
+  assertIncludes(source, "totalReports: reports.length", frontendApiClient);
+  assertIncludes(source, "pendingReports:", frontendApiClient);
+  assertIncludes(source, "activeVisits:", frontendApiClient);
+  assertIncludes(source, "activePlans:", frontendApiClient);
+});


### PR DESCRIPTION
## Summary
- Add guardrail coverage for dashboard live-read behavior.
- Verify the dashboard page does not import mock data directly.
- Verify the dashboard page uses API client wrappers.
- Verify dynamic no-store reads and forwarded cookies.
- Verify dashboard stats are computed from live-read wrappers.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
