### PR TITLE
feat(auth): persist clinic failed login attempts

### DIFF
--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -80,6 +80,20 @@ type AuditWriteInput = {
   };
 };
 
+type LoginFailedAttemptReason =
+  | "missing_credentials"
+  | "invalid_credentials"
+  | "rate_limited";
+
+type RecordLoginFailedAttemptInput = {
+  surface: "clinic";
+  username?: string | null;
+  reason: LoginFailedAttemptReason;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  createdAt: Date;
+};
+
 export type AuthNativeRoutesOptions = {
   createActiveSession?: (input: {
     clinicUserId: number;
@@ -112,6 +126,9 @@ export type AuthNativeRoutesOptions = {
     passwordHash: string,
   ) => Promise<VerifyPasswordResult>;
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  recordLoginFailedAttempt?: (
+    input: RecordLoginFailedAttemptInput,
+  ) => Promise<unknown>;
   loginRateLimitWindowMs?: number;
   loginRateLimitMaxAttempts?: number;
   loginRateLimitStore?: RateLimitStore;
@@ -140,6 +157,7 @@ type NativeAuthDeps = Required<
     | "hashSessionToken"
     | "verifyPassword"
     | "writeAuditLog"
+    | "recordLoginFailedAttempt"
   >
 >;
 
@@ -168,6 +186,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDeps> {
           req: unknown,
           input: AuditWriteInput,
         ) => Promise<void>,
+        recordLoginFailedAttempt: db.recordLoginFailedAttempt,
       };
     })();
   }
@@ -414,6 +433,11 @@ function setLoginRateLimitHeaders(
   );
 }
 
+function getUserAgent(request: FastifyRequest) {
+  const value = request.headers["user-agent"];
+
+  return typeof value === "string" && value.trim() ? value : null;
+}
 
 function createAuditRequestLike(
   request: FastifyRequest,
@@ -538,6 +562,10 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       options.hashSessionToken ?? defaultDeps!.hashSessionToken,
     verifyPassword: options.verifyPassword ?? defaultDeps!.verifyPassword,
     writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+    recordLoginFailedAttempt:
+      options.recordLoginFailedAttempt ??
+      defaultDeps?.recordLoginFailedAttempt ??
+      (async () => undefined),
   };
 
   const now = options.now ?? (() => Date.now());
@@ -622,6 +650,20 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       currentTime,
     );
 
+    const recordFailedLoginAttempt = async (input: {
+      username?: string | null;
+      reason: LoginFailedAttemptReason;
+    }) => {
+      await deps.recordLoginFailedAttempt({
+        surface: "clinic",
+        username: input.username?.trim() || null,
+        reason: input.reason,
+        ipAddress: request.ip || null,
+        userAgent: getUserAgent(request),
+        createdAt: new Date(currentTime),
+      });
+    };
+
     if (failureEntry.count >= loginRateLimitMaxAttempts) {
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -631,13 +673,26 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
 
+      const attemptedUsername =
+        typeof request.body?.username === "string"
+          ? request.body.username.trim()
+          : "";
+
+      await recordFailedLoginAttempt({
+        username: attemptedUsername,
+        reason: "rate_limited",
+      });
+
       return reply.code(429).send({
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
       });
     }
 
-    const markFailure = async () => {
+    const markFailure = async (input: {
+      username?: string | null;
+      reason: LoginFailedAttemptReason;
+    }) => {
       const updatedEntry = await incrementRateLimitEntry(
         loginRateLimitStore,
         rateLimitKey,
@@ -654,6 +709,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         resetAt: failureEntry.resetAt,
         now: currentTime,
       });
+
+      await recordFailedLoginAttempt(input);
     };
 
     const markSuccess = () => {
@@ -674,7 +731,10 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       typeof request.body?.password === "string" ? request.body.password : "";
 
     if (!username || !password) {
-      await markFailure();
+      await markFailure({
+        username,
+        reason: "missing_credentials",
+      });
 
       return reply.code(400).send({
         success: false,
@@ -685,7 +745,10 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     const clinicUser = await deps.getClinicUserByUsername(username);
 
     if (!clinicUser) {
-      await markFailure();
+      await markFailure({
+        username,
+        reason: "invalid_credentials",
+      });
 
       return reply.code(401).send({
         success: false,
@@ -699,7 +762,10 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     );
 
     if (!passwordCheck.valid) {
-      await markFailure();
+      await markFailure({
+        username,
+        reason: "invalid_credentials",
+      });
 
       return reply.code(401).send({
         success: false,

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -41,6 +41,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       needsRehash: false,
     }),
     writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
     ...overrides,
   });
 
@@ -364,6 +365,55 @@ test("clinicAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido",
       success: false,
       error: "Origen no permitido",
     });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes persiste failed login sin secretos", async () => {
+  const attempts: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
+    getClinicUserByUsername: async () => null,
+    recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+      attempts.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+        "user-agent": "vetneb-test-agent",
+      },
+      remoteAddress: "203.0.113.45",
+      payload: {
+        username: " vetneb ",
+        password: "SUPER-SECRET-PASSWORD",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(attempts.length, 1);
+
+    assert.equal(attempts[0].surface, "clinic");
+    assert.equal(attempts[0].username, "vetneb");
+    assert.equal(attempts[0].reason, "invalid_credentials");
+    assert.equal(attempts[0].userAgent, "vetneb-test-agent");
+    assert.ok(attempts[0].createdAt instanceof Date);
+
+    const serializedAttempt = JSON.stringify(attempts[0]).toLowerCase();
+
+    assert.equal(
+      serializedAttempt.includes("super-secret-password".toLowerCase()),
+      false,
+    );
+    assert.equal(serializedAttempt.includes("passwordhash"), false);
+    assert.equal(serializedAttempt.includes("tokenhash"), false);
+    assert.equal(serializedAttempt.includes("cookie"), false);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary

- Persist failed Clinic login attempts from `/api/auth/login`.
- Reuse existing failed-login persistence schema and DB helper.
- Add Clinic auth test coverage for safe failed-login metadata.

## Security

- Backend only.
- Clinic auth only.
- No frontend changes.
- No blocking or lockout behavior added.
- No alerting UI added.
- Sensitive authentication material is not persisted.
- Failed-login reasons remain bounded to `missing_credentials`, `invalid_credentials` and `rate_limited`.

## Validation

- [x] `pnpm test -- .\test\auth.fastify.test.ts`
- [x] `pnpm test -- .\test\admin-auth.fastify.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
