### PR TITLE
refactor(particular): use shared session last access helper in auth

### DIFF
--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -26,6 +26,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ParticularSessionRecord = {
   particularTokenId: number;
@@ -82,7 +83,6 @@ export type ParticularAuthNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__particularAuthRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type ParticularAuthFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -382,16 +382,6 @@ function setLoginRateLimitHeaders(
 }
 
 
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
-}
 
 async function buildParticularResponse(
   deps: NativeParticularAuthDeps,

--- a/test/particular-auth-session-last-access-contract.test.ts
+++ b/test/particular-auth-session-last-access-contract.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const routeSource = readFileSync(
+  resolve(process.cwd(), "server", "routes", "particular-auth.fastify.ts"),
+  "utf8",
+);
+
+test("particular auth route uses shared session last access helper", () => {
+  assert.match(
+    routeSource,
+    /import \{ shouldRefreshSessionLastAccess \} from "\.\.\/lib\/session-last-access\.ts";/,
+  );
+  assert.match(
+    routeSource,
+    /shouldRefreshSessionLastAccess\(session\.lastAccess \?\? null, now\(\)\)/,
+  );
+  assert.doesNotMatch(routeSource, /SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS/);
+  assert.doesNotMatch(routeSource, /function shouldRefreshSessionLastAccess/);
+});


### PR DESCRIPTION
## Summary
- Migrate particular auth session refresh checks to the shared session last-access helper.
- Remove the route-local refresh interval and helper implementation.
- Keep CORS, cookies, login, rate-limit, token validation, signed URLs and response payloads unchanged.
- Add route contract coverage.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
