### PR TITLE
test(security): require audit logging phase in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -160,6 +160,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "sensitive log redaction guardrail source stays ascii only",
         ],
       },
+      {
+        path: "test/security-audit-logging-phase-boundaries.test.ts",
+        markers: [
+          "audit logging phase matrix documents the protected contract",
+          "writeAuditLog keeps audit storage failures isolated from business flow",
+          "audit logging phase guardrail source stays ascii only",
+        ],
+      },
     ],
   },
   {
@@ -593,6 +601,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-cross-auth-surface-boundaries.test.ts",
     "test/security-boundary-suite-completeness.test.ts",
     "test/security-sensitive-log-redaction-boundaries.test.ts",
+    "test/security-audit-logging-phase-boundaries.test.ts",
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/security-validation-cutoff-boundaries.test.ts",


### PR DESCRIPTION
## Summary

- Link audit logging phase boundary guardrail into the critical route surface registry.
- Add audit logging phase guardrail to the final required guardrail list.
- Preserve explicit traceability for preconditions, durable mutations, audit writes, response ordering, and audit failure isolation.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for audit logging phase guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-audit-logging-phase-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`