### PR TITLE
feat(logistics): expose heuristic planning duration

### DIFF
--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -41,6 +41,7 @@ import {
   calculateRouteStopComplianceMetrics,
   type RouteStopComplianceInput,
 } from "../lib/logistics/metrics.ts";
+import { createRuntimeTimer } from "../lib/runtime-timing.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -1584,7 +1585,9 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    const planningTimer = createRuntimeTimer();
     const result = await deps.generateHeuristicRoutePlan(parsed.input);
+    const planningDurationMs = planningTimer.elapsedMs();
 
     if (result.reason) {
       const error = getGenerateHeuristicRoutePlanError(result);
@@ -1606,6 +1609,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
         mode: "heuristic",
         objective: result.routePlan.objective,
         fieldVisitCount: result.routeStops.length,
+        planningDurationMs,
         warnings: result.warnings,
       },
     });

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -139,6 +139,8 @@ test("logistics route plans API exposes heuristic generation endpoint", () => {
   assert.match(routeSource, /app\.post<[\s\S]*>\("\/heuristic", async/);
   assert.match(routeSource, /buildGenerateHeuristicRoutePlanInput/);
   assert.match(routeSource, /deps\.generateHeuristicRoutePlan\(parsed\.input\)/);
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /planningDurationMs/);
   assert.match(routeSource, /planning:\s*{\s*mode: "heuristic"/);
 });
 
@@ -169,7 +171,7 @@ test("logistics route plans API validates heuristic generation input before DB c
 test("logistics route plans API keeps heuristic planning call behind 400 validation cut-off", () => {
   assert.match(
     routeSource,
-    /const parsed = buildGenerateHeuristicRoutePlanInput\([\s\S]*?if \(!parsed\.input\) {[\s\S]*?return reply\.code\(400\)\.send\({[\s\S]*?}\);\s*}\s*const result = await deps\.generateHeuristicRoutePlan\(parsed\.input\);/,
+    /const parsed = buildGenerateHeuristicRoutePlanInput\([\s\S]*?if \(!parsed\.input\) {[\s\S]*?return reply\.code\(400\)\.send\({[\s\S]*?}\);\s*}\s*const planningTimer = createRuntimeTimer\(\);\s*const result = await deps\.generateHeuristicRoutePlan\(parsed\.input\);/,
   );
 });
 


### PR DESCRIPTION
## Summary
- Measure heuristic route planning duration with the runtime timing helper.
- Return planningDurationMs in the heuristic planning response payload.
- Keep heuristic input validation before timing and DB planning calls.
- Add route contract guardrails for the duration metric.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
