### PR TITLE
refactor(admin): use shared session last access helper in token routes

### DIFF
--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -36,6 +36,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -117,7 +118,6 @@ export type AdminReportAccessTokensNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__adminReportAccessTokensRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type AdminReportAccessTokensFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -410,16 +410,6 @@ function setMutationRateLimitHeaders(
 }
 
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 function createAuditRequestLike(
   request: FastifyRequest,

--- a/test/admin-report-access-tokens-session-last-access-contract.test.ts
+++ b/test/admin-report-access-tokens-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "admin-report-access-tokens.fastify.ts"),
+  "utf8",
+);
+
+test("admin report access tokens route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate admin report access token session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep CORS, cookies, rate-limit, admin auth, token create/revoke, audit and response payloads unchanged.
- Add route contract coverage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
