### PR TITLE
fix(frontend): restore admin report upload form

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -23,6 +23,7 @@ import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminParticularTokensCard } from "./AdminParticularTokensCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
+import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 
@@ -301,6 +302,15 @@ export default async function AdminPage({
         subtitle="Auditoría, reportes y estado operacional"
       />
       <main className="dashboard-main">
+        <section id="admin-report-upload" className="surface-note-info flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="font-semibold text-blue-900">Carga de informes</p>
+            <p className="mt-1 text-sm text-blue-700">
+              Suba un PDF y asócielo a una clínica desde administración.
+            </p>
+          </div>
+          <UploadReportModal />
+        </section>
 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card className="border-gray-100">
             <CardHeader className="pb-2">
@@ -591,6 +601,7 @@ export default async function AdminPage({
     </>
   );
 }
+
 
 
 

--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -12,6 +12,11 @@ const adminNavItems: DashboardNavItem[] = [
     exact: true,
   },
   {
+    label: "Subir informe",
+    href: `${ROUTES.dashboardAdmin}#admin-report-upload`,
+    icon: "📄",
+  },
+  {
     label: "Health",
     href: `${ROUTES.dashboardAdmin}#admin-health`,
     icon: "🟢",
@@ -51,4 +56,5 @@ export function AdminDashboardSidebar() {
     />
   );
 }
+
 

--- a/frontend/src/components/dashboard/UploadReportModal.tsx
+++ b/frontend/src/components/dashboard/UploadReportModal.tsx
@@ -22,7 +22,6 @@ type ClinicOption = {
 };
 
 const STUDY_TYPE_OPTIONS = [
-  { value: "", label: "Tipo de estudio" },
   { value: "histopathology", label: "Histopatología" },
   { value: "cytology", label: "Citología" },
   { value: "immunohistochemistry", label: "Inmunohistoquímica" },
@@ -114,7 +113,6 @@ function formatTrackingDateLabel(value: string) {
   }).format(date);
 }
 
-
 export function UploadReportModal() {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -134,8 +132,9 @@ export function UploadReportModal() {
   const [particularTokenLoadError, setParticularTokenLoadError] = useState<
     string | null
   >(null);
+  const [selectedFileName, setSelectedFileName] = useState("");
   const [patientName, setPatientName] = useState("");
-  const [studyType, setStudyType] = useState("");
+  const [studyType, setStudyType] = useState(STUDY_TYPE_OPTIONS[0].value);
   const [uploadDate, setUploadDate] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -296,8 +295,9 @@ export function UploadReportModal() {
     setParticularTokenId("");
     setParticularTokens([]);
     setParticularTokenLoadError(null);
+    setSelectedFileName("");
     setPatientName("");
-    setStudyType("");
+    setStudyType(STUDY_TYPE_OPTIONS[0].value);
     setUploadDate("");
 
     if (fileInputRef.current) {
@@ -342,6 +342,13 @@ export function UploadReportModal() {
     if (token && !patientName.trim()) {
       setPatientName(`${token.petName} / ${token.tutorLastName}`);
     }
+  }
+
+  function handleFileChange() {
+    const file = fileInputRef.current?.files?.[0];
+
+    setSelectedFileName(file?.name ?? "");
+    setErrorMessage(null);
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -607,7 +614,20 @@ export function UploadReportModal() {
               ref={fileInputRef}
               required
               disabled={isSubmitting}
+              onChange={handleFileChange}
+              className="sr-only"
             />
+            <div className="flex flex-col gap-2 rounded-lg border border-input bg-background px-3 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <span className="truncate text-sm text-gray-600">
+                {selectedFileName || "Sin archivo seleccionado"}
+              </span>
+              <label
+                htmlFor="upload-file"
+                className="inline-flex h-10 cursor-pointer items-center justify-center rounded-md border border-input bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm transition-colors hover:bg-gray-50"
+              >
+                Seleccionar archivo
+              </label>
+            </div>
           </div>
 
           <div>
@@ -635,6 +655,7 @@ export function UploadReportModal() {
               value={studyType}
               onChange={(event) => setStudyType(event.target.value)}
               disabled={isSubmitting}
+              required
             >
               {STUDY_TYPE_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -33,6 +33,7 @@ test("dashboard admin includes read-only admin cards", () => {
   assert.ok(source.includes('import { AdminParticularTokensCard } from "./AdminParticularTokensCard";'));
   assert.ok(source.includes('import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";'));
   assert.ok(source.includes('import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";'));
+  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
   assert.ok(source.includes("<AdminMaintenanceDryRunCard />"));
   assert.ok(source.includes("<AdminParticularTokensCard />"));
   assert.ok(source.includes("<AdminSessionsReadOnlyCard />"));
@@ -125,6 +126,8 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes("Eventos de auditoría"));
   assert.ok(source.includes("Tipos de evento"));
   assert.ok(source.includes("Estado del sistema"));
+  assert.ok(source.includes('id="admin-report-upload"'));
+  assert.ok(source.includes("<UploadReportModal />"));
   assert.ok(source.includes('id="admin-health"'));
   assert.ok(source.includes('id="admin-maintenance"'));
   assert.ok(source.includes('id="admin-sessions"'));
@@ -173,4 +176,5 @@ test("dashboard admin avoids duplicate section ids in navigation anchors", () =>
   assert.equal(adminHealthIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });
+
 

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -85,6 +85,7 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
 
   assert.ok(source.includes("const adminNavItems: DashboardNavItem[] = ["));
   assert.ok(source.includes('label: "Administración"'));
+  assert.ok(source.includes('label: "Subir informe"'));
   assert.ok(source.includes('label: "Health"'));
   assert.ok(source.includes('label: "Sesiones"'));
   assert.ok(source.includes('label: "Tokens particulares"'));
@@ -95,5 +96,6 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);
 });
+
 
 

--- a/test/frontend-report-actions.test.ts
+++ b/test/frontend-report-actions.test.ts
@@ -31,7 +31,7 @@ test("upload report modal keeps study type options", () => {
   const source = read(UPLOAD_REPORT_MODAL_PATH);
 
   assert.ok(source.includes("const STUDY_TYPE_OPTIONS = ["));
-  assert.ok(source.includes('{ value: "", label: "Tipo de estudio" }'));
+  assert.equal(source.includes('{ value: "", label: "Tipo de estudio" }'), false);
   assert.ok(source.includes('{ value: "histopathology", label: "Histopatología" }'));
   assert.ok(source.includes('{ value: "cytology", label: "Citología" }'));
   assert.ok(source.includes('{ value: "immunohistochemistry", label: "Inmunohistoquímica" }'));
@@ -49,13 +49,15 @@ test("upload report modal keeps form state reset and file ref handling", () => {
   assert.ok(source.includes("const [particularTokenId, setParticularTokenId] = useState(\"\");"));
   assert.ok(source.includes("AdminParticularTokenSummary"));
   assert.ok(source.includes("const [patientName, setPatientName] = useState(\"\");"));
-  assert.ok(source.includes("const [studyType, setStudyType] = useState(\"\");"));
+  assert.ok(source.includes("const [studyType, setStudyType] = useState(STUDY_TYPE_OPTIONS[0].value);"));
   assert.ok(source.includes("const [uploadDate, setUploadDate] = useState(\"\");"));
   assert.ok(source.includes("const [errorMessage, setErrorMessage] = useState<string | null>(null);"));
   assert.ok(source.includes("const [successMessage, setSuccessMessage] = useState<string | null>(null);"));
   assert.ok(source.includes("const [isSubmitting, setIsSubmitting] = useState(false);"));
   assert.ok(source.includes("function resetForm()"));
   assert.ok(source.includes("fileInputRef.current.value = \"\";"));
+  assert.ok(source.includes("const [selectedFileName, setSelectedFileName] = useState(\"\");"));
+  assert.ok(source.includes("setSelectedFileName(\"\");"));
 });
 
 test("upload report modal validates PDF file and submits FormData safely", () => {
@@ -114,6 +116,10 @@ test("upload report modal renders accessible dialog and form controls", () => {
   assert.ok(source.includes('id="upload-file"'));
   assert.ok(source.includes('type="file"'));
   assert.ok(source.includes('accept="application/pdf"'));
+  assert.ok(source.includes("Seleccionar archivo"));
+  assert.ok(source.includes("Sin archivo seleccionado"));
+  assert.equal(source.includes("Choose File"), false);
+  assert.equal(source.includes("No file chosen"), false);
   assert.ok(source.includes('id="upload-patient-name"'));
   assert.ok(source.includes('id="upload-study-type"'));
   assert.ok(source.includes('id="upload-date"'));
@@ -180,3 +186,4 @@ test("report download button renders labels titles disabled and alert state", ()
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("{errorMessage}"));
 });
+

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 
 const UPLOAD_MODAL_PATH = "frontend/src/components/dashboard/UploadReportModal.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -26,6 +27,30 @@ test("frontend upload report modal remains available as admin-only implementatio
   assert.ok(source.includes("uploadAdminReport"));
 });
 
+test("frontend upload report modal keeps file picker fully localized", () => {
+  const source = read(UPLOAD_MODAL_PATH);
+
+  assert.ok(source.includes('className="sr-only"'));
+  assert.ok(source.includes("selectedFileName"));
+  assert.ok(source.includes("handleFileChange"));
+  assert.ok(source.includes("Seleccionar archivo"));
+  assert.ok(source.includes("Sin archivo seleccionado"));
+  assert.equal(source.includes("Choose File"), false);
+  assert.equal(source.includes("No file chosen"), false);
+});
+
+test("frontend upload report modal keeps study type options without placeholder option", () => {
+  const source = read(UPLOAD_MODAL_PATH);
+
+  assert.ok(source.includes('{ value: "histopathology", label: "Histopatología" }'));
+  assert.ok(source.includes('{ value: "cytology", label: "Citología" }'));
+  assert.ok(source.includes('{ value: "immunohistochemistry", label: "Inmunohistoquímica" }'));
+  assert.ok(source.includes('{ value: "special_stain", label: "Hematología" }'));
+  assert.ok(source.includes("useState(STUDY_TYPE_OPTIONS[0].value)"));
+  assert.ok(source.includes("setStudyType(STUDY_TYPE_OPTIONS[0].value)"));
+  assert.equal(source.includes('{ value: "", label: "Tipo de estudio" }'), false);
+});
+
 test("frontend informes page does not expose admin upload modal in clinic dashboard", () => {
   const source = read(INFORMES_PAGE_PATH);
 
@@ -35,3 +60,11 @@ test("frontend informes page does not expose admin upload modal in clinic dashbo
   assert.ok(source.includes("dashboard administrador"));
 });
 
+test("frontend admin dashboard exposes upload report modal only in admin surface", () => {
+  const source = read(ADMIN_PAGE_PATH);
+
+  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
+  assert.ok(source.includes('id="admin-report-upload"'));
+  assert.ok(source.includes("<UploadReportModal />"));
+  assert.ok(source.includes("Carga de informes"));
+});

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -263,6 +263,7 @@ test("clinic and admin sidebars keep visual parity with separated operational na
       "DashboardSidebarFrame",
       'dashboardLabel="Dashboard admin"',
       'label: "Administración"',
+      'label: "Subir informe"',
       'label: "Health"',
       'label: "Sesiones"',
       'label: "Tokens particulares"',
@@ -374,6 +375,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertInlineStylesAtMost(source, 0, "dashboard admin");
   assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
 });
+
 
 
 


### PR DESCRIPTION
## Summary
- Restores the report upload form in the admin dashboard only.
- Mounts the existing admin-only UploadReportModal in /dashboard/admin.
- Adds admin sidebar navigation to the upload section.
- Keeps clinic dashboard without admin upload access.
- Removes the study type placeholder option so only real study types remain.
- Localizes the file picker UI to Spanish.

## Validation
- pnpm test: 1362/1362 pass
- pnpm build: OK