### PR TITLE
feat(frontend): connect contact form

### DIFF
--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { FormEvent, useState } from "react";
+
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { submitContactMessage } from "@/lib/api";
 
 const contactInfo = [
   {
@@ -27,6 +30,55 @@ const contactInfo = [
 ];
 
 export function ContactoContent() {
+  const [nombre, setNombre] = useState("");
+  const [apellido, setApellido] = useState("");
+  const [email, setEmail] = useState("");
+  const [clinica, setClinica] = useState("");
+  const [mensaje, setMensaje] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      const fullName = [nombre.trim(), apellido.trim()]
+        .filter(Boolean)
+        .join(" ");
+
+      const response = await submitContactMessage({
+        name: fullName,
+        email: email.trim(),
+        clinicName: clinica.trim() || null,
+        message: mensaje.trim(),
+      });
+
+      setSuccessMessage(response.message);
+      setNombre("");
+      setApellido("");
+      setEmail("");
+      setClinica("");
+      setMensaje("");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo enviar el mensaje. Intente nuevamente.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return (
     <PublicLayout>
       {/* Header */}
@@ -43,7 +95,7 @@ export function ContactoContent() {
       <section className="py-16 bg-white">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-5xl mx-auto">
-            {/* Formulario visual */}
+            {/* Formulario conectado */}
             <div>
               <h2 className="text-2xl font-bold text-gray-900 mb-6">
                 Envíenos un mensaje
@@ -51,7 +103,7 @@ export function ContactoContent() {
               <form
                 className="space-y-4"
                 aria-label="Formulario de contacto"
-                onSubmit={(e) => e.preventDefault()}
+                onSubmit={handleSubmit}
               >
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div>
@@ -66,6 +118,10 @@ export function ContactoContent() {
                       type="text"
                       placeholder="Su nombre"
                       autoComplete="given-name"
+                      required
+                      value={nombre}
+                      onChange={(event) => setNombre(event.target.value)}
+                      disabled={isSubmitting}
                     />
                   </div>
                   <div>
@@ -80,6 +136,9 @@ export function ContactoContent() {
                       type="text"
                       placeholder="Su apellido"
                       autoComplete="family-name"
+                      value={apellido}
+                      onChange={(event) => setApellido(event.target.value)}
+                      disabled={isSubmitting}
                     />
                   </div>
                 </div>
@@ -95,6 +154,10 @@ export function ContactoContent() {
                     type="email"
                     placeholder="su@email.com"
                     autoComplete="email"
+                    required
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    disabled={isSubmitting}
                   />
                 </div>
                 <div>
@@ -109,6 +172,9 @@ export function ContactoContent() {
                     type="text"
                     placeholder="Clínica Veterinaria..."
                     autoComplete="organization"
+                    value={clinica}
+                    onChange={(event) => setClinica(event.target.value)}
+                    disabled={isSubmitting}
                   />
                 </div>
                 <div>
@@ -123,15 +189,31 @@ export function ContactoContent() {
                     rows={5}
                     placeholder="Describa su consulta o solicitud de acceso..."
                     className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                    required
+                    minLength={10}
+                    value={mensaje}
+                    onChange={(event) => setMensaje(event.target.value)}
+                    disabled={isSubmitting}
                   />
                 </div>
-                <p className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-                  <strong>Nota de desarrollo:</strong> Este formulario es
-                  visual. La funcionalidad de envío se integrará con el backend
-                  o un servicio de email en un próximo PR.
-                </p>
-                <Button type="submit" className="w-full" disabled>
-                  Enviar mensaje (próximamente)
+
+                {errorMessage ? (
+                  <p
+                    className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2"
+                    role="alert"
+                  >
+                    {errorMessage}
+                  </p>
+                ) : null}
+
+                {successMessage ? (
+                  <p className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-md px-3 py-2">
+                    {successMessage}
+                  </p>
+                ) : null}
+
+                <Button type="submit" className="w-full" disabled={isSubmitting}>
+                  {isSubmitting ? "Enviando mensaje..." : "Enviar mensaje"}
                 </Button>
               </form>
             </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -169,6 +169,31 @@ export async function uploadAdminReport(
   });
 }
 
+
+export type ContactMessagePayload = {
+  name: string;
+  email: string;
+  clinicName?: string | null;
+  message: string;
+};
+
+export type ContactMessageResponse = {
+  success: true;
+  sent: boolean;
+  reason?: "smtp_disabled";
+  message: string;
+};
+
+export async function submitContactMessage(
+  payload: ContactMessagePayload,
+  options?: RequestInit,
+): Promise<ContactMessageResponse> {
+  return apiFetch<ContactMessageResponse>("/api/contact", {
+    ...options,
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
 export async function getLogisticsFieldVisits(
   options?: RequestInit,
 ): Promise<FieldVisit[]> {
@@ -417,4 +442,5 @@ export async function getDashboardStats(
     ).length,
   };
 }
+
 

--- a/test/frontend-contact-form.test.ts
+++ b/test/frontend-contact-form.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const CONTACT_CONTENT_PATH = "frontend/src/components/public/ContactoContent.tsx";
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend contact api client posts to public contact endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export type ContactMessagePayload"));
+  assert.ok(source.includes("export type ContactMessageResponse"));
+  assert.ok(source.includes("export async function submitContactMessage"));
+  assert.ok(source.includes('apiFetch<ContactMessageResponse>("/api/contact"'));
+  assert.ok(source.includes('method: "POST"'));
+  assert.ok(source.includes("body: JSON.stringify(payload)"));
+});
+
+test("frontend contact form submits public contact payload", () => {
+  const source = read(CONTACT_CONTENT_PATH);
+
+  assert.ok(source.includes('"use client"'));
+  assert.ok(source.includes('import { FormEvent, useState } from "react"'));
+  assert.ok(source.includes('import { submitContactMessage } from "@/lib/api"'));
+  assert.ok(source.includes("async function handleSubmit"));
+  assert.ok(source.includes("event.preventDefault()"));
+  assert.ok(source.includes("await submitContactMessage({"));
+  assert.ok(source.includes("name: fullName"));
+  assert.ok(source.includes("email: email.trim()"));
+  assert.ok(source.includes("clinicName: clinica.trim() || null"));
+  assert.ok(source.includes("message: mensaje.trim()"));
+  assert.ok(source.includes("onSubmit={handleSubmit}"));
+});
+
+test("frontend contact form exposes feedback and no longer blocks submit", () => {
+  const source = read(CONTACT_CONTENT_PATH);
+
+  assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
+  assert.ok(source.includes("const [successMessage, setSuccessMessage]"));
+  assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes("Enviar mensaje"));
+  assert.equal(source.includes("Enviar mensaje (próximamente)"), false);
+  assert.equal(source.includes("Nota de desarrollo"), false);
+  assert.equal(source.includes("onSubmit={(e) => e.preventDefault()}"), false);
+});


### PR DESCRIPTION
## Summary

- Add frontend API support for POST /api/contact.
- Connect the public contact form to submitContactMessage.
- Enable contact form submission.
- Add loading, success, and error feedback.
- Reset form fields after successful submission.
- Add a test-only guardrail for contact form wiring.

## Security

- Uses the existing public contact endpoint.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not expose SMTP details.
- Keeps scope limited to frontend contact submission.

## Validation

- [x] `pnpm test -- .\test\frontend-contact-form.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`