### PR TITLE
feat(admin): add maintenance purge dry-run endpoint

### DIFF
--- a/server/db-maintenance.ts
+++ b/server/db-maintenance.ts
@@ -1,0 +1,123 @@
+import { lte, sql } from "drizzle-orm";
+
+import { db } from "./db.ts";
+import {
+  activeSessions,
+  adminSessions,
+  particularSessions,
+} from "../drizzle/schema";
+
+export type MaintenancePurgeCandidateGroup = {
+  category:
+    | "expired_clinic_sessions"
+    | "expired_admin_sessions"
+    | "expired_particular_sessions"
+    | "storage_orphans";
+  label: string;
+  count: number;
+  supported: boolean;
+  destructiveAction: string | null;
+  reason?: string;
+};
+
+export type MaintenancePurgeDryRunSnapshot = {
+  dryRun: true;
+  generatedAt: string;
+  candidates: MaintenancePurgeCandidateGroup[];
+  totals: {
+    candidateRecords: number;
+    supportedCandidateRecords: number;
+    unsupportedGroups: number;
+  };
+};
+
+async function countExpiredClinicSessions(now: Date): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(activeSessions)
+    .where(lte(activeSessions.expiresAt, now));
+
+  return Number(row?.count ?? 0);
+}
+
+async function countExpiredAdminSessions(now: Date): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(adminSessions)
+    .where(lte(adminSessions.expiresAt, now));
+
+  return Number(row?.count ?? 0);
+}
+
+async function countExpiredParticularSessions(now: Date): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(particularSessions)
+    .where(lte(particularSessions.expiresAt, now));
+
+  return Number(row?.count ?? 0);
+}
+
+export async function getMaintenancePurgeDryRunSnapshot(
+  now = new Date(),
+): Promise<MaintenancePurgeDryRunSnapshot> {
+  const [
+    expiredClinicSessions,
+    expiredAdminSessions,
+    expiredParticularSessions,
+  ] = await Promise.all([
+    countExpiredClinicSessions(now),
+    countExpiredAdminSessions(now),
+    countExpiredParticularSessions(now),
+  ]);
+
+  const candidates: MaintenancePurgeCandidateGroup[] = [
+    {
+      category: "expired_clinic_sessions",
+      label: "Sesiones de clínica expiradas",
+      count: expiredClinicSessions,
+      supported: true,
+      destructiveAction: "deleteExpiredSessions",
+    },
+    {
+      category: "expired_admin_sessions",
+      label: "Sesiones admin expiradas",
+      count: expiredAdminSessions,
+      supported: true,
+      destructiveAction: "deleteExpiredAdminSessions",
+    },
+    {
+      category: "expired_particular_sessions",
+      label: "Sesiones particulares expiradas",
+      count: expiredParticularSessions,
+      supported: true,
+      destructiveAction: "deleteExpiredParticularSessions",
+    },
+    {
+      category: "storage_orphans",
+      label: "Archivos huérfanos en Storage",
+      count: 0,
+      supported: false,
+      destructiveAction: null,
+      reason:
+        "Dry-run de Storage pendiente: falta helper seguro para listar objetos remotos antes de comparar contra referencias DB.",
+    },
+  ];
+
+  const supportedCandidates = candidates.filter((item) => item.supported);
+  const unsupportedGroups = candidates.filter((item) => !item.supported);
+
+  return {
+    dryRun: true,
+    generatedAt: now.toISOString(),
+    candidates,
+    totals: {
+      candidateRecords: candidates.reduce((sum, item) => sum + item.count, 0),
+      supportedCandidateRecords: supportedCandidates.reduce(
+        (sum, item) => sum + item.count,
+        0,
+      ),
+      unsupportedGroups: unsupportedGroups.length,
+    },
+  };
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -31,7 +31,12 @@ import {
 import {
   adminSystemHealthNativeRoutes,
   type AdminSystemHealthNativeRoutesOptions,
-} from "./routes/admin-system-health.fastify.ts";import {
+} from "./routes/admin-system-health.fastify.ts";
+import {
+  adminSystemMaintenanceNativeRoutes,
+  type AdminSystemMaintenanceNativeRoutesOptions,
+} from "./routes/admin-system-maintenance.fastify.ts";
+import {
   clinicAuthNativeRoutes,
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
@@ -173,6 +178,7 @@ export type CreateFastifyAppOptions = {
   adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
   adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
   adminSystemHealthRoutes?: AdminSystemHealthNativeRoutesOptions;
+  adminSystemMaintenanceRoutes?: AdminSystemMaintenanceNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
@@ -302,6 +308,11 @@ export async function createFastifyApp(
   await app.register(adminSystemHealthNativeRoutes, {
     prefix: "/api/admin/system/health",
     ...(options.adminSystemHealthRoutes ?? {}),
+  });
+
+  await app.register(adminSystemMaintenanceNativeRoutes, {
+    prefix: "/api/admin/system/maintenance",
+    ...(options.adminSystemMaintenanceRoutes ?? {}),
   });
 
   await app.register(clinicAuthNativeRoutes, {

--- a/server/routes/admin-system-maintenance.fastify.ts
+++ b/server/routes/admin-system-maintenance.fastify.ts
@@ -1,0 +1,283 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import type { MaintenancePurgeDryRunSnapshot } from "../db-maintenance.ts";
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+export type AdminSystemMaintenanceNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getMaintenancePurgeDryRunSnapshot?: (
+    now: Date,
+  ) => Promise<MaintenancePurgeDryRunSnapshot>;
+  now?: () => number;
+};
+
+type NativeAdminSystemMaintenanceDeps = Required<
+  Pick<
+    AdminSystemMaintenanceNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getMaintenancePurgeDryRunSnapshot"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminSystemMaintenanceDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminSystemMaintenanceDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const maintenance = await import("../db-maintenance.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getMaintenancePurgeDryRunSnapshot:
+          maintenance.getMaintenancePurgeDryRunSnapshot,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminSystemMaintenanceDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+export const adminSystemMaintenanceNativeRoutes: FastifyPluginAsync<
+  AdminSystemMaintenanceNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+
+  async function resolveDeps(): Promise<NativeAdminSystemMaintenanceDeps> {
+    const hasAllInjectedDeps =
+      !!options.deleteAdminSession &&
+      !!options.getAdminSessionByToken &&
+      !!options.getAdminUserById &&
+      !!options.updateAdminSessionLastAccess &&
+      !!options.hashSessionToken &&
+      !!options.getMaintenancePurgeDryRunSnapshot;
+
+    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+    return {
+      deleteAdminSession:
+        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+      getAdminSessionByToken:
+        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+      getAdminUserById:
+        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      updateAdminSessionLastAccess:
+        options.updateAdminSessionLastAccess ??
+        defaultDeps!.updateAdminSessionLastAccess,
+      hashSessionToken:
+        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+      getMaintenancePurgeDryRunSnapshot:
+        options.getMaintenancePurgeDryRunSnapshot ??
+        defaultDeps!.getMaintenancePurgeDryRunSnapshot,
+    };
+  }
+
+  app.post("/purge-dry-run", async (request, reply) => {
+    const deps = await resolveDeps();
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const snapshot = await deps.getMaintenancePurgeDryRunSnapshot(
+      new Date(now()),
+    );
+
+    return reply.code(200).send({
+      success: true,
+      checkedBy: {
+        adminUserId: admin.id,
+        username: admin.username,
+      },
+      ...snapshot,
+    });
+  });
+};

--- a/test/admin-system-maintenance.fastify.test.ts
+++ b/test/admin-system-maintenance.fastify.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminSystemMaintenanceNativeRoutes } = await import(
+  "../server/routes/admin-system-maintenance.fastify.ts"
+);
+
+test("admin maintenance purge dry-run requiere sesión admin", async () => {
+  const app = Fastify();
+
+  await app.register(adminSystemMaintenanceNativeRoutes, {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getMaintenancePurgeDryRunSnapshot: async () => ({
+      dryRun: true,
+      generatedAt: "2026-05-07T00:00:00.000Z",
+      candidates: [],
+      totals: {
+        candidateRecords: 0,
+        supportedCandidateRecords: 0,
+        unsupportedGroups: 0,
+      },
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/purge-dry-run",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin maintenance purge dry-run devuelve candidatos sin borrar", async () => {
+  const app = Fastify();
+  let updatedLastAccess = false;
+
+  await app.register(adminSystemMaintenanceNativeRoutes, {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {
+      updatedLastAccess = true;
+    },
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getMaintenancePurgeDryRunSnapshot: async () => ({
+      dryRun: true,
+      generatedAt: "2026-05-07T00:00:00.000Z",
+      candidates: [
+        {
+          category: "expired_clinic_sessions",
+          label: "Sesiones de clínica expiradas",
+          count: 2,
+          supported: true,
+          destructiveAction: "deleteExpiredSessions",
+        },
+        {
+          category: "storage_orphans",
+          label: "Archivos huérfanos en Storage",
+          count: 0,
+          supported: false,
+          destructiveAction: null,
+          reason: "Storage listing pendiente",
+        },
+      ],
+      totals: {
+        candidateRecords: 2,
+        supportedCandidateRecords: 2,
+        unsupportedGroups: 1,
+      },
+    }),
+    now: () => Date.UTC(2026, 4, 7, 0, 0, 0),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/purge-dry-run",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.dryRun, true);
+    assert.deepEqual(body.checkedBy, {
+      adminUserId: 1,
+      username: "VETNEB",
+    });
+    assert.equal(body.candidates.length, 2);
+    assert.equal(body.totals.candidateRecords, 2);
+    assert.equal(body.totals.unsupportedGroups, 1);
+    assert.equal(updatedLastAccess, true);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary
- Add authenticated admin maintenance purge dry-run endpoint.
- Report expired clinic, admin and particular session cleanup candidates without deleting data.
- Mark Storage orphan cleanup as unsupported until safe object listing is implemented.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build