### PR TITLE
feat(ops): add runtime timing helper

### DIFF
--- a/server/lib/runtime-timing.ts
+++ b/server/lib/runtime-timing.ts
@@ -1,0 +1,26 @@
+export type RuntimeTimer = {
+  readonly startedAtMs: number;
+  elapsedMs: () => number;
+};
+
+export function getMonotonicNowMs(): number {
+  if (
+    typeof globalThis.performance?.now === "function" &&
+    Number.isFinite(globalThis.performance.now())
+  ) {
+    return globalThis.performance.now();
+  }
+
+  return Date.now();
+}
+
+export function createRuntimeTimer(
+  nowMs: () => number = getMonotonicNowMs,
+): RuntimeTimer {
+  const startedAtMs = nowMs();
+
+  return {
+    startedAtMs,
+    elapsedMs: () => Math.max(0, nowMs() - startedAtMs),
+  };
+}

--- a/test/runtime-timing.test.ts
+++ b/test/runtime-timing.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createRuntimeTimer,
+  getMonotonicNowMs,
+} from "../server/lib/runtime-timing.ts";
+
+test("getMonotonicNowMs returns a finite non-negative number", () => {
+  const now = getMonotonicNowMs();
+
+  assert.equal(Number.isFinite(now), true);
+  assert.equal(now >= 0, true);
+});
+
+test("createRuntimeTimer measures elapsed milliseconds from injected clock", () => {
+  let now = 100;
+
+  const timer = createRuntimeTimer(() => now);
+
+  assert.equal(timer.startedAtMs, 100);
+  assert.equal(timer.elapsedMs(), 0);
+
+  now = 137;
+
+  assert.equal(timer.elapsedMs(), 37);
+});
+
+test("createRuntimeTimer never returns negative elapsed time", () => {
+  let now = 100;
+
+  const timer = createRuntimeTimer(() => now);
+
+  now = 90;
+
+  assert.equal(timer.elapsedMs(), 0);
+});


### PR DESCRIPTION
## Summary
- Add a small runtime-safe timing helper for future operational metrics.
- Prefer monotonic performance timing when available.
- Clamp elapsed duration at zero to avoid negative values from non-monotonic clocks.
- Add unit coverage for default and injected-clock behavior.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
