### PR TITLE
test(security): require trusted origin cors in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -232,6 +232,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         ],
       },
       {
+        path: "test/security-trusted-origin-cors-boundaries.test.ts",
+        markers: [
+          "auth login y mutations bloquean Origin no permitido antes de tocar dependencias",
+          "auth preflight OPTIONS solo expone CORS con origins confiables y sin wildcard credentials",
+          "CORS con credentials no usa wildcard y trust proxy queda gobernado por ENV",
+        ],
+      },
+      {
         path: "test/admin-particular-tokens.fastify.test.ts",
         markers: [
           "adminParticularTokensNativeRoutes bloquea POST / con origin no permitido",
@@ -560,6 +568,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-session-cookie-boundaries.test.ts",
     "test/security-cross-auth-surface-boundaries.test.ts",
     "test/security-boundary-suite-completeness.test.ts",
+    "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/supabase-storage-boundaries.test.ts",
     "test/public-professionals-route-surface-invariants.test.ts",


### PR DESCRIPTION
## Summary

- Link trusted origin/CORS boundary guardrail into the critical route surface registry.
- Add trusted origin/CORS guardrail to the final required guardrail list.
- Preserve explicit traceability for preflight, trusted origin, wildcard credentials, and trust proxy security coverage.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for trusted origin and CORS guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-trusted-origin-cors-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`