### PR TITLE
test(security): link suite completeness in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -144,6 +144,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "cross auth surface registry keeps every protected route family explicit",
         ],
       },
+      {
+        path: "test/security-boundary-suite-completeness.test.ts",
+        markers: [
+          "security boundary suite completeness registry keeps canonical order",
+          "security boundary guardrails remain connected to runtime anchors",
+          "security boundary suite completeness guardrail source stays ascii only",
+        ],
+      },
     ],
   },
   {
@@ -506,6 +514,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-production-invariants.test.ts",
     "test/security-session-cookie-boundaries.test.ts",
     "test/security-cross-auth-surface-boundaries.test.ts",
+    "test/security-boundary-suite-completeness.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/supabase-storage-boundaries.test.ts",
     "test/public-professionals-route-surface-invariants.test.ts",


### PR DESCRIPTION
## Summary

- Link the critical auth-session-cookie contract to the security boundary suite completeness guardrail.
- Add the suite completeness guardrail to the required critical registry list.
- Preserve traceability between critical registry coverage and the security boundary meta-suite.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for security boundary completeness.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-boundary-suite-completeness.test.ts`
- [x] `pnpm test -- .\test\security-session-cookie-boundaries.test.ts`
- [x] `pnpm test -- .\test\security-cross-auth-surface-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`