### PR TITLE
refactor(admin): use runtime timing helper in audit logs

### DIFF
--- a/server/routes/admin-audit.fastify.ts
+++ b/server/routes/admin-audit.fastify.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
   FastifyPluginAsync,
   FastifyReply,
   FastifyRequest,
@@ -16,6 +16,10 @@ import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
+import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -59,12 +63,12 @@ export type AdminAuditNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__adminAuditRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__adminAuditRequestTimer";
 const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 type AdminAuditFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativeAdminAuditDeps = Required<
@@ -309,19 +313,18 @@ export const adminAuditNativeRoutes: FastifyPluginAsync<
   const now = options.now ?? (() => Date.now());
 
   app.addHook("onRequest", async (request) => {
-    (request as AdminAuditFastifyRequest)[REQUEST_START_TIME_KEY] =
-      process.hrtime.bigint();
+    (request as AdminAuditFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     return undefined;
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as AdminAuditFastifyRequest)[REQUEST_START_TIME_KEY] ??
-      process.hrtime.bigint();
+    const timer =
+      (request as AdminAuditFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/admin-audit-runtime-timing-contract.test.ts
+++ b/test/admin-audit-runtime-timing-contract.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "admin-audit.fastify.ts"),
+  "utf8",
+);
+
+test("admin audit request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(routeSource, /const REQUEST_TIMER_KEY = "__adminAuditRequestTimer"/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -293,6 +293,15 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         markers: ["adminAuditNativeRoutes", "export.csv", "filtros"],
       },
       {
+        path: "test/admin-audit-runtime-timing-contract.test.ts",
+        markers: [
+          "admin audit request logging uses shared runtime timing helper",
+          "createRuntimeTimer",
+          "REQUEST_TIMER_KEY",
+          "assert.doesNotMatch",
+        ],
+      },
+      {
         path: "test/admin-audit.test.ts",
         markers: ["buildAdminAuditListFilters", "buildAdminAuditCsv"],
       },


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in admin audit request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep audit response payloads and export behavior unchanged.
- Add contract coverage and register it in the audit suite completeness guardrail.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
