### PR TITLE
test(frontend): add badge component guardrail

### DIFF
--- a/test/frontend-badge-component.test.ts
+++ b/test/frontend-badge-component.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const BADGE_PATH = "frontend/src/components/ui/badge.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("badge component uses shared variant utilities and class merge utility", () => {
+  const source = read(BADGE_PATH);
+
+  assert.ok(source.includes('import * as React from "react";'));
+  assert.ok(source.includes('import { cva, type VariantProps } from "class-variance-authority";'));
+  assert.ok(source.includes('import { cn } from "@/lib/utils";'));
+  assert.ok(source.includes("const badgeVariants = cva("));
+  assert.ok(source.includes("VariantProps<typeof badgeVariants>"));
+});
+
+test("badge component defines stable base classes", () => {
+  const source = read(BADGE_PATH);
+
+  assert.ok(source.includes("inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold"));
+  assert.ok(source.includes("transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"));
+});
+
+test("badge component defines expected variants and default", () => {
+  const source = read(BADGE_PATH);
+
+  assert.ok(source.includes("variant: {"));
+  assert.ok(source.includes("default:"));
+  assert.ok(source.includes("border-transparent bg-primary text-primary-foreground hover:bg-primary/80"));
+  assert.ok(source.includes("secondary:"));
+  assert.ok(source.includes("border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"));
+  assert.ok(source.includes("destructive:"));
+  assert.ok(source.includes("border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80"));
+  assert.ok(source.includes('outline: "text-foreground"'));
+  assert.ok(source.includes("defaultVariants: {"));
+  assert.ok(source.includes('variant: "default"'));
+});
+
+test("badge component keeps props typing and renders div with merged classes", () => {
+  const source = read(BADGE_PATH);
+
+  assert.ok(source.includes("export interface BadgeProps"));
+  assert.ok(source.includes("extends React.HTMLAttributes<HTMLDivElement>"));
+  assert.ok(source.includes("function Badge({ className, variant, ...props }: BadgeProps)"));
+  assert.ok(source.includes("<div className={cn(badgeVariants({ variant }), className)} {...props} />"));
+});
+
+test("badge component keeps stable named exports", () => {
+  const source = read(BADGE_PATH);
+
+  assert.ok(source.includes("export { Badge, badgeVariants };"));
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for the shared Badge component.
- Verify variant utilities, base classes, visual variants, default variant, props typing, merged class rendering, and stable exports.
- Protect the shared Badge API used by public page specialty labels and dashboard surfaces.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around shared UI badge primitives.

## Validation
- pnpm test -- .\test\frontend-badge-component.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
