### PR TITLE
feat(admin): add read-only sessions endpoint

### DIFF
--- a/server/db-admin-sessions.ts
+++ b/server/db-admin-sessions.ts
@@ -1,0 +1,176 @@
+import { desc } from "drizzle-orm";
+
+import { db } from "./db.ts";
+import {
+  activeSessions,
+  adminSessions,
+  particularSessions,
+} from "../drizzle/schema";
+
+export type AdminSessionType = "admin" | "clinic" | "particular";
+export type AdminSessionStatus = "active" | "expired";
+
+export type AdminSessionSummary = {
+  sessionType: AdminSessionType;
+  sessionId: number;
+  actorType: "admin_user" | "clinic_user" | "particular_token";
+  actorId: number;
+  createdAt: string;
+  lastAccess: string | null;
+  expiresAt: string | null;
+  status: AdminSessionStatus;
+};
+
+export type AdminSessionsQuery = {
+  sessionType?: AdminSessionType;
+  status?: AdminSessionStatus;
+  limit?: number;
+  offset?: number;
+};
+
+export type AdminSessionsSnapshot = {
+  success: true;
+  sessions: AdminSessionSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+function normalizeLimit(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 50;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), 100);
+}
+
+function normalizeOffset(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(Math.trunc(value), 0);
+}
+
+function toIsoDate(value: Date | null | undefined) {
+  return value ? value.toISOString() : null;
+}
+
+function getSessionStatus(
+  expiresAt: Date | null | undefined,
+  now: Date,
+): AdminSessionStatus {
+  return expiresAt && expiresAt.getTime() <= now.getTime()
+    ? "expired"
+    : "active";
+}
+
+function sortSessionsDesc(
+  a: AdminSessionSummary,
+  b: AdminSessionSummary,
+) {
+  return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+}
+
+export async function getAdminSessionsSnapshot(
+  params: AdminSessionsQuery = {},
+  now = new Date(),
+): Promise<AdminSessionsSnapshot> {
+  const limit = normalizeLimit(params.limit);
+  const offset = normalizeOffset(params.offset);
+  const fetchLimit = limit + offset;
+
+  const includeAdmin =
+    params.sessionType === undefined || params.sessionType === "admin";
+  const includeClinic =
+    params.sessionType === undefined || params.sessionType === "clinic";
+  const includeParticular =
+    params.sessionType === undefined || params.sessionType === "particular";
+
+  const [adminRows, clinicRows, particularRows] = await Promise.all([
+    includeAdmin
+      ? db
+          .select({
+            sessionId: adminSessions.id,
+            actorId: adminSessions.adminUserId,
+            createdAt: adminSessions.createdAt,
+            lastAccess: adminSessions.lastAccess,
+            expiresAt: adminSessions.expiresAt,
+          })
+          .from(adminSessions)
+          .orderBy(desc(adminSessions.createdAt))
+          .limit(fetchLimit)
+      : Promise.resolve([]),
+    includeClinic
+      ? db
+          .select({
+            sessionId: activeSessions.id,
+            actorId: activeSessions.clinicUserId,
+            createdAt: activeSessions.createdAt,
+            lastAccess: activeSessions.lastAccess,
+            expiresAt: activeSessions.expiresAt,
+          })
+          .from(activeSessions)
+          .orderBy(desc(activeSessions.createdAt))
+          .limit(fetchLimit)
+      : Promise.resolve([]),
+    includeParticular
+      ? db
+          .select({
+            sessionId: particularSessions.id,
+            actorId: particularSessions.particularTokenId,
+            createdAt: particularSessions.createdAt,
+            lastAccess: particularSessions.lastAccess,
+            expiresAt: particularSessions.expiresAt,
+          })
+          .from(particularSessions)
+          .orderBy(desc(particularSessions.createdAt))
+          .limit(fetchLimit)
+      : Promise.resolve([]),
+  ]);
+
+  const sessions: AdminSessionSummary[] = [
+    ...adminRows.map((row) => ({
+      sessionType: "admin" as const,
+      sessionId: row.sessionId,
+      actorType: "admin_user" as const,
+      actorId: row.actorId,
+      createdAt: row.createdAt.toISOString(),
+      lastAccess: toIsoDate(row.lastAccess),
+      expiresAt: toIsoDate(row.expiresAt),
+      status: getSessionStatus(row.expiresAt, now),
+    })),
+    ...clinicRows.map((row) => ({
+      sessionType: "clinic" as const,
+      sessionId: row.sessionId,
+      actorType: "clinic_user" as const,
+      actorId: row.actorId,
+      createdAt: row.createdAt.toISOString(),
+      lastAccess: toIsoDate(row.lastAccess),
+      expiresAt: toIsoDate(row.expiresAt),
+      status: getSessionStatus(row.expiresAt, now),
+    })),
+    ...particularRows.map((row) => ({
+      sessionType: "particular" as const,
+      sessionId: row.sessionId,
+      actorType: "particular_token" as const,
+      actorId: row.actorId,
+      createdAt: row.createdAt.toISOString(),
+      lastAccess: toIsoDate(row.lastAccess),
+      expiresAt: toIsoDate(row.expiresAt),
+      status: getSessionStatus(row.expiresAt, now),
+    })),
+  ]
+    .filter((session) =>
+      params.status ? session.status === params.status : true,
+    )
+    .sort(sortSessionsDesc);
+
+  return {
+    success: true,
+    sessions: sessions.slice(offset, offset + limit),
+    total: sessions.length,
+    limit,
+    offset,
+  };
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -25,6 +25,10 @@ import {
   type AdminReportsNativeRoutesOptions,
 } from "./routes/admin-reports.fastify.ts";
 import {
+  adminSessionsNativeRoutes,
+  type AdminSessionsNativeRoutesOptions,
+} from "./routes/admin-sessions.fastify.ts";
+import {
   adminStudyTrackingNativeRoutes,
   type AdminStudyTrackingNativeRoutesOptions,
 } from "./routes/admin-study-tracking.fastify.ts";
@@ -175,6 +179,7 @@ export type CreateFastifyAppOptions = {
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   adminParticularTokensRoutes?: AdminParticularTokensNativeRoutesOptions;
   adminReportsRoutes?: AdminReportsNativeRoutesOptions;
+  adminSessionsRoutes?: AdminSessionsNativeRoutesOptions;
   adminReportAccessTokensRoutes?: AdminReportAccessTokensNativeRoutesOptions;
   adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
   adminSystemHealthRoutes?: AdminSystemHealthNativeRoutesOptions;
@@ -303,6 +308,11 @@ export async function createFastifyApp(
   await app.register(adminStudyTrackingNativeRoutes, {
     prefix: "/api/admin/study-tracking",
     ...(options.adminStudyTrackingRoutes ?? {}),
+  });
+
+  await app.register(adminSessionsNativeRoutes, {
+    prefix: "/api/admin/sessions",
+    ...(options.adminSessionsRoutes ?? {}),
   });
 
   await app.register(adminSystemHealthNativeRoutes, {

--- a/server/routes/admin-sessions.fastify.ts
+++ b/server/routes/admin-sessions.fastify.ts
@@ -1,0 +1,370 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import type {
+  AdminSessionsQuery,
+  AdminSessionsSnapshot,
+  AdminSessionStatus,
+  AdminSessionType,
+} from "../db-admin-sessions.ts";
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type AdminSessionsRequestQuery = {
+  sessionType?: string;
+  status?: string;
+  limit?: string;
+  offset?: string;
+};
+
+export type AdminSessionsNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getAdminSessionsSnapshot?: (
+    params: AdminSessionsQuery,
+    now: Date,
+  ) => Promise<AdminSessionsSnapshot>;
+  now?: () => number;
+};
+
+type NativeAdminSessionsDeps = Required<
+  Pick<
+    AdminSessionsNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getAdminSessionsSnapshot"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminSessionsDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminSessionsDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const adminSessions = await import("../db-admin-sessions.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getAdminSessionsSnapshot: adminSessions.getAdminSessionsSnapshot,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminSessionsDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+function parseSessionType(value: string | undefined) {
+  if (value === undefined) return undefined;
+
+  if (value === "admin" || value === "clinic" || value === "particular") {
+    return value satisfies AdminSessionType;
+  }
+
+  return null;
+}
+
+function parseSessionStatus(value: string | undefined) {
+  if (value === undefined) return undefined;
+
+  if (value === "active" || value === "expired") {
+    return value satisfies AdminSessionStatus;
+  }
+
+  return null;
+}
+
+function parseIntegerParam(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed)) {
+    return null;
+  }
+
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function parseSessionsQuery(query: AdminSessionsRequestQuery) {
+  const sessionType = parseSessionType(query.sessionType);
+  const status = parseSessionStatus(query.status);
+  const limit = parseIntegerParam(query.limit, 50, 1, 100);
+  const offset = parseIntegerParam(query.offset, 0, 0, 100_000);
+
+  if (
+    sessionType === null ||
+    status === null ||
+    limit === null ||
+    offset === null
+  ) {
+    return null;
+  }
+
+  return {
+    ...(sessionType ? { sessionType } : {}),
+    ...(status ? { status } : {}),
+    limit,
+    offset,
+  };
+}
+
+export const adminSessionsNativeRoutes: FastifyPluginAsync<
+  AdminSessionsNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+
+  async function resolveDeps(): Promise<NativeAdminSessionsDeps> {
+    const hasAllInjectedDeps =
+      !!options.deleteAdminSession &&
+      !!options.getAdminSessionByToken &&
+      !!options.getAdminUserById &&
+      !!options.updateAdminSessionLastAccess &&
+      !!options.hashSessionToken &&
+      !!options.getAdminSessionsSnapshot;
+
+    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+    return {
+      deleteAdminSession:
+        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+      getAdminSessionByToken:
+        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+      getAdminUserById:
+        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      updateAdminSessionLastAccess:
+        options.updateAdminSessionLastAccess ??
+        defaultDeps!.updateAdminSessionLastAccess,
+      hashSessionToken:
+        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+      getAdminSessionsSnapshot:
+        options.getAdminSessionsSnapshot ??
+        defaultDeps!.getAdminSessionsSnapshot,
+    };
+  }
+
+  app.get<{ Querystring: AdminSessionsRequestQuery }>(
+    "/",
+    async (request, reply) => {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const params = parseSessionsQuery(request.query);
+
+      if (!params) {
+        return reply.code(400).send({
+          success: false,
+          error:
+            "Query inválida. sessionType debe ser admin, clinic o particular; status debe ser active o expired; limit/offset deben ser enteros válidos.",
+        });
+      }
+
+      const snapshot = await deps.getAdminSessionsSnapshot(
+        params,
+        new Date(now()),
+      );
+
+      return reply.code(200).send({
+        ...snapshot,
+        checkedBy: {
+          adminUserId: admin.id,
+          username: admin.username,
+        },
+      });
+    },
+  );
+};

--- a/server/routes/admin-sessions.fastify.ts
+++ b/server/routes/admin-sessions.fastify.ts
@@ -237,21 +237,25 @@ async function authenticateAdminUser(
   };
 }
 
-function parseSessionType(value: string | undefined) {
+function parseSessionType(
+  value: string | undefined,
+): AdminSessionType | undefined | null {
   if (value === undefined) return undefined;
 
   if (value === "admin" || value === "clinic" || value === "particular") {
-    return value satisfies AdminSessionType;
+    return value;
   }
 
   return null;
 }
 
-function parseSessionStatus(value: string | undefined) {
+function parseSessionStatus(
+  value: string | undefined,
+): AdminSessionStatus | undefined | null {
   if (value === undefined) return undefined;
 
   if (value === "active" || value === "expired") {
-    return value satisfies AdminSessionStatus;
+    return value;
   }
 
   return null;
@@ -276,7 +280,9 @@ function parseIntegerParam(
   return Math.min(Math.max(parsed, min), max);
 }
 
-function parseSessionsQuery(query: AdminSessionsRequestQuery) {
+function parseSessionsQuery(
+  query: AdminSessionsRequestQuery,
+): AdminSessionsQuery | null {
   const sessionType = parseSessionType(query.sessionType);
   const status = parseSessionStatus(query.status);
   const limit = parseIntegerParam(query.limit, 50, 1, 100);

--- a/test/admin-sessions.fastify.test.ts
+++ b/test/admin-sessions.fastify.test.ts
@@ -13,6 +13,7 @@ const { ENV } = await import("../server/lib/env.ts");
 const { adminSessionsNativeRoutes } = await import(
   "../server/routes/admin-sessions.fastify.ts"
 );
+
 type AdminSessionsNativeRoutesOptions = import(
   "../server/routes/admin-sessions.fastify.ts"
 ).AdminSessionsNativeRoutesOptions;
@@ -22,6 +23,9 @@ type AdminSessionsQuery = import(
 type AdminSessionsSnapshot = import(
   "../server/db-admin-sessions.ts"
 ).AdminSessionsSnapshot;
+type AdminSessionSummary = import(
+  "../server/db-admin-sessions.ts"
+).AdminSessionSummary;
 
 function buildDeps(
   overrides: Partial<AdminSessionsNativeRoutesOptions> = {},
@@ -54,9 +58,12 @@ function buildDeps(
 test("admin sessions requiere sesión admin", async () => {
   const app = Fastify();
 
-  await app.register(adminSessionsNativeRoutes, buildDeps({
-    getAdminSessionByToken: async () => null,
-  }));
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      getAdminSessionByToken: async () => null,
+    }),
+  );
 
   try {
     const response = await app.inject({
@@ -77,40 +84,49 @@ test("admin sessions requiere sesión admin", async () => {
 test("admin sessions devuelve sesiones sanitizadas sin tokenHash", async () => {
   const app = Fastify();
 
-  await app.register(adminSessionsNativeRoutes, buildDeps({
-    getAdminSessionsSnapshot: async (
-      params: AdminSessionsQuery,
-    ): Promise<AdminSessionsSnapshot> => ({
-      success: true,
-      sessions: [
-        {
-          sessionType: "admin",
-          sessionId: 10,
-          actorType: "admin_user",
-          actorId: 1,
-          createdAt: "2026-05-08T00:00:00.000Z",
-          lastAccess: "2026-05-08T00:10:00.000Z",
-          expiresAt: "2099-01-01T00:00:00.000Z",
-          status: "active",
-        },
-        {
-          sessionType: "clinic",
-          sessionId: 20,
-          actorType: "clinic_user",
-          actorId: 7,
-          createdAt: "2026-05-07T00:00:00.000Z",
-          lastAccess: null,
-          expiresAt: "2026-05-07T01:00:00.000Z",
-          status: "expired",
-        },
-      ].filter((item) =>
-        params.status ? item.status === params.status : true,
-      ),
-      total: params.status === "active" ? 1 : 2,
-      limit: params.limit ?? 50,
-      offset: params.offset ?? 0,
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      getAdminSessionsSnapshot: async (
+        params: AdminSessionsQuery,
+      ): Promise<AdminSessionsSnapshot> => {
+        const sessions: AdminSessionSummary[] = [
+          {
+            sessionType: "admin",
+            sessionId: 10,
+            actorType: "admin_user",
+            actorId: 1,
+            createdAt: "2026-05-08T00:00:00.000Z",
+            lastAccess: "2026-05-08T00:10:00.000Z",
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            status: "active",
+          },
+          {
+            sessionType: "clinic",
+            sessionId: 20,
+            actorType: "clinic_user",
+            actorId: 7,
+            createdAt: "2026-05-07T00:00:00.000Z",
+            lastAccess: null,
+            expiresAt: "2026-05-07T01:00:00.000Z",
+            status: "expired",
+          },
+        ];
+
+        const filtered = sessions.filter((item) =>
+          params.status ? item.status === params.status : true,
+        );
+
+        return {
+          success: true,
+          sessions: filtered,
+          total: filtered.length,
+          limit: params.limit ?? 50,
+          offset: params.offset ?? 0,
+        };
+      },
     }),
-  }));
+  );
 
   try {
     const response = await app.inject({
@@ -146,18 +162,22 @@ test("admin sessions rechaza filtros inválidos", async () => {
   const app = Fastify();
   let snapshotCalled = false;
 
-  await app.register(adminSessionsNativeRoutes, buildDeps({
-    getAdminSessionsSnapshot: async (): Promise<AdminSessionsSnapshot> => {
-      snapshotCalled = true;
-      return {
-        success: true,
-        sessions: [],
-        total: 0,
-        limit: 50,
-        offset: 0,
-      };
-    },
-  }));
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      getAdminSessionsSnapshot: async (): Promise<AdminSessionsSnapshot> => {
+        snapshotCalled = true;
+
+        return {
+          success: true,
+          sessions: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        };
+      },
+    }),
+  );
 
   try {
     const response = await app.inject({

--- a/test/admin-sessions.fastify.test.ts
+++ b/test/admin-sessions.fastify.test.ts
@@ -13,8 +13,19 @@ const { ENV } = await import("../server/lib/env.ts");
 const { adminSessionsNativeRoutes } = await import(
   "../server/routes/admin-sessions.fastify.ts"
 );
+type AdminSessionsNativeRoutesOptions = import(
+  "../server/routes/admin-sessions.fastify.ts"
+).AdminSessionsNativeRoutesOptions;
+type AdminSessionsQuery = import(
+  "../server/db-admin-sessions.ts"
+).AdminSessionsQuery;
+type AdminSessionsSnapshot = import(
+  "../server/db-admin-sessions.ts"
+).AdminSessionsSnapshot;
 
-function buildDeps(overrides = {}) {
+function buildDeps(
+  overrides: Partial<AdminSessionsNativeRoutesOptions> = {},
+): AdminSessionsNativeRoutesOptions {
   return {
     deleteAdminSession: async () => {},
     getAdminSessionByToken: async () => ({
@@ -28,7 +39,7 @@ function buildDeps(overrides = {}) {
     }),
     updateAdminSessionLastAccess: async () => {},
     hashSessionToken: (token: string) => `hash:${token}`,
-    getAdminSessionsSnapshot: async () => ({
+    getAdminSessionsSnapshot: async (): Promise<AdminSessionsSnapshot> => ({
       success: true,
       sessions: [],
       total: 0,
@@ -67,7 +78,9 @@ test("admin sessions devuelve sesiones sanitizadas sin tokenHash", async () => {
   const app = Fastify();
 
   await app.register(adminSessionsNativeRoutes, buildDeps({
-    getAdminSessionsSnapshot: async (params) => ({
+    getAdminSessionsSnapshot: async (
+      params: AdminSessionsQuery,
+    ): Promise<AdminSessionsSnapshot> => ({
       success: true,
       sessions: [
         {
@@ -134,7 +147,7 @@ test("admin sessions rechaza filtros inválidos", async () => {
   let snapshotCalled = false;
 
   await app.register(adminSessionsNativeRoutes, buildDeps({
-    getAdminSessionsSnapshot: async () => {
+    getAdminSessionsSnapshot: async (): Promise<AdminSessionsSnapshot> => {
       snapshotCalled = true;
       return {
         success: true,

--- a/test/admin-sessions.fastify.test.ts
+++ b/test/admin-sessions.fastify.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminSessionsNativeRoutes } = await import(
+  "../server/routes/admin-sessions.fastify.ts"
+);
+
+function buildDeps(overrides = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-05-07T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getAdminSessionsSnapshot: async () => ({
+      success: true,
+      sessions: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    }),
+    now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
+    ...overrides,
+  };
+}
+
+test("admin sessions requiere sesión admin", async () => {
+  const app = Fastify();
+
+  await app.register(adminSessionsNativeRoutes, buildDeps({
+    getAdminSessionByToken: async () => null,
+  }));
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin sessions devuelve sesiones sanitizadas sin tokenHash", async () => {
+  const app = Fastify();
+
+  await app.register(adminSessionsNativeRoutes, buildDeps({
+    getAdminSessionsSnapshot: async (params) => ({
+      success: true,
+      sessions: [
+        {
+          sessionType: "admin",
+          sessionId: 10,
+          actorType: "admin_user",
+          actorId: 1,
+          createdAt: "2026-05-08T00:00:00.000Z",
+          lastAccess: "2026-05-08T00:10:00.000Z",
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          status: "active",
+        },
+        {
+          sessionType: "clinic",
+          sessionId: 20,
+          actorType: "clinic_user",
+          actorId: 7,
+          createdAt: "2026-05-07T00:00:00.000Z",
+          lastAccess: null,
+          expiresAt: "2026-05-07T01:00:00.000Z",
+          status: "expired",
+        },
+      ].filter((item) =>
+        params.status ? item.status === params.status : true,
+      ),
+      total: params.status === "active" ? 1 : 2,
+      limit: params.limit ?? 50,
+      offset: params.offset ?? 0,
+    }),
+  }));
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?status=active&limit=25&offset=0",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.deepEqual(body.checkedBy, {
+      adminUserId: 1,
+      username: "VETNEB",
+    });
+    assert.equal(body.sessions.length, 1);
+    assert.equal(body.sessions[0].sessionType, "admin");
+    assert.equal(body.sessions[0].status, "active");
+    assert.equal(body.sessions[0].tokenHash, undefined);
+    assert.equal(body.sessions[0].token, undefined);
+    assert.equal(body.sessions[0].cookie, undefined);
+    assert.equal(JSON.stringify(body).includes("hash:"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin sessions rechaza filtros inválidos", async () => {
+  const app = Fastify();
+  let snapshotCalled = false;
+
+  await app.register(adminSessionsNativeRoutes, buildDeps({
+    getAdminSessionsSnapshot: async () => {
+      snapshotCalled = true;
+      return {
+        success: true,
+        sessions: [],
+        total: 0,
+        limit: 50,
+        offset: 0,
+      };
+    },
+  }));
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?sessionType=unknown",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(snapshotCalled, false);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add read-only Admin sessions endpoint
- expose sanitized admin, clinic and particular session summaries
- support sessionType, status, limit and offset filters
- register GET /api/admin/sessions
- add contract tests for auth, sanitization and invalid filters

## Security
- does not expose tokenHash, raw tokens, cookies or secrets
- requires authenticated admin session
- read-only endpoint, no revocation or destructive action

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build