### PR TITLE
ci: align backend workflow actions to node24

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -41,15 +41,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.8.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/test/toolchain-contract.test.ts
+++ b/test/toolchain-contract.test.ts
@@ -44,9 +44,10 @@ test("package.json pins the expected package manager", () => {
 test("Backend CI uses the pinned pnpm and Node toolchain", () => {
   const workflow = readTextFile(".github", "workflows", "backend-ci.yml");
 
-  assertContains(workflow, "uses: pnpm/action-setup@v4");
+  assertContains(workflow, "uses: actions/checkout@v6");
+  assertContains(workflow, "uses: pnpm/action-setup@v6");
   assertContains(workflow, "version: 10.8.1");
-  assertContains(workflow, "uses: actions/setup-node@v4");
+  assertContains(workflow, "uses: actions/setup-node@v6");
   assertContains(workflow, "node-version: 24");
   assertContains(workflow, "cache: pnpm");
   assertContains(workflow, "run: pnpm install --frozen-lockfile");
@@ -56,8 +57,8 @@ test("Backend CI installs dependencies after toolchain setup", () => {
   const workflow = readTextFile(".github", "workflows", "backend-ci.yml");
 
   assertOrdered(workflow, [
-    "      - name: Setup pnpm\n        uses: pnpm/action-setup@v4",
-    "      - name: Setup Node.js\n        uses: actions/setup-node@v4",
+    "      - name: Setup pnpm\n        uses: pnpm/action-setup@v6",
+    "      - name: Setup Node.js\n        uses: actions/setup-node@v6",
     "      - name: Install dependencies\n        run: pnpm install --frozen-lockfile",
   ]);
 });


### PR DESCRIPTION
## Summary

- Align Backend CI GitHub Actions with Node 24 readiness.
- Update backend workflow actions to `actions/checkout@v6`, `pnpm/action-setup@v6`, and `actions/setup-node@v6`.
- Update backend toolchain contract tests.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.

## Validation

- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
