### PR TITLE
feat(frontend): strengthen pathology SEO

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,8 +7,8 @@ import { createPageMetadata, getOrganizationJsonLd, SITE_URL } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
-  "Portal VETNEB — Laboratorio Veterinario Digital",
-  "Portal digital de laboratorio veterinario. Informes médicos, estudios veterinarios, gestión de clínicas y logística operativa para profesionales del sector.",
+  "Portal VETNEB — Laboratorio Patológico Veterinario",
+  "Laboratorio patológico veterinario para clínicas y profesionales: histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos e informes digitales.",
   "/",
 );
 
@@ -79,13 +79,13 @@ export default function HomePage() {
           <div className="max-w-3xl">
             <div className="inline-flex items-center gap-2 rounded-full bg-blue-700/50 px-4 py-1.5 text-sm font-medium text-blue-100 mb-6">
               <span className="h-2 w-2 rounded-full bg-green-400 animate-pulse" />
-              Laboratorio veterinario digital
+              Laboratorio patológico veterinario
             </div>
             <h1
               id="hero-heading"
               className="text-4xl md:text-5xl lg:text-6xl font-bold leading-tight mb-6"
             >
-              Gestión digital de
+              Diagnóstico patológico de
               <span className="text-blue-300"> laboratorio veterinario</span>
             </h1>
             <p className="text-lg md:text-xl text-blue-100 leading-relaxed mb-8 max-w-2xl">
@@ -130,7 +130,7 @@ export default function HomePage() {
               id="services-heading"
               className="text-3xl md:text-4xl font-bold text-gray-900 mb-4"
             >
-              Servicios del laboratorio
+              Servicios del laboratorio patológico veterinario
             </h2>
             <p className="text-lg text-gray-500 max-w-2xl mx-auto">
               Una plataforma completa para la gestión de diagnóstico veterinario

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -7,12 +7,27 @@ import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
-  "Servicios de Laboratorio Veterinario",
-  "Informes médicos veterinarios, estudios diagnósticos, gestión digital de clínicas y logística operativa. Conocé todos los servicios de Portal VETNEB.",
+  "Laboratorio Patológico Veterinario: Histopatología, Citología y Hematología",
+  "Servicio patológico veterinario especializado en histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos e informes digitales.",
   "/servicios",
 );
 
 const serviceCategories = [
+  {
+    id: "patologia",
+    title: "Patología, Histopatología y Citopatología Veterinaria",
+    icon: "🔬",
+    description:
+      "Servicio patológico veterinario para diagnóstico tisular, celular y hematológico con trazabilidad completa del caso clínico.",
+    features: [
+      "Histopatología veterinaria y anatomía patológica",
+      "Citología veterinaria y citopatología diagnóstica",
+      "Hematología veterinaria y diagnóstico hematológico",
+      "Búsqueda y reporte de hemoparásitos veterinarios",
+      "Correlación clínico-patológica para profesionales",
+      "Informes diagnósticos digitales con trazabilidad",
+    ],
+  },
   {
     id: "informes",
     title: "Informes Médicos Veterinarios",
@@ -89,11 +104,12 @@ export default function ServiciosPage() {
       <section className="bg-gradient-to-br from-blue-900 to-blue-700 text-white py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Servicios del laboratorio
+            Servicios del laboratorio patológico veterinario
           </h1>
           <p className="text-xl text-blue-100 max-w-2xl">
-            Soluciones digitales completas para la gestión de diagnóstico
-            veterinario. Desde el estudio hasta la entrega del informe.
+            Servicio patológico veterinario para clínicas y profesionales:
+            histopatología, citología, citopatología, hematología, diagnóstico
+            hematológico, hemoparásitos e informes digitales.
           </p>
         </div>
       </section>
@@ -160,11 +176,35 @@ export default function ServiciosPage() {
         </div>
       </section>
 
+      {/* Autoridad patológica veterinaria */}
+      <section className="py-16 bg-white">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            Servicio patológico, histopatológico, citológico y hematológico veterinario
+          </h2>
+          <p className="text-gray-600 leading-relaxed mb-4">
+            VETNEB fortalece el diagnóstico veterinario con un servicio patológico
+            orientado a muestras tisulares, citológicas y hematológicas. El flujo
+            de trabajo acompaña estudios de histopatología veterinaria, citología
+            veterinaria, citopatología, hematología, diagnóstico hematológico y
+            búsqueda de hemoparásitos, con informes organizados para la toma de
+            decisiones clínicas.
+          </p>
+          <p className="text-gray-600 leading-relaxed">
+            El enfoque integra laboratorio patológico veterinario, trazabilidad
+            digital, correlación clínico-patológica e informes accesibles para
+            clínicas y profesionales. Esto permite ordenar casos dermatológicos,
+            oncológicos, infecciosos, inflamatorios y hematológicos bajo un
+            circuito diagnóstico claro y auditable.
+          </p>
+        </div>
+      </section>
+
       {/* Texto SEO adicional */}
       <section className="py-16 bg-gray-50">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Laboratorio veterinario digital en Argentina
+            Laboratorio patológico veterinario en Argentina
           </h2>
           <p className="text-gray-600 leading-relaxed mb-4">
             Portal VETNEB es la plataforma digital de referencia para la gestión
@@ -181,6 +221,22 @@ export default function ServiciosPage() {
           </p>
         </div>
       </section>
+
+      <section className="py-16 bg-white">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            Diagnóstico citológico veterinario integrado
+          </h2>
+          <p className="text-gray-600 leading-relaxed">
+            La citología veterinaria complementa la histopatología veterinaria,
+            la citopatología, la hematología, el diagnóstico hematológico y la
+            búsqueda de hemoparásitos dentro del servicio patológico veterinario.
+          </p>
+        </div>
+      </section>
     </PublicLayout>
   );
 }
+
+
+

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -11,7 +11,7 @@ export const SITE_NAME = "Portal VETNEB";
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com";
 export const SITE_DESCRIPTION =
-  "Portal digital de laboratorio veterinario. Informes médicos, estudios veterinarios, gestión de clínicas y logística operativa para profesionales del sector.";
+  "Laboratorio patológico veterinario especializado en histopatología, citología, citopatología, hematología, diagnóstico hematológico y hemoparásitos. Servicio patológico veterinario con informes digitales para clínicas y profesionales.";
 export const SITE_LOCALE = "es_AR";
 
 // ─── Metadata base ────────────────────────────────────────────────────────────
@@ -24,15 +24,26 @@ export const baseMetadata: Metadata = {
   },
   description: SITE_DESCRIPTION,
   keywords: [
+    "laboratorio patológico veterinario",
     "laboratorio veterinario",
+    "servicio patológico veterinario",
+    "patología veterinaria",
+    "anatomía patológica veterinaria",
+    "histopatología veterinaria",
+    "servicio histopatológico veterinario",
+    "citología veterinaria",
+    "citopatología veterinaria",
+    "servicio citopatológico veterinario",
+    "hematología veterinaria",
+    "diagnóstico hematológico veterinario",
+    "servicio hematológico veterinario",
+    "hemoparásitos veterinarios",
+    "diagnóstico de hemoparásitos",
     "informes veterinarios",
-    "portal veterinario",
     "estudios veterinarios",
-    "gestión clínica veterinaria",
-    "logística veterinaria",
-    "VETNEB",
     "diagnóstico veterinario",
     "resultados veterinarios online",
+    "VETNEB",
   ],
   authors: [{ name: "VETNEB" }],
   creator: "VETNEB",
@@ -60,7 +71,7 @@ export const baseMetadata: Metadata = {
         url: `${SITE_URL}/og-image.png`,
         width: 1200,
         height: 630,
-        alt: "Portal VETNEB — Laboratorio Veterinario Digital",
+        alt: "Portal VETNEB — Laboratorio patológico veterinario, histopatología, citología y hematología",
       },
     ],
   },
@@ -109,7 +120,7 @@ export function getOrganizationJsonLd() {
     "@type": "MedicalOrganization",
     name: "VETNEB",
     description:
-      "Laboratorio veterinario digital especializado en diagnóstico, informes médicos y gestión operativa para clínicas veterinarias.",
+      "Laboratorio patológico veterinario especializado en histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos e informes diagnósticos para clínicas veterinarias.",
     url: SITE_URL,
     logo: `${SITE_URL}/logo.png`,
     contactPoint: {
@@ -122,6 +133,17 @@ export function getOrganizationJsonLd() {
       name: "Argentina",
     },
     medicalSpecialty: "Veterinary",
+    knowsAbout: [
+      "laboratorio patológico veterinario",
+      "servicio patológico veterinario",
+      "histopatología veterinaria",
+      "citología veterinaria",
+      "citopatología veterinaria",
+      "hematología veterinaria",
+      "diagnóstico hematológico veterinario",
+      "hemoparásitos veterinarios",
+      "anatomía patológica veterinaria",
+    ],
   };
 }
 
@@ -131,14 +153,52 @@ export function getServicesJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "Service",
-    serviceType: "Laboratorio Veterinario",
+    serviceType: "Laboratorio patológico veterinario",
     provider: {
       "@type": "MedicalOrganization",
       name: "VETNEB",
       url: SITE_URL,
     },
     description:
-      "Servicios de diagnóstico veterinario: hemogramas, bioquímicas, estudios de imagen, gestión digital de informes y logística operativa.",
+      "Servicios patológicos veterinarios: histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos, informes diagnósticos digitales y trazabilidad clínica.",
     areaServed: "Argentina",
+    hasOfferCatalog: {
+      "@type": "OfferCatalog",
+      name: "Servicios de laboratorio patológico veterinario",
+      itemListElement: [
+        {
+          "@type": "Offer",
+          itemOffered: {
+            "@type": "Service",
+            name: "Histopatología veterinaria",
+            serviceType: "Servicio histopatológico veterinario",
+          },
+        },
+        {
+          "@type": "Offer",
+          itemOffered: {
+            "@type": "Service",
+            name: "Citología y citopatología veterinaria",
+            serviceType: "Servicio citopatológico veterinario",
+          },
+        },
+        {
+          "@type": "Offer",
+          itemOffered: {
+            "@type": "Service",
+            name: "Hematología veterinaria",
+            serviceType: "Servicio hematológico veterinario",
+          },
+        },
+        {
+          "@type": "Offer",
+          itemOffered: {
+            "@type": "Service",
+            name: "Diagnóstico de hemoparásitos",
+            serviceType: "Hemoparásitos veterinarios",
+          },
+        },
+      ],
+    },
   };
 }

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -18,7 +18,7 @@ test("home page defines public metadata and organization JSON-LD", () => {
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { createPageMetadata, getOrganizationJsonLd, SITE_URL } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Portal VETNEB — Laboratorio Veterinario Digital"'));
+  assert.ok(source.includes('"Portal VETNEB — Laboratorio Patológico Veterinario"'));
   assert.ok(source.includes('"/"'));
   assert.ok(source.includes("const jsonLd = getOrganizationJsonLd();"));
   assert.ok(source.includes('type="application/ld+json"'));
@@ -30,9 +30,15 @@ test("home page exposes accessible hero and primary CTAs", () => {
 
   assert.ok(source.includes('aria-labelledby="hero-heading"'));
   assert.ok(source.includes('id="hero-heading"'));
-  assert.ok(source.includes("Gestión digital de"));
+  assert.ok(source.includes("Diagnóstico patológico de"));
   assert.ok(source.includes("laboratorio veterinario"));
   assert.ok(source.includes("Portal centralizado para clínicas y profesionales veterinarios."));
+  assert.ok(source.includes("histopatología"));
+  assert.ok(source.includes("citología"));
+  assert.ok(source.includes("citopatología"));
+  assert.ok(source.includes("hematología"));
+  assert.ok(source.includes("diagnóstico hematológico"));
+  assert.ok(source.includes("hemoparásitos"));
   assert.ok(source.includes('href={ROUTES.login}'));
   assert.ok(source.includes("Acceder al portal"));
   assert.ok(source.includes('href={ROUTES.contacto}'));
@@ -44,7 +50,7 @@ test("home page lists core laboratory services and services route CTA", () => {
 
   assert.ok(source.includes('aria-labelledby="services-heading"'));
   assert.ok(source.includes('id="services-heading"'));
-  assert.ok(source.includes("Servicios del laboratorio"));
+  assert.ok(source.includes("Servicios del laboratorio patológico veterinario"));
   assert.ok(source.includes("Informes Médicos"));
   assert.ok(source.includes("Estudios Veterinarios"));
   assert.ok(source.includes("Gestión Digital"));

--- a/test/frontend-public-page-metadata.test.ts
+++ b/test/frontend-public-page-metadata.test.ts
@@ -20,7 +20,7 @@ test("servicios public page defines SEO metadata and services JSON-LD", () => {
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Servicios de Laboratorio Veterinario"'));
+  assert.ok(source.includes('"Laboratorio Patológico Veterinario: Histopatología, Citología y Hematología"'));
   assert.ok(source.includes('"/servicios"'));
   assert.ok(source.includes("const jsonLd = getServicesJsonLd();"));
   assert.ok(source.includes('type="application/ld+json"'));

--- a/test/frontend-seo-metadata.test.ts
+++ b/test/frontend-seo-metadata.test.ts
@@ -65,6 +65,16 @@ test("frontend SEO helpers create page metadata and organization JSON-LD", () =>
   assert.ok(source.includes('"@context": "https://schema.org"'));
   assert.ok(source.includes('"@type": "MedicalOrganization"'));
   assert.ok(source.includes('medicalSpecialty: "Veterinary"'));
+  assert.ok(source.includes('"laboratorio patológico veterinario"'));
+  assert.ok(source.includes('"servicio patológico veterinario"'));
+  assert.ok(source.includes('"histopatología veterinaria"'));
+  assert.ok(source.includes('"citología veterinaria"'));
+  assert.ok(source.includes('"citopatología veterinaria"'));
+  assert.ok(source.includes('"hematología veterinaria"'));
+  assert.ok(source.includes('"diagnóstico hematológico veterinario"'));
+  assert.ok(source.includes('"hemoparásitos veterinarios"'));
+  assert.ok(source.includes("knowsAbout: ["));
+  assert.ok(source.includes("hasOfferCatalog: {"));
 });
 
 test("frontend robots allows public pages and blocks private/API surfaces", () => {

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -21,7 +21,7 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
   assert.ok(source.includes('import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Servicios de Laboratorio Veterinario"'));
+  assert.ok(source.includes('"Laboratorio Patológico Veterinario: Histopatología, Citología y Hematología"'));
   assert.ok(source.includes('"/servicios"'));
   assert.ok(source.includes("const jsonLd = getServicesJsonLd();"));
   assert.ok(source.includes('type="application/ld+json"'));
@@ -31,9 +31,9 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
 test("servicios page exposes hero content", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Servicios del laboratorio"));
-  assert.ok(source.includes("Soluciones digitales completas para la gestión de diagnóstico"));
-  assert.ok(source.includes("veterinario. Desde el estudio hasta la entrega del informe."));
+  assert.ok(source.includes("Servicios del laboratorio patológico veterinario"));
+  assert.ok(source.includes("Servicio patológico veterinario para clínicas y profesionales:"));
+  assert.ok(source.includes("histopatología, citología, citopatología, hematología, diagnóstico"));
 });
 
 test("servicios page lists laboratory service categories", () => {
@@ -41,7 +41,7 @@ test("servicios page lists laboratory service categories", () => {
 
   assert.ok(source.includes("const serviceCategories = ["));
   assert.ok(source.includes("Informes Médicos Veterinarios"));
-  assert.ok(source.includes("Estudios Veterinarios"));
+  assert.ok(source.includes("Patología, Histopatología y Citopatología Veterinaria"));
   assert.ok(source.includes("Gestión Digital de Clínicas"));
   assert.ok(source.includes("Logística Operativa"));
   assert.ok(source.includes("serviceCategories.map((service) =>"));
@@ -51,7 +51,10 @@ test("servicios page keeps detailed service feature bullets", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes("Carga y procesamiento de estudios"));
-  assert.ok(source.includes("Hemograma completo y diferencial"));
+  assert.ok(source.includes("Histopatología veterinaria y anatomía patológica"));
+  assert.ok(source.includes("Citología veterinaria y citopatología diagnóstica"));
+  assert.ok(source.includes("Hematología veterinaria y diagnóstico hematológico"));
+  assert.ok(source.includes("Búsqueda y reporte de hemoparásitos veterinarios"));
   assert.ok(source.includes("Dashboard privado por clínica"));
   assert.ok(source.includes("Planificación de rutas de entrega"));
   assert.ok(source.includes("Métricas de cumplimiento y SLA"));
@@ -65,7 +68,14 @@ test("servicios page exposes conversion CTAs and SEO copy", () => {
   assert.ok(source.includes("Solicitar información"));
   assert.ok(source.includes('href={ROUTES.clinicas}'));
   assert.ok(source.includes("Ver solución para clínicas"));
-  assert.ok(source.includes("Laboratorio veterinario digital en Argentina"));
+  assert.ok(source.includes("Laboratorio patológico veterinario en Argentina"));
+  assert.ok(source.includes("Servicio patológico, histopatológico, citológico y hematológico veterinario"));
+  assert.ok(source.includes("histopatología veterinaria"));
+  assert.ok(source.includes("citología veterinaria"));
+  assert.ok(source.includes("citopatología"));
+  assert.ok(source.includes("hematología"));
+  assert.ok(source.includes("diagnóstico hematológico"));
+  assert.ok(source.includes("hemoparásitos"));
 });
 
 test("servicios page remains public and avoids direct backend/API calls", () => {


### PR DESCRIPTION
## Summary
- Strengthen public SEO around veterinary pathology services.
- Rework base metadata, keywords, Open Graph alt text, organization JSON-LD, and services JSON-LD toward laboratorio patológico veterinario, servicio patológico veterinario, histopatología, citología, citopatología, hematología, diagnóstico hematológico, and hemoparásitos.
- Update home and services copy to build stronger topical authority around pathology, histopathology, cytology/cytopathology, hematology, and hemoparasite diagnostics.
- Update frontend SEO/home guardrails for the new senior SEO contract.

## Security
- Public SEO/content change only.
- No authentication, authorization, session, cookie, backend, API, or dashboard changes.
- No private route indexing changes.

## Validation
- pnpm test -- .\test\frontend-seo-metadata.test.ts .\test\frontend-home-page-content.test.ts .\test\frontend-servicios-page-content.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
