### PR TITLE
ci: set backend cache dependency path

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/test/toolchain-contract.test.ts
+++ b/test/toolchain-contract.test.ts
@@ -51,6 +51,7 @@ test("Backend CI uses the pinned pnpm and Node toolchain", () => {
   assertContains(workflow, "uses: actions/setup-node@v6");
   assertContains(workflow, "node-version: 24");
   assertContains(workflow, "cache: pnpm");
+  assertContains(workflow, "cache-dependency-path: pnpm-lock.yaml");
   assertContains(workflow, "run: pnpm install --frozen-lockfile");
 });
 


### PR DESCRIPTION
## Summary

- Add explicit pnpm cache dependency path to Backend CI.
- Align Backend CI cache configuration with Frontend CI.
- Extend backend toolchain contract coverage.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.

## Validation

- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
