### PR TITLE
fix(admin): restore audit log detail column

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -518,6 +518,7 @@ export default async function AdminPage({
                   <TableHead>Actor</TableHead>
                   <TableHead>Tipo actor</TableHead>
                   <TableHead>Objetivo</TableHead>
+                  <TableHead>Detalle</TableHead>
                   <TableHead>Fecha</TableHead>
                 </TableRow>
               </TableHeader>
@@ -543,6 +544,9 @@ export default async function AdminPage({
                         {entry.targetType && entry.targetId
                           ? `${entry.targetType} #${entry.targetId}`
                           : "—"}
+                      </TableCell>
+                      <TableCell className="max-w-md whitespace-normal break-words text-xs text-gray-500">
+                        {getAuditMetadataSummary(entry)}
                       </TableCell>
                       <TableCell className="text-gray-400 text-xs">
                         {formatDateTime(entry.createdAt)}


### PR DESCRIPTION
## Summary

- Restore the Admin audit log `Detalle` table column.
- Render `getAuditMetadataSummary(entry)` for each audit row.
- Keep the sensitive metadata guard already enforced.
- Preserve filters, empty state and quick-filter behavior.

## Security

- Frontend only.
- No backend changes.
- No new mutations.
- No destructive actions.
- Sensitive metadata guard remains active.
- No passwordHash, authProId, tokenHash, cookies or secrets are rendered.

## Validation

- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`