### PR TITLE
test(frontend): add SEO metadata guardrail

### DIFF
--- a/test/frontend-seo-metadata.test.ts
+++ b/test/frontend-seo-metadata.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const ROOT_LAYOUT_PATH = "frontend/src/app/layout.tsx";
+const SEO_PATH = "frontend/src/lib/seo.ts";
+const ROBOTS_PATH = "frontend/src/app/robots.ts";
+const SITEMAP_PATH = "frontend/src/app/sitemap.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend root layout wires base metadata and organization JSON-LD", () => {
+  const source = read(ROOT_LAYOUT_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes('import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";'));
+  assert.ok(source.includes("export const metadata: Metadata = baseMetadata;"));
+  assert.ok(source.includes("const orgJsonLd = getOrganizationJsonLd();"));
+  assert.ok(source.includes('type="application/ld+json"'));
+  assert.ok(source.includes("dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}"));
+  assert.ok(source.includes('<html lang="es"'));
+});
+
+test("frontend SEO base metadata defines canonical brand and indexable robots", () => {
+  const source = read(SEO_PATH);
+
+  assert.ok(source.includes('export const SITE_NAME = "Portal VETNEB";'));
+  assert.ok(source.includes('process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com";'));
+  assert.ok(source.includes('export const SITE_LOCALE = "es_AR";'));
+  assert.ok(source.includes("export const baseMetadata: Metadata = {"));
+  assert.ok(source.includes("metadataBase: new URL(SITE_URL),"));
+  assert.ok(source.includes("template: `%s | ${SITE_NAME}`,"));
+  assert.ok(source.includes("index: true,"));
+  assert.ok(source.includes("follow: true,"));
+  assert.ok(source.includes('"max-image-preview": "large",'));
+});
+
+test("frontend SEO metadata exposes Open Graph and Twitter cards", () => {
+  const source = read(SEO_PATH);
+
+  assert.ok(source.includes("openGraph: {"));
+  assert.ok(source.includes('type: "website",'));
+  assert.ok(source.includes("locale: SITE_LOCALE,"));
+  assert.ok(source.includes("siteName: SITE_NAME,"));
+  assert.ok(source.includes("`${SITE_URL}/og-image.png`"));
+  assert.ok(source.includes("twitter: {"));
+  assert.ok(source.includes('card: "summary_large_image",'));
+  assert.ok(source.includes("alternates: {"));
+  assert.ok(source.includes("canonical: SITE_URL,"));
+});
+
+test("frontend SEO helpers create page metadata and organization JSON-LD", () => {
+  const source = read(SEO_PATH);
+
+  assert.ok(source.includes("export function createPageMetadata("));
+  assert.ok(source.includes("const url = `${SITE_URL}${path}`;"));
+  assert.ok(source.includes("canonical: url,"));
+  assert.ok(source.includes("export function getOrganizationJsonLd()"));
+  assert.ok(source.includes('"@context": "https://schema.org"'));
+  assert.ok(source.includes('"@type": "MedicalOrganization"'));
+  assert.ok(source.includes('medicalSpecialty: "Veterinary"'));
+});
+
+test("frontend robots allows public pages and blocks private/API surfaces", () => {
+  const source = read(ROBOTS_PATH);
+
+  assert.ok(source.includes('import { SITE_URL } from "@/lib/seo";'));
+  assert.ok(source.includes('userAgent: "*"'));
+  assert.ok(source.includes('allow: ["/", "/servicios", "/profesionales", "/clinicas", "/contacto"]'));
+  assert.ok(source.includes('disallow: ["/dashboard/", "/login", "/api/"]'));
+  assert.ok(source.includes("sitemap: `${SITE_URL}/sitemap.xml`,"));
+});
+
+test("frontend sitemap lists public indexable pages only", () => {
+  const source = read(SITEMAP_PATH);
+
+  assert.ok(source.includes('import { SITE_URL } from "@/lib/seo";'));
+  assert.ok(source.includes("const now = new Date();"));
+  assert.ok(source.includes("url: SITE_URL,"));
+  assert.ok(source.includes("url: `${SITE_URL}/servicios`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/profesionales`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/clinicas`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/contacto`,"));
+  assert.equal(source.includes("/dashboard"), false);
+  assert.equal(source.includes("/login"), false);
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for SEO metadata wiring.
- Verify root layout wires base metadata and organization JSON-LD.
- Verify base SEO metadata, Open Graph, Twitter card, page metadata, and organization JSON-LD contracts.
- Verify robots allows public pages and blocks private/API surfaces.
- Verify sitemap lists public indexable pages only.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around public SEO and private route indexing boundaries.

## Validation
- pnpm test -- .\test\frontend-seo-metadata.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
