### PR TITLE
feat(frontend): add admin report upload api client

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,7 +52,14 @@ async function apiFetch<T>(
 ): Promise<T> {
   const headers = new Headers(options.headers);
 
-  if (options.body !== undefined && !headers.has("Content-Type")) {
+  const hasFormDataBody =
+    typeof FormData !== "undefined" && options.body instanceof FormData;
+
+  if (
+    options.body !== undefined &&
+    !hasFormDataBody &&
+    !headers.has("Content-Type")
+  ) {
     headers.set("Content-Type", "application/json");
   }
 
@@ -132,6 +139,12 @@ export async function searchReports(
   }
 }
 
+type AdminReportUploadResponse = {
+  success: true;
+  message: string;
+  report: Report;
+};
+
 export async function getReportDownloadUrl(
   reportId: number,
 ): Promise<string | null> {
@@ -143,6 +156,17 @@ export async function getReportDownloadUrl(
   } catch {
     return null;
   }
+}
+
+export async function uploadAdminReport(
+  formData: FormData,
+  options?: RequestInit,
+): Promise<AdminReportUploadResponse> {
+  return apiFetch<AdminReportUploadResponse>("/api/admin/reports/upload", {
+    ...options,
+    method: "POST",
+    body: formData,
+  });
 }
 
 export async function getLogisticsFieldVisits(
@@ -393,3 +417,4 @@ export async function getDashboardStats(
     ).length,
   };
 }
+

--- a/test/frontend-report-upload-api.test.ts
+++ b/test/frontend-report-upload-api.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend api client keeps multipart FormData content type browser-managed", () => {
+  const source = read(API_PATH);
+
+  assert.ok(source.includes("const hasFormDataBody ="));
+  assert.ok(source.includes('typeof FormData !== "undefined"'));
+  assert.ok(source.includes("options.body instanceof FormData"));
+  assert.ok(source.includes("!hasFormDataBody"));
+  assert.ok(source.includes('headers.set("Content-Type", "application/json")'));
+});
+
+test("frontend api client exposes admin report upload endpoint", () => {
+  const source = read(API_PATH);
+
+  assert.ok(source.includes("type AdminReportUploadResponse"));
+  assert.ok(source.includes("success: true"));
+  assert.ok(source.includes("message: string"));
+  assert.ok(source.includes("report: Report"));
+  assert.ok(source.includes("export async function uploadAdminReport("));
+  assert.ok(source.includes("formData: FormData"));
+  assert.ok(source.includes('"/api/admin/reports/upload"'));
+  assert.ok(source.includes('method: "POST"'));
+  assert.ok(source.includes("body: formData"));
+});
+
+test("frontend api client keeps report upload scoped to API layer only", () => {
+  const source = read(API_PATH);
+
+  assert.equal(source.includes("UploadReportModal"), false);
+  assert.equal(source.includes("document."), false);
+  assert.equal(source.includes("window."), false);
+});


### PR DESCRIPTION
## Summary

- Add frontend API support for admin report uploads.
- Preserve browser-managed multipart FormData headers.
- Add uploadAdminReport for POST /api/admin/reports/upload.
- Add a test-only guardrail for multipart upload behavior.

## Security

- Uses the existing admin report upload endpoint.
- Does not touch backend runtime.
- Does not add report upload UI yet.
- Does not introduce mock fallback for uploads.
- Keeps scope limited to the frontend API client.

## Validation

- [x] `pnpm test -- .\test\frontend-report-upload-api.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`