### PR TITLE
feat(admin): add safe clinic user role change

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -136,6 +136,7 @@ export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
   "auth.session.revoked",
+  "clinic_user.role.changed",
   "report.status.changed",
   "report.uploaded",
   "study_tracking.case.created",

--- a/server/db-admin-users-roles.ts
+++ b/server/db-admin-users-roles.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, ne } from "drizzle-orm";
 
 import { db } from "./db.ts";
 import {
@@ -52,6 +52,34 @@ export type AdminUsersRolesSnapshot = {
   };
 };
 
+export type AdminClinicUserRoleChangeInput = {
+  clinicUserId: number;
+  role: ClinicUserRole;
+  now?: Date;
+};
+
+export type AdminClinicUserRoleChangeResult =
+  | {
+      ok: true;
+      user: Extract<AdminRoleUserSummary, { userType: "clinic" }>;
+      previousRole: ClinicUserRole;
+      roleChanged: boolean;
+    }
+  | {
+      ok: false;
+      reason: "not_found" | "last_clinic_owner";
+    };
+
+type ClinicUserRoleRow = {
+  userId: number;
+  username: string;
+  role: ClinicUserRole;
+  clinicId: number;
+  clinicName: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 function normalizeLimit(value: number | undefined) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return 50;
@@ -78,6 +106,42 @@ function sortUsers(a: AdminRoleUserSummary, b: AdminRoleUserSummary) {
   }
 
   return a.username.localeCompare(b.username);
+}
+
+function serializeClinicUserRoleRow(
+  row: ClinicUserRoleRow,
+): Extract<AdminRoleUserSummary, { userType: "clinic" }> {
+  return {
+    userType: "clinic",
+    userId: row.userId,
+    username: row.username,
+    role: row.role,
+    clinicId: row.clinicId,
+    clinicName: row.clinicName ?? null,
+    createdAt: toIsoDate(row.createdAt),
+    updatedAt: toIsoDate(row.updatedAt),
+  };
+}
+
+async function getClinicUserRoleRow(
+  clinicUserId: number,
+): Promise<ClinicUserRoleRow | null> {
+  const rows = await db
+    .select({
+      userId: clinicUsers.id,
+      username: clinicUsers.username,
+      role: clinicUsers.role,
+      clinicId: clinicUsers.clinicId,
+      clinicName: clinics.name,
+      createdAt: clinicUsers.createdAt,
+      updatedAt: clinicUsers.updatedAt,
+    })
+    .from(clinicUsers)
+    .leftJoin(clinics, eq(clinics.id, clinicUsers.clinicId))
+    .where(eq(clinicUsers.id, clinicUserId))
+    .limit(1);
+
+  return rows[0] ?? null;
 }
 
 export async function getAdminUsersRolesSnapshot(
@@ -131,16 +195,17 @@ export async function getAdminUsersRolesSnapshot(
       createdAt: toIsoDate(row.createdAt),
       updatedAt: toIsoDate(row.updatedAt),
     })),
-    ...clinicRows.map((row) => ({
-      userType: "clinic" as const,
-      userId: row.userId,
-      username: row.username,
-      role: row.role,
-      clinicId: row.clinicId,
-      clinicName: row.clinicName ?? null,
-      createdAt: toIsoDate(row.createdAt),
-      updatedAt: toIsoDate(row.updatedAt),
-    })),
+    ...clinicRows.map((row) =>
+      serializeClinicUserRoleRow({
+        userId: row.userId,
+        username: row.username,
+        role: row.role,
+        clinicId: row.clinicId,
+        clinicName: row.clinicName ?? null,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      }),
+    ),
   ]
     .filter((user) => (params.role ? user.role === params.role : true))
     .sort(sortUsers);
@@ -155,5 +220,74 @@ export async function getAdminUsersRolesSnapshot(
       adminUsers: users.filter((user) => user.userType === "admin").length,
       clinicUsers: users.filter((user) => user.userType === "clinic").length,
     },
