### PR TITLE
fix(frontend): surface dashboard overview fetch failures

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -39,10 +39,31 @@ async function getDashboardRequestOptions(): Promise<RequestInit> {
 
 export default async function DashboardPage() {
   const requestOptions = await getDashboardRequestOptions();
-  const [stats, reports, visits] = await Promise.all([
-    getDashboardStats(requestOptions),
-    getReports(requestOptions),
-    getLogisticsFieldVisits(requestOptions),
+  const stats = await getDashboardStats(requestOptions);
+  let reports: Awaited<ReturnType<typeof getReports>> = [];
+  let reportsLoadError = false;
+  let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];
+  let visitsLoadError = false;
+
+  await Promise.all([
+    (async () => {
+      try {
+        reports = await getReports(requestOptions, undefined, {
+          throwOnError: true,
+        });
+      } catch {
+        reportsLoadError = true;
+      }
+    })(),
+    (async () => {
+      try {
+        visits = await getLogisticsFieldVisits(requestOptions, {
+          throwOnError: true,
+        });
+      } catch {
+        visitsLoadError = true;
+      }
+    })(),
   ]);
 
   const recentReports = reports.slice(0, 3);
@@ -115,7 +136,11 @@ export default async function DashboardPage() {
               </Button>
             </CardHeader>
             <CardContent className="space-y-1.5">
-              {recentReports.length ? (
+              {reportsLoadError ? (
+                <p role="alert" className="surface-empty text-amber-700">
+                  No se pudieron cargar los informes recientes. Intente nuevamente.
+                </p>
+              ) : recentReports.length ? (
                 recentReports.map((report) => (
                   <div
                     key={report.id}
@@ -158,7 +183,11 @@ export default async function DashboardPage() {
               </Button>
             </CardHeader>
             <CardContent className="space-y-1.5">
-              {recentVisits.length ? (
+              {visitsLoadError ? (
+                <p role="alert" className="surface-empty text-amber-700">
+                  No se pudieron cargar las visitas de campo recientes. Intente nuevamente.
+                </p>
+              ) : recentVisits.length ? (
                 recentVisits.map((visit) => (
                   <div
                     key={visit.id}

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -14,11 +14,16 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard overview shows empty states for recent lists", () => {
+test("dashboard overview distinguishes recent list load failures from empty states", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
+  assert.ok(source.includes("reportsLoadError ?"));
+  assert.ok(source.includes("visitsLoadError ?"));
   assert.ok(source.includes("recentReports.length ?"));
   assert.ok(source.includes("recentVisits.length ?"));
+  assert.ok(source.includes("No se pudieron cargar los informes recientes. Intente nuevamente."));
+  assert.ok(source.includes("No se pudieron cargar las visitas de campo recientes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay informes recientes disponibles."));
   assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
 });

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -39,10 +39,15 @@ test("dashboard home reads stats reports and field visits through API helpers", 
 
   assert.ok(source.includes("export default async function DashboardPage()"));
   assert.ok(source.includes("const requestOptions = await getDashboardRequestOptions();"));
-  assert.ok(source.includes("const [stats, reports, visits] = await Promise.all(["));
-  assert.ok(source.includes("getDashboardStats(requestOptions),"));
-  assert.ok(source.includes("getReports(requestOptions),"));
-  assert.ok(source.includes("getLogisticsFieldVisits(requestOptions),"));
+  assert.ok(source.includes("const stats = await getDashboardStats(requestOptions);"));
+  assert.ok(source.includes("let reports: Awaited<ReturnType<typeof getReports>> = [];"));
+  assert.ok(source.includes("let reportsLoadError = false;"));
+  assert.ok(source.includes("let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];"));
+  assert.ok(source.includes("let visitsLoadError = false;"));
+  assert.ok(source.includes("await Promise.all(["));
+  assert.ok(source.includes("getReports(requestOptions, undefined, {"));
+  assert.ok(source.includes("getLogisticsFieldVisits(requestOptions, {"));
+  assert.ok(source.includes("throwOnError: true,"));
   assert.ok(source.includes("const recentReports = reports.slice(0, 3);"));
   assert.ok(source.includes("const recentVisits = visits.slice(0, 3);"));
 });
@@ -58,6 +63,11 @@ test("dashboard home renders clinic operational summary, stats, reports, and fie
   assert.ok(source.includes("<StatsCards stats={stats} />"));
   assert.ok(source.includes("Informes recientes"));
   assert.ok(source.includes("Visitas de campo"));
+  assert.ok(source.includes("reportsLoadError ?"));
+  assert.ok(source.includes("visitsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar los informes recientes. Intente nuevamente."));
+  assert.ok(source.includes("No se pudieron cargar las visitas de campo recientes. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay informes recientes disponibles."));
   assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
 });

--- a/test/frontend-dashboard-live-read-contract.test.ts
+++ b/test/frontend-dashboard-live-read-contract.test.ts
@@ -44,13 +44,14 @@ test("frontend dashboard page uses API client wrappers", () => {
   assertIncludes(source, "getReports", dashboardPage);
   assertIncludes(source, "getLogisticsFieldVisits", dashboardPage);
   assertIncludes(source, "Promise.all", dashboardPage);
-  assertIncludes(source, "getDashboardStats(requestOptions)", dashboardPage);
-  assertIncludes(source, "getReports(requestOptions)", dashboardPage);
-  assertIncludes(
-    source,
-    "getLogisticsFieldVisits(requestOptions)",
-    dashboardPage,
-  );
+  assertIncludes(source, "const stats = await getDashboardStats(requestOptions);", dashboardPage);
+  assertIncludes(source, "let reports: Awaited<ReturnType<typeof getReports>> = [];", dashboardPage);
+  assertIncludes(source, "let reportsLoadError = false;", dashboardPage);
+  assertIncludes(source, "let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];", dashboardPage);
+  assertIncludes(source, "let visitsLoadError = false;", dashboardPage);
+  assertIncludes(source, "getReports(requestOptions, undefined, {", dashboardPage);
+  assertIncludes(source, "getLogisticsFieldVisits(requestOptions, {", dashboardPage);
+  assertIncludes(source, "throwOnError: true,", dashboardPage);
 });
 
 test("frontend dashboard page forces dynamic server reads with forwarded cookies", () => {


### PR DESCRIPTION
## Summary
- surface dashboard overview fetch failures for recent reports and field visits
- preserve real empty states for recent reports and visits
- keep dashboard stats read unchanged

## Validation
- pnpm test -- test/frontend-dashboard-home.test.ts test/frontend-dashboard-empty-states.test.ts test/frontend-dashboard-live-read-contract.test.ts test/frontend-dashboard-stats-aggregation.test.ts test/frontend-visual-consistency.test.ts
- pnpm test
- pnpm build