### PR TITLE
fix(frontend): keep contact CTA visible on home

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -251,13 +251,12 @@ export default function HomePage() {
               <Link href={ROUTES.login}>Iniciar sesión</Link>
             </Button>
             <Button
-                asChild
-                size="lg"
-                variant="outline"
-                className="w-full border-white/40 text-white hover:bg-white/10 sm:w-auto"
-              >
-                <Link href={ROUTES.contacto}>Contactar</Link>
-              </Button>
+              asChild
+              size="lg"
+              className="w-full border border-white/70 bg-blue-950/20 font-semibold text-white shadow-sm hover:bg-white hover:text-primary sm:w-auto"
+            >
+              <Link href={ROUTES.contacto}>Contactar</Link>
+            </Button>
           </div>
         </div>
       </section>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -79,6 +79,10 @@ test("home page exposes final conversion CTA without private route metadata", ()
   assert.ok(source.includes("Seguimos trabajando en mejorar"));
   assert.ok(source.includes("Iniciar sesión"));
   assert.ok(source.includes("Contactar"));
+  assert.ok(source.includes("border border-white/70 bg-blue-950/20"));
+  assert.ok(source.includes("font-semibold text-white shadow-sm"));
+  assert.ok(source.includes("hover:bg-white hover:text-primary"));
+  assert.equal(source.includes("w-full border-white/40 text-white hover:bg-white/10 sm:w-auto"), false);
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes('"/api"'), false);
 });


### PR DESCRIPTION
## Summary
- Keep the home final "Contactar" CTA visible without hover
- Replace outline variant with explicit visible contrast styles
- Add guardrail coverage for the final conversion CTA

## Validation
- pnpm test
- pnpm build
- Visual check on home final CTA