### PR TITLE
fix(frontend): block public admin login redirect

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -19,15 +19,18 @@ function getRequiredSessionCookieName(pathname: string): string {
 }
 
 export function middleware(request: NextRequest) {
-  const requiredCookieName = getRequiredSessionCookieName(
-    request.nextUrl.pathname,
-  );
+  const pathname = request.nextUrl.pathname;
+  const requiredCookieName = getRequiredSessionCookieName(pathname);
   const hasRequiredSession = Boolean(
     request.cookies.get(requiredCookieName)?.value,
   );
 
   if (hasRequiredSession) {
     return NextResponse.next();
+  }
+
+  if (isAdminDashboardPath(pathname)) {
+    return new NextResponse("Not Found", { status: 404 });
   }
 
   const loginUrl = request.nextUrl.clone();

--- a/test/frontend-dashboard-middleware.test.ts
+++ b/test/frontend-dashboard-middleware.test.ts
@@ -27,6 +27,7 @@ test("frontend dashboard middleware exists and protects dashboard routes", () =>
   assert.ok(source.includes('LOGIN_PATH = "/login"'));
   assert.ok(source.includes('ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin"'));
   assert.ok(source.includes("NextResponse.next()"));
+  assert.ok(source.includes('new NextResponse("Not Found", { status: 404 })'));
   assert.ok(source.includes("NextResponse.redirect(loginUrl)"));
   assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
 });
@@ -48,7 +49,16 @@ test("frontend dashboard middleware separates clinic and admin sessions", () => 
   assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
-test("frontend dashboard middleware preserves requested dashboard path", () => {
+test("frontend dashboard middleware blocks unauthenticated admin dashboard from public login", () => {
+  const source = read(MIDDLEWARE_PATH);
+
+  assert.ok(source.includes("const pathname = request.nextUrl.pathname;"));
+  assert.ok(source.includes("if (isAdminDashboardPath(pathname)) {"));
+  assert.ok(source.includes('return new NextResponse("Not Found", { status: 404 });'));
+  assert.equal(source.includes("loginUrl.pathname = LOGIN_PATH;\\n  loginUrl.searchParams.set"), false);
+});
+
+test("frontend dashboard middleware preserves requested clinic dashboard path on login redirect", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("request.nextUrl.clone()"));

--- a/test/frontend-middleware.test.ts
+++ b/test/frontend-middleware.test.ts
@@ -37,7 +37,17 @@ test("frontend middleware separates clinic and admin dashboard session cookies",
   assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
-test("frontend middleware redirects unauthenticated dashboard requests to login with next path", () => {
+test("frontend middleware blocks unauthenticated admin dashboard without public login redirect", () => {
+  const source = read(MIDDLEWARE_PATH);
+
+  assert.ok(source.includes("if (isAdminDashboardPath(pathname)) {"));
+  assert.ok(source.includes('return new NextResponse("Not Found", { status: 404 });'));
+  assert.equal(source.includes("notFoundUrl"), false);
+  assert.equal(source.includes("NOT_FOUND_PATH"), false);
+  assert.equal(source.includes('loginUrl.searchParams.set("next", nextPath);\\n\\n  return NextResponse.redirect(loginUrl);\\n}'), false);
+});
+
+test("frontend middleware redirects unauthenticated clinic dashboard requests to login with next path", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('const LOGIN_PATH = "/login";'));


### PR DESCRIPTION
## Summary
- Blocks unauthenticated /dashboard/admin from redirecting to the public login surface.
- Keeps clinic dashboard unauthenticated access redirected to /login with next path.
- Keeps login public surface limited to clinic and particular access.
- Updates frontend middleware contract tests.

## Validation
- pnpm test: 1355/1355 pass
- pnpm build: OK
- Manual: /dashboard/admin without admin_session_id returns 404