### PR TITLE
fix(frontend): surface particular session fetch failure

### DIFF
--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -87,10 +87,18 @@ export function ParticularesContent() {
 
   async function refreshSession() {
     setIsCheckingSession(true);
+    setErrorMessage(null);
 
     try {
       const response = await getParticularSession();
       setSession(response?.particular ?? null);
+    } catch (error) {
+      setSession(null);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo verificar la sesión particular. Intente nuevamente.",
+      );
     } finally {
       setIsCheckingSession(false);
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -106,11 +106,25 @@ export async function loginParticular(
   });
 }
 
+const PARTICULAR_SESSION_RECOVERABLE_ERRORS = new Set([
+  "Particular no autenticado",
+  "Sesión particular inválida",
+  "Sesión particular expirada",
+  "Token particular inválido o inactivo",
+]);
+
 export async function getParticularSession(): Promise<ParticularAuthResponse | null> {
   try {
     return await apiFetch<ParticularAuthResponse>("/api/particular/auth/me");
-  } catch {
-    return null;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      PARTICULAR_SESSION_RECOVERABLE_ERRORS.has(error.message)
+    ) {
+      return null;
+    }
+
+    throw error;
   }
 }
 

--- a/test/frontend-auth-session-api.test.ts
+++ b/test/frontend-auth-session-api.test.ts
@@ -12,6 +12,19 @@ function read(relativePath: string): string {
   );
 }
 
+function getFunctionSource(source: string, functionName: string): string {
+  const signature = `export async function ${functionName}`;
+  const start = source.indexOf(signature);
+
+  if (start === -1) {
+    return "";
+  }
+
+  const nextFunction = source.indexOf("\nexport async function ", start + signature.length);
+
+  return nextFunction === -1 ? source.slice(start) : source.slice(start, nextFunction);
+}
+
 test("frontend API client exposes clinic session lookup against auth me endpoint", () => {
   const source = read(API_CLIENT_PATH);
 
@@ -36,4 +49,22 @@ test("frontend API client keeps auth response types tied to AuthUser", () => {
   assert.ok(source.includes("export async function loginClinic("));
   assert.ok(source.includes("): Promise<AuthUser>"));
   assert.ok(source.includes("export async function getClinicSession(): Promise<AuthUser | null>"));
+});
+
+test("frontend API client recovers null only for expected particular session auth states", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = getFunctionSource(source, "getParticularSession");
+
+  assert.ok(source.includes("const PARTICULAR_SESSION_RECOVERABLE_ERRORS = new Set(["));
+  assert.ok(source.includes('"Particular no autenticado"'));
+  assert.ok(source.includes('"Sesión particular inválida"'));
+  assert.ok(source.includes('"Sesión particular expirada"'));
+  assert.ok(source.includes('"Token particular inválido o inactivo"'));
+  assert.ok(functionSource.includes("export async function getParticularSession(): Promise<ParticularAuthResponse | null>"));
+  assert.ok(functionSource.includes('return await apiFetch<ParticularAuthResponse>("/api/particular/auth/me");'));
+  assert.ok(functionSource.includes("if ("));
+  assert.ok(functionSource.includes("error instanceof Error"));
+  assert.ok(functionSource.includes("PARTICULAR_SESSION_RECOVERABLE_ERRORS.has(error.message)"));
+  assert.ok(functionSource.includes("return null;"));
+  assert.ok(functionSource.includes("throw error;"));
 });

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PARTICULARES_CONTENT_PATH =
+  "frontend/src/components/public/ParticularesContent.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("particulares content keeps refreshSession wired to particular auth me helper", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes('import {'));
+  assert.ok(source.includes("getParticularSession,"));
+  assert.ok(source.includes("async function refreshSession()"));
+  assert.ok(source.includes("setIsCheckingSession(true);"));
+  assert.ok(source.includes("const response = await getParticularSession();"));
+  assert.ok(source.includes("setSession(response?.particular ?? null);"));
+});
+
+test("particulares content surfaces refreshSession fetch failures instead of silent logout state", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("setErrorMessage(null);"));
+  assert.ok(source.includes("} catch (error) {"));
+  assert.ok(source.includes("setSession(null);"));
+  assert.ok(source.includes("error instanceof Error"));
+  assert.ok(source.includes("? error.message"));
+  assert.ok(source.includes(': "No se pudo verificar la sesión particular. Intente nuevamente.",'));
+  assert.ok(source.includes("setIsCheckingSession(false);"));
+  assert.ok(source.includes('role="alert"'));
+});


### PR DESCRIPTION
## Summary
- Surface non-recoverable particular session fetch failures instead of silently clearing the session.
- Preserve recoverable unauthenticated/expired/invalid particular session states as null.
- Add frontend guardrail coverage for the particular session helper and public particulares refresh flow.

## Validation
- pnpm test -- test/frontend-auth-session-api.test.ts test/frontend-particulares-content.test.ts
- pnpm test
- pnpm build