### PR TITLE
fix(frontend): add soft canvas below home hero

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -132,7 +132,7 @@ export default function HomePage() {
 
       {/* Servicios principales */}
       <section
-        className="bg-white py-16 md:py-20"
+        className="public-soft-canvas py-16 md:py-20"
         aria-labelledby="services-heading"
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -260,4 +260,5 @@ export default function HomePage() {
     </PublicLayout>
   );
 }
+
 

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -51,6 +51,7 @@ test("home page lists core laboratory services and services route CTA", () => {
   assert.ok(source.includes('aria-labelledby="services-heading"'));
   assert.ok(source.includes('id="services-heading"'));
   assert.ok(source.includes("Servicios del laboratorio patológico veterinario"));
+  assert.ok(source.includes('className="public-soft-canvas py-16 md:py-20"'));
   assert.ok(source.includes("Estudio Anatomopatológico"));
   assert.ok(source.includes("Estudio Citológico"));
   assert.ok(source.includes("Tinciones Especiales"));
@@ -86,3 +87,4 @@ test("home page exposes final conversion CTA without private route metadata", ()
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes('"/api"'), false);
 });
+

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -131,6 +131,7 @@ test("public home page keeps polished visual hierarchy and responsive sections",
       /className="relative container mx-auto flex min-h-\[calc\(100vh-4\.5rem\)\] items-center px-4 py-16 sm:px-6 lg:px-8"/,
       /className="text-4xl font-semibold leading-tight tracking-\[0\.08em\] text-white sm:text-5xl lg:text-6xl"/,
       /className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4"/,
+      /className="public-soft-canvas py-16 md:py-20"/,
       /className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"/,
       /className="bg-primary py-16 text-white md:py-20"/,
       /className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4"/,
@@ -375,6 +376,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertInlineStylesAtMost(source, 0, "dashboard admin");
   assert.equal(source.includes("fetch("), false, "dashboard admin must avoid fetch()");
 });
+
 
 
 


### PR DESCRIPTION
## Summary
- Keeps the home photographic hero intact.
- Applies the shared public soft canvas to the section below the hero.
- Aligns the home lower section with the visual treatment used by the other public pages.
- Updates home and visual consistency tests.

## Validation
- pnpm test: 1367/1367 pass
- pnpm build: OK