### PR TITLE
test(security): anchor all admin session cookies in suite

### DIFF
--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -179,7 +179,47 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
         markers: ["cookies[ENV.cookieName]", "name: ENV.cookieName"],
       },
       {
+        path: "server/routes/admin-audit.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
         path: "server/routes/admin-auth.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-failed-login-alerts.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-particular-tokens.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-report-access-tokens.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-reports.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-sessions.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-study-tracking.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-system-health.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-system-maintenance.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-users-roles.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
       {


### PR DESCRIPTION
## Summary

- Extend security boundary suite runtime anchors for all Admin session-cookie route surfaces.
- Align the session-cookie guardrail anchors with the expanded Admin session cookie boundary coverage.
- Keep suite completeness consistent with cross-auth and critical route surface registries.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens suite completeness coverage for Admin session cookie boundaries.

## Validation

- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm test -- .\test\security-session-cookie-boundaries.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`