### PR TITLE
style(frontend): optimize public render polish

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,26 +1,43 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-XSS-Protection",
+    value: "1; mode=block",
+  },
+];
+
 const nextConfig: NextConfig = {
   // El frontend se ejecuta como aplicación separada del backend Fastify
   // Para producción, configurar NEXT_PUBLIC_API_URL apuntando al backend
+  compress: true,
+  poweredByHeader: false,
+  images: {
+    formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 60 * 60 * 24 * 7,
+  },
   async headers() {
     return [
       {
-        source: "/(.*)",
+        source: "/images/:path*",
         headers: [
           {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-          {
-            key: "X-Frame-Options",
-            value: "DENY",
-          },
-          {
-            key: "X-XSS-Protection",
-            value: "1; mode=block",
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
           },
         ],
+      },
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
       },
     ];
   },

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -73,6 +73,7 @@
   * {
     @apply border-border;
   }
+
   body {
     @apply bg-background text-foreground;
   }
@@ -104,32 +105,92 @@
   }
 
   .field-textarea {
-    @apply flex w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm ring-offset-background placeholder:text-muted-foreground transition-[border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none;
+    @apply flex w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm ring-offset-background placeholder:text-muted-foreground transition-[border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50;
   }
 
-  .public-soft-canvas {
+  .render-surface {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     background:
       radial-gradient(circle at 12% 16%, rgba(45, 212, 191, 0.18), transparent 32%),
       radial-gradient(circle at 88% 4%, rgba(251, 191, 36, 0.16), transparent 30%),
       linear-gradient(135deg, #f8fafc 0%, #eef6ff 45%, #ecfeff 100%);
   }
 
-  .public-hero-depth {
+  .render-card {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.72);
+    border-radius: 1.25rem;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(248, 250, 252, 0.84));
+    box-shadow: 0 24px 78px rgba(15, 23, 42, 0.10);
+    transform: translateZ(0);
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      border-color 180ms ease,
+      background-color 180ms ease;
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
+    backface-visibility: hidden;
+  }
+
+  .render-card:hover {
+    border-color: rgba(125, 211, 252, 0.65);
+    box-shadow: 0 30px 95px rgba(15, 23, 42, 0.14);
+    transform: translate3d(0, -2px, 0);
+  }
+
+  .render-copy {
+    line-height: 1.68;
+    overflow-wrap: break-word;
+    text-wrap: pretty;
+  }
+
+  .render-gpu-soft {
+    transform: translateZ(0);
+    backface-visibility: hidden;
+  }
+
+  .render-orb {
+    opacity: 0.9;
+    filter: blur(48px);
+    transform: translateZ(0);
+    backface-visibility: hidden;
+    will-change: transform, opacity;
+  }
+
+  .public-soft-canvas,
+  [data-public-soft-canvas="true"] {
     position: relative;
     isolation: isolate;
     overflow: hidden;
     background:
-      radial-gradient(circle at 15% 10%, rgba(34, 211, 238, 0.28), transparent 30%),
-      radial-gradient(circle at 88% 12%, rgba(52, 211, 153, 0.22), transparent 26%),
-      radial-gradient(circle at 62% 112%, rgba(251, 191, 36, 0.14), transparent 32%),
-      linear-gradient(135deg, #071a35 0%, #123f7a 48%, #0f766e 100%);
+      radial-gradient(circle at 12% 16%, rgba(45, 212, 191, 0.18), transparent 32%),
+      radial-gradient(circle at 88% 4%, rgba(251, 191, 36, 0.16), transparent 30%),
+      linear-gradient(135deg, #f8fafc 0%, #eef6ff 45%, #ecfeff 100%);
   }
 
-  .public-hero-depth::after {
+  .public-hero-depth,
+  [data-public-hero-depth="true"] {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 12% 12%, rgba(34, 211, 238, 0.30), transparent 31%),
+      radial-gradient(circle at 88% 15%, rgba(52, 211, 153, 0.30), transparent 34%),
+      radial-gradient(circle at 50% 120%, rgba(251, 191, 36, 0.16), transparent 34%),
+      linear-gradient(135deg, #07365d 0%, #123f7a 42%, #0f766e 100%);
+  }
+
+  .public-hero-depth::after,
+  [data-public-hero-depth="true"]::after {
     content: "";
     position: absolute;
     inset: 0;
-    z-index: -1;
+    z-index: 0;
+    pointer-events: none;
     background-image:
       linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
       linear-gradient(90deg, rgba(255, 255, 255, 0.07) 1px, transparent 1px);
@@ -139,54 +200,20 @@
 
   .premium-card {
     @apply rounded-2xl border border-white/70 bg-white/85 shadow-[0_24px_70px_rgba(15,23,42,0.10)] backdrop-blur transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-[0_30px_90px_rgba(15,23,42,0.14)];
+    transform: translateZ(0);
+    backface-visibility: hidden;
   }
 
   .premium-card-muted {
     @apply rounded-2xl border border-slate-200/80 bg-white/75 shadow-[0_18px_50px_rgba(15,23,42,0.08)] backdrop-blur;
+    transform: translateZ(0);
+    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: blur(14px);
+    backface-visibility: hidden;
   }
 
   .premium-divider {
     background: linear-gradient(90deg, transparent, rgba(14, 165, 233, 0.45), rgba(45, 212, 191, 0.45), transparent);
-  }
-}
-@layer components {
-  [data-public-hero-depth="true"] {
-    position: relative;
-    isolation: isolate;
-    overflow: hidden;
-    background:
-      radial-gradient(circle at 15% 10%, rgba(34, 211, 238, 0.28), transparent 30%),
-      radial-gradient(circle at 88% 12%, rgba(52, 211, 153, 0.22), transparent 26%),
-      radial-gradient(circle at 62% 112%, rgba(251, 191, 36, 0.14), transparent 32%),
-      linear-gradient(135deg, #071a35 0%, #123f7a 48%, #0f766e 100%);
-  }
-
-  [data-public-hero-depth="true"]::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    background-image:
-      linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(255, 255, 255, 0.07) 1px, transparent 1px);
-    background-size: 46px 46px;
-    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 72%);
-  }
-
-  [data-public-soft-canvas="true"] {
-    background:
-      radial-gradient(circle at 12% 16%, rgba(45, 212, 191, 0.18), transparent 32%),
-      radial-gradient(circle at 88% 4%, rgba(251, 191, 36, 0.16), transparent 30%),
-      linear-gradient(135deg, #f8fafc 0%, #eef6ff 45%, #ecfeff 100%);
-  }
-}
-@layer components {
-  [data-public-hero-depth="true"][data-public-hero-depth="true"] {
-    background:
-      radial-gradient(circle at 12% 12%, rgba(34, 211, 238, 0.30), transparent 31%),
-      radial-gradient(circle at 88% 15%, rgba(52, 211, 153, 0.30), transparent 34%),
-      radial-gradient(circle at 50% 120%, rgba(251, 191, 36, 0.16), transparent 34%),
-      linear-gradient(135deg, #07365d 0%, #123f7a 42%, #0f766e 100%) !important;
   }
 
   [data-services-polished="true"] > [id] {
@@ -197,7 +224,14 @@
     background:
       linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(248, 250, 252, 0.84)) !important;
     box-shadow: 0 24px 78px rgba(15, 23, 42, 0.10) !important;
+    transform: translateZ(0);
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      border-color 180ms ease;
+    -webkit-backdrop-filter: blur(18px);
     backdrop-filter: blur(18px);
+    backface-visibility: hidden;
   }
 
   [data-services-polished="true"] > [id]::before {
@@ -211,11 +245,12 @@
   [data-services-polished="true"] > [id]:hover {
     border-color: rgba(125, 211, 252, 0.65) !important;
     box-shadow: 0 30px 95px rgba(15, 23, 42, 0.14) !important;
+    transform: translate3d(0, -2px, 0);
   }
-}
-@layer components {
+
   .public-copy {
     line-height: 1.7;
+    overflow-wrap: break-word;
     text-wrap: pretty;
   }
 
@@ -225,6 +260,7 @@
 
   .public-copy-tight {
     line-height: 1.58;
+    overflow-wrap: break-word;
     text-wrap: pretty;
   }
 
@@ -234,6 +270,7 @@
 
   .public-copy-card {
     line-height: 1.65;
+    overflow-wrap: break-word;
     text-wrap: pretty;
   }
 
@@ -241,5 +278,23 @@
   .public-copy-card > ul + p,
   .public-copy-card > p + ul {
     margin-top: 1lh;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .render-card,
+    .premium-card,
+    [data-services-polished="true"] > [id] {
+      transition: none;
+    }
+
+    .render-card:hover,
+    .premium-card:hover,
+    [data-services-polished="true"] > [id]:hover {
+      transform: translateZ(0);
+    }
+
+    .render-orb {
+      will-change: auto;
+    }
   }
 }

--- a/frontend/src/components/public/RenderPrimitives.tsx
+++ b/frontend/src/components/public/RenderPrimitives.tsx
@@ -1,0 +1,203 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type PublicHeroProps = {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
+};
+
+export function PublicHero({
+  eyebrow,
+  title,
+  description,
+  children,
+  className,
+  contentClassName,
+  titleClassName,
+  descriptionClassName,
+}: PublicHeroProps) {
+  return (
+    <section
+      className={cn("public-hero-depth py-16 text-white md:py-20", className)}
+    >
+      <div className={cn("container relative z-10 mx-auto px-4 sm:px-6 lg:px-8", contentClassName)}>
+        {eyebrow}
+        <h1
+          className={cn(
+            "mb-4 max-w-4xl text-4xl font-bold leading-tight tracking-tight md:text-5xl",
+            titleClassName,
+          )}
+        >
+          {title}
+        </h1>
+        {description ? (
+          <div
+            className={cn(
+              "render-copy max-w-2xl text-lg text-blue-50 md:text-xl",
+              descriptionClassName,
+            )}
+          >
+            {description}
+          </div>
+        ) : null}
+        {children}
+      </div>
+    </section>
+  );
+}
+
+type PublicSectionProps = {
+  children: ReactNode;
+  variant?: "plain" | "soft" | "muted";
+  className?: string;
+  containerClassName?: string;
+  id?: string;
+  labelledBy?: string;
+};
+
+const sectionVariants = {
+  plain: "bg-white py-16 md:py-20",
+  soft: "public-soft-canvas py-16 md:py-20",
+  muted: "bg-gray-50 py-16 md:py-20",
+};
+
+export function PublicSection({
+  children,
+  variant = "plain",
+  className,
+  containerClassName,
+  id,
+  labelledBy,
+}: PublicSectionProps) {
+  return (
+    <section
+      id={id}
+      aria-labelledby={labelledBy}
+      className={cn(sectionVariants[variant], className)}
+    >
+      <div className={cn("container mx-auto px-4 sm:px-6 lg:px-8", containerClassName)}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+type PublicSurfaceCardProps = {
+  children: ReactNode;
+  className?: string;
+  muted?: boolean;
+};
+
+export function PublicSurfaceCard({
+  children,
+  className,
+  muted = false,
+}: PublicSurfaceCardProps) {
+  return (
+    <div
+      className={cn(
+        muted ? "premium-card-muted" : "premium-card",
+        "render-gpu-soft",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type PublicGradientButtonProps = {
+  children: ReactNode;
+  className?: string;
+  href?: string;
+  showArrow?: boolean;
+  type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
+  disabled?: boolean;
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
+};
+
+const gradientButtonClassName =
+  "render-gpu-soft inline-flex h-11 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue-700 to-teal-600 px-5 text-sm font-semibold text-white shadow-[0_14px_35px_rgba(37,99,235,0.22)] transition-[transform,box-shadow,background-color] duration-200 hover:-translate-y-0.5 hover:from-blue-800 hover:to-teal-700 hover:shadow-[0_18px_44px_rgba(37,99,235,0.28)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60";
+
+export function PublicGradientButton({
+  children,
+  className,
+  href,
+  showArrow = false,
+  type = "button",
+  disabled,
+  onClick,
+}: PublicGradientButtonProps) {
+  const content = (
+    <>
+      {children}
+      {showArrow ? <ArrowRight className="h-4 w-4" aria-hidden="true" /> : null}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={cn(gradientButtonClassName, className)}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(gradientButtonClassName, className)}
+    >
+      {content}
+    </button>
+  );
+}
+
+type MetricPillTone = "blue" | "emerald" | "amber" | "slate";
+
+type MetricPillProps = {
+  label: ReactNode;
+  value: ReactNode;
+  tone?: MetricPillTone;
+  className?: string;
+};
+
+const metricToneClasses: Record<MetricPillTone, string> = {
+  blue: "border-blue-100 bg-blue-50/80 text-blue-900",
+  emerald: "border-emerald-100 bg-emerald-50/80 text-emerald-900",
+  amber: "border-amber-100 bg-amber-50/80 text-amber-900",
+  slate: "border-slate-200 bg-slate-50/80 text-slate-900",
+};
+
+export function MetricPill({
+  label,
+  value,
+  tone = "blue",
+  className,
+}: MetricPillProps) {
+  return (
+    <div
+      className={cn(
+        "render-gpu-soft rounded-2xl border px-4 py-3 shadow-sm",
+        metricToneClasses[tone],
+        className,
+      )}
+    >
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-70">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-bold leading-none">{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/public/VisualAccents.tsx
+++ b/frontend/src/components/public/VisualAccents.tsx
@@ -4,14 +4,16 @@ import { cn } from "@/lib/utils";
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
+type VisualTone = "blue" | "emerald" | "amber" | "slate";
+
 type VisualIconProps = {
   icon: IconComponent;
   className?: string;
   iconClassName?: string;
-  tone?: "blue" | "emerald" | "amber" | "slate";
+  tone?: VisualTone;
 };
 
-const toneClasses = {
+const toneClasses: Record<VisualTone, string> = {
   blue: "from-blue-500/15 via-cyan-400/10 to-white text-blue-700 ring-blue-500/15",
   emerald:
     "from-emerald-500/15 via-teal-400/10 to-white text-emerald-700 ring-emerald-500/15",
@@ -30,7 +32,7 @@ export function VisualIcon({
   return (
     <span
       className={cn(
-        "inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br shadow-[0_18px_45px_rgba(15,23,42,0.10)] ring-1",
+        "render-gpu-soft inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br shadow-[0_18px_45px_rgba(15,23,42,0.10)] ring-1",
         toneClasses[tone],
         className,
       )}
@@ -50,7 +52,7 @@ export function Eyebrow({ children, className }: EyebrowProps) {
   return (
     <p
       className={cn(
-        "mb-3 inline-flex items-center rounded-full border border-white/50 bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white/90 shadow-sm backdrop-blur",
+        "render-gpu-soft mb-3 inline-flex items-center rounded-full border border-white/50 bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white/90 shadow-sm backdrop-blur",
         className,
       )}
     >
@@ -61,28 +63,32 @@ export function Eyebrow({ children, className }: EyebrowProps) {
 
 type AmbientOrbsProps = {
   variant?: "light" | "dark";
+  className?: string;
 };
 
-export function AmbientOrbs({ variant = "light" }: AmbientOrbsProps) {
+export function AmbientOrbs({ variant = "light", className }: AmbientOrbsProps) {
   const isDark = variant === "dark";
 
   return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+    <div
+      className={cn("pointer-events-none absolute inset-0 overflow-hidden", className)}
+      aria-hidden="true"
+    >
       <div
         className={cn(
-          "absolute -left-24 -top-28 h-72 w-72 rounded-full blur-3xl",
+          "render-orb absolute -left-24 -top-28 h-72 w-72 rounded-full",
           isDark ? "bg-cyan-300/20" : "bg-cyan-200/45",
         )}
       />
       <div
         className={cn(
-          "absolute right-[-7rem] top-16 h-80 w-80 rounded-full blur-3xl",
+          "render-orb absolute right-[-7rem] top-16 h-80 w-80 rounded-full",
           isDark ? "bg-emerald-300/20" : "bg-emerald-200/45",
         )}
       />
       <div
         className={cn(
-          "absolute bottom-[-9rem] left-1/2 h-72 w-72 -translate-x-1/2 rounded-full blur-3xl",
+          "render-orb absolute bottom-[-9rem] left-1/2 h-72 w-72 -translate-x-1/2 rounded-full",
           isDark ? "bg-amber-200/15" : "bg-amber-100/55",
         )}
       />
@@ -99,7 +105,7 @@ export function PremiumPanel({ children, className }: PremiumPanelProps) {
   return (
     <div
       className={cn(
-        "rounded-3xl border border-white/70 bg-white/80 shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur-xl",
+        "render-gpu-soft rounded-3xl border border-white/70 bg-white/80 shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur-xl",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Add reusable public render primitives for visual polish surfaces, sections, gradient actions, and metric pills.
- Consolidate public render utilities for surfaces, cards, copy rhythm, GPU-safe soft rendering, and ambient orbs.
- Optimize public visual accents and frontend image/static cache headers without changing business logic.

## Validation
- pnpm test
- pnpm build
- pnpm --dir frontend build