### PR TITLE
feat(admin): persist failed login attempts

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -150,6 +150,22 @@ export const AUDIT_EVENTS = [
 ] as const;
 export type AuditEvent = (typeof AUDIT_EVENTS)[number];
 
+export const LOGIN_FAILED_ATTEMPT_SURFACES = [
+  "admin",
+  "clinic",
+  "particular",
+] as const;
+export type LoginFailedAttemptSurface =
+  (typeof LOGIN_FAILED_ATTEMPT_SURFACES)[number];
+
+export const LOGIN_FAILED_ATTEMPT_REASONS = [
+  "missing_credentials",
+  "invalid_credentials",
+  "rate_limited",
+] as const;
+export type LoginFailedAttemptReason =
+  (typeof LOGIN_FAILED_ATTEMPT_REASONS)[number];
+
 
 export const clinics = pgTable("clinics", {
   id: serial("id").primaryKey(),
@@ -389,6 +405,35 @@ export const auditLog = pgTable(
     targetReportAccessTokenIdIdx: index(
       "audit_log_target_report_access_token_id_idx",
     ).on(table.targetReportAccessTokenId),
+  }),
+);
+
+export const loginFailedAttempts = pgTable(
+  "login_failed_attempts",
+  {
+    id: serial("id").primaryKey(),
+    surface: varchar("surface", { length: 32 })
+      .$type<LoginFailedAttemptSurface>()
+      .notNull(),
+    username: varchar("username", { length: 100 }),
+    reason: varchar("reason", { length: 64 })
+      .$type<LoginFailedAttemptReason>()
+      .notNull(),
+    ipAddress: varchar("ip_address", { length: 64 }),
+    userAgent: text("user_agent"),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    surfaceCreatedAtIdx: index(
+      "login_failed_attempts_surface_created_at_idx",
+    ).on(table.surface, table.createdAt),
+    ipCreatedAtIdx: index("login_failed_attempts_ip_created_at_idx").on(
+      table.ipAddress,
+      table.createdAt,
+    ),
+    reasonCreatedAtIdx: index(
+      "login_failed_attempts_reason_created_at_idx",
+    ).on(table.reason, table.createdAt),
   }),
 );
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -8,9 +8,12 @@ import {
   adminUsers,
   clinicUsers,
   clinics,
+  loginFailedAttempts,
   reports,
   reportStatusHistory,
   type ClinicUserRole,
+  type LoginFailedAttemptReason,
+  type LoginFailedAttemptSurface,
   type ReportStatus,
 } from "../drizzle/schema";
 import { ENV } from "./lib/env";
@@ -114,6 +117,31 @@ export async function getAdminUserByUsername(username: string) {
     .from(adminUsers)
     .where(eq(adminUsers.username, username.trim()))
     .limit(1);
+
+  return result[0];
+}
+
+/* ========================= LOGIN FAILED ATTEMPTS ========================= */
+
+export async function recordLoginFailedAttempt(input: {
+  surface: LoginFailedAttemptSurface;
+  username?: string | null;
+  reason: LoginFailedAttemptReason;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  createdAt?: Date;
+}) {
+  const result = await db
+    .insert(loginFailedAttempts)
+    .values({
+      surface: input.surface,
+      username: input.username ?? null,
+      reason: input.reason,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+      createdAt: input.createdAt ?? new Date(),
+    })
+    .returning();
 
   return result[0];
 }

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -65,6 +65,20 @@ type AuditWriteInput = {
   };
 };
 
+type LoginFailedAttemptReason =
+  | "missing_credentials"
+  | "invalid_credentials"
+  | "rate_limited";
+
+type RecordLoginFailedAttemptInput = {
+  surface: "admin";
+  username?: string | null;
+  reason: LoginFailedAttemptReason;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  createdAt: Date;
+};
+
 export type AdminAuthNativeRoutesOptions = {
   createAdminSession?: (input: {
     adminUserId: number;
@@ -89,6 +103,9 @@ export type AdminAuthNativeRoutesOptions = {
     passwordHash: string,
   ) => Promise<VerifyPasswordResult>;
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  recordLoginFailedAttempt?: (
+    input: RecordLoginFailedAttemptInput,
+  ) => Promise<unknown>;
   loginRateLimitWindowMs?: number;
   loginRateLimitMaxAttempts?: number;
   loginRateLimitStore?: RateLimitStore;
@@ -115,6 +132,7 @@ type NativeAdminAuthDeps = Required<
     | "hashSessionToken"
     | "verifyPassword"
     | "writeAuditLog"
+    | "recordLoginFailedAttempt"
   >
 >;
 
@@ -141,6 +159,7 @@ async function loadDefaultDeps(): Promise<NativeAdminAuthDeps> {
           req: unknown,
           input: AuditWriteInput,
         ) => Promise<void>,
+        recordLoginFailedAttempt: db.recordLoginFailedAttempt,
       };
     })();
   }
