### PR TITLE
fix(frontend): separate clinic and admin dashboards

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import Link from "next/link";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { StatsCards } from "@/components/dashboard/StatsCards";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -21,7 +22,7 @@ import {
 } from "@/lib/utils";
 
 export const metadata: Metadata = {
-  title: "Dashboard — Portal VETNEB",
+  title: "Dashboard Clínica — Portal VETNEB",
   robots: { index: false, follow: false },
 };
 
@@ -47,10 +48,11 @@ export default async function DashboardPage() {
 
   return (
     <>
-      <DashboardTopbar title="Dashboard" subtitle="Resumen operativo" />
+      <DashboardTopbar title="Dashboard Clínica" subtitle="Resumen operativo clínica" />
       <main className="dashboard-main">
         <div className="surface-note-info">
-          Lectura conectada a datos operativos del backend.
+          Lectura conectada a datos operativos clinic-scoped del backend. Esta
+          superficie no usa sesión de administración.
         </div>
 
         <StatsCards stats={stats} />
@@ -151,7 +153,11 @@ export default async function DashboardPage() {
                   href: ROUTES.dashboardLogisticaRutas,
                   icon: "🗺️",
                 },
-                { label: "Admin", href: ROUTES.dashboardAdmin, icon: "🔧" },
+                {
+                  label: "Tokens",
+                  href: "#clinic-particular-tokens",
+                  icon: "🔐",
+                },
               ].map((item) => (
                 <Button
                   key={item.href}
@@ -170,6 +176,8 @@ export default async function DashboardPage() {
             </div>
           </CardContent>
         </Card>
+
+        <ClinicParticularTokensCard />
       </main>
     </>
   );

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1,0 +1,546 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  createClinicParticularToken,
+  getClinicParticularTokens,
+  type ClinicParticularTokenCreatePayload,
+  type ClinicParticularTokenSummary,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+
+type ClinicParticularTokenFormState = {
+  reportId: string;
+  tutorLastName: string;
+  petName: string;
+  petAge: string;
+  petBreed: string;
+  petSex: string;
+  petSpecies: string;
+  sampleLocation: string;
+  sampleEvolution: string;
+  detailsLesion: string;
+  extractionDate: string;
+  shippingDate: string;
+};
+
+const INITIAL_FORM_STATE: ClinicParticularTokenFormState = {
+  reportId: "",
+  tutorLastName: "",
+  petName: "",
+  petAge: "",
+  petBreed: "",
+  petSex: "",
+  petSpecies: "",
+  sampleLocation: "",
+  sampleEvolution: "",
+  detailsLesion: "",
+  extractionDate: "",
+  shippingDate: "",
+};
+
+const REQUIRED_FIELD_LABELS: Array<{
+  key: keyof Omit<ClinicParticularTokenFormState, "reportId">;
+  label: string;
+}> = [
+  { key: "tutorLastName", label: "Apellido del tutor" },
+  { key: "petName", label: "Nombre del paciente" },
+  { key: "petAge", label: "Edad" },
+  { key: "petBreed", label: "Raza" },
+  { key: "petSex", label: "Sexo" },
+  { key: "petSpecies", label: "Especie" },
+  { key: "sampleLocation", label: "Ubicación de la muestra" },
+  { key: "sampleEvolution", label: "Evolución" },
+  { key: "detailsLesion", label: "Detalle de lesión" },
+  { key: "extractionDate", label: "Fecha de extracción" },
+  { key: "shippingDate", label: "Fecha de envío" },
+];
+
+const PET_SEX_OPTIONS = [
+  { value: "", label: "Seleccionar sexo" },
+  { value: "Macho", label: "Macho" },
+  { value: "Hembra", label: "Hembra" },
+  { value: "No informado", label: "No informado" },
+];
+
+const PET_SPECIES_OPTIONS = [
+  { value: "", label: "Seleccionar especie" },
+  { value: "Canina", label: "Canina" },
+  { value: "Felina", label: "Felina" },
+  { value: "Equina", label: "Equina" },
+  { value: "Otra", label: "Otra" },
+];
+
+function toIsoDate(value: string): string {
+  return `${value}T00:00:00.000Z`;
+}
+
+function normalizeText(value: string): string {
+  return value.trim();
+}
+
+function parseOptionalReportId(value: string): number | null {
+  const normalizedValue = value.trim();
+
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const parsedValue = Number(normalizedValue);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error("El ID de informe debe ser un número entero positivo.");
+  }
+
+  return parsedValue;
+}
+
+function validateFormState(formState: ClinicParticularTokenFormState): void {
+  const missingField = REQUIRED_FIELD_LABELS.find(
+    (field) => !String(formState[field.key]).trim(),
+  );
+
+  if (missingField) {
+    throw new Error(`Complete el campo obligatorio: ${missingField.label}.`);
+  }
+}
+
+function buildPayload(
+  formState: ClinicParticularTokenFormState,
+): ClinicParticularTokenCreatePayload {
+  validateFormState(formState);
+
+  return {
+    reportId: parseOptionalReportId(formState.reportId),
+    tutorLastName: normalizeText(formState.tutorLastName),
+    petName: normalizeText(formState.petName),
+    petAge: normalizeText(formState.petAge),
+    petBreed: normalizeText(formState.petBreed),
+    petSex: normalizeText(formState.petSex),
+    petSpecies: normalizeText(formState.petSpecies),
+    sampleLocation: normalizeText(formState.sampleLocation),
+    sampleEvolution: normalizeText(formState.sampleEvolution),
+    detailsLesion: normalizeText(formState.detailsLesion),
+    extractionDate: toIsoDate(formState.extractionDate),
+    shippingDate: toIsoDate(formState.shippingDate),
+  };
+}
+
+function formatTokenSource(token: ClinicParticularTokenSummary): string {
+  if (token.createdByClinicUserId) {
+    return `Clínica #${token.createdByClinicUserId}`;
+  }
+
+  if (token.createdByAdminId) {
+    return `Admin #${token.createdByAdminId}`;
+  }
+
+  return "Sistema";
+}
+
+export function ClinicParticularTokensCard() {
+  const [formState, setFormState] =
+    useState<ClinicParticularTokenFormState>(INITIAL_FORM_STATE);
+  const [tokens, setTokens] = useState<ClinicParticularTokenSummary[]>([]);
+  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [isLoadingTokens, setIsLoadingTokens] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function loadTokens() {
+    setIsLoadingTokens(true);
+
+    try {
+      const snapshot = await getClinicParticularTokens({ limit: 10, offset: 0 });
+      setTokens(snapshot.particularTokens);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudieron cargar los tokens particulares.",
+      );
+    } finally {
+      setIsLoadingTokens(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadTokens();
+  }, []);
+
+  function updateField(
+    field: keyof ClinicParticularTokenFormState,
+    value: string,
+  ) {
+    setFormState((current) => ({ ...current, [field]: value }));
+    setErrorMessage(null);
+    setStatusMessage(null);
+  }
+
+  function resetForm() {
+    setFormState(INITIAL_FORM_STATE);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setStatusMessage(null);
+    setGeneratedToken(null);
+
+    let payload: ClinicParticularTokenCreatePayload;
+
+    try {
+      payload = buildPayload(formState);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Revise los datos obligatorios del token.",
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await createClinicParticularToken(payload);
+
+      setGeneratedToken(response.token);
+      setStatusMessage(response.message);
+      resetForm();
+      await loadTokens();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo generar el token particular.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Card id="clinic-particular-tokens">
+      <CardHeader>
+        <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
+        <CardDescription>
+          Alta clinic-scoped en <code>POST /api/particular-tokens</code>. Todos
+          los datos programados son obligatorios, excepto el informe vinculado.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <label htmlFor="clinic-token-report-id" className="field-label">
+                ID informe vinculado
+              </label>
+              <Input
+                id="clinic-token-report-id"
+                name="reportId"
+                type="number"
+                min="1"
+                inputMode="numeric"
+                placeholder="Opcional"
+                value={formState.reportId}
+                onChange={(event) => updateField("reportId", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-tutor-last-name" className="field-label">
+                Apellido del tutor
+              </label>
+              <Input
+                id="clinic-token-tutor-last-name"
+                name="tutorLastName"
+                type="text"
+                required
+                value={formState.tutorLastName}
+                onChange={(event) =>
+                  updateField("tutorLastName", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-pet-name" className="field-label">
+                Nombre del paciente
+              </label>
+              <Input
+                id="clinic-token-pet-name"
+                name="petName"
+                type="text"
+                required
+                value={formState.petName}
+                onChange={(event) => updateField("petName", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-pet-age" className="field-label">
+                Edad
+              </label>
+              <Input
+                id="clinic-token-pet-age"
+                name="petAge"
+                type="text"
+                required
+                value={formState.petAge}
+                onChange={(event) => updateField("petAge", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-pet-breed" className="field-label">
+                Raza
+              </label>
+              <Input
+                id="clinic-token-pet-breed"
+                name="petBreed"
+                type="text"
+                required
+                value={formState.petBreed}
+                onChange={(event) => updateField("petBreed", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-pet-sex" className="field-label">
+                Sexo
+              </label>
+              <select
+                id="clinic-token-pet-sex"
+                name="petSex"
+                className="field-select"
+                required
+                value={formState.petSex}
+                onChange={(event) => updateField("petSex", event.target.value)}
+                disabled={isSubmitting}
+              >
+                {PET_SEX_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-pet-species" className="field-label">
+                Especie
+              </label>
+              <select
+                id="clinic-token-pet-species"
+                name="petSpecies"
+                className="field-select"
+                required
+                value={formState.petSpecies}
+                onChange={(event) =>
+                  updateField("petSpecies", event.target.value)
+                }
+                disabled={isSubmitting}
+              >
+                {PET_SPECIES_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-sample-location" className="field-label">
+                Ubicación de la muestra
+              </label>
+              <Input
+                id="clinic-token-sample-location"
+                name="sampleLocation"
+                type="text"
+                required
+                value={formState.sampleLocation}
+                onChange={(event) =>
+                  updateField("sampleLocation", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-sample-evolution" className="field-label">
+                Evolución
+              </label>
+              <Input
+                id="clinic-token-sample-evolution"
+                name="sampleEvolution"
+                type="text"
+                required
+                value={formState.sampleEvolution}
+                onChange={(event) =>
+                  updateField("sampleEvolution", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-extraction-date" className="field-label">
+                Fecha de extracción
+              </label>
+              <Input
+                id="clinic-token-extraction-date"
+                name="extractionDate"
+                type="date"
+                required
+                value={formState.extractionDate}
+                onChange={(event) =>
+                  updateField("extractionDate", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-shipping-date" className="field-label">
+                Fecha de envío
+              </label>
+              <Input
+                id="clinic-token-shipping-date"
+                name="shippingDate"
+                type="date"
+                required
+                value={formState.shippingDate}
+                onChange={(event) =>
+                  updateField("shippingDate", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="clinic-token-details-lesion" className="field-label">
+              Detalle de lesión
+            </label>
+            <textarea
+              id="clinic-token-details-lesion"
+              name="detailsLesion"
+              className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              required
+              value={formState.detailsLesion}
+              onChange={(event) => updateField("detailsLesion", event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {errorMessage ? (
+            <p
+              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {statusMessage ? (
+            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+              {statusMessage}
+            </p>
+          ) : null}
+
+          {generatedToken ? (
+            <div className="rounded-xl border border-blue-100 bg-blue-50 p-4">
+              <p className="text-sm font-semibold text-blue-900">
+                Token generado
+              </p>
+              <Input
+                className="mt-2 font-mono text-sm"
+                readOnly
+                value={generatedToken}
+                aria-label="Token particular generado"
+              />
+              <p className="mt-2 text-xs text-blue-700">
+                Copiar ahora. El token completo solo se muestra una vez.
+              </p>
+            </div>
+          ) : null}
+
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Generando token..." : "Generar token particular"}
+          </Button>
+        </form>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-gray-800">
+              Últimos tokens de la clínica
+            </h3>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadTokens()}
+              disabled={isLoadingTokens}
+            >
+              {isLoadingTokens ? "Actualizando..." : "Actualizar"}
+            </Button>
+          </div>
+
+          {tokens.length ? (
+            <div className="space-y-2">
+              {tokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3"
+                >
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">
+                        {token.petName} · {token.tutorLastName}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        Token ****{token.tokenLast4} · {token.petSpecies} ·{" "}
+                        {token.petBreed}
+                      </p>
+                    </div>
+                    <Badge variant={token.isActive ? "default" : "destructive"}>
+                      {token.isActive ? "Activo" : "Inactivo"}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 grid grid-cols-1 gap-2 text-xs text-gray-500 md:grid-cols-3">
+                    <p>Extracción: {formatDate(token.extractionDate)}</p>
+                    <p>Envío: {formatDate(token.shippingDate)}</p>
+                    <p>Origen: {formatTokenSource(token)}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="surface-empty">
+              {isLoadingTokens
+                ? "Cargando tokens particulares..."
+                : "No hay tokens particulares generados por esta clínica."}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -295,6 +295,101 @@ export async function linkAdminParticularTokenReport(
 
 
 
+
+export type ClinicParticularTokenSummary = AdminParticularTokenSummary;
+
+export type ClinicParticularTokensSnapshot = {
+  success: true;
+  count: number;
+  particularTokens: ClinicParticularTokenSummary[];
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+};
+
+export type ClinicParticularTokenCreatePayload = {
+  reportId?: number | null;
+  tutorLastName: string;
+  petName: string;
+  petAge: string;
+  petBreed: string;
+  petSex: string;
+  petSpecies: string;
+  sampleLocation: string;
+  sampleEvolution: string;
+  detailsLesion: string;
+  extractionDate: string;
+  shippingDate: string;
+};
+
+export type ClinicParticularTokenCreateResponse = {
+  success: true;
+  message: string;
+  token: string;
+  particularToken: ClinicParticularTokenSummary;
+};
+
+export type ClinicParticularTokenReportLinkResponse = {
+  success: true;
+  message: string;
+  particularToken: ClinicParticularTokenSummary | null;
+};
+
+export async function getClinicParticularTokens(
+  params: {
+    limit?: number;
+    offset?: number;
+  } = {},
+  options?: RequestInit,
+): Promise<ClinicParticularTokensSnapshot> {
+  const query = new URLSearchParams();
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<ClinicParticularTokensSnapshot>(
+    `/api/particular-tokens${qs ? `?${qs}` : ""}`,
+    options,
+  );
+}
+
+export async function createClinicParticularToken(
+  payload: ClinicParticularTokenCreatePayload,
+  options?: RequestInit,
+): Promise<ClinicParticularTokenCreateResponse> {
+  return apiFetch<ClinicParticularTokenCreateResponse>(
+    "/api/particular-tokens",
+    {
+      ...options,
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function linkClinicParticularTokenReport(
+  tokenId: number,
+  reportId: number | null,
+  options?: RequestInit,
+): Promise<ClinicParticularTokenReportLinkResponse> {
+  return apiFetch<ClinicParticularTokenReportLinkResponse>(
+    `/api/particular-tokens/${tokenId}/report`,
+    {
+      ...options,
+      method: "PATCH",
+      body: JSON.stringify({ reportId }),
+    },
+  );
+}
+
 export type AdminStudyTrackingStage =
   | "reception"
   | "processing"
@@ -715,4 +810,5 @@ export async function searchPublicProfessionals(
     };
   }
 }
+
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -3,16 +3,30 @@ import { NextResponse, type NextRequest } from "next/server";
 const CLINIC_SESSION_COOKIE_NAME = "app_session_id";
 const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";
 const LOGIN_PATH = "/login";
+const ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin";
+
+function isAdminDashboardPath(pathname: string): boolean {
+  return (
+    pathname === ADMIN_DASHBOARD_PATH_PREFIX ||
+    pathname.startsWith(`${ADMIN_DASHBOARD_PATH_PREFIX}/`)
+  );
+}
+
+function getRequiredSessionCookieName(pathname: string): string {
+  return isAdminDashboardPath(pathname)
+    ? ADMIN_SESSION_COOKIE_NAME
+    : CLINIC_SESSION_COOKIE_NAME;
+}
 
 export function middleware(request: NextRequest) {
-  const hasClinicSession = Boolean(
-    request.cookies.get(CLINIC_SESSION_COOKIE_NAME)?.value,
+  const requiredCookieName = getRequiredSessionCookieName(
+    request.nextUrl.pathname,
   );
-  const hasAdminSession = Boolean(
-    request.cookies.get(ADMIN_SESSION_COOKIE_NAME)?.value,
+  const hasRequiredSession = Boolean(
+    request.cookies.get(requiredCookieName)?.value,
   );
 
-  if (hasClinicSession || hasAdminSession) {
+  if (hasRequiredSession) {
     return NextResponse.next();
   }
 

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const CLINIC_TOKENS_CARD_PATH =
+  "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
+const API_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("clinic dashboard exists as a clinic-only dashboard and keeps admin out", () => {
+  const source = read(DASHBOARD_PAGE_PATH);
+
+  assert.ok(source.includes('title: "Dashboard Clínica — Portal VETNEB"'));
+  assert.ok(source.includes('title="Dashboard Clínica"'));
+  assert.ok(source.includes("superficie no usa sesión de administración."));
+  assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
+  assert.ok(source.includes("<ClinicParticularTokensCard />"));
+  assert.ok(source.includes('href: "#clinic-particular-tokens"'));
+  assert.equal(source.includes('label: "Admin"'), false);
+  assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
+});
+
+test("clinic particular tokens card exists and uses clinic-scoped endpoints", () => {
+  assert.equal(
+    existsSync(resolve(process.cwd(), CLINIC_TOKENS_CARD_PATH)),
+    true,
+    "clinic particular tokens card must exist",
+  );
+
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("createClinicParticularToken"));
+  assert.ok(source.includes("getClinicParticularTokens"));
+  assert.ok(source.includes('id="clinic-particular-tokens"'));
+  assert.ok(source.includes("POST /api/particular-tokens"));
+  assert.ok(source.includes("Todos"));
+  assert.ok(source.includes("los datos programados son obligatorios"));
+  assert.ok(source.includes("generatedToken"));
+  assert.ok(source.includes("El token completo solo se muestra una vez."));
+  assert.equal(source.includes("/api/admin/particular-tokens"), false);
+});
+
+test("clinic token generation requires all programmed data fields", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+
+  [
+    "tutorLastName",
+    "petName",
+    "petAge",
+    "petBreed",
+    "petSex",
+    "petSpecies",
+    "sampleLocation",
+    "sampleEvolution",
+    "detailsLesion",
+    "extractionDate",
+    "shippingDate",
+  ].forEach((field) => {
+    assert.ok(source.includes(field), `${field} must be present`);
+  });
+
+  assert.ok(source.includes("validateFormState"));
+  assert.ok(source.includes("Complete el campo obligatorio"));
+  assert.ok(source.includes("required"));
+  assert.ok(source.includes("reportId: parseOptionalReportId(formState.reportId)"));
+});
+
+test("frontend api exposes clinic-scoped particular token helpers", () => {
+  const source = read(API_PATH);
+
+  assert.ok(source.includes("export type ClinicParticularTokenSummary"));
+  assert.ok(source.includes("export type ClinicParticularTokenCreatePayload"));
+  assert.ok(source.includes("export async function getClinicParticularTokens("));
+  assert.ok(source.includes("export async function createClinicParticularToken("));
+  assert.ok(source.includes("export async function linkClinicParticularTokenReport("));
+  assert.ok(source.includes('"/api/particular-tokens"'));
+  assert.ok(source.includes("`/api/particular-tokens${qs ? `?${qs}` : \"\"}`"));
+  assert.ok(source.includes("`/api/particular-tokens/${tokenId}/report`"));
+});
+

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -12,16 +12,17 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard home defines non-indexable metadata and imports live dependencies", () => {
+test("dashboard home defines non-indexable clinic metadata and imports live dependencies", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
   assert.ok(source.includes('import Link from "next/link";'));
-  assert.ok(source.includes('title: "Dashboard — Portal VETNEB"'));
+  assert.ok(source.includes('title: "Dashboard Clínica — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
   assert.ok(source.includes('import { StatsCards } from "@/components/dashboard/StatsCards";'));
+  assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
 });
 
 test("dashboard home forwards cookies and disables cache for backend reads", () => {
@@ -46,11 +47,14 @@ test("dashboard home reads stats reports and field visits through API helpers", 
   assert.ok(source.includes("const recentVisits = visits.slice(0, 3);"));
 });
 
-test("dashboard home renders operational summary, stats, reports, and field visits", () => {
+test("dashboard home renders clinic operational summary, stats, reports, and field visits", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
-  assert.ok(source.includes('<DashboardTopbar title="Dashboard" subtitle="Resumen operativo" />'));
-  assert.ok(source.includes("Lectura conectada a datos operativos del backend."));
+  assert.ok(source.includes('title="Dashboard Clínica"'));
+  assert.ok(source.includes('subtitle="Resumen operativo clínica"'));
+  assert.ok(source.includes("Lectura conectada a datos operativos clinic-scoped del backend."));
+  assert.ok(source.includes("Esta"));
+  assert.ok(source.includes("superficie no usa sesión de administración."));
   assert.ok(source.includes("<StatsCards stats={stats} />"));
   assert.ok(source.includes("Informes recientes"));
   assert.ok(source.includes("Visitas de campo"));
@@ -69,7 +73,7 @@ test("dashboard home keeps status badges and date formatting wired", () => {
   assert.ok(source.includes("formatDate(visit.scheduledAt)"));
 });
 
-test("dashboard home exposes route-registry quick links only", () => {
+test("dashboard home exposes clinic route-registry quick links only", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
   assert.ok(source.includes("Accesos rápidos"));
@@ -78,6 +82,9 @@ test("dashboard home exposes route-registry quick links only", () => {
   assert.ok(source.includes("href: ROUTES.dashboardLogisticaVisitas"));
   assert.ok(source.includes('label: "Rutas"'));
   assert.ok(source.includes("href: ROUTES.dashboardLogisticaRutas"));
-  assert.ok(source.includes('label: "Admin", href: ROUTES.dashboardAdmin'));
+  assert.ok(source.includes('label: "Tokens"'));
+  assert.ok(source.includes('href: "#clinic-particular-tokens"'));
+  assert.equal(source.includes('label: "Admin"'), false);
+  assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
   assert.equal(source.includes('"/api"'), false);
 });

--- a/test/frontend-dashboard-middleware.test.ts
+++ b/test/frontend-dashboard-middleware.test.ts
@@ -25,12 +25,27 @@ test("frontend dashboard middleware exists and protects dashboard routes", () =>
   assert.ok(source.includes('CLINIC_SESSION_COOKIE_NAME = "app_session_id"'));
   assert.ok(source.includes('ADMIN_SESSION_COOKIE_NAME = "admin_session_id"'));
   assert.ok(source.includes('LOGIN_PATH = "/login"'));
-  assert.ok(source.includes("request.cookies.get(CLINIC_SESSION_COOKIE_NAME)"));
-  assert.ok(source.includes("request.cookies.get(ADMIN_SESSION_COOKIE_NAME)"));
-  assert.ok(source.includes("hasClinicSession || hasAdminSession"));
+  assert.ok(source.includes('ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin"'));
   assert.ok(source.includes("NextResponse.next()"));
   assert.ok(source.includes("NextResponse.redirect(loginUrl)"));
   assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
+});
+
+test("frontend dashboard middleware separates clinic and admin sessions", () => {
+  const source = read(MIDDLEWARE_PATH);
+
+  assert.ok(source.includes("function isAdminDashboardPath(pathname: string): boolean"));
+  assert.ok(source.includes("pathname === ADMIN_DASHBOARD_PATH_PREFIX"));
+  assert.ok(source.includes('pathname.startsWith(`${ADMIN_DASHBOARD_PATH_PREFIX}/`)'));
+  assert.ok(source.includes("function getRequiredSessionCookieName(pathname: string): string"));
+  assert.ok(source.includes("return isAdminDashboardPath(pathname)"));
+  assert.ok(source.includes("? ADMIN_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes(": CLINIC_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes("const requiredCookieName = getRequiredSessionCookieName("));
+  assert.ok(source.includes("request.nextUrl.pathname"));
+  assert.ok(source.includes("request.cookies.get(requiredCookieName)"));
+  assert.ok(source.includes("hasRequiredSession"));
+  assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
 test("frontend dashboard middleware preserves requested dashboard path", () => {

--- a/test/frontend-middleware.test.ts
+++ b/test/frontend-middleware.test.ts
@@ -19,17 +19,22 @@ test("frontend middleware imports Next response and request types", () => {
   assert.ok(source.includes("export function middleware(request: NextRequest)"));
 });
 
-test("frontend middleware checks clinic and admin session cookies before allowing dashboard access", () => {
+test("frontend middleware separates clinic and admin dashboard session cookies", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('const CLINIC_SESSION_COOKIE_NAME = "app_session_id";'));
   assert.ok(source.includes('const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";'));
-  assert.ok(source.includes("const hasClinicSession = Boolean("));
-  assert.ok(source.includes("const hasAdminSession = Boolean("));
-  assert.ok(source.includes("request.cookies.get(CLINIC_SESSION_COOKIE_NAME)?.value"));
-  assert.ok(source.includes("request.cookies.get(ADMIN_SESSION_COOKIE_NAME)?.value"));
-  assert.ok(source.includes("if (hasClinicSession || hasAdminSession) {"));
+  assert.ok(source.includes('const ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin";'));
+  assert.ok(source.includes("function isAdminDashboardPath(pathname: string): boolean"));
+  assert.ok(source.includes("pathname === ADMIN_DASHBOARD_PATH_PREFIX"));
+  assert.ok(source.includes('pathname.startsWith(`${ADMIN_DASHBOARD_PATH_PREFIX}/`)'));
+  assert.ok(source.includes("function getRequiredSessionCookieName(pathname: string): string"));
+  assert.ok(source.includes("? ADMIN_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes(": CLINIC_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes("request.cookies.get(requiredCookieName)?.value"));
+  assert.ok(source.includes("if (hasRequiredSession) {"));
   assert.ok(source.includes("return NextResponse.next();"));
+  assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
 test("frontend middleware redirects unauthenticated dashboard requests to login with next path", () => {


### PR DESCRIPTION
## Summary
- Separates dashboard session requirements so admin routes require admin session and clinic routes require clinic session.
- Updates clinic dashboard copy and quick links to remove admin access.
- Adds clinic-scoped particular token generation UI using `/api/particular-tokens`.
- Adds and updates frontend contract tests for separated dashboard behavior.

## Validation
- `pnpm test` → 1345/1345 pass
- `pnpm build` → OK

## Scope
- Dashboard particulares unchanged.