### PR TITLE
feat(admin): add audited session revocation endpoint

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -135,6 +135,7 @@ export type AuditActorType = (typeof AUDIT_ACTOR_TYPES)[number];
 export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
+  "auth.session.revoked",
   "report.status.changed",
   "report.uploaded",
   "study_tracking.case.created",

--- a/server/db-admin-sessions.ts
+++ b/server/db-admin-sessions.ts
@@ -1,4 +1,4 @@
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { db } from "./db.ts";
 import {
@@ -172,5 +172,131 @@ export async function getAdminSessionsSnapshot(
     total: sessions.length,
     limit,
     offset,
+  };
+}
+export type AdminSessionRevocationTarget = {
+  sessionType: AdminSessionType;
+  sessionId: number;
+};
+
+export type AdminSessionRevocationResult = AdminSessionSummary & {
+  revokedAt: string;
+};
+
+function buildAdminSessionSummary(input: {
+  sessionType: AdminSessionType;
+  sessionId: number;
+  actorType: AdminSessionSummary["actorType"];
+  actorId: number;
+  createdAt: Date;
+  lastAccess: Date | null;
+  expiresAt: Date | null;
+  now: Date;
+}): AdminSessionSummary {
+  return {
+    sessionType: input.sessionType,
+    sessionId: input.sessionId,
+    actorType: input.actorType,
+    actorId: input.actorId,
+    createdAt: input.createdAt.toISOString(),
+    lastAccess: toIsoDate(input.lastAccess),
+    expiresAt: toIsoDate(input.expiresAt),
+    status: getSessionStatus(input.expiresAt, input.now),
+  };
+}
+
+export async function revokeAdminSessionById(
+  target: AdminSessionRevocationTarget,
+  now = new Date(),
+): Promise<AdminSessionRevocationResult | null> {
+  if (target.sessionType === "admin") {
+    const result = await db
+      .delete(adminSessions)
+      .where(eq(adminSessions.id, target.sessionId))
+      .returning({
+        sessionId: adminSessions.id,
+        actorId: adminSessions.adminUserId,
+        createdAt: adminSessions.createdAt,
+        lastAccess: adminSessions.lastAccess,
+        expiresAt: adminSessions.expiresAt,
+      });
+
+    const row = result[0];
+
+    if (!row) return null;
+
+    return {
+      ...buildAdminSessionSummary({
+        sessionType: "admin",
+        sessionId: row.sessionId,
+        actorType: "admin_user",
+        actorId: row.actorId,
+        createdAt: row.createdAt,
+        lastAccess: row.lastAccess,
+        expiresAt: row.expiresAt,
+        now,
+      }),
+      revokedAt: now.toISOString(),
+    };
+  }
+
+  if (target.sessionType === "clinic") {
+    const result = await db
+      .delete(activeSessions)
+      .where(eq(activeSessions.id, target.sessionId))
+      .returning({
+        sessionId: activeSessions.id,
+        actorId: activeSessions.clinicUserId,
+        createdAt: activeSessions.createdAt,
+        lastAccess: activeSessions.lastAccess,
+        expiresAt: activeSessions.expiresAt,
+      });
+
+    const row = result[0];
+
+    if (!row) return null;
+
+    return {
+      ...buildAdminSessionSummary({
+        sessionType: "clinic",
+        sessionId: row.sessionId,
+        actorType: "clinic_user",
+        actorId: row.actorId,
+        createdAt: row.createdAt,
+        lastAccess: row.lastAccess,
+        expiresAt: row.expiresAt,
+        now,
+      }),
+      revokedAt: now.toISOString(),
+    };
+  }
+
+  const result = await db
+    .delete(particularSessions)
+    .where(eq(particularSessions.id, target.sessionId))
+    .returning({
+      sessionId: particularSessions.id,
+      actorId: particularSessions.particularTokenId,
+      createdAt: particularSessions.createdAt,
+      lastAccess: particularSessions.lastAccess,
+      expiresAt: particularSessions.expiresAt,
+    });
+
+  const row = result[0];
+
+  if (!row) return null;
+
+  return {
+    ...buildAdminSessionSummary({
+      sessionType: "particular",
+      sessionId: row.sessionId,
+      actorType: "particular_token",
+      actorId: row.actorId,
+      createdAt: row.createdAt,
+      lastAccess: row.lastAccess,
+      expiresAt: row.expiresAt,
+      now,
+    }),
+    revokedAt: now.toISOString(),
   };
 }

