### PR TITLE
test(frontend): add visual consistency guardrail

### DIFF
--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+const SERVICIOS_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
+const LOGIN_CONTENT_PATH = "frontend/src/components/public/LoginContent.tsx";
+const DASHBOARD_SIDEBAR_PATH = "frontend/src/components/dashboard/DashboardSidebar.tsx";
+const DASHBOARD_TOPBAR_PATH = "frontend/src/components/dashboard/DashboardTopbar.tsx";
+const DASHBOARD_HOME_PATH = "frontend/src/app/dashboard/page.tsx";
+const DASHBOARD_ADMIN_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertContainsAll(
+  source: string,
+  expected: readonly string[],
+  context: string,
+): void {
+  for (const marker of expected) {
+    assert.ok(source.includes(marker), `${context} must contain: ${marker}`);
+  }
+}
+
+function assertMatchesAll(
+  source: string,
+  patterns: readonly RegExp[],
+  context: string,
+): void {
+  for (const pattern of patterns) {
+    assert.match(source, pattern, `${context} must match ${pattern}`);
+  }
+}
+
+function assertInlineStylesAtMost(
+  source: string,
+  maxAllowed: number,
+  context: string,
+): void {
+  const count = (source.match(/\bstyle=\{\{/g) ?? []).length;
+  assert.ok(
+    count <= maxAllowed,
+    `${context} must keep inline styles <= ${maxAllowed}, received ${count}`,
+  );
+}
+
+function assertNoClientFetchOrApiLiterals(source: string, context: string): void {
+  assert.equal(source.includes("fetch("), false, `${context} must not use fetch()`);
+  assert.equal(
+    source.includes('"/api') || source.includes("'/api"),
+    false,
+    `${context} must not embed /api literals`,
+  );
+}
+
+test("globals css keeps visual tokens and shared frontend surface utilities", () => {
+  const source = read(GLOBALS_CSS_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      '@import "tailwindcss";',
+      '--primary: 210 80% 35%;',
+      "--ring: 210 80% 35%;",
+      "--sidebar-background: 222 47% 11%;",
+      "--sidebar-foreground: 210 40% 96%;",
+      "--sidebar-accent: 217 33% 17%;",
+      "--sidebar-ring: 210 80% 55%;",
+      ".dashboard-main",
+      ".surface-note-info",
+      ".surface-empty",
+      ".surface-soft",
+      ".field-label",
+      ".field-select",
+      ".field-textarea",
+    ],
+    "globals.css visual consistency",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /\.dashboard-main\s*\{[\s\S]*@apply[\s\S]*space-y-6[\s\S]*sm:px-6[\s\S]*lg:px-8[\s\S]*\}/,
+      /\.surface-note-info\s*\{[\s\S]*@apply[\s\S]*rounded-xl[\s\S]*border-blue-200[\s\S]*bg-blue-50[\s\S]*\}/,
+      /\.surface-empty\s*\{[\s\S]*@apply[\s\S]*border-dashed[\s\S]*bg-gray-50[\s\S]*\}/,
+      /\.field-select\s*\{[\s\S]*@apply[\s\S]*h-11[\s\S]*rounded-lg[\s\S]*focus-visible:ring-2[\s\S]*\}/,
+    ],
+    "globals.css utility contracts",
+  );
+});
+
+test("public home page keeps polished visual hierarchy and responsive sections", () => {
+  const source = read(HOME_PAGE_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      "<PublicLayout>",
+      'aria-labelledby="hero-heading"',
+      'aria-labelledby="services-heading"',
+      'aria-labelledby="benefits-heading"',
+      'aria-labelledby="cta-heading"',
+      "services.map((service) =>",
+      "benefits.map((benefit) =>",
+      "transition-shadow hover:shadow-md",
+    ],
+    "home page visual hierarchy",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="relative overflow-hidden bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white"/,
+      /className="container mx-auto px-4 py-16 sm:px-6 md:py-20 lg:px-8 lg:py-24"/,
+      /className="mb-6 text-4xl font-bold leading-tight sm:text-5xl lg:text-6xl"/,
+      /className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"/,
+      /className="bg-primary py-16 text-white md:py-20"/,
+      /className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4"/,
+    ],
+    "home page class contracts",
+  );
+
+  assertInlineStylesAtMost(source, 1, "home page");
+});
+
+test("servicios page keeps professional section/card structure and responsive layout", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      "<PublicLayout>",
+      "const serviceCategories = [",
+      "serviceCategories.map((service) =>",
+      "service.features.map((feature) =>",
+      "transition-shadow hover:shadow-md",
+    ],
+    "servicios visual structure",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="bg-gradient-to-br from-blue-900 to-blue-700 py-16 text-white md:py-20"/,
+      /className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"/,
+      /className="h-full border-gray-100 transition-shadow hover:shadow-md"/,
+      /className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center"/,
+      /className="flex flex-col justify-center gap-3 sm:flex-row"/,
+      /className="bg-gray-50 py-16"/,
+    ],
+    "servicios class contracts",
+  );
+
+  assertInlineStylesAtMost(source, 0, "servicios page");
+  assert.equal(source.includes("fetch("), false, "servicios page must avoid fetch()");
+});
+
+test("login content keeps polished auth card layout and stable visual states", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      '"use client";',
+      'className="w-full max-w-md"',
+      "className=\"field-label\"",
+      'className="space-y-4"',
+      'className="w-full"',
+      'role="alert"',
+    ],
+    "login content layout contracts",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="min-h-screen bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800 flex items-center justify-center p-4"/,
+      /className="border border-white\/80 bg-white\/95 shadow-2xl backdrop-blur"/,
+      /className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"/,
+      /className="text-primary hover:underline font-medium"/,
+      /className="hover:text-white transition-colors"/,
+    ],
+    "login content visual details",
+  );
+
+  assertInlineStylesAtMost(source, 0, "login content");
+  assertNoClientFetchOrApiLiterals(source, "login content");
+});
+
+test("dashboard sidebar keeps shell consistency and responsive navigation classes", () => {
+  const source = read(DASHBOARD_SIDEBAR_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      '"use client";',
+      "const navItems = [",
+      'aria-label="Navegación del dashboard"',
+      'aria-label="Menú principal"',
+      "item.children && isActive(item.href)",
+      "item.children.map((child) =>",
+    ],
+    "dashboard sidebar structure",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="flex min-h-screen w-\[4\.5rem\] shrink-0 flex-col bg-sidebar text-sidebar-foreground sm:w-64"/,
+      /className="flex items-center justify-center gap-3 border-b border-sidebar-border px-2 py-5 sm:justify-start sm:px-6"/,
+      /className="flex-1 space-y-1 px-2 py-4 sm:px-3"/,
+      /"flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors sm:justify-start sm:px-3"/,
+      /className="ml-6 mt-1 hidden space-y-1 sm:block"/,
+      /"flex items-center gap-2 px-3 py-1\.5 rounded-md text-xs font-medium transition-colors"/,
+      /className="border-t border-sidebar-border px-2 py-4 sm:px-3"/,
+    ],
+    "dashboard sidebar classes",
+  );
+
+  assertInlineStylesAtMost(source, 0, "dashboard sidebar");
+  assertNoClientFetchOrApiLiterals(source, "dashboard sidebar");
+});
+
+test("dashboard topbar keeps sticky hierarchy and compact responsive shell", () => {
+  const source = read(DASHBOARD_TOPBAR_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      "interface DashboardTopbarProps",
+      "title: string;",
+      "subtitle?: string;",
+      "{subtitle && (",
+      "Clínica Demo",
+      "<Button asChild variant=\"outline\" size=\"sm\">",
+    ],
+    "dashboard topbar hierarchy",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="sticky top-0 z-40 flex min-h-16 items-center justify-between border-b bg-white\/95 px-4 py-2 shadow-sm backdrop-blur supports-\[backdrop-filter\]:bg-white\/80 sm:px-6"/,
+      /className="truncate text-lg font-semibold text-gray-900 sm:text-xl"/,
+      /className="truncate text-xs text-gray-500 sm:text-sm"/,
+      /className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3"/,
+      /className="flex h-8 w-8 items-center justify-center rounded-full bg-primary\/10 text-xs font-semibold text-primary"/,
+    ],
+    "dashboard topbar class contracts",
+  );
+
+  assertInlineStylesAtMost(source, 0, "dashboard topbar");
+  assertNoClientFetchOrApiLiterals(source, "dashboard topbar");
+});
+
+test("dashboard home keeps visual dashboard states and card spacing conventions", () => {
+  const source = read(DASHBOARD_HOME_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      '<main className="dashboard-main">',
+      '<div className="surface-note-info">',
+      "<StatsCards stats={stats} />",
+      'className="surface-empty"',
+      "recentReports.map((report) =>",
+      "recentVisits.map((visit) =>",
+      "Accesos rápidos",
+    ],
+    "dashboard home shell",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="grid grid-cols-1 gap-6 lg:grid-cols-2"/,
+      /className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0"/,
+      /className="grid grid-cols-2 gap-3 md:grid-cols-4"/,
+      /className="h-16 flex-col gap-1 rounded-xl"/,
+      /className="text-sm font-medium text-gray-900 truncate"/,
+      /className="text-xs text-gray-400"/,
+    ],
+    "dashboard home visual patterns",
+  );
+
+  assertInlineStylesAtMost(source, 0, "dashboard home");
+  assert.equal(source.includes("fetch("), false, "dashboard home must avoid fetch()");
+});
+
+test("dashboard admin keeps dense professional layout and visual state surfaces", () => {
+  const source = read(DASHBOARD_ADMIN_PATH);
+
+  assertContainsAll(
+    source,
+    [
+      '<main className="dashboard-main">',
+      '<div className="surface-note-info">',
+      "<AdminMaintenanceDryRunCard />",
+      "<AdminSessionsReadOnlyCard />",
+      "<AdminFailedLoginAlertsReadOnlyCard />",
+      "<AdminUsersRolesReadOnlyCard />",
+      'id="audit-log"',
+      'id="audit-role-changes"',
+      "getSystemStatusIndicatorClass(",
+    ],
+    "dashboard admin structure",
+  );
+
+  assertMatchesAll(
+    source,
+    [
+      /className="grid grid-cols-1 md:grid-cols-3 gap-4"/,
+      /className="border-gray-100"/,
+      /className="grid grid-cols-1 md:grid-cols-5 gap-3"/,
+      /className="surface-soft"/,
+      /className="grid grid-cols-1 gap-3 md:grid-cols-3"/,
+      /className="flex items-center gap-2 rounded-lg border border-gray-100 bg-gray-50 px-3 py-2"/,
+      /className="mx-6 mt-4 flex flex-col gap-2 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-700 md:flex-row md:items-center md:justify-between"/,
+      /className="max-w-md whitespace-normal break-words text-xs text-gray-500"/,
+    ],
+    "dashboard admin visual contracts",
+  );
+
+  assertInlineStylesAtMost(source, 0, "dashboard admin");
+  assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
+});


### PR DESCRIPTION
## Summary
- Add a frontend visual consistency guardrail test.
- Verify static visual contracts introduced by the recent frontend polish.
- Keep the change test-only with a single new test file.

## Security
- Test-only change.
- No runtime behavior changes.
- No backend, authentication, authorization, session, cookie, database, API, or protected-route logic changes.
- No dependency changes.

## Validation
- `pnpm test -- .\test\frontend-visual-consistency.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test` — 1329 pass, 0 fail
- `pnpm build`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`

## Notes
- Diff is limited to `test/frontend-visual-consistency.test.ts`.