### PR TITLE
perf(frontend): keep root layout server-rendered

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
-import { AuthProvider } from "@/context/AuthContext";
 import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";
 
 const inter = Inter({
@@ -29,7 +28,7 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
-        <AuthProvider>{children}</AuthProvider>
+        {children}
       </body>
     </html>
   );

--- a/test/frontend-auth-context.test.ts
+++ b/test/frontend-auth-context.test.ts
@@ -56,9 +56,12 @@ test("frontend useAuth hook requires provider", () => {
   assert.ok(source.includes("return context"));
 });
 
-test("frontend root layout provides auth context globally", () => {
+test("frontend root layout remains server-rendered without global auth provider", () => {
   const source = read(ROOT_LAYOUT_PATH);
 
-  assert.ok(source.includes('import { AuthProvider } from "@/context/AuthContext"'));
-  assert.ok(source.includes("<AuthProvider>{children}</AuthProvider>"));
+  assert.equal(
+    source.includes('import { AuthProvider } from "@/context/AuthContext"'),
+    false,
+  );
+  assert.equal(source.includes("<AuthProvider>{children}</AuthProvider>"), false);
 });


### PR DESCRIPTION
## Summary
- Removes the global client AuthProvider wrapper from the root layout.
- Keeps the root layout server-rendered to reduce unnecessary client boundary work.
- Updates auth context tests to reflect the server-rendered root layout contract.

## Validation
- pnpm test
- pnpm -C frontend build