### PR TITLE
chore(smoke): require explicit smoke password

### DIFF
--- a/docs/smoke-local.md
+++ b/docs/smoke-local.md
@@ -1,4 +1,4 @@
-﻿# Smoke local
+# Smoke local
 
 Los scripts de smoke validan el backend contra un servidor ya levantado.
 
@@ -28,7 +28,7 @@ $env:SMOKE_USERNAME = "<clinic-user>"
 $env:SMOKE_PASSWORD = "<clinic-password>"
 ```
 
-No usar los defaults internos `admin` / `admin123` salvo que existan explicitamente en la base local.
+SMOKE_PASSWORD es obligatorio. El script falla si no esta configurado para evitar passwords por defecto en smoke local.
 
 Usar `127.0.0.1` evita diferencias locales de resolucion IPv6 de `localhost`.
 

--- a/scripts/smoke/smoke-test.mjs
+++ b/scripts/smoke/smoke-test.mjs
@@ -2,7 +2,17 @@ import "dotenv/config";
 
 const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
 const USERNAME = process.env.SMOKE_USERNAME ?? "admin";
-const PASSWORD = process.env.SMOKE_PASSWORD ?? "admin123";
+const PASSWORD = requiredEnv("SMOKE_PASSWORD");
+
+function requiredEnv(name) {
+  const value = process.env[name];
+
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${name} es requerido para ejecutar este smoke script.`);
+  }
+
+  return value;
+}
 
 function fail(message, error) {
   console.error("SMOKE TEST FALLO");

--- a/scripts/smoke/smoke-upload.mjs
+++ b/scripts/smoke/smoke-upload.mjs
@@ -5,9 +5,19 @@ import path from "node:path";
 
 const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
 const USERNAME = process.env.SMOKE_USERNAME ?? "admin";
-const PASSWORD = process.env.SMOKE_PASSWORD ?? "admin123";
+const PASSWORD = requiredEnv("SMOKE_PASSWORD");
 const TMP_DIR = process.env.SMOKE_TMP_DIR ?? path.join(os.tmpdir(), "portal-vetneb-smoke");
 const PDF_PATH = path.join(TMP_DIR, "smoke-test.pdf");
+
+function requiredEnv(name) {
+  const value = process.env[name];
+
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${name} es requerido para ejecutar este smoke script.`);
+  }
+
+  return value;
+}
 
 function fail(message, error) {
   console.error("SMOKE UPLOAD FALLO");

--- a/test/smoke-env-contract.test.ts
+++ b/test/smoke-env-contract.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -11,13 +11,16 @@ test("smoke scripts document required runtime environment contract", () => {
   const smokeTest = read("scripts/smoke/smoke-test.mjs");
   const smokeUpload = read("scripts/smoke/smoke-upload.mjs");
   const docs = read("docs/smoke-local.md");
+  const forbiddenDefaultPasswordPattern = new RegExp("admin" + "123");
 
   for (const source of [smokeTest, smokeUpload]) {
     assert.match(source, /process\.env\.SMOKE_BASE_URL/);
     assert.match(source, /process\.env\.SMOKE_USERNAME/);
-    assert.match(source, /process\.env\.SMOKE_PASSWORD/);
+    assert.match(source, /requiredEnv\("SMOKE_PASSWORD"\)/);
     assert.match(source, /BASE URL:/);
     assert.match(source, /USUARIO:/);
+    assert.doesNotMatch(source, forbiddenDefaultPasswordPattern);
+
     const consoleLogLines = source
       .split(/\r?\n/)
       .filter((line) => line.includes("console.log"));
@@ -36,12 +39,10 @@ test("smoke scripts document required runtime environment contract", () => {
     "SMOKE_TMP_DIR",
     "pnpm smoke:test",
     "pnpm smoke:upload",
-    "admin",
-    "admin123",
   ]) {
     assert.ok(docs.includes(marker), "docs/smoke-local.md missing " + marker);
   }
 
-  assert.match(docs, /No usar los defaults internos `admin` \/ `admin123`/);
+  assert.match(docs, /SMOKE_PASSWORD es obligatorio/);
   assert.match(docs, /no commitearse/i);
 });

--- a/test/smoke-local-contract.test.ts
+++ b/test/smoke-local-contract.test.ts
@@ -174,13 +174,29 @@ test("upload local smoke keeps temp artifacts outside the repo and covers admin 
 
 test("local smoke documentation keeps credential handling explicit", () => {
   const docs = read("docs/smoke-local.md");
+  const smokeTest = read("scripts/smoke/smoke-test.mjs");
+  const smokeUpload = read("scripts/smoke/smoke-upload.mjs");
+  const forbiddenDefaultPasswordPattern = new RegExp("admin" + "123");
+
+  assert.doesNotMatch(smokeTest, forbiddenDefaultPasswordPattern);
+  assert.doesNotMatch(smokeUpload, forbiddenDefaultPasswordPattern);
+  assertIncludes(
+    smokeTest,
+    'requiredEnv("SMOKE_PASSWORD")',
+    "scripts/smoke/smoke-test.mjs"
+  );
+  assertIncludes(
+    smokeUpload,
+    'requiredEnv("SMOKE_PASSWORD")',
+    "scripts/smoke/smoke-upload.mjs"
+  );
 
   for (const marker of [
     "SMOKE_BASE_URL",
     "SMOKE_USERNAME",
     "SMOKE_PASSWORD",
     "SMOKE_TMP_DIR",
-    "No usar los defaults internos `admin` / `admin123`",
+    "SMOKE_PASSWORD es obligatorio.",
     "Los scripts no deben registrar la password en consola.",
     "Solo muestran BASE URL y USUARIO.",
     "Las credenciales reales deben configurarse por entorno local y no commitearse.",


### PR DESCRIPTION
## Summary
- Require SMOKE_PASSWORD explicitly in local smoke scripts.
- Remove hardcoded smoke password fallback from smoke-test and smoke-upload.
- Update smoke documentation to reflect explicit password handling.
- Extend smoke contract tests to prevent reintroducing default smoke passwords.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
