### PR TITLE
fix(frontend): surface logistics metrics fetch failures

### DIFF
--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -27,12 +27,34 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
 
 export default async function MetricasPage() {
   const requestOptions = await getLogisticsRequestOptions();
-  const routePlans = await getRoutePlans(requestOptions);
-  const routeMetrics = (
-    await Promise.all(
-      routePlans.map((plan) => getRoutePlanMetrics(plan.id, requestOptions)),
-    )
-  ).flat();
+  let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
+  let routePlansLoadError = false;
+  let routeMetrics: Awaited<ReturnType<typeof getRoutePlanMetrics>> = [];
+  let routeMetricsLoadError = false;
+
+  try {
+    routePlans = await getRoutePlans(requestOptions, {
+      throwOnError: true,
+    });
+  } catch {
+    routePlansLoadError = true;
+  }
+
+  if (!routePlansLoadError && routePlans.length) {
+    try {
+      routeMetrics = (
+        await Promise.all(
+          routePlans.map((plan) =>
+            getRoutePlanMetrics(plan.id, requestOptions, {
+              throwOnError: true,
+            }),
+          ),
+        )
+      ).flat();
+    } catch {
+      routeMetricsLoadError = true;
+    }
+  }
 
   const totalStops = routeMetrics.reduce(
     (sum, metric) => sum + metric.totalStops,
@@ -135,7 +157,15 @@ export default async function MetricasPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {routeMetrics.length ? (
+            {routePlansLoadError ? (
+              <div role="alert" className="surface-empty text-amber-700">
+                No se pudieron cargar los planes de ruta para métricas. Intente nuevamente.
+              </div>
+            ) : routeMetricsLoadError ? (
+              <div role="alert" className="surface-empty text-amber-700">
+                No se pudieron cargar las métricas de ruta. Intente nuevamente.
+              </div>
+            ) : routeMetrics.length ? (
               routeMetrics.map((metric) => {
                 const plan = routePlans.find(
                   (routePlan) => routePlan.id === metric.routePlanId,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -606,6 +606,7 @@ export async function getRoutePlans(
 export async function getRoutePlanMetrics(
   planId?: number,
   options?: RequestInit,
+  readOptions: LogisticsReadOptions = {},
 ): Promise<RouteMetrics[]> {
   if (planId !== undefined) {
     try {
@@ -614,8 +615,12 @@ export async function getRoutePlanMetrics(
         options,
       );
       return res.metrics ? [res.metrics] : [];
-    } catch {
+    } catch (error) {
       console.warn("[API] getRoutePlanMetrics: endpoint no disponible");
+      if (readOptions.throwOnError) {
+        throw error;
+      }
+
       return [];
     }
   }

--- a/test/frontend-dashboard-logistica-metricas.test.ts
+++ b/test/frontend-dashboard-logistica-metricas.test.ts
@@ -37,10 +37,15 @@ test("dashboard logistica metricas forwards cookies and disables cache for live 
 test("dashboard logistica metricas reads route plans and plan metrics", () => {
   const source = read(METRICAS_PAGE_PATH);
 
-  assert.ok(source.includes("const routePlans = await getRoutePlans(requestOptions);"));
-  assert.ok(source.includes("const routeMetrics = ("));
+  assert.ok(source.includes("let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];"));
+  assert.ok(source.includes("let routePlansLoadError = false;"));
+  assert.ok(source.includes("routePlans = await getRoutePlans(requestOptions, {"));
+  assert.ok(source.includes("throwOnError: true,"));
+  assert.ok(source.includes("let routeMetrics: Awaited<ReturnType<typeof getRoutePlanMetrics>> = [];"));
   assert.ok(source.includes("await Promise.all("));
-  assert.ok(source.includes("routePlans.map((plan) => getRoutePlanMetrics(plan.id, requestOptions))"));
+  assert.ok(source.includes("let routeMetricsLoadError = false;"));
+  assert.ok(source.includes("routePlans.map((plan) =>"));
+  assert.ok(source.includes("getRoutePlanMetrics(plan.id, requestOptions, {"));
   assert.ok(source.includes(").flat();"));
 });
 
@@ -98,9 +103,14 @@ test("dashboard logistica metricas keeps compliance badge thresholds and progres
   assert.ok(source.includes("aria-label={`Cumplimiento: ${metric.complianceRate}%`}"));
 });
 
-test("dashboard logistica metricas keeps empty state and avoids client-side fetch literals", () => {
+test("dashboard logistica metricas separates fetch failures from empty metrics", () => {
   const source = read(METRICAS_PAGE_PATH);
 
+  assert.ok(source.includes("routePlansLoadError ?"));
+  assert.ok(source.includes("routeMetricsLoadError ?"));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("No se pudieron cargar los planes de ruta para métricas. Intente nuevamente."));
+  assert.ok(source.includes("No se pudieron cargar las métricas de ruta. Intente nuevamente."));
   assert.ok(source.includes("No hay métricas de ruta disponibles."));
   assert.equal(source.includes("fetch("), false);
 });

--- a/test/frontend-logistics-detail-empty-states.test.ts
+++ b/test/frontend-logistics-detail-empty-states.test.ts
@@ -41,7 +41,12 @@ test("logistics route plans detail page shows an empty table state", () => {
 test("logistics metrics detail page shows an empty card state", () => {
   const source = read(METRICAS_PAGE_PATH);
 
-  assert.ok(source.includes("routeMetrics.length ?"));
+  assert.ok(source.includes("routePlansLoadError ?"));
+  assert.ok(source.includes("routeMetricsLoadError ?"));
+  assert.ok(source.includes(": routeMetrics.length ?"));
+  assert.ok(source.includes("No se pudieron cargar los planes de ruta para métricas. Intente nuevamente."));
+  assert.ok(source.includes("No se pudieron cargar las métricas de ruta. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("routeMetrics.map((metric)"));
   assert.ok(source.includes("No hay métricas de ruta disponibles."));
 });

--- a/test/frontend-logistics-metrics-live-read-contract.test.ts
+++ b/test/frontend-logistics-metrics-live-read-contract.test.ts
@@ -42,10 +42,16 @@ test("frontend logistics metrics page uses API client wrappers", () => {
   assertIncludes(source, "getRoutePlans", logisticsMetricsPage);
   assertIncludes(source, "getRoutePlanMetrics", logisticsMetricsPage);
   assertIncludes(source, "Promise.all", logisticsMetricsPage);
+  assertIncludes(source, "let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];", logisticsMetricsPage);
+  assertIncludes(source, "let routePlansLoadError = false;", logisticsMetricsPage);
+  assertIncludes(source, "let routeMetrics: Awaited<ReturnType<typeof getRoutePlanMetrics>> = [];", logisticsMetricsPage);
+  assertIncludes(source, "let routeMetricsLoadError = false;", logisticsMetricsPage);
+  assertIncludes(source, "getRoutePlans(requestOptions, {", logisticsMetricsPage);
+  assertIncludes(source, "throwOnError: true,", logisticsMetricsPage);
   assertIncludes(source, "routePlans.map", logisticsMetricsPage);
   assertIncludes(
     source,
-    "getRoutePlanMetrics(plan.id, requestOptions)",
+    "getRoutePlanMetrics(plan.id, requestOptions, {",
     logisticsMetricsPage,
   );
 });
@@ -71,6 +77,7 @@ test("frontend logistics metrics API wrapper accepts request options", () => {
   );
   assertIncludes(source, "planId?: number", frontendApiClient);
   assertIncludes(source, "options?: RequestInit", frontendApiClient);
+  assertIncludes(source, "readOptions: LogisticsReadOptions = {},", frontendApiClient);
   assertIncludes(
     source,
     "`/api/logistics/route-plans/${planId}/metrics`",
@@ -87,6 +94,8 @@ test("frontend logistics metrics API wrapper accepts request options", () => {
     'console.warn("[API] getRoutePlanMetrics: requiere planId para usar endpoint real")',
     frontendApiClient,
   );
+  assertIncludes(source, "if (readOptions.throwOnError) {", frontendApiClient);
+  assertIncludes(source, "throw error;", frontendApiClient);
   assertIncludes(source, "return []", frontendApiClient);
 });
 


### PR DESCRIPTION
## Summary
- add opt-in throwOnError support to getRoutePlanMetrics
- surface logistics metrics fetch failures for route plans and per-route metrics
- preserve the real empty state for route metrics

## Validation
- pnpm test -- test/frontend-dashboard-logistica-metricas.test.ts test/frontend-logistics-detail-empty-states.test.ts test/frontend-logistics-metrics-live-read-contract.test.ts test/frontend-logistics-no-mock-fallback.test.ts test/frontend-app-mock-isolation-contract.test.ts
- pnpm test
- pnpm build