### PR TITLE
fix(admin): guard sensitive audit metadata

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -123,6 +123,23 @@ function formatUptime(totalSeconds: number | undefined) {
   return `${minutes}m`;
 }
 
+const SENSITIVE_AUDIT_METADATA_KEY_PARTS = [
+  "password",
+  "token",
+  "secret",
+  "cookie",
+  "auth",
+  "hash",
+] as const;
+
+function isSensitiveAuditMetadataKey(key: string) {
+  const normalizedKey = key.toLowerCase();
+
+  return SENSITIVE_AUDIT_METADATA_KEY_PARTS.some((part) =>
+    normalizedKey.includes(part),
+  );
+}
+
 function formatAuditMetadataValue(value: unknown) {
   if (value === null || value === undefined || value === "") {
     return "—";


### PR DESCRIPTION
## Summary

- Guard Admin audit log metadata rendering against sensitive keys.
- Hide metadata keys containing password, token, secret, cookie, auth or hash.
- Keep safe metadata visible in the existing audit detail summary.
- Preserve current audit filters, layout and quick-filter behavior.

## Security

- Frontend only.
- No backend changes.
- No new mutations.
- No destructive actions.
- Sensitive metadata keys are not rendered if they appear in future payloads.
- No passwordHash, authProId, tokenHash, cookies or secrets are rendered.

## Validation

- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`