### PR TITLE
fix(frontend): keep dashboard sidebar sticky

### DIFF
--- a/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
@@ -42,7 +42,7 @@ export function DashboardSidebarFrame({
 
   return (
     <aside
-      className="flex min-h-screen w-[4.5rem] shrink-0 flex-col bg-sidebar text-sidebar-foreground sm:w-64"
+      className="sticky top-0 flex h-screen w-[4.5rem] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground sm:w-64"
       data-dashboard-sidebar-polish="true"
       aria-label="Navegación del dashboard"
     >
@@ -115,3 +115,4 @@ export function DashboardSidebarFrame({
     </aside>
   );
 }
+

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -53,6 +53,8 @@ test("dashboard sidebar frame is the shared visual shell for both roles", () => 
   assert.ok(source.includes("dashboardLabel: string;"));
   assert.ok(source.includes("navItems: DashboardNavItem[];"));
   assert.ok(source.includes('aria-label="Navegación del dashboard"'));
+  assert.ok(source.includes("sticky top-0 flex h-screen"));
+  assert.ok(source.includes("overflow-y-auto"));
   assert.ok(source.includes('aria-label="Menú principal"'));
   assert.ok(source.includes("function isActive(href: string, exact = false)"));
   assert.ok(source.includes("if (exact) return pathname === hrefPath;"));
@@ -92,3 +94,4 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);
 });
+

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -224,7 +224,7 @@ test("dashboard sidebar keeps shell consistency and responsive navigation classe
   assertMatchesAll(
     source,
     [
-      /className="flex min-h-screen w-\[4\.5rem\] shrink-0 flex-col bg-sidebar text-sidebar-foreground sm:w-64"/,
+      /className="sticky top-0 flex h-screen w-\[4\.5rem\] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground sm:w-64"/,
       /className="flex items-center justify-center gap-3 border-b border-sidebar-border px-2 py-5 sm:justify-start sm:px-6"/,
       /className="flex-1 space-y-1 px-2 py-4 sm:px-3"/,
       /"flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors sm:justify-start sm:px-3"/,
@@ -375,3 +375,6 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertInlineStylesAtMost(source, 0, "dashboard admin");
   assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
 });
+
+
+


### PR DESCRIPTION
## Summary
- Keeps the shared dashboard sidebar visible while scrolling.
- Applies to both clinic and admin dashboards through DashboardSidebarFrame.
- Updates dashboard shell and visual consistency tests.

## Validation
- pnpm test: 1355/1355 pass
- pnpm build: OK