### PR TITLE
refactor(particular): use shared session last access helper in tokens

### DIFF
--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -28,6 +28,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ClinicUserRecord = {
   id: number;
@@ -106,7 +107,6 @@ export type ParticularTokensNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__particularTokensRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type ParticularTokensFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -360,17 +360,6 @@ function buildClearSessionCookie() {
     maxAgeSeconds: 0,
     expires: "Thu, 01 Jan 1970 00:00:00 GMT",
   });
-}
-
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
 }
 
 async function authenticateClinicUser(


### PR DESCRIPTION
## Summary
- Replace local particular tokens session last access refresh helper with shared helper.
- Remove duplicated session last access interval constant.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build