### PR TITLE
style(frontend): improve services visual parity

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -180,3 +180,36 @@
       linear-gradient(135deg, #f8fafc 0%, #eef6ff 45%, #ecfeff 100%);
   }
 }
+@layer components {
+  [data-public-hero-depth="true"][data-public-hero-depth="true"] {
+    background:
+      radial-gradient(circle at 12% 12%, rgba(34, 211, 238, 0.30), transparent 31%),
+      radial-gradient(circle at 88% 15%, rgba(52, 211, 153, 0.30), transparent 34%),
+      radial-gradient(circle at 50% 120%, rgba(251, 191, 36, 0.16), transparent 34%),
+      linear-gradient(135deg, #07365d 0%, #123f7a 42%, #0f766e 100%) !important;
+  }
+
+  [data-services-polished="true"] > [id] {
+    position: relative;
+    overflow: hidden;
+    border-color: rgba(255, 255, 255, 0.72) !important;
+    border-radius: 1.25rem !important;
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(248, 250, 252, 0.84)) !important;
+    box-shadow: 0 24px 78px rgba(15, 23, 42, 0.10) !important;
+    backdrop-filter: blur(18px);
+  }
+
+  [data-services-polished="true"] > [id]::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 4px;
+    background: linear-gradient(90deg, rgba(37, 99, 235, 0.70), rgba(20, 184, 166, 0.70), rgba(251, 191, 36, 0.48));
+  }
+
+  [data-services-polished="true"] > [id]:hover {
+    border-color: rgba(125, 211, 252, 0.65) !important;
+    box-shadow: 0 30px 95px rgba(15, 23, 42, 0.14) !important;
+  }
+}

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -145,8 +145,8 @@ export default function ServiciosPage() {
       </section>
 
       <section className="bg-white py-16 md:py-20" data-public-soft-canvas="true">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mb-10 max-w-3xl">
+        <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto mb-10 max-w-4xl">
             <p className="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary">
               Laboratorio VETNEB
             </p>
@@ -159,7 +159,7 @@ export default function ServiciosPage() {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8" data-services-polished="true">
             {serviceCategories.map((service) => (
               <Card
                 key={service.id}


### PR DESCRIPTION
## Summary
- Improves Servicios visual parity with Profesionales and the unified public visual system.
- Refines hero depth, soft canvas and service card definition.
- Keeps changes visual-only: no endpoint, auth or data flow changes.

## Validation
- pnpm test: OK
- pnpm build: OK
- pnpm --dir frontend build: OK