### PR TITLE
test(security): require access lifecycle in critical registry

### DIFF
--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -192,6 +192,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           "clinic writes persist clinic attribution and audit through clinic context",
         ],
       },
+      {
+        path: "test/security-access-lifecycle-boundaries.test.ts",
+        markers: [
+          "access lifecycle matrix documents public token revoke session and rate-limit states",
+          "public report access enforces token lifecycle before signed URLs and audit",
+          "runtime lifecycle tests remain explicit for public report access",
+        ],
+      },
     ],
   },
   {
@@ -629,6 +637,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-actor-relationship-boundaries.test.ts",
     "test/security-resource-ownership-boundaries.test.ts",
     "test/security-write-attribution-boundaries.test.ts",
+    "test/security-access-lifecycle-boundaries.test.ts",
     "test/security-trusted-origin-cors-boundaries.test.ts",
     "test/security-mutation-permission-surface.test.ts",
     "test/security-validation-cutoff-boundaries.test.ts",


### PR DESCRIPTION
## Summary

- Link access lifecycle boundary guardrail into the critical route surface registry.
- Add access lifecycle guardrail to the final required guardrail list.
- Preserve explicit traceability for public token lifecycle, revoke flows, particular sessions, rate-limit states, and public access audit coverage.

## Security

- Test-only change.
- No product behavior changes.
- No backend runtime changes.
- No frontend runtime changes.
- No schema or data changes.
- No secret changes.
- Strengthens critical registry traceability for access lifecycle guardrails.

## Validation

- [x] `pnpm test -- .\test\security-critical-route-surface-registry.test.ts`
- [x] `pnpm test -- .\test\security-access-lifecycle-boundaries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`