--- a/server/routes/admin-sessions.fastify.ts
+++ b/server/routes/admin-sessions.fastify.ts
@@ -9,11 +9,13 @@ import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import type {
   AdminSessionsQuery,
   AdminSessionsSnapshot,
+  AdminSessionRevocationResult,
   AdminSessionStatus,
   AdminSessionType,
 } from "../db-admin-sessions.ts";
 
 type AdminSessionRecord = {
+  id: number;
   adminUserId: number;
   expiresAt: Date | null;
   lastAccess?: Date | null;
@@ -27,6 +29,7 @@ type SessionAdminUserRecord = {
 type AuthenticatedAdminUser = {
   id: number;
   username: string;
+  sessionId: number;
   sessionToken: string;
 };
 
@@ -35,6 +38,27 @@ type AdminSessionsRequestQuery = {
   status?: string;
   limit?: string;
   offset?: string;
+};
+
+type AdminSessionRevokeParams = {
+  sessionType?: string;
+  sessionId?: string;
+};
+
+type CreateSessionAuditLogInput = {
+  event: "auth.session.revoked";
+  actorType: "admin_user";
+  actorAdminUserId: number;
+  targetAdminUserId?: number | null;
+  targetClinicUserId?: number | null;
+  requestMethod?: string | null;
+  requestPath?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  metadata?: Record<string, unknown> | null;
+  action?: string | null;
+  entity?: string | null;
+  entityId?: number | null;
 };
 
 export type AdminSessionsNativeRoutesOptions = {
@@ -51,6 +75,11 @@ export type AdminSessionsNativeRoutesOptions = {
     params: AdminSessionsQuery,
     now: Date,
   ) => Promise<AdminSessionsSnapshot>;
+  revokeAdminSessionById?: (
+    target: { sessionType: AdminSessionType; sessionId: number },
+    now: Date,
+  ) => Promise<AdminSessionRevocationResult | null>;
+  createAuditLog?: (input: CreateSessionAuditLogInput) => Promise<unknown>;
   now?: () => number;
 };
 
@@ -63,6 +92,8 @@ type NativeAdminSessionsDeps = Required<
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "getAdminSessionsSnapshot"
+    | "revokeAdminSessionById"
+    | "createAuditLog"
   >
 >;
 
@@ -74,6 +105,7 @@ async function loadDefaultDeps(): Promise<NativeAdminSessionsDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const adminSessions = await import("../db-admin-sessions.ts");
+      const audit = await import("../db-audit.ts");
 
       return {
         deleteAdminSession: db.deleteAdminSession,
@@ -82,6 +114,8 @@ async function loadDefaultDeps(): Promise<NativeAdminSessionsDeps> {
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         getAdminSessionsSnapshot: adminSessions.getAdminSessionsSnapshot,
+        revokeAdminSessionById: adminSessions.revokeAdminSessionById,
+        createAuditLog: audit.createAuditLog,
       };
     })();
   }
@@ -233,6 +267,7 @@ async function authenticateAdminUser(
   return {
     id: adminUser.id,
     username: adminUser.username,
+    sessionId: session.id,
     sessionToken: token,
   };
 }
@@ -280,6 +315,25 @@ function parseIntegerParam(
   return Math.min(Math.max(parsed, min), max);
 }
 
