### PR TITLE
feat(admin): add failed login alerts endpoint

### DIFF
--- a/server/db-admin-failed-login-alerts.ts
+++ b/server/db-admin-failed-login-alerts.ts
@@ -1,0 +1,122 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import { db } from "./db.ts";
+import {
+  loginFailedAttempts,
+  type LoginFailedAttemptReason,
+  type LoginFailedAttemptSurface,
+} from "../drizzle/schema";
+
+export type AdminFailedLoginAlertSurface = LoginFailedAttemptSurface;
+export type AdminFailedLoginAlertReason = LoginFailedAttemptReason;
+
+export type AdminFailedLoginAlertSummary = {
+  id: number;
+  surface: AdminFailedLoginAlertSurface;
+  username: string | null;
+  reason: AdminFailedLoginAlertReason;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+};
+
+export type AdminFailedLoginAlertsQuery = {
+  surface?: AdminFailedLoginAlertSurface;
+  reason?: AdminFailedLoginAlertReason;
+  limit?: number;
+  offset?: number;
+};
+
+export type AdminFailedLoginAlertsSnapshot = {
+  success: true;
+  failedLoginAlerts: AdminFailedLoginAlertSummary[];
+  count: number;
+  total: number;
+  limit: number;
+  offset: number;
+  filters: {
+    surface: AdminFailedLoginAlertSurface | null;
+    reason: AdminFailedLoginAlertReason | null;
+  };
+};
+
+function normalizeLimit(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 50;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), 100);
+}
+
+function normalizeOffset(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(Math.trunc(value), 0);
+}
+
+export async function listAdminFailedLoginAlerts(
+  params: AdminFailedLoginAlertsQuery = {},
+): Promise<AdminFailedLoginAlertsSnapshot> {
+  const limit = normalizeLimit(params.limit);
+  const offset = normalizeOffset(params.offset);
+  const filters = [];
+
+  if (params.surface) {
+    filters.push(eq(loginFailedAttempts.surface, params.surface));
+  }
+
+  if (params.reason) {
+    filters.push(eq(loginFailedAttempts.reason, params.reason));
+  }
+
+  const whereClause = filters.length > 0 ? and(...filters) : undefined;
+
+  const [rows, totalRows] = await Promise.all([
+    db
+      .select({
+        id: loginFailedAttempts.id,
+        surface: loginFailedAttempts.surface,
+        username: loginFailedAttempts.username,
+        reason: loginFailedAttempts.reason,
+        ipAddress: loginFailedAttempts.ipAddress,
+        userAgent: loginFailedAttempts.userAgent,
+        createdAt: loginFailedAttempts.createdAt,
+      })
+      .from(loginFailedAttempts)
+      .where(whereClause)
+      .orderBy(desc(loginFailedAttempts.createdAt), desc(loginFailedAttempts.id))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({
+        total: sql<number>`count(*)::int`,
+      })
+      .from(loginFailedAttempts)
+      .where(whereClause),
+  ]);
+
+  const failedLoginAlerts = rows.map((row) => ({
+    id: row.id,
+    surface: row.surface,
+    username: row.username,
+    reason: row.reason,
+    ipAddress: row.ipAddress,
+    userAgent: row.userAgent,
+    createdAt: row.createdAt.toISOString(),
+  }));
+
+  return {
+    success: true,
+    failedLoginAlerts,
+    count: failedLoginAlerts.length,
+    total: totalRows[0]?.total ?? 0,
+    limit,
+    offset,
+    filters: {
+      surface: params.surface ?? null,
+      reason: params.reason ?? null,
+    },
+  };
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -13,6 +13,10 @@ import {
   type AdminAuthNativeRoutesOptions,
 } from "./routes/admin-auth.fastify.ts";
 import {
+  adminFailedLoginAlertsNativeRoutes,
+  type AdminFailedLoginAlertsNativeRoutesOptions,
+} from "./routes/admin-failed-login-alerts.fastify.ts";
+import {
   adminParticularTokensNativeRoutes,
   type AdminParticularTokensNativeRoutesOptions,
 } from "./routes/admin-particular-tokens.fastify.ts";
@@ -181,6 +185,7 @@ export type CreateFastifyAppOptions = {
   getServiceInfoPayload?: ServiceInfoFactory;
   adminAuditRoutes?: AdminAuditNativeRoutesOptions;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
+  adminFailedLoginAlertsRoutes?: AdminFailedLoginAlertsNativeRoutesOptions;
   adminParticularTokensRoutes?: AdminParticularTokensNativeRoutesOptions;
   adminReportsRoutes?: AdminReportsNativeRoutesOptions;
   adminSessionsRoutes?: AdminSessionsNativeRoutesOptions;
@@ -288,6 +293,11 @@ export async function createFastifyApp(
   await app.register(adminAuthNativeRoutes, {
     prefix: "/api/admin/auth",
     ...(options.adminAuthRoutes ?? {}),
+  });
+
+  await app.register(adminFailedLoginAlertsNativeRoutes, {
+    prefix: "/api/admin/failed-login-alerts",
+    ...(options.adminFailedLoginAlertsRoutes ?? {}),
   });
 
   await app.register(adminParticularTokensNativeRoutes, {

--- a/server/routes/admin-failed-login-alerts.fastify.ts
+++ b/server/routes/admin-failed-login-alerts.fastify.ts
@@ -1,0 +1,382 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import type {
+  AdminFailedLoginAlertReason,
+  AdminFailedLoginAlertsQuery,
+  AdminFailedLoginAlertsSnapshot,
+  AdminFailedLoginAlertSurface,
+} from "../db-admin-failed-login-alerts.ts";
+
+type AdminSessionRecord = {
+  id: number;
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+type AdminFailedLoginAlertsRequestQuery = {
+  surface?: string;
+  reason?: string;
+  limit?: string;
+  offset?: string;
+};
+
+export type AdminFailedLoginAlertsNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  listAdminFailedLoginAlerts?: (
+    params: AdminFailedLoginAlertsQuery,
+  ) => Promise<AdminFailedLoginAlertsSnapshot>;
+  now?: () => number;
+};
+
+type NativeAdminFailedLoginAlertsDeps = Required<
+  Pick<
+    AdminFailedLoginAlertsNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "listAdminFailedLoginAlerts"
+  >
+>;
+
+let defaultDepsPromise:
+  | Promise<NativeAdminFailedLoginAlertsDeps>
+  | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminFailedLoginAlertsDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const failedLoginAlerts = await import(
+        "../db-admin-failed-login-alerts.ts"
+      );
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        listAdminFailedLoginAlerts:
+          failedLoginAlerts.listAdminFailedLoginAlerts,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminFailedLoginAlertsDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+function parseSurface(
+  value: string | undefined,
+): AdminFailedLoginAlertSurface | undefined | null {
+  if (value === undefined) return undefined;
+
+  if (value === "admin" || value === "clinic" || value === "particular") {
+    return value;
+  }
+
+  return null;
+}
+
+function parseReason(
+  value: string | undefined,
+): AdminFailedLoginAlertReason | undefined | null {
+  if (value === undefined) return undefined;
+
+  if (
+    value === "missing_credentials" ||
+    value === "invalid_credentials" ||
+    value === "rate_limited"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function parseIntegerParam(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed)) {
+    return null;
+  }
+
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function parseFailedLoginAlertsQuery(
+  query: AdminFailedLoginAlertsRequestQuery,
+): AdminFailedLoginAlertsQuery | null {
+  const surface = parseSurface(query.surface);
+  const reason = parseReason(query.reason);
+  const limit = parseIntegerParam(query.limit, 50, 1, 100);
+  const offset = parseIntegerParam(query.offset, 0, 0, 100_000);
+
+  if (
+    surface === null ||
+    reason === null ||
+    limit === null ||
+    offset === null
+  ) {
+    return null;
+  }
+
+  return {
+    ...(surface ? { surface } : {}),
+    ...(reason ? { reason } : {}),
+    limit,
+    offset,
+  };
+}
+
+export const adminFailedLoginAlertsNativeRoutes: FastifyPluginAsync<
+  AdminFailedLoginAlertsNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+
+  async function resolveDeps(): Promise<NativeAdminFailedLoginAlertsDeps> {
+    const hasAllInjectedDeps =
+      !!options.deleteAdminSession &&
+      !!options.getAdminSessionByToken &&
+      !!options.getAdminUserById &&
+      !!options.updateAdminSessionLastAccess &&
+      !!options.hashSessionToken &&
+      !!options.listAdminFailedLoginAlerts;
+
+    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+    return {
+      deleteAdminSession:
+        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+      getAdminSessionByToken:
+        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+      getAdminUserById:
+        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      updateAdminSessionLastAccess:
+        options.updateAdminSessionLastAccess ??
+        defaultDeps!.updateAdminSessionLastAccess,
+      hashSessionToken:
+        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+      listAdminFailedLoginAlerts:
+        options.listAdminFailedLoginAlerts ??
+        defaultDeps!.listAdminFailedLoginAlerts,
+    };
+  }
+
+  app.get<{ Querystring: AdminFailedLoginAlertsRequestQuery }>(
+    "/",
+    async (request, reply) => {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const params = parseFailedLoginAlertsQuery(request.query);
+
+      if (!params) {
+        return reply.code(400).send({
+          success: false,
+          error:
+            "Query inválida. surface debe ser admin, clinic o particular; reason debe ser missing_credentials, invalid_credentials o rate_limited; limit/offset deben ser enteros válidos.",
+        });
+      }
+
+      const snapshot = await deps.listAdminFailedLoginAlerts(params);
+
+      return reply.code(200).send({
+        ...snapshot,
+        checkedBy: {
+          adminUserId: admin.id,
+          username: admin.username,
+        },
+      });
+    },
+  );
+};

--- a/test/admin-failed-login-alerts.fastify.test.ts
+++ b/test/admin-failed-login-alerts.fastify.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminFailedLoginAlertsNativeRoutes } = await import(
+  "../server/routes/admin-failed-login-alerts.fastify.ts"
+);
+
+type AdminFailedLoginAlertsNativeRoutesOptions = import(
+  "../server/routes/admin-failed-login-alerts.fastify.ts"
+).AdminFailedLoginAlertsNativeRoutesOptions;
+type AdminFailedLoginAlertsQuery = import(
+  "../server/db-admin-failed-login-alerts.ts"
+).AdminFailedLoginAlertsQuery;
+type AdminFailedLoginAlertsSnapshot = import(
+  "../server/db-admin-failed-login-alerts.ts"
+).AdminFailedLoginAlertsSnapshot;
+
+function buildDeps(
+  overrides: Partial<AdminFailedLoginAlertsNativeRoutesOptions> = {},
+): AdminFailedLoginAlertsNativeRoutesOptions {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      id: 99,
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-05-07T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAdminFailedLoginAlerts:
+      async (): Promise<AdminFailedLoginAlertsSnapshot> => ({
+        success: true,
+        failedLoginAlerts: [],
+        count: 0,
+        total: 0,
+        limit: 50,
+        offset: 0,
+        filters: {
+          surface: null,
+          reason: null,
+        },
+      }),
+    now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
+    ...overrides,
+  };
+}
+
+test("admin failed-login alerts requiere sesión admin", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminFailedLoginAlertsNativeRoutes,
+    buildDeps({
+      getAdminSessionByToken: async () => null,
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin failed-login alerts devuelve intentos sanitizados", async () => {
+  const app = Fastify();
+  let receivedParams: AdminFailedLoginAlertsQuery | null = null;
+
+  await app.register(
+    adminFailedLoginAlertsNativeRoutes,
+    buildDeps({
+      listAdminFailedLoginAlerts: async (
+        params,
+      ): Promise<AdminFailedLoginAlertsSnapshot> => {
+        receivedParams = params;
+
+        return {
+          success: true,
+          failedLoginAlerts: [
+            {
+              id: 10,
+              surface: "admin",
+              username: "VETNEB",
+              reason: "invalid_credentials",
+              ipAddress: "203.0.113.10",
+              userAgent: "node-test",
+              createdAt: "2026-05-08T00:00:00.000Z",
+            },
+            {
+              id: 11,
+              surface: "particular",
+              username: null,
+              reason: "rate_limited",
+              ipAddress: "203.0.113.11",
+              userAgent: "node-test-2",
+              createdAt: "2026-05-08T00:01:00.000Z",
+            },
+          ],
+          count: 2,
+          total: 2,
+          limit: params.limit ?? 50,
+          offset: params.offset ?? 0,
+          filters: {
+            surface: params.surface ?? null,
+            reason: params.reason ?? null,
+          },
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?surface=admin&reason=invalid_credentials&limit=25&offset=5",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(receivedParams, {
+      surface: "admin",
+      reason: "invalid_credentials",
+      limit: 25,
+      offset: 5,
+    });
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.count, 2);
+    assert.equal(body.total, 2);
+    assert.deepEqual(body.checkedBy, {
+      adminUserId: 1,
+      username: "VETNEB",
+    });
+    assert.equal(body.failedLoginAlerts[0].surface, "admin");
+    assert.equal(body.failedLoginAlerts[0].reason, "invalid_credentials");
+    assert.equal(body.failedLoginAlerts[0].token, undefined);
+    assert.equal(body.failedLoginAlerts[0].tokenHash, undefined);
+    assert.equal(body.failedLoginAlerts[0].cookie, undefined);
+    assert.equal(JSON.stringify(body).includes("hash:"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin failed-login alerts rechaza filtros inválidos", async () => {
+  const app = Fastify();
+  let listCalled = false;
+
+  await app.register(
+    adminFailedLoginAlertsNativeRoutes,
+    buildDeps({
+      listAdminFailedLoginAlerts: async () => {
+        listCalled = true;
+
+        return {
+          success: true,
+          failedLoginAlerts: [],
+          count: 0,
+          total: 0,
+          limit: 50,
+          offset: 0,
+          filters: {
+            surface: null,
+            reason: null,
+          },
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?surface=unknown",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(listCalled, false);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -52,6 +52,28 @@ function buildAdminAuthRouteStubs() {
   };
 }
 
+function buildAdminFailedLoginAlertsRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAdminFailedLoginAlerts: async () => ({
+      success: true,
+      failedLoginAlerts: [],
+      count: 0,
+      total: 0,
+      limit: 50,
+      offset: 0,
+      filters: {
+        surface: null,
+        reason: null,
+      },
+    }),
+  };
+}
+
 
 
 function buildAdminParticularTokensRouteStubs() {
@@ -609,6 +631,7 @@ function buildFastifyDispatchRouteStubs() {
   return {
     adminAuditRoutes: buildAdminAuditRouteStubs(),
     adminAuthRoutes: buildAdminAuthRouteStubs(),
+    adminFailedLoginAlertsRoutes: buildAdminFailedLoginAlertsRouteStubs(),
     adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
     adminReportsRoutes: buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
@@ -2372,6 +2395,73 @@ test(
         database: "up",
         storage: "up",
       });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp despacha /api/admin/failed-login-alerts al router nativo",
+  async () => {
+    const app = await createFastifyApp({
+      ...buildFastifyDispatchRouteStubs(),
+      adminFailedLoginAlertsRoutes: {
+        ...buildAdminFailedLoginAlertsRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          id: 99,
+          adminUserId: 1,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-05-08T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "VETNEB",
+        }),
+        listAdminFailedLoginAlerts: async () => ({
+          success: true,
+          failedLoginAlerts: [
+            {
+              id: 10,
+              surface: "admin",
+              username: "VETNEB",
+              reason: "invalid_credentials",
+              ipAddress: "203.0.113.10",
+              userAgent: "node-test",
+              createdAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+          count: 1,
+          total: 1,
+          limit: 5,
+          offset: 0,
+          filters: {
+            surface: "admin",
+            reason: null,
+          },
+        }),
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/failed-login-alerts?surface=admin&limit=5",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.equal(response.statusCode, 200);
+
+      const body = JSON.parse(response.body);
+
+      assert.equal(body.success, true);
+      assert.equal(body.count, 1);
+      assert.equal(body.failedLoginAlerts[0].surface, "admin");
+      assert.equal(body.failedLoginAlerts[0].tokenHash, undefined);
+      assert.equal(JSON.stringify(body).includes("hash:"), false);
     } finally {
       await app.close();
     }

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -60,7 +60,7 @@ function buildAdminFailedLoginAlertsRouteStubs() {
     updateAdminSessionLastAccess: async () => {},
     hashSessionToken: (token: string) => `hash:${token}`,
     listAdminFailedLoginAlerts: async () => ({
-      success: true,
+      success: true as const,
       failedLoginAlerts: [],
       count: 0,
       total: 0,
@@ -2419,7 +2419,7 @@ test(
           username: "VETNEB",
         }),
         listAdminFailedLoginAlerts: async () => ({
-          success: true,
+          success: true as const,
           failedLoginAlerts: [
             {
               id: 10,


### PR DESCRIPTION
## Summary

- Add read-only Admin endpoint for persisted failed-login attempts.
- Register `GET /api/admin/failed-login-alerts`.
- Add DB helper to list `login_failed_attempts` with safe filters and pagination.
- Add native route tests and Fastify dispatch coverage.

## Security

- Backend only.
- Admin read-only.
- No frontend changes.
- No writes.
- No blocking or lockout behavior added.
- No alerting UI added.
- No password, token, tokenHash, cookie or secret exposure.
- Filters remain bounded to known surfaces and failed-login reasons.

## Validation

- [x] `pnpm test -- .\test\admin-failed-login-alerts.fastify.test.ts`
- [x] `pnpm test -- .\test\fastify-app.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
