### PR TITLE
feat(admin): add read-only users roles endpoint

### DIFF
--- a/server/db-admin-users-roles.ts
+++ b/server/db-admin-users-roles.ts
@@ -1,0 +1,159 @@
+import { asc, eq } from "drizzle-orm";
+
+import { db } from "./db.ts";
+import {
+  adminUsers,
+  clinicUsers,
+  clinics,
+  type ClinicUserRole,
+} from "../drizzle/schema";
+
+export type AdminRoleUserType = "admin" | "clinic";
+export type AdminRoleUserRole = "admin" | ClinicUserRole;
+
+export type AdminRoleUserSummary =
+  | {
+      userType: "admin";
+      userId: number;
+      username: string;
+      role: "admin";
+      clinicId: null;
+      clinicName: null;
+      createdAt: string;
+      updatedAt: string;
+    }
+  | {
+      userType: "clinic";
+      userId: number;
+      username: string;
+      role: ClinicUserRole;
+      clinicId: number;
+      clinicName: string | null;
+      createdAt: string;
+      updatedAt: string;
+    };
+
+export type AdminUsersRolesQuery = {
+  userType?: AdminRoleUserType;
+  role?: AdminRoleUserRole;
+  limit?: number;
+  offset?: number;
+};
+
+export type AdminUsersRolesSnapshot = {
+  success: true;
+  users: AdminRoleUserSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  totals: {
+    adminUsers: number;
+    clinicUsers: number;
+  };
+};
+
+function normalizeLimit(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 50;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), 100);
+}
+
+function normalizeOffset(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(Math.trunc(value), 0);
+}
+
+function toIsoDate(value: Date) {
+  return value.toISOString();
+}
+
+function sortUsers(a: AdminRoleUserSummary, b: AdminRoleUserSummary) {
+  if (a.userType !== b.userType) {
+    return a.userType === "admin" ? -1 : 1;
+  }
+
+  return a.username.localeCompare(b.username);
+}
+
+export async function getAdminUsersRolesSnapshot(
+  params: AdminUsersRolesQuery = {},
+): Promise<AdminUsersRolesSnapshot> {
+  const limit = normalizeLimit(params.limit);
+  const offset = normalizeOffset(params.offset);
+
+  const includeAdmins =
+    params.userType === undefined || params.userType === "admin";
+  const includeClinicUsers =
+    params.userType === undefined || params.userType === "clinic";
+
+  const [adminRows, clinicRows] = await Promise.all([
+    includeAdmins
+      ? db
+          .select({
+            userId: adminUsers.id,
+            username: adminUsers.username,
+            createdAt: adminUsers.createdAt,
+            updatedAt: adminUsers.updatedAt,
+          })
+          .from(adminUsers)
+          .orderBy(asc(adminUsers.username))
+      : Promise.resolve([]),
+    includeClinicUsers
+      ? db
+          .select({
+            userId: clinicUsers.id,
+            username: clinicUsers.username,
+            role: clinicUsers.role,
+            clinicId: clinicUsers.clinicId,
+            clinicName: clinics.name,
+            createdAt: clinicUsers.createdAt,
+            updatedAt: clinicUsers.updatedAt,
+          })
+          .from(clinicUsers)
+          .leftJoin(clinics, eq(clinics.id, clinicUsers.clinicId))
+          .orderBy(asc(clinicUsers.username))
+      : Promise.resolve([]),
+  ]);
+
+  const users: AdminRoleUserSummary[] = [
+    ...adminRows.map((row) => ({
+      userType: "admin" as const,
+      userId: row.userId,
+      username: row.username,
+      role: "admin" as const,
+      clinicId: null,
+      clinicName: null,
+      createdAt: toIsoDate(row.createdAt),
+      updatedAt: toIsoDate(row.updatedAt),
+    })),
+    ...clinicRows.map((row) => ({
+      userType: "clinic" as const,
+      userId: row.userId,
+      username: row.username,
+      role: row.role,
+      clinicId: row.clinicId,
+      clinicName: row.clinicName ?? null,
+      createdAt: toIsoDate(row.createdAt),
+      updatedAt: toIsoDate(row.updatedAt),
+    })),
+  ]
+    .filter((user) => (params.role ? user.role === params.role : true))
+    .sort(sortUsers);
+
+  return {
+    success: true,
+    users: users.slice(offset, offset + limit),
+    total: users.length,
+    limit,
+    offset,
+    totals: {
+      adminUsers: users.filter((user) => user.userType === "admin").length,
+      clinicUsers: users.filter((user) => user.userType === "clinic").length,
+    },
+  };
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -37,6 +37,10 @@ import {
   type AdminSystemHealthNativeRoutesOptions,
 } from "./routes/admin-system-health.fastify.ts";
 import {
+  adminUsersRolesNativeRoutes,
+  type AdminUsersRolesNativeRoutesOptions,
+} from "./routes/admin-users-roles.fastify.ts";
+import {
   adminSystemMaintenanceNativeRoutes,
   type AdminSystemMaintenanceNativeRoutesOptions,
 } from "./routes/admin-system-maintenance.fastify.ts";
@@ -184,6 +188,7 @@ export type CreateFastifyAppOptions = {
   adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
   adminSystemHealthRoutes?: AdminSystemHealthNativeRoutesOptions;
   adminSystemMaintenanceRoutes?: AdminSystemMaintenanceNativeRoutesOptions;
+  adminUsersRolesRoutes?: AdminUsersRolesNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
@@ -323,6 +328,11 @@ export async function createFastifyApp(
   await app.register(adminSystemMaintenanceNativeRoutes, {
     prefix: "/api/admin/system/maintenance",
     ...(options.adminSystemMaintenanceRoutes ?? {}),
+  });
+
+  await app.register(adminUsersRolesNativeRoutes, {
+    prefix: "/api/admin/users-roles",
+    ...(options.adminUsersRolesRoutes ?? {}),
   });
 
   await app.register(clinicAuthNativeRoutes, {

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -1,0 +1,367 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import type {
+  AdminRoleUserRole,
+  AdminRoleUserType,
+  AdminUsersRolesQuery,
+  AdminUsersRolesSnapshot,
+} from "../db-admin-users-roles.ts";
+
+type AdminSessionRecord = {
+  id: number;
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+};
+
+type AdminUsersRolesRequestQuery = {
+  userType?: string;
+  role?: string;
+  limit?: string;
+  offset?: string;
+};
+
+export type AdminUsersRolesNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getAdminUsersRolesSnapshot?: (
+    params: AdminUsersRolesQuery,
+  ) => Promise<AdminUsersRolesSnapshot>;
+  now?: () => number;
+};
+
+type NativeAdminUsersRolesDeps = Required<
+  Pick<
+    AdminUsersRolesNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getAdminUsersRolesSnapshot"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminUsersRolesDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const usersRoles = await import("../db-admin-users-roles.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getAdminUsersRolesSnapshot: usersRoles.getAdminUsersRolesSnapshot,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminUsersRolesDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+  };
+}
+
+function parseUserType(value: string | undefined): AdminRoleUserType | undefined | null {
+  if (value === undefined) return undefined;
+  if (value === "admin" || value === "clinic") return value;
+  return null;
+}
+
+function parseRole(value: string | undefined): AdminRoleUserRole | undefined | null {
+  if (value === undefined) return undefined;
+
+  if (
+    value === "admin" ||
+    value === "clinic_owner" ||
+    value === "clinic_staff"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function parseIntegerParam(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed)) {
+    return null;
+  }
+
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function parseUsersRolesQuery(
+  query: AdminUsersRolesRequestQuery,
+): AdminUsersRolesQuery | null {
+  const userType = parseUserType(query.userType);
+  const role = parseRole(query.role);
+  const limit = parseIntegerParam(query.limit, 50, 1, 100);
+  const offset = parseIntegerParam(query.offset, 0, 0, 100_000);
+
+  if (
+    userType === null ||
+    role === null ||
+    limit === null ||
+    offset === null
+  ) {
+    return null;
+  }
+
+  return {
+    ...(userType ? { userType } : {}),
+    ...(role ? { role } : {}),
+    limit,
+    offset,
+  };
+}
+
+export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
+  AdminUsersRolesNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+
+  async function resolveDeps(): Promise<NativeAdminUsersRolesDeps> {
+    const hasAllInjectedDeps =
+      !!options.deleteAdminSession &&
+      !!options.getAdminSessionByToken &&
+      !!options.getAdminUserById &&
+      !!options.updateAdminSessionLastAccess &&
+      !!options.hashSessionToken &&
+      !!options.getAdminUsersRolesSnapshot;
+
+    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+    return {
+      deleteAdminSession:
+        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+      getAdminSessionByToken:
+        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+      getAdminUserById:
+        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      updateAdminSessionLastAccess:
+        options.updateAdminSessionLastAccess ??
+        defaultDeps!.updateAdminSessionLastAccess,
+      hashSessionToken:
+        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+      getAdminUsersRolesSnapshot:
+        options.getAdminUsersRolesSnapshot ??
+        defaultDeps!.getAdminUsersRolesSnapshot,
+    };
+  }
+
+  app.get<{ Querystring: AdminUsersRolesRequestQuery }>(
+    "/",
+    async (request, reply) => {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const params = parseUsersRolesQuery(request.query);
+
+      if (!params) {
+        return reply.code(400).send({
+          success: false,
+          error:
+            "Query inválida. userType debe ser admin o clinic; role debe ser admin, clinic_owner o clinic_staff; limit/offset deben ser enteros válidos.",
+        });
+      }
+
+      const snapshot = await deps.getAdminUsersRolesSnapshot(params);
+
+      return reply.code(200).send({
+        ...snapshot,
+        checkedBy: {
+          adminUserId: admin.id,
+          username: admin.username,
+        },
+      });
+    },
+  );
+};

--- a/test/admin-users-roles.fastify.test.ts
+++ b/test/admin-users-roles.fastify.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminUsersRolesNativeRoutes } = await import(
+  "../server/routes/admin-users-roles.fastify.ts"
+);
+
+type AdminUsersRolesNativeRoutesOptions = import(
+  "../server/routes/admin-users-roles.fastify.ts"
+).AdminUsersRolesNativeRoutesOptions;
+type AdminUsersRolesQuery = import(
+  "../server/db-admin-users-roles.ts"
+).AdminUsersRolesQuery;
+type AdminUsersRolesSnapshot = import(
+  "../server/db-admin-users-roles.ts"
+).AdminUsersRolesSnapshot;
+type AdminRoleUserSummary = import(
+  "../server/db-admin-users-roles.ts"
+).AdminRoleUserSummary;
+
+function buildDeps(
+  overrides: Partial<AdminUsersRolesNativeRoutesOptions> = {},
+): AdminUsersRolesNativeRoutesOptions {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      id: 1,
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-05-07T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getAdminUsersRolesSnapshot: async (): Promise<AdminUsersRolesSnapshot> => ({
+      success: true,
+      users: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+      totals: {
+        adminUsers: 0,
+        clinicUsers: 0,
+      },
+    }),
+    now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
+    ...overrides,
+  };
+}
+
+test("admin users roles requiere sesión admin", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      getAdminSessionByToken: async () => null,
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin users roles devuelve usuarios sanitizados sin hashes ni auth ids", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      getAdminUsersRolesSnapshot: async (
+        params: AdminUsersRolesQuery,
+      ): Promise<AdminUsersRolesSnapshot> => {
+        const users: AdminRoleUserSummary[] = [
+          {
+            userType: "admin",
+            userId: 1,
+            username: "VETNEB",
+            role: "admin",
+            clinicId: null,
+            clinicName: null,
+            createdAt: "2026-05-08T00:00:00.000Z",
+            updatedAt: "2026-05-08T00:00:00.000Z",
+          },
+          {
+            userType: "clinic",
+            userId: 2,
+            username: "clinic-owner",
+            role: "clinic_owner",
+            clinicId: 10,
+            clinicName: "Clínica Demo",
+            createdAt: "2026-05-08T00:00:00.000Z",
+            updatedAt: "2026-05-08T00:00:00.000Z",
+          },
+        ];
+
+        const filtered = users.filter((user) =>
+          params.role ? user.role === params.role : true,
+        );
+
+        return {
+          success: true,
+          users: filtered,
+          total: filtered.length,
+          limit: params.limit ?? 50,
+          offset: params.offset ?? 0,
+          totals: {
+            adminUsers: filtered.filter((user) => user.userType === "admin")
+              .length,
+            clinicUsers: filtered.filter((user) => user.userType === "clinic")
+              .length,
+          },
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?role=clinic_owner&limit=25&offset=0",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.deepEqual(body.checkedBy, {
+      adminUserId: 1,
+      username: "VETNEB",
+    });
+    assert.equal(body.users.length, 1);
+    assert.equal(body.users[0].userType, "clinic");
+    assert.equal(body.users[0].role, "clinic_owner");
+    assert.equal(body.users[0].passwordHash, undefined);
+    assert.equal(body.users[0].authProId, undefined);
+    assert.equal(JSON.stringify(body).includes("password"), false);
+    assert.equal(JSON.stringify(body).includes("hash:"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin users roles rechaza filtros inválidos", async () => {
+  const app = Fastify();
+  let snapshotCalled = false;
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      getAdminUsersRolesSnapshot: async (): Promise<AdminUsersRolesSnapshot> => {
+        snapshotCalled = true;
+
+        return {
+          success: true,
+          users: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+          totals: {
+            adminUsers: 0,
+            clinicUsers: 0,
+          },
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?role=superadmin",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(snapshotCalled, false);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add read-only Admin users/roles endpoint
- expose sanitized admin and clinic user summaries
- support userType, role, limit and offset filters
- register GET /api/admin/users-roles
- add contract tests for auth, sanitization and invalid filters

## Security
- does not expose passwordHash, authProId, raw tokens, cookies or secrets
- requires authenticated admin session
- read-only endpoint, no role mutation

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build