### PR TITLE
test(security): require write attribution in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -184,6 +184,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "admin-owned linking validates target clinic before binding resources",
         ],
       },
+      {
+        path: "test/security-write-attribution-boundaries.test.ts",
+        markers: [
+          "write attribution matrix documents admin clinic particular and public token actors",
+          "admin writes persist admin attribution and audit through admin context",
+          "clinic writes persist clinic attribution and audit through clinic context",
+        ],
+      },
     ],
   },
   {
@@ -620,6 +628,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-audit-logging-phase-boundaries.test.ts",
     "test/security-actor-relationship-boundaries.test.ts",
     "test/security-resource-ownership-boundaries.test.ts",
+    "test/security-write-attribution-boundaries.test.ts",
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/security-validation-cutoff-boundaries.test.ts",


### PR DESCRIPTION
## Summary

- Link write attribution boundary guardrail into the critical route surface registry.
- Add write attribution guardrail to the final required guardrail list.
- Preserve explicit traceability for admin, clinic, particular, and public token write attribution boundaries.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for write attribution guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-write-attribution-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`