### PR TITLE
test(security): cover all admin session cookie surfaces

### DIFF
--- a/test/security-session-cookie-boundaries.test.ts
+++ b/test/security-session-cookie-boundaries.test.ts
@@ -34,9 +34,17 @@ const CLINIC_SESSION_FILES = [
 ] as const;
 
 const ADMIN_SESSION_FILES = [
-  "server/routes/admin-auth.fastify.ts",
   "server/routes/admin-audit.fastify.ts",
+  "server/routes/admin-auth.fastify.ts",
+  "server/routes/admin-failed-login-alerts.fastify.ts",
+  "server/routes/admin-particular-tokens.fastify.ts",
+  "server/routes/admin-report-access-tokens.fastify.ts",
+  "server/routes/admin-reports.fastify.ts",
+  "server/routes/admin-sessions.fastify.ts",
   "server/routes/admin-study-tracking.fastify.ts",
+  "server/routes/admin-system-health.fastify.ts",
+  "server/routes/admin-system-maintenance.fastify.ts",
+  "server/routes/admin-users-roles.fastify.ts",
 ] as const;
 
 const PARTICULAR_SESSION_FILES = [


### PR DESCRIPTION
## Summary

- Extend session cookie boundary coverage for all Admin cookie-bound route surfaces.
- Add Admin failed-login alerts, particular tokens, report access tokens, reports, sessions, system health, system maintenance, and users/roles routes to ADMIN_SESSION_FILES.
- Keep session-cookie guardrail coverage aligned with cross-auth and suite completeness registries.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens Admin session cookie boundary coverage.

## Validation

- [x] `pnpm test -- .\test\security-session-cookie-boundaries.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`