### PR TITLE
fix(frontend): remove public canvas oblique accent

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -236,7 +236,7 @@
     background:
       linear-gradient(90deg, hsl(var(--vetneb-navy) / 0.045) 1px, transparent 1px),
       linear-gradient(180deg, hsl(var(--vetneb-navy) / 0.035) 1px, transparent 1px),
-      linear-gradient(135deg, transparent 0 41%, hsl(var(--vetneb-teal) / 0.08) 41% 42%, transparent 42% 100%);
+      linear-gradient(135deg, transparent 0 100%);
     background-size: 86px 86px, 86px 86px, 100% 100%;
     opacity: 0.58;
     mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0.18));


### PR DESCRIPTION
## Summary
- Removes the visible oblique accent from the public page canvas.
- Keeps the existing public canvas texture structure and background-size contract intact.
- Preserves the subtle grid and global public background.

## Validation
- pnpm test
- pnpm -C frontend build