### PR TITLE
test(frontend): add clinicas page content guardrail

### DIFF
--- a/test/frontend-clinicas-page-content.test.ts
+++ b/test/frontend-clinicas-page-content.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const CLINICAS_PAGE_PATH = "frontend/src/app/clinicas/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("clinicas page defines metadata and public layout wiring", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
+  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
+  assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
+  assert.ok(source.includes('"Portal para Clínicas Veterinarias"'));
+  assert.ok(source.includes('"/clinicas"'));
+  assert.ok(source.includes("<PublicLayout>"));
+});
+
+test("clinicas page exposes hero content and primary CTAs", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+
+  assert.ok(source.includes("Portal para clínicas veterinarias"));
+  assert.ok(source.includes("Gestión centralizada de informes, estudios y logística"));
+  assert.ok(source.includes('href={ROUTES.login}'));
+  assert.ok(source.includes("Acceder al portal"));
+  assert.ok(source.includes('href={ROUTES.contacto}'));
+  assert.ok(source.includes("Solicitar acceso"));
+});
+
+test("clinicas page lists operational feature cards", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const features = ["));
+  assert.ok(source.includes("Recepción de informes"));
+  assert.ok(source.includes("Búsqueda avanzada"));
+  assert.ok(source.includes("Seguimiento de logística"));
+  assert.ok(source.includes("Acceso seguro y auditado"));
+  assert.ok(source.includes("Gestión de usuarios"));
+  assert.ok(source.includes("Perfil público"));
+  assert.ok(source.includes("features.map((feature) =>"));
+});
+
+test("clinicas page explains onboarding steps", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const steps = ["));
+  assert.ok(source.includes("Solicite acceso"));
+  assert.ok(source.includes("Configure su cuenta"));
+  assert.ok(source.includes("Acceda a sus informes"));
+  assert.ok(source.includes("Gestione su operación"));
+  assert.ok(source.includes("Cómo comenzar"));
+  assert.ok(source.includes("steps.map((step) =>"));
+});
+
+test("clinicas page remains public and avoids direct backend/API calls", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+
+  assert.equal(source.includes('"/dashboard"'), false);
+  assert.equal(source.includes('"/api"'), false);
+  assert.equal(source.includes("fetch("), false);
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for the public clínicas page.
- Verify metadata and PublicLayout wiring.
- Verify hero content and primary CTAs.
- Verify operational feature cards and onboarding steps.
- Verify clínicas remains public and avoids direct backend/API calls.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around public clínicas page content and route boundaries.

## Validation
- pnpm test -- .\test\frontend-clinicas-page-content.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
