### PR TITLE
fix(frontend): surface dashboard stats fetch failure

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -39,11 +39,18 @@ async function getDashboardRequestOptions(): Promise<RequestInit> {
 
 export default async function DashboardPage() {
   const requestOptions = await getDashboardRequestOptions();
-  const stats = await getDashboardStats(requestOptions);
+  let stats: Awaited<ReturnType<typeof getDashboardStats>> | null = null;
+  let statsLoadError = false;
   let reports: Awaited<ReturnType<typeof getReports>> = [];
   let reportsLoadError = false;
   let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];
   let visitsLoadError = false;
+
+  try {
+    stats = await getDashboardStats(requestOptions);
+  } catch {
+    statsLoadError = true;
+  }
 
   await Promise.all([
     (async () => {
@@ -117,6 +124,11 @@ export default async function DashboardPage() {
           <p className="dashboard-section-description">
             Vista rápida de informes, pendientes y actividad logística del día.
           </p>
+          {statsLoadError ? (
+            <p role="alert" className="mt-3 surface-empty text-amber-700">
+              No se pudieron cargar las métricas operativas. Intente nuevamente.
+            </p>
+          ) : null}
           <div className="mt-4">
             <StatsCards stats={stats} />
           </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -905,9 +905,9 @@ export async function getDashboardStats(
   options?: RequestInit,
 ): Promise<DashboardStats> {
   const [reports, visits, routePlans] = await Promise.all([
-    getReports(options),
-    getLogisticsFieldVisits(options),
-    getRoutePlans(options),
+    getReports(options, undefined, { throwOnError: true }),
+    getLogisticsFieldVisits(options, { throwOnError: true }),
+    getRoutePlans(options, { throwOnError: true }),
   ]);
 
   return {

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -17,8 +17,10 @@ function read(relativePath: string): string {
 test("dashboard overview distinguishes recent list load failures from empty states", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
+  assert.ok(source.includes("statsLoadError ?"));
   assert.ok(source.includes("reportsLoadError ?"));
   assert.ok(source.includes("visitsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar las métricas operativas. Intente nuevamente."));
   assert.ok(source.includes("recentReports.length ?"));
   assert.ok(source.includes("recentVisits.length ?"));
   assert.ok(source.includes("No se pudieron cargar los informes recientes. Intente nuevamente."));

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -39,7 +39,10 @@ test("dashboard home reads stats reports and field visits through API helpers", 
 
   assert.ok(source.includes("export default async function DashboardPage()"));
   assert.ok(source.includes("const requestOptions = await getDashboardRequestOptions();"));
-  assert.ok(source.includes("const stats = await getDashboardStats(requestOptions);"));
+  assert.ok(source.includes("let stats: Awaited<ReturnType<typeof getDashboardStats>> | null = null;"));
+  assert.ok(source.includes("let statsLoadError = false;"));
+  assert.ok(source.includes("stats = await getDashboardStats(requestOptions);"));
+  assert.ok(source.includes("statsLoadError = true;"));
   assert.ok(source.includes("let reports: Awaited<ReturnType<typeof getReports>> = [];"));
   assert.ok(source.includes("let reportsLoadError = false;"));
   assert.ok(source.includes("let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];"));
@@ -60,6 +63,8 @@ test("dashboard home renders clinic operational summary, stats, reports, and fie
   assert.ok(source.includes("Lectura conectada a datos operativos clinic-scoped del backend."));
   assert.ok(source.includes("Esta"));
   assert.ok(source.includes("Esta superficie usa solo sesión clínica."));
+  assert.ok(source.includes("statsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar las métricas operativas. Intente nuevamente."));
   assert.ok(source.includes("<StatsCards stats={stats} />"));
   assert.ok(source.includes("Informes recientes"));
   assert.ok(source.includes("Visitas de campo"));

--- a/test/frontend-dashboard-live-read-contract.test.ts
+++ b/test/frontend-dashboard-live-read-contract.test.ts
@@ -44,7 +44,11 @@ test("frontend dashboard page uses API client wrappers", () => {
   assertIncludes(source, "getReports", dashboardPage);
   assertIncludes(source, "getLogisticsFieldVisits", dashboardPage);
   assertIncludes(source, "Promise.all", dashboardPage);
-  assertIncludes(source, "const stats = await getDashboardStats(requestOptions);", dashboardPage);
+  assertIncludes(source, "let stats: Awaited<ReturnType<typeof getDashboardStats>> | null = null;", dashboardPage);
+  assertIncludes(source, "let statsLoadError = false;", dashboardPage);
+  assertIncludes(source, "stats = await getDashboardStats(requestOptions);", dashboardPage);
+  assertIncludes(source, "statsLoadError = true;", dashboardPage);
+  assertIncludes(source, "No se pudieron cargar las métricas operativas. Intente nuevamente.", dashboardPage);
   assertIncludes(source, "let reports: Awaited<ReturnType<typeof getReports>> = [];", dashboardPage);
   assertIncludes(source, "let reportsLoadError = false;", dashboardPage);
   assertIncludes(source, "let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];", dashboardPage);
@@ -74,9 +78,9 @@ test("frontend dashboard stats are computed from live-read wrappers", () => {
     frontendApiClient,
   );
   assertIncludes(source, "options?: RequestInit", frontendApiClient);
-  assertIncludes(source, "getReports(options)", frontendApiClient);
-  assertIncludes(source, "getLogisticsFieldVisits(options)", frontendApiClient);
-  assertIncludes(source, "getRoutePlans(options)", frontendApiClient);
+  assertIncludes(source, "getReports(options, undefined, { throwOnError: true })", frontendApiClient);
+  assertIncludes(source, "getLogisticsFieldVisits(options, { throwOnError: true })", frontendApiClient);
+  assertIncludes(source, "getRoutePlans(options, { throwOnError: true })", frontendApiClient);
   assertIncludes(source, "totalReports: reports.length", frontendApiClient);
   assertIncludes(source, "pendingReports:", frontendApiClient);
   assertIncludes(source, "activeVisits:", frontendApiClient);

--- a/test/frontend-dashboard-stats-aggregation.test.ts
+++ b/test/frontend-dashboard-stats-aggregation.test.ts
@@ -19,9 +19,9 @@ test("frontend API client builds dashboard stats from live read helpers", () => 
   assert.ok(source.includes("options?: RequestInit,"));
   assert.ok(source.includes("): Promise<DashboardStats>"));
   assert.ok(source.includes("const [reports, visits, routePlans] = await Promise.all(["));
-  assert.ok(source.includes("getReports(options),"));
-  assert.ok(source.includes("getLogisticsFieldVisits(options),"));
-  assert.ok(source.includes("getRoutePlans(options),"));
+  assert.ok(source.includes("getReports(options, undefined, { throwOnError: true }),"));
+  assert.ok(source.includes("getLogisticsFieldVisits(options, { throwOnError: true }),"));
+  assert.ok(source.includes("getRoutePlans(options, { throwOnError: true }),"));
 });
 
 test("frontend dashboard stats aggregate report counters explicitly", () => {


### PR DESCRIPTION
## Summary
- Surface dashboard stats fetch failures instead of showing derived empty metrics.
- Propagate read failures from reports, field visits and route plans used by dashboard stats.
- Preserve independent dashboard overview error handling for recent reports and visits.

## Validation
- pnpm test
- pnpm build