### PR TITLE
fix(frontend): surface logistics overview fetch failures

### DIFF
--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -34,9 +34,30 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
 
 export default async function LogisticaPage() {
   const requestOptions = await getLogisticsRequestOptions();
-  const [fieldVisits, routePlans] = await Promise.all([
-    getLogisticsFieldVisits(requestOptions),
-    getRoutePlans(requestOptions),
+  let fieldVisits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];
+  let fieldVisitsLoadError = false;
+  let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
+  let routePlansLoadError = false;
+
+  await Promise.all([
+    (async () => {
+      try {
+        fieldVisits = await getLogisticsFieldVisits(requestOptions, {
+          throwOnError: true,
+        });
+      } catch {
+        fieldVisitsLoadError = true;
+      }
+    })(),
+    (async () => {
+      try {
+        routePlans = await getRoutePlans(requestOptions, {
+          throwOnError: true,
+        });
+      } catch {
+        routePlansLoadError = true;
+      }
+    })(),
   ]);
 
   const activeVisits = fieldVisits.filter(
@@ -154,7 +175,11 @@ export default async function LogisticaPage() {
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
-            {fieldVisits.length ? (
+            {fieldVisitsLoadError ? (
+              <p role="alert" className="surface-empty text-amber-700">
+                No se pudieron cargar las visitas recientes. Intente nuevamente.
+              </p>
+            ) : fieldVisits.length ? (
               fieldVisits.slice(0, 4).map((visit) => (
                 <div
                   key={visit.id}
@@ -193,7 +218,11 @@ export default async function LogisticaPage() {
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
-            {routePlans.length ? (
+            {routePlansLoadError ? (
+              <p role="alert" className="surface-empty text-amber-700">
+                No se pudieron cargar los planes de ruta recientes. Intente nuevamente.
+              </p>
+            ) : routePlans.length ? (
               routePlans.map((plan) => (
                 <div
                   key={plan.id}

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -35,11 +35,16 @@ test("dashboard informes page shows empty state when reports are unavailable", (
   assert.ok(source.includes("reports.map((report)"));
 });
 
-test("dashboard logistics page shows empty states for visits and route plans", () => {
+test("dashboard logistics page distinguishes overview load failures from empty states", () => {
   const source = read(LOGISTICA_PAGE_PATH);
 
+  assert.ok(source.includes("fieldVisitsLoadError ?"));
+  assert.ok(source.includes("routePlansLoadError ?"));
   assert.ok(source.includes("fieldVisits.length ?"));
   assert.ok(source.includes("routePlans.length ?"));
+  assert.ok(source.includes("No se pudieron cargar las visitas recientes. Intente nuevamente."));
+  assert.ok(source.includes("No se pudieron cargar los planes de ruta recientes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay visitas recientes disponibles."));
   assert.ok(source.includes("No hay planes de ruta disponibles."));
   assert.ok(source.includes("fieldVisits.slice(0, 4).map((visit)"));

--- a/test/frontend-dashboard-logistica.test.ts
+++ b/test/frontend-dashboard-logistica.test.ts
@@ -38,9 +38,13 @@ test("dashboard logistica reads field visits and route plans through API helpers
 
   assert.ok(source.includes("export default async function LogisticaPage()"));
   assert.ok(source.includes("const requestOptions = await getLogisticsRequestOptions();"));
-  assert.ok(source.includes("const [fieldVisits, routePlans] = await Promise.all(["));
-  assert.ok(source.includes("getLogisticsFieldVisits(requestOptions),"));
-  assert.ok(source.includes("getRoutePlans(requestOptions),"));
+  assert.ok(source.includes("let fieldVisits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];"));
+  assert.ok(source.includes("let fieldVisitsLoadError = false;"));
+  assert.ok(source.includes("let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];"));
+  assert.ok(source.includes("let routePlansLoadError = false;"));
+  assert.ok(source.includes("await Promise.all(["));
+  assert.ok(source.includes("getLogisticsFieldVisits(requestOptions, {"));
+  assert.ok(source.includes("getRoutePlans(requestOptions, {"));
 });
 
 test("dashboard logistica computes active visits and active route plans explicitly", () => {
@@ -77,6 +81,9 @@ test("dashboard logistica renders recent visits with status badges dates and emp
   assert.ok(source.includes("formatDate(visit.scheduledAt)"));
   assert.ok(source.includes("getFieldVisitStatusVariant(visit.status)"));
   assert.ok(source.includes("getFieldVisitStatusLabel(visit.status)"));
+  assert.ok(source.includes("fieldVisitsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar las visitas recientes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay visitas recientes disponibles."));
 });
 
@@ -90,6 +97,9 @@ test("dashboard logistica renders route plans with status badges dates and empty
   assert.ok(source.includes("formatDate(plan.plannedDate)"));
   assert.ok(source.includes("getRoutePlanStatusVariant(plan.status)"));
   assert.ok(source.includes("getRoutePlanStatusLabel(plan.status)"));
+  assert.ok(source.includes("routePlansLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar los planes de ruta recientes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay planes de ruta disponibles."));
 });
 

--- a/test/frontend-logistics-live-read-contract.test.ts
+++ b/test/frontend-logistics-live-read-contract.test.ts
@@ -54,14 +54,21 @@ test("frontend logistics pages use API client read wrappers", () => {
   assertIncludes(overview, "getLogisticsFieldVisits", logisticsOverviewPage);
   assertIncludes(overview, "getRoutePlans", logisticsOverviewPage);
   assertIncludes(overview, "Promise.all", logisticsOverviewPage);
+  assertIncludes(overview, "let fieldVisits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];", logisticsOverviewPage);
+  assertIncludes(overview, "let fieldVisitsLoadError = false;", logisticsOverviewPage);
+  assertIncludes(overview, "let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];", logisticsOverviewPage);
+  assertIncludes(overview, "let routePlansLoadError = false;", logisticsOverviewPage);
+  assertIncludes(overview, "getLogisticsFieldVisits(requestOptions, {", logisticsOverviewPage);
+  assertIncludes(overview, "getRoutePlans(requestOptions, {", logisticsOverviewPage);
+  assertIncludes(overview, "throwOnError: true,", logisticsOverviewPage);
   assertIncludes(
     overview,
-    "getLogisticsFieldVisits(requestOptions)",
+    "getLogisticsFieldVisits(requestOptions, {",
     logisticsOverviewPage,
   );
   assertIncludes(
     overview,
-    "getRoutePlans(requestOptions)",
+    "getRoutePlans(requestOptions, {",
     logisticsOverviewPage,
   );
 


### PR DESCRIPTION
## Summary
- surface logistics overview fetch failures for recent visits and route plans
- preserve real empty states for visits and route plans
- keep logistics overview reads parallel and live via existing API helpers

## Validation
- pnpm test -- test/frontend-dashboard-logistica.test.ts test/frontend-dashboard-empty-states.test.ts test/frontend-logistics-live-read-contract.test.ts test/frontend-logistics-detail-empty-states.test.ts test/frontend-logistics-no-mock-fallback.test.ts
- pnpm test
- pnpm build