### PR TITLE
feat(admin): add clinic user role editing UI

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -18,13 +18,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getAdminUsersRoles } from "@/lib/api";
+import {
+  changeAdminClinicUserRole,
+  getAdminUsersRoles,
+} from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 import type {
   AdminRoleUserRole,
   AdminRoleUserSummary,
   AdminRoleUserType,
   AdminUsersRolesSnapshot,
+  ClinicUserRole,
 } from "@/types";
 
 const PAGE_SIZE = 25;
@@ -59,12 +63,18 @@ function formatClinic(user: AdminRoleUserSummary) {
   return user.clinicName ? `${user.clinicName} #${user.clinicId}` : `#${user.clinicId}`;
 }
 
+function getNextClinicRole(role: ClinicUserRole): ClinicUserRole {
+  return role === "clinic_owner" ? "clinic_staff" : "clinic_owner";
+}
+
 export function AdminUsersRolesReadOnlyCard() {
   const [snapshot, setSnapshot] = useState<AdminUsersRolesSnapshot | null>(null);
   const [userType, setUserType] = useState<AdminRoleUserType | "all">("all");
   const [role, setRole] = useState<AdminRoleUserRole | "all">("all");
   const [offset, setOffset] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [roleChangeMessage, setRoleChangeMessage] = useState<string | null>(null);
+  const [changingUserKey, setChangingUserKey] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const query = useMemo(
@@ -96,6 +106,56 @@ export function AdminUsersRolesReadOnlyCard() {
     });
   }
 
