### PR TITLE
test(admin): guard failed login clear filters disabled

### DIFF
--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -283,3 +283,57 @@ test("frontend admin failed-login alerts permite limpiar filtros sin mutaciones"
     "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
   );
 });
+
+
+test("frontend admin failed-login alerts deshabilita limpiar filtros sin filtros activos", () => {
+  const cardSource = read(
+    "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  assertIncludes(
+    cardSource,
+    "clearFailedLoginAlertFilters",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    'disabled={surface === "all" && reason === "all" && offset === 0}',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    'setSurface("all")',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    'setReason("all")',
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  assertIncludes(
+    cardSource,
+    "setOffset(0)",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+
+  const clearFiltersBlock = cardSource.slice(
+    cardSource.indexOf("function clearFailedLoginAlertFilters()"),
+    cardSource.indexOf("function loadFailedLoginAlerts()"),
+  );
+
+  assertNotIncludes(
+    clearFiltersBlock,
+    "fetch(",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
+  );
+  assertNotIncludes(
+    clearFiltersBlock,
+    "getAdminFailedLoginAlerts",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
+  );
+  assertNotIncludes(
+    clearFiltersBlock,
+    "buildAdminFailedLoginAlertsCsvUrl",
+    "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
+  );
+});


### PR DESCRIPTION
## Summary

- Add frontend contract coverage for the failed-login alerts clear-filters disabled state.
- Guard that clear filters is disabled when `surface`, `reason`, and `offset` are already reset.
- Guard that clear filters performs local state reset only and does not call APIs.

## Security

- Test only.
- Frontend contract only.
- Admin read-only.
- No product behavior changes.
- No backend changes.
- No writes.
- No blocking or lockout behavior added.
- No password, tokenHash, cookie or secret exposure.

## Validation

- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
