### PR TITLE
ci: add backend workflow concurrency

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: backend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-backend:
     runs-on: ubuntu-latest

--- a/test/toolchain-contract.test.ts
+++ b/test/toolchain-contract.test.ts
@@ -45,6 +45,10 @@ test("Backend CI uses the pinned pnpm and Node toolchain", () => {
   const workflow = readTextFile(".github", "workflows", "backend-ci.yml");
 
   assertContains(workflow, "permissions:\n  contents: read");
+  assertContains(
+    workflow,
+    "concurrency:\n  group: backend-ci-${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true",
+  );
   assertContains(workflow, "uses: actions/checkout@v6");
   assertContains(workflow, "uses: pnpm/action-setup@v6");
   assertContains(workflow, "version: 10.8.1");


### PR DESCRIPTION
## Summary

- Add concurrency guard to Backend CI.
- Cancel obsolete Backend CI runs on the same workflow/ref.
- Extend backend toolchain contract coverage.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.

## Validation

- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
