### PR TITLE
fix(particular): normalize invalid token login response

### DIFF
--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -635,14 +635,22 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     const recordFailedLoginAttempt = async (input: {
       reason: LoginFailedAttemptReason;
     }) => {
-      await deps.recordLoginFailedAttempt({
-        surface: "particular",
-        username: null,
-        reason: input.reason,
-        ipAddress: request.ip || null,
-        userAgent: getUserAgent(request),
-        createdAt: new Date(currentTime),
-      });
+      try {
+        await deps.recordLoginFailedAttempt({
+          surface: "particular",
+          username: null,
+          reason: input.reason,
+          ipAddress: request.ip || null,
+          userAgent: getUserAgent(request),
+          createdAt: new Date(currentTime),
+        });
+      } catch (error) {
+        console.warn("[WARN] PARTICULAR_LOGIN_FAILED_ATTEMPT_RECORD_FAILED", {
+          surface: "particular",
+          reason: input.reason,
+          message: error instanceof Error ? error.message : "unknown error",
+        });
+      }
     };
 
     if (failureEntry.count >= loginRateLimitMaxAttempts) {

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -519,6 +519,42 @@ test(
   },
 );
 
+test(
+  "particularAuthNativeRoutes conserva 401 si falla auditoría de token inválido",
+  async () => {
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 4, 11, 0, 0, 0),
+      getParticularTokenByTokenHash: async () => null,
+      recordLoginFailedAttempt: async () => {
+        throw new Error("simulated failed-login persistence error");
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+          "user-agent": "vetneb-test-agent",
+        },
+        remoteAddress: "203.0.113.77",
+        payload: {
+          token: "INVALID-PARTICULAR-TOKEN",
+        },
+      });
+
+      assert.equal(response.statusCode, 401);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Token inválido",
+      });
+      assert.equal(response.headers["set-cookie"], undefined);
+    } finally {
+      await app.close();
+    }
+  },
+);
 test("particularAuthNativeRoutes persiste failed login sin secretos", async () => {
   const attempts: Array<Record<string, unknown>> = [];
 


### PR DESCRIPTION
## Summary
- Keep invalid particular token login responses as controlled 401 errors when failed-login persistence fails.
- Isolate failed-login audit persistence errors from the auth response path.
- Add regression coverage for invalid token login when failed-login recording throws.

## Validation
- pnpm test
- pnpm build
- pnpm --dir frontend build