### PR TITLE
fix(frontend): remove dashboard topbar mock chip

### DIFF
--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -9,11 +9,16 @@ interface DashboardTopbarProps {
 
 export function DashboardTopbar({ title, subtitle }: DashboardTopbarProps) {
   return (
-    <header className="sticky top-0 z-40 flex min-h-16 items-center justify-between border-b bg-white/95 px-4 py-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/80 sm:px-6"
-      data-dashboard-topbar-polish="true">
+    <header
+      className="sticky top-0 z-40 flex min-h-16 items-center justify-between border-b bg-white/95 px-4 py-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/80 sm:px-6"
+      data-dashboard-topbar-polish="true"
+    >
       <div className="min-w-0">
         <div className="mb-1 hidden items-center gap-2 sm:flex">
-          <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.12)]" aria-hidden="true" />
+          <span
+            className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.12)]"
+            aria-hidden="true"
+          />
           <span className="text-[0.66rem] font-semibold uppercase tracking-[0.22em] text-blue-700">
             Portal operativo
           </span>
@@ -27,14 +32,8 @@ export function DashboardTopbar({ title, subtitle }: DashboardTopbarProps) {
           </p>
         )}
       </div>
+
       <div className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3">
-        {/* Usuario mock — reemplazar con estado real de sesión */}
-        <div className="flex items-center gap-2 rounded-2xl border border-slate-200/80 bg-white/80 px-2 py-1 text-sm text-gray-600 shadow-sm">
-          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-            CL
-          </div>
-          <span className="hidden sm:block">Clínica Demo</span>
-        </div>
         <Button asChild variant="outline" size="sm">
           <Link href={ROUTES.login}>Cerrar sesión</Link>
         </Button>

--- a/test/frontend-dashboard-shared-components.test.ts
+++ b/test/frontend-dashboard-shared-components.test.ts
@@ -36,13 +36,15 @@ test("dashboard topbar keeps typed title and optional subtitle props", () => {
   assert.ok(source.includes("{subtitle}"));
 });
 
-test("dashboard topbar keeps protected dashboard header shell", () => {
+test("dashboard topbar keeps protected dashboard header shell without mock session chip", () => {
   const source = read(DASHBOARD_TOPBAR_PATH);
 
-  assert.ok(source.includes('<header className="sticky top-0 z-40'));
-  assert.ok(source.includes("Clínica Demo"));
-  assert.ok(source.includes("CL"));
+  assert.ok(source.includes('<header'));
+  assert.ok(source.includes("sticky top-0 z-40"));
   assert.ok(source.includes('<Button asChild variant="outline" size="sm">'));
+  assert.equal(source.includes("Usuario mock"), false);
+  assert.equal(source.includes("Clínica Demo"), false);
+  assert.equal(source.includes(">CL<"), false);
 });
 
 test("stats cards keep DashboardStats typing and UI dependencies", () => {
@@ -95,3 +97,4 @@ test("stats cards render configured metrics with fallback and hidden icons", () 
   assert.ok(source.includes("{stats ? stats[config.key] : \"—\"}"));
   assert.ok(source.includes("{config.description}"));
 });
+

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -284,7 +284,6 @@ test("dashboard topbar keeps sticky hierarchy and compact responsive shell", () 
       "title: string;",
       "subtitle?: string;",
       "{subtitle && (",
-      "Clínica Demo",
       "<Button asChild variant=\"outline\" size=\"sm\">",
     ],
     "dashboard topbar hierarchy",
@@ -297,7 +296,6 @@ test("dashboard topbar keeps sticky hierarchy and compact responsive shell", () 
       /className="truncate text-lg font-semibold text-gray-900 sm:text-xl"/,
       /className="truncate text-xs text-gray-500 sm:text-sm"/,
       /className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3"/,
-      /className="flex h-8 w-8 items-center justify-center rounded-full bg-primary\/10 text-xs font-semibold text-primary"/,
     ],
     "dashboard topbar class contracts",
   );
@@ -376,6 +374,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertInlineStylesAtMost(source, 0, "dashboard admin");
   assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
 });
+
 
 
 


### PR DESCRIPTION
## Summary
- Removes the mock CL / Clínica Demo chip from the shared dashboard topbar.
- Applies to both clinic and admin dashboards.
- Keeps title, subtitle, portal indicator, and logout action.
- Updates shared dashboard and visual consistency tests.

## Validation
- pnpm test: 1359/1359 pass
- pnpm build: OK