### PR TITLE
feat(frontend): add logistics detail empty states

### DIFF
--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -135,69 +135,75 @@ export default async function MetricasPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {routeMetrics.map((metric) => {
-              const plan = routePlans.find(
-                (routePlan) => routePlan.id === metric.routePlanId,
-              );
-              return (
-                <div
-                  key={metric.routePlanId}
-                  className="border border-gray-100 rounded-lg p-4 space-y-3"
-                >
-                  <div className="flex items-center justify-between">
-                    <h3 className="font-medium text-gray-900 text-sm">
-                      {plan?.name ?? `Plan #${metric.routePlanId}`}
-                    </h3>
-                    <Badge
-                      variant={
-                        metric.complianceRate >= 90
-                          ? "default"
-                          : metric.complianceRate >= 60
-                            ? "secondary"
-                            : "destructive"
-                      }
-                    >
-                      {metric.complianceRate}% cumplimiento
-                    </Badge>
+            {routeMetrics.length ? (
+              routeMetrics.map((metric) => {
+                const plan = routePlans.find(
+                  (routePlan) => routePlan.id === metric.routePlanId,
+                );
+                return (
+                  <div
+                    key={metric.routePlanId}
+                    className="border border-gray-100 rounded-lg p-4 space-y-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-medium text-gray-900 text-sm">
+                        {plan?.name ?? `Plan #${metric.routePlanId}`}
+                      </h3>
+                      <Badge
+                        variant={
+                          metric.complianceRate >= 90
+                            ? "default"
+                            : metric.complianceRate >= 60
+                              ? "secondary"
+                              : "destructive"
+                        }
+                      >
+                        {metric.complianceRate}% cumplimiento
+                      </Badge>
+                    </div>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+                      <div>
+                        <p className="text-gray-400 text-xs">Total paradas</p>
+                        <p className="font-semibold">{metric.totalStops}</p>
+                      </div>
+                      <div>
+                        <p className="text-gray-400 text-xs">Completadas</p>
+                        <p className="font-semibold text-green-600">
+                          {metric.completedStops}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-gray-400 text-xs">Omitidas</p>
+                        <p className="font-semibold text-amber-600">
+                          {metric.skippedStops}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-gray-400 text-xs">Sin presencia</p>
+                        <p className="font-semibold text-red-600">
+                          {metric.noShowStops}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="w-full bg-gray-100 rounded-full h-2">
+                      <div
+                        className="bg-primary h-2 rounded-full"
+                        style={{ width: `${metric.complianceRate}%` }}
+                        role="progressbar"
+                        aria-valuenow={metric.complianceRate}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-label={`Cumplimiento: ${metric.complianceRate}%`}
+                      />
+                    </div>
                   </div>
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-                    <div>
-                      <p className="text-gray-400 text-xs">Total paradas</p>
-                      <p className="font-semibold">{metric.totalStops}</p>
-                    </div>
-                    <div>
-                      <p className="text-gray-400 text-xs">Completadas</p>
-                      <p className="font-semibold text-green-600">
-                        {metric.completedStops}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-gray-400 text-xs">Omitidas</p>
-                      <p className="font-semibold text-amber-600">
-                        {metric.skippedStops}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-gray-400 text-xs">Sin presencia</p>
-                      <p className="font-semibold text-red-600">
-                        {metric.noShowStops}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="w-full bg-gray-100 rounded-full h-2">
-                    <div
-                      className="bg-primary h-2 rounded-full"
-                      style={{ width: `${metric.complianceRate}%` }}
-                      role="progressbar"
-                      aria-valuenow={metric.complianceRate}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                      aria-label={`Cumplimiento: ${metric.complianceRate}%`}
-                    />
-                  </div>
-                </div>
-              );
-            })}
+                );
+              })
+            ) : (
+              <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                No hay métricas de ruta disponibles.
+              </div>
+            )}
           </CardContent>
         </Card>
       </main>

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -86,52 +86,63 @@ export default async function RutasPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {routePlans.map((plan) => {
-                  const progress =
-                    plan.totalStops > 0
-                      ? Math.round(
-                          (plan.completedStops / plan.totalStops) * 100,
-                        )
-                      : 0;
-                  return (
-                    <TableRow key={plan.id}>
-                      <TableCell className="font-mono text-xs text-gray-400">
-                        #{plan.id}
-                      </TableCell>
-                      <TableCell className="font-medium text-sm">
-                        {plan.name}
-                      </TableCell>
-                      <TableCell className="text-gray-500 text-sm">
-                        {formatDate(plan.plannedDate)}
-                      </TableCell>
-                      <TableCell className="text-gray-600 text-sm">
-                        {plan.completedStops}/{plan.totalStops}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <div className="flex-1 bg-gray-100 rounded-full h-1.5 max-w-[80px]">
-                            <div
-                              className="bg-primary h-1.5 rounded-full transition-all"
-                              style={{ width: `${progress}%` }}
-                              role="progressbar"
-                              aria-valuenow={progress}
-                              aria-valuemin={0}
-                              aria-valuemax={100}
-                            />
+                {routePlans.length ? (
+                  routePlans.map((plan) => {
+                    const progress =
+                      plan.totalStops > 0
+                        ? Math.round(
+                            (plan.completedStops / plan.totalStops) * 100,
+                          )
+                        : 0;
+                    return (
+                      <TableRow key={plan.id}>
+                        <TableCell className="font-mono text-xs text-gray-400">
+                          #{plan.id}
+                        </TableCell>
+                        <TableCell className="font-medium text-sm">
+                          {plan.name}
+                        </TableCell>
+                        <TableCell className="text-gray-500 text-sm">
+                          {formatDate(plan.plannedDate)}
+                        </TableCell>
+                        <TableCell className="text-gray-600 text-sm">
+                          {plan.completedStops}/{plan.totalStops}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <div className="flex-1 bg-gray-100 rounded-full h-1.5 max-w-[80px]">
+                              <div
+                                className="bg-primary h-1.5 rounded-full transition-all"
+                                style={{ width: `${progress}%` }}
+                                role="progressbar"
+                                aria-valuenow={progress}
+                                aria-valuemin={0}
+                                aria-valuemax={100}
+                              />
+                            </div>
+                            <span className="text-xs text-gray-500">
+                              {progress}%
+                            </span>
                           </div>
-                          <span className="text-xs text-gray-500">
-                            {progress}%
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={getRoutePlanStatusVariant(plan.status)}>
-                          {getRoutePlanStatusLabel(plan.status)}
-                        </Badge>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={getRoutePlanStatusVariant(plan.status)}>
+                            {getRoutePlanStatusLabel(plan.status)}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={6}
+                      className="px-6 py-10 text-center text-sm text-gray-500"
+                    >
+                      No hay planes de ruta disponibles.
+                    </TableCell>
+                  </TableRow>
+                )}
               </TableBody>
             </Table>
           </CardContent>

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -89,35 +89,46 @@ export default async function VisitasPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {visits.map((visit) => (
-                  <TableRow key={visit.id}>
-                    <TableCell className="font-mono text-xs text-gray-400">
-                      #{visit.id}
-                    </TableCell>
-                    <TableCell className="font-medium text-sm">
-                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                    </TableCell>
-                    <TableCell className="text-gray-600 text-sm max-w-[180px] truncate">
-                      {visit.address ?? "—"}
-                    </TableCell>
-                    <TableCell className="text-gray-500 text-sm">
-                      {formatDateTime(visit.scheduledAt)}
-                    </TableCell>
-                    <TableCell className="text-gray-500 text-sm">
-                      {visit.completedAt
-                        ? formatDateTime(visit.completedAt)
-                        : "—"}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={getFieldVisitStatusVariant(visit.status)}>
-                        {getFieldVisitStatusLabel(visit.status)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-gray-400 text-xs max-w-[150px] truncate">
-                      {visit.notes ?? "—"}
+                {visits.length ? (
+                  visits.map((visit) => (
+                    <TableRow key={visit.id}>
+                      <TableCell className="font-mono text-xs text-gray-400">
+                        #{visit.id}
+                      </TableCell>
+                      <TableCell className="font-medium text-sm">
+                        {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                      </TableCell>
+                      <TableCell className="text-gray-600 text-sm max-w-[180px] truncate">
+                        {visit.address ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-gray-500 text-sm">
+                        {formatDateTime(visit.scheduledAt)}
+                      </TableCell>
+                      <TableCell className="text-gray-500 text-sm">
+                        {visit.completedAt
+                          ? formatDateTime(visit.completedAt)
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getFieldVisitStatusVariant(visit.status)}>
+                          {getFieldVisitStatusLabel(visit.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-gray-400 text-xs max-w-[150px] truncate">
+                        {visit.notes ?? "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="px-6 py-10 text-center text-sm text-gray-500"
+                    >
+                      No hay visitas de campo disponibles.
                     </TableCell>
                   </TableRow>
-                ))}
+                )}
               </TableBody>
             </Table>
           </CardContent>

--- a/test/frontend-logistics-detail-empty-states.test.ts
+++ b/test/frontend-logistics-detail-empty-states.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const VISITAS_PAGE_PATH =
+  "frontend/src/app/dashboard/logistica/visitas/page.tsx";
+const RUTAS_PAGE_PATH =
+  "frontend/src/app/dashboard/logistica/rutas/page.tsx";
+const METRICAS_PAGE_PATH =
+  "frontend/src/app/dashboard/logistica/metricas/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("logistics visits detail page shows an empty table state", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("visits.length ?"));
+  assert.ok(source.includes("visits.map((visit)"));
+  assert.ok(source.includes("No hay visitas de campo disponibles."));
+  assert.ok(source.includes("colSpan={7}"));
+});
+
+test("logistics route plans detail page shows an empty table state", () => {
+  const source = read(RUTAS_PAGE_PATH);
+
+  assert.ok(source.includes("routePlans.length ?"));
+  assert.ok(source.includes("routePlans.map((plan)"));
+  assert.ok(source.includes("No hay planes de ruta disponibles."));
+  assert.ok(source.includes("colSpan={6}"));
+});
+
+test("logistics metrics detail page shows an empty card state", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("routeMetrics.length ?"));
+  assert.ok(source.includes("routeMetrics.map((metric)"));
+  assert.ok(source.includes("No hay métricas de ruta disponibles."));
+});


### PR DESCRIPTION
## Summary

- Add an empty table state for logistics field visits.
- Add an empty table state for logistics route plans.
- Add an empty card state for route metrics.
- Keep existing live backend reads unchanged.
- Add a test-only guardrail for logistics detail empty-state rendering.

## Security

- Frontend-only UI change.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not change API client fallback behavior.
- Keeps scope limited to empty-state UX after live logistics reads return empty arrays.

## Validation

- [x] `pnpm test -- .\test\frontend-logistics-detail-empty-states.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`