### PR TITLE
fix(frontend): simplify login brand header

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -60,21 +60,16 @@ export function LoginContent() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800 flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        {/* Logo */}
         <div className="mb-8 text-center">
           <Link
             href={ROUTES.home}
-            className="inline-flex items-center gap-3"
-            aria-label="Portal VETNEB — Inicio"
+            className="inline-flex items-center justify-center"
+            aria-label="PORTAL VETNEB — Inicio"
           >
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white text-lg font-bold text-primary shadow-sm">
-              VN
-            </div>
-            <span className="text-2xl font-bold text-white">Portal VETNEB</span>
+            <span className="text-2xl font-bold uppercase tracking-wide text-white">
+              PORTAL VETNEB
+            </span>
           </Link>
-          <p className="mt-2 text-sm text-blue-200">
-            Laboratorio veterinario digital
-          </p>
         </div>
 
         <Card className="border border-white/80 bg-white/95 shadow-2xl backdrop-blur">
@@ -91,10 +86,7 @@ export function LoginContent() {
               onSubmit={handleSubmit}
             >
               <div>
-                <label
-                  htmlFor="username"
-                  className="field-label"
-                >
+                <label htmlFor="username" className="field-label">
                   Usuario
                 </label>
                 <Input
@@ -111,10 +103,7 @@ export function LoginContent() {
                 />
               </div>
               <div>
-                <label
-                  htmlFor="password"
-                  className="field-label"
-                >
+                <label htmlFor="password" className="field-label">
                   Contraseña
                 </label>
                 <Input

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -42,9 +42,11 @@ test("login content keeps standalone login shell and form landmarks", () => {
   assert.ok(source.includes('import Link from "next/link";'));
   assert.ok(source.includes('import { loginClinic } from "@/lib/api";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
-  assert.ok(source.includes('className="min-h-screen bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800 flex items-center justify-center p-4"'));
-  assert.ok(source.includes("Portal VETNEB"));
-  assert.ok(source.includes("Laboratorio veterinario digital"));
+  assert.ok(source.includes("bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800"));
+  assert.ok(source.includes("PORTAL VETNEB"));
+  assert.ok(source.includes('aria-label="PORTAL VETNEB — Inicio"'));
+  assert.equal(source.includes(">VN<"), false);
+  assert.equal(source.includes("Laboratorio veterinario digital"), false);
   assert.ok(source.includes("Iniciar sesión"));
   assert.ok(source.includes('aria-label="Formulario de inicio de sesión"'));
   assert.ok(source.includes("Usuario"));
@@ -66,10 +68,10 @@ test("login content keeps safe dashboard redirect and error handling", () => {
 test("login content exposes public navigation affordances without direct fetch", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
-  assert.ok(source.includes('href={ROUTES.home}'));
-  assert.ok(source.includes('aria-label="Portal VETNEB — Inicio"'));
+  assert.ok(source.includes("href={ROUTES.home}"));
+  assert.ok(source.includes('aria-label="PORTAL VETNEB — Inicio"'));
   assert.ok(source.includes("¿Su clínica no tiene acceso?"));
-  assert.ok(source.includes('href={ROUTES.contacto}'));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicite acceso"));
   assert.ok(source.includes("← Volver al sitio público"));
   assert.equal(source.includes('"/api"'), false);


### PR DESCRIPTION
## Summary
- Remove the VN logo box from the login page brand header
- Remove the "Laboratorio veterinario digital" subtitle from login
- Keep only "PORTAL VETNEB" in uppercase
- Update login page guardrails

## Validation
- pnpm test
- pnpm build