### PR TITLE
fix(frontend): unify footer layout

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -34,6 +34,13 @@ const labInfo = [
   "Horario: Lunes a viernes de 8 a 17hs",
 ];
 
+const footerLinks = [
+  { label: "Servicios", href: ROUTES.servicios },
+  { label: "Profesionales", href: ROUTES.profesionales },
+  { label: "Clínicas", href: ROUTES.clinicas },
+  { label: "Contacto", href: ROUTES.contacto },
+];
+
 const mapsEmbedUrl =
   "https://www.google.com/maps?q=Blvd.%20Italia%20274%2C%20Villa%20Maria%2C%20Cordoba%2C%20Argentina&output=embed";
 
@@ -79,7 +86,7 @@ export function Footer() {
         className="bg-white py-8"
         aria-labelledby="footer-lab-info-heading"
       >
-        <div className="container mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 md:grid-cols-2 lg:px-8">
+        <div className="container mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 md:grid-cols-2 lg:grid-cols-[1.35fr_0.75fr_0.75fr_1.15fr] lg:px-8">
           <div className="text-sm text-gray-950">
             <h2
               id="footer-lab-info-heading"
@@ -115,44 +122,12 @@ export function Footer() {
             </address>
           </div>
 
-          <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-sm">
-            <iframe
-              title="Ubicación de Servicio Patológico VETNEB en Google Maps"
-              src={mapsEmbedUrl}
-              className="h-56 w-full"
-              loading="lazy"
-              allowFullScreen
-              referrerPolicy="no-referrer-when-downgrade"
-            />
-          </div>
-        </div>
-      </section>
-
-      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
-          <div>
-            <div className="mb-3 flex items-center">
-              <span className="flex h-8 items-center justify-center rounded-md bg-primary px-3 text-sm font-bold tracking-wide text-white">
-                VETNEB
-              </span>
-            </div>
-            <p className="text-sm leading-relaxed text-gray-500">
-              Laboratorio veterinario digital. Informes, estudios y gestión
-              operativa para clínicas y profesionales.
-            </p>
-          </div>
-
-          <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-900">
+          <nav aria-label="Navegación secundaria">
+            <h3 className="mb-5 text-sm font-semibold text-gray-900">
               Navegación
             </h3>
-            <ul className="space-y-2">
-              {[
-                { label: "Servicios", href: ROUTES.servicios },
-                { label: "Profesionales", href: ROUTES.profesionales },
-                { label: "Clínicas", href: ROUTES.clinicas },
-                { label: "Contacto", href: ROUTES.contacto },
-              ].map((link) => (
+            <ul className="space-y-3">
+              {footerLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
@@ -163,13 +138,13 @@ export function Footer() {
                 </li>
               ))}
             </ul>
-          </div>
+          </nav>
 
           <div>
-            <h3 className="mb-3 text-sm font-semibold text-gray-900">
+            <h3 className="mb-5 text-sm font-semibold text-gray-900">
               Acceso
             </h3>
-            <ul className="space-y-2">
+            <ul className="space-y-3">
               <li>
                 <Link
                   href={ROUTES.login}
@@ -188,9 +163,22 @@ export function Footer() {
               </li>
             </ul>
           </div>
-        </div>
 
-        <div className="mt-8 flex flex-col items-center justify-between gap-4 border-t border-gray-200 pt-8 sm:flex-row">
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-sm">
+            <iframe
+              title="Ubicación de Servicio Patológico VETNEB en Google Maps"
+              src={mapsEmbedUrl}
+              className="h-40 w-full"
+              loading="lazy"
+              allowFullScreen
+              referrerPolicy="no-referrer-when-downgrade"
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex flex-col items-center justify-between gap-4 border-t border-gray-200 pt-6 sm:flex-row">
           <p className="text-xs text-gray-400">
             &copy; {year} VETNEB. Todos los derechos reservados.
           </p>

--- a/test/frontend-footer-lab-info.test.ts
+++ b/test/frontend-footer-lab-info.test.ts
@@ -37,7 +37,7 @@ test("footer includes public FAQ content in the lower frontend area", () => {
   assert.ok(source.includes("tinciones especiales"));
 });
 
-test("footer includes laboratory contact information and Google Maps embed", () => {
+test("footer unifies laboratory info navigation access and reduced map", () => {
   const source = read(FOOTER_PATH);
 
   assert.ok(source.includes("Servicio Patológico VETNEB"));
@@ -45,23 +45,27 @@ test("footer includes laboratory contact information and Google Maps embed", () 
   assert.ok(source.includes("Lunes a viernes de 8 a 17hs"));
   assert.ok(source.includes("3534138946"));
   assert.ok(source.includes("lab.vetneb@gmail.com"));
+  assert.ok(source.includes('aria-label="Navegación secundaria"'));
+  assert.ok(source.includes("Navegación"));
+  assert.ok(source.includes("Acceso"));
+  assert.ok(source.includes("footerLinks.map((link) =>"));
+  assert.ok(source.includes("lg:grid-cols-[1.35fr_0.75fr_0.75fr_1.15fr]"));
   assert.ok(source.includes("https://www.google.com/maps?q="));
   assert.ok(source.includes("output=embed"));
+  assert.ok(source.includes('className="h-40 w-full"'));
   assert.ok(source.includes("Ubicación de Servicio Patológico VETNEB en Google Maps"));
 });
 
-test("footer keeps public navigation and does not expose private dashboard content", () => {
+test("footer removes redundant brand block and keeps public routes safe", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes("rounded-md bg-primary px-3"));
-  assert.ok(source.includes("font-bold tracking-wide text-white"));
-  assert.ok(source.includes("VETNEB"));
-  assert.equal(source.includes(">VN<"), false);
-  assert.equal(source.includes("Portal VETNEB"), false);
+  assert.equal(source.includes("Laboratorio veterinario digital. Informes, estudios y gestión"), false);
+  assert.equal(source.includes("rounded-md bg-primary px-3"), false);
   assert.ok(source.includes("ROUTES.servicios"));
   assert.ok(source.includes("ROUTES.profesionales"));
   assert.ok(source.includes("ROUTES.clinicas"));
   assert.ok(source.includes("ROUTES.contacto"));
+  assert.ok(source.includes("ROUTES.login"));
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes("admin_session_id"), false);
 });

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -61,24 +61,23 @@ test("footer uses centralized public routes and contentinfo landmark", () => {
   assert.ok(source.includes('import Link from "next/link";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes('role="contentinfo"'));
+  assert.ok(source.includes('const footerLinks = ['));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
   assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
   assert.ok(source.includes('{ label: "Contacto", href: ROUTES.contacto }'));
+  assert.ok(source.includes("footerLinks.map((link) =>"));
 });
 
-test("footer exposes access links and legal brand copy with VETNEB brand", () => {
+test("footer exposes access links and legal copy without redundant brand block", () => {
   const source = read(FOOTER_PATH);
 
   assert.ok(source.includes("href={ROUTES.login}"));
   assert.ok(source.includes("Iniciar sesión"));
   assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicitar acceso"));
-  assert.ok(source.includes("rounded-md bg-primary px-3"));
-  assert.ok(source.includes("font-bold tracking-wide text-white"));
-  assert.ok(source.includes("VETNEB"));
-  assert.equal(source.includes(">VN<"), false);
-  assert.equal(source.includes("Portal VETNEB"), false);
-  assert.ok(source.includes("Laboratorio veterinario digital"));
   assert.ok(source.includes("Todos los derechos reservados"));
+  assert.ok(source.includes("Laboratorio veterinario digital — Argentina"));
+  assert.equal(source.includes("Laboratorio veterinario digital. Informes, estudios y gestión"), false);
+  assert.equal(source.includes("rounded-md bg-primary px-3"), false);
 });


### PR DESCRIPTION
## Summary
- Remove redundant footer brand block and descriptive copy
- Unify laboratory info, navigation, access, and Google Maps into one footer grid
- Reduce Google Maps height
- Update frontend footer guardrails

## Validation
- pnpm test
- pnpm build