### PR TITLE
feat(admin): mount failed login alerts UI

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -18,6 +18,7 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
+import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
@@ -300,7 +301,7 @@ export default async function AdminPage({
       />
       <main className="flex-1 p-6 space-y-6">
         <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
-          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code>, <code>GET /api/admin/sessions</code>, <code>GET /api/admin/users-roles</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
+          Lectura conectada a <code>GET /api/admin/audit-log</code>, <code>GET /api/admin/system/health</code>, <code>GET /api/admin/sessions</code>, <code>GET /api/admin/failed-login-alerts</code>, <code>GET /api/admin/users-roles</code> y <code>POST /api/admin/system/maintenance/purge-dry-run</code>.
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -417,6 +418,7 @@ export default async function AdminPage({
         </Card>
         <AdminMaintenanceDryRunCard />
         <AdminSessionsReadOnlyCard />
+        <AdminFailedLoginAlertsReadOnlyCard />
         <AdminUsersRolesReadOnlyCard />
         <Card id="audit-role-changes">
           <CardHeader>

--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -67,3 +67,63 @@ test("frontend admin audit API wrapper accepts request options", () => {
   assertIncludes(source, "options,", frontendApiClient);
   assertIncludes(source, "return MOCK_AUDIT_ENTRIES", frontendApiClient);
 });
+
+
+test("frontend admin failed-login alerts read-only UI queda montada", () => {
+  const adminPageSource = read(adminPage);
+  const apiSource = read(frontendApiClient);
+  const cardSource = read(
+    "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  assertIncludes(
+    adminPageSource,
+    'import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";',
+    adminPage,
+  );
+  assertIncludes(
+    adminPageSource,
+    "<AdminFailedLoginAlertsReadOnlyCard />",
+    adminPage,
+  );
+  assertIncludes(
+    adminPageSource,
+    "GET /api/admin/failed-login-alerts",
+    adminPage,
+  );
+  assertIncludes(
+    apiSource,
+    "export async function getAdminFailedLoginAlerts(",
+    frontendApiClient,
+  );
+  assertIncludes(
+    apiSource,
+    "/api/admin/failed-login-alerts",
+    frontendApiClient,
+  );
+  assertIncludes(
+    cardSource,
+    "getAdminFailedLoginAlerts(query)",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "Vista Admin read-only",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "no bloquea usuarios",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "no revoca sesiones",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertNotIncludes(
+    cardSource,
+    "tokenHash",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+});


### PR DESCRIPTION
## Summary

- Mount the failed-login alerts read-only card in `/dashboard/admin`.
- Add `GET /api/admin/failed-login-alerts` to the Admin dashboard endpoint banner.
- Extend frontend live-read contract coverage to guard the mounted UI.

## Security

- Frontend only.
- Admin only.
- Read-only.
- No backend changes.
- No writes.
- No blocking or lockout behavior added.
- No active alert notifications added.
- No password, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
