### PR TITLE
test(frontend): add dashboard logistica visitas guardrail

### DIFF
--- a/test/frontend-dashboard-logistica-visitas.test.ts
+++ b/test/frontend-dashboard-logistica-visitas.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const VISITAS_PAGE_PATH = "frontend/src/app/dashboard/logistica/visitas/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("dashboard logistica visitas defines non-indexable metadata and dependencies", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes('import { cookies } from "next/headers";'));
+  assert.ok(source.includes('title: "Visitas de campo — Portal VETNEB"'));
+  assert.ok(source.includes("robots: { index: false, follow: false },"));
+  assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
+  assert.ok(source.includes('import { Badge } from "@/components/ui/badge";'));
+  assert.ok(source.includes('import { getLogisticsFieldVisits } from "@/lib/api";'));
+});
+
+test("dashboard logistica visitas forwards cookies and disables cache for live reads", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("async function getLogisticsRequestOptions(): Promise<RequestInit>"));
+  assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
+  assert.ok(source.includes('cache: "no-store"'));
+  assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
+  assert.ok(source.includes("const visits = await getLogisticsFieldVisits("));
+  assert.ok(source.includes("await getLogisticsRequestOptions(),"));
+});
+
+test("dashboard logistica visitas renders topbar and read-source notice", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes('title="Visitas de campo"'));
+  assert.ok(source.includes('subtitle="Seguimiento de visitas programadas y en curso"'));
+  assert.ok(source.includes("Lectura conectada a"));
+  assert.ok(source.includes("GET /api/logistics/field-visits"));
+});
+
+test("dashboard logistica visitas keeps status counters aligned to field visit statuses", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes('{ status: "pending", label: "Pendientes" }'));
+  assert.ok(source.includes('{ status: "scheduled", label: "Programadas" }'));
+  assert.ok(source.includes('{ status: "in_progress", label: "En curso" }'));
+  assert.ok(source.includes('{ status: "done", label: "Completadas" }'));
+  assert.ok(source.includes("const count = visits.filter((v) => v.status === status).length;"));
+});
+
+test("dashboard logistica visitas renders table columns", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("<TableHead>ID</TableHead>"));
+  assert.ok(source.includes("<TableHead>Clínica</TableHead>"));
+  assert.ok(source.includes("<TableHead>Dirección</TableHead>"));
+  assert.ok(source.includes("<TableHead>Programada</TableHead>"));
+  assert.ok(source.includes("<TableHead>Completada</TableHead>"));
+  assert.ok(source.includes("<TableHead>Estado</TableHead>"));
+  assert.ok(source.includes("<TableHead>Notas</TableHead>"));
+});
+
+test("dashboard logistica visitas keeps row rendering badges dates and fallbacks", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("visits.map((visit) =>"));
+  assert.ok(source.includes("visit.clinicName ?? `Clínica #${visit.clinicId}`"));
+  assert.ok(source.includes('visit.address ?? "—"'));
+  assert.ok(source.includes("formatDateTime(visit.scheduledAt)"));
+  assert.ok(source.includes("visit.completedAt"));
+  assert.ok(source.includes("formatDateTime(visit.completedAt)"));
+  assert.ok(source.includes("getFieldVisitStatusVariant(visit.status)"));
+  assert.ok(source.includes("getFieldVisitStatusLabel(visit.status)"));
+  assert.ok(source.includes('visit.notes ?? "—"'));
+});
+
+test("dashboard logistica visitas keeps empty state and avoids client-side fetch literals", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("No hay visitas de campo disponibles."));
+  assert.ok(source.includes("colSpan={7}"));
+  assert.equal(source.includes("fetch("), false);
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for the dashboard logística visitas page.
- Verify non-indexable metadata, cookie forwarding, no-store field visit reads, status counters, table columns, row fallbacks, badges, date formatting, and empty state.
- Verify visitas avoids client-side fetch literals.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around protected dashboard logística visitas data wiring.

## Validation
- pnpm test -- .\test\frontend-dashboard-logistica-visitas.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
