### PR TITLE
chore(dev): add local admin dashboard launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@10.8.1",
   "scripts": {
     "dev": "tsx server/index.ts",
+    "admin:open": "powershell -ExecutionPolicy Bypass -File scripts/dev/open-admin-dashboard.ps1",
     "build": "esbuild server/index.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/index.js",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
@@ -38,3 +39,4 @@
     "typescript": "^5.9.3"
   }
 }
+

--- a/scripts/dev/open-admin-dashboard.ps1
+++ b/scripts/dev/open-admin-dashboard.ps1
@@ -1,0 +1,174 @@
+param(
+  [string]$BackendUrl = "http://localhost:3000",
+  [string]$FrontendUrl = "http://localhost:3001",
+  [int]$DebugPort = 9223
+)
+
+$ErrorActionPreference = "Stop"
+
+function Convert-SecureStringToPlainText {
+  param([securestring]$SecureString)
+
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+
+  try {
+    return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+  } finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+  }
+}
+
+function Find-Chrome {
+  $candidates = @(
+    "$env:ProgramFiles\Google\Chrome\Application\chrome.exe",
+    "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe",
+    "$env:LOCALAPPDATA\Google\Chrome\Application\chrome.exe"
+  )
+
+  return $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
+function Send-CDP {
+  param(
+    [System.Net.WebSockets.ClientWebSocket]$WebSocket,
+    [int]$Id,
+    [string]$Method,
+    [hashtable]$Params = @{}
+  )
+
+  $payload = @{
+    id = $Id
+    method = $Method
+    params = $Params
+  } | ConvertTo-Json -Depth 20 -Compress
+
+  $bytes = [Text.Encoding]::UTF8.GetBytes($payload)
+
+  $WebSocket.SendAsync(
+    [ArraySegment[byte]]::new($bytes),
+    [System.Net.WebSockets.WebSocketMessageType]::Text,
+    $true,
+    [Threading.CancellationToken]::None
+  ).GetAwaiter().GetResult()
+
+  Start-Sleep -Milliseconds 250
+}
+
+Write-Host "VETNEB admin launcher" -ForegroundColor Cyan
+
+$health = Invoke-WebRequest -UseBasicParsing "$BackendUrl/api/health" -TimeoutSec 8
+if ($health.StatusCode -ne 200) {
+  throw "Backend no respondió OK en $BackendUrl/api/health"
+}
+
+$adminUsername = $env:VETNEB_ADMIN_USERNAME
+if ([string]::IsNullOrWhiteSpace($adminUsername)) {
+  $adminUsername = "VETNEB"
+}
+
+$adminPassword = $env:VETNEB_ADMIN_PASSWORD
+if ([string]::IsNullOrWhiteSpace($adminPassword)) {
+  $securePassword = Read-Host "Contraseña administrador $adminUsername" -AsSecureString
+  $adminPassword = Convert-SecureStringToPlainText $securePassword
+}
+
+$adminSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+$loginBody = @{
+  username = $adminUsername
+  password = $adminPassword
+} | ConvertTo-Json -Compress
+
+$loginResponse = Invoke-WebRequest `
+  -UseBasicParsing `
+  -Uri "$BackendUrl/api/admin/auth/login" `
+  -Method POST `
+  -WebSession $adminSession `
+  -ContentType "application/json" `
+  -Body $loginBody `
+  -TimeoutSec 15
+
+if ($loginResponse.StatusCode -ne 200) {
+  throw "Login administrador falló con status $($loginResponse.StatusCode)"
+}
+
+$adminCookie = $adminSession.Cookies.GetCookies($BackendUrl) |
+  Where-Object { $_.Name -eq "admin_session_id" } |
+  Select-Object -First 1
+
+if (-not $adminCookie) {
+  throw "No se obtuvo admin_session_id desde $BackendUrl"
+}
+
+$chrome = Find-Chrome
+
+if (-not $chrome) {
+  throw "Chrome no encontrado. Instale Google Chrome o ajuste el launcher."
+}
+
+$profile = Join-Path $env:TEMP "vetneb-admin-visible"
+
+Start-Process `
+  -FilePath $chrome `
+  -ArgumentList @(
+    "--remote-debugging-port=$DebugPort",
+    "--user-data-dir=$profile",
+    "--new-window",
+    "about:blank"
+  )
+
+Start-Sleep -Seconds 2
+
+$tab = Invoke-RestMethod `
+  -Method PUT `
+  -Uri "http://127.0.0.1:$DebugPort/json/new?about:blank"
+
+Add-Type -AssemblyName System.Net.WebSockets
+
+$ws = [System.Net.WebSockets.ClientWebSocket]::new()
+
+$ws.ConnectAsync(
+  [Uri]$tab.webSocketDebuggerUrl,
+  [Threading.CancellationToken]::None
+).GetAwaiter().GetResult()
+
+try {
+  Send-CDP -WebSocket $ws -Id 1 -Method "Network.enable"
+  Send-CDP -WebSocket $ws -Id 2 -Method "Page.enable"
+
+  Send-CDP `
+    -WebSocket $ws `
+    -Id 3 `
+    -Method "Network.setCookie" `
+    -Params @{
+      name = "admin_session_id"
+      value = $adminCookie.Value
+      url = $FrontendUrl
+      path = "/"
+      sameSite = "Lax"
+    }
+
+  Send-CDP `
+    -WebSocket $ws `
+    -Id 4 `
+    -Method "Network.setCookie" `
+    -Params @{
+      name = "admin_session_id"
+      value = $adminCookie.Value
+      url = $BackendUrl
+      path = "/"
+      sameSite = "Lax"
+    }
+
+  Send-CDP `
+    -WebSocket $ws `
+    -Id 5 `
+    -Method "Page.navigate" `
+    -Params @{
+      url = "$FrontendUrl/dashboard/admin"
+    }
+} finally {
+  $ws.Dispose()
+}
+
+Write-Host "Administrador abierto: $FrontendUrl/dashboard/admin" -ForegroundColor Green

--- a/test/admin-dashboard-launcher.test.ts
+++ b/test/admin-dashboard-launcher.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PACKAGE_PATH = "package.json";
+const ADMIN_LAUNCHER_PATH = "scripts/dev/open-admin-dashboard.ps1";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("package exposes local admin dashboard launcher", () => {
+  const source = read(PACKAGE_PATH);
+
+  assert.ok(source.includes('"admin:open": "powershell -ExecutionPolicy Bypass -File scripts/dev/open-admin-dashboard.ps1"'));
+});
+
+test("local admin dashboard launcher exists and opens admin through session cookie", () => {
+  assert.equal(existsSync(resolve(process.cwd(), ADMIN_LAUNCHER_PATH)), true);
+
+  const source = read(ADMIN_LAUNCHER_PATH);
+
+  assert.ok(source.includes("VETNEB admin launcher"));
+  assert.ok(source.includes("$BackendUrl/api/admin/auth/login"));
+  assert.ok(source.includes("admin_session_id"));
+  assert.ok(source.includes("Network.setCookie"));
+  assert.ok(source.includes("$FrontendUrl/dashboard/admin"));
+  assert.ok(source.includes("Read-Host"));
+  assert.ok(source.includes("VETNEB_ADMIN_USERNAME"));
+  assert.ok(source.includes("VETNEB_ADMIN_PASSWORD"));
+});
+
+test("local admin dashboard launcher does not hardcode admin password", () => {
+  const source = read(ADMIN_LAUNCHER_PATH);
+
+  assert.equal(source.includes("31731490Neb"), false);
+  assert.equal(source.includes('"password":"'), false);
+  assert.equal(source.includes("'password':'"), false);
+});


### PR DESCRIPTION
## Summary
- Adds a local PowerShell launcher for opening the admin dashboard.
- Adds pnpm admin:open.
- Opens admin through admin_session_id without public admin login.
- Prompts for admin password or reads VETNEB_ADMIN_PASSWORD from environment.
- Adds launcher contract tests and prevents hardcoded password.

## Validation
- pnpm test: 1365/1365 pass
- pnpm build: OK