### PR TITLE
test(frontend): add admin users roles API guardrail

### DIFF
--- a/test/frontend-admin-users-roles-api.test.ts
+++ b/test/frontend-admin-users-roles-api.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend API client builds admin users roles query parameters explicitly", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export async function getAdminUsersRoles("));
+  assert.ok(source.includes("params: AdminUsersRolesQuery = {},"));
+  assert.ok(source.includes("options?: RequestInit,"));
+  assert.ok(source.includes("): Promise<AdminUsersRolesSnapshot>"));
+  assert.ok(source.includes("const query = new URLSearchParams();"));
+  assert.ok(source.includes('query.set("userType", params.userType);'));
+  assert.ok(source.includes('query.set("role", params.role);'));
+  assert.ok(source.includes('query.set("limit", String(params.limit));'));
+  assert.ok(source.includes('query.set("offset", String(params.offset));'));
+  assert.ok(source.includes("const qs = query.toString();"));
+});
+
+test("frontend API client reads admin users roles from backend endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("return apiFetch<AdminUsersRolesSnapshot>("));
+  assert.ok(source.includes("`/api/admin/users-roles${qs ? `?${qs}` : \"\"}`,"));
+  assert.ok(source.includes("options,"));
+});
+
+test("frontend API client changes clinic user role with PATCH", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export async function changeAdminClinicUserRole("));
+  assert.ok(source.includes("clinicUserId: number,"));
+  assert.ok(source.includes("role: ClinicUserRole,"));
+  assert.ok(source.includes("options?: RequestInit,"));
+  assert.ok(source.includes("): Promise<AdminClinicUserRoleChangeResponse>"));
+  assert.ok(source.includes("return apiFetch<AdminClinicUserRoleChangeResponse>("));
+  assert.ok(source.includes("`/api/admin/users-roles/clinic/${clinicUserId}/role`,"));
+  assert.ok(source.includes('method: "PATCH",'));
+  assert.ok(source.includes("body: JSON.stringify({ role }),"));
+});
+
+test("frontend admin users roles API helpers remain typed around role snapshots", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("AdminUsersRolesQuery,"));
+  assert.ok(source.includes("AdminUsersRolesSnapshot,"));
+  assert.ok(source.includes("AdminClinicUserRoleChangeResponse,"));
+  assert.ok(source.includes("ClinicUserRole,"));
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for admin users/roles API helpers.
- Verify getAdminUsersRoles builds explicit optional query parameters.
- Verify getAdminUsersRoles targets /api/admin/users-roles.
- Verify changeAdminClinicUserRole targets the typed clinic role endpoint with PATCH.
- Verify admin users/roles helpers remain typed around role snapshots.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around frontend admin users/roles API wiring.

## Validation
- pnpm test -- .\test\frontend-admin-users-roles-api.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
