### PR TITLE
feat(frontend): add dashboard empty states

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -109,36 +109,47 @@ export default async function InformesPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {reports.map((report) => (
-                  <TableRow key={report.id}>
-                    <TableCell className="font-mono text-xs text-gray-400">
-                      #{report.id}
-                    </TableCell>
-                    <TableCell className="font-medium">
-                      {report.patientName ?? "—"}
-                    </TableCell>
-                    <TableCell className="text-gray-600">
-                      {report.studyType ?? "—"}
-                    </TableCell>
-                    <TableCell className="text-gray-600 text-sm">
-                      {report.clinicName ?? `Clínica #${report.clinicId}`}
-                    </TableCell>
-                    <TableCell className="text-gray-500 text-sm">
-                      {formatDate(report.uploadDate)}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={getReportStatusVariant(report.status)}>
-                        {getReportStatusLabel(report.status)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <ReportDownloadButton
-                        reportId={report.id}
-                        hasStoragePath={Boolean(report.storagePath)}
-                      />
+                {reports.length ? (
+                  reports.map((report) => (
+                    <TableRow key={report.id}>
+                      <TableCell className="font-mono text-xs text-gray-400">
+                        #{report.id}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {report.patientName ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-gray-600">
+                        {report.studyType ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-gray-600 text-sm">
+                        {report.clinicName ?? `Clínica #${report.clinicId}`}
+                      </TableCell>
+                      <TableCell className="text-gray-500 text-sm">
+                        {formatDate(report.uploadDate)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getReportStatusVariant(report.status)}>
+                          {getReportStatusLabel(report.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <ReportDownloadButton
+                          reportId={report.id}
+                          hasStoragePath={Boolean(report.storagePath)}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="px-6 py-10 text-center text-sm text-gray-500"
+                    >
+                      No hay informes disponibles.
                     </TableCell>
                   </TableRow>
-                ))}
+                )}
               </TableBody>
             </Table>
           </CardContent>

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -149,28 +149,34 @@ export default async function LogisticaPage() {
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
-            {fieldVisits.slice(0, 4).map((visit) => (
-              <div
-                key={visit.id}
-                className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
-              >
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">
-                    {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                  </p>
-                  <p className="text-xs text-gray-400">
-                    {visit.address ?? "Sin dirección"} ·{" "}
-                    {formatDate(visit.scheduledAt)}
-                  </p>
-                </div>
-                <Badge
-                  variant={getFieldVisitStatusVariant(visit.status)}
-                  className="ml-2 shrink-0"
+            {fieldVisits.length ? (
+              fieldVisits.slice(0, 4).map((visit) => (
+                <div
+                  key={visit.id}
+                  className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
                 >
-                  {getFieldVisitStatusLabel(visit.status)}
-                </Badge>
-              </div>
-            ))}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      {visit.address ?? "Sin dirección"} ·{" "}
+                      {formatDate(visit.scheduledAt)}
+                    </p>
+                  </div>
+                  <Badge
+                    variant={getFieldVisitStatusVariant(visit.status)}
+                    className="ml-2 shrink-0"
+                  >
+                    {getFieldVisitStatusLabel(visit.status)}
+                  </Badge>
+                </div>
+              ))
+            ) : (
+              <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                No hay visitas recientes disponibles.
+              </p>
+            )}
           </CardContent>
         </Card>
 
@@ -182,28 +188,34 @@ export default async function LogisticaPage() {
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
-            {routePlans.map((plan) => (
-              <div
-                key={plan.id}
-                className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
-              >
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">
-                    {plan.name}
-                  </p>
-                  <p className="text-xs text-gray-400">
-                    {plan.completedStops}/{plan.totalStops} paradas ·{" "}
-                    {formatDate(plan.plannedDate)}
-                  </p>
-                </div>
-                <Badge
-                  variant={getRoutePlanStatusVariant(plan.status)}
-                  className="ml-2 shrink-0"
+            {routePlans.length ? (
+              routePlans.map((plan) => (
+                <div
+                  key={plan.id}
+                  className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
                 >
-                  {getRoutePlanStatusLabel(plan.status)}
-                </Badge>
-              </div>
-            ))}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {plan.name}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      {plan.completedStops}/{plan.totalStops} paradas ·{" "}
+                      {formatDate(plan.plannedDate)}
+                    </p>
+                  </div>
+                  <Badge
+                    variant={getRoutePlanStatusVariant(plan.status)}
+                    className="ml-2 shrink-0"
+                  >
+                    {getRoutePlanStatusLabel(plan.status)}
+                  </Badge>
+                </div>
+              ))
+            ) : (
+              <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                No hay planes de ruta disponibles.
+              </p>
+            )}
           </CardContent>
         </Card>
       </main>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -64,27 +64,33 @@ export default async function DashboardPage() {
               </Button>
             </CardHeader>
             <CardContent className="space-y-3">
-              {recentReports.map((report) => (
-                <div
-                  key={report.id}
-                  className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
-                >
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-900 truncate">
-                      {report.patientName ?? "Sin nombre"}
-                    </p>
-                    <p className="text-xs text-gray-400">
-                      {report.studyType} · {formatDate(report.uploadDate)}
-                    </p>
-                  </div>
-                  <Badge
-                    variant={getReportStatusVariant(report.status)}
-                    className="ml-2 shrink-0"
+              {recentReports.length ? (
+                recentReports.map((report) => (
+                  <div
+                    key={report.id}
+                    className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
                   >
-                    {getReportStatusLabel(report.status)}
-                  </Badge>
-                </div>
-              ))}
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {report.patientName ?? "Sin nombre"}
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        {report.studyType} · {formatDate(report.uploadDate)}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={getReportStatusVariant(report.status)}
+                      className="ml-2 shrink-0"
+                    >
+                      {getReportStatusLabel(report.status)}
+                    </Badge>
+                  </div>
+                ))
+              ) : (
+                <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                  No hay informes recientes disponibles.
+                </p>
+              )}
             </CardContent>
           </Card>
 
@@ -96,27 +102,33 @@ export default async function DashboardPage() {
               </Button>
             </CardHeader>
             <CardContent className="space-y-3">
-              {recentVisits.map((visit) => (
-                <div
-                  key={visit.id}
-                  className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
-                >
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-900 truncate">
-                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                    </p>
-                    <p className="text-xs text-gray-400">
-                      {formatDate(visit.scheduledAt)}
-                    </p>
-                  </div>
-                  <Badge
-                    variant={getFieldVisitStatusVariant(visit.status)}
-                    className="ml-2 shrink-0"
+              {recentVisits.length ? (
+                recentVisits.map((visit) => (
+                  <div
+                    key={visit.id}
+                    className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"
                   >
-                    {getFieldVisitStatusLabel(visit.status)}
-                  </Badge>
-                </div>
-              ))}
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        {formatDate(visit.scheduledAt)}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={getFieldVisitStatusVariant(visit.status)}
+                      className="ml-2 shrink-0"
+                    >
+                      {getFieldVisitStatusLabel(visit.status)}
+                    </Badge>
+                  </div>
+                ))
+              ) : (
+                <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                  No hay visitas de campo recientes disponibles.
+                </p>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const LOGISTICA_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("dashboard overview shows empty states for recent lists", () => {
+  const source = read(DASHBOARD_PAGE_PATH);
+
+  assert.ok(source.includes("recentReports.length ?"));
+  assert.ok(source.includes("recentVisits.length ?"));
+  assert.ok(source.includes("No hay informes recientes disponibles."));
+  assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
+});
+
+test("dashboard informes page shows empty state when reports are unavailable", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("reports.length ?"));
+  assert.ok(source.includes("No hay informes disponibles."));
+  assert.ok(source.includes("colSpan={7}"));
+  assert.ok(source.includes("reports.map((report)"));
+});
+
+test("dashboard logistics page shows empty states for visits and route plans", () => {
+  const source = read(LOGISTICA_PAGE_PATH);
+
+  assert.ok(source.includes("fieldVisits.length ?"));
+  assert.ok(source.includes("routePlans.length ?"));
+  assert.ok(source.includes("No hay visitas recientes disponibles."));
+  assert.ok(source.includes("No hay planes de ruta disponibles."));
+  assert.ok(source.includes("fieldVisits.slice(0, 4).map((visit)"));
+  assert.ok(source.includes("routePlans.map((plan)"));
+});


### PR DESCRIPTION
## Summary

- Add dashboard overview empty states for recent reports and field visits.
- Add informes table empty state when no reports are available.
- Add logistics empty states for recent visits and route plans.
- Keep existing live backend reads unchanged.
- Add a test-only guardrail for dashboard empty-state rendering.

## Security

- Frontend-only UI change.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not change API client fallback behavior.
- Keeps scope limited to empty-state UX after live reads return empty arrays.

## Validation

- [x] `pnpm test -- .\test\frontend-dashboard-empty-states.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`