### PR TITLE
feat(auth): persist particular failed login attempts

### DIFF
--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -48,6 +48,20 @@ type AuthenticatedParticularUser = {
   sessionToken: string;
 };
 
+type LoginFailedAttemptReason =
+  | "missing_credentials"
+  | "invalid_credentials"
+  | "rate_limited";
+
+type RecordLoginFailedAttemptInput = {
+  surface: "particular";
+  username?: string | null;
+  reason: LoginFailedAttemptReason;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  createdAt: Date;
+};
+
 export type ParticularAuthNativeRoutesOptions = {
   createParticularSession?: (input: {
     particularTokenId: number;
@@ -75,6 +89,9 @@ export type ParticularAuthNativeRoutesOptions = {
   ) => Promise<string>;
   generateSessionToken?: () => string;
   hashSessionToken?: (token: string) => string;
+  recordLoginFailedAttempt?: (
+    input: RecordLoginFailedAttemptInput,
+  ) => Promise<unknown>;
   loginRateLimitWindowMs?: number;
   loginRateLimitMaxAttempts?: number;
   loginRateLimitStore?: RateLimitStore;
@@ -103,6 +120,7 @@ type NativeParticularAuthDeps = Required<
     | "createSignedReportDownloadUrl"
     | "generateSessionToken"
     | "hashSessionToken"
+    | "recordLoginFailedAttempt"
   >
 >;
 
@@ -133,6 +151,7 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDeps> {
           supabase.createSignedReportDownloadUrl,
         generateSessionToken: authSecurity.generateSessionToken,
         hashSessionToken: authSecurity.hashSessionToken,
+        recordLoginFailedAttempt: db.recordLoginFailedAttempt,
       };
     })();
   }
@@ -381,7 +400,11 @@ function setLoginRateLimitHeaders(
   );
 }
 
+function getUserAgent(request: FastifyRequest) {
+  const value = request.headers["user-agent"];
 
+  return typeof value === "string" && value.trim() ? value : null;
+}
 
 async function buildParticularResponse(
   deps: NativeParticularAuthDeps,
@@ -517,6 +540,10 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       options.generateSessionToken ?? defaultDeps!.generateSessionToken,
     hashSessionToken:
       options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    recordLoginFailedAttempt:
+      options.recordLoginFailedAttempt ??
+      defaultDeps?.recordLoginFailedAttempt ??
+      (async () => undefined),
   };
 
   const now = options.now ?? (() => Date.now());
@@ -605,6 +632,19 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       currentTime,
     );
 
+    const recordFailedLoginAttempt = async (input: {
+      reason: LoginFailedAttemptReason;
+    }) => {
+      await deps.recordLoginFailedAttempt({
+        surface: "particular",
+        username: null,
+        reason: input.reason,
+        ipAddress: request.ip || null,
+        userAgent: getUserAgent(request),
+        createdAt: new Date(currentTime),
+      });
+    };
+
     if (failureEntry.count >= loginRateLimitMaxAttempts) {
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -614,13 +654,19 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
 
+      await recordFailedLoginAttempt({
+        reason: "rate_limited",
+      });
+
       return reply.code(429).send({
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
       });
     }
 
-    const markFailure = async () => {
+    const markFailure = async (input: {
+      reason: LoginFailedAttemptReason;
+    }) => {
       const updatedEntry = await incrementRateLimitEntry(
         loginRateLimitStore,
         rateLimitKey,
@@ -637,6 +683,8 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
         resetAt: failureEntry.resetAt,
         now: currentTime,
       });
+
+      await recordFailedLoginAttempt(input);
     };
 
     const markSuccess = () => {
@@ -653,7 +701,9 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       typeof request.body?.token === "string" ? request.body.token.trim() : "";
 
     if (!providedToken) {
-      await markFailure();
+      await markFailure({
+        reason: "missing_credentials",
+      });
 
       return reply.code(400).send({
         success: false,
@@ -665,7 +715,9 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     const particularToken = await deps.getParticularTokenByTokenHash(tokenHash);
 
     if (!particularToken || !particularToken.isActive) {
-      await markFailure();
+      await markFailure({
+        reason: "invalid_credentials",
+      });
 
       return reply.code(401).send({
         success: false,

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -79,6 +79,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     ) => `signed-download:${storagePath}:${fileName ?? ""}`,
     generateSessionToken: () => "particular-session-token",
     hashSessionToken: (token: string) => `hash:${token}`,
+    recordLoginFailedAttempt: async () => {},
     ...overrides,
   });
 
@@ -517,3 +518,48 @@ test(
     }
   },
 );
+
+test("particularAuthNativeRoutes persiste failed login sin secretos", async () => {
+  const attempts: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
+    getParticularTokenByTokenHash: async () => null,
+    recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+      attempts.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+        "user-agent": "vetneb-test-agent",
+      },
+      remoteAddress: "203.0.113.46",
+      payload: {
+        token: "SUPER-SECRET-PARTICULAR-TOKEN",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(attempts.length, 1);
+
+    assert.equal(attempts[0].surface, "particular");
+    assert.equal(attempts[0].username, null);
+    assert.equal(attempts[0].reason, "invalid_credentials");
+    assert.equal(attempts[0].userAgent, "vetneb-test-agent");
+    assert.ok(attempts[0].createdAt instanceof Date);
+
+    const serializedAttempt = JSON.stringify(attempts[0]).toLowerCase();
+
+    assert.equal(serializedAttempt.includes("super-secret-particular-token"), false);
+    assert.equal(serializedAttempt.includes("tokenhash"), false);
+    assert.equal(serializedAttempt.includes("cookie"), false);
+    assert.equal(serializedAttempt.includes("password"), false);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary

- Persist failed Particular login attempts from `/api/particular/auth/login`.
- Reuse existing failed-login persistence schema and DB helper.
- Store safe metadata only for the particular surface.
- Add Particular auth test coverage for failed-login persistence without storing raw tokens.

## Security

- Backend only.
- Particular auth only.
- No frontend changes.
- No blocking or lockout behavior added.
- No alerting UI added.
- Raw particular tokens are not persisted.
- Session tokens, token hashes, cookies and secrets are not persisted.
- Failed-login reasons remain bounded to `missing_credentials`, `invalid_credentials` and `rate_limited`.

## Validation

- [x] `pnpm test -- .\test\particular-auth.fastify.test.ts`
- [x] `pnpm test -- .\test\admin-auth.fastify.test.ts`
- [x] `pnpm test -- .\test\auth.fastify.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
