### PR TITLE
refactor(logging): use runtime timing helper in request logger

### DIFF
--- a/server/middlewares/request-logger.ts
+++ b/server/middlewares/request-logger.ts
@@ -1,4 +1,5 @@
-﻿import type { NextFunction, Request, Response } from "../lib/http-types.ts";
+import type { NextFunction, Request, Response } from "../lib/http-types.ts";
+import { createRuntimeTimer } from "../lib/runtime-timing.ts";
 
 export function sanitizeUrlForLogs(url: string): string {
   return url
@@ -28,10 +29,10 @@ export function buildRequestLogLine(input: {
 }
 
 export function requestLogger(req: Request, res: Response, next: NextFunction) {
-  const startTime = process.hrtime.bigint();
+  const timer = createRuntimeTimer();
 
   res.on("finish", () => {
-    const durationMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
+    const durationMs = timer.elapsedMs();
     const safeUrl = sanitizeUrlForLogs(req.originalUrl);
 
     console.log(

--- a/test/request-logger-runtime-timing-contract.test.ts
+++ b/test/request-logger-runtime-timing-contract.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const middlewareSource = readFileSync(
+  resolve(process.cwd(), "server", "middlewares", "request-logger.ts"),
+  "utf8",
+);
+
+test("request logger uses shared runtime timing helper", () => {
+  assert.match(middlewareSource, /createRuntimeTimer/);
+  assert.match(middlewareSource, /const timer = createRuntimeTimer\(\)/);
+  assert.match(middlewareSource, /const durationMs = timer\.elapsedMs\(\)/);
+  assert.doesNotMatch(middlewareSource, /process\.hrtime\.bigint/);
+});


### PR DESCRIPTION
## Summary
- Reuse the shared runtime timing helper in the request logger middleware.
- Remove direct process.hrtime.bigint timing from request logging.
- Keep URL sanitization, log format and RATE_LIMITED behavior unchanged.
- Add contract coverage to prevent timing drift.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
