### PR TITLE
test(frontend): add dashboard logistica metricas guardrail

### DIFF
--- a/test/frontend-dashboard-logistica-metricas.test.ts
+++ b/test/frontend-dashboard-logistica-metricas.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const METRICAS_PAGE_PATH = "frontend/src/app/dashboard/logistica/metricas/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("dashboard logistica metricas defines non-indexable metadata and dependencies", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes('import { cookies } from "next/headers";'));
+  assert.ok(source.includes('title: "Métricas de logística — Portal VETNEB"'));
+  assert.ok(source.includes("robots: { index: false, follow: false },"));
+  assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
+  assert.ok(source.includes('import { Badge } from "@/components/ui/badge";'));
+  assert.ok(source.includes('import { getRoutePlanMetrics, getRoutePlans } from "@/lib/api";'));
+});
+
+test("dashboard logistica metricas forwards cookies and disables cache for live reads", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("async function getLogisticsRequestOptions(): Promise<RequestInit>"));
+  assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
+  assert.ok(source.includes('cache: "no-store"'));
+  assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
+  assert.ok(source.includes("const requestOptions = await getLogisticsRequestOptions();"));
+});
+
+test("dashboard logistica metricas reads route plans and plan metrics", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const routePlans = await getRoutePlans(requestOptions);"));
+  assert.ok(source.includes("const routeMetrics = ("));
+  assert.ok(source.includes("await Promise.all("));
+  assert.ok(source.includes("routePlans.map((plan) => getRoutePlanMetrics(plan.id, requestOptions))"));
+  assert.ok(source.includes(").flat();"));
+});
+
+test("dashboard logistica metricas computes aggregate operational metrics", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const totalStops = routeMetrics.reduce("));
+  assert.ok(source.includes("const completedStops = routeMetrics.reduce("));
+  assert.ok(source.includes("const avgCompliance ="));
+  assert.ok(source.includes("metric.complianceRate"));
+  assert.ok(source.includes("const metricsWithDuration = routeMetrics.filter("));
+  assert.ok(source.includes("metric.averageDurationMinutes !== null"));
+  assert.ok(source.includes("const avgDuration ="));
+});
+
+test("dashboard logistica metricas renders summary cards and read-source notice", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes('title="Métricas de logística"'));
+  assert.ok(source.includes('subtitle="Cumplimiento, SLA y reportes operativos"'));
+  assert.ok(source.includes("GET /api/logistics/route-plans/:id/metrics"));
+  assert.ok(source.includes("Cumplimiento promedio"));
+  assert.ok(source.includes("Paradas completadas"));
+  assert.ok(source.includes("Duración promedio"));
+  assert.ok(source.includes("Planes analizados"));
+});
+
+test("dashboard logistica metricas renders per-route metric detail", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("Métricas por plan de ruta"));
+  assert.ok(source.includes("Detalle de cumplimiento por cada plan ejecutado"));
+  assert.ok(source.includes("routeMetrics.map((metric) =>"));
+  assert.ok(source.includes("routePlans.find("));
+  assert.ok(source.includes("plan?.name ?? `Plan #${metric.routePlanId}`"));
+  assert.ok(source.includes("Total paradas"));
+  assert.ok(source.includes("Completadas"));
+  assert.ok(source.includes("Omitidas"));
+  assert.ok(source.includes("Sin presencia"));
+});
+
+test("dashboard logistica metricas keeps compliance badge thresholds and progress accessibility", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("metric.complianceRate >= 90"));
+  assert.ok(source.includes("? \"default\""));
+  assert.ok(source.includes("metric.complianceRate >= 60"));
+  assert.ok(source.includes("? \"secondary\""));
+  assert.ok(source.includes(": \"destructive\""));
+  assert.ok(source.includes("style={{ width: `${metric.complianceRate}%` }}"));
+  assert.ok(source.includes('role="progressbar"'));
+  assert.ok(source.includes("aria-valuenow={metric.complianceRate}"));
+  assert.ok(source.includes("aria-valuemin={0}"));
+  assert.ok(source.includes("aria-valuemax={100}"));
+  assert.ok(source.includes("aria-label={`Cumplimiento: ${metric.complianceRate}%`}"));
+});
+
+test("dashboard logistica metricas keeps empty state and avoids client-side fetch literals", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("No hay métricas de ruta disponibles."));
+  assert.equal(source.includes("fetch("), false);
+});


### PR DESCRIPTION
## Summary
- Add a frontend guardrail for the dashboard logística métricas page.
- Verify non-indexable metadata, cookie forwarding, no-store route plan and metric reads, aggregate calculations, summary cards, per-route detail, compliance badge thresholds, accessible progressbar, and empty state.
- Verify métricas avoids client-side fetch literals.

## Security
- Test-only change.
- No runtime behavior changes.
- No authentication, authorization, session, cookie, or backend changes.
- Adds guardrail coverage around protected dashboard logística métricas data wiring.

## Validation
- pnpm test -- .\test\frontend-dashboard-logistica-metricas.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
