### PR TITLE
ci: pin frontend pnpm version

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.8.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -95,6 +95,7 @@ test("Frontend CI define toolchain y cache de pnpm esperados", () => {
   const source = readWorkflow();
 
   assertContains(source, "uses: pnpm/action-setup@v6");
+  assertContains(source, "version: 10.8.1");
   assertContains(source, "uses: actions/setup-node@v6");
   assertContains(source, "node-version: 24");
   assertContains(source, "cache: pnpm");


### PR DESCRIPTION
## Summary

- Pin Frontend CI pnpm version to `10.8.1`.
- Align Frontend CI with the repository `packageManager`.
- Extend Frontend CI workflow contract coverage.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.

## Validation

- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
