### PR TITLE
test(security): anchor admin cookies in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -41,6 +41,18 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
       {
+        path: "server/routes/admin-failed-login-alerts.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-sessions.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-users-roles.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
         path: "server/routes/particular-auth.fastify.ts",
         markers: [
           "cookies[ENV.particularCookieName]",


### PR DESCRIPTION
## Summary

- Extend the critical route surface registry for current Admin cookie-bound route surfaces.
- Add Admin failed-login alerts, sessions, and users/roles routes to the auth-session-cookie contract.
- Keep critical registry coverage aligned with protected Admin runtime files.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry coverage for Admin cookie-boundary assertions.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-production-invariants.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`