### PR TITLE
fix(frontend): surface failed login alerts empty error state

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -287,7 +287,9 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
                   >
                     {isPending
                       ? "Cargando intentos fallidos..."
-                      : "No hay intentos fallidos para los filtros seleccionados."}
+                      : error
+                        ? "No se pudieron cargar los intentos fallidos."
+                        : "No hay intentos fallidos para los filtros seleccionados."}
                   </TableCell>
                 </TableRow>
               )}

--- a/test/frontend-admin-failed-login-alerts-card.test.ts
+++ b/test/frontend-admin-failed-login-alerts-card.test.ts
@@ -141,7 +141,12 @@ test("admin failed login alerts card renders filters table columns and rows", ()
 test("admin failed login alerts card keeps empty state pagination and read-only endpoint copy", () => {
   const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
 
-  assert.ok(source.includes("Cargando intentos fallidos..."));
+  assert.ok(
+    source.includes(
+      'isPending\n                      ? "Cargando intentos fallidos..."\n                      : error',
+    ),
+  );
+  assert.ok(source.includes('                        ? "No se pudieron cargar los intentos fallidos."'));
   assert.ok(source.includes("No hay intentos fallidos para los filtros seleccionados."));
   assert.ok(source.includes("const hasPreviousPage = offset > 0;"));
   assert.ok(source.includes("const hasNextPage = snapshot"));


### PR DESCRIPTION
## Summary
- Surface failed login alerts fetch failures in the empty table row instead of showing the real empty-state copy.
- Preserve the existing explicit error banner and loading message.
- Keep the change limited to the read-only admin failed login alerts card and its frontend guardrail test.

## Validation
- pnpm test -- test/frontend-admin-failed-login-alerts-card.test.ts
- pnpm test
- pnpm build