### PR TITLE
feat(frontend): connect report download action

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
+import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
@@ -131,17 +132,10 @@ export default async function InformesPage() {
                       </Badge>
                     </TableCell>
                     <TableCell className="text-right">
-                      <button
-                        className="text-xs text-primary hover:underline disabled:opacity-40"
-                        disabled={!report.storagePath}
-                        title={
-                          report.storagePath
-                            ? "Descargar informe"
-                            : "Informe no disponible aún"
-                        }
-                      >
-                        {report.storagePath ? "Descargar" : "No disponible"}
-                      </button>
+                      <ReportDownloadButton
+                        reportId={report.id}
+                        hasStoragePath={Boolean(report.storagePath)}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}
@@ -153,3 +147,5 @@ export default async function InformesPage() {
     </>
   );
 }
+
+

--- a/frontend/src/components/dashboard/ReportDownloadButton.tsx
+++ b/frontend/src/components/dashboard/ReportDownloadButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+
+import { getReportDownloadUrl } from "@/lib/api";
+
+type ReportDownloadButtonProps = {
+  reportId: number;
+  hasStoragePath: boolean;
+};
+
+export function ReportDownloadButton({
+  reportId,
+  hasStoragePath,
+}: ReportDownloadButtonProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleDownload() {
+    if (!hasStoragePath || isLoading) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setIsLoading(true);
+
+    try {
+      const url = await getReportDownloadUrl(reportId);
+
+      if (!url) {
+        setErrorMessage("Informe no disponible para descarga.");
+        return;
+      }
+
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo obtener el enlace de descarga.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        className="text-xs text-primary hover:underline disabled:opacity-40"
+        disabled={!hasStoragePath || isLoading}
+        title={hasStoragePath ? "Descargar informe" : "Informe no disponible aún"}
+        onClick={handleDownload}
+      >
+        {isLoading
+          ? "Preparando..."
+          : hasStoragePath
+            ? "Descargar"
+            : "No disponible"}
+      </button>
+
+      {errorMessage ? (
+        <span className="max-w-40 text-right text-[11px] text-red-600" role="alert">
+          {errorMessage}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/test/frontend-report-download-action.test.ts
+++ b/test/frontend-report-download-action.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const DOWNLOAD_BUTTON_PATH =
+  "frontend/src/components/dashboard/ReportDownloadButton.tsx";
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend report download button exists and uses download url api", () => {
+  assert.equal(existsSync(resolve(process.cwd(), DOWNLOAD_BUTTON_PATH)), true);
+
+  const source = read(DOWNLOAD_BUTTON_PATH);
+
+  assert.ok(source.includes('"use client"'));
+  assert.ok(source.includes('import { getReportDownloadUrl } from "@/lib/api"'));
+  assert.ok(source.includes("async function handleDownload()"));
+  assert.ok(source.includes("await getReportDownloadUrl(reportId)"));
+  assert.ok(source.includes('window.open(url, "_blank", "noopener,noreferrer")'));
+});
+
+test("frontend report download button handles loading unavailable and error states", () => {
+  const source = read(DOWNLOAD_BUTTON_PATH);
+
+  assert.ok(source.includes("const [isLoading, setIsLoading]"));
+  assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
+  assert.ok(source.includes("disabled={!hasStoragePath || isLoading}"));
+  assert.ok(source.includes("Informe no disponible para descarga."));
+  assert.ok(source.includes("Preparando..."));
+  assert.ok(source.includes('role="alert"'));
+});
+
+test("frontend informes page uses report download button", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton"',
+    ),
+  );
+  assert.ok(source.includes("<ReportDownloadButton"));
+  assert.ok(source.includes("reportId={report.id}"));
+  assert.ok(source.includes("hasStoragePath={Boolean(report.storagePath)}"));
+  assert.equal(source.includes("<button"), false);
+});


### PR DESCRIPTION
## Summary

- Add a frontend report download button component.
- Connect dashboard informes download action to getReportDownloadUrl.
- Open signed report download URLs in a new tab.
- Add loading, unavailable, and error states per report.
- Add a test-only guardrail for report download wiring.

## Security

- Uses the existing report download URL API client.
- Does not touch backend runtime.
- Does not change upload, contact, or auth behavior.
- Does not expose storage paths directly.
- Keeps scope limited to frontend report download action.

## Validation

- [x] `pnpm test -- .\test\frontend-report-download-action.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`