### PR TITLE
test(routes): guard against legacy runtime timing

### DIFF
--- a/test/routes-runtime-timing-legacy-guard.test.ts
+++ b/test/routes-runtime-timing-legacy-guard.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const routesDir = resolve(process.cwd(), "server", "routes");
+
+const legacyTimingMarkers = [
+  "REQUEST_START_TIME_KEY",
+  "process.hrtime.bigint",
+];
+
+test("native route files do not use legacy request timing markers", () => {
+  const offenders = readdirSync(routesDir)
+    .filter((fileName) => fileName.endsWith(".ts"))
+    .sort()
+    .flatMap((fileName) => {
+      const source = readFileSync(join(routesDir, fileName), "utf8");
+      const markers = legacyTimingMarkers.filter((marker) =>
+        source.includes(marker),
+      );
+
+      return markers.length > 0
+        ? [`${fileName}: ${markers.join(", ")}`]
+        : [];
+    });
+
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary
- Add a routes-level guardrail against legacy request timing markers.
- Prevent reintroducing REQUEST_START_TIME_KEY and process.hrtime.bigint in native route files.
- Preserve existing runtime timing helper migrations.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
