### PR TITLE
ci: add frontend workflow timeout

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,6 +27,7 @@ jobs:
   validate-frontend:
     name: validate-frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -94,6 +94,7 @@ test("Frontend CI dispara en push y pull_request para rutas de frontend", () => 
 test("Frontend CI define toolchain y cache de pnpm esperados", () => {
   const source = readWorkflow();
 
+  assertContains(source, "timeout-minutes: 20");
   assertContains(source, "uses: pnpm/action-setup@v6");
   assertContains(source, "version: 10.8.1");
   assertContains(source, "uses: actions/setup-node@v6");


### PR DESCRIPTION
## Summary

- Add explicit timeout to Frontend CI.
- Guard the timeout in the frontend workflow contract.
- Align frontend workflow hardening with backend workflow timeout posture.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.

## Validation

- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
