### PR TITLE
feat(frontend): add report upload modal

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
+
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
@@ -51,6 +53,10 @@ export default async function InformesPage() {
         subtitle="Gestión de informes médicos veterinarios"
       />
       <main className="flex-1 p-6 space-y-6">
+        <div className="flex justify-end">
+          <UploadReportModal />
+        </div>
+
         <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
           Lectura conectada a <code>GET /api/reports</code>.
         </div>

--- a/frontend/src/components/dashboard/UploadReportModal.tsx
+++ b/frontend/src/components/dashboard/UploadReportModal.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { FormEvent, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { uploadAdminReport } from "@/lib/api";
+
+const STUDY_TYPE_OPTIONS = [
+  { value: "", label: "Tipo de estudio" },
+  { value: "histopathology", label: "Histopatología" },
+  { value: "cytology", label: "Citología" },
+  { value: "immunohistochemistry", label: "Inmunohistoquímica" },
+  { value: "special_stain", label: "Tinción especial" },
+];
+
+export function UploadReportModal() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [clinicId, setClinicId] = useState("");
+  const [patientName, setPatientName] = useState("");
+  const [studyType, setStudyType] = useState("");
+  const [uploadDate, setUploadDate] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function resetForm() {
+    setClinicId("");
+    setPatientName("");
+    setStudyType("");
+    setUploadDate("");
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const file = fileInputRef.current?.files?.[0];
+
+    if (!file) {
+      setErrorMessage("Seleccione un archivo PDF para subir.");
+      return;
+    }
+
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData();
+    formData.append("clinicId", clinicId);
+    formData.append("file", file);
+
+    if (patientName.trim()) {
+      formData.append("patientName", patientName.trim());
+    }
+
+    if (studyType) {
+      formData.append("studyType", studyType);
+    }
+
+    if (uploadDate) {
+      formData.append("uploadDate", uploadDate);
+    }
+
+    try {
+      const response = await uploadAdminReport(formData);
+      setSuccessMessage(response.message);
+      resetForm();
+      router.refresh();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo subir el informe. Intente nuevamente.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <Button type="button" onClick={() => setIsOpen(true)}>
+        Subir informe
+      </Button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="presentation"
+        >
+          <div
+            className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="upload-report-title"
+          >
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div>
+                <h2
+                  id="upload-report-title"
+                  className="text-lg font-semibold text-gray-900"
+                >
+                  Subir informe
+                </h2>
+                <p className="text-sm text-gray-500">
+                  Cargue un PDF y asócielo a una clínica.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsOpen(false)}
+                disabled={isSubmitting}
+              >
+                Cerrar
+              </Button>
+            </div>
+
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div>
+                <label
+                  htmlFor="upload-clinic-id"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  ID de clínica
+                </label>
+                <Input
+                  id="upload-clinic-id"
+                  name="clinicId"
+                  type="number"
+                  min="1"
+                  required
+                  value={clinicId}
+                  onChange={(event) => setClinicId(event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="upload-file"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  Archivo PDF
+                </label>
+                <Input
+                  id="upload-file"
+                  name="file"
+                  type="file"
+                  accept="application/pdf"
+                  ref={fileInputRef}
+                  required
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="upload-patient-name"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  Paciente
+                </label>
+                <Input
+                  id="upload-patient-name"
+                  name="patientName"
+                  type="text"
+                  value={patientName}
+                  onChange={(event) => setPatientName(event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="upload-study-type"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  Tipo de estudio
+                </label>
+                <select
+                  id="upload-study-type"
+                  name="studyType"
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  value={studyType}
+                  onChange={(event) => setStudyType(event.target.value)}
+                  disabled={isSubmitting}
+                >
+                  {STUDY_TYPE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="upload-date"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  Fecha de carga
+                </label>
+                <Input
+                  id="upload-date"
+                  name="uploadDate"
+                  type="date"
+                  value={uploadDate}
+                  onChange={(event) => setUploadDate(event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              {errorMessage ? (
+                <p
+                  className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  role="alert"
+                >
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              {successMessage ? (
+                <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                  {successMessage}
+                </p>
+              ) : null}
+
+              <Button type="submit" className="w-full" disabled={isSubmitting}>
+                {isSubmitting ? "Subiendo informe..." : "Subir informe"}
+              </Button>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const UPLOAD_MODAL_PATH =
+  "frontend/src/components/dashboard/UploadReportModal.tsx";
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend report upload modal exists and uses upload api client", () => {
+  assert.equal(existsSync(resolve(process.cwd(), UPLOAD_MODAL_PATH)), true);
+
+  const source = read(UPLOAD_MODAL_PATH);
+
+  assert.ok(source.includes('"use client"'));
+  assert.ok(source.includes('import { uploadAdminReport } from "@/lib/api"'));
+  assert.ok(source.includes("new FormData()"));
+  assert.ok(source.includes('formData.append("clinicId", clinicId)'));
+  assert.ok(source.includes('formData.append("file", file)'));
+  assert.ok(source.includes('formData.append("patientName", patientName.trim())'));
+  assert.ok(source.includes('formData.append("studyType", studyType)'));
+  assert.ok(source.includes('formData.append("uploadDate", uploadDate)'));
+  assert.ok(source.includes("await uploadAdminReport(formData)"));
+  assert.ok(source.includes("router.refresh()"));
+});
+
+test("frontend report upload modal handles user feedback and submit state", () => {
+  const source = read(UPLOAD_MODAL_PATH);
+
+  assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
+  assert.ok(source.includes("const [successMessage, setSuccessMessage]"));
+  assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes("Seleccione un archivo PDF para subir."));
+});
+
+test("frontend report upload modal stays scoped to frontend ui", () => {
+  const source = read(UPLOAD_MODAL_PATH);
+
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("/api/admin/reports/upload"), false);
+  assert.equal(source.includes("process.env"), false);
+});
+
+test("frontend informes page exposes upload report modal", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal"'));
+  assert.ok(source.includes("<UploadReportModal />"));
+});


### PR DESCRIPTION
## Summary

- Add a dashboard report upload modal.
- Connect the informes page to the new upload modal.
- Submit report uploads through uploadAdminReport using FormData.
- Support clinicId, file, patientName, studyType, and uploadDate fields.
- Refresh the informes page after successful upload.
- Add a test-only guardrail for upload modal wiring.

## Security

- Uses the existing frontend uploadAdminReport API client.
- Does not touch backend runtime.
- Does not change auth/session logic.
- Does not change report download or filters.
- Keeps scope limited to report upload UI.

## Validation

- [x] `pnpm test -- .\test\frontend-report-upload-modal.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`