+  };
+}
+
+export async function changeClinicUserRole(
+  input: AdminClinicUserRoleChangeInput,
+): Promise<AdminClinicUserRoleChangeResult> {
+  const current = await getClinicUserRoleRow(input.clinicUserId);
+
+  if (!current) {
+    return {
+      ok: false,
+      reason: "not_found",
+    };
+  }
+
+  if (current.role === input.role) {
+    return {
+      ok: true,
+      user: serializeClinicUserRoleRow(current),
+      previousRole: current.role,
+      roleChanged: false,
+    };
+  }
+
+  if (current.role === "clinic_owner" && input.role === "clinic_staff") {
+    const otherOwners = await db
+      .select({
+        userId: clinicUsers.id,
+      })
+      .from(clinicUsers)
+      .where(
+        and(
+          eq(clinicUsers.clinicId, current.clinicId),
+          eq(clinicUsers.role, "clinic_owner"),
+          ne(clinicUsers.id, input.clinicUserId),
+        ),
+      )
+      .limit(1);
+
+    if (otherOwners.length === 0) {
+      return {
+        ok: false,
+        reason: "last_clinic_owner",
+      };
+    }
+  }
+
+  await db
+    .update(clinicUsers)
+    .set({
+      role: input.role,
+      updatedAt: input.now ?? new Date(),
+    })
+    .where(eq(clinicUsers.id, input.clinicUserId));
+
+  const updated = await getClinicUserRoleRow(input.clinicUserId);
+
+  if (!updated) {
+    return {
+      ok: false,
+      reason: "not_found",
+    };
+  }
+
+  return {
+    ok: true,
+    user: serializeClinicUserRoleRow(updated),
+    previousRole: current.role,
+    roleChanged: true,
   };
 }

--- a/server/lib/audit-log.ts
+++ b/server/lib/audit-log.ts
@@ -10,6 +10,7 @@ export type AuditActorType = (typeof AUDIT_ACTOR_TYPES)[number];
 export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
+  "clinic_user.role.changed",
   "report.status.changed",
   "report.uploaded",
   "study_tracking.case.created",

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -5,6 +5,7 @@ import { sanitizeUrlForLogs } from "../middlewares/request-logger.ts";
 export const AUDIT_EVENTS = {
   ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
   CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
+  CLINIC_USER_ROLE_CHANGED: "clinic_user.role.changed",
   REPORT_STATUS_CHANGED: "report.status.changed",
   REPORT_UPLOADED: "report.uploaded",
   STUDY_TRACKING_CASE_CREATED: "study_tracking.case.created",

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -102,12 +102,15 @@ async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
         hashSessionToken: authSecurity.hashSessionToken,
         getAdminUsersRolesSnapshot: usersRoles.getAdminUsersRolesSnapshot,
         changeClinicUserRole: usersRoles.changeClinicUserRole,
-        writeAuditLog: audit.writeAuditLog,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
       };
     })();
   }
 
-  return defaultDepsPromise;
+  return defaultDepsPromise!;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -5,13 +5,18 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import type {
+  AdminClinicUserRoleChangeInput,
+  AdminClinicUserRoleChangeResult,
   AdminRoleUserRole,
   AdminRoleUserType,
   AdminUsersRolesQuery,
   AdminUsersRolesSnapshot,
 } from "../db-admin-users-roles.ts";
