### PR TITLE
feat(admin): add read-only sessions UI

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getAdminSessions } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type {
+  AdminSessionStatus,
+  AdminSessionSummary,
+  AdminSessionType,
+  AdminSessionsSnapshot,
+} from "@/types";
+
+const PAGE_SIZE = 25;
+
+function formatOptionalDate(value: string | null) {
+  return value ? formatDateTime(value) : "—";
+}
+
+function formatSessionType(value: AdminSessionType) {
+  if (value === "admin") return "Admin";
+  if (value === "clinic") return "Clínica";
+  return "Particular";
+}
+
+function formatActorType(value: AdminSessionSummary["actorType"]) {
+  if (value === "admin_user") return "Admin";
+  if (value === "clinic_user") return "Clínica";
+  return "Token particular";
+}
+
+function getSessionTypeVariant(
+  value: AdminSessionType,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (value === "admin") return "default";
+  if (value === "clinic") return "secondary";
+  return "outline";
+}
+
+function getStatusVariant(
+  value: AdminSessionStatus,
+): "default" | "secondary" | "destructive" | "outline" {
+  return value === "active" ? "default" : "destructive";
+}
+
+function formatStatus(value: AdminSessionStatus) {
+  return value === "active" ? "Activa" : "Expirada";
+}
+
+export function AdminSessionsReadOnlyCard() {
+  const [snapshot, setSnapshot] = useState<AdminSessionsSnapshot | null>(null);
+  const [sessionType, setSessionType] = useState<AdminSessionType | "all">(
+    "all",
+  );
+  const [status, setStatus] = useState<AdminSessionStatus | "all">("all");
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const query = useMemo(
+    () => ({
+      ...(sessionType !== "all" ? { sessionType } : {}),
+      ...(status !== "all" ? { status } : {}),
+      limit: PAGE_SIZE,
+      offset,
+    }),
+    [offset, sessionType, status],
+  );
+
+  function loadSessions() {
+    setError(null);
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          const result = await getAdminSessions(query);
+          setSnapshot(result);
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "No se pudieron cargar las sesiones.",
+          );
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    loadSessions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const hasPreviousPage = offset > 0;
+  const hasNextPage = snapshot ? offset + snapshot.sessions.length < snapshot.total : false;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <CardTitle className="text-base">Sesiones activas y expiradas</CardTitle>
+          <CardDescription>
+            Vista read-only de sesiones Admin, clínica y particulares. No expone
+            tokens, hashes ni cookies.
+          </CardDescription>
+        </div>
+
+        <Button type="button" onClick={loadSessions} disabled={isPending}>
+          {isPending ? "Actualizando..." : "Actualizar"}
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Total filtrado</p>
+            <p className="mt-1 text-2xl font-bold text-gray-900">
+              {snapshot?.total ?? "—"}
+            </p>
+          </div>
+
+          <label className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <span className="text-xs text-gray-400">Tipo de sesión</span>
+            <select
+              className="mt-2 w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700"
+              value={sessionType}
+              onChange={(event) => {
+                setOffset(0);
+                setSessionType(event.target.value as AdminSessionType | "all");
+              }}
+            >
+              <option value="all">Todas</option>
+              <option value="admin">Admin</option>
+              <option value="clinic">Clínica</option>
+              <option value="particular">Particular</option>
+            </select>
+          </label>
+
+          <label className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <span className="text-xs text-gray-400">Estado</span>
+            <select
+              className="mt-2 w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700"
+              value={status}
+              onChange={(event) => {
+                setOffset(0);
+                setStatus(event.target.value as AdminSessionStatus | "all");
+              }}
+            >
+              <option value="all">Todos</option>
+              <option value="active">Activas</option>
+              <option value="expired">Expiradas</option>
+            </select>
+          </label>
+
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Página</p>
+            <p className="mt-1 text-sm font-semibold text-gray-700">
+              {Math.floor(offset / PAGE_SIZE) + 1}
+            </p>
+            <p className="mt-1 text-xs text-gray-400">
+              {snapshot ? `${snapshot.sessions.length} visibles` : "—"}
+            </p>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="overflow-hidden rounded-lg border border-gray-100">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Sesión</TableHead>
+                <TableHead>Actor</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead>Creada</TableHead>
+                <TableHead>Último acceso</TableHead>
+                <TableHead>Expira</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {snapshot?.sessions.length ? (
+                snapshot.sessions.map((session) => (
+                  <TableRow key={`${session.sessionType}-${session.sessionId}`}>
+                    <TableCell>
+                      <div className="flex flex-col gap-1">
+                        <Badge variant={getSessionTypeVariant(session.sessionType)}>
+                          {formatSessionType(session.sessionType)}
+                        </Badge>
+                        <span className="font-mono text-xs text-gray-400">
+                          #{session.sessionId}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-600">
+                      {formatActorType(session.actorType)} #{session.actorId}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getStatusVariant(session.status)}>
+                        {formatStatus(session.status)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-400">
+                      {formatOptionalDate(session.createdAt)}
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-400">
+                      {formatOptionalDate(session.lastAccess)}
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-400">
+                      {formatOptionalDate(session.expiresAt)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={6}
+                    className="py-8 text-center text-sm text-gray-400"
+                  >
+                    {isPending
+                      ? "Cargando sesiones..."
+                      : "No hay sesiones para los filtros seleccionados."}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <p className="text-xs text-gray-400">
+            Endpoint: <code>GET /api/admin/sessions</code>. Vista sin acciones
+            destructivas.
+          </p>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasPreviousPage || isPending}
+              onClick={() => setOffset(Math.max(offset - PAGE_SIZE, 0))}
+            >
+              Anterior
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasNextPage || isPending}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Siguiente
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -18,6 +18,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
+import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 
@@ -160,7 +161,7 @@ export default async function AdminPage() {
       />
       <main className="flex-1 p-6 space-y-6">
         <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
-          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
+          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code>, <code>GET /api/admin/sessions</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -276,6 +277,8 @@ export default async function AdminPage() {
           </CardContent>
         </Card>
         <AdminMaintenanceDryRunCard />
+        <AdminSessionsReadOnlyCard />
+
 
         <Card>
           <CardHeader>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,8 @@ import type {
   DashboardStats,
   SystemHealth,
   MaintenancePurgeDryRunSnapshot,
+  AdminSessionsQuery,
+  AdminSessionsSnapshot,
 } from "@/types";
 
 import {
@@ -217,6 +219,36 @@ export async function getAdminSystemHealth(
     return null;
   }
 }
+export async function getAdminSessions(
+  params: AdminSessionsQuery = {},
+  options?: RequestInit,
+): Promise<AdminSessionsSnapshot> {
+  const query = new URLSearchParams();
+
+  if (params.sessionType) {
+    query.set("sessionType", params.sessionType);
+  }
+
+  if (params.status) {
+    query.set("status", params.status);
+  }
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<AdminSessionsSnapshot>(
+    `/api/admin/sessions${qs ? `?${qs}` : ""}`,
+    options,
+  );
+}
+
 export async function getAdminMaintenancePurgeDryRun(
   options?: RequestInit,
 ): Promise<MaintenancePurgeDryRunSnapshot> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -186,6 +186,39 @@ export type DashboardStats = {
   activePlans: number;
 };
 
+export type AdminSessionType = "admin" | "clinic" | "particular";
+export type AdminSessionStatus = "active" | "expired";
+
+export type AdminSessionSummary = {
+  sessionType: AdminSessionType;
+  sessionId: number;
+  actorType: "admin_user" | "clinic_user" | "particular_token";
+  actorId: number;
+  createdAt: string;
+  lastAccess: string | null;
+  expiresAt: string | null;
+  status: AdminSessionStatus;
+};
+
+export type AdminSessionsQuery = {
+  sessionType?: AdminSessionType;
+  status?: AdminSessionStatus;
+  limit?: number;
+  offset?: number;
+};
+
+export type AdminSessionsSnapshot = {
+  success: true;
+  sessions: AdminSessionSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  checkedBy?: {
+    adminUserId: number;
+    username: string;
+  };
+};
+
 export type MaintenancePurgeCandidateCategory =
   | "expired_clinic_sessions"
   | "expired_admin_sessions"


### PR DESCRIPTION
## Summary
- add Admin read-only sessions card
- consume GET /api/admin/sessions from frontend
- show admin, clinic and particular sessions
- add sessionType/status filters and basic pagination
- keep the UI read-only without revocation actions

## Security
- does not display tokenHash, raw tokens, cookies or secrets
- no destructive actions
- sessions are displayed through sanitized backend response only

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend build