### PR TITLE
feat(contact): add public contact endpoint

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -53,6 +53,10 @@ import {
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
 import {
+  contactNativeRoutes,
+  type ContactNativeRoutesOptions,
+} from "./routes/contact.fastify.ts";
+import {
   clinicAuditNativeRoutes,
   type ClinicAuditNativeRoutesOptions,
 } from "./routes/clinic-audit.fastify.ts";
@@ -195,6 +199,7 @@ export type CreateFastifyAppOptions = {
   adminSystemMaintenanceRoutes?: AdminSystemMaintenanceNativeRoutesOptions;
   adminUsersRolesRoutes?: AdminUsersRolesNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
+  contactRoutes?: ContactNativeRoutesOptions;
   clinicAuditRoutes?: ClinicAuditNativeRoutesOptions;
   clinicPublicProfileRoutes?: ClinicPublicProfileNativeRoutesOptions;
   particularAuditRoutes?: ParticularAuditNativeRoutesOptions;
@@ -350,6 +355,11 @@ export async function createFastifyApp(
     ...(options.clinicAuthRoutes ?? {}),
   });
 
+  await app.register(contactNativeRoutes, {
+    prefix: "/api/contact",
+    ...(options.contactRoutes ?? {}),
+  });
+
   await app.register(clinicAuditNativeRoutes, {
     prefix: "/api/clinic/audit-log",
     ...(options.clinicAuditRoutes ?? {}),
@@ -437,5 +447,6 @@ export async function createFastifyApp(
 
   return app;
 }
+
 
 

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -107,6 +107,68 @@ function buildSpecialStainRequiredText(input: {
   return lines.join("\n");
 }
 
+
+function buildContactMessageText(input: {
+  name: string;
+  email: string;
+  clinicName: string | null;
+  message: string;
+}) {
+  return [
+    "Nuevo mensaje desde el formulario de contacto de Portal VETNEB",
+    "",
+    `Nombre: ${input.name}`,
+    `Email: ${input.email}`,
+    `Clinica: ${input.clinicName ?? "No informada"}`,
+    "",
+    "Mensaje:",
+    input.message,
+    "",
+    "Equipo VETNEB",
+  ].join("\n");
+}
+
+export async function sendContactMessageEmail(input: {
+  name: string;
+  email: string;
+  clinicName: string | null;
+  message: string;
+}): Promise<
+  | { sent: false; reason: "smtp_disabled" }
+  | { sent: true; messageId: string }
+> {
+  const recipient = normalizeRecipients([ENV.smtp.from])[0];
+
+  const transporter = getTransporter();
+
+  if (!transporter || !recipient) {
+    console.info("[EMAIL] contact_message skipped: smtp disabled", {
+      email: input.email,
+      clinicName: input.clinicName,
+    });
+
+    return { sent: false, reason: "smtp_disabled" as const };
+  }
+
+  const info = await transporter.sendMail({
+    from: ENV.smtp.from,
+    to: recipient,
+    replyTo: input.email,
+    subject: `[VETNEB] Contacto web: ${input.name}`,
+    text: buildContactMessageText(input),
+  });
+
+  console.info("[EMAIL] contact_message sent", {
+    email: input.email,
+    clinicName: input.clinicName,
+    messageId: info.messageId,
+  });
+
+  return {
+    sent: true,
+    messageId: info.messageId,
+  };
+}
 export async function sendSpecialStainRequiredEmail(input: {
   to: Array<string | null | undefined>;
   clinicName: string;
@@ -158,3 +220,4 @@ export async function sendSpecialStainRequiredEmail(input: {
     messageId: info.messageId,
   };
 }
+

--- a/server/routes/contact.fastify.ts
+++ b/server/routes/contact.fastify.ts
@@ -1,0 +1,257 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+import { z } from "zod";
+
+import { ENV } from "../lib/env.ts";
+
+type ContactEmailResult =
+  | { sent: true; messageId: string }
+  | { sent: false; reason: "smtp_disabled" };
+
+type ContactMessageInput = {
+  name: string;
+  email: string;
+  clinicName: string | null;
+  message: string;
+};
+
+export type ContactNativeRoutesOptions = {
+  sendContactMessageEmail?: (
+    input: ContactMessageInput,
+  ) => Promise<ContactEmailResult>;
+};
+
+const contactSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  email: z.string().trim().email().max(255),
+  clinicName: z.string().trim().max(180).optional().nullable(),
+  message: z.string().trim().min(10).max(4000),
+});
+
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+let defaultDepsPromise:
+  | Promise<Required<ContactNativeRoutesOptions>>
+  | undefined;
+
+async function loadDefaultDeps(): Promise<Required<ContactNativeRoutesOptions>> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const email = await import("../lib/email.ts");
+
+      return {
+        sendContactMessageEmail: email.sendContactMessageEmail,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+async function resolveDeps(
+  options: ContactNativeRoutesOptions,
+): Promise<Required<ContactNativeRoutesOptions>> {
+  const defaultDeps = options.sendContactMessageEmail
+    ? undefined
+    : await loadDefaultDeps();
+
+  return {
+    sendContactMessageEmail:
+      options.sendContactMessageEmail ?? defaultDeps!.sendContactMessageEmail,
+  };
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+function normalizeOptionalText(value: string | null | undefined) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+
+  return trimmed ? trimmed : null;
+}
+
+export const contactNativeRoutes: FastifyPluginAsync<
+  ContactNativeRoutesOptions
+> = async (app, options) => {
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    applyCorsHeaders(request, reply, allowedOrigins);
+
+    return undefined;
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "POST,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+
+  app.post("/", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const parsed = contactSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({
+        success: false,
+        error: "Solicitud de contacto inválida",
+        details: parsed.error.issues.map((issue) => issue.message),
+      });
+    }
+
+    const deps = await resolveDeps(options);
+    const result = await deps.sendContactMessageEmail({
+      name: parsed.data.name,
+      email: parsed.data.email,
+      clinicName: normalizeOptionalText(parsed.data.clinicName),
+      message: parsed.data.message,
+    });
+
+    return reply.code(result.sent ? 200 : 202).send({
+      success: true,
+      sent: result.sent,
+      reason: result.sent ? undefined : result.reason,
+      message: result.sent
+        ? "Mensaje enviado correctamente"
+        : "Mensaje recibido. SMTP no configurado para envío inmediato.",
+    });
+  });
+};

--- a/test/contact-route.test.ts
+++ b/test/contact-route.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+import {
+  contactNativeRoutes,
+  type ContactNativeRoutesOptions,
+} from "../server/routes/contact.fastify.ts";
+
+async function createContactTestApp(options: ContactNativeRoutesOptions) {
+  const app = Fastify({ logger: false });
+
+  await app.register(contactNativeRoutes, options);
+
+  return app;
+}
+
+test("contact endpoint validates required public contact payload", async () => {
+  const app = await createContactTestApp({
+    sendContactMessageEmail: async () => {
+      throw new Error("sendContactMessageEmail should not be called");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/",
+      payload: {
+        name: "",
+        email: "invalid",
+        message: "short",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+
+    const body = response.json() as {
+      success: boolean;
+      error: string;
+      details: string[];
+    };
+
+    assert.equal(body.success, false);
+    assert.equal(body.error, "Solicitud de contacto inválida");
+    assert.ok(Array.isArray(body.details));
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact endpoint sends valid public contact payload", async () => {
+  const sentPayloads: unknown[] = [];
+  const app = await createContactTestApp({
+    sendContactMessageEmail: async (input) => {
+      sentPayloads.push(input);
+
+      return { sent: true, messageId: "contact-message-id" };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/",
+      payload: {
+        name: "Juan Perez",
+        email: "juan@example.com",
+        clinicName: "Clinica Norte",
+        message: "Necesito registrar mi clinica en el portal.",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(sentPayloads, [
+      {
+        name: "Juan Perez",
+        email: "juan@example.com",
+        clinicName: "Clinica Norte",
+        message: "Necesito registrar mi clinica en el portal.",
+      },
+    ]);
+
+    const body = response.json() as {
+      success: boolean;
+      sent: boolean;
+      message: string;
+    };
+
+    assert.equal(body.success, true);
+    assert.equal(body.sent, true);
+    assert.equal(body.message, "Mensaje enviado correctamente");
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact endpoint accepts message when smtp is disabled", async () => {
+  const app = await createContactTestApp({
+    sendContactMessageEmail: async () => ({
+      sent: false,
+      reason: "smtp_disabled",
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/",
+      payload: {
+        name: "Maria Gomez",
+        email: "maria@example.com",
+        message: "Quiero consultar por los servicios de VETNEB.",
+      },
+    });
+
+    assert.equal(response.statusCode, 202);
+
+    const body = response.json() as {
+      success: boolean;
+      sent: boolean;
+      reason: string;
+    };
+
+    assert.equal(body.success, true);
+    assert.equal(body.sent, false);
+    assert.equal(body.reason, "smtp_disabled");
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact endpoint rejects untrusted unsafe origins", async () => {
+  const app = await createContactTestApp({
+    sendContactMessageEmail: async () => ({
+      sent: true,
+      messageId: "unexpected",
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/",
+      headers: {
+        origin: "https://evil.example",
+      },
+      payload: {
+        name: "Bad Origin",
+        email: "bad@example.com",
+        message: "Este mensaje no debe procesarse.",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+
+    const body = response.json() as {
+      success: boolean;
+      error: string;
+    };
+
+    assert.equal(body.success, false);
+    assert.equal(body.error, "Origen no permitido");
+  } finally {
+    await app.close();
+  }
+});
+

--- a/test/contact-route.test.ts
+++ b/test/contact-route.test.ts
@@ -2,12 +2,38 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify from "fastify";
 
-import {
-  contactNativeRoutes,
-  type ContactNativeRoutesOptions,
-} from "../server/routes/contact.fastify.ts";
+type ContactEmailResult =
+  | { sent: true; messageId: string }
+  | { sent: false; reason: "smtp_disabled" };
+
+type ContactMessageInput = {
+  name: string;
+  email: string;
+  clinicName: string | null;
+  message: string;
+};
+
+type ContactNativeRoutesOptions = {
+  sendContactMessageEmail?: (
+    input: ContactMessageInput,
+  ) => Promise<ContactEmailResult>;
+};
+
+function ensureContactRouteTestEnv() {
+  process.env.NODE_ENV ??= "test";
+  process.env.DATABASE_URL ??= "postgres://postgres:postgres@localhost:5432/test";
+  process.env.SUPABASE_URL ??= "https://example.supabase.co";
+  process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+}
 
 async function createContactTestApp(options: ContactNativeRoutesOptions) {
+  ensureContactRouteTestEnv();
+
+  const { contactNativeRoutes } = await import(
+    "../server/routes/contact.fastify.ts"
+  );
+
   const app = Fastify({ logger: false });
 
   await app.register(contactNativeRoutes, options);
@@ -165,4 +191,3 @@ test("contact endpoint rejects untrusted unsafe origins", async () => {
     await app.close();
   }
 });
-


### PR DESCRIPTION
## Summary

- Add a public POST /api/contact endpoint.
- Validate contact payload fields before sending email.
- Reuse existing SMTP infrastructure through sendContactMessageEmail.
- Accept contact messages with 202 when SMTP is disabled.
- Add native route coverage for validation, sending, SMTP-disabled behavior, and trusted-origin rejection.

## Security

- Public endpoint validates body fields with zod.
- Rejects untrusted unsafe origins.
- Does not expose SMTP credentials.
- Does not touch frontend yet.
- Does not touch auth/session behavior.
- Does not touch schema or migrations.

## Validation

- [x] `pnpm test -- .\test\contact-route.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`