### PR TITLE
feat(frontend): add public professionals search bank

### DIFF
--- a/frontend/src/app/profesionales/page.tsx
+++ b/frontend/src/app/profesionales/page.tsx
@@ -1,167 +1,19 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
-import Link from "next/link";
-import { PublicLayout } from "@/components/layout/PublicLayout";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+
+import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSearchContent";
 import { createPageMetadata } from "@/lib/seo";
-import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
   "Red de Profesionales Veterinarios",
-  "Directorio y red de profesionales veterinarios en Portal VETNEB. Accedé a informes, estudios y herramientas de gestión clínica.",
+  "Banco público de profesionales vinculados a VETNEB. Búsqueda por texto libre con coincidencias aproximadas.",
   "/profesionales",
 );
 
-const specialties = [
-  "Clínica general",
-  "Cirugía",
-  "Diagnóstico por imagen",
-  "Laboratorio clínico",
-  "Cardiología",
-  "Dermatología",
-  "Oncología",
-  "Neurología",
-  "Oftalmología",
-  "Medicina interna",
-];
-
-const benefits = [
-  {
-    icon: "🔐",
-    title: "Acceso seguro",
-    description:
-      "Acceso autenticado a informes y estudios de sus pacientes con tokens seguros y trazabilidad completa.",
-  },
-  {
-    icon: "📱",
-    title: "Multiplataforma",
-    description:
-      "Acceda desde cualquier dispositivo: computadora, tablet o celular. Interfaz responsive y optimizada.",
-  },
-  {
-    icon: "📊",
-    title: "Seguimiento de casos",
-    description:
-      "Historial completo de estudios por paciente. Seguimiento del estado de cada análisis en tiempo real.",
-  },
-  {
-    icon: "🤝",
-    title: "Integración con clínicas",
-    description:
-      "Trabaje en conjunto con las clínicas donde ejerce. Acceso compartido con control de permisos.",
-  },
-];
-
 export default function ProfesionalesPage() {
   return (
-    <PublicLayout>
-      {/* Header */}
-      <section className="bg-gradient-to-br from-blue-900 to-blue-700 text-white py-16">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Red de profesionales veterinarios
-          </h1>
-          <p className="text-xl text-blue-100 max-w-2xl">
-            Herramientas digitales diseñadas para el profesional veterinario
-            moderno. Gestione estudios, informes y casos clínicos desde un único
-            portal.
-          </p>
-        </div>
-      </section>
-
-      {/* Beneficios */}
-      <section className="py-16 bg-white">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold text-gray-900 mb-8 text-center">
-            Herramientas para el profesional
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
-            {benefits.map((benefit) => (
-              <Card key={benefit.title} className="border-gray-100">
-                <CardHeader>
-                  <div className="text-3xl mb-2" aria-hidden="true">
-                    {benefit.icon}
-                  </div>
-                  <CardTitle className="text-lg">{benefit.title}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-gray-600 leading-relaxed">
-                    {benefit.description}
-                  </p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Especialidades */}
-      <section className="py-16 bg-gray-50">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4 text-center">
-            Especialidades atendidas
-          </h2>
-          <p className="text-gray-500 text-center mb-8 max-w-xl mx-auto">
-            Portal VETNEB da soporte a profesionales de todas las especialidades
-            de la medicina veterinaria.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3 max-w-3xl mx-auto">
-            {specialties.map((specialty) => (
-              <Badge
-                key={specialty}
-                variant="secondary"
-                className="text-sm px-4 py-1.5"
-              >
-                {specialty}
-              </Badge>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="py-16 bg-white">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            ¿Querés integrar tu práctica a Portal VETNEB?
-          </h2>
-          <p className="text-gray-600 leading-relaxed mb-8">
-            Contactanos para coordinar el acceso profesional o conocer cómo una
-            clínica puede operar con informes digitales, trazabilidad y gestión
-            segura desde el portal.
-          </p>
-          <div className="flex flex-col sm:flex-row justify-center gap-3">
-            <Button asChild size="lg">
-              <Link href={ROUTES.contacto}>Contactar a VETNEB</Link>
-            </Button>
-            <Button asChild size="lg" variant="outline">
-              <Link href={ROUTES.clinicas}>Ver portal para clínicas</Link>
-            </Button>
-          </div>
-        </div>
-      </section>
-
-      {/* Texto SEO */}
-      <section className="py-16 bg-white">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Portal veterinario para profesionales en Argentina
-          </h2>
-          <p className="text-gray-600 leading-relaxed mb-4">
-            Portal VETNEB está diseñado para acompañar al profesional
-            veterinario en su práctica diaria. Desde el acceso a resultados de
-            laboratorio hasta el seguimiento de casos clínicos complejos,
-            nuestra plataforma centraliza la información que necesita para tomar
-            decisiones clínicas informadas.
-          </p>
-          <p className="text-gray-600 leading-relaxed">
-            La red de profesionales de VETNEB está en desarrollo. Próximamente
-            podrá crear su perfil profesional, conectar con clínicas y acceder
-            a herramientas colaborativas para el sector veterinario argentino.
-          </p>
-        </div>
-      </section>
-    </PublicLayout>
+    <Suspense fallback={null}>
+      <ProfesionalesSearchContent />
+    </Suspense>
   );
 }

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { PublicLayout } from "@/components/layout/PublicLayout";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  searchPublicProfessionals,
+  type PublicProfessional,
+} from "@/lib/api";
+import { ROUTES } from "@/lib/routes";
+
+type SearchState =
+  | { status: "idle"; professionals: PublicProfessional[]; total: number }
+  | { status: "loading"; professionals: PublicProfessional[]; total: number }
+  | { status: "success"; professionals: PublicProfessional[]; total: number }
+  | { status: "error"; professionals: PublicProfessional[]; total: number };
+
+export function ProfesionalesSearchContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentQuery = searchParams.get("q")?.trim() ?? "";
+  const [query, setQuery] = useState(currentQuery);
+  const [state, setState] = useState<SearchState>({
+    status: "idle",
+    professionals: [],
+    total: 0,
+  });
+
+  useEffect(() => {
+    setQuery(currentQuery);
+
+    if (!currentQuery) {
+      setState({ status: "idle", professionals: [], total: 0 });
+      return;
+    }
+
+    let isCurrent = true;
+
+    setState((previous) => ({
+      status: "loading",
+      professionals: previous.professionals,
+      total: previous.total,
+    }));
+
+    searchPublicProfessionals(
+      {
+        query: currentQuery,
+        limit: 20,
+        offset: 0,
+      },
+      { cache: "no-store" },
+    )
+      .then((snapshot) => {
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          status: "success",
+          professionals: snapshot.professionals,
+          total: snapshot.total,
+        });
+      })
+      .catch(() => {
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({ status: "error", professionals: [], total: 0 });
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [currentQuery]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextQuery = query.trim();
+    const params = new URLSearchParams();
+
+    if (nextQuery) {
+      params.set("q", nextQuery);
+    }
+
+    router.push(`${ROUTES.profesionales}${params.size ? `?${params}` : ""}`);
+  }
+
+  return (
+    <PublicLayout>
+      <section className="bg-gradient-to-br from-blue-900 to-blue-700 py-16 text-white">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="mb-4 text-4xl font-bold md:text-5xl">
+            Red de profesionales veterinarios
+          </h1>
+          <p className="max-w-2xl text-xl text-blue-100">
+            Banco público de profesionales vinculados a VETNEB.
+          </p>
+        </div>
+      </section>
+
+      <section className="bg-white py-16">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-3 text-2xl font-bold text-gray-900">
+              Buscar profesionales
+            </h2>
+            <p className="mb-6 text-sm leading-relaxed text-gray-600">
+              Ingrese texto libre, incluso una sola letra. La búsqueda admite coincidencias por nombre,
+              especialidad, servicios, localidad, país, email, teléfono o
+              descripción para reducir errores por escritura parcial.
+            </p>
+
+            <form
+              className="flex flex-col gap-3 rounded-xl border border-gray-100 bg-gray-50 p-4 sm:flex-row"
+              aria-label="Buscador de profesionales"
+              onSubmit={handleSubmit}
+            >
+              <label htmlFor="professional-search" className="sr-only">
+                Buscar profesional
+              </label>
+              <input
+                id="professional-search"
+                name="q"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Buscar desde una letra: nombre, especialidad, localidad o dato asociado"
+                className="h-11 flex-1 rounded-md border border-input bg-white px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              />
+              <Button type="submit" className="h-11">
+                Buscar
+              </Button>
+            </form>
+
+            <div className="mt-8" aria-live="polite">
+              {!currentQuery ? (
+                <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-6 text-sm text-gray-500">
+                  Realice una búsqueda para consultar el banco público de
+                  profesionales.
+                </div>
+              ) : null}
+
+              {state.status === "loading" ? (
+                <div className="rounded-xl border border-blue-100 bg-blue-50 p-6 text-sm text-blue-700">
+                  Buscando profesionales...
+                </div>
+              ) : null}
+
+              {state.status === "error" ? (
+                <div className="rounded-xl border border-red-100 bg-red-50 p-6 text-sm text-red-700">
+                  No se pudo realizar la búsqueda. Intente nuevamente.
+                </div>
+              ) : null}
+
+              {state.status === "success" && state.professionals.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-6 text-sm text-gray-500">
+                  No se encontraron profesionales para “{currentQuery}”.
+                </div>
+              ) : null}
+
+              {state.status === "success" && state.professionals.length > 0 ? (
+                <div>
+                  <p className="mb-4 text-sm text-gray-500">
+                    {state.total} resultado(s) para “{currentQuery}”.
+                  </p>
+                  <div className="space-y-4">
+                    {state.professionals.map((professional) => (
+                      <Card
+                        key={professional.clinicId}
+                        className="border-gray-100"
+                      >
+                        <CardHeader>
+                          <CardTitle className="text-lg">
+                            {professional.displayName}
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3 text-sm text-gray-600">
+                          {professional.specialtyText ? (
+                            <p>{professional.specialtyText}</p>
+                          ) : null}
+                          {professional.servicesText ? (
+                            <p>{professional.servicesText}</p>
+                          ) : null}
+                          {professional.aboutText ? (
+                            <p className="leading-relaxed">
+                              {professional.aboutText}
+                            </p>
+                          ) : null}
+                          <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            {professional.locality || professional.country ? (
+                              <div>
+                                <dt className="font-medium text-gray-900">
+                                  Ubicación
+                                </dt>
+                                <dd>
+                                  {[professional.locality, professional.country]
+                                    .filter(Boolean)
+                                    .join(", ")}
+                                </dd>
+                              </div>
+                            ) : null}
+                            {professional.email ? (
+                              <div>
+                                <dt className="font-medium text-gray-900">
+                                  Email
+                                </dt>
+                                <dd>
+                                  <a
+                                    href={`mailto:${professional.email}`}
+                                    className="underline underline-offset-2 hover:text-primary"
+                                  >
+                                    {professional.email}
+                                  </a>
+                                </dd>
+                              </div>
+                            ) : null}
+                            {professional.phone ? (
+                              <div>
+                                <dt className="font-medium text-gray-900">
+                                  Teléfono
+                                </dt>
+                                <dd>
+                                  <a
+                                    href={`https://wa.me/549${professional.phone.replace(/\D/g, "")}`}
+                                    className="underline underline-offset-2 hover:text-primary"
+                                  >
+                                    {professional.phone}
+                                  </a>
+                                </dd>
+                              </div>
+                            ) : null}
+                          </dl>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </section>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -431,9 +431,87 @@ export async function getDashboardStats(
     ).length,
   };
 }
+export type PublicProfessional = {
+  clinicId: number;
+  displayName: string;
+  avatarUrl: string | null;
+  specialtyText: string | null;
+  servicesText: string | null;
+  email: string | null;
+  phone: string | null;
+  locality: string | null;
+  country: string | null;
+  aboutText: string | null;
+  updatedAt: string;
+  relevance: {
+    rank: number;
+    similarity: number;
+    score: number;
+  };
+  profileQualityScore: number | null;
+};
 
+export type PublicProfessionalsSearchSnapshot = {
+  success: true;
+  count: number;
+  total: number;
+  professionals: PublicProfessional[];
+  filters: {
+    query: string | null;
+    locality: string | null;
+    country: string | null;
+  };
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+};
 
+export async function searchPublicProfessionals(
+  params: {
+    query?: string;
+    limit?: number;
+    offset?: number;
+  },
+  options?: RequestInit,
+): Promise<PublicProfessionalsSearchSnapshot> {
+  const query = new URLSearchParams();
 
+  if (params.query?.trim()) {
+    query.set("q", params.query.trim());
+  }
 
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
 
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  try {
+    return await apiFetch<PublicProfessionalsSearchSnapshot>(
+      `/api/public/professionals/search${qs ? `?${qs}` : ""}`,
+      options,
+    );
+  } catch {
+    return {
+      success: true,
+      count: 0,
+      total: 0,
+      professionals: [],
+      filters: {
+        query: params.query?.trim() || null,
+        locality: null,
+        country: null,
+      },
+      pagination: {
+        limit: params.limit ?? 20,
+        offset: params.offset ?? 0,
+      },
+    };
+  }
+}
 

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
+import { Suspense } from "react";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
 const PROFESIONALES_PAGE_PATH = "frontend/src/app/profesionales/page.tsx";
+const PROFESIONALES_SEARCH_CONTENT_PATH =
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx";
+const API_PATH = "frontend/src/lib/api.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -12,66 +16,78 @@ function read(relativePath: string): string {
   );
 }
 
-test("profesionales page defines metadata and public layout wiring", () => {
+test("profesionales page defines metadata and delegates to search content", () => {
   const source = read(PROFESIONALES_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import Link from "next/link";'));
-  assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
+  assert.ok(source.includes('import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSearchContent";'));
   assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
-  assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
   assert.ok(source.includes('"Red de Profesionales Veterinarios"'));
+  assert.ok(source.includes('"Banco público de profesionales vinculados a VETNEB'));
   assert.ok(source.includes('"/profesionales"'));
+  assert.ok(source.includes("<Suspense fallback={null}>"));
+  assert.ok(source.includes("<ProfesionalesSearchContent />"));
+});
+
+test("profesionales search content renders only the professional bank search surface", () => {
+  const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes("<PublicLayout>"));
-});
-
-test("profesionales page exposes hero content", () => {
-  const source = read(PROFESIONALES_PAGE_PATH);
-
   assert.ok(source.includes("Red de profesionales veterinarios"));
-  assert.ok(source.includes("Herramientas digitales diseñadas para el profesional veterinario"));
-  assert.ok(source.includes("portal."));
+  assert.ok(source.includes("Banco público de profesionales"));
+  assert.ok(source.includes("Buscar profesionales"));
+  assert.ok(source.includes("Ingrese texto libre, incluso una sola letra"));
+  assert.ok(source.includes("Buscar desde una letra: nombre, especialidad, localidad o dato asociado"));
+  assert.ok(source.includes('aria-label="Buscador de profesionales"'));
+  assert.ok(source.includes('type="search"'));
+  assert.equal(source.includes("minLength"), false);
+  assert.equal(source.includes("minlength"), false);
+  assert.ok(source.includes('name="q"'));
+  assert.ok(source.includes("Buscar desde una letra: nombre, especialidad, localidad o dato asociado"));
+  assert.equal(source.includes("Herramientas para el profesional"), false);
+  assert.equal(source.includes("Especialidades atendidas"), false);
+  assert.equal(source.includes("const benefits = ["), false);
+  assert.equal(source.includes("const specialties = ["), false);
 });
 
-test("profesionales page lists professional benefits", () => {
-  const source = read(PROFESIONALES_PAGE_PATH);
+test("profesionales search content uses free text query and approximate backend search helper", () => {
+  const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+  const apiSource = read(API_PATH);
 
-  assert.ok(source.includes("const benefits = ["));
-  assert.ok(source.includes("Acceso seguro"));
-  assert.ok(source.includes("Multiplataforma"));
-  assert.ok(source.includes("Seguimiento de casos"));
-  assert.ok(source.includes("Integración con clínicas"));
-  assert.ok(source.includes("benefits.map((benefit) =>"));
+  assert.ok(source.includes("useSearchParams"));
+  assert.ok(source.includes("router.push(`${ROUTES.profesionales}${params.size ? `?${params}` : \"\"}`)"));
+  assert.ok(source.includes("searchPublicProfessionals("));
+  assert.ok(source.includes("query: currentQuery"));
+  assert.ok(source.includes("limit: 20"));
+  assert.ok(source.includes('{ cache: "no-store" }'));
+  assert.ok(source.includes("coincidencias por nombre"));
+  assert.ok(apiSource.includes("export async function searchPublicProfessionals("));
+  assert.ok(apiSource.includes("q"));
+  assert.ok(apiSource.includes("/api/public/professionals/search"));
 });
 
-test("profesionales page lists veterinary specialties", () => {
-  const source = read(PROFESIONALES_PAGE_PATH);
+test("profesionales search content renders professional result cards", () => {
+  const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
 
-  assert.ok(source.includes("const specialties = ["));
-  assert.ok(source.includes("Clínica general"));
-  assert.ok(source.includes("Cirugía"));
-  assert.ok(source.includes("Diagnóstico por imagen"));
-  assert.ok(source.includes("Laboratorio clínico"));
-  assert.ok(source.includes("Medicina interna"));
-  assert.ok(source.includes("specialties.map((specialty) =>"));
+  assert.ok(source.includes("state.professionals.map((professional) =>"));
+  assert.ok(source.includes("professional.displayName"));
+  assert.ok(source.includes("professional.specialtyText"));
+  assert.ok(source.includes("professional.servicesText"));
+  assert.ok(source.includes("professional.aboutText"));
+  assert.ok(source.includes("professional.locality"));
+  assert.ok(source.includes("professional.country"));
+  assert.ok(source.includes("mailto:${professional.email}"));
+  assert.ok(source.includes("https://wa.me/549"));
 });
 
-test("profesionales page exposes conversion CTAs and SEO copy", () => {
-  const source = read(PROFESIONALES_PAGE_PATH);
+test("profesionales page remains public and avoids private route literals", () => {
+  const pageSource = read(PROFESIONALES_PAGE_PATH);
+  const contentSource = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+  const combined = [pageSource, contentSource].join("\n");
 
-  assert.ok(source.includes("¿Querés integrar tu práctica a Portal VETNEB?"));
-  assert.ok(source.includes('href={ROUTES.contacto}'));
-  assert.ok(source.includes("Contactar a VETNEB"));
-  assert.ok(source.includes('href={ROUTES.clinicas}'));
-  assert.ok(source.includes("Ver portal para clínicas"));
-  assert.ok(source.includes("Portal veterinario para profesionales en Argentina"));
-});
-
-test("profesionales page remains public and avoids direct backend/API calls", () => {
-  const source = read(PROFESIONALES_PAGE_PATH);
-
-  assert.equal(source.includes('"/dashboard"'), false);
-  assert.equal(source.includes('"/api"'), false);
-  assert.equal(source.includes("fetch("), false);
+  assert.equal(combined.includes('"/dashboard"'), false);
+  assert.equal(combined.includes("admin_session_id"), false);
 });

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const PROFESIONALES_PAGE_PATH = "frontend/src/app/profesionales/page.tsx";
+const PROFESIONALES_SEARCH_CONTENT_PATH =
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx";
 const SERVICIOS_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
 
 function read(relativePath: string): string {
@@ -13,17 +15,18 @@ function read(relativePath: string): string {
   );
 }
 
-test("profesionales public page exposes actionable CTAs", () => {
-  const source = read(PROFESIONALES_PAGE_PATH);
+test("profesionales public page exposes search instead of conversion CTAs", () => {
+  const pageSource = read(PROFESIONALES_PAGE_PATH);
+  const contentSource = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+  const combined = [pageSource, contentSource].join("\n");
 
-  assert.ok(source.includes('import Link from "next/link"'));
-  assert.ok(source.includes('import { Button } from "@/components/ui/button"'));
-  assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
-  assert.ok(source.includes("¿Querés integrar tu práctica a Portal VETNEB?"));
-  assert.ok(source.includes("Contactar a VETNEB"));
-  assert.ok(source.includes("Ver portal para clínicas"));
-  assert.ok(source.includes("href={ROUTES.contacto}"));
-  assert.ok(source.includes("href={ROUTES.clinicas}"));
+  assert.ok(combined.includes("ProfesionalesSearchContent"));
+  assert.ok(combined.includes("Buscar profesionales"));
+  assert.ok(combined.includes('aria-label="Buscador de profesionales"'));
+  assert.ok(combined.includes('name="q"'));
+  assert.equal(combined.includes("¿Querés integrar tu práctica a Portal VETNEB?"), false);
+  assert.equal(combined.includes("Contactar a VETNEB"), false);
+  assert.equal(combined.includes("Ver portal para clínicas"), false);
 });
 
 test("servicios public page exposes conversion CTAs", () => {

--- a/test/frontend-public-page-metadata.test.ts
+++ b/test/frontend-public-page-metadata.test.ts
@@ -34,7 +34,7 @@ test("profesionales public page defines SEO metadata", () => {
   assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
   assert.ok(source.includes('"Red de Profesionales Veterinarios"'));
-  assert.ok(source.includes('"Directorio y red de profesionales veterinarios en Portal VETNEB.'));
+  assert.ok(source.includes('"Banco público de profesionales vinculados a VETNEB'));
   assert.ok(source.includes('"/profesionales"'));
 });
 


### PR DESCRIPTION
## Summary
- Replace the profesionales static marketing content with a public professional search bank
- Remove tools, specialties, and conversion CTA sections from /profesionales
- Add free-text professional search against the public professionals backend endpoint
- Render professional result cards with contact and location data
- Update frontend guardrails for the new search-only surface

## Validation
- pnpm test
- pnpm build