### PR TITLE
test(security): anchor all admin cookies in suite

### DIFF
--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -210,6 +210,10 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
         markers: ["cookies[ENV.cookieName]"],
       },
       {
+        path: "server/routes/admin-audit.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
         path: "server/routes/admin-auth.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]"],
       },
@@ -218,11 +222,23 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
         markers: ["cookies[ENV.adminCookieName]"],
       },
       {
+        path: "server/routes/admin-particular-tokens.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
+        path: "server/routes/admin-report-access-tokens.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
         path: "server/routes/admin-reports.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]"],
       },
       {
         path: "server/routes/admin-sessions.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]"],
+      },
+      {
+        path: "server/routes/admin-study-tracking.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]"],
       },
       {


### PR DESCRIPTION
## Summary

- Extend security boundary suite runtime anchors for all Admin cookie-bound route surfaces.
- Add Admin audit, particular tokens, report access tokens, and study tracking routes to the cross-auth suite registry.
- Keep suite-level coverage aligned with the explicit Admin cross-auth and critical route surface registries.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens suite completeness coverage for Admin cookie-boundary assertions.

## Validation

- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`