### PR TITLE
test(security): require sensitive log redaction in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -152,6 +152,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "security boundary suite completeness guardrail source stays ascii only",
         ],
       },
+      {
+        path: "test/security-sensitive-log-redaction-boundaries.test.ts",
+        markers: [
+          "sensitive log redaction matrix documents protected boundaries",
+          "request logger keeps token and query redaction centralized",
+          "sensitive log redaction guardrail source stays ascii only",
+        ],
+      },
     ],
   },
   {
@@ -584,6 +592,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-session-cookie-boundaries.test.ts",
     "test/security-cross-auth-surface-boundaries.test.ts",
     "test/security-boundary-suite-completeness.test.ts",
+    "test/security-sensitive-log-redaction-boundaries.test.ts",
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/security-validation-cutoff-boundaries.test.ts",


### PR DESCRIPTION
## Summary

- Link sensitive log redaction boundary guardrail into the critical route surface registry.
- Add sensitive log redaction guardrail to the final required guardrail list.
- Preserve explicit traceability for request log redaction, auth secret safety, token routes, audit helpers, and smoke secret logging coverage.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for sensitive log redaction guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-sensitive-log-redaction-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`