### PR TITLE
feat(admin): add system health read endpoint

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -29,6 +29,9 @@ import {
   type AdminStudyTrackingNativeRoutesOptions,
 } from "./routes/admin-study-tracking.fastify.ts";
 import {
+  adminSystemHealthNativeRoutes,
+  type AdminSystemHealthNativeRoutesOptions,
+} from "./routes/admin-system-health.fastify.ts";import {
   clinicAuthNativeRoutes,
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
@@ -169,6 +172,7 @@ export type CreateFastifyAppOptions = {
   adminReportsRoutes?: AdminReportsNativeRoutesOptions;
   adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
   adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
+  adminSystemHealthRoutes?: AdminSystemHealthNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
@@ -293,6 +297,11 @@ export async function createFastifyApp(
   await app.register(adminStudyTrackingNativeRoutes, {
     prefix: "/api/admin/study-tracking",
     ...(options.adminStudyTrackingRoutes ?? {}),
+  });
+
+  await app.register(adminSystemHealthNativeRoutes, {
+    prefix: "/api/admin/system/health",
+    ...(options.adminSystemHealthRoutes ?? {}),
   });
 
   await app.register(clinicAuthNativeRoutes, {

--- a/server/routes/admin-system-health.fastify.ts
+++ b/server/routes/admin-system-health.fastify.ts
@@ -1,0 +1,311 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type SystemHealthSnapshot = {
+  statusCode: number;
+  payload: Record<string, unknown>;
+};
+
+export type AdminSystemHealthNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getSystemHealthSnapshot?: () => Promise<SystemHealthSnapshot>;
+  getBackendVersion?: () => string;
+  now?: () => number;
+};
+
+type NativeAdminSystemHealthDeps = Required<
+  Pick<
+    AdminSystemHealthNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getSystemHealthSnapshot"
+    | "getBackendVersion"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminSystemHealthDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminSystemHealthDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const httpRuntime = await import("../lib/http-runtime.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getSystemHealthSnapshot: httpRuntime.getHealthCheckResponse,
+        getBackendVersion: () => process.env.npm_package_version ?? "unknown",
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminSystemHealthDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+function toMegabytes(value: number) {
+  return Math.round((value / 1024 / 1024) * 100) / 100;
+}
+
+function buildRuntimePayload() {
+  const memory = process.memoryUsage();
+
+  return {
+    uptimeSeconds: Math.round(process.uptime()),
+    memory: {
+      rssMb: toMegabytes(memory.rss),
+      heapTotalMb: toMegabytes(memory.heapTotal),
+      heapUsedMb: toMegabytes(memory.heapUsed),
+      externalMb: toMegabytes(memory.external),
+      arrayBuffersMb: toMegabytes(memory.arrayBuffers),
+    },
+  };
+}
+
+export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
+  AdminSystemHealthNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getSystemHealthSnapshot &&
+    !!options.getBackendVersion;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminSystemHealthDeps = {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById:
+      options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    hashSessionToken:
+      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getSystemHealthSnapshot:
+      options.getSystemHealthSnapshot ?? defaultDeps!.getSystemHealthSnapshot,
+    getBackendVersion:
+      options.getBackendVersion ?? defaultDeps!.getBackendVersion,
+  };
+
+  const now = options.now ?? (() => Date.now());
+
+  app.get("/", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const health = await deps.getSystemHealthSnapshot();
+    const healthPayload = health.payload;
+
+    const status =
+      typeof healthPayload.status === "string" ? healthPayload.status : "unknown";
+
+    return reply.code(health.statusCode).send({
+      success: health.statusCode >= 200 && health.statusCode < 400,
+      status,
+      version: deps.getBackendVersion(),
+      checkedBy: {
+        adminUserId: admin.id,
+        username: admin.username,
+      },
+      services: healthPayload.checks ?? {},
+      runtime: buildRuntimePayload(),
+      health: healthPayload,
+    });
+  });
+};

--- a/test/admin-system-health.fastify.test.ts
+++ b/test/admin-system-health.fastify.test.ts
@@ -2,8 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify from "fastify";
 
-import { ENV } from "../server/lib/env.ts";
-import { adminSystemHealthNativeRoutes } from "../server/routes/admin-system-health.fastify.ts";
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminSystemHealthNativeRoutes } = await import(
+  "../server/routes/admin-system-health.fastify.ts"
+);
 
 test("admin system health requiere sesión admin", async () => {
   const app = Fastify();

--- a/test/admin-system-health.fastify.test.ts
+++ b/test/admin-system-health.fastify.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+import { ENV } from "../server/lib/env.ts";
+import { adminSystemHealthNativeRoutes } from "../server/routes/admin-system-health.fastify.ts";
+
+test("admin system health requiere sesión admin", async () => {
+  const app = Fastify();
+
+  await app.register(adminSystemHealthNativeRoutes, {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSystemHealthSnapshot: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+        checks: {
+          database: "up",
+          storage: "up",
+        },
+      },
+    }),
+    getBackendVersion: () => "test-version",
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin system health expone servicios, runtime y versión para admin autenticado", async () => {
+  const app = Fastify();
+  let updatedLastAccess = false;
+
+  await app.register(adminSystemHealthNativeRoutes, {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {
+      updatedLastAccess = true;
+    },
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSystemHealthSnapshot: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+        checks: {
+          database: "up",
+          storage: "up",
+        },
+        uptimeSeconds: 123,
+        responseTimeMs: 5,
+        timestamp: "2026-05-07T00:00:00.000Z",
+      },
+    }),
+    getBackendVersion: () => "2.1.0-test",
+    now: () => Date.UTC(2026, 4, 7, 0, 0, 0),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.status, "ok");
+    assert.equal(body.version, "2.1.0-test");
+    assert.deepEqual(body.services, {
+      database: "up",
+      storage: "up",
+    });
+    assert.deepEqual(body.checkedBy, {
+      adminUserId: 1,
+      username: "VETNEB",
+    });
+    assert.equal(typeof body.runtime.uptimeSeconds, "number");
+    assert.equal(typeof body.runtime.memory.rssMb, "number");
+    assert.equal(body.health.status, "ok");
+    assert.equal(updatedLastAccess, true);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -584,6 +584,27 @@ function buildLogisticsSlaRouteStubs() {
     }),
   };
 }
