### PR TITLE
fix(frontend): reposition dashboard quick actions

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -1,6 +1,15 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
+import {
+  Activity,
+  ClipboardPlus,
+  KeyRound,
+  ScrollText,
+  ShieldCheck,
+  TicketCheck,
+  UsersRound,
+} from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -18,6 +27,7 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminParticularTokensCard } from "./AdminParticularTokensCard";
@@ -313,6 +323,60 @@ export default async function AdminPage({
         subtitle="Auditoría, reportes y estado operacional"
       />
       <main className="dashboard-main">
+        <Card className="dashboard-surface">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Accesos rápidos</CardTitle>
+            <CardDescription>
+              Atajos operativos para navegar las superficies administrativas clave.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-7">
+              {[
+                {
+                  label: "Subir informe",
+                  href: "#admin-report-upload",
+                  icon: ClipboardPlus,
+                },
+                { label: "Estado", href: "#admin-health", icon: Activity },
+                {
+                  label: "Tokens particulares",
+                  href: "#admin-particular-tokens",
+                  icon: TicketCheck,
+                },
+                { label: "Sesiones", href: "#admin-sessions", icon: KeyRound },
+                {
+                  label: "Roles clínica",
+                  href: "#admin-users-roles",
+                  icon: UsersRound,
+                },
+                { label: "Auditoría", href: "#audit-log", icon: ScrollText },
+                {
+                  label: "Mantenimiento",
+                  href: "#admin-maintenance",
+                  icon: ShieldCheck,
+                },
+              ].map((item) => {
+                const Icon = item.icon;
+
+                return (
+                  <Button
+                    key={item.href}
+                    asChild
+                    variant="outline"
+                    className="h-16 flex-col gap-1 rounded-lg"
+                  >
+                    <Link href={item.href}>
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                      <span className="text-xs">{item.label}</span>
+                    </Link>
+                  </Button>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+
         <section
           id="admin-report-upload"
           className="surface-note-info overflow-hidden rounded-2xl p-0"

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -80,6 +80,58 @@ export default async function DashboardPage() {
     <>
       <DashboardTopbar title="Dashboard Clínica" subtitle="Resumen operativo clínica" />
       <main className="dashboard-main">
+        <Card className="dashboard-surface">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Accesos rápidos</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Acciones frecuentes para operación clínica diaria.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+              {[
+                { label: "Informes", href: ROUTES.dashboardInformes, icon: FileText },
+                {
+                  label: "Visitas",
+                  href: ROUTES.dashboardLogisticaVisitas,
+                  icon: Route,
+                },
+                {
+                  label: "Rutas",
+                  href: ROUTES.dashboardLogisticaRutas,
+                  icon: Map,
+                },
+                {
+                  label: "Tokens",
+                  href: `${ROUTES.dashboard}#clinic-particular-tokens`,
+                  icon: KeyRound,
+                },
+                {
+                  label: "Perfil",
+                  href: `${ROUTES.dashboard}#clinic-public-profile`,
+                  icon: Building2,
+                },
+              ].map((item) => {
+                const Icon = item.icon;
+
+                return (
+                  <Button
+                    key={item.href}
+                    asChild
+                    variant="outline"
+                    className="h-16 flex-col gap-1 rounded-lg"
+                  >
+                    <Link href={item.href}>
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                      <span className="text-xs">{item.label}</span>
+                    </Link>
+                  </Button>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+
         <section className="surface-note-info" aria-labelledby="dashboard-operational-priority">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="max-w-3xl">
@@ -229,58 +281,6 @@ export default async function DashboardPage() {
             </CardContent>
           </Card>
         </div>
-
-        <Card className="dashboard-surface">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base">Accesos rápidos</CardTitle>
-            <p className="text-xs text-muted-foreground">
-              Acciones frecuentes para operación clínica diaria.
-            </p>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
-              {[
-                { label: "Informes", href: ROUTES.dashboardInformes, icon: FileText },
-                {
-                  label: "Visitas",
-                  href: ROUTES.dashboardLogisticaVisitas,
-                  icon: Route,
-                },
-                {
-                  label: "Rutas",
-                  href: ROUTES.dashboardLogisticaRutas,
-                  icon: Map,
-                },
-                {
-                  label: "Tokens",
-                  href: `${ROUTES.dashboard}#clinic-particular-tokens`,
-                  icon: KeyRound,
-                },
-                {
-                  label: "Perfil",
-                  href: `${ROUTES.dashboard}#clinic-public-profile`,
-                  icon: Building2,
-                },
-              ].map((item) => {
-                const Icon = item.icon;
-
-                return (
-                <Button
-                  key={item.href}
-                  asChild
-                  variant="outline"
-                  className="h-16 flex-col gap-1 rounded-lg"
-                >
-                  <Link href={item.href}>
-                    <Icon className="h-5 w-5" aria-hidden="true" />
-                    <span className="text-xs">{item.label}</span>
-                  </Link>
-                </Button>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
 
         <ClinicPublicProfileCard />
         <ClinicParticularTokensCard />

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -145,6 +145,34 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);
 });
 
+test("dashboard admin places quick actions before report upload with expected labels and anchors", () => {
+  const source = read(ADMIN_PAGE_PATH);
+  const quickActionsTitleIndex = source.indexOf("Accesos rápidos");
+  const reportUploadTitleIndex = source.indexOf("Carga de informes");
+  const quickActionsTitleMatches = source.match(/Accesos rápidos/g) ?? [];
+
+  assert.ok(quickActionsTitleIndex >= 0);
+  assert.ok(reportUploadTitleIndex >= 0);
+  assert.ok(quickActionsTitleIndex < reportUploadTitleIndex);
+  assert.equal(quickActionsTitleMatches.length, 1);
+
+  assert.ok(source.includes('label: "Subir informe"'));
+  assert.ok(source.includes('label: "Estado"'));
+  assert.ok(source.includes('label: "Tokens particulares"'));
+  assert.ok(source.includes('label: "Sesiones"'));
+  assert.ok(source.includes('label: "Roles clínica"'));
+  assert.ok(source.includes('label: "Auditoría"'));
+  assert.ok(source.includes('label: "Mantenimiento"'));
+
+  assert.ok(source.includes('href: "#admin-report-upload"'));
+  assert.ok(source.includes('href: "#admin-health"'));
+  assert.ok(source.includes('href: "#admin-particular-tokens"'));
+  assert.ok(source.includes('href: "#admin-sessions"'));
+  assert.ok(source.includes('href: "#admin-users-roles"'));
+  assert.ok(source.includes('href: "#audit-log"'));
+  assert.ok(source.includes('href: "#admin-maintenance"'));
+});
+
 test("dashboard admin surfaces system health fetch failures", () => {
   const source = read(ADMIN_PAGE_PATH);
 
@@ -196,5 +224,4 @@ test("dashboard admin avoids duplicate section ids in navigation anchors", () =>
   assert.equal(adminHealthIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });
-
 

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -92,6 +92,7 @@ test("dashboard home exposes clinic route-registry quick links only", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
   assert.ok(source.includes("Accesos rápidos"));
+  assert.ok(source.includes('label: "Perfil"'));
   assert.ok(source.includes('label: "Informes", href: ROUTES.dashboardInformes'));
   assert.ok(source.includes('label: "Visitas"'));
   assert.ok(source.includes("href: ROUTES.dashboardLogisticaVisitas"));
@@ -101,7 +102,25 @@ test("dashboard home exposes clinic route-registry quick links only", () => {
   assert.ok(
     source.includes('href: `${ROUTES.dashboard}#clinic-particular-tokens`'),
   );
+  assert.ok(
+    source.includes('href: `${ROUTES.dashboard}#clinic-public-profile`'),
+  );
   assert.equal(source.includes('label: "Admin"'), false);
   assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
   assert.equal(source.includes('"/api"'), false);
+});
+
+test("dashboard home places quick actions before operational and metrics sections without duplicates", () => {
+  const source = read(DASHBOARD_PAGE_PATH);
+  const quickActionsTitleIndex = source.indexOf("Accesos rápidos");
+  const operationalStatusIndex = source.indexOf("Estado operativo clínica");
+  const metricsIndex = source.indexOf("Métricas operativas");
+  const quickActionsTitleMatches = source.match(/Accesos rápidos/g) ?? [];
+
+  assert.ok(quickActionsTitleIndex >= 0);
+  assert.ok(operationalStatusIndex >= 0);
+  assert.ok(metricsIndex >= 0);
+  assert.ok(quickActionsTitleIndex < operationalStatusIndex);
+  assert.ok(quickActionsTitleIndex < metricsIndex);
+  assert.equal(quickActionsTitleMatches.length, 1);
 });


### PR DESCRIPTION
## Summary
- Move clinic dashboard quick actions to the top of the dashboard flow before operational status and metrics.
- Add admin dashboard quick actions above the report upload section.
- Keep the change scoped to page layout and native tests only: no sticky behavior, no animations, no global CSS changes.

## Visual QA
- Clinic quick actions render above operational content without overlap.
- Admin quick actions render above report upload without overlap.
- No sticky/motion/animation selectors were introduced.

## Validation
- `pnpm test -- test/frontend-dashboard-home.test.ts test/frontend-dashboard-admin.test.ts`
- `pnpm test` -> 1392/1392 OK
- `pnpm --dir frontend build` -> OK
- `pnpm build` -> OK