### PR TITLE
feat(frontend): add clinic public profile to dashboard

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
-import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -51,15 +50,13 @@ export default async function InformesPage() {
     <>
       <DashboardTopbar
         title="Informes"
-        subtitle="Gestión de informes médicos veterinarios"
+        subtitle="Consulta de informes médicos veterinarios"
       />
       <main className="dashboard-main">
-        <div className="flex justify-end">
-          <UploadReportModal />
-        </div>
-
         <div className="surface-note-info">
-          Lectura conectada a <code>GET /api/reports</code>.
+          Lectura clinic-scoped conectada a <code>GET /api/reports</code>.
+          Las acciones administrativas de carga se gestionan únicamente desde
+          el dashboard administrador.
         </div>
 
         <Card>
@@ -158,5 +155,3 @@ export default async function InformesPage() {
     </>
   );
 }
-
-

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import Link from "next/link";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
+import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
 import { StatsCards } from "@/components/dashboard/StatsCards";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -51,8 +52,7 @@ export default async function DashboardPage() {
       <DashboardTopbar title="Dashboard Clínica" subtitle="Resumen operativo clínica" />
       <main className="dashboard-main">
         <div className="surface-note-info">
-          Lectura conectada a datos operativos clinic-scoped del backend. Esta
-          superficie no usa sesión de administración.
+          Lectura conectada a datos operativos clinic-scoped del backend. Esta superficie usa solo sesión clínica.
         </div>
 
         <StatsCards stats={stats} />
@@ -158,6 +158,11 @@ export default async function DashboardPage() {
                   href: "#clinic-particular-tokens",
                   icon: "🔐",
                 },
+                {
+                  label: "Perfil",
+                  href: "#clinic-public-profile",
+                  icon: "🏥",
+                },
               ].map((item) => (
                 <Button
                   key={item.href}
@@ -177,8 +182,11 @@ export default async function DashboardPage() {
           </CardContent>
         </Card>
 
+        <ClinicPublicProfileCard />
         <ClinicParticularTokensCard />
       </main>
     </>
   );
 }
+
+

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  getClinicPublicProfile,
+  updateClinicPublicProfile,
+  type ClinicPublicProfile,
+  type ClinicPublicProfileUpdatePayload,
+} from "@/lib/api";
+
+type ProfileFormState = {
+  displayName: string;
+  specialtyText: string;
+  servicesText: string;
+  aboutText: string;
+  email: string;
+  phone: string;
+  locality: string;
+  country: string;
+  isPublic: boolean;
+};
+
+const INITIAL_FORM_STATE: ProfileFormState = {
+  displayName: "",
+  specialtyText: "",
+  servicesText: "",
+  aboutText: "",
+  email: "",
+  phone: "",
+  locality: "",
+  country: "",
+  isPublic: false,
+};
+
+const PUBLICATION_FIELD_LABELS: Record<string, string> = {
+  displayName: "Nombre visible",
+  specialtyText: "Especialidad",
+  locality: "Localidad",
+  country: "País",
+  avatar: "Avatar",
+  aboutText: "Descripción profesional",
+  servicesText: "Servicios",
+  email: "Email",
+  phone: "Teléfono",
+};
+
+function getFieldLabel(field: string) {
+  return PUBLICATION_FIELD_LABELS[field] ?? field;
+}
+
+function normalizeOptionalText(value: string) {
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+function toFormState(profile: ClinicPublicProfile): ProfileFormState {
+  return {
+    displayName: profile.displayName ?? "",
+    specialtyText: profile.specialtyText ?? "",
+    servicesText: profile.servicesText ?? "",
+    aboutText: profile.aboutText ?? "",
+    email: profile.email ?? "",
+    phone: profile.phone ?? "",
+    locality: profile.locality ?? "",
+    country: profile.country ?? "",
+    isPublic: profile.isPublic,
+  };
+}
+
+function buildPayload(formState: ProfileFormState): ClinicPublicProfileUpdatePayload {
+  return {
+    displayName: normalizeOptionalText(formState.displayName),
+    specialtyText: normalizeOptionalText(formState.specialtyText),
+    servicesText: normalizeOptionalText(formState.servicesText),
+    aboutText: normalizeOptionalText(formState.aboutText),
+    email: normalizeOptionalText(formState.email),
+    phone: normalizeOptionalText(formState.phone),
+    locality: normalizeOptionalText(formState.locality),
+    country: normalizeOptionalText(formState.country),
+    isPublic: formState.isPublic,
+  };
+}
+
+function getPublicationVariant(
+  profile: ClinicPublicProfile | null,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (!profile) return "outline";
+  if (profile.publication.isSearchEligible) return "default";
+  if (profile.isPublic && profile.publication.publicationErrors.length > 0) {
+    return "destructive";
+  }
+  return "secondary";
+}
+
+function getPublicationLabel(profile: ClinicPublicProfile | null) {
+  if (!profile) return "Sin cargar";
+  if (profile.publication.isSearchEligible) return "Visible en banco";
+  if (profile.isPublic) return "Publicación incompleta";
+  return "Borrador privado";
+}
+
+export function ClinicPublicProfileCard() {
+  const [profile, setProfile] = useState<ClinicPublicProfile | null>(null);
+  const [formState, setFormState] = useState<ProfileFormState>(INITIAL_FORM_STATE);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function loadProfile() {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const snapshot = await getClinicPublicProfile();
+
+      setProfile(snapshot.profile);
+      setFormState(toFormState(snapshot.profile));
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo cargar el perfil público de la clínica.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadProfile();
+  }, []);
+
+  function updateField<K extends keyof ProfileFormState>(
+    field: K,
+    value: ProfileFormState[K],
+  ) {
+    setFormState((current) => ({ ...current, [field]: value }));
+    setStatusMessage(null);
+    setErrorMessage(null);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const response = await updateClinicPublicProfile(buildPayload(formState));
+
+      setProfile(response.profile);
+      setFormState(toFormState(response.profile));
+      setStatusMessage(response.message);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo actualizar el perfil público.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const publication = profile?.publication;
+  const missingRequiredFields = publication?.missingRequiredFields ?? [];
+  const missingRecommendedFields = publication?.missingRecommendedFields ?? [];
+  const publicationErrors = publication?.publicationErrors ?? [];
+
+  return (
+    <Card id="clinic-public-profile">
+      <CardHeader>
+        <CardTitle className="text-base">Perfil para banco de especialidades</CardTitle>
+        <CardDescription>
+          Complete y publique el perfil de la clínica para aparecer en el banco
+          público de especialidades y profesionales.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+          <div className="surface-soft">
+            <p className="text-xs text-gray-400">Estado</p>
+            <Badge className="mt-2" variant={getPublicationVariant(profile)}>
+              {getPublicationLabel(profile)}
+            </Badge>
+          </div>
+          <div className="surface-soft">
+            <p className="text-xs text-gray-400">Calidad</p>
+            <p className="mt-1 text-2xl font-bold text-gray-900">
+              {publication ? publication.qualityScore : "—"}
+              <span className="text-sm font-medium text-gray-400">
+                /{publication?.minimumQualityScore ?? 75}
+              </span>
+            </p>
+          </div>
+          <div className="surface-soft">
+            <p className="text-xs text-gray-400">Campos obligatorios</p>
+            <p className="mt-1 text-sm font-semibold text-gray-800">
+              {publication?.hasRequiredPublicFields ? "Completos" : "Pendientes"}
+            </p>
+          </div>
+          <div className="surface-soft">
+            <p className="text-xs text-gray-400">Banco público</p>
+            <p className="mt-1 text-sm font-semibold text-gray-800">
+              {publication?.isSearchEligible ? "Visible" : "No visible"}
+            </p>
+          </div>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <label htmlFor="clinic-profile-display-name" className="field-label">
+                Nombre visible
+              </label>
+              <Input
+                id="clinic-profile-display-name"
+                name="displayName"
+                type="text"
+                required
+                value={formState.displayName}
+                onChange={(event) => updateField("displayName", event.target.value)}
+                disabled={isLoading || isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-profile-specialty" className="field-label">
+                Especialidad
+              </label>
+              <Input
+                id="clinic-profile-specialty"
+                name="specialtyText"
+                type="text"
+                required
+                value={formState.specialtyText}
+                onChange={(event) => updateField("specialtyText", event.target.value)}
+                disabled={isLoading || isSubmitting}
+                placeholder="Ej: Anatomía patológica veterinaria"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-profile-locality" className="field-label">
+                Localidad
+              </label>
+              <Input
+                id="clinic-profile-locality"
+                name="locality"
+                type="text"
+                required
+                value={formState.locality}
+                onChange={(event) => updateField("locality", event.target.value)}
+                disabled={isLoading || isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-profile-country" className="field-label">
+                País
+              </label>
+              <Input
+                id="clinic-profile-country"
+                name="country"
+                type="text"
+                required
+                value={formState.country}
+                onChange={(event) => updateField("country", event.target.value)}
+                disabled={isLoading || isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-profile-email" className="field-label">
+                Email público
+              </label>
+              <Input
+                id="clinic-profile-email"
+                name="email"
+                type="email"
+                value={formState.email}
+                onChange={(event) => updateField("email", event.target.value)}
+                disabled={isLoading || isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-profile-phone" className="field-label">
+                Teléfono público
+              </label>
+              <Input
+                id="clinic-profile-phone"
+                name="phone"
+                type="text"
+                value={formState.phone}
+                onChange={(event) => updateField("phone", event.target.value)}
+                disabled={isLoading || isSubmitting}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="clinic-profile-services" className="field-label">
+              Servicios
+            </label>
+            <textarea
+              id="clinic-profile-services"
+              name="servicesText"
+              className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              value={formState.servicesText}
+              onChange={(event) => updateField("servicesText", event.target.value)}
+              disabled={isLoading || isSubmitting}
+              placeholder="Describa prestaciones, estudios y servicios ofrecidos."
+            />
+          </div>
+
+          <div>
+            <label htmlFor="clinic-profile-about" className="field-label">
+              Descripción profesional
+            </label>
+            <textarea
+              id="clinic-profile-about"
+              name="aboutText"
+              className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              value={formState.aboutText}
+              onChange={(event) => updateField("aboutText", event.target.value)}
+              disabled={isLoading || isSubmitting}
+              placeholder="Complete trayectoria, foco profesional y datos relevantes para el banco de especialidades."
+            />
+          </div>
+
+          <label className="flex items-start gap-3 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={formState.isPublic}
+              onChange={(event) => updateField("isPublic", event.target.checked)}
+              disabled={isLoading || isSubmitting}
+            />
+            <span>
+              Publicar perfil cuando cumpla los requisitos para aparecer en el
+              banco de especialidades.
+            </span>
+          </label>
+
+          {missingRequiredFields.length ? (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+              <p className="font-semibold">Campos obligatorios pendientes:</p>
+              <p>{missingRequiredFields.map(getFieldLabel).join(", ")}</p>
+            </div>
+          ) : null}
+
+          {missingRecommendedFields.length ? (
+            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+              <p className="font-semibold">Recomendados para mejorar calidad:</p>
+              <p>{missingRecommendedFields.map(getFieldLabel).join(", ")}</p>
+            </div>
+          ) : null}
+
+          {publicationErrors.length ? (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {publicationErrors.map((error) => (
+                <p key={error}>{error}</p>
+              ))}
+            </div>
+          ) : null}
+
+          {errorMessage ? (
+            <p
+              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {statusMessage ? (
+            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+              {statusMessage}
+            </p>
+          ) : null}
+
+          <Button type="submit" disabled={isLoading || isSubmitting}>
+            {isSubmitting ? "Guardando perfil..." : "Guardar perfil público"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebar.tsx
@@ -28,9 +28,9 @@ const navItems = [
     ],
   },
   {
-    label: "Administración",
-    href: ROUTES.dashboardAdmin,
-    icon: "🔧",
+    label: "Perfil público",
+    href: "#clinic-public-profile",
+    icon: "🏥",
   },
 ];
 
@@ -38,6 +38,7 @@ export function DashboardSidebar() {
   const pathname = usePathname();
 
   function isActive(href: string, exact = false) {
+    if (href.startsWith("#")) return false;
     if (exact) return pathname === href;
     return pathname.startsWith(href);
   }
@@ -48,7 +49,6 @@ export function DashboardSidebar() {
       data-dashboard-sidebar-polish="true"
       aria-label="Navegación del dashboard"
     >
-      {/* Logo */}
       <div className="flex items-center justify-center gap-3 border-b border-sidebar-border px-2 py-5 sm:justify-start sm:px-6">
         <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-teal-500 text-sm font-black text-white shadow-[0_16px_40px_rgba(37,99,235,0.32)] ring-1 ring-white/20">
           VN
@@ -57,11 +57,10 @@ export function DashboardSidebar() {
           <p className="font-semibold text-sm text-sidebar-foreground">
             Portal VETNEB
           </p>
-          <p className="text-xs text-sidebar-foreground/60">Dashboard</p>
+          <p className="text-xs text-sidebar-foreground/60">Dashboard clínica</p>
         </div>
       </div>
 
-      {/* Navegación */}
       <nav className="flex-1 space-y-1 px-2 py-4 sm:px-3" aria-label="Menú principal">
         {navItems.map((item) => (
           <div key={item.href}>
@@ -80,7 +79,7 @@ export function DashboardSidebar() {
               </span>
               <span className="hidden sm:inline">{item.label}</span>
             </Link>
-            {/* Sub-navegación */}
+
             {item.children && isActive(item.href) && (
               <div className="ml-6 mt-1 hidden space-y-1 sm:block">
                 {item.children.map((child) => (
@@ -105,7 +104,6 @@ export function DashboardSidebar() {
         ))}
       </nav>
 
-      {/* Footer del sidebar */}
       <div className="border-t border-sidebar-border px-2 py-4 sm:px-3">
         <Link
           href={ROUTES.home}
@@ -118,3 +116,5 @@ export function DashboardSidebar() {
     </aside>
   );
 }
+
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -706,6 +706,95 @@ export function buildAdminFailedLoginAlertsCsvUrl(
   return `${API_BASE_URL}/api/admin/failed-login-alerts/export.csv${qs ? `?${qs}` : ""}`;
 }
 
+
+export type ClinicPublicProfilePublication = {
+  hasRequiredPublicFields: boolean;
+  hasQualitySupplement: boolean;
+  qualityScore: number;
+  minimumQualityScore: number;
+  isSearchEligible: boolean;
+  missingRequiredFields: string[];
+  missingRecommendedFields: string[];
+  publicationErrors: string[];
+};
+
+export type ClinicPublicProfile = {
+  clinicId: number;
+  clinicName: string;
+  displayName: string;
+  avatarUrl: string | null;
+  avatarStoragePath: string | null;
+  aboutText: string | null;
+  specialtyText: string | null;
+  servicesText: string | null;
+  email: string | null;
+  phone: string | null;
+  locality: string | null;
+  country: string | null;
+  isPublic: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+  publication: ClinicPublicProfilePublication;
+};
+
+export type ClinicPublicProfileSearchSnapshot = {
+  clinicId?: number;
+  isPublic?: boolean;
+  hasRequiredPublicFields?: boolean;
+  isSearchEligible?: boolean;
+  profileQualityScore?: number;
+  updatedAt?: string;
+  searchText?: string;
+};
+
+export type ClinicPublicProfileSnapshot = {
+  success: true;
+  profile: ClinicPublicProfile;
+  search: ClinicPublicProfileSearchSnapshot | null;
+};
+
+export type ClinicPublicProfileUpdatePayload = {
+  displayName?: string | null;
+  aboutText?: string | null;
+  specialtyText?: string | null;
+  servicesText?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  locality?: string | null;
+  country?: string | null;
+  isPublic?: boolean;
+};
+
+export type ClinicPublicProfileUpdateResponse = {
+  success: true;
+  message: string;
+  profile: ClinicPublicProfile;
+  search: ClinicPublicProfileSearchSnapshot | null;
+};
+
+export async function getClinicPublicProfile(
+  options?: RequestInit,
+): Promise<ClinicPublicProfileSnapshot> {
+  return apiFetch<ClinicPublicProfileSnapshot>(
+    "/api/clinic/profile",
+    options,
+  );
+}
+
+export async function updateClinicPublicProfile(
+  payload: ClinicPublicProfileUpdatePayload,
+  options?: RequestInit,
+): Promise<ClinicPublicProfileUpdateResponse> {
+  return apiFetch<ClinicPublicProfileUpdateResponse>(
+    "/api/clinic/profile",
+    {
+      ...options,
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
 export async function getDashboardStats(
   options?: RequestInit,
 ): Promise<DashboardStats> {
@@ -810,5 +899,6 @@ export async function searchPublicProfessionals(
     };
   }
 }
+
 
 

--- a/test/frontend-clinic-public-profile.test.ts
+++ b/test/frontend-clinic-public-profile.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PROFILE_CARD_PATH =
+  "frontend/src/components/dashboard/ClinicPublicProfileCard.tsx";
+const API_PATH = "frontend/src/lib/api.ts";
+const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("clinic public profile card exists and is clinic scoped", () => {
+  assert.equal(existsSync(resolve(process.cwd(), PROFILE_CARD_PATH)), true);
+
+  const source = read(PROFILE_CARD_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("getClinicPublicProfile"));
+  assert.ok(source.includes("updateClinicPublicProfile"));
+  assert.ok(source.includes('id="clinic-public-profile"'));
+  assert.ok(source.includes("Perfil para banco de especialidades"));
+  assert.ok(source.includes("especialidades"));
+  assert.equal(source.includes("/api/admin"), false);
+});
+
+test("clinic public profile card exposes required publication fields", () => {
+  const source = read(PROFILE_CARD_PATH);
+
+  [
+    "displayName",
+    "specialtyText",
+    "locality",
+    "country",
+    "servicesText",
+    "aboutText",
+    "email",
+    "phone",
+    "isPublic",
+  ].forEach((field) => {
+    assert.ok(source.includes(field), `${field} must be present`);
+  });
+
+  assert.ok(source.includes("missingRequiredFields"));
+  assert.ok(source.includes("missingRecommendedFields"));
+  assert.ok(source.includes("publicationErrors"));
+  assert.ok(source.includes("qualityScore"));
+  assert.ok(source.includes("minimumQualityScore"));
+  assert.ok(source.includes("isSearchEligible"));
+});
+
+test("frontend api exposes clinic public profile helpers", () => {
+  const source = read(API_PATH);
+
+  assert.ok(source.includes("export type ClinicPublicProfilePublication"));
+  assert.ok(source.includes("export type ClinicPublicProfile"));
+  assert.ok(source.includes("export type ClinicPublicProfileUpdatePayload"));
+  assert.ok(source.includes("export async function getClinicPublicProfile("));
+  assert.ok(source.includes("export async function updateClinicPublicProfile("));
+  assert.ok(source.includes('"/api/clinic/profile"'));
+});
+
+test("clinic dashboard renders public profile before token generation", () => {
+  const source = read(DASHBOARD_PAGE_PATH);
+
+  assert.ok(source.includes("ClinicPublicProfileCard"));
+  assert.ok(source.includes("<ClinicPublicProfileCard />"));
+  assert.ok(source.includes("<ClinicParticularTokensCard />"));
+  assert.ok(
+    source.indexOf("<ClinicPublicProfileCard />") <
+      source.indexOf("<ClinicParticularTokensCard />"),
+  );
+  assert.ok(source.includes('href: "#clinic-public-profile"'));
+  assert.ok(source.includes('label: "Perfil"'));
+});

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -20,7 +20,7 @@ test("clinic dashboard exists as a clinic-only dashboard and keeps admin out", (
 
   assert.ok(source.includes('title: "Dashboard Clínica — Portal VETNEB"'));
   assert.ok(source.includes('title="Dashboard Clínica"'));
-  assert.ok(source.includes("superficie no usa sesión de administración."));
+  assert.ok(source.includes("Esta superficie usa solo sesión clínica."));
   assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
   assert.ok(source.includes("<ClinicParticularTokensCard />"));
   assert.ok(source.includes('href: "#clinic-particular-tokens"'));
@@ -86,4 +86,5 @@ test("frontend api exposes clinic-scoped particular token helpers", () => {
   assert.ok(source.includes("`/api/particular-tokens${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("`/api/particular-tokens/${tokenId}/report`"));
 });
+
 

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -54,7 +54,7 @@ test("dashboard home renders clinic operational summary, stats, reports, and fie
   assert.ok(source.includes('subtitle="Resumen operativo clínica"'));
   assert.ok(source.includes("Lectura conectada a datos operativos clinic-scoped del backend."));
   assert.ok(source.includes("Esta"));
-  assert.ok(source.includes("superficie no usa sesión de administración."));
+  assert.ok(source.includes("Esta superficie usa solo sesión clínica."));
   assert.ok(source.includes("<StatsCards stats={stats} />"));
   assert.ok(source.includes("Informes recientes"));
   assert.ok(source.includes("Visitas de campo"));
@@ -88,3 +88,4 @@ test("dashboard home exposes clinic route-registry quick links only", () => {
   assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
   assert.equal(source.includes('"/api"'), false);
 });
+

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -12,7 +12,7 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard informes defines non-indexable metadata and dashboard dependencies", () => {
+test("dashboard informes defines non-indexable metadata and clinic read dependencies", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
@@ -20,8 +20,8 @@ test("dashboard informes defines non-indexable metadata and dashboard dependenci
   assert.ok(source.includes('title: "Informes — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
-  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
   assert.ok(source.includes('import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";'));
+  assert.equal(source.includes("UploadReportModal"), false);
 });
 
 test("dashboard informes forwards cookies and disables cache for report reads", () => {
@@ -45,14 +45,16 @@ test("dashboard informes keeps status filter options aligned to report statuses"
   assert.ok(source.includes('{ value: "delivered", label: "Entregado" }'));
 });
 
-test("dashboard informes renders topbar upload action and read-source notice", () => {
+test("dashboard informes renders read-only clinic source notice", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes('title="Informes"'));
-  assert.ok(source.includes('subtitle="Gestión de informes médicos veterinarios"'));
-  assert.ok(source.includes("<UploadReportModal />"));
-  assert.ok(source.includes("Lectura conectada a"));
+  assert.ok(source.includes('subtitle="Consulta de informes médicos veterinarios"'));
+  assert.ok(source.includes("Lectura clinic-scoped conectada a"));
   assert.ok(source.includes("GET /api/reports"));
+  assert.ok(source.includes("dashboard administrador"));
+  assert.equal(source.includes("<UploadReportModal />"), false);
+  assert.equal(source.includes("/api/admin"), false);
 });
 
 test("dashboard informes renders filters and reports table columns", () => {
@@ -74,8 +76,8 @@ test("dashboard informes keeps row rendering badges dates and download action", 
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("reports.map((report) =>"));
-  assert.ok(source.includes("report.patientName ?? \"—\""));
-  assert.ok(source.includes("report.studyType ?? \"—\""));
+  assert.ok(source.includes('report.patientName ?? "—"'));
+  assert.ok(source.includes('report.studyType ?? "—"'));
   assert.ok(source.includes("report.clinicName ?? `Clínica #${report.clinicId}`"));
   assert.ok(source.includes("formatDate(report.uploadDate)"));
   assert.ok(source.includes("getReportStatusVariant(report.status)"));

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -35,7 +35,7 @@ test("dashboard sidebar is client-side and uses route registry", () => {
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
 });
 
-test("dashboard sidebar defines primary dashboard navigation items", () => {
+test("dashboard sidebar defines clinic navigation items only", () => {
   const source = read(DASHBOARD_SIDEBAR_PATH);
 
   assert.ok(source.includes("const navItems = ["));
@@ -46,8 +46,10 @@ test("dashboard sidebar defines primary dashboard navigation items", () => {
   assert.ok(source.includes("href: ROUTES.dashboardInformes"));
   assert.ok(source.includes('label: "Logística"'));
   assert.ok(source.includes("href: ROUTES.dashboardLogistica"));
-  assert.ok(source.includes('label: "Administración"'));
-  assert.ok(source.includes("href: ROUTES.dashboardAdmin"));
+  assert.ok(source.includes('label: "Perfil público"'));
+  assert.ok(source.includes('href: "#clinic-public-profile"'));
+  assert.equal(source.includes('label: "Administración"'), false);
+  assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
 });
 
 test("dashboard sidebar defines logistics subnavigation", () => {
@@ -65,6 +67,7 @@ test("dashboard sidebar keeps active state and accessibility markers", () => {
   const source = read(DASHBOARD_SIDEBAR_PATH);
 
   assert.ok(source.includes("function isActive(href: string, exact = false)"));
+  assert.ok(source.includes('if (href.startsWith("#")) return false;'));
   assert.ok(source.includes("if (exact) return pathname === href;"));
   assert.ok(source.includes("return pathname.startsWith(href);"));
   assert.ok(source.includes('aria-label="Navegación del dashboard"'));
@@ -77,7 +80,9 @@ test("dashboard sidebar exposes brand and public-site escape link", () => {
   const source = read(DASHBOARD_SIDEBAR_PATH);
 
   assert.ok(source.includes("Portal VETNEB"));
-  assert.ok(source.includes("Dashboard"));
+  assert.ok(source.includes("Dashboard clínica"));
   assert.ok(source.includes("href={ROUTES.home}"));
   assert.ok(source.includes("Volver al sitio público"));
 });
+
+

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -3,8 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
-const UPLOAD_MODAL_PATH =
-  "frontend/src/components/dashboard/UploadReportModal.tsx";
+const UPLOAD_MODAL_PATH = "frontend/src/components/dashboard/UploadReportModal.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
 
 function read(relativePath: string): string {
@@ -14,45 +13,25 @@ function read(relativePath: string): string {
   );
 }
 
-test("frontend report upload modal exists and uses upload api client", () => {
+test("frontend upload report modal remains available as admin-only implementation", () => {
   assert.equal(existsSync(resolve(process.cwd(), UPLOAD_MODAL_PATH)), true);
 
   const source = read(UPLOAD_MODAL_PATH);
 
-  assert.ok(source.includes('"use client"'));
-  assert.ok(source.includes('import { uploadAdminReport } from "@/lib/api"'));
-  assert.ok(source.includes("new FormData()"));
-  assert.ok(source.includes('formData.append("clinicId", clinicId)'));
-  assert.ok(source.includes('formData.append("file", file)'));
-  assert.ok(source.includes('formData.append("patientName", patientName.trim())'));
-  assert.ok(source.includes('formData.append("studyType", studyType)'));
-  assert.ok(source.includes('formData.append("uploadDate", uploadDate)'));
-  assert.ok(source.includes("await uploadAdminReport(formData)"));
-  assert.ok(source.includes("router.refresh()"));
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("uploadAdminReport"));
+  assert.ok(source.includes("getAdminUsersRoles"));
+  assert.ok(source.includes("getAdminParticularTokens"));
+  assert.ok(source.includes("createAdminStudyTrackingCase"));
+  assert.ok(source.includes("uploadAdminReport"));
 });
 
-test("frontend report upload modal handles user feedback and submit state", () => {
-  const source = read(UPLOAD_MODAL_PATH);
-
-  assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
-  assert.ok(source.includes("const [successMessage, setSuccessMessage]"));
-  assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
-  assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("disabled={isSubmitting}"));
-  assert.ok(source.includes("Seleccione un archivo PDF para subir."));
-});
-
-test("frontend report upload modal stays scoped to frontend ui", () => {
-  const source = read(UPLOAD_MODAL_PATH);
-
-  assert.equal(source.includes("fetch("), false);
-  assert.equal(source.includes("/api/admin/reports/upload"), false);
-  assert.equal(source.includes("process.env"), false);
-});
-
-test("frontend informes page exposes upload report modal", () => {
+test("frontend informes page does not expose admin upload modal in clinic dashboard", () => {
   const source = read(INFORMES_PAGE_PATH);
 
-  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal"'));
-  assert.ok(source.includes("<UploadReportModal />"));
+  assert.equal(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal"'), false);
+  assert.equal(source.includes("<UploadReportModal />"), false);
+  assert.ok(source.includes("Lectura clinic-scoped conectada a"));
+  assert.ok(source.includes("dashboard administrador"));
 });
+


### PR DESCRIPTION
## Summary
- Adds a clinic-scoped public profile card to the clinic dashboard using `/api/clinic/profile`.
- Removes admin navigation from the clinic dashboard sidebar.
- Keeps clinic reports page read-only by removing the admin upload modal from clinic informes.
- Updates frontend contract tests for clinic-only dashboard behavior and public profile publishing requirements.

## Validation
- `pnpm test` → 1347/1347 pass
- `pnpm build` → OK

## Scope
- Dashboard particulares unchanged.
- Admin dashboard remains separate.