### PR TITLE
feat(admin): add read-only users roles UI

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getAdminUsersRoles } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type {
+  AdminRoleUserRole,
+  AdminRoleUserSummary,
+  AdminRoleUserType,
+  AdminUsersRolesSnapshot,
+} from "@/types";
+
+const PAGE_SIZE = 25;
+
+function formatUserType(value: AdminRoleUserType) {
+  return value === "admin" ? "Admin" : "Clínica";
+}
+
+function formatRole(value: AdminRoleUserRole) {
+  if (value === "admin") return "Admin";
+  if (value === "clinic_owner") return "Owner clínica";
+  return "Staff clínica";
+}
+
+function getUserTypeVariant(
+  value: AdminRoleUserType,
+): "default" | "secondary" | "destructive" | "outline" {
+  return value === "admin" ? "default" : "secondary";
+}
+
+function getRoleVariant(
+  value: AdminRoleUserRole,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (value === "admin") return "default";
+  if (value === "clinic_owner") return "secondary";
+  return "outline";
+}
+
+function formatClinic(user: AdminRoleUserSummary) {
+  if (user.userType === "admin") return "—";
+
+  return user.clinicName ? `${user.clinicName} #${user.clinicId}` : `#${user.clinicId}`;
+}
+
+export function AdminUsersRolesReadOnlyCard() {
+  const [snapshot, setSnapshot] = useState<AdminUsersRolesSnapshot | null>(null);
+  const [userType, setUserType] = useState<AdminRoleUserType | "all">("all");
+  const [role, setRole] = useState<AdminRoleUserRole | "all">("all");
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const query = useMemo(
+    () => ({
+      ...(userType !== "all" ? { userType } : {}),
+      ...(role !== "all" ? { role } : {}),
+      limit: PAGE_SIZE,
+      offset,
+    }),
+    [offset, role, userType],
+  );
+
+  function loadUsersRoles() {
+    setError(null);
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          const result = await getAdminUsersRoles(query);
+          setSnapshot(result);
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "No se pudieron cargar usuarios y roles.",
+          );
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    loadUsersRoles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const hasPreviousPage = offset > 0;
+  const hasNextPage = snapshot
+    ? offset + snapshot.users.length < snapshot.total
+    : false;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <CardTitle className="text-base">Usuarios y roles</CardTitle>
+          <CardDescription>
+            Vista read-only de usuarios Admin y clínica. No permite edición,
+            revocación ni acciones destructivas.
+          </CardDescription>
+        </div>
+
+        <Button type="button" onClick={loadUsersRoles} disabled={isPending}>
+          {isPending ? "Actualizando..." : "Actualizar"}
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Total filtrado</p>
+            <p className="mt-1 text-2xl font-bold text-gray-900">
+              {snapshot?.total ?? "—"}
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Admins</p>
+            <p className="mt-1 text-2xl font-bold text-gray-900">
+              {snapshot?.totals.adminUsers ?? "—"}
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Clínicas</p>
+            <p className="mt-1 text-2xl font-bold text-gray-900">
+              {snapshot?.totals.clinicUsers ?? "—"}
+            </p>
+          </div>
+
+          <label className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <span className="text-xs text-gray-400">Tipo usuario</span>
+            <select
+              className="mt-2 w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700"
+              value={userType}
+              onChange={(event) => {
+                setOffset(0);
+                setUserType(event.target.value as AdminRoleUserType | "all");
+              }}
+            >
+              <option value="all">Todos</option>
+              <option value="admin">Admin</option>
+              <option value="clinic">Clínica</option>
+            </select>
+          </label>
+
+          <label className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <span className="text-xs text-gray-400">Rol</span>
+            <select
+              className="mt-2 w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700"
+              value={role}
+              onChange={(event) => {
+                setOffset(0);
+                setRole(event.target.value as AdminRoleUserRole | "all");
+              }}
+            >
+              <option value="all">Todos</option>
+              <option value="admin">Admin</option>
+              <option value="clinic_owner">Owner clínica</option>
+              <option value="clinic_staff">Staff clínica</option>
+            </select>
+          </label>
+        </div>
+
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="overflow-hidden rounded-lg border border-gray-100">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Usuario</TableHead>
+                <TableHead>Tipo</TableHead>
+                <TableHead>Rol</TableHead>
+                <TableHead>Clínica</TableHead>
+                <TableHead>Creado</TableHead>
+                <TableHead>Actualizado</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {snapshot?.users.length ? (
+                snapshot.users.map((user) => (
+                  <TableRow key={`${user.userType}-${user.userId}`}>
+                    <TableCell>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-sm font-semibold text-gray-700">
+                          {user.username}
+                        </span>
+                        <span className="font-mono text-xs text-gray-400">
+                          #{user.userId}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getUserTypeVariant(user.userType)}>
+                        {formatUserType(user.userType)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getRoleVariant(user.role)}>
+                        {formatRole(user.role)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-500">
+                      {formatClinic(user)}
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-400">
+                      {formatDateTime(user.createdAt)}
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-400">
+                      {formatDateTime(user.updatedAt)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={6}
+                    className="py-8 text-center text-sm text-gray-400"
+                  >
+                    {isPending
+                      ? "Cargando usuarios y roles..."
+                      : "No hay usuarios para los filtros seleccionados."}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <p className="text-xs text-gray-400">
+            Endpoint: <code>GET /api/admin/users-roles</code>. Campos sensibles
+            como <code>passwordHash</code>, <code>authProId</code> y tokens no
+            se renderizan.
+          </p>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasPreviousPage || isPending}
+              onClick={() => setOffset(Math.max(offset - PAGE_SIZE, 0))}
+            >
+              Anterior
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasNextPage || isPending}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Siguiente
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/card";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
+import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 
@@ -161,7 +162,7 @@ export default async function AdminPage() {
       />
       <main className="flex-1 p-6 space-y-6">
         <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
-          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code>, <code>GET /api/admin/sessions</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
+          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code>, <code>GET /api/admin/sessions</code>, <code>GET /api/admin/users-roles</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -278,6 +279,7 @@ export default async function AdminPage() {
         </Card>
         <AdminMaintenanceDryRunCard />
         <AdminSessionsReadOnlyCard />
+        <AdminUsersRolesReadOnlyCard />
 
 
         <Card>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,8 @@ import type {
   MaintenancePurgeDryRunSnapshot,
   AdminSessionsQuery,
   AdminSessionsSnapshot,
+  AdminUsersRolesQuery,
+  AdminUsersRolesSnapshot,
   AdminSessionRevocationResponse,
   AdminSessionType,
 } from "@/types";
@@ -220,6 +222,36 @@ export async function getAdminSystemHealth(
     console.warn("[API] getAdminSystemHealth: endpoint no disponible");
     return null;
   }
+}
+
+export async function getAdminUsersRoles(
+  params: AdminUsersRolesQuery = {},
+  options?: RequestInit,
+): Promise<AdminUsersRolesSnapshot> {
+  const query = new URLSearchParams();
+
+  if (params.userType) {
+    query.set("userType", params.userType);
+  }
+
+  if (params.role) {
+    query.set("role", params.role);
+  }
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<AdminUsersRolesSnapshot>(
+    `/api/admin/users-roles${qs ? `?${qs}` : ""}`,
+    options,
+  );
 }
 export async function getAdminSessions(
   params: AdminSessionsQuery = {},

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -186,6 +186,54 @@ export type DashboardStats = {
   activePlans: number;
 };
 
+
+export type AdminRoleUserType = "admin" | "clinic";
+export type AdminRoleUserRole = "admin" | ClinicUserRole;
+
+export type AdminRoleUserSummary =
+  | {
+      userType: "admin";
+      userId: number;
+      username: string;
+      role: "admin";
+      clinicId: null;
+      clinicName: null;
+      createdAt: string;
+      updatedAt: string;
+    }
+  | {
+      userType: "clinic";
+      userId: number;
+      username: string;
+      role: ClinicUserRole;
+      clinicId: number;
+      clinicName: string | null;
+      createdAt: string;
+      updatedAt: string;
+    };
+
+export type AdminUsersRolesQuery = {
+  userType?: AdminRoleUserType;
+  role?: AdminRoleUserRole;
+  limit?: number;
+  offset?: number;
+};
+
+export type AdminUsersRolesSnapshot = {
+  success: true;
+  users: AdminRoleUserSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  totals: {
+    adminUsers: number;
+    clinicUsers: number;
+  };
+  checkedBy?: {
+    adminUserId: number;
+    username: string;
+  };
+};
 export type AdminSessionType = "admin" | "clinic" | "particular";
 export type AdminSessionStatus = "active" | "expired";
 


### PR DESCRIPTION
## Summary

- Add read-only Admin UI for users and roles.
- Consume `GET /api/admin/users-roles`.
- Show Admin users and clinic users in a paginated table.
- Add `userType` and `role` filters.
- Keep UI strictly read-only.

## Security

- No role edition.
- No destructive actions.
- No write endpoint is consumed for users/roles.
- Sensitive fields such as `passwordHash`, `authProId`, tokens, cookies, and secrets are not rendered.

## Validation

- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`