### PR TITLE
test(security): cover admin routes in cross-auth surface

### DIFF
--- a/test/security-cross-auth-surface-boundaries.test.ts
+++ b/test/security-cross-auth-surface-boundaries.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -21,9 +21,12 @@ const clinicFiles = [
 const adminFiles = [
   "server/routes/admin-auth.fastify.ts",
   "server/routes/admin-audit.fastify.ts",
+  "server/routes/admin-failed-login-alerts.fastify.ts",
   "server/routes/admin-particular-tokens.fastify.ts",
   "server/routes/admin-report-access-tokens.fastify.ts",
+  "server/routes/admin-sessions.fastify.ts",
   "server/routes/admin-study-tracking.fastify.ts",
+  "server/routes/admin-users-roles.fastify.ts",
 ] as const;
 
 const particularFiles = [
@@ -122,9 +125,12 @@ test("cross auth surface registry keeps every protected route family explicit", 
       "server/routes/study-tracking.fastify.ts",
       "server/routes/admin-auth.fastify.ts",
       "server/routes/admin-audit.fastify.ts",
+      "server/routes/admin-failed-login-alerts.fastify.ts",
       "server/routes/admin-particular-tokens.fastify.ts",
       "server/routes/admin-report-access-tokens.fastify.ts",
+      "server/routes/admin-sessions.fastify.ts",
       "server/routes/admin-study-tracking.fastify.ts",
+      "server/routes/admin-users-roles.fastify.ts",
       "server/routes/particular-audit.fastify.ts",
       "server/routes/particular-auth.fastify.ts",
       "server/routes/particular-study-tracking.fastify.ts",


### PR DESCRIPTION
## Summary

- Extend cross-auth surface guardrail coverage for current Admin routes.
- Add admin failed-login alerts, sessions, and users/roles route files to the Admin cookie boundary registry.
- Keep protected route families explicit in the static security test.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens route coverage for Admin cookie-boundary assertions.

## Validation

- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`