### PR TITLE
feat(admin): add failed login alerts CSV link

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -18,7 +18,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getAdminFailedLoginAlerts } from "@/lib/api";
+import {
+  buildAdminFailedLoginAlertsCsvUrl,
+  getAdminFailedLoginAlerts,
+} from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 import type {
   AdminFailedLoginAlertReason,
@@ -83,6 +86,15 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
     [offset, reason, surface],
   );
 
+  const csvUrl = useMemo(
+    () =>
+      buildAdminFailedLoginAlertsCsvUrl({
+        ...(surface !== "all" ? { surface } : {}),
+        ...(reason !== "all" ? { reason } : {}),
+      }),
+    [reason, surface],
+  );
+
   function loadFailedLoginAlerts() {
     setError(null);
 
@@ -125,13 +137,22 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           </CardDescription>
         </div>
 
-        <Button
-          type="button"
-          onClick={loadFailedLoginAlerts}
-          disabled={isPending}
-        >
-          {isPending ? "Actualizando..." : "Actualizar"}
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            asChild
+          >
+            <a href={csvUrl}>Exportar CSV</a>
+          </Button>
+          <Button
+            type="button"
+            onClick={loadFailedLoginAlerts}
+            disabled={isPending}
+          >
+            {isPending ? "Actualizando..." : "Actualizar"}
+          </Button>
+        </div>
       </CardHeader>
 
       <CardContent className="space-y-4">
@@ -262,7 +283,8 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
 
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <p className="text-xs text-gray-400">
-            Endpoint: <code>GET /api/admin/failed-login-alerts</code>. Vista
+            Endpoints: <code>GET /api/admin/failed-login-alerts</code> y{" "}
+            <code>GET /api/admin/failed-login-alerts/export.csv</code>. Vista
             read-only: no bloquea usuarios, no revoca sesiones y no dispara
             notificaciones.
           </p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -328,10 +328,9 @@ export async function getAdminMaintenancePurgeDryRun(
   );
 }
 
-export async function getAdminFailedLoginAlerts(
+function buildAdminFailedLoginAlertsQueryString(
   params: AdminFailedLoginAlertsQuery = {},
-  options?: RequestInit,
-): Promise<AdminFailedLoginAlertsSnapshot> {
+) {
   const query = new URLSearchParams();
 
   if (params.surface) {
@@ -350,12 +349,27 @@ export async function getAdminFailedLoginAlerts(
     query.set("offset", String(params.offset));
   }
 
-  const qs = query.toString();
+  return query.toString();
+}
+
+export async function getAdminFailedLoginAlerts(
+  params: AdminFailedLoginAlertsQuery = {},
+  options?: RequestInit,
+): Promise<AdminFailedLoginAlertsSnapshot> {
+  const qs = buildAdminFailedLoginAlertsQueryString(params);
 
   return apiFetch<AdminFailedLoginAlertsSnapshot>(
     `/api/admin/failed-login-alerts${qs ? `?${qs}` : ""}`,
     options,
   );
+}
+
+export function buildAdminFailedLoginAlertsCsvUrl(
+  params: AdminFailedLoginAlertsQuery = {},
+) {
+  const qs = buildAdminFailedLoginAlertsQueryString(params);
+
+  return `${API_BASE_URL}/api/admin/failed-login-alerts/export.csv${qs ? `?${qs}` : ""}`;
 }
 
 export async function getDashboardStats(

--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -127,3 +127,52 @@ test("frontend admin failed-login alerts read-only UI queda montada", () => {
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
 });
+
+
+test("frontend admin failed-login alerts expone export CSV read-only", () => {
+  const apiSource = read(frontendApiClient);
+  const cardSource = read(
+    "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  assertIncludes(
+    apiSource,
+    "export function buildAdminFailedLoginAlertsCsvUrl(",
+    frontendApiClient,
+  );
+  assertIncludes(
+    apiSource,
+    "/api/admin/failed-login-alerts/export.csv",
+    frontendApiClient,
+  );
+  assertIncludes(
+    cardSource,
+    "buildAdminFailedLoginAlertsCsvUrl",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "Exportar CSV",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "GET /api/admin/failed-login-alerts/export.csv",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "no bloquea usuarios",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "no revoca sesiones",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertNotIncludes(
+    cardSource,
+    "tokenHash",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+});


### PR DESCRIPTION
## Summary

- Add CSV export link to the Admin failed-login alerts read-only card.
- Build CSV URL for `GET /api/admin/failed-login-alerts/export.csv`.
- Preserve active `surface` and `reason` filters in the export URL.
- Extend frontend live-read contract coverage.

## Security

- Frontend only.
- Admin only.
- Read-only.
- No backend changes.
- No writes.
- No blocking or lockout behavior added.
- No active alert notifications added.
- No password, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
