### PR TITLE
fix(frontend): remove public eyebrow pills

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -89,9 +89,6 @@ export default function HomePage() {
         <div className="absolute inset-0 bg-black/55" aria-hidden="true" />
         <div className="relative container mx-auto flex min-h-[calc(100vh-4.5rem)] items-center px-4 py-16 sm:px-6 lg:px-8">
           <div className="mx-auto w-full max-w-4xl text-center">
-            <div className="mb-6 inline-flex items-center justify-center rounded-full border border-white/30 bg-black/35 px-4 py-1.5 text-sm font-medium tracking-wide text-slate-100">
-              Servicio patológico veterinario
-            </div>
             <h1
               id="hero-heading"
               className="text-4xl font-semibold leading-tight tracking-[0.08em] text-white sm:text-5xl lg:text-6xl"
@@ -263,3 +260,4 @@ export default function HomePage() {
     </PublicLayout>
   );
 }
+

--- a/frontend/src/components/public/VisualAccents.tsx
+++ b/frontend/src/components/public/VisualAccents.tsx
@@ -48,17 +48,8 @@ type EyebrowProps = {
   className?: string;
 };
 
-export function Eyebrow({ children, className }: EyebrowProps) {
-  return (
-    <p
-      className={cn(
-        "render-gpu-soft mb-3 inline-flex items-center rounded-full border border-white/50 bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white/90 shadow-sm backdrop-blur",
-        className,
-      )}
-    >
-      {children}
-    </p>
-  );
+export function Eyebrow(_props: EyebrowProps) {
+  return null;
 }
 
 type AmbientOrbsProps = {

--- a/test/frontend-public-eyebrow-pills.test.ts
+++ b/test/frontend-public-eyebrow-pills.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const VISUAL_ACCENTS_PATH = "frontend/src/components/public/VisualAccents.tsx";
+const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("public visual accents no longer render decorative eyebrow pills", () => {
+  const source = read(VISUAL_ACCENTS_PATH);
+
+  assert.ok(source.includes("export function Eyebrow(_props: EyebrowProps)"));
+  assert.ok(source.includes("return null;"));
+  assert.equal(source.includes("tracking-[0.22em]"), false);
+  assert.equal(source.includes("rounded-full border border-white/50"), false);
+  assert.equal(source.includes("uppercase"), false);
+});
+
+test("home page no longer renders the hero eyebrow pill", () => {
+  const source = read(HOME_PAGE_PATH);
+
+  assert.equal(source.includes("Servicio patológico veterinario"), false);
+  assert.equal(
+    source.includes("rounded-full border border-white/30 bg-black/35"),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- Removes decorative eyebrow pills from public pages.
- Keeps public page titles, content, routing, and layout structure intact.
- Removes the hardcoded home hero eyebrow pill.
- Adds visual contract coverage to prevent the pills from returning.

## Validation
- pnpm test: 1367/1367 pass
- pnpm build: OK