### PR TITLE
fix(frontend): use single public canvas background

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -161,8 +161,7 @@
     will-change: transform, opacity;
   }
 
-  .public-soft-canvas,
-  [data-public-soft-canvas="true"] {
+  .public-page-canvas {
     position: relative;
     isolation: isolate;
     overflow: hidden;
@@ -172,98 +171,94 @@
       linear-gradient(135deg, #f8fafc 0%, #eef6ff 45%, #ecfeff 100%);
   }
 
-  .public-soft-canvas::before,
-  [data-public-soft-canvas="true"]::before {
+  .public-page-canvas::before {
     content: "";
     position: absolute;
-    inset: -30% -18%;
+    inset: -18rem -12rem;
     z-index: 0;
     pointer-events: none;
     background:
-      radial-gradient(circle at 18% 32%, rgba(56, 189, 248, 0.34), transparent 28%),
-      radial-gradient(circle at 82% 18%, rgba(45, 212, 191, 0.26), transparent 31%),
-      radial-gradient(circle at 58% 78%, rgba(186, 230, 253, 0.40), transparent 35%);
-    filter: blur(36px);
-    opacity: 0.86;
+      radial-gradient(circle at 18% 22%, rgba(56, 189, 248, 0.30), transparent 28%),
+      radial-gradient(circle at 82% 14%, rgba(45, 212, 191, 0.24), transparent 31%),
+      radial-gradient(circle at 52% 62%, rgba(186, 230, 253, 0.38), transparent 36%);
+    filter: blur(38px);
+    opacity: 0.84;
     transform: translate3d(0, 0, 0) scale(1);
-    animation: public-soft-canvas-drift 12s ease-in-out infinite alternate;
+    animation: public-page-canvas-drift 14s ease-in-out infinite alternate;
   }
 
-  .public-soft-canvas > *,
-  [data-public-soft-canvas="true"] > * {
+  .public-page-canvas > * {
     position: relative;
     z-index: 1;
   }
 
-  @keyframes public-soft-canvas-drift {
-    0% {
-      transform: translate3d(-3%, -1.5%, 0) scale(1);
-      opacity: 0.68;
-    }
-
-    50% {
-      transform: translate3d(2.5%, 1.5%, 0) scale(1.06);
-      opacity: 0.92;
-    }
-
-    100% {
-      transform: translate3d(4%, -2%, 0) scale(1.03);
-      opacity: 0.74;
-    }
-  }
-
-  .public-soft-canvas::before,
-  [data-public-soft-canvas="true"]::before {
-    content: "";
-    position: absolute;
-    inset: -30% -18%;
-    z-index: 0;
-    pointer-events: none;
-    background:
-      radial-gradient(circle at 18% 32%, rgba(56, 189, 248, 0.34), transparent 28%),
-      radial-gradient(circle at 82% 18%, rgba(45, 212, 191, 0.26), transparent 31%),
-      radial-gradient(circle at 58% 78%, rgba(186, 230, 253, 0.40), transparent 35%);
-    filter: blur(36px);
-    opacity: 0.86;
-    transform: translate3d(0, 0, 0) scale(1);
-    animation: public-soft-canvas-drift 12s ease-in-out infinite alternate;
-  }
-
-  .public-soft-canvas > *,
-  [data-public-soft-canvas="true"] > * {
-    position: relative;
-    z-index: 1;
-  }
-
-  @keyframes public-soft-canvas-drift {
-    0% {
-      transform: translate3d(-3%, -1.5%, 0) scale(1);
-      opacity: 0.68;
-    }
-
-    50% {
-      transform: translate3d(2.5%, 1.5%, 0) scale(1.06);
-      opacity: 0.92;
-    }
-
-    100% {
-      transform: translate3d(4%, -2%, 0) scale(1.03);
-      opacity: 0.74;
-    }
-  }
-
+  .public-soft-canvas,
+  [data-public-soft-canvas="true"],
   .public-hero-depth,
   [data-public-hero-depth="true"] {
     position: relative;
     isolation: isolate;
-    overflow: hidden;
-    background:
-      radial-gradient(circle at 12% 12%, rgba(34, 211, 238, 0.30), transparent 31%),
-      radial-gradient(circle at 88% 15%, rgba(52, 211, 153, 0.30), transparent 34%),
-      radial-gradient(circle at 50% 120%, rgba(251, 191, 36, 0.16), transparent 34%),
-      linear-gradient(135deg, #07365d 0%, #123f7a 42%, #0f766e 100%) !important;
+    overflow: visible;
+    background: transparent !important;
   }
 
+  .public-soft-canvas::before,
+  [data-public-soft-canvas="true"]::before,
+  .public-hero-depth::before,
+  [data-public-hero-depth="true"]::before {
+    content: none !important;
+    display: none !important;
+  }
+
+  .public-soft-canvas > *,
+  [data-public-soft-canvas="true"] > *,
+  .public-hero-depth > *,
+  [data-public-hero-depth="true"] > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  @keyframes public-page-canvas-drift {
+    0% {
+      transform: translate3d(-2.5%, -1.5%, 0) scale(1);
+      opacity: 0.72;
+    }
+
+    50% {
+      transform: translate3d(2%, 1.25%, 0) scale(1.05);
+      opacity: 0.92;
+    }
+
+    100% {
+      transform: translate3d(3.5%, -2%, 0) scale(1.03);
+      opacity: 0.78;
+    }
+  }
+
+  .public-hero-depth :is(h1, h2, h3),
+  [data-public-hero-depth="true"] :is(h1, h2, h3),
+  .public-hero-depth [class*="text-white"],
+  [data-public-hero-depth="true"] [class*="text-white"] {
+    color: rgb(15 23 42) !important;
+  }
+
+  .public-hero-depth :is(p, span),
+  [data-public-hero-depth="true"] :is(p, span),
+  .public-hero-depth [class*="text-blue-50"],
+  [data-public-hero-depth="true"] [class*="text-blue-50"] {
+    color: rgb(55 65 81) !important;
+  }
+
+  .public-hero-depth [class*="border-white"],
+  [data-public-hero-depth="true"] [class*="border-white"] {
+    border-color: rgba(191, 219, 254, 0.85) !important;
+  }
+
+  .public-hero-depth [class*="bg-blue-950/20"],
+  [data-public-hero-depth="true"] [class*="bg-blue-950/20"] {
+    background: rgba(255, 255, 255, 0.82) !important;
+    color: rgb(30 58 138) !important;
+  }
 
   .premium-card {
     @apply rounded-2xl border border-white/70 bg-white/85 shadow-[0_24px_70px_rgba(15,23,42,0.10)] backdrop-blur transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-[0_30px_90px_rgba(15,23,42,0.14)];
@@ -548,6 +543,10 @@
   }
 }
 /* dashboard-auth-visual-system:end */
+
+
+
+
 
 
 

--- a/frontend/src/components/layout/PublicLayout.tsx
+++ b/frontend/src/components/layout/PublicLayout.tsx
@@ -9,10 +9,11 @@ export function PublicLayout({ children }: PublicLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
-      <main className="flex-1" id="main-content">
+      <main className="public-page-canvas flex-1" id="main-content">
         {children}
       </main>
       <Footer />
     </div>
   );
 }
+

--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -84,7 +84,7 @@ export function LoginContent() {
   const clinicSubmitLabel = isSubmitting ? "Iniciando sesión..." : "Iniciar sesión";
 
   return (
-    <div className="min-h-screen public-soft-canvas flex items-center justify-center p-4"
+    <div className="min-h-screen public-page-canvas public-soft-canvas flex items-center justify-center p-4"
       data-auth-login-polish="true">
       <div className="w-full max-w-md">
         <div className="mb-8 text-center">
@@ -270,5 +270,6 @@ export function LoginContent() {
     </div>
   );
 }
+
 
 

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -42,7 +42,7 @@ test("login content keeps standalone login shell and form landmarks", () => {
   assert.ok(source.includes('import Link from "next/link";'));
   assert.ok(source.includes('import { loginClinic } from "@/lib/api";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
-  assert.ok(source.includes("min-h-screen public-soft-canvas flex items-center justify-center p-4"));
+  assert.ok(source.includes("min-h-screen public-page-canvas public-soft-canvas flex items-center justify-center p-4"));
   assert.equal(source.includes("bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800"), false);
   assert.ok(source.includes("PORTAL VETNEB"));
   assert.ok(source.includes('aria-label="PORTAL VETNEB — Inicio"'));
@@ -78,6 +78,7 @@ test("login content exposes public navigation affordances without direct fetch",
   assert.equal(source.includes('"/api"'), false);
   assert.equal(source.includes("fetch("), false);
 });
+
 
 
 

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -22,7 +22,7 @@ test("public layout wraps pages with navbar main landmark and footer", () => {
   assert.ok(source.includes("interface PublicLayoutProps"));
   assert.ok(source.includes("children: React.ReactNode;"));
   assert.ok(source.includes("<Navbar />"));
-  assert.ok(source.includes('<main className="flex-1" id="main-content">'));
+  assert.ok(source.includes('<main className="public-page-canvas flex-1" id="main-content">'));
   assert.ok(source.includes("{children}"));
   assert.ok(source.includes("<Footer />"));
 });
@@ -81,4 +81,5 @@ test("footer exposes access links and legal copy without redundant brand block",
   assert.equal(source.includes("Laboratorio veterinario digital. Informes, estudios y gestión"), false);
   assert.equal(source.includes("rounded-md bg-primary px-3"), false);
 });
+
 

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -194,7 +194,7 @@ test("login content keeps polished auth card layout and stable visual states", (
   assertMatchesAll(
     source,
     [
-      /className="min-h-screen public-soft-canvas flex items-center justify-center p-4"/,
+      /className="min-h-screen public-page-canvas public-soft-canvas flex items-center justify-center p-4"/,
       /className="border border-white\/80 bg-white\/95 shadow-2xl backdrop-blur"/,
       /className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"/,
       /className="text-primary hover:underline font-medium"/,
@@ -417,3 +417,22 @@ test("public medical card system keeps clinical premium card surfaces", () => {
 
 
 
+
+
+
+
+test("public pages use one single shared canvas background", () => {
+  const globals = read(GLOBALS_CSS_PATH);
+  const login = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(globals.includes(".public-page-canvas"));
+  assert.ok(globals.includes(".public-page-canvas::before"));
+  assert.ok(globals.includes("public-page-canvas-drift 14s ease-in-out infinite alternate"));
+  assert.ok(globals.includes("background: transparent !important;"));
+  assert.ok(globals.includes(".public-soft-canvas::before"));
+  assert.ok(globals.includes(".public-hero-depth::before"));
+  assert.ok(globals.includes("content: none !important;"));
+  assert.equal(globals.includes("linear-gradient(135deg, #07365d 0%, #123f7a 42%, #0f766e 100%) !important;"), false);
+  assert.equal(globals.includes("public-soft-canvas-drift 12s ease-in-out infinite alternate"), false);
+  assert.ok(login.includes("min-h-screen public-page-canvas public-soft-canvas flex items-center justify-center p-4"));
+});


### PR DESCRIPTION
## Summary
- Moves the public soft canvas background to the shared public layout main surface.
- Prevents duplicate hero and section background layers.
- Keeps public sections transparent over one continuous canvas.
- Keeps the home photographic hero intact.
- Updates login and visual contracts.

## Validation
- pnpm test: 1372/1372 pass
- pnpm build: OK