### PR TITLE
style(frontend): unify public page visuals

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -149,3 +149,34 @@
     background: linear-gradient(90deg, transparent, rgba(14, 165, 233, 0.45), rgba(45, 212, 191, 0.45), transparent);
   }
 }
+@layer components {
+  [data-public-hero-depth="true"] {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 15% 10%, rgba(34, 211, 238, 0.28), transparent 30%),
+      radial-gradient(circle at 88% 12%, rgba(52, 211, 153, 0.22), transparent 26%),
+      radial-gradient(circle at 62% 112%, rgba(251, 191, 36, 0.14), transparent 32%),
+      linear-gradient(135deg, #071a35 0%, #123f7a 48%, #0f766e 100%);
+  }
+
+  [data-public-hero-depth="true"]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background-image:
+      linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.07) 1px, transparent 1px);
+    background-size: 46px 46px;
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 72%);
+  }
+
+  [data-public-soft-canvas="true"] {
+    background:
+      radial-gradient(circle at 12% 16%, rgba(45, 212, 191, 0.18), transparent 32%),
+      radial-gradient(circle at 88% 4%, rgba(251, 191, 36, 0.16), transparent 30%),
+      linear-gradient(135deg, #f8fafc 0%, #eef6ff 45%, #ecfeff 100%);
+  }
+}

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -1,8 +1,26 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+  ArrowRight,
+  ClipboardCheck,
+  FlaskConical,
+  Microscope,
+  MonitorCheck,
+  Network,
+  Sparkles,
+  Stethoscope,
+} from "lucide-react";
+
 import { PublicLayout } from "@/components/layout/PublicLayout";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { AmbientOrbs, Eyebrow, VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -16,7 +34,8 @@ const serviceCategories = [
   {
     id: "anatomopatologia",
     title: "Estudio anatomopatológico de tejidos",
-    icon: "🔬",
+    icon: Microscope,
+    tone: "blue" as const,
     description:
       "Evaluación de tejidos y órganos para estudiar motivos, desarrollo y consecuencias de enfermedades en pacientes veterinarios.",
     features: [
@@ -31,7 +50,8 @@ const serviceCategories = [
   {
     id: "citologia",
     title: "Estudio citológico de muestras",
-    icon: "🧪",
+    icon: FlaskConical,
+    tone: "emerald" as const,
     description:
       "Análisis citológico de líquidos y punciones para valorar alteraciones celulares con un enfoque clínico-patológico.",
     features: [
@@ -46,7 +66,8 @@ const serviceCategories = [
   {
     id: "tinciones",
     title: "Tinciones especiales aplicadas",
-    icon: "🧬",
+    icon: Sparkles,
+    tone: "amber" as const,
     description:
       "Aplicación de tinciones especiales para ampliar hallazgos histológicos y reforzar diagnósticos diferenciales.",
     features: [
@@ -61,7 +82,8 @@ const serviceCategories = [
   {
     id: "integral",
     title: "Diagnóstico integral interdisciplinario",
-    icon: "📋",
+    icon: Network,
+    tone: "slate" as const,
     description:
       "Integración del análisis histológico y citológico con información clínica para construir un diagnóstico específico por paciente.",
     features: [
@@ -76,7 +98,8 @@ const serviceCategories = [
   {
     id: "informes",
     title: "Informes y seguimiento",
-    icon: "🖥️",
+    icon: MonitorCheck,
+    tone: "blue" as const,
     description:
       "Entrega y seguimiento de informes con comunicación continua para clínicas y profesionales durante todo el proceso diagnóstico.",
     features: [
@@ -100,10 +123,17 @@ export default function ServiciosPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      {/* Header */}
-      <section className="bg-gradient-to-br from-blue-900 to-blue-700 py-16 text-white md:py-20">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="mb-4 text-4xl font-bold leading-tight md:text-5xl">
+      <section
+        className="bg-gradient-to-br from-blue-900 to-blue-700 py-16 text-white md:py-20"
+        data-public-hero-depth="true"
+      >
+        <AmbientOrbs variant="dark" />
+        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+          <Eyebrow>
+            <Stethoscope className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+            Servicios diagnósticos
+          </Eyebrow>
+          <h1 className="mb-4 max-w-4xl text-4xl font-bold leading-tight tracking-tight md:text-5xl">
             Servicio patológico veterinario
           </h1>
           <p className="max-w-2xl text-lg leading-relaxed text-blue-100 md:text-xl">
@@ -114,9 +144,21 @@ export default function ServiciosPage() {
         </div>
       </section>
 
-      {/* Servicios */}
-      <section className="bg-white py-16 md:py-20">
+      <section className="bg-white py-16 md:py-20" data-public-soft-canvas="true">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-10 max-w-3xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary">
+              Laboratorio VETNEB
+            </p>
+            <h2 className="text-2xl font-bold text-gray-950 md:text-3xl">
+              Estudios con criterio clínico-patológico
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              Unificamos histopatología, citología, técnicas complementarias y
+              seguimiento para sostener decisiones clínicas con mayor claridad.
+            </p>
+          </div>
+
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8">
             {serviceCategories.map((service) => (
               <Card
@@ -125,11 +167,11 @@ export default function ServiciosPage() {
                 className="h-full border-gray-100 transition-shadow hover:shadow-md"
               >
                 <CardHeader>
-                  <div className="mb-2 text-4xl" aria-hidden="true">
-                    {service.icon}
-                  </div>
-                  <CardTitle className="text-xl">{service.title}</CardTitle>
-                  <CardDescription className="text-sm leading-relaxed">
+                  <VisualIcon icon={service.icon} tone={service.tone} className="mb-2" />
+                  <CardTitle className="text-xl text-gray-950">
+                    {service.title}
+                  </CardTitle>
+                  <CardDescription className="text-sm leading-relaxed text-gray-600">
                     {service.description}
                   </CardDescription>
                 </CardHeader>
@@ -154,80 +196,97 @@ export default function ServiciosPage() {
         </div>
       </section>
 
-      {/* CTA */}
-      <section className="bg-blue-50 py-16">
+      <section className="bg-blue-50 py-16" data-public-soft-canvas="true">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Seguimos trabajando en mejorar
-          </h2>
-          <p className="text-gray-600 leading-relaxed mb-8">
-            Estamos enfocados en agilizar la recepción y entrega de informes, y
-            en fortalecer los medios de comunicación con clínicas y
-            profesionales para reducir tiempos de espera de resultados.
-          </p>
-          <div className="flex flex-col justify-center gap-3 sm:flex-row">
-            <Button asChild size="lg" className="w-full sm:w-auto">
-              <Link href={ROUTES.contacto}>Solicitar información</Link>
-            </Button>
-            <Button asChild size="lg" variant="outline" className="w-full sm:w-auto">
-              <Link href={ROUTES.clinicas}>Ver solución para clínicas</Link>
-            </Button>
+          <div className="rounded-3xl border border-white/70 bg-white/80 p-8 shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              Seguimos trabajando en mejorar
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-8">
+              Estamos enfocados en agilizar la recepción y entrega de informes, y
+              en fortalecer los medios de comunicación con clínicas y
+              profesionales para reducir tiempos de espera de resultados.
+            </p>
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                className="w-full bg-gradient-to-r from-blue-700 to-teal-600 shadow-[0_14px_35px_rgba(37,99,235,0.22)] hover:from-blue-800 hover:to-teal-700 sm:w-auto"
+              >
+                <Link href={ROUTES.contacto}>
+                  Solicitar información
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+              <Button asChild size="lg" variant="outline" className="w-full bg-white/80 sm:w-auto">
+                <Link href={ROUTES.clinicas}>Ver solución para clínicas</Link>
+              </Button>
+            </div>
           </div>
         </div>
       </section>
 
-      {/* Diagnóstico integral */}
       <section className="bg-white py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Diagnóstico integral para medicina veterinaria
-          </h2>
-          <p className="text-gray-600 leading-relaxed mb-4">
-            El diagnóstico anatomopatológico veterinario requiere integrar no
-            sólo el análisis de tejido y citología, sino también el
-            conocimiento clínico global de cada paciente. Esta articulación
-            permite enriquecer la lectura diagnóstica junto con otras áreas de
-            práctica veterinaria.
-          </p>
-          <p className="text-gray-600 leading-relaxed">
-            Nuestro objetivo es colaborar de forma permanente con equipos
-            quirúrgicos y clínicos, estudiando tejidos extirpados y muestras de
-            punción para construir diagnósticos específicos y apoyar planes de
-            tratamiento personalizados.
-          </p>
+          <div className="premium-card-muted p-6">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              Diagnóstico integral para medicina veterinaria
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              El diagnóstico anatomopatológico veterinario requiere integrar no
+              sólo el análisis de tejido y citología, sino también el
+              conocimiento clínico global de cada paciente. Esta articulación
+              permite enriquecer la lectura diagnóstica junto con otras áreas de
+              práctica veterinaria.
+            </p>
+            <p className="text-gray-600 leading-relaxed">
+              Nuestro objetivo es colaborar de forma permanente con equipos
+              quirúrgicos y clínicos, estudiando tejidos extirpados y muestras de
+              punción para construir diagnósticos específicos y apoyar planes de
+              tratamiento personalizados.
+            </p>
+          </div>
         </div>
       </section>
 
-      {/* Para tener en cuenta */}
-      <section className="bg-gray-50 py-16">
+      <section className="bg-gray-50 py-16" data-public-soft-canvas="true">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Para tener en cuenta
-          </h2>
-          <p className="text-gray-600 leading-relaxed mb-4">
-            El estudio anatomopatológico requiere integrar datos clínicos con la
-            evaluación histológica y citológica realizada por el médico
-            veterinario patólogo en microscopía.
-          </p>
-          <p className="text-gray-600 leading-relaxed">
-            No se trata de un diagnóstico automatizado, por lo que los tiempos
-            son variables según complejidad. En ciertos casos se requiere
-            interconsulta profesional para alcanzar mayor precisión diagnóstica.
-          </p>
+          <div className="premium-card-muted p-6">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              Para tener en cuenta
+            </h2>
+            <p className="text-gray-600 leading-relaxed mb-4">
+              El estudio anatomopatológico requiere integrar datos clínicos con la
+              evaluación histológica y citológica realizada por el médico
+              veterinario patólogo en microscopía.
+            </p>
+            <p className="text-gray-600 leading-relaxed">
+              No se trata de un diagnóstico automatizado, por lo que los tiempos
+              son variables según complejidad. En ciertos casos se requiere
+              interconsulta profesional para alcanzar mayor precisión diagnóstica.
+            </p>
+          </div>
         </div>
       </section>
 
       <section className="bg-white py-16">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            Valores que guían el servicio
-          </h2>
-          <p className="text-gray-600 leading-relaxed">
-            Basamos nuestro trabajo en compromiso, seriedad, respeto,
-            responsabilidad, confianza, diálogo, trabajo en equipo, empatía y
-            capacitación constante para sostener un servicio patológico
-            veterinario confiable.
-          </p>
+          <div className="rounded-3xl border border-emerald-100 bg-gradient-to-r from-white via-emerald-50 to-blue-50 p-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)]">
+            <div className="flex items-start gap-3">
+              <VisualIcon icon={ClipboardCheck} tone="emerald" className="h-11 w-11 shrink-0 rounded-xl" />
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 mb-4">
+                  Valores que guían el servicio
+                </h2>
+                <p className="text-gray-600 leading-relaxed">
+                  Basamos nuestro trabajo en compromiso, seriedad, respeto,
+                  responsabilidad, confianza, diálogo, trabajo en equipo, empatía y
+                  capacitación constante para sostener un servicio patológico
+                  veterinario confiable.
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
     </PublicLayout>

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -1,8 +1,20 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import {
+  ArrowRight,
+  Building2,
+  Mail,
+  MapPin,
+  MessageCircle,
+  Phone,
+  Send,
+  Sparkles,
+  UserRound,
+} from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { AmbientOrbs, Eyebrow, VisualIcon } from "@/components/public/VisualAccents";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,22 +22,25 @@ import { submitContactMessage } from "@/lib/api";
 
 const contactInfo = [
   {
-    icon: "📧",
+    icon: Mail,
     label: "Email",
     value: "lab.vetneb@gmail.com",
     href: "mailto:lab.vetneb@gmail.com",
+    tone: "blue" as const,
   },
   {
-    icon: "📞",
+    icon: Phone,
     label: "Teléfono",
     value: "3534138946",
     href: "https://wa.me/5493534138946",
+    tone: "emerald" as const,
   },
   {
-    icon: "📍",
+    icon: MapPin,
     label: "Ubicación",
     value: "Villa María, Córdoba, Argentina",
     href: null,
+    tone: "amber" as const,
   },
 ];
 
@@ -81,29 +96,46 @@ export function ContactoContent() {
 
   return (
     <PublicLayout>
-      <section className="bg-gradient-to-br from-blue-900 to-blue-700 text-white py-16">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">Contacto</h1>
-          <p className="text-xl text-blue-100 max-w-2xl">
+      <section className="public-hero-depth py-16 text-white md:py-20">
+        <AmbientOrbs variant="dark" />
+        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+          <Eyebrow>
+            <Sparkles className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+            Contacto VETNEB
+          </Eyebrow>
+          <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            Contacto
+          </h1>
+          <p className="max-w-2xl text-xl leading-relaxed text-blue-50">
             ¿Desea registrar su clínica o tiene consultas sobre nuestros
             servicios? Comuníquese con nuestro equipo.
           </p>
         </div>
       </section>
 
-      <section className="py-16 bg-white">
+      <section className="public-soft-canvas py-16 md:py-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-5xl mx-auto">
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-6">
-                Envíenos un mensaje
-              </h2>
+          <div className="grid max-w-5xl grid-cols-1 gap-12 mx-auto lg:grid-cols-2">
+            <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur">
+              <div className="mb-6 flex items-start gap-3">
+                <VisualIcon icon={MessageCircle} tone="blue" className="h-11 w-11 rounded-xl" />
+                <div>
+                  <h2 className="text-2xl font-bold text-gray-950">
+                    Envíenos un mensaje
+                  </h2>
+                  <p className="mt-1 text-sm leading-relaxed text-gray-600">
+                    Complete el formulario y nuestro equipo responderá por el
+                    canal indicado.
+                  </p>
+                </div>
+              </div>
+
               <form
                 className="space-y-4"
                 aria-label="Formulario de contacto"
                 onSubmit={handleSubmit}
               >
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <div>
                     <label
                       htmlFor="nombre"
@@ -111,16 +143,20 @@ export function ContactoContent() {
                     >
                       Nombre
                     </label>
-                    <Input
-                      id="nombre"
-                      type="text"
-                      placeholder="Su nombre"
-                      autoComplete="given-name"
-                      required
-                      value={nombre}
-                      onChange={(event) => setNombre(event.target.value)}
-                      disabled={isSubmitting}
-                    />
+                    <div className="relative">
+                      <UserRound className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+                      <Input
+                        id="nombre"
+                        type="text"
+                        placeholder="Su nombre"
+                        autoComplete="given-name"
+                        required
+                        value={nombre}
+                        onChange={(event) => setNombre(event.target.value)}
+                        disabled={isSubmitting}
+                        className="pl-10"
+                      />
+                    </div>
                   </div>
                   <div>
                     <label
@@ -147,16 +183,20 @@ export function ContactoContent() {
                   >
                     Email
                   </label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="su@email.com"
-                    autoComplete="email"
-                    required
-                    value={email}
-                    onChange={(event) => setEmail(event.target.value)}
-                    disabled={isSubmitting}
-                  />
+                  <div className="relative">
+                    <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+                    <Input
+                      id="email"
+                      type="email"
+                      placeholder="su@email.com"
+                      autoComplete="email"
+                      required
+                      value={email}
+                      onChange={(event) => setEmail(event.target.value)}
+                      disabled={isSubmitting}
+                      className="pl-10"
+                    />
+                  </div>
                 </div>
                 <div>
                   <label
@@ -165,15 +205,19 @@ export function ContactoContent() {
                   >
                     Nombre de la clínica (opcional)
                   </label>
-                  <Input
-                    id="clinica"
-                    type="text"
-                    placeholder="Clínica Veterinaria..."
-                    autoComplete="organization"
-                    value={clinica}
-                    onChange={(event) => setClinica(event.target.value)}
-                    disabled={isSubmitting}
-                  />
+                  <div className="relative">
+                    <Building2 className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+                    <Input
+                      id="clinica"
+                      type="text"
+                      placeholder="Clínica Veterinaria..."
+                      autoComplete="organization"
+                      value={clinica}
+                      onChange={(event) => setClinica(event.target.value)}
+                      disabled={isSubmitting}
+                      className="pl-10"
+                    />
+                  </div>
                 </div>
                 <div>
                   <label
@@ -186,7 +230,7 @@ export function ContactoContent() {
                     id="mensaje"
                     rows={5}
                     placeholder="Describa su consulta o solicitud de acceso..."
-                    className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                    className="flex w-full resize-none rounded-xl border border-input bg-white/90 px-3 py-2 text-sm shadow-inner ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                     required
                     minLength={10}
                     value={mensaje}
@@ -210,22 +254,36 @@ export function ContactoContent() {
                   </p>
                 ) : null}
 
-                <Button type="submit" className="w-full" disabled={isSubmitting}>
+                <Button
+                  type="submit"
+                  className="w-full bg-gradient-to-r from-blue-700 to-teal-600 shadow-[0_14px_35px_rgba(37,99,235,0.22)] hover:from-blue-800 hover:to-teal-700"
+                  disabled={isSubmitting}
+                >
+                  <Send className="h-4 w-4" aria-hidden="true" />
                   {isSubmitting ? "Enviando mensaje..." : "Enviar mensaje"}
                 </Button>
               </form>
             </div>
 
             <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-6">
-                Información de contacto
-              </h2>
+              <div className="mb-6 flex items-start gap-3">
+                <VisualIcon icon={Phone} tone="emerald" className="h-11 w-11 rounded-xl" />
+                <div>
+                  <h2 className="text-2xl font-bold text-gray-950">
+                    Información de contacto
+                  </h2>
+                  <p className="mt-1 text-sm leading-relaxed text-gray-600">
+                    Canales oficiales para coordinación y consultas.
+                  </p>
+                </div>
+              </div>
+
               <div className="space-y-4 mb-8">
                 {contactInfo.map((info) => (
-                  <Card key={info.label} className="border-gray-100">
+                  <Card key={info.label} className="premium-card">
                     <CardHeader className="pb-2">
-                      <CardTitle className="text-base flex items-center gap-2">
-                        <span aria-hidden="true">{info.icon}</span>
+                      <CardTitle className="text-base flex items-center gap-3">
+                        <VisualIcon icon={info.icon} tone={info.tone} className="h-9 w-9 rounded-xl" />
                         {info.label}
                       </CardTitle>
                     </CardHeader>
@@ -245,7 +303,7 @@ export function ContactoContent() {
                 ))}
               </div>
 
-              <div className="bg-blue-50 rounded-lg p-6 border border-blue-100">
+              <div className="rounded-3xl border border-blue-100 bg-gradient-to-r from-blue-50 via-white to-emerald-50 p-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)]">
                 <h3 className="font-semibold text-blue-900 mb-2">
                   ¿Es una clínica veterinaria?
                 </h3>
@@ -254,6 +312,10 @@ export function ContactoContent() {
                   su mensaje. Nuestro equipo se pondrá en contacto para
                   configurar su acceso y explicarle el proceso de integración.
                 </p>
+                <div className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary">
+                  Solicitar integración
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Unifies Servicios and Contacto with the visual system used by Profesionales and Particulares.
- Keeps public pages under the same stable senior-level visual language.
- Adds subtle gradient depth, soft canvas backgrounds, React/Lucide iconography, glass panels and refined cards.
- Preserves behavior: no endpoint, auth, form contract or data flow changes.

## Validation
- pnpm test: 1338 pass
- pnpm build: OK
- pnpm --dir frontend build: OK