### PR TITLE
refactor(logistics): use shared session last access helper in field visits

### DIFF
--- a/server/routes/logistics-field-visits.fastify.ts
+++ b/server/routes/logistics-field-visits.fastify.ts
@@ -28,6 +28,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -108,7 +109,6 @@ type NativeLogisticsFieldVisitsDeps = Required<
   >
 >;
 
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 let defaultDepsPromise: Promise<NativeLogisticsFieldVisitsDeps> | undefined;
@@ -370,17 +370,6 @@ function buildClearSessionCookie(): string {
     maxAgeSeconds: 0,
     expires: "Thu, 01 Jan 1970 00:00:00 GMT",
   });
-}
-
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-): boolean {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
 }
 
 async function authenticateClinicUser(


### PR DESCRIPTION
## Summary
- Replace local logistics field visits session last access refresh helper with shared helper.
- Remove duplicated session last access interval constant.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build