@@ -391,6 +410,12 @@ function setLoginRateLimitHeaders(
 
 
 
+function getUserAgent(request: FastifyRequest) {
+  const value = request.headers["user-agent"];
+
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
 function createAuditRequestLike(
   request: FastifyRequest,
   admin?: Pick<AuthenticatedAdminUser, "id" | "username">,
@@ -508,6 +533,10 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       options.hashSessionToken ?? defaultDeps!.hashSessionToken,
     verifyPassword: options.verifyPassword ?? defaultDeps!.verifyPassword,
     writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+    recordLoginFailedAttempt:
+      options.recordLoginFailedAttempt ??
+      defaultDeps?.recordLoginFailedAttempt ??
+      (async () => undefined),
   };
 
   const now = options.now ?? (() => Date.now());
@@ -595,6 +624,20 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       currentTime,
     );
 
+    const recordFailedLoginAttempt = async (input: {
+      username?: string | null;
+      reason: LoginFailedAttemptReason;
+    }) => {
+      await deps.recordLoginFailedAttempt({
+        surface: "admin",
+        username: input.username?.trim() || null,
+        reason: input.reason,
+        ipAddress: request.ip || null,
+        userAgent: getUserAgent(request),
+        createdAt: new Date(currentTime),
+      });
+    };
+
     if (failureEntry.count >= loginRateLimitMaxAttempts) {
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -604,13 +647,26 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
 
+      const attemptedUsername =
+        typeof request.body?.username === "string"
+          ? request.body.username.trim()
+          : "";
+
+      await recordFailedLoginAttempt({
+        username: attemptedUsername,
+        reason: "rate_limited",
+      });
+
       return reply.code(429).send({
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
       });
     }
 
-    const markFailure = async () => {
+    const markFailure = async (input: {
+      username?: string | null;
+      reason: LoginFailedAttemptReason;
+    }) => {
       const updatedEntry = await incrementRateLimitEntry(
         loginRateLimitStore,
         rateLimitKey,
@@ -627,6 +683,8 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
         resetAt: failureEntry.resetAt,
         now: currentTime,
       });
+
+      await recordFailedLoginAttempt(input);
     };
 
     const markSuccess = () => {
@@ -647,7 +705,10 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       typeof request.body?.password === "string" ? request.body.password : "";
 
     if (!username || !password) {
-      await markFailure();
+      await markFailure({
+        username,
+        reason: "missing_credentials",
+      });
 
       return reply.code(400).send({
         success: false,
@@ -658,7 +719,10 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     const admin = await deps.getAdminUserByUsername(username);
 
     if (!admin) {
-      await markFailure();
+      await markFailure({
+        username,
+        reason: "invalid_credentials",
+      });
 
       return reply.code(401).send({
         success: false,
@@ -669,7 +733,10 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     const valid = await deps.verifyPassword(password, admin.passwordHash);
 
     if (!valid.valid) {
-      await markFailure();
+      await markFailure({
+        username,
+        reason: "invalid_credentials",
+      });
 
       return reply.code(401).send({
         success: false,

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -36,6 +36,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       needsRehash: false,
     }),
     writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
     ...overrides,
   });
 
@@ -436,6 +437,52 @@ test("adminAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido", 
       success: false,
       error: "Origen no permitido",
     });
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminAuthNativeRoutes persiste failed login sin secretos", async () => {
+  const attempts: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
+    getAdminUserByUsername: async () => null,
+    recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+      attempts.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+        "user-agent": "vetneb-test-agent",
+      },
+      remoteAddress: "203.0.113.44",
+      payload: {
+        username: " VETNEB ",
+        password: "SUPER-SECRET-PASSWORD",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(attempts.length, 1);
+
+    assert.equal(attempts[0].surface, "admin");
+    assert.equal(attempts[0].username, "VETNEB");
+    assert.equal(attempts[0].reason, "invalid_credentials");
+    assert.equal(attempts[0].userAgent, "vetneb-test-agent");
+    assert.ok(attempts[0].createdAt instanceof Date);
+
+    const serializedAttempt = JSON.stringify(attempts[0]).toLowerCase();
+
+    assert.equal(serializedAttempt.includes("super-secret-password".toLowerCase()), false);
+    assert.equal(serializedAttempt.includes("passwordhash"), false);
+    assert.equal(serializedAttempt.includes("tokenhash"), false);
+    assert.equal(serializedAttempt.includes("cookie"), false);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary

- Add minimal failed-login persistence schema.
- Add `recordLoginFailedAttempt` DB helper.
- Persist failed Admin login attempts from `/api/admin/auth/login`.
- Capture safe metadata only: surface, username, reason, IP, user agent and timestamp.
- Add Admin auth test coverage for failed-login persistence without secrets.

## Security

- Backend only.
- Admin auth only.
- No frontend changes.
- No blocking or lockout behavior added.
- No alerting UI added.
- No password, token, tokenHash, cookie, passwordHash, raw payload or secret is persisted.
- Failed-login reasons are bounded to `missing_credentials`, `invalid_credentials` and `rate_limited`.

## Validation

- [x] `pnpm test -- .\test\admin-auth.fastify.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`