### PR TITLE
feat(frontend): connect clinic login form

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
+
 import { createPageMetadata } from "@/lib/seo";
 import { LoginContent } from "@/components/public/LoginContent";
 
@@ -12,5 +14,9 @@ export const metadata: Metadata = {
 };
 
 export default function LoginPage() {
-  return <LoginContent />;
+  return (
+    <Suspense fallback={null}>
+      <LoginContent />
+    </Suspense>
+  );
 }

--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -1,12 +1,62 @@
 "use client";
 
+import { FormEvent, useState } from "react";
 import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { loginClinic } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 
+function getSafeNextPath(nextPath: string | null): string {
+  if (!nextPath?.startsWith("/dashboard")) {
+    return ROUTES.dashboard;
+  }
+
+  return nextPath;
+}
+
 export function LoginContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      await loginClinic({ username, password });
+      router.replace(getSafeNextPath(searchParams.get("next")));
+      router.refresh();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo iniciar sesión. Intente nuevamente.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800 flex items-center justify-center p-4">
       <div className="w-full max-w-md">
@@ -38,7 +88,7 @@ export function LoginContent() {
             <form
               className="space-y-4"
               aria-label="Formulario de inicio de sesión"
-              onSubmit={(e) => e.preventDefault()}
+              onSubmit={handleSubmit}
             >
               <div>
                 <label
@@ -49,10 +99,15 @@ export function LoginContent() {
                 </label>
                 <Input
                   id="username"
+                  name="username"
                   type="text"
                   placeholder="nombre_usuario"
                   autoComplete="username"
                   autoFocus
+                  required
+                  value={username}
+                  onChange={(event) => setUsername(event.target.value)}
+                  disabled={isSubmitting}
                 />
               </div>
               <div>
@@ -64,27 +119,28 @@ export function LoginContent() {
                 </label>
                 <Input
                   id="password"
+                  name="password"
                   type="password"
                   placeholder="••••••••"
                   autoComplete="current-password"
+                  required
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  disabled={isSubmitting}
                 />
               </div>
 
-              <p className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-                <strong>Nota de desarrollo:</strong> La autenticación real se
-                conectará con{" "}
-                <code className="font-mono">POST /api/auth/login</code> en un
-                próximo PR.
-              </p>
+              {errorMessage ? (
+                <p
+                  className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2"
+                  role="alert"
+                >
+                  {errorMessage}
+                </p>
+              ) : null}
 
-              <Button type="submit" className="w-full" disabled>
-                Iniciar sesión (próximamente)
-              </Button>
-
-              <Button asChild variant="outline" className="w-full">
-                <Link href={ROUTES.dashboard}>
-                  Ver dashboard (demo sin auth)
-                </Link>
+              <Button type="submit" className="w-full" disabled={isSubmitting}>
+                {isSubmitting ? "Iniciando sesión..." : "Iniciar sesión"}
               </Button>
             </form>
 

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const LOGIN_CONTENT_PATH = "frontend/src/components/public/LoginContent.tsx";
+const LOGIN_PAGE_PATH = "frontend/src/app/login/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend login content calls clinic login and redirects to dashboard", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes('"use client"'));
+  assert.ok(source.includes('import { loginClinic } from "@/lib/api"'));
+  assert.ok(source.includes('import { useRouter, useSearchParams } from "next/navigation"'));
+  assert.ok(source.includes("await loginClinic({ username, password })"));
+  assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
+  assert.ok(source.includes("router.refresh()"));
+});
+
+test("frontend login content preserves dashboard next path safely", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
+  assert.ok(source.includes('nextPath?.startsWith("/dashboard")'));
+  assert.ok(source.includes("return ROUTES.dashboard"));
+});
+
+test("frontend login content removes demo bypass and development placeholder", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.equal(source.includes("Ver dashboard (demo sin auth)"), false);
+  assert.equal(source.includes("Iniciar sesión (próximamente)"), false);
+  assert.equal(source.includes("Nota de desarrollo"), false);
+  assert.equal(source.includes("onSubmit={(e) => e.preventDefault()}"), false);
+});
+
+test("frontend login content handles controlled credentials loading and errors", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes('const [username, setUsername] = useState("")'));
+  assert.ok(source.includes('const [password, setPassword] = useState("")'));
+  assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
+  assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("disabled={isSubmitting}"));
+});
+
+test("frontend login page wraps client search params usage in suspense", () => {
+  const source = read(LOGIN_PAGE_PATH);
+
+  assert.ok(source.includes('import { Suspense } from "react"'));
+  assert.ok(source.includes("<Suspense fallback={null}>"));
+  assert.ok(source.includes("<LoginContent />"));
+  assert.ok(source.includes("</Suspense>"));
+});


### PR DESCRIPTION
## Summary

- Connect the clinic login form to the existing frontend API client.
- Submit username and password through loginClinic and redirect to the preserved dashboard next path.
- Add loading and error states.
- Remove the unauthenticated dashboard demo bypass.
- Wrap the login page in Suspense for useSearchParams compatibility.
- Add a test-only guardrail for login integration behavior.

## Security

- Removes the dashboard demo bypass from the login page.
- Uses existing cookie-based clinic login flow.
- Preserves only safe dashboard next paths.
- Does not touch backend runtime.
- Does not introduce admin or particular auth behavior in this PR.
- Does not add AuthContext yet.

## Validation

- [x] `pnpm test -- .\test\frontend-login-content.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`