### PR TITLE
test(security): anchor all admin cookies in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -64,6 +64,10 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         markers: ["cookies[ENV.cookieName]", "name: ENV.cookieName"],
       },
       {
+        path: "server/routes/admin-audit.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
         path: "server/routes/admin-auth.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
@@ -72,11 +76,23 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
       {
+        path: "server/routes/admin-particular-tokens.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-report-access-tokens.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
         path: "server/routes/admin-reports.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
       {
         path: "server/routes/admin-sessions.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-study-tracking.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
       {


### PR DESCRIPTION
## Summary

- Extend the critical route surface registry with all Admin cookie-bound route anchors.
- Add Admin audit, particular tokens, report access tokens, and study tracking routes to the auth-session-cookie contract.
- Keep critical registry cookie coverage aligned with the explicit Admin cross-auth surface registry.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry coverage for Admin cookie-boundary assertions.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-production-invariants.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`