### PR TITLE
fix(frontend): surface admin audit log fetch failure

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -257,7 +257,17 @@ export default async function AdminPage({
   const resolvedSearchParams = (await searchParams) ?? {};
   const selectedAuditEvent = normalizeAuditFilter(resolvedSearchParams.event);
   const selectedActorType = normalizeAuditFilter(resolvedSearchParams.actorType);
-  const auditEntries = await getAuditEntries(await getAdminRequestOptions());
+  let auditEntries: Awaited<ReturnType<typeof getAuditEntries>> = [];
+  let auditEntriesLoadError = false;
+
+  try {
+    auditEntries = await getAuditEntries(await getAdminRequestOptions(), {
+      throwOnError: true,
+    });
+  } catch {
+    auditEntriesLoadError = true;
+  }
+
   const systemHealth = await getAdminSystemHealth(await getAdminRequestOptions());
   const hasSystemHealthFetchError = systemHealth === null;
   const serviceChecks = systemHealth?.services ?? {};
@@ -566,7 +576,17 @@ export default async function AdminPage({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredAuditEntries.length ? (
+                {auditEntriesLoadError ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      role="alert"
+                      className="py-8 text-center text-sm text-amber-700"
+                    >
+                      No se pudieron cargar los eventos de auditoría. Intente nuevamente.
+                    </TableCell>
+                  </TableRow>
+                ) : filteredAuditEntries.length ? (
                   filteredAuditEntries.map((entry) => (
                     <TableRow key={entry.id}>
                       <TableCell className="whitespace-nowrap font-mono text-xs text-gray-400">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -624,8 +624,13 @@ export async function getRoutePlanMetrics(
   return [];
 }
 
+type AdminReadOptions = {
+  throwOnError?: boolean;
+};
+
 export async function getAuditEntries(
   options?: RequestInit,
+  readOptions: AdminReadOptions = {},
 ): Promise<AuditEntry[]> {
   try {
     const res = await apiFetch<{ entries: AuditEntry[] }>(
@@ -633,8 +638,12 @@ export async function getAuditEntries(
       options,
     );
     return res.entries ?? [];
-  } catch {
+  } catch (error) {
     console.warn("[API] getAuditEntries: endpoint no disponible");
+    if (readOptions.throwOnError) {
+      throw error;
+    }
+
     return [];
   }
 }

--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -38,7 +38,11 @@ test("frontend admin page uses audit API client wrapper", () => {
 
   assertIncludes(source, 'from "@/lib/api"', adminPage);
   assertIncludes(source, "getAuditEntries", adminPage);
-  assertIncludes(source, "getAuditEntries(await getAdminRequestOptions())", adminPage);
+  assertIncludes(source, "let auditEntries: Awaited<ReturnType<typeof getAuditEntries>> = [];", adminPage);
+  assertIncludes(source, "let auditEntriesLoadError = false;", adminPage);
+  assertIncludes(source, "auditEntries = await getAuditEntries(await getAdminRequestOptions(), {", adminPage);
+  assertIncludes(source, "throwOnError: true,", adminPage);
+  assertIncludes(source, "auditEntriesLoadError = true;", adminPage);
   assertIncludes(source, "auditEntries.reduce", adminPage);
   assertIncludes(source, "auditEntries.map", adminPage);
 });
@@ -63,6 +67,7 @@ test("frontend admin audit API wrapper accepts request options", () => {
     frontendApiClient,
   );
   assertIncludes(source, "options?: RequestInit", frontendApiClient);
+  assertIncludes(source, "readOptions: AdminReadOptions = {}", frontendApiClient);
   assertIncludes(source, '"/api/admin/audit-log"', frontendApiClient);
   assertIncludes(source, "options,", frontendApiClient);
   assertIncludes(
@@ -70,6 +75,8 @@ test("frontend admin audit API wrapper accepts request options", () => {
     'console.warn("[API] getAuditEntries: endpoint no disponible")',
     frontendApiClient,
   );
+  assertIncludes(source, "if (readOptions.throwOnError) {", frontendApiClient);
+  assertIncludes(source, "throw error;", frontendApiClient);
   assertIncludes(source, "return []", frontendApiClient);
   assertNotIncludes(source, "return MOCK_AUDIT_ENTRIES", frontendApiClient);
 });

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -100,7 +100,10 @@ test("dashboard admin forwards cookies and performs no-store admin reads", () =>
   assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
   assert.ok(source.includes('cache: "no-store"'));
   assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
-  assert.ok(source.includes("const auditEntries = await getAuditEntries(await getAdminRequestOptions());"));
+  assert.ok(source.includes("let auditEntries: Awaited<ReturnType<typeof getAuditEntries>> = [];"));
+  assert.ok(source.includes("let auditEntriesLoadError = false;"));
+  assert.ok(source.includes("auditEntries = await getAuditEntries(await getAdminRequestOptions(), {"));
+  assert.ok(source.includes("throwOnError: true,"));
   assert.ok(source.includes("const systemHealth = await getAdminSystemHealth(await getAdminRequestOptions());"));
 });
 
@@ -172,9 +175,12 @@ test("dashboard admin renders role-change audit and audit log table", () => {
   assert.ok(source.includes("<TableHead>Fecha</TableHead>"));
 });
 
-test("dashboard admin keeps filtered empty states and avoids client-side fetch literals", () => {
+test("dashboard admin distinguishes audit log load failures from empty states", () => {
   const source = read(ADMIN_PAGE_PATH);
 
+  assert.ok(source.includes("auditEntriesLoadError ? ("));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("No se pudieron cargar los eventos de auditoría. Intente nuevamente."));
   assert.ok(source.includes("No hay eventos para los filtros seleccionados."));
   assert.ok(source.includes("No hay eventos de auditoría disponibles."));
   assert.ok(source.includes("Limpiar filtros"));


### PR DESCRIPTION
## Summary
- add opt-in throwOnError support to getAuditEntries
- surface admin audit log fetch failures in dashboard/admin
- preserve filtered and real empty states for audit entries

## Validation
- pnpm test -- test/frontend-admin-live-read-contract.test.ts test/frontend-dashboard-admin.test.ts test/frontend-audit-no-mock-fallback.test.ts test/frontend-admin-system-api.test.ts test/frontend-visual-consistency.test.ts
- pnpm test
- pnpm build