### PR TITLE
refactor(reports): use shared session last access helper in status

### DIFF
--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -28,6 +28,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ClinicUserRecord = {
   id: number;
@@ -95,7 +96,6 @@ export type ReportsStatusNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__reportsStatusRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type ReportsStatusFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -395,16 +395,6 @@ function buildClearSessionCookie() {
   });
 }
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 function createAuditRequestLike(
   request: FastifyRequest,

--- a/test/reports-status-session-last-access-contract.test.ts
+++ b/test/reports-status-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "reports-status.fastify.ts"),
+  "utf8",
+);
+
+test("reports status route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate reports status session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep CORS, cookies, permissions, status transitions, audit and response payloads unchanged.
- Add route contract coverage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
