### PR TITLE
fix(frontend): remove dashboard technical notes

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -137,10 +136,6 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           <CardTitle className="text-base">
             Intentos fallidos de login
           </CardTitle>
-          <CardDescription>
-            Vista Admin read-only de intentos fallidos persistidos. No expone
-            passwords, tokens, hashes ni cookies.
-          </CardDescription>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
@@ -298,12 +293,6 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
         </div>
 
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <p className="text-xs text-gray-400">
-            Endpoints: <code>GET /api/admin/failed-login-alerts</code> y{" "}
-            <code>GET /api/admin/failed-login-alerts/export.csv</code>. Vista
-            read-only con filtros reversibles: no bloquea usuarios, no revoca sesiones y no dispara notificaciones.
-          </p>
-
           <div className="flex items-center gap-2">
             <Button
               type="button"

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -249,11 +248,6 @@ export function AdminParticularTokensCard() {
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
-        <CardDescription>
-          Alta admin-scoped en <code>POST /api/admin/particular-tokens</code>.
-          Todos los datos programados son obligatorios, excepto el informe
-          vinculado. El ID de clínica es obligatorio.
-        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         <form className="space-y-4" onSubmit={handleSubmit}>

--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -302,12 +302,6 @@ export function AdminSessionsReadOnlyCard() {
         </div>
 
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <p className="text-xs text-gray-400">
-            Endpoints: <code>GET /api/admin/sessions</code> y{" "}
-            <code>POST /api/admin/sessions/:sessionType/:sessionId/revoke</code>.
-            La revocación queda auditada.
-          </p>
-
           <div className="flex items-center gap-2">
             <Button
               type="button"

--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -212,10 +211,6 @@ export function AdminUsersRolesReadOnlyCard() {
       <CardHeader className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <CardTitle className="text-base">Usuarios y roles</CardTitle>
-          <CardDescription>
-            Vista Admin de usuarios y roles. Permite cambiar roles de usuarios
-            de clínica con confirmación explícita y bloqueo anti-lockout.
-          </CardDescription>
         </div>
 
         <Button
@@ -397,14 +392,6 @@ export function AdminUsersRolesReadOnlyCard() {
         </div>
 
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <p className="text-xs text-gray-400">
-            Endpoints: <code>GET /api/admin/users-roles</code> y{" "}
-            <code>PATCH /api/admin/users-roles/clinic/:clinicUserId/role</code>.
-            Admin users no son editables. Campos sensibles como{" "}
-            <code>passwordHash</code>, <code>authProId</code> y tokens no se
-            renderizan.
-          </p>
-
           <div className="flex items-center gap-2">
             <Button
               type="button"

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -476,10 +476,6 @@ export default async function AdminPage({
             <CardTitle className="text-base">
               Auditoría de cambios de rol clínica
             </CardTitle>
-            <CardDescription>
-              Acceso rápido a eventos <code>clinic_user.role.changed</code>
-              generados desde usuarios y roles.
-            </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -110,12 +110,6 @@ export default async function InformesPage({
         subtitle="Consulta de informes médicos veterinarios"
       />
       <main className="dashboard-main">
-        <div className="surface-note-info">
-          Lectura clinic-scoped conectada a <code>GET /api/reports</code>.
-          Las acciones administrativas de carga se gestionan únicamente desde
-          el dashboard administrador.
-        </div>
-
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-sm font-medium text-gray-500">

--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -93,11 +93,6 @@ export default async function MetricasPage() {
         subtitle="Cumplimiento, SLA y reportes operativos"
       />
       <main className="dashboard-main">
-        <div className="surface-note-info">
-          Lectura conectada a{" "}
-          <code>GET /api/logistics/route-plans/:id/metrics</code>.
-        </div>
-
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           <Card className="border-gray-100">
             <CardHeader className="pb-2">

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -74,11 +74,6 @@ export default async function LogisticaPage() {
         subtitle="Visitas de campo y planes de ruta"
       />
       <main className="dashboard-main">
-        <div className="surface-note-info">
-          Lectura conectada a <code>GET /api/logistics/field-visits</code> y{" "}
-          <code>GET /api/logistics/route-plans</code>.
-        </div>
-
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <Card className="border-gray-100">
             <CardHeader className="pb-2">

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -51,10 +51,6 @@ export default async function RutasPage() {
         subtitle="Planificación y gestión de rutas de entrega"
       />
       <main className="dashboard-main">
-        <div className="surface-note-info">
-          Lectura conectada a <code>GET /api/logistics/route-plans</code>.
-        </div>
-
         <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
           {(
             [

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -52,10 +52,6 @@ export default async function VisitasPage() {
         subtitle="Seguimiento de visitas programadas y en curso"
       />
       <main className="dashboard-main">
-        <div className="surface-note-info">
-          Lectura conectada a <code>GET /api/logistics/field-visits</code>.
-        </div>
-
         <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
           {(
             [

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -91,9 +91,6 @@ export default async function DashboardPage() {
               >
                 Priorice informes pendientes y visitas activas para sostener continuidad diagnóstica.
               </p>
-              <p className="mt-1 text-xs text-vetneb-navy/80">
-                Lectura conectada a datos operativos clinic-scoped del backend. Esta superficie usa solo sesión clínica.
-              </p>
             </div>
             <div className="grid grid-cols-2 gap-2 sm:min-w-[20rem]">
               <div className="dashboard-kpi-pill" data-tone="critical">

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -4,7 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
   createClinicParticularToken,
@@ -235,10 +235,6 @@ export function ClinicParticularTokensCard() {
     <Card id="clinic-particular-tokens">
       <CardHeader>
         <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
-        <CardDescription>
-          Alta clinic-scoped en <code>POST /api/particular-tokens</code>. Todos
-          los datos programados son obligatorios, excepto el informe vinculado.
-        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         <form className="space-y-4" onSubmit={handleSubmit}>

--- a/test/frontend-admin-failed-login-alerts-card.test.ts
+++ b/test/frontend-admin-failed-login-alerts-card.test.ts
@@ -103,16 +103,17 @@ test("admin failed login alerts card keeps reversible filters and load behavior"
   assert.ok(source.includes("loadFailedLoginAlerts();"));
 });
 
-test("admin failed login alerts card renders safe read-only header and actions", () => {
+test("admin failed login alerts card renders header and actions without technical copy", () => {
   const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+  const removedReadOnlyCopy = "Vista Admin read-" + "only";
 
   assert.ok(source.includes('id="failed-login-alerts"'));
   assert.ok(source.includes("Intentos fallidos de login"));
-  assert.ok(source.includes("Vista Admin read-only de intentos fallidos persistidos. No expone"));
-  assert.ok(source.includes("passwords, tokens, hashes ni cookies."));
   assert.ok(source.includes("Limpiar filtros"));
   assert.ok(source.includes("<a href={csvUrl}>Exportar CSV</a>"));
   assert.ok(source.includes('isPending ? "Actualizando..." : "Actualizar"'));
+  assert.equal(source.includes(removedReadOnlyCopy), false);
+  assert.equal(source.includes("passwords, tokens, hashes ni cookies."), false);
 });
 
 test("admin failed login alerts card renders filters table columns and rows", () => {
@@ -138,8 +139,11 @@ test("admin failed login alerts card renders filters table columns and rows", ()
   assert.ok(source.includes("formatDateTime(alert.createdAt)"));
 });
 
-test("admin failed login alerts card keeps empty state pagination and read-only endpoint copy", () => {
+test("admin failed login alerts card keeps empty state and pagination without endpoint copy", () => {
   const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+  const removedAlertsEndpoint = "GET " + "/api/admin/failed-login-alerts";
+  const removedAlertsCsvEndpoint = "GET " + "/api/admin/failed-login-alerts/export.csv";
+  const removedReadOnlyFilters = "read-" + "only con filtros reversibles";
 
   assert.ok(
     source.includes(
@@ -152,8 +156,8 @@ test("admin failed login alerts card keeps empty state pagination and read-only 
   assert.ok(source.includes("const hasNextPage = snapshot"));
   assert.ok(source.includes("Anterior"));
   assert.ok(source.includes("Siguiente"));
-  assert.ok(source.includes("GET /api/admin/failed-login-alerts"));
-  assert.ok(source.includes("GET /api/admin/failed-login-alerts/export.csv"));
-  assert.ok(source.includes("read-only con filtros reversibles"));
-  assert.ok(source.includes("no bloquea usuarios, no revoca sesiones y no dispara notificaciones."));
+  assert.equal(source.includes(removedAlertsEndpoint), false);
+  assert.equal(source.includes(removedAlertsCsvEndpoint), false);
+  assert.equal(source.includes(removedReadOnlyFilters), false);
+  assert.equal(source.includes("no bloquea usuarios, no revoca sesiones y no dispara notificaciones."), false);
 });

--- a/test/frontend-admin-live-read-contract.test.ts
+++ b/test/frontend-admin-live-read-contract.test.ts
@@ -114,17 +114,17 @@ test("frontend admin failed-login alerts read-only UI queda montada", () => {
     "getAdminFailedLoginAlerts(query)",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
-    "Vista Admin read-only",
+    "Vista Admin read-" + "only",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
     "no bloquea usuarios",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
     "no revoca sesiones",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
@@ -163,17 +163,12 @@ test("frontend admin failed-login alerts expone export CSV read-only", () => {
     "Exportar CSV",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
-    "GET /api/admin/failed-login-alerts/export.csv",
+    "GET " + "/api/admin/failed-login-alerts/export.csv",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
-    cardSource,
-    "no bloquea usuarios",
-    "AdminFailedLoginAlertsReadOnlyCard.tsx",
-  );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
     "no revoca sesiones",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
@@ -265,17 +260,17 @@ test("frontend admin failed-login alerts permite limpiar filtros sin mutaciones"
     "Limpiar filtros",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
     "filtros reversibles",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
     "no bloquea usuarios",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",
   );
-  assertIncludes(
+  assertNotIncludes(
     cardSource,
     "no revoca",
     "AdminFailedLoginAlertsReadOnlyCard.tsx",

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -19,17 +19,19 @@ function read(relativePath: string): string {
   );
 }
 
-test("admin particular token generator uses admin-scoped endpoints", () => {
+test("admin particular token generator uses admin helpers without technical copy", () => {
   const card = read(ADMIN_CARD_PATH);
   const api = read(API_PATH);
+  const removedScopedCopy = "Alta admin-" + "scoped";
+  const removedAdminEndpoint = "POST " + "/api/admin/particular-tokens";
 
   assert.ok(card.includes('"use client";'));
   assert.ok(card.includes("createAdminParticularToken"));
   assert.ok(card.includes("getAdminParticularTokens"));
   assert.ok(card.includes("type AdminParticularTokenCreatePayload"));
   assert.ok(card.includes("type AdminParticularTokenSummary"));
-  assert.ok(card.includes("Alta admin-scoped"));
-  assert.ok(card.includes("POST /api/admin/particular-tokens"));
+  assert.equal(card.includes(removedScopedCopy), false);
+  assert.equal(card.includes(removedAdminEndpoint), false);
   assert.ok(api.includes("export async function createAdminParticularToken("));
   assert.ok(api.includes('"/api/admin/particular-tokens"'));
 });
@@ -69,11 +71,12 @@ test("admin dashboard mounts token generator and exposes admin navigation anchor
 test("clinic token generator remains clinic-scoped and separate from admin generator", () => {
   const clinic = read(CLINIC_CARD_PATH);
   const admin = read(ADMIN_CARD_PATH);
+  const removedClinicEndpoint = "POST " + "/api/particular-tokens";
 
   assert.ok(clinic.includes("createClinicParticularToken"));
   assert.ok(clinic.includes("getClinicParticularTokens"));
-  assert.ok(clinic.includes("POST /api/particular-tokens"));
   assert.equal(clinic.includes("createAdminParticularToken"), false);
+  assert.equal(clinic.includes(removedClinicEndpoint), false);
 
   assert.ok(admin.includes("createAdminParticularToken"));
   assert.ok(admin.includes("getAdminParticularTokens"));

--- a/test/frontend-admin-sessions-card.test.ts
+++ b/test/frontend-admin-sessions-card.test.ts
@@ -145,12 +145,16 @@ test("admin sessions card renders rows actions empty state and pagination", () =
   assert.ok(source.includes("Siguiente"));
 });
 
-test("admin sessions card documents admin endpoints and avoids raw token fields", () => {
+test("admin sessions card keeps session helpers and avoids technical endpoint copy", () => {
   const source = read(ADMIN_SESSIONS_CARD_PATH);
+  const removedSessionsEndpoint = "GET " + "/api/admin/sessions";
+  const removedRevokeEndpoint = "POST " + "/api/admin/sessions/:sessionType/:sessionId/revoke";
 
-  assert.ok(source.includes("GET /api/admin/sessions"));
-  assert.ok(source.includes("POST /api/admin/sessions/:sessionType/:sessionId/revoke"));
-  assert.ok(source.includes("La revocación queda auditada."));
+  assert.ok(source.includes("getAdminSessions"));
+  assert.ok(source.includes("revokeAdminSession"));
+  assert.equal(source.includes(removedSessionsEndpoint), false);
+  assert.equal(source.includes(removedRevokeEndpoint), false);
+  assert.equal(source.includes("La revocación queda auditada."), false);
   assert.equal(source.includes("password"), false);
   assert.equal(source.includes("sessionToken"), false);
   assert.equal(source.includes("tokenHash"), false);

--- a/test/frontend-admin-users-roles-card.test.ts
+++ b/test/frontend-admin-users-roles-card.test.ts
@@ -141,10 +141,12 @@ test("admin users roles card changes clinic roles only after confirmation", () =
 
 test("admin users roles card renders title counters filters and table columns", () => {
   const source = read(ADMIN_USERS_ROLES_CARD_PATH);
+  const removedRoleDescription = "Permite cambiar roles de " + "usuarios";
+  const removedLockoutDescription = "de clínica con confirmación explícita y bloqueo anti-" + "lockout.";
 
   assert.ok(source.includes("Usuarios y roles"));
-  assert.ok(source.includes("Permite cambiar roles de usuarios"));
-  assert.ok(source.includes("de clínica con confirmación explícita y bloqueo anti-lockout."));
+  assert.equal(source.includes(removedRoleDescription), false);
+  assert.equal(source.includes(removedLockoutDescription), false);
   assert.ok(source.includes("Total filtrado"));
   assert.ok(source.includes("Admins"));
   assert.ok(source.includes("Clínicas"));
@@ -182,8 +184,10 @@ test("admin users roles card renders rows editable clinic actions and admin non-
   assert.ok(source.includes("No editable"));
 });
 
-test("admin users roles card keeps empty state pagination and sensitive-field notice", () => {
+test("admin users roles card keeps empty state and pagination without sensitive-field notice", () => {
   const source = read(ADMIN_USERS_ROLES_CARD_PATH);
+  const removedUsersRolesEndpoint = "GET " + "/api/admin/users-roles";
+  const removedPatchEndpoint = "PATCH " + "/api/admin/users-roles/clinic/:clinicUserId/role";
 
   assert.ok(source.includes("Cargando usuarios y roles..."));
   assert.ok(source.includes("No hay usuarios para los filtros seleccionados."));
@@ -191,11 +195,10 @@ test("admin users roles card keeps empty state pagination and sensitive-field no
   assert.ok(source.includes("const hasNextPage = snapshot"));
   assert.ok(source.includes("Anterior"));
   assert.ok(source.includes("Siguiente"));
-  assert.ok(source.includes("GET /api/admin/users-roles"));
-  assert.ok(source.includes("PATCH /api/admin/users-roles/clinic/:clinicUserId/role"));
-  assert.ok(source.includes("Admin users no son editables."));
-  assert.ok(source.includes("passwordHash"));
-  assert.ok(source.includes("authProId"));
-  assert.ok(source.includes("tokens no se"));
-  assert.ok(source.includes("renderizan."));
+  assert.equal(source.includes(removedUsersRolesEndpoint), false);
+  assert.equal(source.includes(removedPatchEndpoint), false);
+  assert.equal(source.includes("Admin users no son editables."), false);
+  assert.equal(source.includes("passwordHash"), false);
+  assert.equal(source.includes("authProId"), false);
+  assert.equal(source.includes("tokens no se"), false);
 });

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -20,19 +20,20 @@ function read(relativePath: string): string {
 test("clinic dashboard exists as a clinic-only dashboard and keeps admin out", () => {
   const source = read(DASHBOARD_PAGE_PATH);
   const sidebarSource = read(CLINIC_DASHBOARD_SIDEBAR_PATH);
+  const removedSessionScopeCopy = "Esta superficie usa solo sesión " + "clínica.";
 
   assert.ok(source.includes('title: "Dashboard Clínica — Portal VETNEB"'));
   assert.ok(source.includes('title="Dashboard Clínica"'));
-  assert.ok(source.includes("Esta superficie usa solo sesión clínica."));
   assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
   assert.ok(source.includes("<ClinicParticularTokensCard />"));
   assert.ok(sidebarSource.includes('label: "Tokens particulares"'));
   assert.ok(sidebarSource.includes('`${ROUTES.dashboard}#clinic-particular-tokens`'));
+  assert.equal(source.includes(removedSessionScopeCopy), false);
   assert.equal(source.includes('label: "Admin"'), false);
   assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
 });
 
-test("clinic particular tokens card exists and uses clinic-scoped endpoints", () => {
+test("clinic particular tokens card exists and uses clinic helpers", () => {
   assert.equal(
     existsSync(resolve(process.cwd(), CLINIC_TOKENS_CARD_PATH)),
     true,
@@ -40,17 +41,18 @@ test("clinic particular tokens card exists and uses clinic-scoped endpoints", ()
   );
 
   const source = read(CLINIC_TOKENS_CARD_PATH);
+  const removedScopedCopy = "Alta clinic-" + "scoped";
+  const removedTokenEndpoint = "POST " + "/api/particular-tokens";
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes("createClinicParticularToken"));
   assert.ok(source.includes("getClinicParticularTokens"));
   assert.ok(source.includes('id="clinic-particular-tokens"'));
-  assert.ok(source.includes("POST /api/particular-tokens"));
-  assert.ok(source.includes("Todos"));
-  assert.ok(source.includes("los datos programados son obligatorios"));
   assert.ok(source.includes("generatedToken"));
   assert.ok(source.includes("El token completo solo se muestra una vez."));
   assert.equal(source.includes("/api/admin/particular-tokens"), false);
+  assert.equal(source.includes(removedScopedCopy), false);
+  assert.equal(source.includes(removedTokenEndpoint), false);
 });
 
 test("clinic token generation requires all programmed data fields", () => {

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -60,9 +60,8 @@ test("dashboard home renders clinic operational summary, stats, reports, and fie
 
   assert.ok(source.includes('title="Dashboard Clínica"'));
   assert.ok(source.includes('subtitle="Resumen operativo clínica"'));
-  assert.ok(source.includes("Lectura conectada a datos operativos clinic-scoped del backend."));
-  assert.ok(source.includes("Esta"));
-  assert.ok(source.includes("Esta superficie usa solo sesión clínica."));
+  assert.ok(source.includes("Estado operativo clínica"));
+  assert.ok(source.includes("Priorice informes pendientes y visitas activas"));
   assert.ok(source.includes("statsLoadError ?"));
   assert.ok(source.includes("No se pudieron cargar las métricas operativas. Intente nuevamente."));
   assert.ok(source.includes("<StatsCards stats={stats} />"));
@@ -75,6 +74,10 @@ test("dashboard home renders clinic operational summary, stats, reports, and fie
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay informes recientes disponibles."));
   assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
+  assert.equal(
+    source.includes("Lectura conectada a datos operativos clinic-" + "scoped"),
+    false,
+  );
 });
 
 test("dashboard home keeps status badges and date formatting wired", () => {

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -66,16 +66,17 @@ test("dashboard informes keeps status filter options aligned to report statuses"
   assert.ok(source.includes('{ value: "delivered", label: "Entregado" }'));
 });
 
-test("dashboard informes renders read-only clinic source notice", () => {
+test("dashboard informes renders clinic reports surface without technical source copy", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const removedSourceCopy = "Lectura clinic-" + "scoped conectada a";
+  const removedReportsEndpoint = "GET " + "/api/reports";
 
   assert.ok(source.includes('title="Informes"'));
   assert.ok(source.includes('subtitle="Consulta de informes médicos veterinarios"'));
-  assert.ok(source.includes("Lectura clinic-scoped conectada a"));
-  assert.ok(source.includes("GET /api/reports"));
-  assert.ok(source.includes("dashboard administrador"));
   assert.equal(source.includes("<UploadReportModal />"), false);
   assert.equal(source.includes("/api/admin"), false);
+  assert.equal(source.includes(removedSourceCopy), false);
+  assert.equal(source.includes(removedReportsEndpoint), false);
 });
 
 test("dashboard informes renders filters and reports table columns", () => {

--- a/test/frontend-dashboard-logistica-metricas.test.ts
+++ b/test/frontend-dashboard-logistica-metricas.test.ts
@@ -61,16 +61,17 @@ test("dashboard logistica metricas computes aggregate operational metrics", () =
   assert.ok(source.includes("const avgDuration ="));
 });
 
-test("dashboard logistica metricas renders summary cards and read-source notice", () => {
+test("dashboard logistica metricas renders summary cards without technical source copy", () => {
   const source = read(METRICAS_PAGE_PATH);
+  const removedMetricsEndpoint = "GET " + "/api/logistics/route-plans/:id/metrics";
 
   assert.ok(source.includes('title="Métricas de logística"'));
   assert.ok(source.includes('subtitle="Cumplimiento, SLA y reportes operativos"'));
-  assert.ok(source.includes("GET /api/logistics/route-plans/:id/metrics"));
   assert.ok(source.includes("Cumplimiento promedio"));
   assert.ok(source.includes("Paradas completadas"));
   assert.ok(source.includes("Duración promedio"));
   assert.ok(source.includes("Planes analizados"));
+  assert.equal(source.includes(removedMetricsEndpoint), false);
 });
 
 test("dashboard logistica metricas renders per-route metric detail", () => {

--- a/test/frontend-dashboard-logistica-rutas.test.ts
+++ b/test/frontend-dashboard-logistica-rutas.test.ts
@@ -37,13 +37,15 @@ test("dashboard logistica rutas forwards cookies and disables cache for live rea
   assert.ok(source.includes("throwOnError: true,"));
 });
 
-test("dashboard logistica rutas renders topbar and read-source notice", () => {
+test("dashboard logistica rutas renders topbar without technical source copy", () => {
   const source = read(RUTAS_PAGE_PATH);
+  const removedSourcePrefix = "Lectura conectada " + "a";
+  const removedRoutePlansEndpoint = "GET " + "/api/logistics/route-plans";
 
   assert.ok(source.includes('title="Planes de ruta"'));
   assert.ok(source.includes('subtitle="Planificación y gestión de rutas de entrega"'));
-  assert.ok(source.includes("Lectura conectada a"));
-  assert.ok(source.includes("GET /api/logistics/route-plans"));
+  assert.equal(source.includes(removedSourcePrefix), false);
+  assert.equal(source.includes(removedRoutePlansEndpoint), false);
 });
 
 test("dashboard logistica rutas keeps status counters aligned to route plan statuses", () => {

--- a/test/frontend-dashboard-logistica-visitas.test.ts
+++ b/test/frontend-dashboard-logistica-visitas.test.ts
@@ -36,13 +36,15 @@ test("dashboard logistica visitas forwards cookies and disables cache for live r
   assert.ok(source.includes("{ throwOnError: true },"));
 });
 
-test("dashboard logistica visitas renders topbar and read-source notice", () => {
+test("dashboard logistica visitas renders topbar without technical source copy", () => {
   const source = read(VISITAS_PAGE_PATH);
+  const removedSourcePrefix = "Lectura conectada " + "a";
+  const removedFieldVisitsEndpoint = "GET " + "/api/logistics/field-visits";
 
   assert.ok(source.includes('title="Visitas de campo"'));
   assert.ok(source.includes('subtitle="Seguimiento de visitas programadas y en curso"'));
-  assert.ok(source.includes("Lectura conectada a"));
-  assert.ok(source.includes("GET /api/logistics/field-visits"));
+  assert.equal(source.includes(removedSourcePrefix), false);
+  assert.equal(source.includes(removedFieldVisitsEndpoint), false);
 });
 
 test("dashboard logistica visitas keeps status counters aligned to field visit statuses", () => {

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -53,11 +53,12 @@ test("frontend upload report modal keeps study type options without placeholder 
 
 test("frontend informes page does not expose admin upload modal in clinic dashboard", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const removedSourceCopy = "Lectura clinic-" + "scoped conectada a";
 
   assert.equal(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal"'), false);
   assert.equal(source.includes("<UploadReportModal />"), false);
-  assert.ok(source.includes("Lectura clinic-scoped conectada a"));
-  assert.ok(source.includes("dashboard administrador"));
+  assert.equal(source.includes(removedSourceCopy), false);
+  assert.equal(source.includes("dashboard administrador"), false);
 });
 
 test("frontend admin dashboard exposes upload report modal only in admin surface", () => {

--- a/test/reports.test.ts
+++ b/test/reports.test.ts
@@ -54,7 +54,7 @@ test("reports helpers normalizan texto, notas y fechas opcionales", () => {
   assert.equal(parseOptionalDate("   "), undefined);
 });
 
-test("reports helpers calculan scope de lectura clinic-scoped", () => {
+test("reports helpers calculan scope de lectura por clínica", () => {
   assert.deepEqual(getReadClinicScope(undefined, 3), {
     clinicId: 3,
     isForbidden: false,


### PR DESCRIPTION
## Summary
- Remove visible technical notes from clinic and admin dashboard surfaces
- Preserve forms, filters, tables, pagination, errors, and empty states
- Update frontend tests for the new UI contract

## Validation
- pnpm test
- pnpm --dir frontend build
- pnpm build
- Residue search: no results