### PR TITLE
refactor(public): use runtime timing helper in report access logs

### DIFF
--- a/server/routes/public-report-access.fastify.ts
+++ b/server/routes/public-report-access.fastify.ts
@@ -36,6 +36,10 @@ import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
+import {
+  createRuntimeTimer,
+  type RuntimeTimer,
+} from "../lib/runtime-timing.ts";
 
 type ReportAccessTokenWithReportRecord = {
   token: ReportAccessToken;
@@ -74,10 +78,10 @@ export type PublicReportAccessNativeRoutesOptions = {
   now?: () => number;
 };
 
-const REQUEST_START_TIME_KEY = "__publicReportAccessRequestStartTimeNs";
+const REQUEST_TIMER_KEY = "__publicReportAccessRequestTimer";
 
 type PublicReportAccessFastifyRequest = FastifyRequest & {
-  [REQUEST_START_TIME_KEY]?: bigint;
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
 
 type NativePublicReportAccessDeps = Required<
@@ -262,8 +266,8 @@ export const publicReportAccessNativeRoutes: FastifyPluginAsync<
     options.publicReportAccessRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
-    (request as PublicReportAccessFastifyRequest)[REQUEST_START_TIME_KEY] =
-      process.hrtime.bigint();
+    (request as PublicReportAccessFastifyRequest)[REQUEST_TIMER_KEY] =
+      createRuntimeTimer();
 
     applyCorsHeaders(request, reply, allowedOrigins);
 
@@ -271,12 +275,11 @@ export const publicReportAccessNativeRoutes: FastifyPluginAsync<
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const startedAt =
-      (request as PublicReportAccessFastifyRequest)[REQUEST_START_TIME_KEY] ??
-      process.hrtime.bigint();
+    const timer =
+      (request as PublicReportAccessFastifyRequest)[REQUEST_TIMER_KEY] ??
+      createRuntimeTimer();
 
-    const durationMs =
-      Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(request.url);
 
     console.log(

--- a/test/public-report-access-runtime-timing-contract.test.ts
+++ b/test/public-report-access-runtime-timing-contract.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "public-report-access.fastify.ts"),
+  "utf8",
+);
+
+test("public report access request logging uses shared runtime timing helper", () => {
+  assert.match(routeSource, /createRuntimeTimer/);
+  assert.match(routeSource, /type RuntimeTimer/);
+  assert.match(
+    routeSource,
+    /const REQUEST_TIMER_KEY = "__publicReportAccessRequestTimer"/,
+  );
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\]\?: RuntimeTimer/);
+  assert.match(routeSource, /\[REQUEST_TIMER_KEY\] =\s*createRuntimeTimer\(\)/);
+  assert.match(routeSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(routeSource, /REQUEST_START_TIME_KEY/);
+  assert.doesNotMatch(routeSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in public report access request logging.
- Remove route-local process.hrtime.bigint timing logic.
- Keep response payloads, CORS, rate-limit, token state, signed URL and audit behavior unchanged.
- Add contract coverage to prevent timing drift.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
