### PR TITLE
test(security): anchor admin preflight in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -177,6 +177,30 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         ],
       },
       {
+        path: "server/routes/admin-particular-tokens.fastify.ts",
+        markers: [
+          'app.options("/", optionsHandler)',
+          'app.options("/:tokenId", optionsHandler)',
+          'app.options("/:tokenId/report", optionsHandler)',
+        ],
+      },
+      {
+        path: "server/routes/admin-report-access-tokens.fastify.ts",
+        markers: [
+          'app.options("/", optionsHandler)',
+          'app.options("/:tokenId", optionsHandler)',
+          'app.options("/:tokenId/revoke", optionsHandler)',
+        ],
+      },
+      {
+        path: "server/routes/admin-study-tracking.fastify.ts",
+        markers: [
+          'app.options("/", optionsHandler)',
+          'app.options("/notifications", optionsHandler)',
+          'app.options("/:trackingCaseId", optionsHandler)',
+        ],
+      },
+      {
         path: "server/routes/reports.fastify.ts",
         markers: [
           'app.options("/", optionsHandler)',


### PR DESCRIPTION
## Summary

- Extend the critical preflight/CORS registry with Admin routes that expose explicit optionsHandler coverage.
- Add Admin particular tokens, report access tokens, and study tracking preflight anchors.
- Keep critical preflight registry coverage aligned with Admin mutation/read route surfaces.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for Admin preflight/CORS boundaries.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\admin-particular-tokens.fastify.test.ts`
- [x] `pnpm test -- .\test\admin-report-access-tokens.fastify.test.ts`
- [x] `pnpm test -- .\test\admin-study-tracking.fastify.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`