### PR TITLE
fix(frontend): polish admin dashboard visual hierarchy

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -107,7 +107,7 @@ function getSystemStatusIndicatorClass(status: string) {
 }
 
 function formatSystemStatusDetail(services: Record<string, unknown>) {
-  return `DB: ${formatServiceStatus(services.database)} · Storage: ${formatServiceStatus(
+  return `Base de datos: ${formatServiceStatus(services.database)} · Almacenamiento: ${formatServiceStatus(
     services.storage,
   )}`;
 }
@@ -302,14 +302,27 @@ export default async function AdminPage({
         subtitle="Auditoría, reportes y estado operacional"
       />
       <main className="dashboard-main">
-        <section id="admin-report-upload" className="surface-note-info flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="font-semibold text-blue-900">Carga de informes</p>
-            <p className="mt-1 text-sm text-blue-700">
-              Suba un PDF y asócielo a una clínica desde administración.
-            </p>
+        <section
+          id="admin-report-upload"
+          className="surface-note-info overflow-hidden rounded-2xl p-0"
+        >
+          <div className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-700">
+                Panel administrador
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-gray-950">
+                Carga de informes
+              </h2>
+              <p className="mt-1 max-w-2xl text-sm text-blue-800/80">
+                Suba PDFs, asócielos a una clínica y vincule tokens particulares
+                desde una única superficie administrativa.
+              </p>
+            </div>
+            <div className="shrink-0">
+              <UploadReportModal />
+            </div>
           </div>
-          <UploadReportModal />
         </section>
 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card className="border-gray-100">
@@ -363,7 +376,7 @@ export default async function AdminPage({
         </div>
         <Card id="admin-health">
           <CardHeader>
-            <CardTitle className="text-base">Health & Maintenance</CardTitle>
+            <CardTitle className="text-base">Estado y mantenimiento</CardTitle>
             <CardDescription>
               Estado de servicios, versión y consumo runtime del backend en producción
             </CardDescription>
@@ -371,13 +384,13 @@ export default async function AdminPage({
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
               <div className="surface-soft">
-                <p className="text-xs text-gray-400 mb-2">Database</p>
+                <p className="text-xs text-gray-400 mb-2">Base de datos</p>
                 <Badge variant={getServiceVariant(serviceChecks.database)}>
                   {formatServiceStatus(serviceChecks.database)}
                 </Badge>
               </div>
               <div className="surface-soft">
-                <p className="text-xs text-gray-400 mb-2">Storage</p>
+                <p className="text-xs text-gray-400 mb-2">Almacenamiento</p>
                 <Badge variant={getServiceVariant(serviceChecks.storage)}>
                   {formatServiceStatus(serviceChecks.storage)}
                 </Badge>
@@ -390,12 +403,12 @@ export default async function AdminPage({
                 <p className="text-xs text-gray-400 mt-1">Versión activa</p>
               </div>
               <div className="surface-soft">
-                <p className="text-xs text-gray-400">Uptime</p>
+                <p className="text-xs text-gray-400">Tiempo activo</p>
                 <p className="text-lg font-semibold text-gray-800 mt-1">
                   {formatUptime(systemHealth?.runtime.uptimeSeconds)}
                 </p>
                 <p className="text-xs text-gray-400 mt-1">
-                  Check: {formatHealthTimestamp(systemHealth?.health?.timestamp)}
+                  Control: {formatHealthTimestamp(systemHealth?.health?.timestamp)}
                 </p>
               </div>
               <div className="surface-soft">
@@ -412,10 +425,10 @@ export default async function AdminPage({
                     Heap total: {systemHealth?.runtime.memory.heapTotalMb ?? "—"} MB
                   </p>
                   <p>
-                    External: {systemHealth?.runtime.memory.externalMb ?? "—"} MB
+                    Memoria externa: {systemHealth?.runtime.memory.externalMb ?? "—"} MB
                   </p>
                   <p>
-                    Array buffers:{" "}
+                    Buffers:{" "}
                     {systemHealth?.runtime.memory.arrayBuffersMb ?? "—"} MB
                   </p>
                 </div>
@@ -601,6 +614,8 @@ export default async function AdminPage({
     </>
   );
 }
+
+
 
 
 

--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -17,7 +17,7 @@ const adminNavItems: DashboardNavItem[] = [
     icon: "📄",
   },
   {
-    label: "Health",
+    label: "Estado",
     href: `${ROUTES.dashboardAdmin}#admin-health`,
     icon: "🟢",
   },