+function buildAdminSystemHealthRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSystemHealthSnapshot: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+        checks: {
+          database: "up",
+          storage: "up",
+        },
+      },
+    }),
+    getBackendVersion: () => "test-version",
+  };
+}
 function buildFastifyDispatchRouteStubs() {
   return {
     adminAuditRoutes: buildAdminAuditRouteStubs(),
@@ -592,6 +613,7 @@ function buildFastifyDispatchRouteStubs() {
     adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
     adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
     clinicAuthRoutes: buildClinicAuthRouteStubs(),
     clinicAuditRoutes: buildClinicAuditRouteStubs(),
     clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -641,6 +663,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -750,6 +773,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -820,6 +844,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -881,6 +906,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: {
         ...buildClinicAuthRouteStubs(),
         getActiveSessionByToken: async () => ({
@@ -963,6 +989,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
         ...buildClinicAuditRouteStubs(),
@@ -1075,6 +1102,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: {
@@ -1171,6 +1199,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1278,6 +1307,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1346,6 +1376,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1463,6 +1494,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1626,6 +1658,7 @@ test(
         ],
       },
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1724,6 +1757,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1782,6 +1816,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -1898,6 +1933,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -2018,6 +2054,7 @@ test(
       adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: buildClinicAuthRouteStubs(),
       clinicAuditRoutes: buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
@@ -2279,6 +2316,61 @@ test(
           },
           profileQualityScore: 0.91,
         },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp despacha /api/admin/system/health al router nativo",
+  async () => {
+    const app = await createFastifyApp({
+      ...buildFastifyDispatchRouteStubs(),
+      adminSystemHealthRoutes: {
+        ...buildAdminSystemHealthRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "VETNEB",
+        }),
+        getSystemHealthSnapshot: async () => ({
+          statusCode: 200,
+          payload: {
+            success: true,
+            status: "ok",
+            checks: {
+              database: "up",
+              storage: "up",
+            },
+          },
+        }),
+        getBackendVersion: () => "2.1.0-test",
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/system/health",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      const body = JSON.parse(response.body);
+      assert.equal(body.success, true);
+      assert.equal(body.version, "2.1.0-test");
+      assert.deepEqual(body.services, {
+        database: "up",
+        storage: "up",
       });
     } finally {
       await app.close();


### PR DESCRIPTION
## Summary
- Add authenticated admin system health endpoint.
- Expose backend version, service checks, runtime uptime and memory usage.
- Reuse existing native health snapshot for DB and Storage status.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build