### PR TITLE
fix(frontend): surface logistics routes fetch failure

### DIFF
--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -33,7 +33,16 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
 }
 
 export default async function RutasPage() {
-  const routePlans = await getRoutePlans(await getLogisticsRequestOptions());
+  let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
+  let routePlansLoadError = false;
+
+  try {
+    routePlans = await getRoutePlans(await getLogisticsRequestOptions(), {
+      throwOnError: true,
+    });
+  } catch {
+    routePlansLoadError = true;
+  }
 
   return (
     <>
@@ -86,7 +95,17 @@ export default async function RutasPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {routePlans.length ? (
+                {routePlansLoadError ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={6}
+                      role="alert"
+                      className="px-6 py-10 text-center text-sm text-amber-700"
+                    >
+                      No se pudieron cargar los planes de ruta. Intente nuevamente.
+                    </TableCell>
+                  </TableRow>
+                ) : routePlans.length ? (
                   routePlans.map((plan) => {
                     const progress =
                       plan.totalStops > 0

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -585,6 +585,7 @@ export async function getLogisticsFieldVisits(
 
 export async function getRoutePlans(
   options?: RequestInit,
+  readOptions: LogisticsReadOptions = {},
 ): Promise<RoutePlan[]> {
   try {
     const res = await apiFetch<{ plans: RoutePlan[] }>(
@@ -592,8 +593,12 @@ export async function getRoutePlans(
       options,
     );
     return res.plans ?? [];
-  } catch {
+  } catch (error) {
     console.warn("[API] getRoutePlans: endpoint no disponible");
+    if (readOptions.throwOnError) {
+      throw error;
+    }
+
     return [];
   }
 }

--- a/test/frontend-dashboard-logistica-rutas.test.ts
+++ b/test/frontend-dashboard-logistica-rutas.test.ts
@@ -31,7 +31,10 @@ test("dashboard logistica rutas forwards cookies and disables cache for live rea
   assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
   assert.ok(source.includes('cache: "no-store"'));
   assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
-  assert.ok(source.includes("const routePlans = await getRoutePlans(await getLogisticsRequestOptions());"));
+  assert.ok(source.includes("let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];"));
+  assert.ok(source.includes("let routePlansLoadError = false;"));
+  assert.ok(source.includes("routePlans = await getRoutePlans(await getLogisticsRequestOptions(), {"));
+  assert.ok(source.includes("throwOnError: true,"));
 });
 
 test("dashboard logistica rutas renders topbar and read-source notice", () => {
@@ -82,9 +85,12 @@ test("dashboard logistica rutas keeps row rendering progress badges and dates", 
   assert.ok(source.includes("getRoutePlanStatusLabel(plan.status)"));
 });
 
-test("dashboard logistica rutas keeps empty state and avoids client-side fetch literals", () => {
+test("dashboard logistica rutas distinguishes load failures from real empty state", () => {
   const source = read(RUTAS_PAGE_PATH);
 
+  assert.ok(source.includes("routePlansLoadError ? ("));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("No se pudieron cargar los planes de ruta. Intente nuevamente."));
   assert.ok(source.includes("No hay planes de ruta disponibles."));
   assert.ok(source.includes("colSpan={6}"));
   assert.equal(source.includes("fetch("), false);


### PR DESCRIPTION
## Summary
- add opt-in throwOnError support to getRoutePlans
- surface logistics route plan fetch failures in dashboard/logistica/rutas
- preserve the real empty state for route plans

## Validation
- pnpm test -- test/frontend-dashboard-logistica-rutas.test.ts test/frontend-logistics-detail-empty-states.test.ts test/frontend-logistics-live-read-contract.test.ts test/frontend-logistics-no-mock-fallback.test.ts
- pnpm test -- test/frontend-app-mock-isolation-contract.test.ts
- pnpm test
- pnpm build