### PR TITLE
feat(frontend): wire reports filters to live backend

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Table,
@@ -14,7 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getReports } from "@/lib/api";
+import { getReports, searchReports } from "@/lib/api";
 import {
   getReportStatusLabel,
   getReportStatusVariant,
@@ -34,6 +35,28 @@ const statusOptions = [
   { value: "delivered", label: "Entregado" },
 ];
 
+type InformesPageSearchParams = {
+  query?: string | string[];
+  status?: string | string[];
+  studyType?: string | string[];
+};
+
+function normalizeSearchParamValue(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+
+  return value ?? "";
+}
+
+function normalizeStatusFilter(value: string) {
+  if (statusOptions.some((option) => option.value === value)) {
+    return value;
+  }
+
+  return "";
+}
+
 async function getReportsRequestOptions(): Promise<RequestInit> {
   const cookieHeader = (await cookies()).toString();
 
@@ -43,8 +66,30 @@ async function getReportsRequestOptions(): Promise<RequestInit> {
   };
 }
 
-export default async function InformesPage() {
-  const reports = await getReports(await getReportsRequestOptions());
+export default async function InformesPage({
+  searchParams,
+}: {
+  searchParams?: Promise<InformesPageSearchParams>;
+}) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const query = normalizeSearchParamValue(resolvedSearchParams.query).trim();
+  const status = normalizeStatusFilter(
+    normalizeSearchParamValue(resolvedSearchParams.status),
+  );
+  const studyType = normalizeSearchParamValue(resolvedSearchParams.studyType).trim();
+  const requestOptions = await getReportsRequestOptions();
+  const reports = query
+    ? await searchReports(
+        {
+          query,
+          status: status || undefined,
+          studyType: studyType || undefined,
+        },
+        requestOptions,
+      )
+    : await getReports(requestOptions, {
+        status: status || undefined,
+      });
 
   return (
     <>
@@ -66,13 +111,17 @@ export default async function InformesPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex flex-col gap-3 sm:flex-row">
+            <form method="get" className="flex flex-col gap-3 sm:flex-row">
               <Input
+                name="query"
+                defaultValue={query}
                 placeholder="Buscar por paciente o tipo de estudio..."
                 className="sm:max-w-sm"
                 aria-label="Buscar informes"
               />
               <select
+                name="status"
+                defaultValue={status}
                 className="field-select sm:w-56"
                 aria-label="Filtrar por estado"
               >
@@ -82,7 +131,15 @@ export default async function InformesPage() {
                   </option>
                 ))}
               </select>
-            </div>
+              <div className="flex items-center gap-2">
+                <Button type="submit" size="sm">
+                  Filtrar
+                </Button>
+                <Button size="sm" variant="ghost" asChild>
+                  <a href="/dashboard/informes">Limpiar</a>
+                </Button>
+              </div>
+            </form>
           </CardContent>
         </Card>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,9 +134,34 @@ export async function getParticularReportDownloadUrl(): Promise<string> {
   return response.downloadUrl;
 }
 
-export async function getReports(options?: RequestInit): Promise<Report[]> {
+export async function getReports(
+  options?: RequestInit,
+  params?: {
+    status?: string;
+    limit?: number;
+    offset?: number;
+  },
+): Promise<Report[]> {
   try {
-    const res = await apiFetch<{ reports: Report[] }>("/api/reports", options);
+    const query = new URLSearchParams();
+
+    if (params?.status?.trim()) {
+      query.set("status", params.status.trim());
+    }
+
+    if (typeof params?.limit === "number") {
+      query.set("limit", String(params.limit));
+    }
+
+    if (typeof params?.offset === "number") {
+      query.set("offset", String(params.offset));
+    }
+
+    const qs = query.toString();
+    const res = await apiFetch<{ reports: Report[] }>(
+      `/api/reports${qs ? `?${qs}` : ""}`,
+      options,
+    );
     return res.reports ?? [];
   } catch {
     console.warn("[API] getReports: endpoint no disponible");
@@ -937,7 +962,6 @@ export async function searchPublicProfessionals(
     };
   }
 }
-
 
 
 

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -17,6 +18,7 @@ test("dashboard informes defines non-indexable metadata and clinic read dependen
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
+  assert.ok(source.includes('import { getReports, searchReports } from "@/lib/api";'));
   assert.ok(source.includes('title: "Informes — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
@@ -24,14 +26,32 @@ test("dashboard informes defines non-indexable metadata and clinic read dependen
   assert.equal(source.includes("UploadReportModal"), false);
 });
 
-test("dashboard informes forwards cookies and disables cache for report reads", () => {
+test("dashboard informes reads filters from searchParams and uses live search endpoint", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("type InformesPageSearchParams = {"));
+  assert.ok(source.includes("query?: string | string[];"));
+  assert.ok(source.includes("status?: string | string[];"));
+  assert.ok(source.includes("searchParams?: Promise<InformesPageSearchParams>;"));
+  assert.ok(source.includes("const resolvedSearchParams = (await searchParams) ?? {};"));
+  assert.ok(source.includes("const query = normalizeSearchParamValue(resolvedSearchParams.query).trim();"));
+  assert.ok(source.includes("const status = normalizeStatusFilter("));
+  assert.ok(source.includes("const reports = query"));
+  assert.ok(source.includes("? await searchReports("));
+  assert.ok(source.includes("query,"));
+  assert.ok(source.includes("status: status || undefined,"));
+  assert.ok(source.includes(": await getReports(requestOptions, {"));
+});
+
+test("dashboard informes preserves request options with forwarded cookies and no-store reads", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("async function getReportsRequestOptions(): Promise<RequestInit>"));
   assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
   assert.ok(source.includes('cache: "no-store"'));
   assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
-  assert.ok(source.includes("const reports = await getReports(await getReportsRequestOptions());"));
+  assert.ok(source.includes("const requestOptions = await getReportsRequestOptions();"));
+  assert.ok(source.includes("requestOptions,"));
 });
 
 test("dashboard informes keeps status filter options aligned to report statuses", () => {
@@ -60,9 +80,18 @@ test("dashboard informes renders read-only clinic source notice", () => {
 test("dashboard informes renders filters and reports table columns", () => {
   const source = read(INFORMES_PAGE_PATH);
 
+  assert.ok(source.includes('<form method="get"'));
   assert.ok(source.includes('placeholder="Buscar por paciente o tipo de estudio..."'));
+  assert.ok(source.includes('name="query"'));
+  assert.ok(source.includes("defaultValue={query}"));
   assert.ok(source.includes('aria-label="Buscar informes"'));
+  assert.ok(source.includes('name="status"'));
+  assert.ok(source.includes("defaultValue={status}"));
   assert.ok(source.includes('aria-label="Filtrar por estado"'));
+  assert.ok(source.includes("<Button type=\"submit\" size=\"sm\">"));
+  assert.ok(source.includes("Filtrar"));
+  assert.ok(source.includes('href="/dashboard/informes"'));
+  assert.ok(source.includes("Limpiar"));
   assert.ok(source.includes("<TableHead>ID</TableHead>"));
   assert.ok(source.includes("<TableHead>Paciente</TableHead>"));
   assert.ok(source.includes("<TableHead>Tipo de estudio</TableHead>"));
@@ -92,4 +121,18 @@ test("dashboard informes keeps empty state and avoids client-side fetch literals
   assert.ok(source.includes("No hay informes disponibles."));
   assert.ok(source.includes("colSpan={7}"));
   assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("mock"), false);
+});
+
+test("api client supports reports status filter without bypassing wrappers", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export async function getReports("));
+  assert.ok(source.includes("params?: {"));
+  assert.ok(source.includes("status?: string;"));
+  assert.ok(source.includes("limit?: number;"));
+  assert.ok(source.includes("offset?: number;"));
+  assert.ok(source.includes('query.set("status", params.status.trim());'));
+  assert.ok(source.includes("`/api/reports${qs ? `?${qs}` : \"\"}`"));
+  assert.ok(source.includes('export async function searchReports('));
 });

--- a/test/frontend-reports-api-read.test.ts
+++ b/test/frontend-reports-api-read.test.ts
@@ -15,8 +15,14 @@ function read(relativePath: string): string {
 test("frontend API client reads reports from backend reports endpoint", () => {
   const source = read(API_CLIENT_PATH);
 
-  assert.ok(source.includes("export async function getReports(options?: RequestInit): Promise<Report[]>"));
-  assert.ok(source.includes('const res = await apiFetch<{ reports: Report[] }>("/api/reports", options);'));
+  assert.ok(source.includes("export async function getReports("));
+  assert.ok(source.includes("options?: RequestInit,"));
+  assert.ok(source.includes("params?: {"));
+  assert.ok(source.includes("status?: string;"));
+  assert.ok(source.includes("limit?: number;"));
+  assert.ok(source.includes("offset?: number;"));
+  assert.ok(source.includes("const query = new URLSearchParams();"));
+  assert.ok(source.includes("`/api/reports${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("return res.reports ?? [];"));
   assert.ok(source.includes('console.warn("[API] getReports: endpoint no disponible");'));
   assert.ok(source.includes("return [];"));

--- a/test/frontend-reports-live-read-contract.test.ts
+++ b/test/frontend-reports-live-read-contract.test.ts
@@ -39,7 +39,11 @@ test("frontend reports page uses reports API client wrapper", () => {
 
   assertIncludes(source, 'from "@/lib/api"', reportsPage);
   assertIncludes(source, "getReports", reportsPage);
-  assertIncludes(source, "getReports(await getReportsRequestOptions())", reportsPage);
+  assertIncludes(source, "searchReports", reportsPage);
+  assertIncludes(source, "const requestOptions = await getReportsRequestOptions();", reportsPage);
+  assertIncludes(source, "const reports = query", reportsPage);
+  assertIncludes(source, "? await searchReports(", reportsPage);
+  assertIncludes(source, ": await getReports(requestOptions, {", reportsPage);
   assertIncludes(source, "reports.map", reportsPage);
   assertIncludes(source, "reports.length", reportsPage);
 });
@@ -60,10 +64,17 @@ test("frontend reports API wrappers accept request options", () => {
 
   assertIncludes(
     source,
-    "export async function getReports(options?: RequestInit)",
+    "export async function getReports(",
     frontendApiClient,
   );
-  assertIncludes(source, '"/api/reports", options', frontendApiClient);
+  assertIncludes(source, "options?: RequestInit,", frontendApiClient);
+  assertIncludes(source, "params?: {", frontendApiClient);
+  assertIncludes(source, "status?: string;", frontendApiClient);
+  assertIncludes(
+    source,
+    '`/api/reports${qs ? `?${qs}` : ""}`',
+    frontendApiClient,
+  );
   assertIncludes(source, "export async function searchReports(", frontendApiClient);
   assertIncludes(source, "options?: RequestInit", frontendApiClient);
   assertIncludes(
@@ -84,4 +95,3 @@ test("frontend reports API wrappers accept request options", () => {
   assertIncludes(source, "return []", frontendApiClient);
   assertNotIncludes(source, "return MOCK_REPORTS", frontendApiClient);
 });
-

--- a/test/frontend-reports-no-mock-fallback.test.ts
+++ b/test/frontend-reports-no-mock-fallback.test.ts
@@ -23,7 +23,8 @@ test("frontend reports api client uses real reports endpoints", () => {
   const source = read(API_CLIENT_PATH);
 
   assert.ok(source.includes("export async function getReports("));
-  assert.ok(source.includes('apiFetch<{ reports: Report[] }>("/api/reports"'));
+  assert.ok(source.includes("apiFetch<{ reports: Report[] }>("));
+  assert.ok(source.includes("`/api/reports${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("export async function searchReports("));
   assert.ok(source.includes("`/api/reports/search${qs ? `?${qs}` : \"\"}`"));
 });


### PR DESCRIPTION
## Summary
- Wire dashboard reports filters to live backend query/search endpoints.
- Preserve server-side cookie forwarding and no-store reads.
- Add native coverage for searchParams-driven filters.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build