+
+type AdminClinicUserRole = Exclude<AdminRoleUserRole, "admin">;
 
 type AdminSessionRecord = {
   id: number;
@@ -37,6 +42,14 @@ type AdminUsersRolesRequestQuery = {
   offset?: string;
 };
 
+type AdminUsersRolesRoleChangeParams = {
+  clinicUserId: string;
+};
+
+type AdminUsersRolesRoleChangeBody = {
+  role?: unknown;
+};
+
 export type AdminUsersRolesNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
   getAdminSessionByToken?: (
@@ -50,6 +63,10 @@ export type AdminUsersRolesNativeRoutesOptions = {
   getAdminUsersRolesSnapshot?: (
     params: AdminUsersRolesQuery,
   ) => Promise<AdminUsersRolesSnapshot>;
+  changeClinicUserRole?: (
+    input: AdminClinicUserRoleChangeInput,
+  ) => Promise<AdminClinicUserRoleChangeResult>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   now?: () => number;
 };
 
@@ -62,6 +79,8 @@ type NativeAdminUsersRolesDeps = Required<
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "getAdminUsersRolesSnapshot"
+    | "changeClinicUserRole"
+    | "writeAuditLog"
   >
 >;
 
@@ -72,6 +91,7 @@ async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
+      const audit = await import("../lib/audit.ts");
       const usersRoles = await import("../db-admin-users-roles.ts");
 
       return {
@@ -81,6 +101,8 @@ async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         getAdminUsersRolesSnapshot: usersRoles.getAdminUsersRolesSnapshot,
+        changeClinicUserRole: usersRoles.changeClinicUserRole,
+        writeAuditLog: audit.writeAuditLog,
       };
     })();
   }
@@ -255,6 +277,14 @@ function parseRole(value: string | undefined): AdminRoleUserRole | undefined | n
   return null;
 }
 
+function parseClinicUserRole(value: unknown): AdminClinicUserRole | null {
+  if (value === "clinic_owner" || value === "clinic_staff") {
+    return value;
+  }
+
+  return null;
+}
+
 function parseIntegerParam(
   value: string | undefined,
   fallback: number,
@@ -272,6 +302,20 @@ function parseIntegerParam(
   }
 
   return Math.min(Math.max(parsed, min), max);
+}
+
+function parsePositiveIntegerParam(value: string | undefined) {
+  if (value === undefined || value.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return null;
+  }
+
+  return parsed;
 }
 
 function parseUsersRolesQuery(
@@ -299,6 +343,23 @@ function parseUsersRolesQuery(
   };
 }
 
+function createAuditRequestLike(
+  request: FastifyRequest,
+  admin: AuthenticatedAdminUser,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    requestId: request.id,
+    adminAuth: {
+      id: admin.id,
+      username: admin.username,
+    },
+  };
+}
+
 export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
   AdminUsersRolesNativeRoutesOptions
 > = async (app, options) => {
@@ -311,7 +372,9 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       !!options.getAdminUserById &&
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
-      !!options.getAdminUsersRolesSnapshot;
+      !!options.getAdminUsersRolesSnapshot &&
+      !!options.changeClinicUserRole &&
+      !!options.writeAuditLog;
 
     const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -330,6 +393,9 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       getAdminUsersRolesSnapshot:
         options.getAdminUsersRolesSnapshot ??
         defaultDeps!.getAdminUsersRolesSnapshot,
+      changeClinicUserRole:
+        options.changeClinicUserRole ?? defaultDeps!.changeClinicUserRole,
+      writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
     };
   }
 
@@ -364,4 +430,84 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       });
     },
   );
+
+  app.patch<{
+    Params: AdminUsersRolesRoleChangeParams;
+    Body: AdminUsersRolesRoleChangeBody;
+  }>("/clinic/:clinicUserId/role", async (request, reply) => {
+    const deps = await resolveDeps();
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const clinicUserId = parsePositiveIntegerParam(request.params.clinicUserId);
+
+    if (clinicUserId === null) {
+      return reply.code(400).send({
+        success: false,
+        error: "clinicUserId inválido.",
+      });
+    }
+
+    const role = parseClinicUserRole(request.body?.role);
+
+    if (!role) {
+      return reply.code(400).send({
+        success: false,
+        error: "role inválido. Debe ser clinic_owner o clinic_staff.",
+      });
+    }
+
+    const result = await deps.changeClinicUserRole({
+      clinicUserId,
+      role,
+      now: new Date(now()),
+    });
+
+    if (!result.ok && result.reason === "not_found") {
+      return reply.code(404).send({
+        success: false,
+        error: "Usuario de clínica no encontrado.",
+      });
+    }
+
+    if (!result.ok && result.reason === "last_clinic_owner") {
+      return reply.code(409).send({
+        success: false,
+        error:
+          "No se puede degradar el último clinic_owner de la clínica.",
+      });
+    }
+
+    if (!result.ok) {
+      return reply.code(500).send({
+        success: false,
+        error: "No se pudo cambiar el rol del usuario.",
+      });
+    }
+
+    await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+      event: AUDIT_EVENTS.CLINIC_USER_ROLE_CHANGED,
+      clinicId: result.user.clinicId,
+      targetClinicUserId: result.user.userId,
+      metadata: {
+        username: result.user.username,
+        clinicName: result.user.clinicName,
+        previousRole: result.previousRole,
+        newRole: result.user.role,
+        roleChanged: result.roleChanged,
+      },
+    });
+
+    return reply.code(200).send({
+      success: true,
+      user: result.user,
+      changedBy: {
+        adminUserId: admin.id,
+        username: admin.username,
+      },
+    });
+  });
 };

