### PR TITLE
refactor(auth): share session last access refresh helper

### DIFF
--- a/server/lib/session-last-access.ts
+++ b/server/lib/session-last-access.ts
@@ -1,0 +1,13 @@
+export const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+
+export function shouldRefreshSessionLastAccess(
+  lastAccess: Date | null | undefined,
+  nowMs: number,
+  intervalMs = SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS,
+) {
+  if (!(lastAccess instanceof Date)) {
+    return true;
+  }
+
+  return nowMs - lastAccess.getTime() >= intervalMs;
+}

--- a/server/routes/admin-audit.fastify.ts
+++ b/server/routes/admin-audit.fastify.ts
@@ -20,6 +20,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -64,7 +65,6 @@ export type AdminAuditNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminAuditRequestTimer";
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const ADMIN_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 type AdminAuditFastifyRequest = FastifyRequest & {
@@ -198,16 +198,6 @@ function buildClearAdminSessionCookie() {
   });
 }
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 async function authenticateAdminUser(
   request: FastifyRequest,

--- a/test/routes-session-last-access-contract.test.ts
+++ b/test/routes-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "admin-audit.fastify.ts"),
+  "utf8",
+);
+
+test("admin audit route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(routeSource, /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/);
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(
+    routeSource,
+    /function shouldRefreshSessionLastAccess/,
+  );
+});

--- a/test/session-last-access.test.ts
+++ b/test/session-last-access.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS,
+  shouldRefreshSessionLastAccess,
+} from "../server/lib/session-last-access.ts";
+
+test("shouldRefreshSessionLastAccess refreshes missing last access timestamps", () => {
+  assert.equal(shouldRefreshSessionLastAccess(null, Date.now()), true);
+  assert.equal(shouldRefreshSessionLastAccess(undefined, Date.now()), true);
+});
+
+test("shouldRefreshSessionLastAccess keeps fresh sessions untouched", () => {
+  const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+  const freshLastAccess = new Date(
+    now - SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS + 1,
+  );
+
+  assert.equal(shouldRefreshSessionLastAccess(freshLastAccess, now), false);
+});
+
+test("shouldRefreshSessionLastAccess refreshes stale sessions at the interval boundary", () => {
+  const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+  const staleLastAccess = new Date(now - SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS);
+
+  assert.equal(shouldRefreshSessionLastAccess(staleLastAccess, now), true);
+});
+
+test("shouldRefreshSessionLastAccess supports custom refresh intervals", () => {
+  const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+  const lastAccess = new Date(now - 1_000);
+
+  assert.equal(shouldRefreshSessionLastAccess(lastAccess, now, 2_000), false);
+  assert.equal(shouldRefreshSessionLastAccess(lastAccess, now, 1_000), true);
+});


### PR DESCRIPTION
## Summary
- Add a shared session last-access refresh helper.
- Migrate admin audit authentication to use the shared helper.
- Preserve the existing 10-minute refresh interval and session behavior.
- Add helper and route contract coverage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
