### PR TITLE
feat(admin): add maintenance dry-run card

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getAdminMaintenancePurgeDryRun } from "@/lib/api";
+import type {
+  MaintenancePurgeCandidateGroup,
+  MaintenancePurgeDryRunSnapshot,
+} from "@/types";
+
+function formatGeneratedAt(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("es-AR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function getCandidateVariant(
+  candidate: MaintenancePurgeCandidateGroup,
+): "default" | "secondary" | "destructive" | "outline" {
+  return candidate.supported ? "secondary" : "outline";
+}
+
+function formatSupportLabel(candidate: MaintenancePurgeCandidateGroup) {
+  return candidate.supported ? "Soportado" : "No soportado";
+}
+
+function MaintenanceCandidateRow({
+  candidate,
+}: {
+  candidate: MaintenancePurgeCandidateGroup;
+}) {
+  return (
+    <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-gray-800">
+            {candidate.label}
+          </p>
+          <p className="mt-1 font-mono text-xs text-gray-400">
+            {candidate.category}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={getCandidateVariant(candidate)}>
+            {formatSupportLabel(candidate)}
+          </Badge>
+          <span className="text-lg font-bold text-gray-900">
+            {candidate.count}
+          </span>
+        </div>
+      </div>
+
+      {candidate.destructiveAction ? (
+        <p className="mt-2 text-xs text-gray-400">
+          Acción futura:{" "}
+          <span className="font-mono">{candidate.destructiveAction}</span>
+        </p>
+      ) : null}
+
+      {candidate.reason ? (
+        <p className="mt-2 text-xs text-amber-700">{candidate.reason}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function AdminMaintenanceDryRunCard() {
+  const [snapshot, setSnapshot] =
+    useState<MaintenancePurgeDryRunSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleAnalyze() {
+    setError(null);
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          const result = await getAdminMaintenancePurgeDryRun();
+          setSnapshot(result);
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "No se pudo analizar la limpieza.",
+          );
+        }
+      })();
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <CardTitle className="text-base">
+            Mantenimiento seguro dry-run
+          </CardTitle>
+          <CardDescription>
+            Analiza candidatos de limpieza sin borrar registros ni archivos.
+          </CardDescription>
+        </div>
+        <Button type="button" onClick={handleAnalyze} disabled={isPending}>
+          {isPending ? "Analizando..." : "Analizar limpieza"}
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        ) : null}
+
+        {!snapshot ? (
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+            Sin análisis ejecutado. Presioná{" "}
+            <span className="font-semibold">Analizar limpieza</span> para
+            consultar el endpoint dry-run.
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Dry-run</p>
+                <Badge variant={snapshot.dryRun ? "default" : "destructive"}>
+                  {snapshot.dryRun ? "true" : "false"}
+                </Badge>
+              </div>
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Candidatos totales</p>
+                <p className="mt-1 text-2xl font-bold text-gray-900">
+                  {snapshot.totals.candidateRecords}
+                </p>
+              </div>
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Candidatos soportados</p>
+                <p className="mt-1 text-2xl font-bold text-gray-900">
+                  {snapshot.totals.supportedCandidateRecords}
+                </p>
+              </div>
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Grupos no soportados</p>
+                <p className="mt-1 text-2xl font-bold text-gray-900">
+                  {snapshot.totals.unsupportedGroups}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1 text-xs text-gray-400">
+              <p>Generado: {formatGeneratedAt(snapshot.generatedAt)}</p>
+              {snapshot.checkedBy ? (
+                <p>
+                  Admin: {snapshot.checkedBy.username} #
+                  {snapshot.checkedBy.adminUserId}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-3">
+              {snapshot.candidates.map((candidate) => (
+                <MaintenanceCandidateRow
+                  key={candidate.category}
+                  candidate={candidate}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -17,6 +17,7 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
+import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 
@@ -119,7 +120,7 @@ export default async function AdminPage() {
       />
       <main className="flex-1 p-6 space-y-6">
         <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
-          Lectura conectada a <code>GET /api/admin/audit-log</code> y <code>GET /api/admin/system/health</code>.
+          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -207,7 +208,7 @@ export default async function AdminPage() {
             </div>
           </CardContent>
         </Card>
-
+        <AdminMaintenanceDryRunCard />
 
         <Card>
           <CardHeader>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   LoginCredentials,
   DashboardStats,
   SystemHealth,
+  MaintenancePurgeDryRunSnapshot,
 } from "@/types";
 
 import {
@@ -216,6 +217,18 @@ export async function getAdminSystemHealth(
     return null;
   }
 }
+export async function getAdminMaintenancePurgeDryRun(
+  options?: RequestInit,
+): Promise<MaintenancePurgeDryRunSnapshot> {
+  return apiFetch<MaintenancePurgeDryRunSnapshot>(
+    "/api/admin/system/maintenance/purge-dry-run",
+    {
+      ...options,
+      method: "POST",
+    },
+  );
+}
+
 export async function getDashboardStats(
   options?: RequestInit,
 ): Promise<DashboardStats> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -185,6 +185,38 @@ export type DashboardStats = {
   activeVisits: number;
   activePlans: number;
 };
+
+export type MaintenancePurgeCandidateCategory =
+  | "expired_clinic_sessions"
+  | "expired_admin_sessions"
+  | "expired_particular_sessions"
+  | "storage_orphans";
+
+export type MaintenancePurgeCandidateGroup = {
+  category: MaintenancePurgeCandidateCategory;
+  label: string;
+  count: number;
+  supported: boolean;
+  destructiveAction: string | null;
+  reason?: string;
+};
+
+export type MaintenancePurgeDryRunSnapshot = {
+  success: boolean;
+  dryRun: true;
+  generatedAt: string;
+  checkedBy?: {
+    adminUserId: number;
+    username: string;
+  };
+  candidates: MaintenancePurgeCandidateGroup[];
+  totals: {
+    candidateRecords: number;
+    supportedCandidateRecords: number;
+    unsupportedGroups: number;
+  };
+};
+
 export type SystemHealth = {
   success: boolean;
   status: string;


### PR DESCRIPTION
## Summary
- add Admin maintenance dry-run card
- add frontend API wrapper for POST /api/admin/system/maintenance/purge-dry-run
- show dryRun, candidate totals, supported candidates, unsupported groups and candidate groups

## Validation
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build