### PR TITLE
feat(frontend): add auth session context

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+
+import { AuthProvider } from "@/context/AuthContext";
 import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";
 
 const inter = Inter({
@@ -27,7 +29,7 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { getClinicSession, logout as logoutClinic } from "@/lib/api";
+import type { AuthUser } from "@/types";
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  refreshSession: () => Promise<AuthUser | null>;
+  logout: () => Promise<void>;
+};
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refreshSession = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const session = await getClinicSession();
+      setUser(session);
+      return session;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const logout = useCallback(async () => {
+    await logoutClinic();
+    setUser(null);
+  }, []);
+
+  useEffect(() => {
+    void refreshSession();
+  }, [refreshSession]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      isLoading,
+      isAuthenticated: user !== null,
+      refreshSession,
+      logout,
+    }),
+    [user, isLoading, refreshSession, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useContext } from "react";
+
+import { AuthContext } from "@/context/AuthContext";
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context === null) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+
+  return context;
+}

--- a/test/frontend-auth-context.test.ts
+++ b/test/frontend-auth-context.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const AUTH_CONTEXT_PATH = "frontend/src/context/AuthContext.tsx";
+const USE_AUTH_PATH = "frontend/src/hooks/useAuth.ts";
+const ROOT_LAYOUT_PATH = "frontend/src/app/layout.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend auth context exposes clinic session state and actions", () => {
+  assert.equal(existsSync(resolve(process.cwd(), AUTH_CONTEXT_PATH)), true);
+
+  const source = read(AUTH_CONTEXT_PATH);
+
+  assert.ok(source.includes('"use client"'));
+  assert.ok(source.includes('import { getClinicSession, logout as logoutClinic } from "@/lib/api"'));
+  assert.ok(source.includes("type AuthContextValue"));
+  assert.ok(source.includes("user: AuthUser | null"));
+  assert.ok(source.includes("isLoading: boolean"));
+  assert.ok(source.includes("isAuthenticated: boolean"));
+  assert.ok(source.includes("refreshSession: () => Promise<AuthUser | null>"));
+  assert.ok(source.includes("logout: () => Promise<void>"));
+  assert.ok(source.includes("export const AuthContext = createContext<AuthContextValue | null>(null)"));
+});
+
+test("frontend auth provider loads session and clears user on logout", () => {
+  const source = read(AUTH_CONTEXT_PATH);
+
+  assert.ok(source.includes("export function AuthProvider"));
+  assert.ok(source.includes("const [user, setUser] = useState<AuthUser | null>(null)"));
+  assert.ok(source.includes("const [isLoading, setIsLoading] = useState(true)"));
+  assert.ok(source.includes("const session = await getClinicSession()"));
+  assert.ok(source.includes("setUser(session)"));
+  assert.ok(source.includes("await logoutClinic()"));
+  assert.ok(source.includes("setUser(null)"));
+  assert.ok(source.includes("useEffect(() =>"));
+  assert.ok(source.includes("void refreshSession()"));
+});
+
+test("frontend useAuth hook requires provider", () => {
+  assert.equal(existsSync(resolve(process.cwd(), USE_AUTH_PATH)), true);
+
+  const source = read(USE_AUTH_PATH);
+
+  assert.ok(source.includes('"use client"'));
+  assert.ok(source.includes('import { AuthContext } from "@/context/AuthContext"'));
+  assert.ok(source.includes("useContext(AuthContext)"));
+  assert.ok(source.includes("throw new Error(\"useAuth must be used within AuthProvider\")"));
+  assert.ok(source.includes("return context"));
+});
+
+test("frontend root layout provides auth context globally", () => {
+  const source = read(ROOT_LAYOUT_PATH);
+
+  assert.ok(source.includes('import { AuthProvider } from "@/context/AuthContext"'));
+  assert.ok(source.includes("<AuthProvider>{children}</AuthProvider>"));
+});


### PR DESCRIPTION
## Summary

- Add a frontend AuthProvider for clinic session state.
- Add a useAuth hook for shared authenticated user access.
- Load the current clinic session through getClinicSession on app start.
- Expose refreshSession and logout actions.
- Wrap the root layout with AuthProvider.
- Add a test-only guardrail for auth context wiring.

## Security

- Uses the existing cookie-based clinic session API.
- Does not touch backend runtime.
- Does not introduce admin or particular auth behavior in this PR.
- Does not change dashboard authorization middleware.
- Keeps scope limited to shared frontend clinic session state.

## Validation

- [x] `pnpm test -- .\test\frontend-auth-context.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`