### PR TITLE
test(security): require rate limit isolation in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -334,6 +334,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "validation cut-off guardrail source stays ascii only",
         ],
       },
+      {
+        path: "test/security-rate-limit-isolation-boundaries.test.ts",
+        markers: [
+          "rate limit isolation matrix documents the protected contract",
+          "auth login rate limits keep separate in-memory stores per auth domain",
+          "rate limit isolation guardrail source stays ascii only",
+        ],
+      },
     ],
   },
   {
@@ -579,6 +587,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/security-validation-cutoff-boundaries.test.ts",
+    "test/security-rate-limit-isolation-boundaries.test.ts",
     "test/supabase-storage-boundaries.test.ts",
     "test/public-professionals-route-surface-invariants.test.ts",
     "test/public-professionals-fixture-suite-completeness-invariants.test.ts",


### PR DESCRIPTION
## Summary

- Link rate limit isolation boundary guardrail into the critical route surface registry.
- Add rate limit isolation guardrail to the final required guardrail list.
- Preserve explicit traceability for auth login, public read, protected mutation, 429, and no-cookie rate-limit coverage.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for rate limit isolation guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-rate-limit-isolation-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`