--- a/test/admin-users-roles.fastify.test.ts
+++ b/test/admin-users-roles.fastify.test.ts
@@ -26,6 +26,20 @@ type AdminUsersRolesSnapshot = import(
 type AdminRoleUserSummary = import(
   "../server/db-admin-users-roles.ts"
 ).AdminRoleUserSummary;
+type AdminClinicUserRoleChangeResult = import(
+  "../server/db-admin-users-roles.ts"
+).AdminClinicUserRoleChangeResult;
+
+const demoClinicUser: Extract<AdminRoleUserSummary, { userType: "clinic" }> = {
+  userType: "clinic",
+  userId: 2,
+  username: "clinic-owner",
+  role: "clinic_owner",
+  clinicId: 10,
+  clinicName: "Clínica Demo",
+  createdAt: "2026-05-08T00:00:00.000Z",
+  updatedAt: "2026-05-08T00:00:00.000Z",
+};
 
 function buildDeps(
   overrides: Partial<AdminUsersRolesNativeRoutesOptions> = {},
@@ -55,6 +69,14 @@ function buildDeps(
         clinicUsers: 0,
       },
     }),
+    changeClinicUserRole:
+      async (): Promise<AdminClinicUserRoleChangeResult> => ({
+        ok: true,
+        user: demoClinicUser,
+        previousRole: "clinic_staff",
+        roleChanged: true,
+      }),
+    writeAuditLog: async () => {},
     now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
     ...overrides,
   };
@@ -106,16 +128,7 @@ test("admin users roles devuelve usuarios sanitizados sin hashes ni auth ids", a
             createdAt: "2026-05-08T00:00:00.000Z",
             updatedAt: "2026-05-08T00:00:00.000Z",
           },
