### PR TITLE
test(security): anchor admin system routes in suite

### DIFF
--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -218,7 +218,19 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
         markers: ["cookies[ENV.adminCookieName]"],
       },
       {
+        path: "server/routes/admin-reports.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
         path: "server/routes/admin-sessions.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
+        path: "server/routes/admin-system-health.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
+        path: "server/routes/admin-system-maintenance.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]"],
       },
       {


### PR DESCRIPTION
## Summary

- Extend security boundary suite runtime anchors for remaining Admin cross-auth surfaces.
- Add Admin reports, system health, and system maintenance routes to the suite completeness registry.
- Keep suite-level coverage aligned with the explicit Admin cookie-boundary registry.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens suite completeness coverage for Admin cookie-boundary assertions.

## Validation

- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`