### PR TITLE
feat(admin): export failed login alerts CSV

### DIFF
--- a/server/routes/admin-failed-login-alerts.fastify.ts
+++ b/server/routes/admin-failed-login-alerts.fastify.ts
@@ -38,6 +38,61 @@ type AdminFailedLoginAlertsRequestQuery = {
   offset?: string;
 };
 
+const ADMIN_FAILED_LOGIN_ALERTS_CSV_EXPORT_MAX_ROWS = 10_000;
+
+type AdminFailedLoginAlertCsvItem =
+  AdminFailedLoginAlertsSnapshot["failedLoginAlerts"][number];
+
+const ADMIN_FAILED_LOGIN_ALERT_CSV_HEADERS = [
+  "id",
+  "surface",
+  "username",
+  "reason",
+  "ipAddress",
+  "userAgent",
+  "createdAt",
+] as const;
+
+function escapeCsvValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const raw = String(value);
+
+  if (/[",\n\r]/.test(raw)) {
+    return `"${raw.replace(/"/g, '""')}"`;
+  }
+
+  return raw;
+}
+
+export function buildAdminFailedLoginAlertsCsv(
+  items: AdminFailedLoginAlertCsvItem[],
+) {
+  const rows = items.map((item) =>
+    [
+      item.id,
+      item.surface,
+      item.username,
+      item.reason,
+      item.ipAddress,
+      item.userAgent,
+      item.createdAt,
+    ]
+      .map(escapeCsvValue)
+      .join(","),
+  );
+
+  return [ADMIN_FAILED_LOGIN_ALERT_CSV_HEADERS.join(","), ...rows].join("\n");
+}
+
+export function buildAdminFailedLoginAlertsCsvFilename(now = new Date()) {
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+
+  return `admin-failed-login-alerts-${timestamp}.csv`;
+}
+
 export type AdminFailedLoginAlertsNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
   getAdminSessionByToken?: (
@@ -51,6 +106,10 @@ export type AdminFailedLoginAlertsNativeRoutesOptions = {
   listAdminFailedLoginAlerts?: (
     params: AdminFailedLoginAlertsQuery,
   ) => Promise<AdminFailedLoginAlertsSnapshot>;
+  buildAdminFailedLoginAlertsCsv?: (
+    items: AdminFailedLoginAlertCsvItem[],
+  ) => string;
+  buildAdminFailedLoginAlertsCsvFilename?: (now?: Date) => string;
   now?: () => number;
 };
 
@@ -63,6 +122,8 @@ type NativeAdminFailedLoginAlertsDeps = Required<
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "listAdminFailedLoginAlerts"
+    | "buildAdminFailedLoginAlertsCsv"
+    | "buildAdminFailedLoginAlertsCsvFilename"
   >
 >;
 
@@ -87,6 +148,9 @@ async function loadDefaultDeps(): Promise<NativeAdminFailedLoginAlertsDeps> {
         hashSessionToken: authSecurity.hashSessionToken,
         listAdminFailedLoginAlerts:
           failedLoginAlerts.listAdminFailedLoginAlerts,
+        buildAdminFailedLoginAlertsCsv: buildAdminFailedLoginAlertsCsv,
+        buildAdminFailedLoginAlertsCsvFilename:
+          buildAdminFailedLoginAlertsCsvFilename,
       };
     })();
   }
@@ -326,7 +390,9 @@ export const adminFailedLoginAlertsNativeRoutes: FastifyPluginAsync<
       !!options.getAdminUserById &&
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
-      !!options.listAdminFailedLoginAlerts;
+      !!options.listAdminFailedLoginAlerts &&
+      !!options.buildAdminFailedLoginAlertsCsv &&
+      !!options.buildAdminFailedLoginAlertsCsvFilename;
 
     const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -345,8 +411,64 @@ export const adminFailedLoginAlertsNativeRoutes: FastifyPluginAsync<
       listAdminFailedLoginAlerts:
         options.listAdminFailedLoginAlerts ??
         defaultDeps!.listAdminFailedLoginAlerts,
+      buildAdminFailedLoginAlertsCsv:
+        options.buildAdminFailedLoginAlertsCsv ??
+        buildAdminFailedLoginAlertsCsv,
+      buildAdminFailedLoginAlertsCsvFilename:
+        options.buildAdminFailedLoginAlertsCsvFilename ??
+        buildAdminFailedLoginAlertsCsvFilename,
     };
   }
+
+  app.get<{ Querystring: AdminFailedLoginAlertsRequestQuery }>(
+    "/export.csv",
+    async (request, reply) => {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const params = parseFailedLoginAlertsQuery(request.query);
+
+      if (!params) {
+        return reply.code(400).send({
+          success: false,
+          error:
+            "Query inválida. surface debe ser admin, clinic o particular; reason debe ser missing_credentials, invalid_credentials o rate_limited; limit/offset deben ser enteros válidos.",
+        });
+      }
+
+      const exportParams: AdminFailedLoginAlertsQuery = {
+        ...params,
+        limit: ADMIN_FAILED_LOGIN_ALERTS_CSV_EXPORT_MAX_ROWS,
+        offset: 0,
+      };
+
+      const snapshot = await deps.listAdminFailedLoginAlerts(exportParams);
+
+      if (snapshot.total > ADMIN_FAILED_LOGIN_ALERTS_CSV_EXPORT_MAX_ROWS) {
+        return reply.code(400).send({
+          success: false,
+          error: `Demasiados registros para exportar. Aplica filtros mas especificos (maximo ${ADMIN_FAILED_LOGIN_ALERTS_CSV_EXPORT_MAX_ROWS}).`,
+        });
+      }
+
+      const csv = deps.buildAdminFailedLoginAlertsCsv(
+        snapshot.failedLoginAlerts,
+      );
+      const filename = deps.buildAdminFailedLoginAlertsCsvFilename();
+
+      reply.header("content-type", "text/csv; charset=utf-8");
+      reply.header(
+        "content-disposition",
+        `attachment; filename="${filename}"`,
+      );
+
+      return reply.code(200).send(csv);
+    },
+  );
 
   app.get<{ Querystring: AdminFailedLoginAlertsRequestQuery }>(
     "/",

--- a/test/admin-failed-login-alerts.fastify.test.ts
+++ b/test/admin-failed-login-alerts.fastify.test.ts
@@ -54,6 +54,23 @@ function buildDeps(
           reason: null,
         },
       }),
