### PR TITLE
fix(frontend): simplify public brand badge

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -131,11 +131,10 @@ export function Footer() {
       <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
           <div>
-            <div className="mb-3 flex items-center gap-2">
-              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-sm font-bold text-white">
-                VN
-              </div>
-              <span className="font-semibold text-gray-900">Portal VETNEB</span>
+            <div className="mb-3 flex items-center">
+              <span className="flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-bold tracking-wide text-white">
+                VETNEB
+              </span>
             </div>
             <p className="text-sm leading-relaxed text-gray-500">
               Laboratorio veterinario digital. Informes, estudios y gestión

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
-import { ROUTES } from "@/lib/routes";
+
 import { Button } from "@/components/ui/button";
+import { ROUTES } from "@/lib/routes";
 
 const navLinks = [
   { label: "Servicios", href: ROUTES.servicios },
@@ -13,37 +14,31 @@ export function Navbar() {
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
-        {/* Logo */}
         <Link
           href={ROUTES.home}
-          className="flex items-center gap-2"
-          aria-label="Portal VETNEB — Inicio"
+          className="flex items-center"
+          aria-label="VETNEB — Inicio"
         >
-          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-white font-bold text-sm">
-            VN
-          </div>
-          <span className="font-semibold text-gray-900 text-lg hidden sm:block">
-            Portal VETNEB
+          <span className="flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-bold tracking-wide text-white">
+            VETNEB
           </span>
         </Link>
 
-        {/* Navegación desktop */}
         <nav
-          className="hidden md:flex items-center gap-6"
+          className="hidden items-center gap-6 md:flex"
           aria-label="Navegación principal"
         >
           {navLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="text-sm font-medium text-gray-600 hover:text-primary transition-colors"
+              className="text-sm font-medium text-gray-600 transition-colors hover:text-primary"
             >
               {link.label}
             </Link>
           ))}
         </nav>
 
-        {/* CTA */}
         <div className="flex items-center gap-3">
           <Button asChild variant="outline" size="sm">
             <Link href={ROUTES.login}>Iniciar sesión</Link>

--- a/test/frontend-footer-lab-info.test.ts
+++ b/test/frontend-footer-lab-info.test.ts
@@ -53,7 +53,11 @@ test("footer includes laboratory contact information and Google Maps embed", () 
 test("footer keeps public navigation and does not expose private dashboard content", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes("Portal VETNEB"));
+  assert.ok(source.includes("rounded-md bg-primary px-3"));
+  assert.ok(source.includes("font-bold tracking-wide text-white"));
+  assert.ok(source.includes("VETNEB"));
+  assert.equal(source.includes(">VN<"), false);
+  assert.equal(source.includes("Portal VETNEB"), false);
   assert.ok(source.includes("ROUTES.servicios"));
   assert.ok(source.includes("ROUTES.profesionales"));
   assert.ok(source.includes("ROUTES.clinicas"));

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -39,15 +39,19 @@ test("navbar uses centralized public routes for primary navigation", () => {
   assert.ok(source.includes('aria-label="Navegación principal"'));
 });
 
-test("navbar exposes home login and access CTAs", () => {
+test("navbar exposes home login and access CTAs with VETNEB brand", () => {
   const source = read(NAVBAR_PATH);
 
-  assert.ok(source.includes('href={ROUTES.home}'));
-  assert.ok(source.includes('aria-label="Portal VETNEB — Inicio"'));
-  assert.ok(source.includes("Portal VETNEB"));
-  assert.ok(source.includes('href={ROUTES.login}'));
+  assert.ok(source.includes("href={ROUTES.home}"));
+  assert.ok(source.includes('aria-label="VETNEB — Inicio"'));
+  assert.ok(source.includes("rounded-md bg-primary px-3"));
+  assert.ok(source.includes("font-bold tracking-wide text-white"));
+  assert.ok(source.includes("VETNEB"));
+  assert.equal(source.includes(">VN<"), false);
+  assert.equal(source.includes("Portal VETNEB"), false);
+  assert.ok(source.includes("href={ROUTES.login}"));
   assert.ok(source.includes("Iniciar sesión"));
-  assert.ok(source.includes('href={ROUTES.contacto}'));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicitar acceso"));
 });
 
@@ -63,14 +67,18 @@ test("footer uses centralized public routes and contentinfo landmark", () => {
   assert.ok(source.includes('{ label: "Contacto", href: ROUTES.contacto }'));
 });
 
-test("footer exposes access links and legal brand copy", () => {
+test("footer exposes access links and legal brand copy with VETNEB brand", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes('href={ROUTES.login}'));
+  assert.ok(source.includes("href={ROUTES.login}"));
   assert.ok(source.includes("Iniciar sesión"));
-  assert.ok(source.includes('href={ROUTES.contacto}'));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicitar acceso"));
-  assert.ok(source.includes("Portal VETNEB"));
+  assert.ok(source.includes("rounded-md bg-primary px-3"));
+  assert.ok(source.includes("font-bold tracking-wide text-white"));
+  assert.ok(source.includes("VETNEB"));
+  assert.equal(source.includes(">VN<"), false);
+  assert.equal(source.includes("Portal VETNEB"), false);
   assert.ok(source.includes("Laboratorio veterinario digital"));
   assert.ok(source.includes("Todos los derechos reservados"));
 });


### PR DESCRIPTION
## Summary
- Keep the public brand inside the colored badge
- Replace "VN" and "Portal VETNEB" with "VETNEB"
- Apply the same public brand treatment in navbar and footer
- Update frontend guardrails for the public brand badge

## Validation
- pnpm test
- pnpm build