### PR TITLE
refactor(frontend): stop audit mock fallback

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,7 +37,6 @@ import type {
 
 import {
   MOCK_REPORTS,
-  MOCK_AUDIT_ENTRIES,
 } from "@/lib/mock-data";
 
 const API_BASE_URL =
@@ -252,8 +251,8 @@ export async function getAuditEntries(
     );
     return res.entries ?? [];
   } catch {
-    console.warn("[API] getAuditEntries: usando mock data");
-    return MOCK_AUDIT_ENTRIES;
+    console.warn("[API] getAuditEntries: endpoint no disponible");
+    return [];
   }
 }
 
@@ -437,6 +436,7 @@ export async function getDashboardStats(
     ).length,
   };
 }
+
 
 
 

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -349,6 +349,14 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         markers: ["buildClinicAuditListFilters", "clinicId"],
       },
       {
+        path: "test/frontend-audit-no-mock-fallback.test.ts",
+        markers: [
+          "frontend audit api client does not import audit mock dataset",
+          "frontend audit api client uses real admin audit endpoint",
+          "frontend audit api client returns empty state instead of mock fallback",
+        ],
+      },
+      {
         path: "test/particular-audit.fastify.test.ts",
         markers: ["particularAuditNativeRoutes", "export.csv", "particular"],
       },
@@ -607,3 +615,4 @@ test("audit suite completeness guardrail source stays ascii only", () => {
     );
   }
 });
+

--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -65,7 +65,13 @@ test("frontend admin audit API wrapper accepts request options", () => {
   assertIncludes(source, "options?: RequestInit", frontendApiClient);
   assertIncludes(source, '"/api/admin/audit-log"', frontendApiClient);
   assertIncludes(source, "options,", frontendApiClient);
-  assertIncludes(source, "return MOCK_AUDIT_ENTRIES", frontendApiClient);
+  assertIncludes(
+    source,
+    'console.warn("[API] getAuditEntries: endpoint no disponible")',
+    frontendApiClient,
+  );
+  assertIncludes(source, "return []", frontendApiClient);
+  assertNotIncludes(source, "return MOCK_AUDIT_ENTRIES", frontendApiClient);
 });
 
 
@@ -337,3 +343,4 @@ test("frontend admin failed-login alerts deshabilita limpiar filtros sin filtros
     "AdminFailedLoginAlertsReadOnlyCard.tsx clear filters",
   );
 });
+

--- a/test/frontend-app-mock-isolation-contract.test.ts
+++ b/test/frontend-app-mock-isolation-contract.test.ts
@@ -50,7 +50,6 @@ test("frontend API client keeps remaining mock fallbacks centralized", () => {
 
   for (const expected of [
     "MOCK_REPORTS",
-    "MOCK_AUDIT_ENTRIES",
   ]) {
     assert.ok(source.includes(expected), `${apiClientPath} missing ${expected}`);
   }
@@ -65,4 +64,5 @@ test("frontend API client keeps remaining mock fallbacks centralized", () => {
     `${apiClientPath} must not import unused dashboard stats mock`,
   );
 });
+
 

--- a/test/frontend-audit-no-mock-fallback.test.ts
+++ b/test/frontend-audit-no-mock-fallback.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend audit api client does not import audit mock dataset", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.equal(source.includes("MOCK_AUDIT_ENTRIES"), false);
+});
+
+test("frontend audit api client uses real admin audit endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export async function getAuditEntries("));
+  assert.ok(source.includes('"/api/admin/audit-log"'));
+});
+
+test("frontend audit api client returns empty state instead of mock fallback", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes(
+      'console.warn("[API] getAuditEntries: endpoint no disponible")',
+    ),
+  );
+  assert.equal(
+    source.includes('console.warn("[API] getAuditEntries: usando mock data")'),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

- Stop using audit mock fallback data in the frontend API client.
- Keep audit calls pointed at the existing admin audit endpoint.
- Return an empty state when the audit endpoint is unavailable.
- Keep report mock fallback behavior unchanged.
- Update frontend mock/admin audit guardrails.
- Register the new audit fallback guardrail in audit suite completeness.

## Security

- Frontend-only behavior change.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not expose mock audit data when API calls fail.
- Keeps scope limited to audit API client fallback behavior.

## Validation

- [x] `pnpm test -- .\test\frontend-audit-no-mock-fallback.test.ts`
- [x] `pnpm test -- .\test\frontend-app-mock-isolation-contract.test.ts`
- [x] `pnpm test -- .\test\audit-suite-completeness.test.ts`
- [x] `pnpm test -- .\test\frontend-admin-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`