### PR TITLE
test(security): require validation cutoff in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -326,6 +326,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "rutas mutantes sensibles validan origin, sesión y permiso antes de operar",
         ],
       },
+      {
+        path: "test/security-validation-cutoff-boundaries.test.ts",
+        markers: [
+          "validation cut-off matrix documents the protected contract",
+          "public report access validates raw token before hash db signing and audit",
+          "validation cut-off guardrail source stays ascii only",
+        ],
+      },
     ],
   },
   {
@@ -570,6 +578,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-boundary-suite-completeness.test.ts",
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
+    "test/security-validation-cutoff-boundaries.test.ts",
     "test/supabase-storage-boundaries.test.ts",
     "test/public-professionals-route-surface-invariants.test.ts",
     "test/public-professionals-fixture-suite-completeness-invariants.test.ts",


### PR DESCRIPTION
## Summary

- Link validation cut-off boundary guardrail into the critical route surface registry.
- Add validation cut-off guardrail to the final required guardrail list.
- Preserve explicit traceability for invalid token, param, body, upload, and audit filter cut-off coverage.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for validation cut-off guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-validation-cutoff-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`