-          {
-            userType: "clinic",
-            userId: 2,
-            username: "clinic-owner",
-            role: "clinic_owner",
-            clinicId: 10,
-            clinicName: "Clínica Demo",
-            createdAt: "2026-05-08T00:00:00.000Z",
-            updatedAt: "2026-05-08T00:00:00.000Z",
-          },
+          demoClinicUser,
         ];
 
         const filtered = users.filter((user) =>
@@ -206,6 +219,201 @@ test("admin users roles rechaza filtros inválidos", async () => {
     assert.equal(response.statusCode, 400);
     assert.equal(JSON.parse(response.body).success, false);
     assert.equal(snapshotCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin users roles cambia rol de clinic user y escribe audit log", async () => {
+  const app = Fastify();
+  const auditWrites: Array<{
+    input: {
+      event?: string;
+      clinicId?: number | null;
+      targetClinicUserId?: number | null;
+      metadata?: Record<string, unknown>;
+    };
+  }> = [];
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      changeClinicUserRole: async (input) => {
+        assert.deepEqual(input, {
+          clinicUserId: 2,
+          role: "clinic_owner",
+          now: new Date("2026-05-08T00:00:00.000Z"),
+        });
+
+        return {
+          ok: true,
+          user: {
+            ...demoClinicUser,
+            role: "clinic_owner",
+          },
+          previousRole: "clinic_staff",
+          roleChanged: true,
+        };
+      },
+      writeAuditLog: async (_req, input) => {
+        auditWrites.push({ input });
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/clinic/2/role",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        role: "clinic_owner",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.user.userType, "clinic");
+    assert.equal(body.user.userId, 2);
+    assert.equal(body.user.role, "clinic_owner");
+    assert.deepEqual(body.changedBy, {
+      adminUserId: 1,
+      username: "VETNEB",
+    });
+    assert.equal(body.user.passwordHash, undefined);
+    assert.equal(body.user.authProId, undefined);
+    assert.equal(JSON.stringify(body).includes("password"), false);
+
+    assert.equal(auditWrites.length, 1);
+    assert.equal(auditWrites[0].input.event, "clinic_user.role.changed");
+    assert.equal(auditWrites[0].input.clinicId, 10);
+    assert.equal(auditWrites[0].input.targetClinicUserId, 2);
+    assert.deepEqual(auditWrites[0].input.metadata, {
+      username: "clinic-owner",
+      clinicName: "Clínica Demo",
+      previousRole: "clinic_staff",
+      newRole: "clinic_owner",
+      roleChanged: true,
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin users roles rechaza rol inválido en cambio", async () => {
+  const app = Fastify();
+  let roleChangeCalled = false;
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      changeClinicUserRole: async (): Promise<AdminClinicUserRoleChangeResult> => {
+        roleChangeCalled = true;
+
+        return {
+          ok: true,
+          user: demoClinicUser,
+          previousRole: "clinic_staff",
+          roleChanged: true,
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/clinic/2/role",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        role: "admin",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(roleChangeCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin users roles no degrada último clinic_owner", async () => {
+  const app = Fastify();
+  let auditCalled = false;
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      changeClinicUserRole: async (): Promise<AdminClinicUserRoleChangeResult> => ({
+        ok: false,
+        reason: "last_clinic_owner",
+      }),
+      writeAuditLog: async () => {
+        auditCalled = true;
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/clinic/2/role",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        role: "clinic_staff",
+      },
+    });
+
+    assert.equal(response.statusCode, 409);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(auditCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin users roles devuelve 404 si clinic user no existe", async () => {
+  const app = Fastify();
+  let auditCalled = false;
+
+  await app.register(
+    adminUsersRolesNativeRoutes,
+    buildDeps({
+      changeClinicUserRole: async (): Promise<AdminClinicUserRoleChangeResult> => ({
+        ok: false,
+        reason: "not_found",
+      }),
+      writeAuditLog: async () => {
+        auditCalled = true;
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/clinic/999/role",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        role: "clinic_staff",
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(auditCalled, false);
   } finally {
     await app.close();
   }

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -12,6 +12,7 @@ test("AUDIT_EVENTS conserva los eventos públicos esperados", () => {
   assert.deepEqual(AUDIT_EVENTS, {
     ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
     CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
+    CLINIC_USER_ROLE_CHANGED: "clinic_user.role.changed",
     REPORT_STATUS_CHANGED: "report.status.changed",
     REPORT_UPLOADED: "report.uploaded",
     STUDY_TRACKING_CASE_CREATED: "study_tracking.case.created",


### PR DESCRIPTION
## Summary

- Add backend endpoint to change clinic user roles safely.
- Support only `clinic_owner` and `clinic_staff` as target roles.
- Keep Admin users immutable in this PR.
- Add anti-lockout guard to prevent downgrading the last `clinic_owner` of a clinic.
- Add audit event `clinic_user.role.changed`.
- Add native route coverage for success, invalid role, not found, anti-lockout and audit write behavior.

## Security

- Admin authentication is required.
- No frontend changes.
- No destructive actions.
- No passwordHash, authProId, tokens, cookies or secrets are exposed.
- Role changes write an audit event with target clinic user metadata.
- Last clinic owner downgrade is blocked with HTTP 409.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`