### PR TITLE
feat(frontend): create tracking on report upload

### DIFF
--- a/frontend/src/components/dashboard/UploadReportModal.tsx
+++ b/frontend/src/components/dashboard/UploadReportModal.tsx
@@ -10,8 +10,8 @@ import { Input } from "@/components/ui/input";
 import { uploadAdminReport } from "@/lib/api";
 import { getAdminUsersRoles } from "@/lib/api";
 import {
+  createAdminStudyTrackingCase,
   getAdminParticularTokens,
-  linkAdminParticularTokenReport,
   type AdminParticularTokenSummary,
 } from "@/lib/api";
 
@@ -91,6 +91,29 @@ function buildParticularTokenLabel(token: AdminParticularTokenSummary) {
 
   return `Token ****${token.tokenLast4} · ${token.petName} · ${token.tutorLastName} · ${linkedLabel}`;
 }
+
+function getTrackingReceptionAt(uploadDate: string) {
+  if (uploadDate) {
+    return `${uploadDate}T00:00:00.000Z`;
+  }
+
+  return new Date().toISOString();
+}
+
+function formatTrackingDateLabel(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "calculada automáticamente";
+  }
+
+  return new Intl.DateTimeFormat("es-AR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(date);
+}
+
 
 export function UploadReportModal() {
   const router = useRouter();
@@ -364,13 +387,20 @@ export function UploadReportModal() {
       const response = await uploadAdminReport(formData);
 
       if (selectedParticularToken) {
-        await linkAdminParticularTokenReport(
-          selectedParticularToken.id,
-          response.report.id,
+        const trackingResponse = await createAdminStudyTrackingCase({
+          clinicId: Number(clinicId),
+          reportId: response.report.id,
+          particularTokenId: selectedParticularToken.id,
+          receptionAt: getTrackingReceptionAt(uploadDate),
+          currentStage: "reception",
+        });
+
+        const estimatedDelivery = formatTrackingDateLabel(
+          trackingResponse.trackingCase.estimatedDeliveryAt,
         );
 
         setSuccessMessage(
-          `${response.message}. Token particular vinculado al informe.`,
+          `${response.message}. Seguimiento particular creado con entrega estimada ${estimatedDelivery}.`,
         );
       } else {
         setSuccessMessage(response.message);
@@ -625,7 +655,13 @@ export function UploadReportModal() {
               value={uploadDate}
               onChange={(event) => setUploadDate(event.target.value)}
               disabled={isSubmitting}
+              aria-describedby="upload-date-help"
             />
+            <p id="upload-date-help" className="mt-1 text-xs text-gray-500">
+              El seguimiento particular usará esta fecha como recepción y
+              calculará entrega automática en 15 días hábiles, excluyendo
+              domingos y feriados nacionales argentinos.
+            </p>
           </div>
 
           {errorMessage ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -294,6 +294,74 @@ export async function linkAdminParticularTokenReport(
 }
 
 
+
+export type AdminStudyTrackingStage =
+  | "reception"
+  | "processing"
+  | "evaluation"
+  | "report_development"
+  | "delivered";
+
+export type AdminStudyTrackingCaseSummary = {
+  id: number;
+  clinicId: number;
+  reportId: number | null;
+  particularTokenId: number | null;
+  createdByAdminId: number | null;
+  createdByClinicUserId: number | null;
+  receptionAt: string;
+  estimatedDeliveryAt: string;
+  estimatedDeliveryAutoCalculatedAt: string;
+  estimatedDeliveryWasManuallyAdjusted: boolean;
+  currentStage: AdminStudyTrackingStage;
+  processingAt: string | null;
+  evaluationAt: string | null;
+  reportDevelopmentAt: string | null;
+  deliveredAt: string | null;
+  specialStainRequired: boolean;
+  specialStainNotifiedAt: string | null;
+  paymentUrl: string | null;
+  adminContactEmail: string | null;
+  adminContactPhone: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminStudyTrackingCreatePayload = {
+  clinicId: number;
+  reportId?: number | null;
+  particularTokenId?: number | null;
+  receptionAt: string;
+  estimatedDeliveryAt?: string | null;
+  currentStage?: AdminStudyTrackingStage;
+  specialStainRequired?: boolean;
+  paymentUrl?: string | null;
+  adminContactEmail?: string | null;
+  adminContactPhone?: string | null;
+  notes?: string | null;
+};
+
+export type AdminStudyTrackingCreateResponse = {
+  success: true;
+  message: string;
+  trackingCase: AdminStudyTrackingCaseSummary;
+};
+
+export async function createAdminStudyTrackingCase(
+  payload: AdminStudyTrackingCreatePayload,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingCreateResponse> {
+  return apiFetch<AdminStudyTrackingCreateResponse>(
+    "/api/admin/study-tracking",
+    {
+      ...options,
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
 export type ContactMessagePayload = {
   name: string;
   email: string;

--- a/test/frontend-report-actions.test.ts
+++ b/test/frontend-report-actions.test.ts
@@ -24,7 +24,7 @@ test("upload report modal is client-side and imports upload dependencies", () =>
   assert.ok(source.includes('import { uploadAdminReport } from "@/lib/api";'));
   assert.ok(source.includes('import { getAdminUsersRoles } from "@/lib/api";'));
   assert.ok(source.includes("getAdminParticularTokens"));
-  assert.ok(source.includes("linkAdminParticularTokenReport"));
+  assert.ok(source.includes("createAdminStudyTrackingCase"));
 });
 
 test("upload report modal keeps study type options", () => {
@@ -79,9 +79,10 @@ test("upload report modal calls upload API refreshes dashboard and handles error
   const source = read(UPLOAD_REPORT_MODAL_PATH);
 
   assert.ok(source.includes("const response = await uploadAdminReport(formData);"));
-  assert.ok(source.includes("await linkAdminParticularTokenReport("));
+  assert.ok(source.includes("const trackingResponse = await createAdminStudyTrackingCase({"));
   assert.ok(source.includes("response.report.id"));
-  assert.ok(source.includes("Token particular vinculado al informe."));
+  assert.ok(source.includes("trackingResponse.trackingCase.estimatedDeliveryAt"));
+  assert.ok(source.includes("Seguimiento particular creado con entrega estimada"));
   assert.ok(source.includes("setSuccessMessage(response.message);"));
   assert.ok(source.includes("resetForm();"));
   assert.ok(source.includes("router.refresh();"));
@@ -117,6 +118,8 @@ test("upload report modal renders accessible dialog and form controls", () => {
   assert.ok(source.includes('id="upload-study-type"'));
   assert.ok(source.includes('id="upload-date"'));
   assert.ok(source.includes('type="date"'));
+  assert.ok(source.includes("15 días hábiles"));
+  assert.ok(source.includes("feriados nacionales argentinos"));
 });
 
 test("upload report modal renders error success and submit states", () => {

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -13,6 +13,11 @@ const { ENV } = await import("../server/lib/env.ts");
 const {
   studyTrackingNativeRoutes,
 } = await import("../server/routes/study-tracking.fastify.ts");
+const {
+  calculateEstimatedDeliveryAt,
+  getBusinessDayWeight,
+  isArgentinaNationalHoliday,
+} = await import("../server/lib/study-tracking.ts");
 
 function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
   return {
@@ -23,8 +28,8 @@ function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
     createdByAdminId: null,
     createdByClinicUserId: 9,
     receptionAt: new Date("2026-04-20T00:00:00.000Z"),
-    estimatedDeliveryAt: new Date("2026-05-11T00:00:00.000Z"),
-    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-08T00:00:00.000Z"),
     estimatedDeliveryWasManuallyAdjusted: false,
     currentStage: "reception",
     processingAt: null,
@@ -146,6 +151,32 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
 
   return app;
 }
+
+test("study tracking calcula entrega con feriados nacionales argentinos perpetuos", () => {
+  const futureIndependenceDay = new Date("2040-07-09T00:00:00.000Z");
+  const futureChristmas = new Date("2099-12-25T00:00:00.000Z");
+
+  assert.equal(isArgentinaNationalHoliday(futureIndependenceDay), true);
+  assert.equal(getBusinessDayWeight(futureIndependenceDay), 0);
+  assert.equal(isArgentinaNationalHoliday(futureChristmas), true);
+  assert.equal(getBusinessDayWeight(futureChristmas), 0);
+
+  const oneBusinessDayAcrossHoliday = calculateEstimatedDeliveryAt(
+    new Date("2040-07-08T00:00:00.000Z"),
+    1,
+  );
+
+  assert.equal(
+    oneBusinessDayAcrossHoliday.toISOString(),
+    "2040-07-10T00:00:00.000Z",
+  );
+
+  const fifteenBusinessDays = calculateEstimatedDeliveryAt(
+    new Date("2026-04-20T00:00:00.000Z"),
+  );
+
+  assert.equal(fifteenBusinessDays.toISOString(), "2026-05-08T00:00:00.000Z");
+});
 
 test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async () => {
   const listCalls: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Create a study tracking case when an uploaded report is linked to a particular token.
- Use the upload date as receptionAt so backend estimated delivery rules calculate the due date automatically.
- Keep Argentine national holidays as non-working days in regression coverage.

## Validation
- pnpm test
- pnpm build
- pnpm --dir frontend build