### PR TITLE
refactor(reports): use runtime timing helper in request logs

### DIFF
--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -21,6 +21,10 @@ import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
+import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
 
 type ClinicUserRecord = {
   id: number;
@@ -80,11 +84,11 @@ export type ReportsNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__reportsRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__reportsRequestTimer";
 const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type ReportsFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativeReportsDeps = Required<
@@ -493,8 +497,8 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     const allowedOrigins = new Set(getAllowedOrigins());
 
     app.addHook("onRequest", async (request, reply) => {
-      (request as ReportsFastifyRequest)[REQUEST_START_TIME_KEY] =
-        process.hrtime.bigint();
+      (request as ReportsFastifyRequest)[REQUEST_TIMER_KEY] =
+        createRuntimeTimer();
 
       applyCorsHeaders(request, reply, allowedOrigins);
 
@@ -502,12 +506,11 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
     });
 
     app.addHook("onResponse", async (request, reply) => {
-      const startedAt =
-        (request as ReportsFastifyRequest)[REQUEST_START_TIME_KEY] ??
-        process.hrtime.bigint();
+      const timer =
+        (request as ReportsFastifyRequest)[REQUEST_TIMER_KEY] ??
+        createRuntimeTimer();
 
-      const durationMs =
-        Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      const durationMs = timer.elapsedMs();
       const safeUrl = sanitizeUrlForLogs(request.url);
 
       console.log(

--- a/test/reports-runtime-timing-contract.test.ts
+++ b/test/reports-runtime-timing-contract.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "reports.fastify.ts"),
+  "utf8",
+);
+
+test("reports request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(routeSource, /const REQUEST_TIMER_KEY = "__reportsRequestTimer"/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in reports request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep reports response payloads, CORS and session behavior unchanged.
- Add contract coverage to prevent timing drift.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
