### PR TITLE
fix(frontend): surface reports list fetch failure

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -78,18 +78,30 @@ export default async function InformesPage({
   );
   const studyType = normalizeSearchParamValue(resolvedSearchParams.studyType).trim();
   const requestOptions = await getReportsRequestOptions();
-  const reports = query
-    ? await searchReports(
-        {
-          query,
-          status: status || undefined,
-          studyType: studyType || undefined,
-        },
-        requestOptions,
-      )
-    : await getReports(requestOptions, {
-        status: status || undefined,
-      });
+  let reports: Awaited<ReturnType<typeof getReports>> = [];
+  let reportsLoadError = false;
+
+  try {
+    reports = query
+      ? await searchReports(
+          {
+            query,
+            status: status || undefined,
+            studyType: studyType || undefined,
+          },
+          requestOptions,
+          { throwOnError: true },
+        )
+      : await getReports(
+          requestOptions,
+          {
+            status: status || undefined,
+          },
+          { throwOnError: true },
+        );
+  } catch {
+    reportsLoadError = true;
+  }
 
   return (
     <>
@@ -163,7 +175,17 @@ export default async function InformesPage({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {reports.length ? (
+                {reportsLoadError ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      role="alert"
+                      className="px-6 py-10 text-center text-sm text-amber-700"
+                    >
+                      No se pudieron cargar los informes. Intente nuevamente.
+                    </TableCell>
+                  </TableRow>
+                ) : reports.length ? (
                   reports.map((report) => (
                     <TableRow key={report.id}>
                       <TableCell className="font-mono text-xs text-gray-400">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,10 @@ export async function getParticularReportDownloadUrl(): Promise<string> {
   return response.downloadUrl;
 }
 
+type ReportReadOptions = {
+  throwOnError?: boolean;
+};
+
 export async function getReports(
   options?: RequestInit,
   params?: {
@@ -141,6 +145,7 @@ export async function getReports(
     limit?: number;
     offset?: number;
   },
+  readOptions: ReportReadOptions = {},
 ): Promise<Report[]> {
   try {
     const query = new URLSearchParams();
@@ -163,8 +168,12 @@ export async function getReports(
       options,
     );
     return res.reports ?? [];
-  } catch {
+  } catch (error) {
     console.warn("[API] getReports: endpoint no disponible");
+    if (readOptions.throwOnError) {
+      throw error;
+    }
+
     return [];
   }
 }
@@ -176,6 +185,7 @@ export async function searchReports(
     studyType?: string;
   },
   options?: RequestInit,
+  readOptions: ReportReadOptions = {},
 ): Promise<Report[]> {
   try {
     const qs = new URLSearchParams(
@@ -188,8 +198,12 @@ export async function searchReports(
       options,
     );
     return res.reports ?? [];
-  } catch {
+  } catch (error) {
     console.warn("[API] searchReports: endpoint no disponible");
+    if (readOptions.throwOnError) {
+      throw error;
+    }
+
     return [];
   }
 }
@@ -944,5 +958,4 @@ export async function searchPublicProfessionals(
     options,
   );
 }
-
 

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -26,7 +26,10 @@ test("dashboard overview shows empty states for recent lists", () => {
 test("dashboard informes page shows empty state when reports are unavailable", () => {
   const source = read(INFORMES_PAGE_PATH);
 
+  assert.ok(source.includes("reportsLoadError ?"));
   assert.ok(source.includes("reports.length ?"));
+  assert.ok(source.includes("No se pudieron cargar los informes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay informes disponibles."));
   assert.ok(source.includes("colSpan={7}"));
   assert.ok(source.includes("reports.map((report)"));

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -36,11 +36,12 @@ test("dashboard informes reads filters from searchParams and uses live search en
   assert.ok(source.includes("const resolvedSearchParams = (await searchParams) ?? {};"));
   assert.ok(source.includes("const query = normalizeSearchParamValue(resolvedSearchParams.query).trim();"));
   assert.ok(source.includes("const status = normalizeStatusFilter("));
-  assert.ok(source.includes("const reports = query"));
+  assert.ok(source.includes("reports = query"));
   assert.ok(source.includes("? await searchReports("));
   assert.ok(source.includes("query,"));
   assert.ok(source.includes("status: status || undefined,"));
-  assert.ok(source.includes(": await getReports(requestOptions, {"));
+  assert.ok(source.includes(": await getReports("));
+  assert.ok(source.includes("{ throwOnError: true }"));
 });
 
 test("dashboard informes preserves request options with forwarded cookies and no-store reads", () => {
@@ -124,6 +125,20 @@ test("dashboard informes keeps empty state and avoids client-side fetch literals
   assert.equal(source.includes("mock"), false);
 });
 
+test("dashboard informes separates fetch failures from real empty report lists", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("let reports: Awaited<ReturnType<typeof getReports>> = [];"));
+  assert.ok(source.includes("let reportsLoadError = false;"));
+  assert.ok(source.includes("try {"));
+  assert.ok(source.includes("reportsLoadError = true;"));
+  assert.ok(source.includes("reportsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar los informes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes(": reports.length ?"));
+  assert.ok(source.includes("No hay informes disponibles."));
+});
+
 test("api client supports reports status filter without bypassing wrappers", () => {
   const source = read(API_CLIENT_PATH);
 
@@ -135,4 +150,5 @@ test("api client supports reports status filter without bypassing wrappers", () 
   assert.ok(source.includes('query.set("status", params.status.trim());'));
   assert.ok(source.includes("`/api/reports${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes('export async function searchReports('));
+  assert.ok(source.includes("throwOnError?: boolean;"));
 });

--- a/test/frontend-reports-api-read.test.ts
+++ b/test/frontend-reports-api-read.test.ts
@@ -21,10 +21,14 @@ test("frontend API client reads reports from backend reports endpoint", () => {
   assert.ok(source.includes("status?: string;"));
   assert.ok(source.includes("limit?: number;"));
   assert.ok(source.includes("offset?: number;"));
+  assert.ok(source.includes("readOptions: ReportReadOptions = {},"));
+  assert.ok(source.includes("throwOnError?: boolean;"));
   assert.ok(source.includes("const query = new URLSearchParams();"));
   assert.ok(source.includes("`/api/reports${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("return res.reports ?? [];"));
   assert.ok(source.includes('console.warn("[API] getReports: endpoint no disponible");'));
+  assert.ok(source.includes("if (readOptions.throwOnError) {"));
+  assert.ok(source.includes("throw error;"));
   assert.ok(source.includes("return [];"));
 });
 
@@ -36,11 +40,14 @@ test("frontend API client searches reports with optional query parameters", () =
   assert.ok(source.includes("status?: string;"));
   assert.ok(source.includes("studyType?: string;"));
   assert.ok(source.includes("options?: RequestInit,"));
+  assert.ok(source.includes("readOptions: ReportReadOptions = {},"));
   assert.ok(source.includes("const qs = new URLSearchParams("));
   assert.ok(source.includes("Object.entries(params).filter(([, v]) => v !== undefined)"));
   assert.ok(source.includes("/api/reports/search"));
   assert.ok(source.includes("return res.reports ?? [];"));
   assert.ok(source.includes('console.warn("[API] searchReports: endpoint no disponible");'));
+  assert.ok(source.includes("if (readOptions.throwOnError) {"));
+  assert.ok(source.includes("throw error;"));
 });
 
 test("frontend API client requests report download URLs by report id", () => {

--- a/test/frontend-reports-live-read-contract.test.ts
+++ b/test/frontend-reports-live-read-contract.test.ts
@@ -41,11 +41,28 @@ test("frontend reports page uses reports API client wrapper", () => {
   assertIncludes(source, "getReports", reportsPage);
   assertIncludes(source, "searchReports", reportsPage);
   assertIncludes(source, "const requestOptions = await getReportsRequestOptions();", reportsPage);
-  assertIncludes(source, "const reports = query", reportsPage);
+  assertIncludes(source, "reports = query", reportsPage);
   assertIncludes(source, "? await searchReports(", reportsPage);
-  assertIncludes(source, ": await getReports(requestOptions, {", reportsPage);
+  assertIncludes(source, ": await getReports(", reportsPage);
+  assertIncludes(source, "{ throwOnError: true }", reportsPage);
   assertIncludes(source, "reports.map", reportsPage);
   assertIncludes(source, "reports.length", reportsPage);
+});
+
+test("frontend reports page surfaces fetch failures separately from empty data", () => {
+  const source = read(reportsPage);
+
+  assertIncludes(source, "let reportsLoadError = false;", reportsPage);
+  assertIncludes(source, "try {", reportsPage);
+  assertIncludes(source, "reportsLoadError = true;", reportsPage);
+  assertIncludes(source, "reportsLoadError ?", reportsPage);
+  assertIncludes(
+    source,
+    "No se pudieron cargar los informes. Intente nuevamente.",
+    reportsPage,
+  );
+  assertIncludes(source, 'role="alert"', reportsPage);
+  assertIncludes(source, "No hay informes disponibles.", reportsPage);
 });
 
 test("frontend reports page forces dynamic server reads with forwarded cookies", () => {
@@ -70,6 +87,8 @@ test("frontend reports API wrappers accept request options", () => {
   assertIncludes(source, "options?: RequestInit,", frontendApiClient);
   assertIncludes(source, "params?: {", frontendApiClient);
   assertIncludes(source, "status?: string;", frontendApiClient);
+  assertIncludes(source, "throwOnError?: boolean;", frontendApiClient);
+  assertIncludes(source, "readOptions: ReportReadOptions = {},", frontendApiClient);
   assertIncludes(
     source,
     '`/api/reports${qs ? `?${qs}` : ""}`',
@@ -82,6 +101,8 @@ test("frontend reports API wrappers accept request options", () => {
     '`/api/reports/search${qs ? `?${qs}` : ""}`',
     frontendApiClient,
   );
+  assertIncludes(source, "if (readOptions.throwOnError) {", frontendApiClient);
+  assertIncludes(source, "throw error;", frontendApiClient);
   assertIncludes(
     source,
     'console.warn("[API] getReports: endpoint no disponible")',


### PR DESCRIPTION
## Summary
- Surface report list/search fetch failures in the clinic reports dashboard.
- Preserve legacy empty fallback behavior outside the reports page via opt-in error propagation.
- Keep real empty states distinct from backend fetch failures.

## Validation
- pnpm test -- test/frontend-dashboard-informes.test.ts test/frontend-dashboard-empty-states.test.ts test/frontend-reports-api-read.test.ts test/frontend-reports-live-read-contract.test.ts test/frontend-reports-no-mock-fallback.test.ts
- pnpm test -- test/frontend-app-mock-isolation-contract.test.ts
- pnpm test
- pnpm build