### PR TITLE
feat(admin): add failed login alerts UI

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getAdminFailedLoginAlerts } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type {
+  AdminFailedLoginAlertReason,
+  AdminFailedLoginAlertsSnapshot,
+  AdminFailedLoginAlertSurface,
+} from "@/types";
+
+const PAGE_SIZE = 25;
+
+function formatSurface(value: AdminFailedLoginAlertSurface) {
+  if (value === "admin") return "Admin";
+  if (value === "clinic") return "Clínica";
+  return "Particular";
+}
+
+function formatReason(value: AdminFailedLoginAlertReason) {
+  if (value === "missing_credentials") return "Credenciales faltantes";
+  if (value === "invalid_credentials") return "Credenciales inválidas";
+  return "Rate limit";
+}
+
+function getSurfaceVariant(
+  value: AdminFailedLoginAlertSurface,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (value === "admin") return "default";
+  if (value === "clinic") return "secondary";
+  return "outline";
+}
+
+function getReasonVariant(
+  value: AdminFailedLoginAlertReason,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (value === "rate_limited") return "destructive";
+  if (value === "invalid_credentials") return "secondary";
+  return "outline";
+}
+
+function formatNullable(value: string | null) {
+  return value && value.trim() ? value : "—";
+}
+
+export function AdminFailedLoginAlertsReadOnlyCard() {
+  const [snapshot, setSnapshot] =
+    useState<AdminFailedLoginAlertsSnapshot | null>(null);
+  const [surface, setSurface] = useState<
+    AdminFailedLoginAlertSurface | "all"
+  >("all");
+  const [reason, setReason] = useState<AdminFailedLoginAlertReason | "all">(
+    "all",
+  );
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const query = useMemo(
+    () => ({
+      ...(surface !== "all" ? { surface } : {}),
+      ...(reason !== "all" ? { reason } : {}),
+      limit: PAGE_SIZE,
+      offset,
+    }),
+    [offset, reason, surface],
+  );
+
+  function loadFailedLoginAlerts() {
+    setError(null);
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          const result = await getAdminFailedLoginAlerts(query);
+          setSnapshot(result);
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "No se pudieron cargar los intentos fallidos.",
+          );
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    loadFailedLoginAlerts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const hasPreviousPage = offset > 0;
+  const hasNextPage = snapshot
+    ? offset + snapshot.failedLoginAlerts.length < snapshot.total
+    : false;
+
+  return (
+    <Card id="failed-login-alerts">
+      <CardHeader className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <CardTitle className="text-base">
+            Intentos fallidos de login
+          </CardTitle>
+          <CardDescription>
+            Vista Admin read-only de intentos fallidos persistidos. No expone
+            passwords, tokens, hashes ni cookies.
+          </CardDescription>
+        </div>
+
+        <Button
+          type="button"
+          onClick={loadFailedLoginAlerts}
+          disabled={isPending}
+        >
+          {isPending ? "Actualizando..." : "Actualizar"}
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Total filtrado</p>
+            <p className="mt-1 text-2xl font-bold text-gray-900">
+              {snapshot?.total ?? "—"}
+            </p>
+          </div>
+
+          <label className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <span className="text-xs text-gray-400">Superficie</span>
+            <select
+              className="mt-2 w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700"
+              value={surface}
+              onChange={(event) => {
+                setOffset(0);
+                setSurface(
+                  event.target.value as AdminFailedLoginAlertSurface | "all",
+                );
+              }}
+            >
+              <option value="all">Todas</option>
+              <option value="admin">Admin</option>
+              <option value="clinic">Clínica</option>
+              <option value="particular">Particular</option>
+            </select>
+          </label>
+
+          <label className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <span className="text-xs text-gray-400">Motivo</span>
+            <select
+              className="mt-2 w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-700"
+              value={reason}
+              onChange={(event) => {
+                setOffset(0);
+                setReason(
+                  event.target.value as AdminFailedLoginAlertReason | "all",
+                );
+              }}
+            >
+              <option value="all">Todos</option>
+              <option value="missing_credentials">Credenciales faltantes</option>
+              <option value="invalid_credentials">Credenciales inválidas</option>
+              <option value="rate_limited">Rate limit</option>
+            </select>
+          </label>
+
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+            <p className="text-xs text-gray-400">Página</p>
+            <p className="mt-1 text-sm font-semibold text-gray-700">
+              {Math.floor(offset / PAGE_SIZE) + 1}
+            </p>
+            <p className="mt-1 text-xs text-gray-400">
+              {snapshot
+                ? `${snapshot.failedLoginAlerts.length} visibles`
+                : "—"}
+            </p>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="overflow-hidden rounded-lg border border-gray-100">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Superficie</TableHead>
+                <TableHead>Usuario</TableHead>
+                <TableHead>Motivo</TableHead>
+                <TableHead>IP</TableHead>
+                <TableHead>User agent</TableHead>
+                <TableHead>Fecha</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {snapshot?.failedLoginAlerts.length ? (
+                snapshot.failedLoginAlerts.map((alert) => (
+                  <TableRow key={alert.id}>
+                    <TableCell className="whitespace-nowrap font-mono text-xs text-gray-400">
+                      #{alert.id}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getSurfaceVariant(alert.surface)}>
+                        {formatSurface(alert.surface)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-600">
+                      {formatNullable(alert.username)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getReasonVariant(alert.reason)}>
+                        {formatReason(alert.reason)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-500">
+                      {formatNullable(alert.ipAddress)}
+                    </TableCell>
+                    <TableCell className="max-w-xs truncate text-xs text-gray-500">
+                      {formatNullable(alert.userAgent)}
+                    </TableCell>
+                    <TableCell className="text-xs text-gray-400">
+                      {formatDateTime(alert.createdAt)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={7}
+                    className="py-8 text-center text-sm text-gray-400"
+                  >
+                    {isPending
+                      ? "Cargando intentos fallidos..."
+                      : "No hay intentos fallidos para los filtros seleccionados."}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <p className="text-xs text-gray-400">
+            Endpoint: <code>GET /api/admin/failed-login-alerts</code>. Vista
+            read-only: no bloquea usuarios, no revoca sesiones y no dispara
+            notificaciones.
+          </p>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasPreviousPage || isPending}
+              onClick={() => setOffset(Math.max(offset - PAGE_SIZE, 0))}
+            >
+              Anterior
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasNextPage || isPending}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Siguiente
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,6 +31,8 @@ import type {
   ClinicUserRole,
   AdminSessionRevocationResponse,
   AdminSessionType,
+  AdminFailedLoginAlertsQuery,
+  AdminFailedLoginAlertsSnapshot,
 } from "@/types";
 
 import {
@@ -323,6 +325,36 @@ export async function getAdminMaintenancePurgeDryRun(
       ...options,
       method: "POST",
     },
+  );
+}
+
+export async function getAdminFailedLoginAlerts(
+  params: AdminFailedLoginAlertsQuery = {},
+  options?: RequestInit,
+): Promise<AdminFailedLoginAlertsSnapshot> {
+  const query = new URLSearchParams();
+
+  if (params.surface) {
+    query.set("surface", params.surface);
+  }
+
+  if (params.reason) {
+    query.set("reason", params.reason);
+  }
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<AdminFailedLoginAlertsSnapshot>(
+    `/api/admin/failed-login-alerts${qs ? `?${qs}` : ""}`,
+    options,
   );
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -290,6 +290,46 @@ export type AdminSessionRevocationResponse = {
   };
 };
 
+export type AdminFailedLoginAlertSurface = "admin" | "clinic" | "particular";
+export type AdminFailedLoginAlertReason =
+  | "missing_credentials"
+  | "invalid_credentials"
+  | "rate_limited";
+
+export type AdminFailedLoginAlertSummary = {
+  id: number;
+  surface: AdminFailedLoginAlertSurface;
+  username: string | null;
+  reason: AdminFailedLoginAlertReason;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+};
+
+export type AdminFailedLoginAlertsQuery = {
+  surface?: AdminFailedLoginAlertSurface;
+  reason?: AdminFailedLoginAlertReason;
+  limit?: number;
+  offset?: number;
+};
+
+export type AdminFailedLoginAlertsSnapshot = {
+  success: true;
+  failedLoginAlerts: AdminFailedLoginAlertSummary[];
+  count: number;
+  total: number;
+  limit: number;
+  offset: number;
+  filters: {
+    surface: AdminFailedLoginAlertSurface | null;
+    reason: AdminFailedLoginAlertReason | null;
+  };
+  checkedBy?: {
+    adminUserId: number;
+    username: string;
+  };
+};
+
 export type MaintenancePurgeCandidateCategory =
   | "expired_clinic_sessions"
   | "expired_admin_sessions"


### PR DESCRIPTION
## Summary

- Add Admin read-only UI card for failed-login alerts.
- Consume `GET /api/admin/failed-login-alerts`.
- Add frontend API wrapper and typed frontend contract.
- Mount the card in `/dashboard/admin`.
- Extend frontend live-read contract coverage.

## Security

- Frontend only.
- Admin only.
- Read-only.
- No writes.
- No blocking or lockout behavior added.
- No active alert notifications added.
- No password, token, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
