### PR TITLE
fix(auth): keep clinic invalid login failures controlled

### DIFF
--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -654,14 +654,25 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       username?: string | null;
       reason: LoginFailedAttemptReason;
     }) => {
-      await deps.recordLoginFailedAttempt({
-        surface: "clinic",
-        username: input.username?.trim() || null,
-        reason: input.reason,
-        ipAddress: request.ip || null,
-        userAgent: getUserAgent(request),
-        createdAt: new Date(currentTime),
-      });
+      try {
+        await deps.recordLoginFailedAttempt({
+          surface: "clinic",
+          username: input.username?.trim() || null,
+          reason: input.reason,
+          ipAddress: request.ip || null,
+          userAgent: getUserAgent(request),
+          createdAt: new Date(currentTime),
+        });
+      } catch (error) {
+        request.log.warn(
+          {
+            err: error,
+            surface: "clinic",
+            reason: input.reason,
+          },
+          "No se pudo persistir intento fallido de login clinic",
+        );
+      }
     };
 
     if (failureEntry.count >= loginRateLimitMaxAttempts) {
@@ -872,5 +883,4 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     });
   });
 };
-
 

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -370,6 +370,137 @@ test("clinicAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido",
   }
 });
 
+test("clinicAuthNativeRoutes responde 401 para username inexistente", async () => {
+  const app = await createTestApp({
+    getClinicUserByUsername: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        username: "noexiste",
+        password: "noexiste",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Usuario o contraseña inválidos",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes responde 401 para password inválida", async () => {
+  const app = await createTestApp({
+    getClinicUserByUsername: async () => ({
+      id: 7,
+      clinicId: 3,
+      username: "vetneb",
+      passwordHash: "stored-hash",
+      authProId: null,
+      role: "clinic_staff",
+    }),
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        username: "vetneb",
+        password: "incorrecta",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Usuario o contraseña inválidos",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes responde 400 para credenciales faltantes", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        username: "vetneb",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Usuario y contrasena son obligatorios",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes mantiene 401 aunque falle recordLoginFailedAttempt", async () => {
+  const app = await createTestApp({
+    getClinicUserByUsername: async () => null,
+    recordLoginFailedAttempt: async () => {
+      throw new Error("record failed attempt write failed");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        username: "noexiste",
+        password: "noexiste",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Usuario o contraseña inválidos",
+    });
+    assert.equal(
+      response.body.toLowerCase().includes("record failed attempt write failed"),
+      false,
+    );
+    assert.equal(
+      response.body.toLowerCase().includes("error interno del servidor"),
+      false,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
 test("clinicAuthNativeRoutes persiste failed login sin secretos", async () => {
   const attempts: Array<Record<string, unknown>> = [];
 


### PR DESCRIPTION
## Summary
- Keep clinic invalid-login responses controlled when failed-login persistence fails.
- Make `recordLoginFailedAttempt` best-effort for clinic auth failure paths so invalid credentials still return the intended 400/401/429 responses instead of surfacing a 500.
- Add clinic auth coverage for nonexistent usernames, invalid passwords, missing credentials, and failed login-attempt persistence.

## Security
- Backend auth error-handling fix only.
- No frontend, dashboard, admin auth, particular auth, database schema, migration, dependency, package, or tooling changes.
- Internal failed-login persistence errors are not exposed to the client.
- Successful login/session creation behavior is unchanged.

## Validation
- `pnpm test -- .\test\auth.fastify.test.ts`
- `pnpm test` — 1333 pass, 0 fail
- `pnpm build`

## Manual verification
- `POST http://127.0.0.1:3000/api/auth/login` with `{ "username": "noexiste", "password": "noexiste" }` now returns `401` with `Usuario o contraseña inválidos`, instead of the previous `500 Error interno del servidor`.

## Senior review notes
- Scope is limited to `server/routes/auth.fastify.ts` and `test/auth.fastify.test.ts`.
- `git diff --check` passed.
- No changes outside the intended auth route and auth test file.