### PR TITLE
test(admin): guard audit log detail column

### DIFF
--- a/test/frontend-admin-metadata-guard.test.ts
+++ b/test/frontend-admin-metadata-guard.test.ts
@@ -101,3 +101,16 @@ test("frontend admin role-change metadata summary only reads approved fields", (
     );
   }
 });
+test("frontend admin audit table keeps detail column wired to safe metadata summary", () => {
+  const source = read(adminPage);
+
+  assertIncludes(source, "<TableHead>Detalle</TableHead>", adminPage);
+  assertIncludes(source, "{getAuditMetadataSummary(entry)}", adminPage);
+  assertIncludes(source, "colSpan={7}", adminPage);
+  assertIncludes(source, "function getAuditMetadataSummary", adminPage);
+  assert.match(
+    source,
+    /!\s*isSensitiveAuditMetadataKey\(key\)/,
+    "detail column summary must keep sensitive metadata filtering",
+  );
+});


### PR DESCRIPTION
## Summary

- Add a frontend guardrail test for the Admin audit log detail column.
- Assert the audit table keeps the `Detalle` header.
- Assert rows render `getAuditMetadataSummary(entry)`.
- Assert the empty state keeps `colSpan={7}`.
- Assert detail metadata summary keeps sensitive metadata filtering.

## Security

- Test only.
- No frontend product changes.
- No backend changes.
- No new mutations.
- No destructive actions.
- Sensitive metadata guard remains covered.
- No passwordHash, authProId, tokenHash, cookies or secrets are rendered.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-metadata-guard.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`