### PR TITLE
test(security): anchor admin routes in suite completeness

### DIFF
--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -214,6 +214,18 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
         markers: ["cookies[ENV.adminCookieName]"],
       },
       {
+        path: "server/routes/admin-failed-login-alerts.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
+        path: "server/routes/admin-sessions.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
+        path: "server/routes/admin-users-roles.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
         path: "server/routes/particular-auth.fastify.ts",
         markers: ["cookies[ENV.particularCookieName]"],
       },


### PR DESCRIPTION
## Summary

- Extend security boundary suite runtime anchors for current Admin route surfaces.
- Connect cross-auth surface completeness to Admin failed-login alerts, sessions, and users/roles routes.
- Keep suite-level guardrail coverage aligned with the explicit Admin cookie-boundary registry.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens suite completeness coverage for Admin cookie-boundary assertions.

## Validation

- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`