### PR TITLE
chore(frontend): remove unused dashboard stats fallback

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,7 +29,6 @@ import {
   MOCK_ROUTE_PLANS,
   MOCK_ROUTE_METRICS,
   MOCK_AUDIT_ENTRIES,
-  MOCK_DASHBOARD_STATS,
 } from "@/lib/mock-data";
 
 const API_BASE_URL =
@@ -222,8 +221,4 @@ export async function getDashboardStats(
       (plan) => plan.status === "released" || plan.status === "in_progress",
     ).length,
   };
-}
-
-export async function getFallbackDashboardStats(): Promise<DashboardStats> {
-  return MOCK_DASHBOARD_STATS;
 }


### PR DESCRIPTION
## Summary
- Remove unused dashboard stats fallback helper from the frontend API client.
- Remove the now-unused MOCK_DASHBOARD_STATS import from the API client.
- Keep dashboard stats computed from live-read wrappers.

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
