### PR TITLE
refactor(logistics): use shared session last access helper in route events

### DIFF
--- a/server/routes/logistics-route-events.fastify.ts
+++ b/server/routes/logistics-route-events.fastify.ts
@@ -25,6 +25,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -95,7 +96,6 @@ type NativeLogisticsRouteEventsDeps = Required<
   >
 >;
 
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 let defaultDepsPromise: Promise<NativeLogisticsRouteEventsDeps> | undefined;
@@ -356,17 +356,6 @@ function buildClearSessionCookie(): string {
     maxAgeSeconds: 0,
     expires: "Thu, 01 Jan 1970 00:00:00 GMT",
   });
-}
-
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-): boolean {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
 }
 
 async function authenticateClinicUser(


### PR DESCRIPTION
## Summary
- Replace local logistics route events session last access refresh helper with shared helper.
- Remove duplicated session last access interval constant.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build