### PR TITLE
fix(frontend): remove dashboard quick actions

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -1,15 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
-import {
-  Activity,
-  ClipboardPlus,
-  KeyRound,
-  ScrollText,
-  ShieldCheck,
-  TicketCheck,
-  UsersRound,
-} from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -27,7 +18,6 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminParticularTokensCard } from "./AdminParticularTokensCard";
@@ -323,60 +313,6 @@ export default async function AdminPage({
         subtitle="Auditoría, reportes y estado operacional"
       />
       <main className="dashboard-main">
-        <Card className="dashboard-surface">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base">Accesos rápidos</CardTitle>
-            <CardDescription>
-              Atajos operativos para navegar las superficies administrativas clave.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-7">
-              {[
-                {
-                  label: "Subir informe",
-                  href: "#admin-report-upload",
-                  icon: ClipboardPlus,
-                },
-                { label: "Estado", href: "#admin-health", icon: Activity },
-                {
-                  label: "Tokens particulares",
-                  href: "#admin-particular-tokens",
-                  icon: TicketCheck,
-                },
-                { label: "Sesiones", href: "#admin-sessions", icon: KeyRound },
-                {
-                  label: "Roles clínica",
-                  href: "#admin-users-roles",
-                  icon: UsersRound,
-                },
-                { label: "Auditoría", href: "#audit-log", icon: ScrollText },
-                {
-                  label: "Mantenimiento",
-                  href: "#admin-maintenance",
-                  icon: ShieldCheck,
-                },
-              ].map((item) => {
-                const Icon = item.icon;
-
-                return (
-                  <Button
-                    key={item.href}
-                    asChild
-                    variant="outline"
-                    className="h-16 flex-col gap-1 rounded-lg"
-                  >
-                    <Link href={item.href}>
-                      <Icon className="h-5 w-5" aria-hidden="true" />
-                      <span className="text-xs">{item.label}</span>
-                    </Link>
-                  </Button>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
-
         <section
           id="admin-report-upload"
           className="surface-note-info overflow-hidden rounded-2xl p-0"

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import Link from "next/link";
-import { Building2, FileText, KeyRound, Map, Route } from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
@@ -80,58 +79,6 @@ export default async function DashboardPage() {
     <>
       <DashboardTopbar title="Dashboard Clínica" subtitle="Resumen operativo clínica" />
       <main className="dashboard-main">
-        <Card className="dashboard-surface">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base">Accesos rápidos</CardTitle>
-            <p className="text-xs text-muted-foreground">
-              Acciones frecuentes para operación clínica diaria.
-            </p>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
-              {[
-                { label: "Informes", href: ROUTES.dashboardInformes, icon: FileText },
-                {
-                  label: "Visitas",
-                  href: ROUTES.dashboardLogisticaVisitas,
-                  icon: Route,
-                },
-                {
-                  label: "Rutas",
-                  href: ROUTES.dashboardLogisticaRutas,
-                  icon: Map,
-                },
-                {
-                  label: "Tokens",
-                  href: `${ROUTES.dashboard}#clinic-particular-tokens`,
-                  icon: KeyRound,
-                },
-                {
-                  label: "Perfil",
-                  href: `${ROUTES.dashboard}#clinic-public-profile`,
-                  icon: Building2,
-                },
-              ].map((item) => {
-                const Icon = item.icon;
-
-                return (
-                  <Button
-                    key={item.href}
-                    asChild
-                    variant="outline"
-                    className="h-16 flex-col gap-1 rounded-lg"
-                  >
-                    <Link href={item.href}>
-                      <Icon className="h-5 w-5" aria-hidden="true" />
-                      <span className="text-xs">{item.label}</span>
-                    </Link>
-                  </Button>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
-
         <section className="surface-note-info" aria-labelledby="dashboard-operational-priority">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="max-w-3xl">

--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -44,7 +44,7 @@ const adminNavItems: DashboardNavItem[] = [
   },
   {
     label: "Roles clínica",
-    href: `${ROUTES.dashboardAdmin}#audit-role-changes`,
+    href: `${ROUTES.dashboardAdmin}#admin-users-roles`,
     icon: UsersRound,
   },
   {

--- a/test/frontend-clinic-public-profile.test.ts
+++ b/test/frontend-clinic-public-profile.test.ts
@@ -7,6 +7,8 @@ const PROFILE_CARD_PATH =
   "frontend/src/components/dashboard/ClinicPublicProfileCard.tsx";
 const API_PATH = "frontend/src/lib/api.ts";
 const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const CLINIC_DASHBOARD_SIDEBAR_PATH =
+  "frontend/src/components/dashboard/ClinicDashboardSidebar.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -65,8 +67,9 @@ test("frontend api exposes clinic public profile helpers", () => {
   assert.ok(source.includes('"/api/clinic/profile"'));
 });
 
-test("clinic dashboard renders public profile before token generation", () => {
+test("clinic dashboard renders public profile before token generation and keeps sidebar navigation", () => {
   const source = read(DASHBOARD_PAGE_PATH);
+  const sidebarSource = read(CLINIC_DASHBOARD_SIDEBAR_PATH);
 
   assert.ok(source.includes("ClinicPublicProfileCard"));
   assert.ok(source.includes("<ClinicPublicProfileCard />"));
@@ -75,8 +78,6 @@ test("clinic dashboard renders public profile before token generation", () => {
     source.indexOf("<ClinicPublicProfileCard />") <
       source.indexOf("<ClinicParticularTokensCard />"),
   );
-  assert.ok(
-    source.includes('href: `${ROUTES.dashboard}#clinic-public-profile`'),
-  );
-  assert.ok(source.includes('label: "Perfil"'));
+  assert.ok(sidebarSource.includes('label: "Perfil público"'));
+  assert.ok(sidebarSource.includes('`${ROUTES.dashboard}#clinic-public-profile`'));
 });

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -145,32 +145,64 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);
 });
 
-test("dashboard admin places quick actions before report upload with expected labels and anchors", () => {
+test("dashboard admin removes horizontal quick actions and preserves admin sections", () => {
   const source = read(ADMIN_PAGE_PATH);
-  const quickActionsTitleIndex = source.indexOf("Accesos rápidos");
+  const quickActionsTitle = ["Accesos", "rápidos"].join(" ");
+  const quickActionsDescription = [
+    "Atajos operativos",
+    "para navegar las superficies administrativas clave.",
+  ].join(" ");
+  const removedSnippets = [
+    quickActionsTitle,
+    quickActionsDescription,
+    'label: "Subir informe"',
+    'label: "Estado"',
+    'label: "Tokens particulares"',
+    'label: "Sesiones"',
+    'label: "Roles clínica"',
+    'label: "Auditoría"',
+    'label: "Mantenimiento"',
+    'href: "#admin-report-upload"',
+    'href: "#admin-health"',
+    'href: "#admin-particular-tokens"',
+    'href: "#admin-sessions"',
+    'href: "#admin-users-roles"',
+    'href: "#audit-log"',
+    'href: "#admin-maintenance"',
+    `xl:grid-cols-${7}`,
+  ];
+
+  for (const snippet of removedSnippets) {
+    assert.equal(source.includes(snippet), false);
+  }
+
+  assert.ok(source.includes('id="admin-report-upload"'));
+  assert.ok(source.includes("Carga de informes"));
+  assert.ok(source.includes("Eventos de auditoría"));
+  assert.ok(source.includes("Tipos de evento"));
+  assert.ok(source.includes("Estado del sistema"));
+  assert.ok(source.includes('id="admin-health"'));
+  assert.ok(source.includes('id="admin-maintenance"'));
+  assert.ok(source.includes('id="admin-particular-tokens"'));
+  assert.ok(source.includes('id="admin-sessions"'));
+  assert.ok(source.includes('id="admin-users-roles"'));
+  assert.ok(source.includes('id="audit-role-changes"'));
+  assert.ok(source.includes('id="audit-log"'));
+
+  const mainIndex = source.indexOf('<main className="dashboard-main">');
   const reportUploadTitleIndex = source.indexOf("Carga de informes");
-  const quickActionsTitleMatches = source.match(/Accesos rápidos/g) ?? [];
 
-  assert.ok(quickActionsTitleIndex >= 0);
+  assert.ok(mainIndex >= 0);
   assert.ok(reportUploadTitleIndex >= 0);
-  assert.ok(quickActionsTitleIndex < reportUploadTitleIndex);
-  assert.equal(quickActionsTitleMatches.length, 1);
-
-  assert.ok(source.includes('label: "Subir informe"'));
-  assert.ok(source.includes('label: "Estado"'));
-  assert.ok(source.includes('label: "Tokens particulares"'));
-  assert.ok(source.includes('label: "Sesiones"'));
-  assert.ok(source.includes('label: "Roles clínica"'));
-  assert.ok(source.includes('label: "Auditoría"'));
-  assert.ok(source.includes('label: "Mantenimiento"'));
-
-  assert.ok(source.includes('href: "#admin-report-upload"'));
-  assert.ok(source.includes('href: "#admin-health"'));
-  assert.ok(source.includes('href: "#admin-particular-tokens"'));
-  assert.ok(source.includes('href: "#admin-sessions"'));
-  assert.ok(source.includes('href: "#admin-users-roles"'));
-  assert.ok(source.includes('href: "#audit-log"'));
-  assert.ok(source.includes('href: "#admin-maintenance"'));
+  assert.ok(mainIndex < reportUploadTitleIndex);
+  assert.equal(
+    source.slice(mainIndex, reportUploadTitleIndex).includes(quickActionsTitle),
+    false,
+  );
+  assert.equal(
+    source.slice(mainIndex, reportUploadTitleIndex).includes("dashboard-surface"),
+    false,
+  );
 });
 
 test("dashboard admin surfaces system health fetch failures", () => {
@@ -224,4 +256,3 @@ test("dashboard admin avoids duplicate section ids in navigation anchors", () =>
   assert.equal(adminHealthIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });
-

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const CLINIC_DASHBOARD_SIDEBAR_PATH =
+  "frontend/src/components/dashboard/ClinicDashboardSidebar.tsx";
 const CLINIC_TOKENS_CARD_PATH =
   "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
 const API_PATH = "frontend/src/lib/api.ts";
@@ -17,15 +19,15 @@ function read(relativePath: string): string {
 
 test("clinic dashboard exists as a clinic-only dashboard and keeps admin out", () => {
   const source = read(DASHBOARD_PAGE_PATH);
+  const sidebarSource = read(CLINIC_DASHBOARD_SIDEBAR_PATH);
 
   assert.ok(source.includes('title: "Dashboard Clínica — Portal VETNEB"'));
   assert.ok(source.includes('title="Dashboard Clínica"'));
   assert.ok(source.includes("Esta superficie usa solo sesión clínica."));
   assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
   assert.ok(source.includes("<ClinicParticularTokensCard />"));
-  assert.ok(
-    source.includes('href: `${ROUTES.dashboard}#clinic-particular-tokens`'),
-  );
+  assert.ok(sidebarSource.includes('label: "Tokens particulares"'));
+  assert.ok(sidebarSource.includes('`${ROUTES.dashboard}#clinic-particular-tokens`'));
   assert.equal(source.includes('label: "Admin"'), false);
   assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
 });
@@ -88,4 +90,3 @@ test("frontend api exposes clinic-scoped particular token helpers", () => {
   assert.ok(source.includes("`/api/particular-tokens${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("`/api/particular-tokens/${tokenId}/report`"));
 });
-

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -88,39 +88,48 @@ test("dashboard home keeps status badges and date formatting wired", () => {
   assert.ok(source.includes("formatDate(visit.scheduledAt)"));
 });
 
-test("dashboard home exposes clinic route-registry quick links only", () => {
+test("dashboard home removes horizontal quick actions and preserves clinic sections", () => {
   const source = read(DASHBOARD_PAGE_PATH);
+  const quickActionsTitle = ["Accesos", "rápidos"].join(" ");
+  const quickActionsDescription = [
+    "Acciones frecuentes",
+    "para operación clínica diaria.",
+  ].join(" ");
+  const removedSnippets = [
+    quickActionsTitle,
+    quickActionsDescription,
+    'label: "Informes", href: ROUTES.dashboardInformes',
+    'label: "Visitas"',
+    'label: "Rutas"',
+    'label: "Tokens"',
+    'label: "Perfil"',
+    `xl:grid-cols-${5}`,
+  ];
 
-  assert.ok(source.includes("Accesos rápidos"));
-  assert.ok(source.includes('label: "Perfil"'));
-  assert.ok(source.includes('label: "Informes", href: ROUTES.dashboardInformes'));
-  assert.ok(source.includes('label: "Visitas"'));
-  assert.ok(source.includes("href: ROUTES.dashboardLogisticaVisitas"));
-  assert.ok(source.includes('label: "Rutas"'));
-  assert.ok(source.includes("href: ROUTES.dashboardLogisticaRutas"));
-  assert.ok(source.includes('label: "Tokens"'));
-  assert.ok(
-    source.includes('href: `${ROUTES.dashboard}#clinic-particular-tokens`'),
-  );
-  assert.ok(
-    source.includes('href: `${ROUTES.dashboard}#clinic-public-profile`'),
-  );
-  assert.equal(source.includes('label: "Admin"'), false);
-  assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
-  assert.equal(source.includes('"/api"'), false);
-});
+  for (const snippet of removedSnippets) {
+    assert.equal(source.includes(snippet), false);
+  }
 
-test("dashboard home places quick actions before operational and metrics sections without duplicates", () => {
-  const source = read(DASHBOARD_PAGE_PATH);
-  const quickActionsTitleIndex = source.indexOf("Accesos rápidos");
+  assert.ok(source.includes("Estado operativo clínica"));
+  assert.ok(source.includes("Métricas operativas"));
+  assert.ok(source.includes("Informes recientes"));
+  assert.ok(source.includes("Visitas de campo"));
+
+  const mainIndex = source.indexOf('<main className="dashboard-main">');
   const operationalStatusIndex = source.indexOf("Estado operativo clínica");
   const metricsIndex = source.indexOf("Métricas operativas");
-  const quickActionsTitleMatches = source.match(/Accesos rápidos/g) ?? [];
 
-  assert.ok(quickActionsTitleIndex >= 0);
+  assert.ok(mainIndex >= 0);
   assert.ok(operationalStatusIndex >= 0);
   assert.ok(metricsIndex >= 0);
-  assert.ok(quickActionsTitleIndex < operationalStatusIndex);
-  assert.ok(quickActionsTitleIndex < metricsIndex);
-  assert.equal(quickActionsTitleMatches.length, 1);
+  assert.ok(mainIndex < operationalStatusIndex);
+  assert.ok(operationalStatusIndex < metricsIndex);
+  assert.equal(
+    source.slice(mainIndex, operationalStatusIndex).includes(quickActionsTitle),
+    false,
+  );
+  assert.equal(
+    source.slice(mainIndex, operationalStatusIndex).includes("dashboard-surface"),
+    false,
+  );
 });

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -93,10 +93,11 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.ok(source.includes('label: "Auditoría"'));
   assert.ok(source.includes('label: "Mantenimiento"'));
   assert.ok(source.includes("ROUTES.dashboardAdmin"));
+  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}#admin-users-roles`'));
+  assert.equal(source.includes('href: `${ROUTES.dashboardAdmin}#audit-role-changes`'), false);
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);
 });
-
 
 
 

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -312,6 +312,9 @@ test("dashboard topbar keeps sticky hierarchy and compact responsive shell", () 
 
 test("dashboard home keeps visual dashboard states and card spacing conventions", () => {
   const source = read(DASHBOARD_HOME_PATH);
+  const removedQuickActionsTitle = "Accesos " + "rápidos";
+  const removedQuickActionsGrid = "xl:grid-cols-" + "5";
+  const removedQuickActionsButton = "h-16 flex-col gap-1 rounded-" + "lg";
 
   assertContainsAll(
     source,
@@ -322,7 +325,6 @@ test("dashboard home keeps visual dashboard states and card spacing conventions"
       'className="surface-empty"',
       "recentReports.map((report) =>",
       "recentVisits.map((visit) =>",
-      "Accesos rápidos",
     ],
     "dashboard home shell",
   );
@@ -332,14 +334,15 @@ test("dashboard home keeps visual dashboard states and card spacing conventions"
     [
       /className="grid grid-cols-1 gap-6 lg:grid-cols-2"/,
       /className="dashboard-list-row"/,
-      /className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5"/,
-      /className="h-16 flex-col gap-1 rounded-lg"/,
       /className="truncate text-sm font-semibold text-vetneb-ink"/,
       /className="text-xs text-muted-foreground"/,
     ],
     "dashboard home visual patterns",
   );
 
+  assert.equal(source.includes(removedQuickActionsTitle), false);
+  assert.equal(source.includes(removedQuickActionsGrid), false);
+  assert.equal(source.includes(removedQuickActionsButton), false);
   assertInlineStylesAtMost(source, 0, "dashboard home");
   assert.equal(source.includes("fetch("), false, "dashboard home must avoid fetch()");
 });


### PR DESCRIPTION
## Summary
- Remove horizontal quick actions from clinic and admin dashboards
- Keep equivalent navigation in dashboard sidebars
- Point admin Roles clínica navigation to the operational roles panel
- Update legacy frontend tests to assert the new sidebar-based navigation contract

## Validation
- Select-String residue search: no results
- pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-clinic-public-profile.test.ts test/frontend-dashboard-clinic-tokens.test.ts test/frontend-visual-consistency.test.ts test/frontend-dashboard-home.test.ts test/frontend-dashboard-admin.test.ts test/frontend-dashboard-shell.test.ts
- pnpm test
- pnpm --dir frontend build
- pnpm build