### PR TITLE
feat(frontend): align public copy with Google Sites

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,54 +8,54 @@ import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
   "Portal VETNEB — Laboratorio Patológico Veterinario",
-  "Laboratorio patológico veterinario para clínicas y profesionales: histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos e informes digitales.",
+  "La anatomía patológica veterinaria estudia los motivos, el desarrollo y las consecuencias de distintas enfermedades mediante el análisis de tejidos, órganos y muestras celulares. VETNEB integra histopatología, citología, citopatología, hematología, diagnóstico hematológico y hemoparásitos.",
   "/",
 );
 
 const services = [
   {
     icon: "📋",
-    title: "Informes Médicos",
+    title: "Estudio Anatomopatológico",
     description:
-      "Acceso digital seguro a resultados de estudios veterinarios. Descarga, seguimiento y gestión de informes en tiempo real.",
+      "Estudio anatomopatológico de todo tipo de tejidos para caracterizar lesiones y aportar precisión diagnóstica en medicina veterinaria.",
   },
   {
     icon: "🔬",
-    title: "Estudios Veterinarios",
+    title: "Estudio Citológico",
     description:
-      "Hemogramas, bioquímicas, uroanálisis, estudios de imagen y más. Resultados precisos con trazabilidad completa.",
+      "Estudio citológico de muestras, líquidos y punciones para evaluar alteraciones celulares con criterio clínico-patológico.",
   },
   {
     icon: "🏥",
-    title: "Gestión Digital",
+    title: "Tinciones Especiales",
     description:
-      "Portal centralizado para clínicas. Administración de pacientes, historial de estudios y comunicación directa con el laboratorio.",
+      "Estudios aplicados con tinciones especiales para ampliar hallazgos histológicos y reforzar diagnósticos diferenciales.",
   },
   {
     icon: "🚐",
-    title: "Logística Operativa",
+    title: "Diagnóstico Integral",
     description:
-      "Planificación de rutas, visitas de campo y seguimiento en tiempo real. Optimización de la cadena de entrega de resultados.",
+      "Integración de datos clínicos con evaluación histológica y citológica para orientar decisiones diagnósticas y terapéuticas.",
   },
 ];
 
 const benefits = [
   {
-    title: "Para clínicas veterinarias",
+    title: "Diagnóstico integral",
     items: [
-      "Acceso inmediato a resultados de estudios",
-      "Historial completo de pacientes",
-      "Notificaciones de estado en tiempo real",
-      "Descarga segura de informes en PDF",
+      "Integramos hallazgos de tejidos y células con la información clínica de cada caso",
+      "Articulamos el análisis con equipos de diagnóstico por imágenes y áreas quirúrgicas",
+      "Priorizamos un diagnóstico específico para cada paciente veterinario",
+      "Acompañamos la toma de decisiones terapéuticas con criterios anatomopatológicos",
     ],
   },
   {
-    title: "Para profesionales",
+    title: "Para tener en cuenta",
     items: [
-      "Plataforma centralizada de gestión",
-      "Seguimiento de casos clínicos",
-      "Comunicación directa con el laboratorio",
-      "Acceso desde cualquier dispositivo",
+      "Los tiempos pueden variar según la complejidad diagnóstica de cada muestra",
+      "El análisis no es automatizado: requiere evaluación microscópica especializada",
+      "En algunos casos se requieren tinciones especiales o interconsultas profesionales",
+      "Seguimos trabajando en mejorar los tiempos de recepción, diagnóstico y entrega",
     ],
   },
 ];