+function parseSessionId(value: string | undefined) {
+  if (value === undefined || value.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function getRequestUserAgent(request: FastifyRequest) {
+  const value = request.headers["user-agent"];
+
+  return typeof value === "string" ? value : null;
+}
 function parseSessionsQuery(
   query: AdminSessionsRequestQuery,
 ): AdminSessionsQuery | null {
@@ -317,7 +371,9 @@ export const adminSessionsNativeRoutes: FastifyPluginAsync<
       !!options.getAdminUserById &&
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
-      !!options.getAdminSessionsSnapshot;
+      !!options.getAdminSessionsSnapshot &&
+      !!options.revokeAdminSessionById &&
+      !!options.createAuditLog;
 
     const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -336,6 +392,9 @@ export const adminSessionsNativeRoutes: FastifyPluginAsync<
       getAdminSessionsSnapshot:
         options.getAdminSessionsSnapshot ??
         defaultDeps!.getAdminSessionsSnapshot,
+      revokeAdminSessionById:
+        options.revokeAdminSessionById ?? defaultDeps!.revokeAdminSessionById,
+      createAuditLog: options.createAuditLog ?? defaultDeps!.createAuditLog,
     };
   }
 
@@ -367,6 +426,89 @@ export const adminSessionsNativeRoutes: FastifyPluginAsync<
       return reply.code(200).send({
         ...snapshot,
         checkedBy: {
+          adminUserId: admin.id,
+          username: admin.username,
+        },
+      });
+    },
+  );
+
+  app.post<{ Params: AdminSessionRevokeParams }>(
+    "/:sessionType/:sessionId/revoke",
+    async (request, reply) => {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const sessionType = parseSessionType(request.params.sessionType);
+      const sessionId = parseSessionId(request.params.sessionId);
+
+      if (!sessionType || sessionId === null) {
+        return reply.code(400).send({
+          success: false,
+          error:
+            "Parámetros inválidos. sessionType debe ser admin, clinic o particular; sessionId debe ser entero positivo.",
+        });
+      }
+
+      if (sessionType === "admin" && sessionId === admin.sessionId) {
+        return reply.code(400).send({
+          success: false,
+          error: "No se puede revocar la sesión admin actual.",
+        });
+      }
+
+      const revokedSession = await deps.revokeAdminSessionById(
+        { sessionType, sessionId },
+        new Date(now()),
+      );
+
+      if (!revokedSession) {
+        return reply.code(404).send({
+          success: false,
+          error: "Sesión no encontrada",
+        });
+      }
+
+      await deps.createAuditLog({
+        event: "auth.session.revoked",
+        actorType: "admin_user",
+        actorAdminUserId: admin.id,
+        targetAdminUserId:
+          revokedSession.actorType === "admin_user"
+            ? revokedSession.actorId
+            : null,
+        targetClinicUserId:
+          revokedSession.actorType === "clinic_user"
+            ? revokedSession.actorId
+            : null,
+        requestMethod: request.method,
+        requestPath: request.url,
+        ipAddress: request.ip,
+        userAgent: getRequestUserAgent(request),
+        metadata: {
+          sessionType: revokedSession.sessionType,
+          sessionId: revokedSession.sessionId,
+          actorType: revokedSession.actorType,
+          actorId: revokedSession.actorId,
+          statusAtRevocation: revokedSession.status,
+          createdAt: revokedSession.createdAt,
+          lastAccess: revokedSession.lastAccess,
+          expiresAt: revokedSession.expiresAt,
+          revokedAt: revokedSession.revokedAt,
+        },
+        action: "auth.session.revoked",
+        entity: "session",
+        entityId: revokedSession.sessionId,
+      });
+
+      return reply.code(200).send({
+        success: true,
+        revokedSession,
+        revokedBy: {
           adminUserId: admin.id,
           username: admin.username,
         },

--- a/test/admin-sessions.fastify.test.ts
+++ b/test/admin-sessions.fastify.test.ts
@@ -26,6 +26,9 @@ type AdminSessionsSnapshot = import(
 type AdminSessionSummary = import(
   "../server/db-admin-sessions.ts"
 ).AdminSessionSummary;
+type AdminSessionRevocationResult = import(
+  "../server/db-admin-sessions.ts"
+).AdminSessionRevocationResult;
 
 function buildDeps(
   overrides: Partial<AdminSessionsNativeRoutesOptions> = {},
@@ -33,6 +36,7 @@ function buildDeps(
   return {
     deleteAdminSession: async () => {},
     getAdminSessionByToken: async () => ({
+      id: 99,
       adminUserId: 1,
       expiresAt: new Date("2099-01-01T00:00:00.000Z"),
       lastAccess: new Date("2026-05-07T00:00:00.000Z"),
@@ -50,6 +54,9 @@ function buildDeps(
       limit: 50,
       offset: 0,
     }),
+    revokeAdminSessionById: async (): Promise<AdminSessionRevocationResult | null> =>
+      null,
+    createAuditLog: async () => ({}),
     now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
     ...overrides,
   };
@@ -191,6 +198,137 @@ test("admin sessions rechaza filtros inválidos", async () => {
     assert.equal(response.statusCode, 400);
     assert.equal(JSON.parse(response.body).success, false);
     assert.equal(snapshotCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin sessions revoca sesión remota y audita sin filtrar tokenHash", async () => {
+  const app = Fastify();
+  const auditCalls: unknown[] = [];
+  const revokeCalls: unknown[] = [];
+
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      revokeAdminSessionById: async (target): Promise<AdminSessionRevocationResult> => {
+        revokeCalls.push(target);
+
+        return {
+          sessionType: "clinic",
+          sessionId: target.sessionId,
+          actorType: "clinic_user",
+          actorId: 7,
+          createdAt: "2026-05-08T00:00:00.000Z",
+          lastAccess: "2026-05-08T00:10:00.000Z",
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          status: "active",
+          revokedAt: "2026-05-08T00:00:00.000Z",
+        };
+      },
+      createAuditLog: async (input) => {
+        auditCalls.push(input);
+        return {};
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/clinic/20/revoke",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "user-agent": "node-test",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.revokedSession.sessionType, "clinic");
+    assert.equal(body.revokedSession.sessionId, 20);
+    assert.equal(body.revokedSession.tokenHash, undefined);
+    assert.equal(body.revokedSession.token, undefined);
+    assert.equal(JSON.stringify(body).includes("hash:"), false);
+    assert.deepEqual(revokeCalls, [{ sessionType: "clinic", sessionId: 20 }]);
+    assert.equal(auditCalls.length, 1);
+    assert.equal((auditCalls[0] as { event?: string }).event, "auth.session.revoked");
+    assert.equal(
+      (auditCalls[0] as { actorAdminUserId?: number }).actorAdminUserId,
+      1,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin sessions bloquea auto-revocación de sesión admin actual", async () => {
+  const app = Fastify();
+  let revokeCalled = false;
+  let auditCalled = false;
+
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      revokeAdminSessionById: async () => {
+        revokeCalled = true;
+        return null;
+      },
+      createAuditLog: async () => {
+        auditCalled = true;
+        return {};
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/99/revoke",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(revokeCalled, false);
+    assert.equal(auditCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin sessions devuelve 404 si la sesión a revocar no existe", async () => {
+  const app = Fastify();
+  let auditCalled = false;
+
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      revokeAdminSessionById: async () => null,
+      createAuditLog: async () => {
+        auditCalled = true;
+        return {};
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/particular/123/revoke",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(auditCalled, false);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary
- add backend endpoint to revoke admin, clinic and particular sessions by sanitized session id
- keep tokenHash, raw tokens and cookies hidden from API responses
- block self-revocation of the current admin session
- audit successful revocations with auth.session.revoked
- add contract tests for success, self-revocation guard and not-found behavior

## Security
- does not expose tokenHash, raw tokens, cookies or secrets
- revocation uses sessionType + sessionId only
- current admin session cannot revoke itself
- successful revocations are audited

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build