### PR TITLE
feat(admin): surface users roles audit visibility

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -31,6 +31,7 @@ export const metadata: Metadata = {
 const EVENT_LABELS: Record<string, string> = {
   "auth.admin.login.succeeded": "Login admin",
   "auth.clinic.login.succeeded": "Login clínica",
+  "clinic_user.role.changed": "Cambio rol clínica",
   "report.status.changed": "Estado informe",
   "report.uploaded": "Informe subido",
   "study_tracking.case.created": "Caso creado",
@@ -280,6 +281,44 @@ export default async function AdminPage() {
         <AdminMaintenanceDryRunCard />
         <AdminSessionsReadOnlyCard />
         <AdminUsersRolesReadOnlyCard />
+        <Card id="audit-role-changes">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Auditoría de cambios de rol clínica
+            </CardTitle>
+            <CardDescription>
+              Acceso rápido a eventos <code>clinic_user.role.changed</code>
+              generados desde usuarios y roles.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Cambios registrados</p>
+                <p className="mt-1 text-2xl font-bold text-gray-900">
+                  {roleChangeAuditEntries.length}
+                </p>
+              </div>
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Último cambio</p>
+                <p className="mt-1 text-sm font-semibold text-gray-800">
+                  {lastRoleChangeAuditEntry
+                    ? formatDateTime(lastRoleChangeAuditEntry.createdAt)
+                    : "—"}
+                </p>
+              </div>
+              <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                <p className="text-xs text-gray-400">Filtro audit</p>
+                <a
+                  href="#audit-log"
+                  className="mt-1 inline-flex text-sm font-semibold text-blue-700 hover:text-blue-900"
+                >
+                  Ver log completo
+                </a>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
 
         <Card>

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -154,6 +154,10 @@ export default async function AdminPage() {
     },
     {} as Record<string, number>,
   );
+  const roleChangeAuditEntries = auditEntries.filter(
+    (entry) => entry.event === "clinic_user.role.changed",
+  );
+  const lastRoleChangeAuditEntry = roleChangeAuditEntries[0];
 
   return (
     <>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,6 +47,7 @@ export type RouteStopStatus = (typeof ROUTE_STOP_STATUSES)[number];
 export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
+  "clinic_user.role.changed",
   "report.status.changed",
   "report.uploaded",
   "study_tracking.case.created",


### PR DESCRIPTION
## Summary

- Add audit visibility for clinic user role changes in Admin.
- Surface `clinic_user.role.changed` with a dedicated summary card.
- Add quick navigation from users/roles to the role-change audit section.
- Add an anchor for the full audit log.

## Security

- Frontend only.
- No backend changes.
- No new mutations.
- No destructive actions.
- No passwordHash, authProId, tokenHash, cookies or secrets are rendered.

## Validation

- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`