### PR TITLE
test(admin): guard failed login CSV filter URL

### DIFF
--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -176,3 +176,52 @@ test("frontend admin failed-login alerts expone export CSV read-only", () => {
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
 });
+
+
+test("frontend admin failed-login alerts CSV usa filtros sin paginacion", () => {
+  const cardSource = read(
+    "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  assertIncludes(
+    cardSource,
+    "const csvUrl = useMemo(",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "buildAdminFailedLoginAlertsCsvUrl({",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    '...(surface !== "all" ? { surface } : {})',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    '...(reason !== "all" ? { reason } : {})',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "[reason, surface]",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  const csvUrlBlock = cardSource.slice(
+    cardSource.indexOf("const csvUrl = useMemo("),
+    cardSource.indexOf("function loadFailedLoginAlerts()"),
+  );
+
+  assertNotIncludes(
+    csvUrlBlock,
+    "limit: PAGE_SIZE",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx csvUrl",
+  );
+  assertNotIncludes(
+    csvUrlBlock,
+    "offset",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx csvUrl",
+  );
+});


### PR DESCRIPTION
## Summary

- Add frontend contract coverage for the failed-login alerts CSV URL.
- Guard that CSV export preserves `surface` and `reason` filters.
- Guard that CSV export does not inherit table pagination (`limit` / `offset`).

## Security

- Test only.
- Frontend contract only.
- Admin read-only.
- No product behavior changes.
- No backend changes.
- No writes.
- No blocking or lockout behavior added.
- No password, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
