### PR TITLE
ci: restrict backend workflow permissions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -15,6 +15,9 @@ on:
       - test/**
       - codex/**
 
+permissions:
+  contents: read
+
 jobs:
   validate-backend:
     runs-on: ubuntu-latest

--- a/test/toolchain-contract.test.ts
+++ b/test/toolchain-contract.test.ts
@@ -44,6 +44,7 @@ test("package.json pins the expected package manager", () => {
 test("Backend CI uses the pinned pnpm and Node toolchain", () => {
   const workflow = readTextFile(".github", "workflows", "backend-ci.yml");
 
+  assertContains(workflow, "permissions:\n  contents: read");
   assertContains(workflow, "uses: actions/checkout@v6");
   assertContains(workflow, "uses: pnpm/action-setup@v6");
   assertContains(workflow, "version: 10.8.1");


### PR DESCRIPTION
## Summary

- Add explicit read-only permissions to Backend CI.
- Align Backend CI permissions posture with Frontend CI.
- Extend backend toolchain contract coverage.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Restricts workflow token permissions to `contents: read`.

## Validation

- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