@@ -42,7 +42,7 @@ const adminNavItems: DashboardNavItem[] = [
     icon: "🧾",
   },
   {
-    label: "Maintenance",
+    label: "Mantenimiento",
     href: `${ROUTES.dashboardAdmin}#admin-maintenance`,
     icon: "🧹",
   },
@@ -51,10 +51,11 @@ const adminNavItems: DashboardNavItem[] = [
 export function AdminDashboardSidebar() {
   return (
     <DashboardSidebarFrame
-      dashboardLabel="Dashboard admin"
+      dashboardLabel="Administración"
       navItems={adminNavItems}
     />
   );
 }
+
 
 

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -127,6 +127,8 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes("Tipos de evento"));
   assert.ok(source.includes("Estado del sistema"));
   assert.ok(source.includes('id="admin-report-upload"'));
+  assert.ok(source.includes("Panel administrador"));
+  assert.ok(source.includes("única superficie administrativa"));
   assert.ok(source.includes("<UploadReportModal />"));
   assert.ok(source.includes('id="admin-health"'));
   assert.ok(source.includes('id="admin-maintenance"'));
@@ -134,7 +136,8 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes('id="admin-particular-tokens"'));
   assert.ok(source.includes('id="admin-users-roles"'));
   assert.ok(source.includes('id="admin-event-summary"'));
-  assert.ok(source.includes("Health & Maintenance"));
+  assert.ok(source.includes("Estado y mantenimiento"));
+  assert.equal(source.includes("Health & Maintenance"), false);
   assert.equal(source.includes("AdminSourceContractMarkers"), false);
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);
 });
@@ -176,5 +179,6 @@ test("dashboard admin avoids duplicate section ids in navigation anchors", () =>
   assert.equal(adminHealthIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });
+
 
 

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -86,16 +86,17 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.ok(source.includes("const adminNavItems: DashboardNavItem[] = ["));
   assert.ok(source.includes('label: "Administración"'));
   assert.ok(source.includes('label: "Subir informe"'));
-  assert.ok(source.includes('label: "Health"'));
+  assert.ok(source.includes('label: "Estado"'));
   assert.ok(source.includes('label: "Sesiones"'));
   assert.ok(source.includes('label: "Tokens particulares"'));
   assert.ok(source.includes('label: "Roles clínica"'));
   assert.ok(source.includes('label: "Auditoría"'));
-  assert.ok(source.includes('label: "Maintenance"'));
+  assert.ok(source.includes('label: "Mantenimiento"'));
   assert.ok(source.includes("ROUTES.dashboardAdmin"));
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);
 });
+
 
 
 

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -261,15 +261,15 @@ test("clinic and admin sidebars keep visual parity with separated operational na
     adminSource,
     [
       "DashboardSidebarFrame",
-      'dashboardLabel="Dashboard admin"',
+      'dashboardLabel="Administración"',
       'label: "Administración"',
       'label: "Subir informe"',
-      'label: "Health"',
+      'label: "Estado"',
       'label: "Sesiones"',
       'label: "Tokens particulares"',
       'label: "Roles clínica"',
       'label: "Auditoría"',
-      'label: "Maintenance"',
+      'label: "Mantenimiento"',
     ],
     "admin dashboard sidebar contracts",
   );
@@ -375,6 +375,8 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertInlineStylesAtMost(source, 0, "dashboard admin");
   assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
 });
+
+
 
 
 


### PR DESCRIPTION
## Summary
- Improves the visual hierarchy of the admin dashboard upload surface.
- Keeps the admin report upload form and admin-report-upload anchor intact.
- Translates remaining visible admin dashboard labels to Spanish.
- Updates admin sidebar labels from Health/Maintenance to Estado/Mantenimiento.
- Updates frontend visual and dashboard contract tests.

## Validation
- pnpm test: 1365/1365 pass
- pnpm build: OK