### PR TITLE
feat(frontend): add public page CTAs

### DIFF
--- a/frontend/src/app/profesionales/page.tsx
+++ b/frontend/src/app/profesionales/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { createPageMetadata } from "@/lib/seo";
+import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
   "Red de Profesionales Veterinarios",
@@ -113,6 +116,28 @@ export default function ProfesionalesPage() {
                 {specialty}
               </Badge>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-white">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            ¿Querés integrar tu práctica a Portal VETNEB?
+          </h2>
+          <p className="text-gray-600 leading-relaxed mb-8">
+            Contactanos para coordinar el acceso profesional o conocer cómo una
+            clínica puede operar con informes digitales, trazabilidad y gestión
+            segura desde el portal.
+          </p>
+          <div className="flex flex-col sm:flex-row justify-center gap-3">
+            <Button asChild size="lg">
+              <Link href={ROUTES.contacto}>Contactar a VETNEB</Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href={ROUTES.clinicas}>Ver portal para clínicas</Link>
+            </Button>
           </div>
         </div>
       </section>

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
+import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
   "Servicios de Laboratorio Veterinario",
@@ -131,6 +134,28 @@ export default function ServiciosPage() {
                 </CardContent>
               </Card>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-blue-50">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            ¿Necesitás digitalizar la gestión de estudios?
+          </h2>
+          <p className="text-gray-600 leading-relaxed mb-8">
+            Solicitá acceso para tu clínica o contactanos para conocer cómo
+            Portal VETNEB puede acompañar el flujo completo de informes,
+            logística y trazabilidad.
+          </p>
+          <div className="flex flex-col sm:flex-row justify-center gap-3">
+            <Button asChild size="lg">
+              <Link href={ROUTES.contacto}>Solicitar información</Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href={ROUTES.clinicas}>Ver solución para clínicas</Link>
+            </Button>
           </div>
         </div>
       </section>

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PROFESIONALES_PAGE_PATH = "frontend/src/app/profesionales/page.tsx";
+const SERVICIOS_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("profesionales public page exposes actionable CTAs", () => {
+  const source = read(PROFESIONALES_PAGE_PATH);
+
+  assert.ok(source.includes('import Link from "next/link"'));
+  assert.ok(source.includes('import { Button } from "@/components/ui/button"'));
+  assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
+  assert.ok(source.includes("¿Querés integrar tu práctica a Portal VETNEB?"));
+  assert.ok(source.includes("Contactar a VETNEB"));
+  assert.ok(source.includes("Ver portal para clínicas"));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
+  assert.ok(source.includes("href={ROUTES.clinicas}"));
+});
+
+test("servicios public page exposes conversion CTAs", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  assert.ok(source.includes('import Link from "next/link"'));
+  assert.ok(source.includes('import { Button } from "@/components/ui/button"'));
+  assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
+  assert.ok(source.includes("¿Necesitás digitalizar la gestión de estudios?"));
+  assert.ok(source.includes("Solicitar información"));
+  assert.ok(source.includes("Ver solución para clínicas"));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
+  assert.ok(source.includes("href={ROUTES.clinicas}"));
+});


### PR DESCRIPTION
## Summary

- Add actionable CTAs to the public profesionales page.
- Add conversion CTAs to the public servicios page.
- Link public CTAs to contacto and clínicas routes.
- Keep existing public page content and metadata unchanged.
- Add a test-only guardrail for public CTA wiring.

## Security

- Frontend-only UI change.
- Does not touch backend runtime.
- Does not touch auth/session behavior.
- Does not change API client behavior.
- Keeps scope limited to public page navigation CTAs.

## Validation

- [x] `pnpm test -- .\test\frontend-public-page-ctas.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`