### PR TITLE
test(security): require resource ownership in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -176,6 +176,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "clinic routes force authenticated clinic relationships and reject cross clinic links",
         ],
       },
+      {
+        path: "test/security-resource-ownership-boundaries.test.ts",
+        markers: [
+          "resource ownership matrix documents protected owner keys",
+          "clinic-owned resources reject cross-clinic reports tokens and tracking cases",
+          "admin-owned linking validates target clinic before binding resources",
+        ],
+      },
     ],
   },
   {
@@ -611,6 +619,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-sensitive-log-redaction-boundaries.test.ts",
     "test/security-audit-logging-phase-boundaries.test.ts",
     "test/security-actor-relationship-boundaries.test.ts",
+    "test/security-resource-ownership-boundaries.test.ts",
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/security-validation-cutoff-boundaries.test.ts",


### PR DESCRIPTION
## Summary

- Link resource ownership boundary guardrail into the critical route surface registry.
- Add resource ownership guardrail to the final required guardrail list.
- Preserve explicit traceability for report, token, tracking case, notification, clinic, admin, particular, and public ownership boundaries.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for resource ownership guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-resource-ownership-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`