### PR TITLE
refactor(frontend): stop logistics mock fallback

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,9 +37,6 @@ import type {
 
 import {
   MOCK_REPORTS,
-  MOCK_FIELD_VISITS,
-  MOCK_ROUTE_PLANS,
-  MOCK_ROUTE_METRICS,
   MOCK_AUDIT_ENTRIES,
 } from "@/lib/mock-data";
 
@@ -204,8 +201,8 @@ export async function getLogisticsFieldVisits(
     );
     return res.visits ?? [];
   } catch {
-    console.warn("[API] getLogisticsFieldVisits: usando mock data");
-    return MOCK_FIELD_VISITS;
+    console.warn("[API] getLogisticsFieldVisits: endpoint no disponible");
+    return [];
   }
 }
 
@@ -219,8 +216,8 @@ export async function getRoutePlans(
     );
     return res.plans ?? [];
   } catch {
-    console.warn("[API] getRoutePlans: usando mock data");
-    return MOCK_ROUTE_PLANS;
+    console.warn("[API] getRoutePlans: endpoint no disponible");
+    return [];
   }
 }
 
@@ -236,15 +233,13 @@ export async function getRoutePlanMetrics(
       );
       return res.metrics ? [res.metrics] : [];
     } catch {
-      console.warn("[API] getRoutePlanMetrics: usando mock data");
-      return MOCK_ROUTE_METRICS.filter(
-        (metric) => metric.routePlanId === planId,
-      );
+      console.warn("[API] getRoutePlanMetrics: endpoint no disponible");
+      return [];
     }
   }
 
-  console.warn("[API] getRoutePlanMetrics: usando mock data");
-  return MOCK_ROUTE_METRICS;
+  console.warn("[API] getRoutePlanMetrics: requiere planId para usar endpoint real");
+  return [];
 }
 
 export async function getAuditEntries(
@@ -442,5 +437,7 @@ export async function getDashboardStats(
     ).length,
   };
 }
+
+
 
 

--- a/test/frontend-app-mock-isolation-contract.test.ts
+++ b/test/frontend-app-mock-isolation-contract.test.ts
@@ -40,7 +40,7 @@ test("frontend app pages do not import mock data directly", () => {
   assert.deepEqual(offenders, []);
 });
 
-test("frontend API client keeps mock fallbacks centralized", () => {
+test("frontend API client keeps remaining mock fallbacks centralized", () => {
   const source = read(apiClientPath);
 
   assert.ok(
@@ -50,9 +50,6 @@ test("frontend API client keeps mock fallbacks centralized", () => {
 
   for (const expected of [
     "MOCK_REPORTS",
-    "MOCK_FIELD_VISITS",
-    "MOCK_ROUTE_PLANS",
-    "MOCK_ROUTE_METRICS",
     "MOCK_AUDIT_ENTRIES",
   ]) {
     assert.ok(source.includes(expected), `${apiClientPath} missing ${expected}`);
@@ -68,3 +65,4 @@ test("frontend API client keeps mock fallbacks centralized", () => {
     `${apiClientPath} must not import unused dashboard stats mock`,
   );
 });
+

--- a/test/frontend-logistics-metrics-live-read-contract.test.ts
+++ b/test/frontend-logistics-metrics-live-read-contract.test.ts
@@ -79,7 +79,14 @@ test("frontend logistics metrics API wrapper accepts request options", () => {
   assertIncludes(source, "options,", frontendApiClient);
   assertIncludes(
     source,
-    "MOCK_ROUTE_METRICS.filter(",
+    'console.warn("[API] getRoutePlanMetrics: endpoint no disponible")',
     frontendApiClient,
   );
+  assertIncludes(
+    source,
+    'console.warn("[API] getRoutePlanMetrics: requiere planId para usar endpoint real")',
+    frontendApiClient,
+  );
+  assertIncludes(source, "return []", frontendApiClient);
 });
+

--- a/test/frontend-logistics-no-mock-fallback.test.ts
+++ b/test/frontend-logistics-no-mock-fallback.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend logistics api client does not import logistics mock datasets", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.equal(source.includes("MOCK_FIELD_VISITS"), false);
+  assert.equal(source.includes("MOCK_ROUTE_PLANS"), false);
+  assert.equal(source.includes("MOCK_ROUTE_METRICS"), false);
+});
+
+test("frontend logistics api client uses real logistics endpoints", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes('"/api/logistics/field-visits"'));
+  assert.ok(source.includes('"/api/logistics/route-plans"'));
+  assert.ok(source.includes("`/api/logistics/route-plans/${planId}/metrics`"));
+});
+
+test("frontend logistics api client returns empty state instead of mock fallback", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes(
+      'console.warn("[API] getLogisticsFieldVisits: endpoint no disponible")',
+    ),
+  );
+  assert.ok(
+    source.includes(
+      'console.warn("[API] getRoutePlans: endpoint no disponible")',
+    ),
+  );
+  assert.ok(
+    source.includes(
+      'console.warn("[API] getRoutePlanMetrics: endpoint no disponible")',
+    ),
+  );
+  assert.ok(
+    source.includes(
+      'console.warn("[API] getRoutePlanMetrics: requiere planId para usar endpoint real")',
+    ),
+  );
+});


### PR DESCRIPTION
## Summary

- Stop using logistics mock fallback datasets in the frontend API client.
- Keep logistics calls pointed at the existing backend endpoints.
- Return empty states when logistics endpoints are unavailable.
- Keep report and audit mock fallback behavior unchanged.
- Update existing frontend mock/logistics guardrails.
- Add a test-only guardrail for logistics API fallback behavior.

## Security

- Frontend-only change.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not expose mock logistics data when API calls fail.
- Keeps scope limited to logistics API client fallback behavior.

## Validation

- [x] `pnpm test -- .\test\frontend-logistics-no-mock-fallback.test.ts`
- [x] `pnpm test -- .\test\frontend-app-mock-isolation-contract.test.ts`
- [x] `pnpm test -- .\test\frontend-logistics-metrics-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`