### PR TITLE
ci: add frontend workflow concurrency

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: frontend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-frontend:
     name: validate-frontend

--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -86,6 +86,10 @@ test("Frontend CI dispara en push y pull_request para rutas de frontend", () => 
   assertContains(source, "push:");
   assertContains(source, "pull_request:");
   assertContains(source, "  contents: read");
+  assertContains(
+    source,
+    "concurrency:\n  group: frontend-ci-${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true",
+  );
 
   assertEventPathFilters(source, "push");
   assertEventPathFilters(source, "pull_request");


### PR DESCRIPTION
## Summary

- Add concurrency guard to Frontend CI.
- Cancel obsolete Frontend CI runs on the same workflow/ref.
- Align frontend workflow hardening with Backend CI.
- Extend frontend workflow contract coverage.

## Security

- CI only.
- Test contract only.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.

## Validation

- [x] `pnpm test -- .\test\frontend-ci-workflow.test.ts`
- [x] `pnpm test -- .\test\toolchain-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd .\frontend && pnpm typecheck`
- [x] `cd .\frontend && pnpm build`
