### PR TITLE
fix(admin): link role change audit filter

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -423,12 +423,14 @@ export default async function AdminPage({
               </div>
               <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
                 <p className="text-xs text-gray-400">Filtro audit</p>
-                <a
-                  href="#audit-log"
+                <Link
+                  href={buildAdminAuditFilterHref({
+                    event: "clinic_user.role.changed",
+                  })}
                   className="mt-1 inline-flex text-sm font-semibold text-blue-700 hover:text-blue-900"
                 >
-                  Ver log completo
-                </a>
+                  Ver cambios de rol
+                </Link>
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary

- Polish role-change audit quick navigation.
- Change the role-change audit card link to open the audit log filtered by `clinic_user.role.changed`.
- Use the existing `buildAdminAuditFilterHref` helper.
- Keep current filters, metadata and layout behavior.

## Security

- Frontend only.
- No backend changes.
- No new mutations.
- No destructive actions.
- No passwordHash, authProId, tokenHash, cookies or secrets are rendered.

## Validation

- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`