### PR TITLE
refactor(particular): use runtime timing helper in tracking logs

### DIFF
--- a/server/routes/particular-study-tracking.fastify.ts
+++ b/server/routes/particular-study-tracking.fastify.ts
@@ -21,6 +21,10 @@ import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
+import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
 
 type ParticularSessionRecord = {
   particularTokenId: number;
@@ -64,11 +68,11 @@ export type ParticularStudyTrackingNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__particularStudyTrackingRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__particularStudyTrackingRequestTimer";
 const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type ParticularStudyTrackingFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativeParticularStudyTrackingDeps = Required<
@@ -417,9 +421,8 @@ export const particularStudyTrackingNativeRoutes: FastifyPluginAsync<
   const allowedOrigins = new Set(getAllowedOrigins());
 
   app.addHook("onRequest", async (request, reply) => {
-    (request as ParticularStudyTrackingFastifyRequest)[
-      REQUEST_START_TIME_KEY
-    ] = process.hrtime.bigint();
+    (request as ParticularStudyTrackingFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     applyCorsHeaders(request, reply, allowedOrigins);
 
@@ -427,13 +430,11 @@ export const particularStudyTrackingNativeRoutes: FastifyPluginAsync<
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as ParticularStudyTrackingFastifyRequest)[
-        REQUEST_START_TIME_KEY
-      ] ?? process.hrtime.bigint();
+    const timer =
+      (request as ParticularStudyTrackingFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/particular-study-tracking-runtime-timing-contract.test.ts
+++ b/test/particular-study-tracking-runtime-timing-contract.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "particular-study-tracking.fastify.ts"),
+  "utf8",
+);
+
+test("particular study tracking request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(
+    routeSource,
+    /const REQUEST_TIMER_KEY = "__particularStudyTrackingRequestTimer"/,
+  );
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in particular study tracking request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep response payloads, CORS, sessions, auth and query behavior unchanged.
- Add contract coverage to prevent timing drift.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
