### PR TITLE
refactor(frontend): stop reports mock fallback

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,8 +6,7 @@
  *
  * Convención:
  * - Si el endpoint está confirmado en el backend, se llama directamente.
- * - Si el endpoint NO está confirmado, se devuelve mock data desde mock-data.ts.
- * - Las funciones mock están claramente marcadas con el comentario @mock.
+ * - Si el endpoint no está disponible, las funciones devuelven un estado vacío seguro.
  *
  * Autenticación: el backend usa cookies de sesión (credentials: 'include').
  */
@@ -34,10 +33,6 @@ import type {
   AdminFailedLoginAlertsQuery,
   AdminFailedLoginAlertsSnapshot,
 } from "@/types";
-
-import {
-  MOCK_REPORTS,
-} from "@/lib/mock-data";
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
@@ -105,8 +100,8 @@ export async function getReports(options?: RequestInit): Promise<Report[]> {
     const res = await apiFetch<{ reports: Report[] }>("/api/reports", options);
     return res.reports ?? [];
   } catch {
-    console.warn("[API] getReports: usando mock data");
-    return MOCK_REPORTS;
+    console.warn("[API] getReports: endpoint no disponible");
+    return [];
   }
 }
 
@@ -130,8 +125,8 @@ export async function searchReports(
     );
     return res.reports ?? [];
   } catch {
-    console.warn("[API] searchReports: usando mock data");
-    return MOCK_REPORTS;
+    console.warn("[API] searchReports: endpoint no disponible");
+    return [];
   }
 }
 
@@ -436,6 +431,7 @@ export async function getDashboardStats(
     ).length,
   };
 }
+
 
 
 

--- a/test/frontend-app-mock-isolation-contract.test.ts
+++ b/test/frontend-app-mock-isolation-contract.test.ts
@@ -40,19 +40,18 @@ test("frontend app pages do not import mock data directly", () => {
   assert.deepEqual(offenders, []);
 });
 
-test("frontend API client keeps remaining mock fallbacks centralized", () => {
+test("frontend API client does not use mock-data fallbacks", () => {
   const source = read(apiClientPath);
 
   assert.ok(
-    source.includes('from "@/lib/mock-data"'),
-    `${apiClientPath} should own centralized mock-data fallback imports`,
+    !source.includes('from "@/lib/mock-data"'),
+    `${apiClientPath} must not import mock-data fallback datasets`,
   );
 
-  for (const expected of [
-    "MOCK_REPORTS",
-  ]) {
-    assert.ok(source.includes(expected), `${apiClientPath} missing ${expected}`);
-  }
+  assert.ok(
+    !source.includes("MOCK_"),
+    `${apiClientPath} must not reference mock datasets`,
+  );
 
   assert.ok(
     !source.includes("getFallbackDashboardStats"),
@@ -64,5 +63,6 @@ test("frontend API client keeps remaining mock fallbacks centralized", () => {
     `${apiClientPath} must not import unused dashboard stats mock`,
   );
 });
+
 
 

--- a/test/frontend-reports-live-read-contract.test.ts
+++ b/test/frontend-reports-live-read-contract.test.ts
@@ -71,5 +71,17 @@ test("frontend reports API wrappers accept request options", () => {
     '`/api/reports/search${qs ? `?${qs}` : ""}`',
     frontendApiClient,
   );
-  assertIncludes(source, "return MOCK_REPORTS", frontendApiClient);
+  assertIncludes(
+    source,
+    'console.warn("[API] getReports: endpoint no disponible")',
+    frontendApiClient,
+  );
+  assertIncludes(
+    source,
+    'console.warn("[API] searchReports: endpoint no disponible")',
+    frontendApiClient,
+  );
+  assertIncludes(source, "return []", frontendApiClient);
+  assertNotIncludes(source, "return MOCK_REPORTS", frontendApiClient);
 });
+

--- a/test/frontend-reports-no-mock-fallback.test.ts
+++ b/test/frontend-reports-no-mock-fallback.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend reports api client does not import report mock dataset", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.equal(source.includes('from "@/lib/mock-data"'), false);
+  assert.equal(source.includes("MOCK_REPORTS"), false);
+});
+
+test("frontend reports api client uses real reports endpoints", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export async function getReports("));
+  assert.ok(source.includes('apiFetch<{ reports: Report[] }>("/api/reports"'));
+  assert.ok(source.includes("export async function searchReports("));
+  assert.ok(source.includes("`/api/reports/search${qs ? `?${qs}` : \"\"}`"));
+});
+
+test("frontend reports api client returns empty state instead of mock fallback", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes('console.warn("[API] getReports: endpoint no disponible")'),
+  );
+  assert.ok(
+    source.includes(
+      'console.warn("[API] searchReports: endpoint no disponible")',
+    ),
+  );
+  assert.equal(
+    source.includes('console.warn("[API] getReports: usando mock data")'),
+    false,
+  );
+  assert.equal(
+    source.includes('console.warn("[API] searchReports: usando mock data")'),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

- Stop using reports mock fallback data in the frontend API client.
- Keep report calls pointed at the existing reports endpoints.
- Return empty states when reports endpoints are unavailable.
- Remove the final frontend mock-data fallback import from the API client.
- Update frontend mock/reports guardrails.
- Add a test-only guardrail for reports API fallback behavior.

## Security

- Frontend-only behavior change.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not expose mock report data when API calls fail.
- Keeps scope limited to reports API client fallback behavior.

## Validation

- [x] `pnpm test -- .\test\frontend-reports-no-mock-fallback.test.ts`
- [x] `pnpm test -- .\test\frontend-app-mock-isolation-contract.test.ts`
- [x] `pnpm test -- .\test\frontend-reports-live-read-contract.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`