### PR TITLE
feat(frontend): protect dashboard routes with middleware

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const CLINIC_SESSION_COOKIE_NAME = "app_session_id";
+const LOGIN_PATH = "/login";
+
+export function middleware(request: NextRequest) {
+  const hasClinicSession = Boolean(
+    request.cookies.get(CLINIC_SESSION_COOKIE_NAME)?.value,
+  );
+
+  if (hasClinicSession) {
+    return NextResponse.next();
+  }
+
+  const loginUrl = request.nextUrl.clone();
+  const nextPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+
+  loginUrl.pathname = LOGIN_PATH;
+  loginUrl.searchParams.set("next", nextPath);
+
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*"],
+};

--- a/test/frontend-dashboard-middleware.test.ts
+++ b/test/frontend-dashboard-middleware.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const MIDDLEWARE_PATH = "frontend/src/middleware.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend dashboard middleware exists and protects dashboard routes", () => {
+  assert.equal(
+    existsSync(resolve(process.cwd(), MIDDLEWARE_PATH)),
+    true,
+    "frontend dashboard middleware must exist",
+  );
+
+  const source = read(MIDDLEWARE_PATH);
+
+  assert.ok(source.includes('from "next/server"'));
+  assert.ok(source.includes('CLINIC_SESSION_COOKIE_NAME = "app_session_id"'));
+  assert.ok(source.includes('LOGIN_PATH = "/login"'));
+  assert.ok(source.includes('request.cookies.get(CLINIC_SESSION_COOKIE_NAME)'));
+  assert.ok(source.includes("NextResponse.next()"));
+  assert.ok(source.includes("NextResponse.redirect(loginUrl)"));
+  assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
+});
+
+test("frontend dashboard middleware preserves requested dashboard path", () => {
+  const source = read(MIDDLEWARE_PATH);
+
+  assert.ok(source.includes("request.nextUrl.clone()"));
+  assert.ok(
+    source.includes(
+      "`${request.nextUrl.pathname}${request.nextUrl.search}`",
+    ),
+  );
+  assert.ok(source.includes('loginUrl.searchParams.set("next", nextPath)'));
+});
+
+test("frontend dashboard middleware stays scoped to frontend route protection", () => {
+  const source = read(MIDDLEWARE_PATH);
+
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("admin_session_id"), false);
+  assert.equal(source.includes("particular_session_id"), false);
+  assert.equal(source.includes("process.env"), false);
+});


### PR DESCRIPTION
## Summary

- Add Next.js middleware to protect dashboard routes.
- Redirect unauthenticated dashboard requests to /login with a preserved next path.
- Add a test-only guardrail for dashboard middleware scope and cookie behavior.

## Security

- Protects /dashboard/:path* from unauthenticated access when app_session_id is missing.
- Does not touch backend runtime.
- Does not touch login form behavior yet.
- Does not introduce admin or particular auth behavior in this PR.
- Keeps scope limited to clinic dashboard route protection.

## Validation

- [x] pnpm test -- .\test\frontend-dashboard-middleware.test.ts
- [x] pnpm typecheck
- [x] pnpm typecheck:test
- [x] pnpm test
- [x] pnpm build
- [x] pnpm --dir frontend typecheck
- [x] pnpm --dir frontend build