### PR TITLE
fix(frontend): surface admin health fetch failure

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -259,6 +259,7 @@ export default async function AdminPage({
   const selectedActorType = normalizeAuditFilter(resolvedSearchParams.actorType);
   const auditEntries = await getAuditEntries(await getAdminRequestOptions());
   const systemHealth = await getAdminSystemHealth(await getAdminRequestOptions());
+  const hasSystemHealthFetchError = systemHealth === null;
   const serviceChecks = systemHealth?.services ?? {};
   const systemStatus = systemHealth?.status ?? "unknown";
   const eventCounts = auditEntries.reduce(
@@ -369,7 +370,9 @@ export default async function AdminPage({
                 </Badge>
               </div>
               <p className="text-xs text-gray-400 mt-2">
-                {formatSystemStatusDetail(serviceChecks)}
+                {hasSystemHealthFetchError
+                  ? "No se pudo consultar el estado del sistema."
+                  : formatSystemStatusDetail(serviceChecks)}
               </p>
             </CardContent>
           </Card>
@@ -382,6 +385,15 @@ export default async function AdminPage({
             </CardDescription>
           </CardHeader>
           <CardContent>
+            {hasSystemHealthFetchError ? (
+              <div
+                role="alert"
+                className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+              >
+                No se pudo consultar el estado del sistema. Los valores de salud
+                operacional se muestran como desconocidos hasta recuperar la lectura.
+              </div>
+            ) : null}
             <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
               <div className="surface-soft">
                 <p className="text-xs text-gray-400 mb-2">Base de datos</p>

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -142,6 +142,17 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);
 });
 
+test("dashboard admin surfaces system health fetch failures", () => {
+  const source = read(ADMIN_PAGE_PATH);
+
+  assert.ok(source.includes("const hasSystemHealthFetchError = systemHealth === null;"));
+  assert.ok(source.includes("hasSystemHealthFetchError"));
+  assert.ok(source.includes("No se pudo consultar el estado del sistema."));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("Los valores de salud"));
+  assert.ok(source.includes("formatSystemStatusDetail(serviceChecks)"));
+});
+
 test("dashboard admin renders role-change audit and audit log table", () => {
   const source = read(ADMIN_PAGE_PATH);
 
@@ -179,6 +190,5 @@ test("dashboard admin avoids duplicate section ids in navigation anchors", () =>
   assert.equal(adminHealthIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });
-
 
 


### PR DESCRIPTION
## Summary
- Surface admin system health fetch failures instead of showing only unknown values.
- Keep the existing API client nullable contract.
- Add/update native frontend coverage for the admin health error state.

## Validation
- pnpm test -- test/frontend-dashboard-admin.test.ts test/frontend-admin-system-api.test.ts
- pnpm test -- test/frontend-app-mock-isolation-contract.test.ts
- pnpm test
- pnpm build