### PR TITLE
refactor(particular): use shared session last access helper in audit

### DIFF
--- a/server/routes/particular-audit.fastify.ts
+++ b/server/routes/particular-audit.fastify.ts
@@ -20,6 +20,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ParticularSessionRecord = {
   particularTokenId: number;
@@ -72,7 +73,6 @@ export type ParticularAuditNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__particularAuditRequestTimer";
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const PARTICULAR_AUDIT_CSV_EXPORT_MAX_ROWS = 10_000;
 
 type ParticularAuditFastifyRequest = FastifyRequest & {
@@ -209,16 +209,6 @@ function buildClearParticularSessionCookie() {
   });
 }
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 async function authenticateParticularUser(
   request: FastifyRequest,

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -362,6 +362,15 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         ],
       },
       {
+        path: "test/particular-audit-session-last-access-contract.test.ts",
+        markers: [
+          "particular audit route uses shared session last access helper",
+          "shouldRefreshSessionLastAccess",
+          "SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS",
+          "function shouldRefreshSessionLastAccess",
+        ],
+      },
+      {
         path: "test/logistics-audit-runtime.test.ts",
         markers: [
           "logistics route plan lifecycle runtime writes audit metadata",

--- a/test/particular-audit-session-last-access-contract.test.ts
+++ b/test/particular-audit-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "particular-audit.fastify.ts"),
+  "utf8",
+);
+
+test("particular audit route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate particular audit session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep cookies, token validation, payloads, CSV export and logging behavior unchanged.
- Add route contract coverage and register it in the audit completeness guardrail.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
