### PR TITLE
refactor(public): use runtime timing helper

### DIFF
--- a/server/routes/public-professionals.fastify.ts
+++ b/server/routes/public-professionals.fastify.ts
@@ -20,6 +20,10 @@ import {
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
 import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
+import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
@@ -82,10 +86,10 @@ export type PublicProfessionalsNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__publicProfessionalsRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__publicProfessionalsRequestTimer";
 
 type PublicProfessionalsFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 function getAllowedOrigins(): string[] {
@@ -328,8 +332,8 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
   });
 
   app.addHook("onRequest", async (request, reply) => {
-    (request as PublicProfessionalsFastifyRequest)[REQUEST_START_TIME_KEY] =
-      process.hrtime.bigint();
+    (request as PublicProfessionalsFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     const corsAccepted = applyCorsHeaders(request, reply, allowedOrigins);
 
@@ -341,12 +345,11 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as PublicProfessionalsFastifyRequest)[REQUEST_START_TIME_KEY] ??
-      process.hrtime.bigint();
+    const timer =
+      (request as PublicProfessionalsFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/public-professionals-runtime-timing-contract.test.ts
+++ b/test/public-professionals-runtime-timing-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "public-professionals.fastify.ts"),
+  "utf8",
+);
+
+test("public professionals request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(
+    routeSource,
+    /const REQUEST_TIMER_KEY = "__publicProfessionalsRequestTimer"/,
+  );
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in public professionals request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep public response payloads and rate-limit behavior unchanged.
- Add a contract test to prevent timing drift.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
