### PR TITLE
fix(dev): improve admin launcher websocket compatibility

### DIFF
--- a/scripts/dev/open-admin-dashboard.ps1
+++ b/scripts/dev/open-admin-dashboard.ps1
@@ -68,7 +68,7 @@ if ([string]::IsNullOrWhiteSpace($adminUsername)) {
 
 $adminPassword = $env:VETNEB_ADMIN_PASSWORD
 if ([string]::IsNullOrWhiteSpace($adminPassword)) {
-  $securePassword = Read-Host "Contraseña administrador $adminUsername" -AsSecureString
+  $securePassword = Read-Host "Password administrador $adminUsername" -AsSecureString
   $adminPassword = Convert-SecureStringToPlainText $securePassword
 }
 
@@ -123,8 +123,6 @@ $tab = Invoke-RestMethod `
   -Method PUT `
   -Uri "http://127.0.0.1:$DebugPort/json/new?about:blank"
 
-Add-Type -AssemblyName System.Net.WebSockets
-
 $ws = [System.Net.WebSockets.ClientWebSocket]::new()
 
 $ws.ConnectAsync(
@@ -172,3 +170,5 @@ try {
 }
 
 Write-Host "Administrador abierto: $FrontendUrl/dashboard/admin" -ForegroundColor Green
+
+

--- a/test/admin-dashboard-launcher.test.ts
+++ b/test/admin-dashboard-launcher.test.ts
@@ -30,8 +30,11 @@ test("local admin dashboard launcher exists and opens admin through session cook
   assert.ok(source.includes("Network.setCookie"));
   assert.ok(source.includes("$FrontendUrl/dashboard/admin"));
   assert.ok(source.includes("Read-Host"));
+  assert.ok(source.includes("Password administrador"));
   assert.ok(source.includes("VETNEB_ADMIN_USERNAME"));
   assert.ok(source.includes("VETNEB_ADMIN_PASSWORD"));
+  assert.ok(source.includes("[System.Net.WebSockets.ClientWebSocket]::new()"));
+  assert.equal(source.includes("Add-Type -AssemblyName System.Net.WebSockets"), false);
 });
 
 test("local admin dashboard launcher does not hardcode admin password", () => {


### PR DESCRIPTION
## Summary
- Removes incompatible System.Net.WebSockets assembly loading from the admin launcher.
- Keeps ClientWebSocket usage compatible with Windows PowerShell.
- Avoids mojibake in the admin password prompt.
- Updates launcher contract tests.

## Validation
- pnpm test: 1365/1365 pass
- pnpm build: OK
- Manual: pnpm admin:open