### PR TITLE
fix(backend): add failed login attempts migration

### DIFF
--- a/drizzle/migrations/0022_login_failed_attempts.sql
+++ b/drizzle/migrations/0022_login_failed_attempts.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "login_failed_attempts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "surface" varchar(32) NOT NULL,
+  "username" varchar(100),
+  "reason" varchar(64) NOT NULL,
+  "ip_address" varchar(64),
+  "user_agent" text,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "login_failed_attempts_surface_created_at_idx"
+  ON "login_failed_attempts" ("surface", "created_at");
+CREATE INDEX IF NOT EXISTS "login_failed_attempts_ip_created_at_idx"
+  ON "login_failed_attempts" ("ip_address", "created_at");
+CREATE INDEX IF NOT EXISTS "login_failed_attempts_reason_created_at_idx"
+  ON "login_failed_attempts" ("reason", "created_at");

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
                         "when":  1776442203573,
                         "tag":  "0021_logistics_sla",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  22,
+                        "version":  "7",
+                        "when":  1777000000000,
+                        "tag":  "0022_login_failed_attempts",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/test/admin-failed-login-alerts-migration.test.ts
+++ b/test/admin-failed-login-alerts-migration.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const migrationPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "0022_login_failed_attempts.sql",
+);
+const journalPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "meta",
+  "_journal.json",
+);
+const schemaPath = resolve(process.cwd(), "drizzle", "schema.ts");
+
+function readText(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+test("login_failed_attempts migration exists with table and indexes", () => {
+  assert.ok(existsSync(migrationPath), "missing 0022_login_failed_attempts.sql");
+
+  const source = readText(migrationPath);
+  assert.match(source, /CREATE TABLE IF NOT EXISTS "login_failed_attempts"/);
+  assert.match(source, /"surface" varchar\(32\) NOT NULL/);
+  assert.match(source, /"reason" varchar\(64\) NOT NULL/);
+  assert.match(source, /"created_at" timestamp DEFAULT now\(\) NOT NULL/);
+  assert.match(source, /login_failed_attempts_surface_created_at_idx/);
+  assert.match(source, /login_failed_attempts_ip_created_at_idx/);
+  assert.match(source, /login_failed_attempts_reason_created_at_idx/);
+});
+
+test("login_failed_attempts migration is registered in drizzle journal", () => {
+  const journal = JSON.parse(readText(journalPath)) as {
+    entries?: Array<{ tag?: string }>;
+  };
+  const tags = new Set((journal.entries ?? []).map((entry) => entry.tag));
+  assert.ok(
+    tags.has("0022_login_failed_attempts"),
+    "journal missing 0022_login_failed_attempts",
+  );
+});
+
+test("drizzle schema keeps login_failed_attempts table contract", () => {
+  const schemaSource = readText(schemaPath);
+  assert.match(schemaSource, /pgTable\(\s*"login_failed_attempts"/);
+});


### PR DESCRIPTION
## Summary
- Add the missing `login_failed_attempts` migration required by the admin failed login alerts endpoint.
- Register the migration in the Drizzle journal.
- Add native coverage to keep the migration and schema contract present.

## QA finding
- Before migration: `GET /api/admin/failed-login-alerts` returned 500 in local QA.
- After `pnpm db:migrate`: endpoint returns 200 with an empty snapshot when no failed attempts exist.

## Validation
- `pnpm db:migrate`
- `GET /api/admin/failed-login-alerts` -> 200
- `pnpm test` -> 1390/1390 OK
- `pnpm build` -> OK