### PR TITLE
refactor(clinic): use runtime timing helper in auth logs

### DIFF
--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -25,6 +25,10 @@ import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
+import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
 
 type VerifyPasswordResult = {
   valid: boolean;
@@ -114,11 +118,11 @@ export type AuthNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__clinicAuthRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__clinicAuthRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type AuthFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativeAuthDeps = Required<
@@ -546,8 +550,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     options.loginRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
-    (request as AuthFastifyRequest)[REQUEST_START_TIME_KEY] =
-      process.hrtime.bigint();
+    (request as AuthFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     applyCorsHeaders(request, reply, allowedOrigins);
 
@@ -555,12 +559,11 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as AuthFastifyRequest)[REQUEST_START_TIME_KEY] ??
-      process.hrtime.bigint();
+    const timer =
+      (request as AuthFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/clinic-auth-runtime-timing-contract.test.ts
+++ b/test/clinic-auth-runtime-timing-contract.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "auth.fastify.ts"),
+  "utf8",
+);
+
+test("clinic auth request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(routeSource, /const REQUEST_TIMER_KEY = "__clinicAuthRequestTimer"/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in clinic auth request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep auth response payloads, CORS and session behavior unchanged.
- Add contract coverage to prevent timing drift.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
