### PR TITLE
feat(admin): add failed login alerts clear filters

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -95,6 +95,12 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
     [reason, surface],
   );
 
+  function clearFailedLoginAlertFilters() {
+    setSurface("all");
+    setReason("all");
+    setOffset(0);
+  }
+
   function loadFailedLoginAlerts() {
     setError(null);
 
@@ -138,6 +144,14 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={clearFailedLoginAlertFilters}
+            disabled={surface === "all" && reason === "all" && offset === 0}
+          >
+            Limpiar filtros
+          </Button>
           <Button
             type="button"
             variant="outline"
@@ -285,8 +299,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           <p className="text-xs text-gray-400">
             Endpoints: <code>GET /api/admin/failed-login-alerts</code> y{" "}
             <code>GET /api/admin/failed-login-alerts/export.csv</code>. Vista
-            read-only: no bloquea usuarios, no revoca sesiones y no dispara
-            notificaciones.
+            read-only con filtros reversibles: no bloquea usuarios, no revoca sesiones y no dispara notificaciones.
           </p>
 
           <div className="flex items-center gap-2">

--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -225,3 +225,61 @@ test("frontend admin failed-login alerts CSV usa filtros sin paginacion", () => 
     "AdminFailedLoginAlertsReadOnlyCard.tsx csvUrl",
   );
 });
+
+
+test("frontend admin failed-login alerts permite limpiar filtros sin mutaciones", () => {
+  const cardSource = read(
+    "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  assertIncludes(
+    cardSource,
+    "function clearFailedLoginAlertFilters()",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    'setSurface("all")',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    'setReason("all")',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "setOffset(0)",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "Limpiar filtros",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "filtros reversibles",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "no bloquea usuarios",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "no revoca",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertNotIncludes(
+    cardSource,
+    "fetch(",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
+  );
+  assertNotIncludes(
+    cardSource,
+    "method: \"POST\"",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
+  );
+});


### PR DESCRIPTION
## Summary

- Add clear-filters action to the Admin failed-login alerts card.
- Reset `surface`, `reason`, and pagination offset.
- Add frontend contract coverage for reversible read-only filters.

## Security

- Frontend only.
- Admin only.
- Read-only.
- No backend changes.
- No writes.
- No blocking or lockout behavior added.
- No active alert notifications added.
- No password, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
