### PR TITLE
test(security): link admin preflight guardrails

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -232,6 +232,27 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         ],
       },
       {
+        path: "test/admin-particular-tokens.fastify.test.ts",
+        markers: [
+          "adminParticularTokensNativeRoutes bloquea POST / con origin no permitido",
+          "adminParticularTokensNativeRoutes vincula PATCH /:tokenId/report con trusted origin",
+        ],
+      },
+      {
+        path: "test/admin-report-access-tokens.fastify.test.ts",
+        markers: [
+          "adminReportAccessTokensNativeRoutes bloquea POST / con origin no permitido",
+          "adminReportAccessTokensNativeRoutes aplica rate limit nativo fijo sobre mutaciones",
+        ],
+      },
+      {
+        path: "test/admin-study-tracking.fastify.test.ts",
+        markers: [
+          "adminStudyTrackingNativeRoutes bloquea POST / con origin no permitido",
+          "adminStudyTrackingNativeRoutes actualiza PATCH /:trackingCaseId y notifica tinción especial",
+        ],
+      },
+      {
         path: "test/reports.fastify.test.ts",
         markers: [
           "reportsNativeRoutes responde preflight OPTIONS para superficie clinic read-only sin autenticar",


### PR DESCRIPTION
## Summary

- Link Admin preflight/CORS runtime anchors to their dedicated Fastify guardrail tests.
- Add Admin particular tokens, report access tokens, and study tracking tests to the critical preflight/CORS contract.
- Keep critical registry guardrail traceability aligned with the Admin preflight runtime surface.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for Admin preflight/CORS boundaries.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\admin-particular-tokens.fastify.test.ts`
- [x] `pnpm test -- .\test\admin-report-access-tokens.fastify.test.ts`
- [x] `pnpm test -- .\test\admin-study-tracking.fastify.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`