### PR TITLE
refactor(clinic): use runtime timing helper in audit logs

### DIFF
--- a/server/routes/clinic-audit.fastify.ts
+++ b/server/routes/clinic-audit.fastify.ts
@@ -17,6 +17,10 @@ import {
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
 import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
+import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
@@ -74,12 +78,12 @@ export type ClinicAuditNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__clinicAuditRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__clinicAuditRequestTimer";
 const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 type ClinicAuditFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativeClinicAuditDeps = Required<
@@ -326,19 +330,18 @@ export const clinicAuditNativeRoutes: FastifyPluginAsync<
   const now = options.now ?? (() => Date.now());
 
   app.addHook("onRequest", async (request) => {
-    (request as ClinicAuditFastifyRequest)[REQUEST_START_TIME_KEY] =
-      process.hrtime.bigint();
+    (request as ClinicAuditFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     return undefined;
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as ClinicAuditFastifyRequest)[REQUEST_START_TIME_KEY] ??
-      process.hrtime.bigint();
+    const timer =
+      (request as ClinicAuditFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -327,6 +327,15 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         markers: ["clinicAuditNativeRoutes", "export.csv", "ENV.cookieName"],
       },
       {
+        path: "test/clinic-audit-runtime-timing-contract.test.ts",
+        markers: [
+          "clinic audit request logging uses shared runtime timing helper",
+          "createRuntimeTimer",
+          "REQUEST_TIMER_KEY",
+          "assert.doesNotMatch",
+        ],
+      },
+      {
         path: "test/clinic-audit.test.ts",
         markers: ["buildClinicAuditListFilters", "clinicId"],
       },

--- a/test/clinic-audit-runtime-timing-contract.test.ts
+++ b/test/clinic-audit-runtime-timing-contract.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "clinic-audit.fastify.ts"),
+  "utf8",
+);
+
+test("clinic audit request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(routeSource, /const REQUEST_TIMER_KEY = "__clinicAuditRequestTimer"/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in clinic audit request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep audit response payloads and export behavior unchanged.
- Add contract coverage and register it in the audit suite completeness guardrail.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