+  async function handleChangeClinicRole(
+    user: Extract<AdminRoleUserSummary, { userType: "clinic" }>,
+  ) {
+    const nextRole = getNextClinicRole(user.role);
+    const confirmed = window.confirm(
+      `¿Cambiar el rol de ${user.username} de ${formatRole(user.role)} a ${formatRole(nextRole)}?`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const userKey = `${user.userType}-${user.userId}`;
+
+    setError(null);
+    setRoleChangeMessage(null);
+    setChangingUserKey(userKey);
+
+    try {
+      const result = await changeAdminClinicUserRole(user.userId, nextRole);
+
+      setSnapshot((current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          users: current.users.map((entry) =>
+            entry.userType === "clinic" && entry.userId === result.user.userId
+              ? result.user
+              : entry,
+          ),
+        };
+      });
+
+      setRoleChangeMessage(
+        `Rol actualizado: ${result.user.username} ahora es ${formatRole(result.user.role)}.`,
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "No se pudo cambiar el rol del usuario.",
+      );
+    } finally {
+      setChangingUserKey(null);
+    }
+  }
+
   useEffect(() => {
     loadUsersRoles();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -112,8 +172,8 @@ export function AdminUsersRolesReadOnlyCard() {
         <div>
           <CardTitle className="text-base">Usuarios y roles</CardTitle>
           <CardDescription>
-            Vista read-only de usuarios Admin y clínica. No permite edición,
-            revocación ni acciones destructivas.
+            Vista Admin de usuarios y roles. Permite cambiar roles de usuarios
+            de clínica con confirmación explícita y bloqueo anti-lockout.
           </CardDescription>
         </div>
 
@@ -185,6 +245,12 @@ export function AdminUsersRolesReadOnlyCard() {
           </div>
         ) : null}
 
+        {roleChangeMessage ? (
+          <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+            {roleChangeMessage}
+          </div>
+        ) : null}
+
         <div className="overflow-hidden rounded-lg border border-gray-100">
           <Table>
             <TableHeader>
@@ -195,47 +261,71 @@ export function AdminUsersRolesReadOnlyCard() {
                 <TableHead>Clínica</TableHead>
                 <TableHead>Creado</TableHead>
                 <TableHead>Actualizado</TableHead>
+                <TableHead className="text-right">Acción</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {snapshot?.users.length ? (
-                snapshot.users.map((user) => (
-                  <TableRow key={`${user.userType}-${user.userId}`}>
-                    <TableCell>
-                      <div className="flex flex-col gap-1">
-                        <span className="text-sm font-semibold text-gray-700">
-                          {user.username}
-                        </span>
-                        <span className="font-mono text-xs text-gray-400">
-                          #{user.userId}
-                        </span>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={getUserTypeVariant(user.userType)}>
-                        {formatUserType(user.userType)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={getRoleVariant(user.role)}>
-                        {formatRole(user.role)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-gray-500">
-                      {formatClinic(user)}
-                    </TableCell>
-                    <TableCell className="text-xs text-gray-400">
-                      {formatDateTime(user.createdAt)}
-                    </TableCell>
-                    <TableCell className="text-xs text-gray-400">
-                      {formatDateTime(user.updatedAt)}
-                    </TableCell>
-                  </TableRow>
-                ))
+                snapshot.users.map((user) => {
+                  const userKey = `${user.userType}-${user.userId}`;
+                  const isChanging = changingUserKey === userKey;
+
+                  return (
+                    <TableRow key={userKey}>
+                      <TableCell>
+                        <div className="flex flex-col gap-1">
+                          <span className="text-sm font-semibold text-gray-700">
+                            {user.username}
+                          </span>
+                          <span className="font-mono text-xs text-gray-400">
+                            #{user.userId}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getUserTypeVariant(user.userType)}>
+                          {formatUserType(user.userType)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getRoleVariant(user.role)}>
+                          {formatRole(user.role)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-500">
+                        {formatClinic(user)}
+                      </TableCell>
+                      <TableCell className="text-xs text-gray-400">
+                        {formatDateTime(user.createdAt)}
+                      </TableCell>
+                      <TableCell className="text-xs text-gray-400">
+                        {formatDateTime(user.updatedAt)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {user.userType === "clinic" ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            disabled={isChanging}
+                            onClick={() => void handleChangeClinicRole(user)}
+                          >
+                            {isChanging
+                              ? "Cambiando..."
+                              : `Cambiar a ${formatRole(getNextClinicRole(user.role))}`}
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-gray-400">
+                            No editable
+                          </span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
               ) : (
                 <TableRow>
                   <TableCell
-                    colSpan={6}
+                    colSpan={7}
                     className="py-8 text-center text-sm text-gray-400"
                   >
                     {isPending
@@ -250,9 +340,11 @@ export function AdminUsersRolesReadOnlyCard() {
 
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <p className="text-xs text-gray-400">
-            Endpoint: <code>GET /api/admin/users-roles</code>. Campos sensibles
-            como <code>passwordHash</code>, <code>authProId</code> y tokens no
-            se renderizan.
+            Endpoints: <code>GET /api/admin/users-roles</code> y{" "}
+            <code>PATCH /api/admin/users-roles/clinic/:clinicUserId/role</code>.
+            Admin users no son editables. Campos sensibles como{" "}
+            <code>passwordHash</code>, <code>authProId</code> y tokens no se
+            renderizan.
           </p>
 
           <div className="flex items-center gap-2">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,6 +27,8 @@ import type {
   AdminSessionsSnapshot,
   AdminUsersRolesQuery,
   AdminUsersRolesSnapshot,
+  AdminClinicUserRoleChangeResponse,
+  ClinicUserRole,
   AdminSessionRevocationResponse,
   AdminSessionType,
 } from "@/types";
@@ -251,6 +253,21 @@ export async function getAdminUsersRoles(
   return apiFetch<AdminUsersRolesSnapshot>(
     `/api/admin/users-roles${qs ? `?${qs}` : ""}`,
     options,
+  );
+}
+
+export async function changeAdminClinicUserRole(
+  clinicUserId: number,
+  role: ClinicUserRole,
+  options?: RequestInit,
+): Promise<AdminClinicUserRoleChangeResponse> {
+  return apiFetch<AdminClinicUserRoleChangeResponse>(
+    `/api/admin/users-roles/clinic/${clinicUserId}/role`,
+    {
+      ...options,
+      method: "PATCH",
+      body: JSON.stringify({ role }),
+    },
   );
 }
 export async function getAdminSessions(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -219,6 +219,15 @@ export type AdminUsersRolesQuery = {
   offset?: number;
 };
 
+
+export type AdminClinicUserRoleChangeResponse = {
+  success: true;
+  user: Extract<AdminRoleUserSummary, { userType: "clinic" }>;
+  changedBy: {
+    adminUserId: number;
+    username: string;
+  };
+};
 export type AdminUsersRolesSnapshot = {
   success: true;
   users: AdminRoleUserSummary[];


### PR DESCRIPTION
## Summary

- Add Admin UI action to change clinic user roles.
- Consume `PATCH /api/admin/users-roles/clinic/:clinicUserId/role`.
- Keep Admin users non-editable.
- Require explicit confirmation before changing a clinic user role.
- Update the visible row after a successful role change.
- Surface backend errors, including anti-lockout `409`.

## Security

- Frontend only.
- No destructive actions.
- No Admin user role mutation.
- No passwordHash, authProId, tokenHash, cookies or secrets are rendered.
- Backend anti-lockout remains enforced by the API.

## Validation

- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`