### PR TITLE
test(frontend): add contact form integration guardrail

### DIFF
--- a/test/frontend-contact-form-integration.test.ts
+++ b/test/frontend-contact-form-integration.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const CONTACTO_CONTENT_PATH = "frontend/src/components/public/ContactoContent.tsx";
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("contact public page submits messages through the API client", () => {
+  const source = read(CONTACTO_CONTENT_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes('import { submitContactMessage } from "@/lib/api";'));
+  assert.ok(source.includes("async function handleSubmit"));
+  assert.ok(source.includes("event.preventDefault();"));
+  assert.ok(source.includes("await submitContactMessage({"));
+  assert.ok(source.includes("name: fullName,"));
+  assert.ok(source.includes("email: email.trim(),"));
+  assert.ok(source.includes("clinicName: clinica.trim() || null,"));
+  assert.ok(source.includes("message: mensaje.trim(),"));
+  assert.ok(source.includes('aria-label="Formulario de contacto"'));
+  assert.ok(source.includes("onSubmit={handleSubmit}"));
+});
+
+test("contact public page handles loading, success, error and reset states", () => {
+  const source = read(CONTACTO_CONTENT_PATH);
+
+  assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
+  assert.ok(source.includes("const [successMessage, setSuccessMessage]"));
+  assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes("if (isSubmitting)"));
+  assert.ok(source.includes("setIsSubmitting(true);"));
+  assert.ok(source.includes("setSuccessMessage(response.message);"));
+  assert.ok(source.includes('setNombre("");'));
+  assert.ok(source.includes('setApellido("");'));
+  assert.ok(source.includes('setEmail("");'));
+  assert.ok(source.includes('setClinica("");'));
+  assert.ok(source.includes('setMensaje("");'));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes('isSubmitting ? "Enviando mensaje..." : "Enviar mensaje"'));
+});
+
+test("API client exposes contact message contract against backend contact endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export type ContactMessagePayload = {"));
+  assert.ok(source.includes("name: string;"));
+  assert.ok(source.includes("email: string;"));
+  assert.ok(source.includes("clinicName?: string | null;"));
+  assert.ok(source.includes("message: string;"));
+  assert.ok(source.includes("export type ContactMessageResponse = {"));
+  assert.ok(source.includes("success: true;"));
+  assert.ok(source.includes("sent: boolean;"));
+  assert.ok(source.includes('reason?: "smtp_disabled";'));
+  assert.ok(source.includes("export async function submitContactMessage("));
+  assert.ok(source.includes('return apiFetch<ContactMessageResponse>("/api/contact", {'));
+  assert.ok(source.includes('method: "POST",'));
+  assert.ok(source.includes("body: JSON.stringify(payload),"));
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for the public contact form integration.
- Verify ContactoContent submits through submitContactMessage.
- Verify loading, success, error, and reset state wiring.
- Verify the API client contact contract targets /api/contact.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- No sensitive data handling changes.

## Validation
- pnpm test -- .\test\frontend-contact-form-integration.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
