### PR TITLE
refactor(clinic): use shared session last access helper in audit

### DIFF
--- a/server/routes/clinic-audit.fastify.ts
+++ b/server/routes/clinic-audit.fastify.ts
@@ -24,6 +24,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ClinicUserRecord = {
   id: number;
@@ -79,7 +80,6 @@ export type ClinicAuditNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__clinicAuditRequestTimer";
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const CLINIC_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 type ClinicAuditFastifyRequest = FastifyRequest & {
@@ -211,16 +211,6 @@ function buildClearSessionCookie() {
   });
 }
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 async function authenticateClinicUser(
   request: FastifyRequest,

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -336,6 +336,15 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         ],
       },
       {
+        path: "test/clinic-audit-session-last-access-contract.test.ts",
+        markers: [
+          "clinic audit route uses shared session last access helper",
+          "shouldRefreshSessionLastAccess",
+          "SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS",
+          "function shouldRefreshSessionLastAccess",
+        ],
+      },
+      {
         path: "test/clinic-audit.test.ts",
         markers: ["buildClinicAuditListFilters", "clinicId"],
       },

--- a/test/clinic-audit-session-last-access-contract.test.ts
+++ b/test/clinic-audit-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "clinic-audit.fastify.ts"),
+  "utf8",
+);
+
+test("clinic audit route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate clinic audit session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep cookies, permissions, payloads, CSV export and logging behavior unchanged.
- Add route contract coverage and register it in the audit completeness guardrail.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
