### PR TITLE
test(frontend): add contacto page guardrail

### DIFF
--- a/test/frontend-contacto-page.test.ts
+++ b/test/frontend-contacto-page.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const CONTACTO_PAGE_PATH = "frontend/src/app/contacto/page.tsx";
+const CONTACTO_CONTENT_PATH = "frontend/src/components/public/ContactoContent.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("contacto public page defines metadata through SEO helper", () => {
+  const source = read(CONTACTO_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
+  assert.ok(source.includes('"Contacto — Portal VETNEB"'));
+  assert.ok(source.includes('"Contacte con el equipo de Portal VETNEB.'));
+  assert.ok(source.includes('"/contacto"'));
+});
+
+test("contacto public page delegates rendering to ContactoContent", () => {
+  const source = read(CONTACTO_PAGE_PATH);
+
+  assert.ok(source.includes('import { ContactoContent } from "@/components/public/ContactoContent";'));
+  assert.ok(source.includes("export default function ContactoPage()"));
+  assert.ok(source.includes("return <ContactoContent />;"));
+});
+
+test("contacto content keeps public layout and contact form landmarks", () => {
+  const source = read(CONTACTO_CONTENT_PATH);
+
+  assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
+  assert.ok(source.includes("<PublicLayout>"));
+  assert.ok(source.includes("Contacto"));
+  assert.ok(source.includes("Envíenos un mensaje"));
+  assert.ok(source.includes('aria-label="Formulario de contacto"'));
+  assert.ok(source.includes("Información de contacto"));
+});
+
+test("contacto content keeps clinic onboarding guidance visible", () => {
+  const source = read(CONTACTO_CONTENT_PATH);
+
+  assert.ok(source.includes("¿Es una clínica veterinaria?"));
+  assert.ok(source.includes("registrar su clínica en Portal VETNEB"));
+  assert.ok(source.includes("configurar su acceso"));
+  assert.ok(source.includes("Nombre de la clínica (opcional)"));
+  assert.ok(source.includes("Describa su consulta o solicitud de acceso"));
+});
+
+test("contacto page remains public and does not expose private route literals", () => {
+  const pageSource = read(CONTACTO_PAGE_PATH);
+  const contentSource = read(CONTACTO_CONTENT_PATH);
+  const combined = [pageSource, contentSource].join("\n");
+
+  assert.equal(combined.includes('"/dashboard"'), false);
+  assert.equal(combined.includes('"/api"'), false);
+  assert.equal(combined.includes('"/login"'), false);
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for the public contacto page.
- Verify /contacto defines metadata through createPageMetadata.
- Verify the page delegates rendering to ContactoContent.
- Verify ContactoContent keeps public layout, form landmarks, and clinic onboarding guidance.
- Verify contacto remains scoped to public content without private route literals.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around public contacto page boundaries.

## Validation
- pnpm test -- .\test\frontend-contacto-page.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
