### PR TITLE
fix(frontend): surface admin sessions empty error state

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -291,7 +291,9 @@ export function AdminSessionsReadOnlyCard() {
                   >
                     {isPending
                       ? "Cargando sesiones..."
-                      : "No hay sesiones para los filtros seleccionados."}
+                      : error
+                        ? "No se pudieron cargar las sesiones."
+                        : "No hay sesiones para los filtros seleccionados."}
                   </TableCell>
                 </TableRow>
               )}

--- a/test/frontend-admin-sessions-card.test.ts
+++ b/test/frontend-admin-sessions-card.test.ts
@@ -132,7 +132,12 @@ test("admin sessions card renders rows actions empty state and pagination", () =
   assert.ok(source.includes("formatOptionalDate(session.expiresAt)"));
   assert.ok(source.includes("onClick={() => void handleRevokeSession(session)}"));
   assert.ok(source.includes('isRevoking ? "Revocando..." : "Revocar"'));
-  assert.ok(source.includes("Cargando sesiones..."));
+  assert.ok(
+    source.includes(
+      'isPending\n                      ? "Cargando sesiones..."\n                      : error',
+    ),
+  );
+  assert.ok(source.includes('                        ? "No se pudieron cargar las sesiones."'));
   assert.ok(source.includes("No hay sesiones para los filtros seleccionados."));
   assert.ok(source.includes("const hasPreviousPage = offset > 0;"));
   assert.ok(source.includes("const hasNextPage = snapshot"));


### PR DESCRIPTION
## Summary
- Surface admin sessions fetch failures in the empty table row instead of showing the real empty-state copy.
- Preserve the existing explicit error banner and loading message.
- Keep the change limited to the read-only admin sessions card and its frontend guardrail test.

## Validation
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-sessions-card.test.ts
- pnpm test
- pnpm build