### PR TITLE
feat(frontend): add admin particular token generator

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -1,0 +1,582 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  createAdminParticularToken,
+  getAdminParticularTokens,
+  type AdminParticularTokenCreatePayload,
+  type AdminParticularTokenSummary,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+
+type AdminParticularTokenFormState = {
+  clinicId: string;
+  reportId: string;
+  tutorLastName: string;
+  petName: string;
+  petAge: string;
+  petBreed: string;
+  petSex: string;
+  petSpecies: string;
+  sampleLocation: string;
+  sampleEvolution: string;
+  detailsLesion: string;
+  extractionDate: string;
+  shippingDate: string;
+};
+
+const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
+  clinicId: "",
+  reportId: "",
+  tutorLastName: "",
+  petName: "",
+  petAge: "",
+  petBreed: "",
+  petSex: "",
+  petSpecies: "",
+  sampleLocation: "",
+  sampleEvolution: "",
+  detailsLesion: "",
+  extractionDate: "",
+  shippingDate: "",
+};
+
+const REQUIRED_FIELD_LABELS: Array<{
+  key: keyof Omit<AdminParticularTokenFormState, "reportId">;
+  label: string;
+}> = [
+  { key: "clinicId", label: "ID de clínica" },
+  { key: "tutorLastName", label: "Apellido del tutor" },
+  { key: "petName", label: "Nombre del paciente" },
+  { key: "petAge", label: "Edad" },
+  { key: "petBreed", label: "Raza" },
+  { key: "petSex", label: "Sexo" },
+  { key: "petSpecies", label: "Especie" },
+  { key: "sampleLocation", label: "Ubicación de la muestra" },
+  { key: "sampleEvolution", label: "Evolución" },
+  { key: "detailsLesion", label: "Detalle de lesión" },
+  { key: "extractionDate", label: "Fecha de extracción" },
+  { key: "shippingDate", label: "Fecha de envío" },
+];
+
+const PET_SEX_OPTIONS = [
+  { value: "", label: "Seleccionar sexo" },
+  { value: "Macho", label: "Macho" },
+  { value: "Hembra", label: "Hembra" },
+  { value: "No informado", label: "No informado" },
+];
+
+const PET_SPECIES_OPTIONS = [
+  { value: "", label: "Seleccionar especie" },
+  { value: "Canina", label: "Canina" },
+  { value: "Felina", label: "Felina" },
+  { value: "Equina", label: "Equina" },
+  { value: "Otra", label: "Otra" },
+];
+
+function toIsoDate(value: string): string {
+  return `${value}T00:00:00.000Z`;
+}
+
+function normalizeText(value: string): string {
+  return value.trim();
+}
+
+function parsePositiveInteger(value: string, label: string): number {
+  const parsedValue = Number(value.trim());
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(`${label} debe ser un número entero positivo.`);
+  }
+
+  return parsedValue;
+}
+
+function parseOptionalReportId(value: string): number | null {
+  const normalizedValue = value.trim();
+
+  if (!normalizedValue) {
+    return null;
+  }
+
+  return parsePositiveInteger(normalizedValue, "El ID de informe");
+}
+
+function validateFormState(formState: AdminParticularTokenFormState): void {
+  const missingField = REQUIRED_FIELD_LABELS.find(
+    (field) => !String(formState[field.key]).trim(),
+  );
+
+  if (missingField) {
+    throw new Error(`Complete el campo obligatorio: ${missingField.label}.`);
+  }
+}
+
+function buildPayload(
+  formState: AdminParticularTokenFormState,
+): AdminParticularTokenCreatePayload {
+  validateFormState(formState);
+
+  return {
+    clinicId: parsePositiveInteger(formState.clinicId, "El ID de clínica"),
+    reportId: parseOptionalReportId(formState.reportId),
+    tutorLastName: normalizeText(formState.tutorLastName),
+    petName: normalizeText(formState.petName),
+    petAge: normalizeText(formState.petAge),
+    petBreed: normalizeText(formState.petBreed),
+    petSex: normalizeText(formState.petSex),
+    petSpecies: normalizeText(formState.petSpecies),
+    sampleLocation: normalizeText(formState.sampleLocation),
+    sampleEvolution: normalizeText(formState.sampleEvolution),
+    detailsLesion: normalizeText(formState.detailsLesion),
+    extractionDate: toIsoDate(formState.extractionDate),
+    shippingDate: toIsoDate(formState.shippingDate),
+  };
+}
+
+function formatTokenSource(token: AdminParticularTokenSummary): string {
+  if (token.createdByAdminId) {
+    return `Admin #${token.createdByAdminId}`;
+  }
+
+  if (token.createdByClinicUserId) {
+    return `Clínica #${token.createdByClinicUserId}`;
+  }
+
+  return "Sistema";
+}
+
+export function AdminParticularTokensCard() {
+  const [formState, setFormState] =
+    useState<AdminParticularTokenFormState>(INITIAL_FORM_STATE);
+  const [tokens, setTokens] = useState<AdminParticularTokenSummary[]>([]);
+  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [isLoadingTokens, setIsLoadingTokens] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function loadTokens() {
+    setIsLoadingTokens(true);
+
+    try {
+      const snapshot = await getAdminParticularTokens({ limit: 10, offset: 0 });
+      setTokens(snapshot.particularTokens);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudieron cargar los tokens particulares.",
+      );
+    } finally {
+      setIsLoadingTokens(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadTokens();
+  }, []);
+
+  function updateField(
+    field: keyof AdminParticularTokenFormState,
+    value: string,
+  ) {
+    setFormState((current) => ({ ...current, [field]: value }));
+    setErrorMessage(null);
+    setStatusMessage(null);
+  }
+
+  function resetForm() {
+    setFormState(INITIAL_FORM_STATE);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setStatusMessage(null);
+    setGeneratedToken(null);
+
+    let payload: AdminParticularTokenCreatePayload;
+
+    try {
+      payload = buildPayload(formState);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Revise los datos obligatorios del token.",
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await createAdminParticularToken(payload);
+
+      setGeneratedToken(response.token);
+      setStatusMessage(response.message);
+      resetForm();
+      await loadTokens();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo generar el token particular.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
+        <CardDescription>
+          Alta admin-scoped en <code>POST /api/admin/particular-tokens</code>.
+          Todos los datos programados son obligatorios, excepto el informe
+          vinculado. El ID de clínica es obligatorio.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <label htmlFor="admin-token-clinic-id" className="field-label">
+                ID de clínica
+              </label>
+              <Input
+                id="admin-token-clinic-id"
+                name="clinicId"
+                type="number"
+                min="1"
+                inputMode="numeric"
+                required
+                value={formState.clinicId}
+                onChange={(event) => updateField("clinicId", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-report-id" className="field-label">
+                ID informe vinculado
+              </label>
+              <Input
+                id="admin-token-report-id"
+                name="reportId"
+                type="number"
+                min="1"
+                inputMode="numeric"
+                placeholder="Opcional"
+                value={formState.reportId}
+                onChange={(event) => updateField("reportId", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-tutor-last-name" className="field-label">
+                Apellido del tutor
+              </label>
+              <Input
+                id="admin-token-tutor-last-name"
+                name="tutorLastName"
+                type="text"
+                required
+                value={formState.tutorLastName}
+                onChange={(event) =>
+                  updateField("tutorLastName", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-pet-name" className="field-label">
+                Nombre del paciente
+              </label>
+              <Input
+                id="admin-token-pet-name"
+                name="petName"
+                type="text"
+                required
+                value={formState.petName}
+                onChange={(event) => updateField("petName", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-pet-age" className="field-label">
+                Edad
+              </label>
+              <Input
+                id="admin-token-pet-age"
+                name="petAge"
+                type="text"
+                required
+                value={formState.petAge}
+                onChange={(event) => updateField("petAge", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-pet-breed" className="field-label">
+                Raza
+              </label>
+              <Input
+                id="admin-token-pet-breed"
+                name="petBreed"
+                type="text"
+                required
+                value={formState.petBreed}
+                onChange={(event) => updateField("petBreed", event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-pet-sex" className="field-label">
+                Sexo
+              </label>
+              <select
+                id="admin-token-pet-sex"
+                name="petSex"
+                className="field-select"
+                required
+                value={formState.petSex}
+                onChange={(event) => updateField("petSex", event.target.value)}
+                disabled={isSubmitting}
+              >
+                {PET_SEX_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-pet-species" className="field-label">
+                Especie
+              </label>
+              <select
+                id="admin-token-pet-species"
+                name="petSpecies"
+                className="field-select"
+                required
+                value={formState.petSpecies}
+                onChange={(event) =>
+                  updateField("petSpecies", event.target.value)
+                }
+                disabled={isSubmitting}
+              >
+                {PET_SPECIES_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-sample-location" className="field-label">
+                Ubicación de la muestra
+              </label>
+              <Input
+                id="admin-token-sample-location"
+                name="sampleLocation"
+                type="text"
+                required
+                value={formState.sampleLocation}
+                onChange={(event) =>
+                  updateField("sampleLocation", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-sample-evolution" className="field-label">
+                Evolución
+              </label>
+              <Input
+                id="admin-token-sample-evolution"
+                name="sampleEvolution"
+                type="text"
+                required
+                value={formState.sampleEvolution}
+                onChange={(event) =>
+                  updateField("sampleEvolution", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-extraction-date" className="field-label">
+                Fecha de extracción
+              </label>
+              <Input
+                id="admin-token-extraction-date"
+                name="extractionDate"
+                type="date"
+                required
+                value={formState.extractionDate}
+                onChange={(event) =>
+                  updateField("extractionDate", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-shipping-date" className="field-label">
+                Fecha de envío
+              </label>
+              <Input
+                id="admin-token-shipping-date"
+                name="shippingDate"
+                type="date"
+                required
+                value={formState.shippingDate}
+                onChange={(event) =>
+                  updateField("shippingDate", event.target.value)
+                }
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="admin-token-details-lesion" className="field-label">
+              Detalle de lesión
+            </label>
+            <textarea
+              id="admin-token-details-lesion"
+              name="detailsLesion"
+              className="field-textarea"
+              required
+              value={formState.detailsLesion}
+              onChange={(event) =>
+                updateField("detailsLesion", event.target.value)
+              }
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {errorMessage ? (
+            <p
+              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {statusMessage ? (
+            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+              {statusMessage}
+            </p>
+          ) : null}
+
+          {generatedToken ? (
+            <div className="rounded-xl border border-blue-100 bg-blue-50 p-4">
+              <p className="text-sm font-semibold text-blue-900">
+                Token generado
+              </p>
+              <Input
+                className="mt-2 font-mono text-sm"
+                readOnly
+                value={generatedToken}
+                aria-label="Token particular generado por admin"
+              />
+              <p className="mt-2 text-xs text-blue-700">
+                Copiar ahora. El token completo solo se muestra una vez.
+              </p>
+            </div>
+          ) : null}
+
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Generando token..." : "Generar token particular"}
+          </Button>
+        </form>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-gray-800">
+              Últimos tokens administrados
+            </h3>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadTokens()}
+              disabled={isLoadingTokens}
+            >
+              {isLoadingTokens ? "Actualizando..." : "Actualizar"}
+            </Button>
+          </div>
+
+          {tokens.length ? (
+            <div className="space-y-2">
+              {tokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3"
+                >
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">
+                        Clínica #{token.clinicId} · {token.petName} ·{" "}
+                        {token.tutorLastName}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        Token ****{token.tokenLast4} · {token.petSpecies} ·{" "}
+                        {token.petBreed}
+                      </p>
+                    </div>
+                    <Badge variant={token.isActive ? "default" : "destructive"}>
+                      {token.isActive ? "Activo" : "Inactivo"}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 grid grid-cols-1 gap-2 text-xs text-gray-500 md:grid-cols-4">
+                    <p>Extracción: {formatDate(token.extractionDate)}</p>
+                    <p>Envío: {formatDate(token.shippingDate)}</p>
+                    <p>Informe: {token.reportId ? `#${token.reportId}` : "—"}</p>
+                    <p>Origen: {formatTokenSource(token)}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="surface-empty">
+              {isLoadingTokens
+                ? "Cargando tokens particulares..."
+                : "No hay tokens particulares administrados."}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/card";
 import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
+import { AdminParticularTokensCard } from "./AdminParticularTokensCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
@@ -415,6 +416,9 @@ export default async function AdminPage({
         <section id="admin-maintenance">
           <AdminMaintenanceDryRunCard />
         </section>
+        <section id="admin-particular-tokens">
+          <AdminParticularTokensCard />
+        </section>
         <section id="admin-sessions">
           <AdminSessionsReadOnlyCard />
         </section>
@@ -587,6 +591,7 @@ export default async function AdminPage({
     </>
   );
 }
+
 
 
 

--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -17,6 +17,11 @@ const adminNavItems: DashboardNavItem[] = [
     icon: "🟢",
   },
   {
+    label: "Tokens particulares",
+    href: `${ROUTES.dashboardAdmin}#admin-particular-tokens`,
+    icon: "🎫",
+  },
+  {
     label: "Sesiones",
     href: `${ROUTES.dashboardAdmin}#admin-sessions`,
     icon: "🔐",
@@ -46,3 +51,4 @@ export function AdminDashboardSidebar() {
     />
   );
 }
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -248,6 +248,44 @@ export type AdminParticularTokenReportLinkResponse = {
   particularToken: AdminParticularTokenDetail | null;
 };
 
+
+export type AdminParticularTokenCreatePayload = {
+  clinicId: number;
+  reportId?: number | null;
+  tutorLastName: string;
+  petName: string;
+  petAge: string;
+  petBreed: string;
+  petSex: string;
+  petSpecies: string;
+  sampleLocation: string;
+  sampleEvolution: string;
+  detailsLesion: string;
+  extractionDate: string;
+  shippingDate: string;
+};
+
+export type AdminParticularTokenCreateResponse = {
+  success: true;
+  message: string;
+  token: string;
+  particularToken: AdminParticularTokenSummary;
+};
+
+export async function createAdminParticularToken(
+  payload: AdminParticularTokenCreatePayload,
+  options?: RequestInit,
+): Promise<AdminParticularTokenCreateResponse> {
+  return apiFetch<AdminParticularTokenCreateResponse>(
+    "/api/admin/particular-tokens",
+    {
+      ...options,
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
 export async function getAdminParticularTokens(
   params: {
     clinicId?: number;
@@ -899,6 +937,7 @@ export async function searchPublicProfessionals(
     };
   }
 }
+
 
 
 

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const ADMIN_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const ADMIN_SIDEBAR_PATH =
+  "frontend/src/components/dashboard/AdminDashboardSidebar.tsx";
+const API_PATH = "frontend/src/lib/api.ts";
+const CLINIC_CARD_PATH =
+  "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("admin particular token generator uses admin-scoped endpoints", () => {
+  const card = read(ADMIN_CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes('"use client";'));
+  assert.ok(card.includes("createAdminParticularToken"));
+  assert.ok(card.includes("getAdminParticularTokens"));
+  assert.ok(card.includes("type AdminParticularTokenCreatePayload"));
+  assert.ok(card.includes("type AdminParticularTokenSummary"));
+  assert.ok(card.includes("Alta admin-scoped"));
+  assert.ok(card.includes("POST /api/admin/particular-tokens"));
+  assert.ok(api.includes("export async function createAdminParticularToken("));
+  assert.ok(api.includes('"/api/admin/particular-tokens"'));
+});
+
+test("admin particular token generator requires clinic id and programmed fields", () => {
+  const source = read(ADMIN_CARD_PATH);
+
+  assert.ok(source.includes("clinicId: string;"));
+  assert.ok(source.includes('{ key: "clinicId", label: "ID de clínica" }'));
+  assert.ok(source.includes('id="admin-token-clinic-id"'));
+  assert.ok(source.includes("clinicId: parsePositiveInteger(formState.clinicId"));
+  assert.ok(source.includes("Complete el campo obligatorio"));
+  assert.ok(source.includes("tutorLastName"));
+  assert.ok(source.includes("petName"));
+  assert.ok(source.includes("petAge"));
+  assert.ok(source.includes("petBreed"));
+  assert.ok(source.includes("petSex"));
+  assert.ok(source.includes("petSpecies"));
+  assert.ok(source.includes("sampleLocation"));
+  assert.ok(source.includes("sampleEvolution"));
+  assert.ok(source.includes("detailsLesion"));
+  assert.ok(source.includes("extractionDate"));
+  assert.ok(source.includes("shippingDate"));
+});
+
+test("admin dashboard mounts token generator and exposes admin navigation anchor", () => {
+  const page = read(ADMIN_PAGE_PATH);
+  const sidebar = read(ADMIN_SIDEBAR_PATH);
+
+  assert.ok(page.includes('import { AdminParticularTokensCard } from "./AdminParticularTokensCard";'));
+  assert.ok(page.includes('id="admin-particular-tokens"'));
+  assert.ok(page.includes("<AdminParticularTokensCard />"));
+  assert.ok(sidebar.includes('label: "Tokens particulares"'));
+  assert.ok(sidebar.includes('`${ROUTES.dashboardAdmin}#admin-particular-tokens`'));
+});
+
+test("clinic token generator remains clinic-scoped and separate from admin generator", () => {
+  const clinic = read(CLINIC_CARD_PATH);
+  const admin = read(ADMIN_CARD_PATH);
+
+  assert.ok(clinic.includes("createClinicParticularToken"));
+  assert.ok(clinic.includes("getClinicParticularTokens"));
+  assert.ok(clinic.includes("POST /api/particular-tokens"));
+  assert.equal(clinic.includes("createAdminParticularToken"), false);
+
+  assert.ok(admin.includes("createAdminParticularToken"));
+  assert.ok(admin.includes("getAdminParticularTokens"));
+  assert.equal(admin.includes("createClinicParticularToken"), false);
+});

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -30,9 +30,11 @@ test("dashboard admin includes read-only admin cards", () => {
 
   assert.ok(source.includes('import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";'));
   assert.ok(source.includes('import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";'));
+  assert.ok(source.includes('import { AdminParticularTokensCard } from "./AdminParticularTokensCard";'));
   assert.ok(source.includes('import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";'));
   assert.ok(source.includes('import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";'));
   assert.ok(source.includes("<AdminMaintenanceDryRunCard />"));
+  assert.ok(source.includes("<AdminParticularTokensCard />"));
   assert.ok(source.includes("<AdminSessionsReadOnlyCard />"));
   assert.ok(source.includes("<AdminFailedLoginAlertsReadOnlyCard />"));
   assert.ok(source.includes("<AdminUsersRolesReadOnlyCard />"));
@@ -126,6 +128,7 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes('id="admin-health"'));
   assert.ok(source.includes('id="admin-maintenance"'));
   assert.ok(source.includes('id="admin-sessions"'));
+  assert.ok(source.includes('id="admin-particular-tokens"'));
   assert.ok(source.includes('id="admin-users-roles"'));
   assert.ok(source.includes('id="admin-event-summary"'));
   assert.ok(source.includes("Health & Maintenance"));
@@ -170,3 +173,4 @@ test("dashboard admin avoids duplicate section ids in navigation anchors", () =>
   assert.equal(adminHealthIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });
+

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -87,6 +87,7 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.ok(source.includes('label: "Administración"'));
   assert.ok(source.includes('label: "Health"'));
   assert.ok(source.includes('label: "Sesiones"'));
+  assert.ok(source.includes('label: "Tokens particulares"'));
   assert.ok(source.includes('label: "Roles clínica"'));
   assert.ok(source.includes('label: "Auditoría"'));
   assert.ok(source.includes('label: "Maintenance"'));
@@ -94,4 +95,5 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);
 });
+
 

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -265,6 +265,7 @@ test("clinic and admin sidebars keep visual parity with separated operational na
       'label: "Administración"',
       'label: "Health"',
       'label: "Sesiones"',
+      'label: "Tokens particulares"',
       'label: "Roles clínica"',
       'label: "Auditoría"',
       'label: "Maintenance"',
@@ -375,6 +376,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertInlineStylesAtMost(source, 0, "dashboard admin");
   assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
 });
+
 
 
 


### PR DESCRIPTION
## Summary
- Adds the same particular token generation workflow to the admin dashboard.
- Uses admin-scoped /api/admin/particular-tokens endpoints.
- Requires clinicId for admin-created tokens.
- Keeps clinic token generation clinic-scoped and separate.
- Adds admin sidebar navigation anchor for token generation.

## Validation
- pnpm test: 1359/1359 pass
- pnpm build: OK