### PR TITLE
test(security): link session guardrails in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -128,6 +128,22 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "rutas clinic-scoped que limpian sesión usan contrato central ENV",
         ],
       },
+      {
+        path: "test/security-session-cookie-boundaries.test.ts",
+        markers: [
+          "session cookie boundary matrix documents separated auth domains",
+          "clinic admin and particular route surfaces read only their own cookie",
+          "session cookie guardrail source stays ascii only",
+        ],
+      },
+      {
+        path: "test/security-cross-auth-surface-boundaries.test.ts",
+        markers: [
+          "admin route surfaces accept only admin session cookies",
+          "public token surfaces do not accept browser session cookies",
+          "cross auth surface registry keeps every protected route family explicit",
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Link the critical auth-session-cookie contract to the dedicated session-cookie and cross-auth guardrails.
- Keep critical registry guardrail coverage aligned with the completed Admin cookie-bound route surface.
- Preserve explicit test anchors for session domain separation and cross-auth cookie rejection.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for session cookie boundaries.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-session-cookie-boundaries.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`