### PR TITLE
fix(frontend): surface logistics visits fetch failure

### DIFF
--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -33,9 +33,17 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
 }
 
 export default async function VisitasPage() {
-  const visits = await getLogisticsFieldVisits(
-    await getLogisticsRequestOptions(),
-  );
+  let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];
+  let visitsLoadError = false;
+
+  try {
+    visits = await getLogisticsFieldVisits(
+      await getLogisticsRequestOptions(),
+      { throwOnError: true },
+    );
+  } catch {
+    visitsLoadError = true;
+  }
 
   return (
     <>
@@ -89,7 +97,17 @@ export default async function VisitasPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {visits.length ? (
+                {visitsLoadError ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      role="alert"
+                      className="px-6 py-10 text-center text-sm text-amber-700"
+                    >
+                      No se pudieron cargar las visitas de campo. Intente nuevamente.
+                    </TableCell>
+                  </TableRow>
+                ) : visits.length ? (
                   visits.map((visit) => (
                     <TableRow key={visit.id}>
                       <TableCell className="font-mono text-xs text-gray-400">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -558,8 +558,14 @@ export async function submitContactMessage(
     body: JSON.stringify(payload),
   });
 }
+
+type LogisticsReadOptions = {
+  throwOnError?: boolean;
+};
+
 export async function getLogisticsFieldVisits(
   options?: RequestInit,
+  readOptions: LogisticsReadOptions = {},
 ): Promise<FieldVisit[]> {
   try {
     const res = await apiFetch<{ visits: FieldVisit[] }>(
@@ -567,8 +573,12 @@ export async function getLogisticsFieldVisits(
       options,
     );
     return res.visits ?? [];
-  } catch {
+  } catch (error) {
     console.warn("[API] getLogisticsFieldVisits: endpoint no disponible");
+    if (readOptions.throwOnError) {
+      throw error;
+    }
+
     return [];
   }
 }
@@ -958,4 +968,3 @@ export async function searchPublicProfessionals(
     options,
   );
 }
-

--- a/test/frontend-dashboard-logistica-visitas.test.ts
+++ b/test/frontend-dashboard-logistica-visitas.test.ts
@@ -31,8 +31,9 @@ test("dashboard logistica visitas forwards cookies and disables cache for live r
   assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
   assert.ok(source.includes('cache: "no-store"'));
   assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
-  assert.ok(source.includes("const visits = await getLogisticsFieldVisits("));
+  assert.ok(source.includes("visits = await getLogisticsFieldVisits("));
   assert.ok(source.includes("await getLogisticsRequestOptions(),"));
+  assert.ok(source.includes("{ throwOnError: true },"));
 });
 
 test("dashboard logistica visitas renders topbar and read-source notice", () => {
@@ -86,4 +87,18 @@ test("dashboard logistica visitas keeps empty state and avoids client-side fetch
   assert.ok(source.includes("No hay visitas de campo disponibles."));
   assert.ok(source.includes("colSpan={7}"));
   assert.equal(source.includes("fetch("), false);
+});
+
+test("dashboard logistica visitas separates fetch failures from real empty visits", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];"));
+  assert.ok(source.includes("let visitsLoadError = false;"));
+  assert.ok(source.includes("try {"));
+  assert.ok(source.includes("visitsLoadError = true;"));
+  assert.ok(source.includes("visitsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar las visitas de campo. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes(": visits.length ?"));
+  assert.ok(source.includes("No hay visitas de campo disponibles."));
 });

--- a/test/frontend-logistics-detail-empty-states.test.ts
+++ b/test/frontend-logistics-detail-empty-states.test.ts
@@ -20,8 +20,11 @@ function read(relativePath: string): string {
 test("logistics visits detail page shows an empty table state", () => {
   const source = read(VISITAS_PAGE_PATH);
 
+  assert.ok(source.includes("visitsLoadError ?"));
   assert.ok(source.includes("visits.length ?"));
   assert.ok(source.includes("visits.map((visit)"));
+  assert.ok(source.includes("No se pudieron cargar las visitas de campo. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay visitas de campo disponibles."));
   assert.ok(source.includes("colSpan={7}"));
 });

--- a/test/frontend-logistics-live-read-contract.test.ts
+++ b/test/frontend-logistics-live-read-contract.test.ts
@@ -68,10 +68,27 @@ test("frontend logistics pages use API client read wrappers", () => {
   assertIncludes(visits, 'from "@/lib/api"', logisticsVisitsPage);
   assertIncludes(visits, "getLogisticsFieldVisits", logisticsVisitsPage);
   assertIncludes(visits, "getLogisticsFieldVisits(", logisticsVisitsPage);
+  assertIncludes(visits, "{ throwOnError: true }", logisticsVisitsPage);
 
   assertIncludes(routes, 'from "@/lib/api"', logisticsRoutesPage);
   assertIncludes(routes, "getRoutePlans", logisticsRoutesPage);
   assertIncludes(routes, "getRoutePlans(", logisticsRoutesPage);
+});
+
+test("frontend logistics visits page surfaces fetch failures separately from empty data", () => {
+  const source = read(logisticsVisitsPage);
+
+  assertIncludes(source, "let visitsLoadError = false;", logisticsVisitsPage);
+  assertIncludes(source, "try {", logisticsVisitsPage);
+  assertIncludes(source, "visitsLoadError = true;", logisticsVisitsPage);
+  assertIncludes(source, "visitsLoadError ?", logisticsVisitsPage);
+  assertIncludes(
+    source,
+    "No se pudieron cargar las visitas de campo. Intente nuevamente.",
+    logisticsVisitsPage,
+  );
+  assertIncludes(source, 'role="alert"', logisticsVisitsPage);
+  assertIncludes(source, "No hay visitas de campo disponibles.", logisticsVisitsPage);
 });
 
 test("frontend logistics pages force dynamic server reads with forwarded cookies", () => {
@@ -114,8 +131,12 @@ test("frontend logistics API wrappers accept request options for server-side rea
     frontendApiClient,
   );
   assertIncludes(source, "options?: RequestInit", frontendApiClient);
+  assertIncludes(source, "throwOnError?: boolean;", frontendApiClient);
+  assertIncludes(source, "readOptions: LogisticsReadOptions = {},", frontendApiClient);
   assertIncludes(source, '"/api/logistics/field-visits"', frontendApiClient);
   assertIncludes(source, "options,", frontendApiClient);
+  assertIncludes(source, "if (readOptions.throwOnError) {", frontendApiClient);
+  assertIncludes(source, "throw error;", frontendApiClient);
 
   assertIncludes(
     source,


### PR DESCRIPTION
## Summary
- Surface field visits fetch failures in the logistics visits dashboard.
- Preserve legacy empty fallback behavior outside the visits page via opt-in error propagation.
- Keep real empty states distinct from backend fetch failures.

## Validation
- pnpm test -- test/frontend-dashboard-logistica-visitas.test.ts test/frontend-logistics-detail-empty-states.test.ts test/frontend-logistics-live-read-contract.test.ts test/frontend-logistics-no-mock-fallback.test.ts
- pnpm test -- test/frontend-app-mock-isolation-contract.test.ts
- pnpm test
- pnpm build