### PR TITLE
refactor(particular): use runtime timing helper in audit logs

### DIFF
--- a/server/routes/particular-audit.fastify.ts
+++ b/server/routes/particular-audit.fastify.ts
@@ -16,6 +16,10 @@ import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
+import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
 
 type ParticularSessionRecord = {
   particularTokenId: number;
@@ -67,12 +71,12 @@ export type ParticularAuditNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__particularAuditRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__particularAuditRequestTimer";
 const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const PARTICULAR_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 type ParticularAuditFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativeParticularAuditDeps = Required<
@@ -325,19 +329,18 @@ export const particularAuditNativeRoutes: FastifyPluginAsync<
   const now = options.now ?? (() => Date.now());
 
   app.addHook("onRequest", async (request) => {
-    (request as ParticularAuditFastifyRequest)[REQUEST_START_TIME_KEY] =
-      process.hrtime.bigint();
+    (request as ParticularAuditFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     return undefined;
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as ParticularAuditFastifyRequest)[REQUEST_START_TIME_KEY] ??
-      process.hrtime.bigint();
+    const timer =
+      (request as ParticularAuditFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -344,6 +344,15 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         markers: ["particularAuditNativeRoutes", "export.csv", "particular"],
       },
       {
+        path: "test/particular-audit-runtime-timing-contract.test.ts",
+        markers: [
+          "particular audit request logging uses shared runtime timing helper",
+          "createRuntimeTimer",
+          "REQUEST_TIMER_KEY",
+          "assert.doesNotMatch",
+        ],
+      },
+      {
         path: "test/logistics-audit-runtime.test.ts",
         markers: [
           "logistics route plan lifecycle runtime writes audit metadata",

--- a/test/particular-audit-runtime-timing-contract.test.ts
+++ b/test/particular-audit-runtime-timing-contract.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "particular-audit.fastify.ts"),
+  "utf8",
+);
+
+test("particular audit request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(routeSource, /const REQUEST_TIMER_KEY = "__particularAuditRequestTimer"/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in particular audit request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep audit response payloads and export behavior unchanged.
- Add contract coverage and register it in the audit suite completeness guardrail.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
