### PR TITLE
test(security): anchor admin route registration

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -33,6 +33,17 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         ],
       },
       {
+        path: "server/fastify-app.ts",
+        markers: [
+          "adminFailedLoginAlertsNativeRoutes",
+          'prefix: "/api/admin/failed-login-alerts"',
+          "adminSessionsNativeRoutes",
+          'prefix: "/api/admin/sessions"',
+          "adminUsersRolesNativeRoutes",
+          'prefix: "/api/admin/users-roles"',
+        ],
+      },
+      {
         path: "server/routes/auth.fastify.ts",
         markers: ["cookies[ENV.cookieName]", "name: ENV.cookieName"],
       },


### PR DESCRIPTION
## Summary

- Extend the critical route surface registry with Admin route registration anchors.
- Assert Admin failed-login alerts, sessions, and users/roles routes remain mounted in Fastify.
- Keep route registration coverage aligned with the Admin cookie-bound critical surface.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry coverage for Admin route availability.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`