### PR TITLE
refactor(admin): use shared session last access helper in reports

### DIFF
--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -24,6 +24,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -106,7 +107,6 @@ export type AdminReportsNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminReportsRequestTimer";
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type AdminReportsFastifyRequest = FastifyRequest & {
@@ -428,16 +428,6 @@ function buildClearAdminSessionCookie() {
   });
 }
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 async function authenticateAdminUser(
   request: FastifyRequest,

--- a/test/admin-reports-session-last-access-contract.test.ts
+++ b/test/admin-reports-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "admin-reports.fastify.ts"),
+  "utf8",
+);
+
+test("admin reports route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate admin reports session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep CORS, cookies, multipart upload, storage, upsert, audit and response payloads unchanged.
- Add route contract coverage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