+    buildAdminFailedLoginAlertsCsv: (items) =>
+      [
+        "id,surface,username,reason,ipAddress,userAgent,createdAt",
+        ...items.map((item) =>
+          [
+            item.id,
+            item.surface,
+            item.username ?? "",
+            item.reason,
+            item.ipAddress ?? "",
+            item.userAgent ?? "",
+            item.createdAt,
+          ].join(","),
+        ),
+      ].join("\n"),
+    buildAdminFailedLoginAlertsCsvFilename: () =>
+      "admin-failed-login-alerts-test.csv",
     now: () => Date.UTC(2026, 4, 8, 0, 0, 0),
     ...overrides,
   };
@@ -199,6 +216,140 @@ test("admin failed-login alerts rechaza filtros inválidos", async () => {
     const response = await app.inject({
       method: "GET",
       url: "/?surface=unknown",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(JSON.parse(response.body).success, false);
+    assert.equal(listCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+
+test("admin failed-login alerts exporta CSV sanitizado", async () => {
+  const app = Fastify();
+  let receivedParams: AdminFailedLoginAlertsQuery | null = null;
+
+  await app.register(
+    adminFailedLoginAlertsNativeRoutes,
+    buildDeps({
+      listAdminFailedLoginAlerts: async (
+        params,
+      ): Promise<AdminFailedLoginAlertsSnapshot> => {
+        receivedParams = params;
+
+        return {
+          success: true,
+          failedLoginAlerts: [
+            {
+              id: 20,
+              surface: "clinic",
+              username: "clinic-user",
+              reason: "invalid_credentials",
+              ipAddress: "203.0.113.20",
+              userAgent: "csv-test-agent",
+              createdAt: "2026-05-08T00:02:00.000Z",
+            },
+            {
+              id: 21,
+              surface: "particular",
+              username: null,
+              reason: "rate_limited",
+              ipAddress: "203.0.113.21",
+              userAgent: "csv-test-agent-2",
+              createdAt: "2026-05-08T00:03:00.000Z",
+            },
+          ],
+          count: 2,
+          total: 2,
+          limit: params.limit ?? 50,
+          offset: params.offset ?? 0,
+          filters: {
+            surface: params.surface ?? null,
+            reason: params.reason ?? null,
+          },
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/export.csv?surface=clinic&reason=invalid_credentials&limit=25&offset=5",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.headers["content-type"],
+      "text/csv; charset=utf-8",
+    );
+    assert.equal(
+      response.headers["content-disposition"],
+      'attachment; filename="admin-failed-login-alerts-test.csv"',
+    );
+    assert.deepEqual(receivedParams, {
+      surface: "clinic",
+      reason: "invalid_credentials",
+      limit: 10000,
+      offset: 0,
+    });
+
+    assert.equal(
+      response.body,
+      [
+        "id,surface,username,reason,ipAddress,userAgent,createdAt",
+        "20,clinic,clinic-user,invalid_credentials,203.0.113.20,csv-test-agent,2026-05-08T00:02:00.000Z",
+        "21,particular,,rate_limited,203.0.113.21,csv-test-agent-2,2026-05-08T00:03:00.000Z",
+      ].join("\n"),
+    );
+
+    assert.equal(response.body.includes("tokenHash"), false);
+    assert.equal(response.body.includes("hash:"), false);
+    assert.equal(response.body.includes("password"), false);
+    assert.equal(response.body.includes("cookie"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin failed-login alerts export rechaza filtros inválidos", async () => {
+  const app = Fastify();
+  let listCalled = false;
+
+  await app.register(
+    adminFailedLoginAlertsNativeRoutes,
+    buildDeps({
+      listAdminFailedLoginAlerts: async () => {
+        listCalled = true;
+
+        return {
+          success: true,
+          failedLoginAlerts: [],
+          count: 0,
+          total: 0,
+          limit: 50,
+          offset: 0,
+          filters: {
+            surface: null,
+            reason: null,
+          },
+        };
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/export.csv?reason=bad",
       headers: {
         cookie: `${ENV.adminCookieName}=admin-session-token`,
       },

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -71,6 +71,10 @@ function buildAdminFailedLoginAlertsRouteStubs() {
         reason: null,
       },
     }),
+    buildAdminFailedLoginAlertsCsv: () =>
+      "id,surface,username,reason,ipAddress,userAgent,createdAt",
+    buildAdminFailedLoginAlertsCsvFilename: () =>
+      "admin-failed-login-alerts-test.csv",
   };
 }
 


### PR DESCRIPTION
## Summary

- Add CSV export for Admin failed-login alerts.
- Register `GET /api/admin/failed-login-alerts/export.csv`.
- Reuse existing Admin auth and failed-login alert filters.
- Cap CSV export to 10,000 rows.
- Add native route coverage and Fastify dispatch stub coverage.

## Security

- Backend only.
- Admin only.
- Read-only.
- No frontend changes.
- No writes.
- No blocking or lockout behavior added.
- No active alert notifications added.
- No password, token, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\admin-failed-login-alerts.fastify.test.ts`
- [x] `pnpm test -- .\test\fastify-app.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
