### PR TITLE
feat(frontend): support admin dashboard session cookie

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,14 +1,18 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 const CLINIC_SESSION_COOKIE_NAME = "app_session_id";
+const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";
 const LOGIN_PATH = "/login";
 
 export function middleware(request: NextRequest) {
   const hasClinicSession = Boolean(
     request.cookies.get(CLINIC_SESSION_COOKIE_NAME)?.value,
   );
+  const hasAdminSession = Boolean(
+    request.cookies.get(ADMIN_SESSION_COOKIE_NAME)?.value,
+  );
 
-  if (hasClinicSession) {
+  if (hasClinicSession || hasAdminSession) {
     return NextResponse.next();
   }
 

--- a/test/frontend-dashboard-middleware.test.ts
+++ b/test/frontend-dashboard-middleware.test.ts
@@ -23,8 +23,11 @@ test("frontend dashboard middleware exists and protects dashboard routes", () =>
 
   assert.ok(source.includes('from "next/server"'));
   assert.ok(source.includes('CLINIC_SESSION_COOKIE_NAME = "app_session_id"'));
+  assert.ok(source.includes('ADMIN_SESSION_COOKIE_NAME = "admin_session_id"'));
   assert.ok(source.includes('LOGIN_PATH = "/login"'));
-  assert.ok(source.includes('request.cookies.get(CLINIC_SESSION_COOKIE_NAME)'));
+  assert.ok(source.includes("request.cookies.get(CLINIC_SESSION_COOKIE_NAME)"));
+  assert.ok(source.includes("request.cookies.get(ADMIN_SESSION_COOKIE_NAME)"));
+  assert.ok(source.includes("hasClinicSession || hasAdminSession"));
   assert.ok(source.includes("NextResponse.next()"));
   assert.ok(source.includes("NextResponse.redirect(loginUrl)"));
   assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
@@ -46,7 +49,6 @@ test("frontend dashboard middleware stays scoped to frontend route protection", 
   const source = read(MIDDLEWARE_PATH);
 
   assert.equal(source.includes("fetch("), false);
-  assert.equal(source.includes("admin_session_id"), false);
   assert.equal(source.includes("particular_session_id"), false);
   assert.equal(source.includes("process.env"), false);
 });

--- a/test/frontend-middleware.test.ts
+++ b/test/frontend-middleware.test.ts
@@ -19,13 +19,16 @@ test("frontend middleware imports Next response and request types", () => {
   assert.ok(source.includes("export function middleware(request: NextRequest)"));
 });
 
-test("frontend middleware checks clinic session cookie before allowing dashboard access", () => {
+test("frontend middleware checks clinic and admin session cookies before allowing dashboard access", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('const CLINIC_SESSION_COOKIE_NAME = "app_session_id";'));
+  assert.ok(source.includes('const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";'));
   assert.ok(source.includes("const hasClinicSession = Boolean("));
+  assert.ok(source.includes("const hasAdminSession = Boolean("));
   assert.ok(source.includes("request.cookies.get(CLINIC_SESSION_COOKIE_NAME)?.value"));
-  assert.ok(source.includes("if (hasClinicSession) {"));
+  assert.ok(source.includes("request.cookies.get(ADMIN_SESSION_COOKIE_NAME)?.value"));
+  assert.ok(source.includes("if (hasClinicSession || hasAdminSession) {"));
   assert.ok(source.includes("return NextResponse.next();"));
 });
 


### PR DESCRIPTION
## Summary
- Allow frontend dashboard middleware to accept `admin_session_id` alongside `app_session_id`
- Update frontend middleware guardrails for admin dashboard access
- Keep middleware scoped to `/dashboard` routes only

## Validation
- pnpm test
- pnpm build