### PR TITLE
fix(frontend): surface report download fetch failure

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -217,14 +217,11 @@ type AdminReportUploadResponse = {
 export async function getReportDownloadUrl(
   reportId: number,
 ): Promise<string | null> {
-  try {
-    const res = await apiFetch<{ url: string }>(
-      `/api/reports/${reportId}/download-url`,
-    );
-    return res.url ?? null;
-  } catch {
-    return null;
-  }
+  const res = await apiFetch<{ url: string | null }>(
+    `/api/reports/${reportId}/download-url`,
+  );
+
+  return res.url ?? null;
 }
 
 export async function uploadAdminReport(

--- a/test/frontend-reports-api-read.test.ts
+++ b/test/frontend-reports-api-read.test.ts
@@ -12,6 +12,19 @@ function read(relativePath: string): string {
   );
 }
 
+function getFunctionSource(source: string, functionName: string): string {
+  const signature = `export async function ${functionName}`;
+  const start = source.indexOf(signature);
+
+  if (start === -1) {
+    return "";
+  }
+
+  const nextFunction = source.indexOf("\nexport async function ", start + signature.length);
+
+  return nextFunction === -1 ? source.slice(start) : source.slice(start, nextFunction);
+}
+
 test("frontend API client reads reports from backend reports endpoint", () => {
   const source = read(API_CLIENT_PATH);
 
@@ -52,13 +65,15 @@ test("frontend API client searches reports with optional query parameters", () =
 
 test("frontend API client requests report download URLs by report id", () => {
   const source = read(API_CLIENT_PATH);
+  const functionSource = getFunctionSource(source, "getReportDownloadUrl");
 
-  assert.ok(source.includes("export async function getReportDownloadUrl("));
-  assert.ok(source.includes("reportId: number,"));
-  assert.ok(source.includes("): Promise<string | null>"));
-  assert.ok(source.includes("`/api/reports/${reportId}/download-url`,"));
-  assert.ok(source.includes("return res.url ?? null;"));
-  assert.ok(source.includes("return null;"));
+  assert.ok(functionSource.includes("export async function getReportDownloadUrl("));
+  assert.ok(functionSource.includes("reportId: number,"));
+  assert.ok(functionSource.includes("): Promise<string | null>"));
+  assert.ok(functionSource.includes("`/api/reports/${reportId}/download-url`,"));
+  assert.ok(functionSource.includes("const res = await apiFetch<{ url: string | null }>("));
+  assert.ok(functionSource.includes("return res.url ?? null;"));
+  assert.equal(functionSource.includes("} catch {"), false);
 });
 
 test("frontend reports API helpers remain typed around Report", () => {


### PR DESCRIPTION
## Summary
- Surface report download fetch failures instead of converting them to a silent null result.
- Preserve the existing unavailable-download state for valid empty download URLs.
- Keep ReportDownloadButton error handling responsible for displaying fetch/API failures.

## Validation
- pnpm test
- pnpm build