### PR TITLE
refactor(admin): use shared session last access helper in auth

### DIFF
--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -25,6 +25,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type VerifyPasswordResult = {
   valid: boolean;
@@ -96,7 +97,6 @@ export type AdminAuthNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__adminAuthRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type AdminAuthFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -390,16 +390,6 @@ function setLoginRateLimitHeaders(
 }
 
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 function createAuditRequestLike(
   request: FastifyRequest,

--- a/test/admin-auth-session-last-access-contract.test.ts
+++ b/test/admin-auth-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "admin-auth.fastify.ts"),
+  "utf8",
+);
+
+test("admin auth route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate admin auth session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep login, logout, cookies, CORS, rate-limit and audit behavior unchanged.
- Add route contract coverage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