@@ -79,19 +79,20 @@ export default function HomePage() {
           <div className="max-w-3xl">
             <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-blue-700/50 px-4 py-1.5 text-sm font-medium text-blue-100">
               <span className="h-2 w-2 rounded-full bg-green-400 animate-pulse" />
-              Laboratorio patológico veterinario
+              Servicio patológico veterinario
             </div>
             <h1
               id="hero-heading"
               className="mb-6 text-4xl font-bold leading-tight sm:text-5xl lg:text-6xl"
             >
-              Diagnóstico patológico de
-              <span className="text-blue-300"> laboratorio veterinario</span>
+              Diagnóstico anatomopatológico
+              <span className="text-blue-300"> veterinario integral</span>
             </h1>
             <p className="mb-8 max-w-2xl text-lg leading-relaxed text-blue-100 md:text-xl">
-              Portal centralizado para clínicas y profesionales veterinarios.
-              Acceda a informes, estudios y logística operativa desde un único
-              lugar seguro y confiable.
+              La anatomía patológica veterinaria estudia los motivos, el
+              desarrollo y las consecuencias de distintas enfermedades a partir
+              del análisis de tejidos, órganos y muestras celulares. Consultá
+              los resultados de tus informes las 24 hs desde el portal.
             </p>
             <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
               <Button
@@ -133,8 +134,8 @@ export default function HomePage() {
               Servicios del laboratorio patológico veterinario
             </h2>
             <p className="text-lg text-gray-500 max-w-2xl mx-auto">
-              Una plataforma completa para la gestión de diagnóstico veterinario
-              y operaciones de laboratorio.
+              Cobertura diagnóstica orientada a estudio anatomopatológico,
+              citología, tinciones especiales e integración clínico-patológica.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
@@ -176,11 +177,12 @@ export default function HomePage() {
               id="benefits-heading"
               className="text-3xl md:text-4xl font-bold text-gray-900 mb-4"
             >
-              Diseñado para el sector veterinario
+              Trabajo interdisciplinario y criterio diagnóstico
             </h2>
             <p className="text-lg text-gray-500 max-w-2xl mx-auto">
-              Herramientas específicas para clínicas y profesionales que
-              necesitan eficiencia y confiabilidad.
+              Colaboramos de forma permanente con equipos clínicos para evaluar
+              lesiones, integrar contexto médico y definir conductas de
+              tratamiento.
             </p>
           </div>
           <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
@@ -220,11 +222,12 @@ export default function HomePage() {
             id="cta-heading"
             className="text-3xl md:text-4xl font-bold mb-4"
           >
-            ¿Listo para digitalizar su laboratorio?
+            Seguimos trabajando en mejorar
           </h2>
           <p className="mx-auto mb-8 max-w-xl text-lg text-blue-100">
-            Únase a las clínicas y profesionales que ya gestionan sus estudios
-            veterinarios de forma digital con Portal VETNEB.
+            Agilizamos la recepción y entrega de informes, fortalecemos la
+            comunicación con clínicas y profesionales, y sostenemos un servicio
+            guiado por compromiso, responsabilidad y trabajo constante.
           </p>
           <div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
             <Button

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -7,85 +7,85 @@ import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
-  "Laboratorio Patológico Veterinario: Histopatología, Citología y Hematología",
-  "Servicio patológico veterinario especializado en histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos e informes digitales.",
+  "Servicio Patológico Veterinario: Histopatología, Citología y Hematología",
+  "La anatomía patológica veterinaria integra estudio anatomopatológico, citológico y tinciones especiales para un diagnóstico integral con criterio clínico-patológico.",
   "/servicios",
 );
 
 const serviceCategories = [
   {
-    id: "patologia",
-    title: "Patología, Histopatología y Citopatología Veterinaria",
+    id: "anatomopatologia",
+    title: "Estudio anatomopatológico de tejidos",
     icon: "🔬",
     description:
-      "Servicio patológico veterinario para diagnóstico tisular, celular y hematológico con trazabilidad completa del caso clínico.",
+      "Evaluación de tejidos y órganos para estudiar motivos, desarrollo y consecuencias de enfermedades en pacientes veterinarios.",
     features: [
-      "Histopatología veterinaria y anatomía patológica",
-      "Citología veterinaria y citopatología diagnóstica",
-      "Hematología veterinaria y diagnóstico hematológico",
-      "Búsqueda y reporte de hemoparásitos veterinarios",
-      "Correlación clínico-patológica para profesionales",
-      "Informes diagnósticos digitales con trazabilidad",
+      "Recepción y procesamiento de muestras de tejidos",
+      "Evaluación microscópica de lesiones histológicas",
+      "Correlación anatomopatológica del caso clínico",
+      "Informe diagnóstico con hallazgos relevantes",
+      "Apoyo para decisiones terapéuticas",
+      "Seguimiento del caso con el equipo tratante",
+    ],
+  },
+  {
+    id: "citologia",
+    title: "Estudio citológico de muestras",
+    icon: "🧪",
+    description:
+      "Análisis citológico de líquidos y punciones para valorar alteraciones celulares con un enfoque clínico-patológico.",
+    features: [
+      "Estudio citológico de líquidos y punciones",
+      "Valoración celular orientada a diagnóstico",
+      "Identificación de patrones inflamatorios y proliferativos",
+      "Apoyo diagnóstico en lesiones de tejidos blandos",
+      "Integración con antecedentes clínicos del paciente",
+      "Informe citológico con conclusión profesional",
+    ],
+  },
+  {
+    id: "tinciones",
+    title: "Tinciones especiales aplicadas",
+    icon: "🧬",
+    description:
+      "Aplicación de tinciones especiales para ampliar hallazgos histológicos y reforzar diagnósticos diferenciales.",
+    features: [
+      "Selección de técnicas según complejidad del caso",
+      "Caracterización adicional de lesiones tisulares",
+      "Soporte para diagnósticos diferenciales",
+      "Complemento de histopatología y citopatología",
+      "Mayor precisión frente a hallazgos complejos",
+      "Registro diagnóstico trazable",
+    ],
+  },
+  {
+    id: "integral",
+    title: "Diagnóstico integral interdisciplinario",
+    icon: "📋",
+    description:
+      "Integración del análisis histológico y citológico con información clínica para construir un diagnóstico específico por paciente.",
+    features: [
+      "Integración de análisis histológico y citológico",
+      "Trabajo conjunto con diagnóstico por imágenes",
+      "Articulación con cirugía y clínica veterinaria",
+      "Interconsulta profesional cuando el caso lo requiere",
+      "Definición diagnóstica específica por paciente",
+      "Orientación para tratamiento personalizado",
     ],
   },
   {
     id: "informes",
-    title: "Informes Médicos Veterinarios",
-    icon: "📋",
+    title: "Informes y seguimiento",
+    icon: "🖥️",
     description:
-      "Gestión completa del ciclo de vida de informes médicos veterinarios. Desde la carga hasta la entrega digital segura a la clínica.",
+      "Entrega y seguimiento de informes con comunicación continua para clínicas y profesionales durante todo el proceso diagnóstico.",
     features: [
-      "Carga y procesamiento de estudios",
-      "Estados en tiempo real: subido, procesando, listo, entregado",
-      "Descarga segura con URLs firmadas y con vencimiento",
-      "Historial completo por paciente y clínica",
-      "Búsqueda y filtrado avanzado",
-      "Notificaciones de cambio de estado",
-    ],
-  },
-  {
-    id: "estudios",
-    title: "Estudios Veterinarios",
-    icon: "🔬",
-    description:
-      "Procesamiento y gestión de una amplia gama de estudios diagnósticos veterinarios con trazabilidad completa.",
-    features: [
-      "Hemograma completo y diferencial",
-      "Bioquímica sérica y hepática",
-      "Uroanálisis y sedimento urinario",
-      "Estudios de imagen (radiografía, ecografía)",
-      "Citologías y anatomía patológica",
-      "Seguimiento de casos clínicos",
-    ],
-  },
-  {
-    id: "gestion",
-    title: "Gestión Digital de Clínicas",
-    icon: "🏥",
-    description:
-      "Portal centralizado para que las clínicas veterinarias administren su relación con el laboratorio de forma eficiente.",
-    features: [
-      "Dashboard privado por clínica",
-      "Gestión de usuarios y roles",
-      "Acceso a informes con tokens seguros",
-      "Auditoría de accesos y acciones",
-      "Perfil público de la clínica",
-      "Integración con flujos de trabajo existentes",
-    ],
-  },
-  {
-    id: "logistica",
-    title: "Logística Operativa",
-    icon: "🚐",
-    description:
-      "Sistema de planificación y seguimiento de visitas de campo y rutas de entrega para optimizar las operaciones del laboratorio.",
-    features: [
-      "Planificación de rutas de entrega",
-      "Seguimiento de visitas de campo",
-      "Eventos de ruta en tiempo real",
-      "Métricas de cumplimiento y SLA",
-      "Optimización heurística de recorridos",
-      "Reportes operativos",
+      "Consulta de resultados de informes las 24 hs",
+      "Seguimiento del estado del estudio en portal",
+      "Comunicación directa para coordinación de muestras",
+      "Priorización según complejidad diagnóstica",
+      "Tiempos variables según necesidad del caso",
+      "Entrega final con criterio profesional y responsable",
     ],
   },
 ];
@@ -104,12 +104,12 @@ export default function ServiciosPage() {
       <section className="bg-gradient-to-br from-blue-900 to-blue-700 py-16 text-white md:py-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="mb-4 text-4xl font-bold leading-tight md:text-5xl">
-            Servicios del laboratorio patológico veterinario
+            Servicio patológico veterinario
           </h1>
           <p className="max-w-2xl text-lg leading-relaxed text-blue-100 md:text-xl">
-            Servicio patológico veterinario para clínicas y profesionales:
-            histopatología, citología, citopatología, hematología, diagnóstico
-            hematológico, hemoparásitos e informes digitales.
+            La anatomía patológica veterinaria estudia los motivos, el
+            desarrollo y las consecuencias de distintas enfermedades mediante el
+            análisis de tejidos, órganos y muestras celulares.
           </p>
         </div>
       </section>
@@ -158,12 +158,12 @@ export default function ServiciosPage() {
       <section className="bg-blue-50 py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            ¿Necesitás digitalizar la gestión de estudios?
+            Seguimos trabajando en mejorar
           </h2>
           <p className="text-gray-600 leading-relaxed mb-8">
-            Solicitá acceso para tu clínica o contactanos para conocer cómo
-            Portal VETNEB puede acompañar el flujo completo de informes,
-            logística y trazabilidad.
+            Estamos enfocados en agilizar la recepción y entrega de informes, y
+            en fortalecer los medios de comunicación con clínicas y
+            profesionales para reducir tiempos de espera de resultados.
           </p>
           <div className="flex flex-col justify-center gap-3 sm:flex-row">
             <Button asChild size="lg" className="w-full sm:w-auto">
@@ -176,48 +176,43 @@ export default function ServiciosPage() {
         </div>
       </section>
 
-      {/* Autoridad patológica veterinaria */}
+      {/* Diagnóstico integral */}
       <section className="bg-white py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Servicio patológico, histopatológico, citológico y hematológico veterinario
+            Diagnóstico integral para medicina veterinaria
           </h2>
           <p className="text-gray-600 leading-relaxed mb-4">
-            VETNEB fortalece el diagnóstico veterinario con un servicio patológico
-            orientado a muestras tisulares, citológicas y hematológicas. El flujo
-            de trabajo acompaña estudios de histopatología veterinaria, citología
-            veterinaria, citopatología, hematología, diagnóstico hematológico y
-            búsqueda de hemoparásitos, con informes organizados para la toma de
-            decisiones clínicas.
+            El diagnóstico anatomopatológico veterinario requiere integrar no
+            sólo el análisis de tejido y citología, sino también el
+            conocimiento clínico global de cada paciente. Esta articulación
+            permite enriquecer la lectura diagnóstica junto con otras áreas de
+            práctica veterinaria.
           </p>
           <p className="text-gray-600 leading-relaxed">
-            El enfoque integra laboratorio patológico veterinario, trazabilidad
-            digital, correlación clínico-patológica e informes accesibles para
-            clínicas y profesionales. Esto permite ordenar casos dermatológicos,
-            oncológicos, infecciosos, inflamatorios y hematológicos bajo un
-            circuito diagnóstico claro y auditable.
+            Nuestro objetivo es colaborar de forma permanente con equipos
+            quirúrgicos y clínicos, estudiando tejidos extirpados y muestras de
+            punción para construir diagnósticos específicos y apoyar planes de
+            tratamiento personalizados.
           </p>
         </div>
       </section>
 
-      {/* Texto SEO adicional */}
+      {/* Para tener en cuenta */}
       <section className="bg-gray-50 py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Laboratorio patológico veterinario en Argentina
+            Para tener en cuenta
           </h2>
           <p className="text-gray-600 leading-relaxed mb-4">
-            Portal VETNEB es la plataforma digital de referencia para la gestión
-            de laboratorio veterinario en Argentina. Ofrecemos a clínicas y
-            profesionales veterinarios un sistema centralizado, seguro y
-            eficiente para el manejo de estudios diagnósticos, informes médicos
-            y logística operativa.
+            El estudio anatomopatológico requiere integrar datos clínicos con la
+            evaluación histológica y citológica realizada por el médico
+            veterinario patólogo en microscopía.
           </p>
           <p className="text-gray-600 leading-relaxed">
-            Nuestra plataforma está diseñada para reducir los tiempos de entrega
-            de resultados, mejorar la comunicación entre el laboratorio y las
-            clínicas, y garantizar la trazabilidad completa de cada estudio
-            desde su ingreso hasta su entrega final.
+            No se trata de un diagnóstico automatizado, por lo que los tiempos
+            son variables según complejidad. En ciertos casos se requiere
+            interconsulta profesional para alcanzar mayor precisión diagnóstica.
           </p>
         </div>
       </section>
@@ -225,18 +220,16 @@ export default function ServiciosPage() {
       <section className="bg-white py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Diagnóstico citológico veterinario integrado
+            Valores que guían el servicio
           </h2>
           <p className="text-gray-600 leading-relaxed">
-            La citología veterinaria complementa la histopatología veterinaria,
-            la citopatología, la hematología, el diagnóstico hematológico y la
-            búsqueda de hemoparásitos dentro del servicio patológico veterinario.
+            Basamos nuestro trabajo en compromiso, seriedad, respeto,
+            responsabilidad, confianza, diálogo, trabajo en equipo, empatía y
+            capacitación constante para sostener un servicio patológico
+            veterinario confiable.
           </p>
         </div>
       </section>
     </PublicLayout>
   );
 }
-
-
-

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -11,7 +11,7 @@ export const SITE_NAME = "Portal VETNEB";
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com";
 export const SITE_DESCRIPTION =
-  "Laboratorio patológico veterinario especializado en histopatología, citología, citopatología, hematología, diagnóstico hematológico y hemoparásitos. Servicio patológico veterinario con informes digitales para clínicas y profesionales.";
+  "La anatomía patológica veterinaria estudia los motivos, el desarrollo y las consecuencias de distintas enfermedades mediante el análisis de tejidos, órganos y muestras celulares. Servicio patológico veterinario con histopatología, citología, citopatología, hematología, diagnóstico hematológico y hemoparásitos.";
 export const SITE_LOCALE = "es_AR";
 
 // ─── Metadata base ────────────────────────────────────────────────────────────
@@ -120,7 +120,7 @@ export function getOrganizationJsonLd() {
     "@type": "MedicalOrganization",
     name: "VETNEB",
     description:
-      "Laboratorio patológico veterinario especializado en histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos e informes diagnósticos para clínicas veterinarias.",
+      "Laboratorio patológico veterinario orientado a diagnóstico integral mediante estudio anatomopatológico, citológico y tinciones especiales para clínicas y profesionales.",
     url: SITE_URL,
     logo: `${SITE_URL}/logo.png`,
     contactPoint: {
@@ -160,7 +160,7 @@ export function getServicesJsonLd() {
       url: SITE_URL,
     },
     description:
-      "Servicios patológicos veterinarios: histopatología, citología, citopatología, hematología, diagnóstico hematológico, hemoparásitos, informes diagnósticos digitales y trazabilidad clínica.",
+      "Servicios patológicos veterinarios para diagnóstico integral: estudio anatomopatológico de tejidos, citología de muestras, tinciones especiales, hematología y seguimiento de informes diagnósticos.",
     areaServed: "Argentina",
     hasOfferCatalog: {
       "@type": "OfferCatalog",

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -30,9 +30,10 @@ test("home page exposes accessible hero and primary CTAs", () => {
 
   assert.ok(source.includes('aria-labelledby="hero-heading"'));
   assert.ok(source.includes('id="hero-heading"'));
-  assert.ok(source.includes("Diagnóstico patológico de"));
-  assert.ok(source.includes("laboratorio veterinario"));
-  assert.ok(source.includes("Portal centralizado para clínicas y profesionales veterinarios."));
+  assert.ok(source.includes("Diagnóstico anatomopatológico"));
+  assert.ok(source.includes("veterinario integral"));
+  assert.ok(source.includes("La anatomía patológica veterinaria estudia los motivos"));
+  assert.ok(source.includes("resultados de tus informes las 24 hs"));
   assert.ok(source.includes("histopatología"));
   assert.ok(source.includes("citología"));
   assert.ok(source.includes("citopatología"));
@@ -51,10 +52,10 @@ test("home page lists core laboratory services and services route CTA", () => {
   assert.ok(source.includes('aria-labelledby="services-heading"'));
   assert.ok(source.includes('id="services-heading"'));
   assert.ok(source.includes("Servicios del laboratorio patológico veterinario"));
-  assert.ok(source.includes("Informes Médicos"));
-  assert.ok(source.includes("Estudios Veterinarios"));
-  assert.ok(source.includes("Gestión Digital"));
-  assert.ok(source.includes("Logística Operativa"));
+  assert.ok(source.includes("Estudio Anatomopatológico"));
+  assert.ok(source.includes("Estudio Citológico"));
+  assert.ok(source.includes("Tinciones Especiales"));
+  assert.ok(source.includes("Diagnóstico Integral"));
   assert.ok(source.includes('href={ROUTES.servicios}'));
   assert.ok(source.includes("Ver todos los servicios"));
 });
@@ -64,11 +65,11 @@ test("home page lists benefits for clinics and professionals", () => {
 
   assert.ok(source.includes('aria-labelledby="benefits-heading"'));
   assert.ok(source.includes('id="benefits-heading"'));
-  assert.ok(source.includes("Diseñado para el sector veterinario"));
-  assert.ok(source.includes("Para clínicas veterinarias"));
-  assert.ok(source.includes("Para profesionales"));
-  assert.ok(source.includes("Acceso inmediato a resultados de estudios"));
-  assert.ok(source.includes("Seguimiento de casos clínicos"));
+  assert.ok(source.includes("Trabajo interdisciplinario y criterio diagnóstico"));
+  assert.ok(source.includes("Diagnóstico integral"));
+  assert.ok(source.includes("Para tener en cuenta"));
+  assert.ok(source.includes("Articulamos el análisis con equipos de diagnóstico por imágenes"));
+  assert.ok(source.includes("El análisis no es automatizado: requiere evaluación microscópica especializada"));
 });
 
 test("home page exposes final conversion CTA without private route metadata", () => {
@@ -76,7 +77,7 @@ test("home page exposes final conversion CTA without private route metadata", ()
 
   assert.ok(source.includes('aria-labelledby="cta-heading"'));
   assert.ok(source.includes('id="cta-heading"'));
-  assert.ok(source.includes("¿Listo para digitalizar su laboratorio?"));
+  assert.ok(source.includes("Seguimos trabajando en mejorar"));
   assert.ok(source.includes("Iniciar sesión"));
   assert.ok(source.includes("Contactar"));
   assert.equal(source.includes('"/dashboard"'), false);

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -32,7 +32,7 @@ test("servicios public page exposes conversion CTAs", () => {
   assert.ok(source.includes('import Link from "next/link"'));
   assert.ok(source.includes('import { Button } from "@/components/ui/button"'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
-  assert.ok(source.includes("¿Necesitás digitalizar la gestión de estudios?"));
+  assert.ok(source.includes("Seguimos trabajando en mejorar"));
   assert.ok(source.includes("Solicitar información"));
   assert.ok(source.includes("Ver solución para clínicas"));
   assert.ok(source.includes("href={ROUTES.contacto}"));

--- a/test/frontend-public-page-metadata.test.ts
+++ b/test/frontend-public-page-metadata.test.ts
@@ -20,7 +20,7 @@ test("servicios public page defines SEO metadata and services JSON-LD", () => {
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Laboratorio Patológico Veterinario: Histopatología, Citología y Hematología"'));
+  assert.ok(source.includes('"Servicio Patológico Veterinario: Histopatología, Citología y Hematología"'));
   assert.ok(source.includes('"/servicios"'));
   assert.ok(source.includes("const jsonLd = getServicesJsonLd();"));
   assert.ok(source.includes('type="application/ld+json"'));

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -21,7 +21,7 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
   assert.ok(source.includes('import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Laboratorio Patológico Veterinario: Histopatología, Citología y Hematología"'));
+  assert.ok(source.includes('"Servicio Patológico Veterinario: Histopatología, Citología y Hematología"'));
   assert.ok(source.includes('"/servicios"'));
   assert.ok(source.includes("const jsonLd = getServicesJsonLd();"));
   assert.ok(source.includes('type="application/ld+json"'));
@@ -31,51 +31,46 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
 test("servicios page exposes hero content", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Servicios del laboratorio patológico veterinario"));
-  assert.ok(source.includes("Servicio patológico veterinario para clínicas y profesionales:"));
-  assert.ok(source.includes("histopatología, citología, citopatología, hematología, diagnóstico"));
+  assert.ok(source.includes("Servicio patológico veterinario"));
+  assert.ok(source.includes("La anatomía patológica veterinaria estudia los motivos"));
+  assert.ok(source.includes("desarrollo y las consecuencias de distintas enfermedades"));
 });
 
 test("servicios page lists laboratory service categories", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes("const serviceCategories = ["));
-  assert.ok(source.includes("Informes Médicos Veterinarios"));
-  assert.ok(source.includes("Patología, Histopatología y Citopatología Veterinaria"));
-  assert.ok(source.includes("Gestión Digital de Clínicas"));
-  assert.ok(source.includes("Logística Operativa"));
+  assert.ok(source.includes("Estudio anatomopatológico de tejidos"));
+  assert.ok(source.includes("Estudio citológico de muestras"));
+  assert.ok(source.includes("Tinciones especiales aplicadas"));
+  assert.ok(source.includes("Diagnóstico integral interdisciplinario"));
+  assert.ok(source.includes("Informes y seguimiento"));
   assert.ok(source.includes("serviceCategories.map((service) =>"));
 });
 
 test("servicios page keeps detailed service feature bullets", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Carga y procesamiento de estudios"));
-  assert.ok(source.includes("Histopatología veterinaria y anatomía patológica"));
-  assert.ok(source.includes("Citología veterinaria y citopatología diagnóstica"));
-  assert.ok(source.includes("Hematología veterinaria y diagnóstico hematológico"));
-  assert.ok(source.includes("Búsqueda y reporte de hemoparásitos veterinarios"));
-  assert.ok(source.includes("Dashboard privado por clínica"));
-  assert.ok(source.includes("Planificación de rutas de entrega"));
-  assert.ok(source.includes("Métricas de cumplimiento y SLA"));
+  assert.ok(source.includes("Recepción y procesamiento de muestras de tejidos"));
+  assert.ok(source.includes("Estudio citológico de líquidos y punciones"));
+  assert.ok(source.includes("Complemento de histopatología y citopatología"));
+  assert.ok(source.includes("Interconsulta profesional cuando el caso lo requiere"));
+  assert.ok(source.includes("Consulta de resultados de informes las 24 hs"));
+  assert.ok(source.includes("Priorización según complejidad diagnóstica"));
 });
 
 test("servicios page exposes conversion CTAs and SEO copy", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("¿Necesitás digitalizar la gestión de estudios?"));
+  assert.ok(source.includes("Seguimos trabajando en mejorar"));
   assert.ok(source.includes('href={ROUTES.contacto}'));
   assert.ok(source.includes("Solicitar información"));
   assert.ok(source.includes('href={ROUTES.clinicas}'));
   assert.ok(source.includes("Ver solución para clínicas"));
-  assert.ok(source.includes("Laboratorio patológico veterinario en Argentina"));
-  assert.ok(source.includes("Servicio patológico, histopatológico, citológico y hematológico veterinario"));
-  assert.ok(source.includes("histopatología veterinaria"));
-  assert.ok(source.includes("citología veterinaria"));
-  assert.ok(source.includes("citopatología"));
-  assert.ok(source.includes("hematología"));
-  assert.ok(source.includes("diagnóstico hematológico"));
-  assert.ok(source.includes("hemoparásitos"));
+  assert.ok(source.includes("Diagnóstico integral para medicina veterinaria"));
+  assert.ok(source.includes("Para tener en cuenta"));
+  assert.ok(source.includes("Valores que guían el servicio"));
+  assert.ok(source.includes("veterinario confiable"));
 });
 
 test("servicios page remains public and avoids direct backend/API calls", () => {


### PR DESCRIPTION
## Summary
- Align public home and services copy with the official Google Sites wording for VETNEB.
- Update public SEO descriptions and JSON-LD descriptions to match the anatomy pathology, cytology, special stains, and integrated veterinary diagnosis positioning.
- Update affected frontend content and public-page tests to reflect the new copy contract.

## Security
- Public frontend copy/SEO change only.
- No backend, authentication, authorization, session, cookie, database, API, dashboard, or protected-route logic changes.
- No dependency or tooling changes.

## Validation
- `pnpm test -- .\test\frontend-seo-metadata.test.ts .\test\frontend-home-page-content.test.ts .\test\frontend-servicios-page-content.test.ts .\test\frontend-visual-consistency.test.ts .\test\frontend-public-page-ctas.test.ts .\test\frontend-public-page-metadata.test.ts`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test` — 1329 pass, 0 fail
- `pnpm build`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`

## Senior review notes
- Scope is limited to public frontend copy, SEO text, and affected tests.
- `git diff --check` reported only Windows LF/CRLF warnings.
- No old public copy matches were found for the checked legacy strings.
- No changes outside the allowed frontend/test scope were reported by the exclude diff check.
- A PowerShell `Select-String` check using `fetch(` failed because the pattern was interpreted as regex; no code was changed based on that failed command.