### PR TITLE
feat(pricing): add pricing API foundation

### DIFF
--- a/drizzle/migrations/0023_pricing_items.sql
+++ b/drizzle/migrations/0023_pricing_items.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS "pricing_items" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "category" varchar(80) NOT NULL,
+  "study_name" varchar(160) NOT NULL,
+  "price_label" varchar(80),
+  "display_order" integer NOT NULL,
+  "is_active" boolean NOT NULL DEFAULT true,
+  "updated_at" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "pricing_items_active_category_display_order_idx"
+  ON "pricing_items" ("is_active", "category", "display_order");
+
+INSERT INTO "pricing_items" (
+  "category",
+  "study_name",
+  "price_label",
+  "display_order",
+  "is_active"
+)
+SELECT
+  seed.category,
+  seed.study_name,
+  NULL,
+  seed.display_order,
+  true
+FROM (
+  VALUES
+    ('CITOLOGÍAS', 'UNA LESIÓN (VARIOS VIDRIOS)', 1),
+    ('CITOLOGÍAS', 'REPETICIÓN (DENTRO DE 15 DÍAS)', 2),
+    ('CITOLOGÍAS', 'LESIÓN ADICIONAL (SOBRE SU VALOR)', 3),
+    ('CITOLOGÍAS', 'MÉDULA ÓSEA', 4),
+    ('CITOLOGÍAS', 'CITOLOGIA VAGINAL (PAP)', 5),
+    ('CITOLOGÍAS', 'ZIEHL-NEELSEN', 6),
+    ('CITOLOGÍAS', 'FROTIS CAPILAR', 7),
+    ('HISTOPATOLOGÍAS', 'PIEZAS HASTA 10 CM', 1),
+    ('HISTOPATOLOGÍAS', 'PIEZAS MÁS DE 10 CM', 2),
+    ('HISTOPATOLOGÍAS', 'DERMATOPATOLOGÍA', 3),
+    ('HISTOPATOLOGÍAS', 'LÍNEA MAMARIA COMPLETA', 4),
+    ('HISTOPATOLOGÍAS', 'PIEZAS CON HUESO', 5),
+    ('HISTOPATOLOGÍAS', 'PIEZA ADICIONAL (SOBRE SU VALOR)', 6),
+    ('HISTOPATOLOGÍAS', 'TINCIONES ESPECIALES', 7),
+    ('HISTOPATOLOGÍAS', 'URGENTES (ADICIONAL)', 8)
+) AS seed(category, study_name, display_order)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "pricing_items" existing
+  WHERE existing."category" = seed.category
+    AND existing."study_name" = seed.study_name
+);

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
                         "when":  1777000000000,
                         "tag":  "0022_login_failed_attempts",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  23,
+                        "version":  "7",
+                        "when":  1777089600000,
+                        "tag":  "0023_pricing_items",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -137,6 +137,7 @@ export const AUDIT_EVENTS = [
   "auth.clinic.login.succeeded",
   "auth.session.revoked",
   "clinic_user.role.changed",
+  "admin.pricing.update",
   "report.status.changed",
   "report.uploaded",
   "study_tracking.case.created",
@@ -434,6 +435,24 @@ export const loginFailedAttempts = pgTable(
     reasonCreatedAtIdx: index(
       "login_failed_attempts_reason_created_at_idx",
     ).on(table.reason, table.createdAt),
+  }),
+);
+
+export const pricingItems = pgTable(
+  "pricing_items",
+  {
+    id: serial("id").primaryKey(),
+    category: varchar("category", { length: 80 }).notNull(),
+    studyName: varchar("study_name", { length: 160 }).notNull(),
+    priceLabel: varchar("price_label", { length: 80 }),
+    displayOrder: integer("display_order").notNull(),
+    isActive: boolean("is_active").default(true).notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    activeCategoryDisplayOrderIdx: index(
+      "pricing_items_active_category_display_order_idx",
+    ).on(table.isActive, table.category, table.displayOrder),
   }),
 );
 
@@ -1112,3 +1131,6 @@ export type NewStudyTrackingNotification = InferInsertModel<
 
 export type ParticularSession = InferSelectModel<typeof particularSessions>;
 export type NewParticularSession = InferInsertModel<typeof particularSessions>;
+
+export type PricingItem = InferSelectModel<typeof pricingItems>;
+export type NewPricingItem = InferInsertModel<typeof pricingItems>;

--- a/server/db-pricing.ts
+++ b/server/db-pricing.ts
@@ -1,0 +1,160 @@
+import { asc, eq } from "drizzle-orm";
+
+import { db } from "./db.ts";
+import { pricingItems } from "../drizzle/schema";
+
+export type PricingItem = {
+  id: number;
+  category: string;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+  isActive: boolean;
+  updatedAt: string;
+};
+
+export type UpdatePricingItemInput = {
+  priceLabel?: string | null;
+  isActive?: boolean;
+  displayOrder?: number;
+  now?: Date;
+};
+
+type PricingItemRow = {
+  id: number;
+  category: string;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+  isActive: boolean;
+  updatedAt: Date;
+};
+
+function serializePricingItem(row: PricingItemRow): PricingItem {
+  return {
+    id: row.id,
+    category: row.category,
+    studyName: row.studyName,
+    priceLabel: row.priceLabel ?? null,
+    displayOrder: row.displayOrder,
+    isActive: row.isActive,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function hasPatchFields(input: UpdatePricingItemInput) {
+  return (
+    Object.prototype.hasOwnProperty.call(input, "priceLabel") ||
+    Object.prototype.hasOwnProperty.call(input, "isActive") ||
+    Object.prototype.hasOwnProperty.call(input, "displayOrder")
+  );
+}
+
+async function getPricingItemById(id: number): Promise<PricingItem | null> {
+  const rows = await db
+    .select({
+      id: pricingItems.id,
+      category: pricingItems.category,
+      studyName: pricingItems.studyName,
+      priceLabel: pricingItems.priceLabel,
+      displayOrder: pricingItems.displayOrder,
+      isActive: pricingItems.isActive,
+      updatedAt: pricingItems.updatedAt,
+    })
+    .from(pricingItems)
+    .where(eq(pricingItems.id, id))
+    .limit(1);
+
+  const row = rows[0];
+  return row ? serializePricingItem(row) : null;
+}
+
+export async function listPublicPricingItems(): Promise<PricingItem[]> {
+  const rows = await db
+    .select({
+      id: pricingItems.id,
+      category: pricingItems.category,
+      studyName: pricingItems.studyName,
+      priceLabel: pricingItems.priceLabel,
+      displayOrder: pricingItems.displayOrder,
+      isActive: pricingItems.isActive,
+      updatedAt: pricingItems.updatedAt,
+    })
+    .from(pricingItems)
+    .where(eq(pricingItems.isActive, true))
+    .orderBy(
+      asc(pricingItems.category),
+      asc(pricingItems.displayOrder),
+      asc(pricingItems.id),
+    );
+
+  return rows.map((row) => serializePricingItem(row));
+}
+
+export async function listAdminPricingItems(): Promise<PricingItem[]> {
+  const rows = await db
+    .select({
+      id: pricingItems.id,
+      category: pricingItems.category,
+      studyName: pricingItems.studyName,
+      priceLabel: pricingItems.priceLabel,
+      displayOrder: pricingItems.displayOrder,
+      isActive: pricingItems.isActive,
+      updatedAt: pricingItems.updatedAt,
+    })
+    .from(pricingItems)
+    .orderBy(
+      asc(pricingItems.category),
+      asc(pricingItems.displayOrder),
+      asc(pricingItems.id),
+    );
+
+  return rows.map((row) => serializePricingItem(row));
+}
+
+export async function updatePricingItem(
+  id: number,
+  input: UpdatePricingItemInput,
+): Promise<PricingItem | null> {
+  if (!hasPatchFields(input)) {
+    return getPricingItemById(id);
+  }
+
+  const setValues: {
+    priceLabel?: string | null;
+    isActive?: boolean;
+    displayOrder?: number;
+    updatedAt: Date;
+  } = {
+    updatedAt: input.now ?? new Date(),
+  };
+
+  if (Object.prototype.hasOwnProperty.call(input, "priceLabel")) {
+    setValues.priceLabel = input.priceLabel ?? null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "isActive")) {
+    setValues.isActive = input.isActive;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "displayOrder")) {
+    setValues.displayOrder = input.displayOrder;
+  }
+
+  const rows = await db
+    .update(pricingItems)
+    .set(setValues)
+    .where(eq(pricingItems.id, id))
+    .returning({
+      id: pricingItems.id,
+      category: pricingItems.category,
+      studyName: pricingItems.studyName,
+      priceLabel: pricingItems.priceLabel,
+      displayOrder: pricingItems.displayOrder,
+      isActive: pricingItems.isActive,
+      updatedAt: pricingItems.updatedAt,
+    });
+
+  const row = rows[0];
+  return row ? serializePricingItem(row) : null;
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -17,6 +17,10 @@ import {
   type AdminFailedLoginAlertsNativeRoutesOptions,
 } from "./routes/admin-failed-login-alerts.fastify.ts";
 import {
+  adminPricingNativeRoutes,
+  type AdminPricingNativeRoutesOptions,
+} from "./routes/admin-pricing.fastify.ts";
+import {
   adminParticularTokensNativeRoutes,
   type AdminParticularTokensNativeRoutesOptions,
 } from "./routes/admin-particular-tokens.fastify.ts";
@@ -84,6 +88,10 @@ import {
   publicProfessionalsNativeRoutes,
   type PublicProfessionalsNativeRoutesOptions,
 } from "./routes/public-professionals.fastify.ts";
+import {
+  publicPricingNativeRoutes,
+  type PublicPricingNativeRoutesOptions,
+} from "./routes/public-pricing.fastify.ts";
 import {
   publicReportAccessNativeRoutes,
   type PublicReportAccessNativeRoutesOptions,
@@ -190,6 +198,7 @@ export type CreateFastifyAppOptions = {
   adminAuditRoutes?: AdminAuditNativeRoutesOptions;
   adminAuthRoutes?: AdminAuthNativeRoutesOptions;
   adminFailedLoginAlertsRoutes?: AdminFailedLoginAlertsNativeRoutesOptions;
+  adminPricingRoutes?: AdminPricingNativeRoutesOptions;
   adminParticularTokensRoutes?: AdminParticularTokensNativeRoutesOptions;
   adminReportsRoutes?: AdminReportsNativeRoutesOptions;
   adminSessionsRoutes?: AdminSessionsNativeRoutesOptions;
@@ -206,6 +215,7 @@ export type CreateFastifyAppOptions = {
   particularAuthRoutes?: ParticularAuthNativeRoutesOptions;
   particularStudyTrackingRoutes?: ParticularStudyTrackingNativeRoutesOptions;
   particularTokensRoutes?: ParticularTokensNativeRoutesOptions;
+  publicPricingRoutes?: PublicPricingNativeRoutesOptions;
   publicProfessionalsRoutes?: PublicProfessionalsNativeRoutesOptions;
   publicReportAccessRoutes?: PublicReportAccessNativeRoutesOptions;
   reportAccessTokensRoutes?: ReportAccessTokensNativeRoutesOptions;
@@ -305,6 +315,11 @@ export async function createFastifyApp(
     ...(options.adminFailedLoginAlertsRoutes ?? {}),
   });
 
+  await app.register(adminPricingNativeRoutes, {
+    prefix: "/api/admin/pricing",
+    ...(options.adminPricingRoutes ?? {}),
+  });
+
   await app.register(adminParticularTokensNativeRoutes, {
     prefix: "/api/admin/particular-tokens",
     ...(options.adminParticularTokensRoutes ?? {}),
@@ -400,6 +415,11 @@ export async function createFastifyApp(
     ...(options.publicProfessionalsRoutes ?? {}),
   });
 
+  await app.register(publicPricingNativeRoutes, {
+    prefix: "/api/public/pricing",
+    ...(options.publicPricingRoutes ?? {}),
+  });
+
   await app.register(publicReportAccessNativeRoutes, {
     prefix: "/api/public/report-access",
     ...(options.publicReportAccessRoutes ?? {}),
@@ -447,6 +467,5 @@ export async function createFastifyApp(
 
   return app;
 }
-
 
 

--- a/server/lib/audit-log.ts
+++ b/server/lib/audit-log.ts
@@ -11,6 +11,7 @@ export const AUDIT_EVENTS = [
   "auth.admin.login.succeeded",
   "auth.clinic.login.succeeded",
   "clinic_user.role.changed",
+  "admin.pricing.update",
   "report.status.changed",
   "report.uploaded",
   "study_tracking.case.created",

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -6,6 +6,7 @@ export const AUDIT_EVENTS = {
   ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
   CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
   CLINIC_USER_ROLE_CHANGED: "clinic_user.role.changed",
+  ADMIN_PRICING_UPDATED: "admin.pricing.update",
   REPORT_STATUS_CHANGED: "report.status.changed",
   REPORT_UPLOADED: "report.uploaded",
   STUDY_TRACKING_CASE_CREATED: "study_tracking.case.created",
@@ -251,4 +252,3 @@ export function createWriteAuditLog(
 }
 
 export const writeAuditLog = createWriteAuditLog();
-

--- a/server/routes/admin-pricing.fastify.ts
+++ b/server/routes/admin-pricing.fastify.ts
@@ -342,7 +342,11 @@ function parsePatchPayload(
   if (Object.prototype.hasOwnProperty.call(rawBody, "displayOrder")) {
     const value = rawBody.displayOrder;
 
-    if (!Number.isInteger(value) || value < 0) {
+    if (
+      typeof value !== "number" ||
+      !Number.isInteger(value) ||
+      value < 0
+    ) {
       return {
         error: "displayOrder inválido. Debe ser un entero mayor o igual a 0.",
       };

--- a/server/routes/admin-pricing.fastify.ts
+++ b/server/routes/admin-pricing.fastify.ts
@@ -1,0 +1,578 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import type {
+  PricingItem,
+  UpdatePricingItemInput,
+} from "../db-pricing.ts";
+
+type AdminSessionRecord = {
+  id: number;
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+};
+
+type UpdatePricingPayload = Pick<
+  UpdatePricingItemInput,
+  "priceLabel" | "isActive" | "displayOrder"
+>;
+
+type ListAdminPricingItemsFn = () => Promise<PricingItem[]>;
+type UpdatePricingItemFn = (
+  id: number,
+  payload: UpdatePricingPayload & { now?: Date },
+) => Promise<PricingItem | null>;
+
+type AdminPricingRequestParams = {
+  id?: unknown;
+};
+
+type AdminPricingPatchBody = {
+  priceLabel?: unknown;
+  isActive?: unknown;
+  displayOrder?: unknown;
+  [key: string]: unknown;
+};
+
+type AdminPricingCategoryItem = {
+  id: number;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+  isActive: boolean;
+  updatedAt: string;
+};
+
+type AdminPricingCategory = {
+  category: string;
+  items: AdminPricingCategoryItem[];
+};
+
+export type AdminPricingNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  listAdminPricingItems?: ListAdminPricingItemsFn;
+  updatePricingItem?: UpdatePricingItemFn;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  now?: () => number;
+};
+
+type NativeAdminPricingDeps = Required<
+  Pick<
+    AdminPricingNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "listAdminPricingItems"
+    | "updatePricingItem"
+    | "writeAuditLog"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminPricingDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminPricingDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const pricing = await import("../db-pricing.ts");
+      const audit = await import("../lib/audit.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        listAdminPricingItems: pricing.listAdminPricingItems,
+        updatePricingItem: pricing.updatePricingItem as UpdatePricingItemFn,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminPricingDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+  };
+}
+
+function parsePositiveInteger(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parsePatchPayload(
+  body: unknown,
+): { payload?: UpdatePricingPayload; error?: string } {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      error:
+        "Body inválido. Debe ser un objeto con priceLabel, isActive o displayOrder.",
+    };
+  }
+
+  const rawBody = body as AdminPricingPatchBody;
+  const keys = Object.keys(rawBody);
+  const allowedKeys = new Set(["priceLabel", "isActive", "displayOrder"]);
+  const invalidKeys = keys.filter((key) => !allowedKeys.has(key));
+
+  if (keys.length === 0) {
+    return {
+      error:
+        "Body inválido. Debe incluir al menos uno de: priceLabel, isActive, displayOrder.",
+    };
+  }
+
+  if (invalidKeys.length > 0) {
+    return {
+      error:
+        "Body inválido. Solo se permiten priceLabel, isActive y displayOrder.",
+    };
+  }
+
+  const payload: UpdatePricingPayload = {};
+
+  if (Object.prototype.hasOwnProperty.call(rawBody, "priceLabel")) {
+    const value = rawBody.priceLabel;
+
+    if (value === null) {
+      payload.priceLabel = null;
+    } else if (typeof value === "string" && value.length <= 80) {
+      payload.priceLabel = value;
+    } else {
+      return {
+        error: "priceLabel inválido. Debe ser string de hasta 80 caracteres o null.",
+      };
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(rawBody, "isActive")) {
+    if (typeof rawBody.isActive !== "boolean") {
+      return {
+        error: "isActive inválido. Debe ser boolean.",
+      };
+    }
+
+    payload.isActive = rawBody.isActive;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(rawBody, "displayOrder")) {
+    const value = rawBody.displayOrder;
+
+    if (!Number.isInteger(value) || value < 0) {
+      return {
+        error: "displayOrder inválido. Debe ser un entero mayor o igual a 0.",
+      };
+    }
+
+    payload.displayOrder = value;
+  }
+
+  if (
+    !Object.prototype.hasOwnProperty.call(payload, "priceLabel") &&
+    !Object.prototype.hasOwnProperty.call(payload, "isActive") &&
+    !Object.prototype.hasOwnProperty.call(payload, "displayOrder")
+  ) {
+    return {
+      error:
+        "Body inválido. Debe incluir al menos uno de: priceLabel, isActive, displayOrder.",
+    };
+  }
+
+  return { payload };
+}
+
+function serializeAdminPricingItem(item: PricingItem) {
+  return {
+    id: item.id,
+    category: item.category,
+    studyName: item.studyName,
+    priceLabel: item.priceLabel ?? null,
+    displayOrder: item.displayOrder,
+    isActive: item.isActive,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function groupAdminPricingItems(items: PricingItem[]): AdminPricingCategory[] {
+  const categories: AdminPricingCategory[] = [];
+  let currentCategory: AdminPricingCategory | undefined;
+
+  for (const item of items) {
+    if (!currentCategory || currentCategory.category !== item.category) {
+      currentCategory = {
+        category: item.category,
+        items: [],
+      };
+
+      categories.push(currentCategory);
+    }
+
+    currentCategory.items.push({
+      id: item.id,
+      studyName: item.studyName,
+      priceLabel: item.priceLabel ?? null,
+      displayOrder: item.displayOrder,
+      isActive: item.isActive,
+      updatedAt: item.updatedAt,
+    });
+  }
+
+  return categories;
+}
+
+function createAuditRequestLike(
+  request: FastifyRequest,
+  admin: AuthenticatedAdminUser,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    requestId: request.id,
+    adminAuth: {
+      id: admin.id,
+      username: admin.username,
+    },
+  };
+}
+
+export const adminPricingNativeRoutes: FastifyPluginAsync<
+  AdminPricingNativeRoutesOptions
+> = async (app, options) => {
+  const now = options.now ?? (() => Date.now());
+
+  async function resolveDeps(): Promise<NativeAdminPricingDeps> {
+    const hasAllInjectedDeps =
+      !!options.deleteAdminSession &&
+      !!options.getAdminSessionByToken &&
+      !!options.getAdminUserById &&
+      !!options.updateAdminSessionLastAccess &&
+      !!options.hashSessionToken &&
+      !!options.listAdminPricingItems &&
+      !!options.updatePricingItem &&
+      !!options.writeAuditLog;
+
+    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+    return {
+      deleteAdminSession:
+        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+      getAdminSessionByToken:
+        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+      getAdminUserById:
+        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      updateAdminSessionLastAccess:
+        options.updateAdminSessionLastAccess ??
+        defaultDeps!.updateAdminSessionLastAccess,
+      hashSessionToken:
+        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+      listAdminPricingItems:
+        options.listAdminPricingItems ?? defaultDeps!.listAdminPricingItems,
+      updatePricingItem: options.updatePricingItem ?? defaultDeps!.updatePricingItem,
+      writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+    };
+  }
+
+  app.get("/", async (request, reply) => {
+    try {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const items = await deps.listAdminPricingItems();
+
+      return reply.code(200).send({
+        success: true,
+        categories: groupAdminPricingItems(items),
+      });
+    } catch (error) {
+      console.error("[ADMIN_PRICING_LIST_ERROR]", {
+        path: request.url,
+        error,
+      });
+
+      return reply.code(500).send({
+        success: false,
+        error: "Error interno del servidor",
+      });
+    }
+  });
+
+  app.patch<{
+    Params: AdminPricingRequestParams;
+    Body: AdminPricingPatchBody;
+  }>("/:id", async (request, reply) => {
+    try {
+      const deps = await resolveDeps();
+      const admin = await authenticateAdminUser(request, reply, deps, now);
+
+      if (!admin) {
+        return reply;
+      }
+
+      const pricingItemId = parsePositiveInteger(request.params.id);
+
+      if (pricingItemId === null) {
+        return reply.code(400).send({
+          success: false,
+          error: "ID inválido. Debe ser un entero positivo.",
+        });
+      }
+
+      const parsed = parsePatchPayload(request.body);
+
+      if (!parsed.payload) {
+        return reply.code(400).send({
+          success: false,
+          error: parsed.error ?? "Body inválido.",
+        });
+      }
+
+      const previousItem = (await deps.listAdminPricingItems()).find(
+        (item) => item.id === pricingItemId,
+      );
+
+      if (!previousItem) {
+        return reply.code(404).send({
+          success: false,
+          error: "Ítem de precio no encontrado",
+        });
+      }
+
+      const updated = await deps.updatePricingItem(pricingItemId, {
+        ...parsed.payload,
+        now: new Date(now()),
+      });
+
+      if (!updated) {
+        return reply.code(404).send({
+          success: false,
+          error: "Ítem de precio no encontrado",
+        });
+      }
+
+      await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+        event: AUDIT_EVENTS.ADMIN_PRICING_UPDATED,
+        metadata: {
+          pricingItemId: updated.id,
+          category: updated.category,
+          studyName: updated.studyName,
+          updatedFields: Object.keys(parsed.payload),
+          previous: {
+            priceLabel: previousItem.priceLabel,
+            isActive: previousItem.isActive,
+            displayOrder: previousItem.displayOrder,
+          },
+          next: {
+            priceLabel: updated.priceLabel,
+            isActive: updated.isActive,
+            displayOrder: updated.displayOrder,
+          },
+        },
+      });
+
+      return reply.code(200).send({
+        success: true,
+        pricingItem: serializeAdminPricingItem(updated),
+      });
+    } catch (error) {
+      console.error("[ADMIN_PRICING_PATCH_ERROR]", {
+        path: request.url,
+        error,
+      });
+
+      return reply.code(500).send({
+        success: false,
+        error: "Error interno del servidor",
+      });
+    }
+  });
+};

--- a/server/routes/public-pricing.fastify.ts
+++ b/server/routes/public-pricing.fastify.ts
@@ -1,0 +1,108 @@
+import type { FastifyPluginAsync } from "fastify";
+
+type PricingItem = {
+  id: number;
+  category: string;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+};
+
+type ListPublicPricingItemsFn = () => Promise<PricingItem[]>;
+
+export type PublicPricingNativeRoutesOptions = {
+  listPublicPricingItems?: ListPublicPricingItemsFn;
+};
+
+type NativePublicPricingDeps = Required<
+  Pick<PublicPricingNativeRoutesOptions, "listPublicPricingItems">
+>;
+
+type PublicPricingCategoryItem = {
+  id: number;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+};
+
+type PublicPricingCategory = {
+  category: string;
+  items: PublicPricingCategoryItem[];
+};
+
+let defaultDepsPromise: Promise<NativePublicPricingDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativePublicPricingDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const pricing = await import("../db-pricing.ts");
+
+      return {
+        listPublicPricingItems: pricing.listPublicPricingItems,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function groupPublicPricingItems(items: PricingItem[]): PublicPricingCategory[] {
+  const categories: PublicPricingCategory[] = [];
+  let currentCategory: PublicPricingCategory | undefined;
+
+  for (const item of items) {
+    if (!currentCategory || currentCategory.category !== item.category) {
+      currentCategory = {
+        category: item.category,
+        items: [],
+      };
+
+      categories.push(currentCategory);
+    }
+
+    currentCategory.items.push({
+      id: item.id,
+      studyName: item.studyName,
+      priceLabel: item.priceLabel ?? null,
+      displayOrder: item.displayOrder,
+    });
+  }
+
+  return categories;
+}
+
+export const publicPricingNativeRoutes: FastifyPluginAsync<
+  PublicPricingNativeRoutesOptions
+> = async (app, options) => {
+  async function resolveDeps(): Promise<NativePublicPricingDeps> {
+    const hasAllInjectedDeps = !!options.listPublicPricingItems;
+    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+    return {
+      listPublicPricingItems:
+        options.listPublicPricingItems ?? defaultDeps!.listPublicPricingItems,
+    };
+  }
+
+  app.get("/", async (request, reply) => {
+    try {
+      const deps = await resolveDeps();
+      const items = await deps.listPublicPricingItems();
+
+      return reply.code(200).send({
+        success: true,
+        categories: groupPublicPricingItems(items),
+      });
+    } catch (error) {
+      console.error("[PUBLIC_PRICING_LIST_ERROR]", {
+        path: request.url,
+        error,
+      });
+
+      return reply.code(500).send({
+        success: false,
+        error: "Error interno del servidor",
+      });
+    }
+  });
+};

--- a/test/admin-pricing-api.test.ts
+++ b/test/admin-pricing-api.test.ts
@@ -1,0 +1,391 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminPricingNativeRoutes } = await import(
+  "../server/routes/admin-pricing.fastify.ts"
+);
+
+type AdminPricingNativeRoutesOptions = import(
+  "../server/routes/admin-pricing.fastify.ts"
+).AdminPricingNativeRoutesOptions;
+type PricingItem = import("../server/db-pricing.ts").PricingItem;
+
+function createPricingItem(overrides: Record<string, unknown> = {}): PricingItem {
+  return {
+    id: 1,
+    category: "CITOLOGÍAS",
+    studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+    priceLabel: null,
+    displayOrder: 1,
+    isActive: true,
+    updatedAt: "2026-05-15T12:00:00.000Z",
+    ...overrides,
+  } as PricingItem;
+}
+
+function buildDeps(
+  overrides: Partial<AdminPricingNativeRoutesOptions> = {},
+): AdminPricingNativeRoutesOptions {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      id: 90,
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-05-15T11:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({
+      id: 1,
+      username: "VETNEB",
+    }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAdminPricingItems: async () => [],
+    updatePricingItem: async () => null,
+    writeAuditLog: async () => {},
+    now: () => Date.UTC(2026, 4, 15, 12, 0, 0),
+    ...overrides,
+  };
+}
+
+test("admin pricing requiere sesión admin para GET y PATCH", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      getAdminSessionByToken: async () => null,
+    }),
+  );
+
+  try {
+    const getResponse = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(getResponse.statusCode, 401);
+    assert.deepEqual(JSON.parse(getResponse.body), {
+      success: false,
+      error: "Sesión admin inválida",
+    });
+
+    const patchResponse = await app.inject({
+      method: "PATCH",
+      url: "/1",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        isActive: false,
+      },
+    });
+
+    assert.equal(patchResponse.statusCode, 401);
+    assert.deepEqual(JSON.parse(patchResponse.body), {
+      success: false,
+      error: "Sesión admin inválida",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin pricing GET devuelve todos los items agrupados por categoría", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      listAdminPricingItems: async () => [
+        createPricingItem({
+          id: 1,
+          category: "CITOLOGÍAS",
+          studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+          priceLabel: null,
+          displayOrder: 1,
+          isActive: true,
+        }),
+        createPricingItem({
+          id: 2,
+          category: "CITOLOGÍAS",
+          studyName: "REPETICIÓN (DENTRO DE 15 DÍAS)",
+          priceLabel: "A CONSULTAR",
+          displayOrder: 2,
+          isActive: false,
+        }),
+        createPricingItem({
+          id: 8,
+          category: "HISTOPATOLOGÍAS",
+          studyName: "PIEZAS HASTA 10 CM",
+          priceLabel: null,
+          displayOrder: 1,
+          isActive: true,
+        }),
+      ],
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      categories: [
+        {
+          category: "CITOLOGÍAS",
+          items: [
+            {
+              id: 1,
+              studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+              priceLabel: null,
+              displayOrder: 1,
+              isActive: true,
+              updatedAt: "2026-05-15T12:00:00.000Z",
+            },
+            {
+              id: 2,
+              studyName: "REPETICIÓN (DENTRO DE 15 DÍAS)",
+              priceLabel: "A CONSULTAR",
+              displayOrder: 2,
+              isActive: false,
+              updatedAt: "2026-05-15T12:00:00.000Z",
+            },
+          ],
+        },
+        {
+          category: "HISTOPATOLOGÍAS",
+          items: [
+            {
+              id: 8,
+              studyName: "PIEZAS HASTA 10 CM",
+              priceLabel: null,
+              displayOrder: 1,
+              isActive: true,
+              updatedAt: "2026-05-15T12:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin pricing PATCH valida payload y bloquea edición de category/study_name", async () => {
+  const app = Fastify();
+  let updateCalls = 0;
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      listAdminPricingItems: async () => [createPricingItem()],
+      updatePricingItem: async () => {
+        updateCalls += 1;
+        return createPricingItem();
+      },
+    }),
+  );
+
+  try {
+    const commonHeaders = {
+      cookie: `${ENV.adminCookieName}=admin-session-token`,
+    };
+
+    const cases: Array<{ payload: unknown; label: string }> = [
+      { payload: {}, label: "empty body" },
+      { payload: { category: "X" }, label: "category forbidden" },
+      { payload: { studyName: "X" }, label: "studyName forbidden" },
+      { payload: { priceLabel: "x".repeat(81) }, label: "priceLabel too long" },
+      { payload: { isActive: "true" }, label: "isActive invalid type" },
+      { payload: { displayOrder: -1 }, label: "displayOrder negative" },
+    ];
+
+    for (const item of cases) {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/1",
+        headers: commonHeaders,
+        payload: item.payload,
+      });
+
+      assert.equal(response.statusCode, 400, item.label);
+      assert.equal(JSON.parse(response.body).success, false, item.label);
+    }
+
+    assert.equal(updateCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin pricing PATCH devuelve 404 cuando el item no existe", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      listAdminPricingItems: async () => [],
+      updatePricingItem: async () => {
+        throw new Error("no debe intentar update cuando el item no existe");
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/999",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        isActive: false,
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Ítem de precio no encontrado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin pricing PATCH actualiza campos permitidos y responde contrato", async () => {
+  const app = Fastify();
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      listAdminPricingItems: async () => [createPricingItem()],
+      updatePricingItem: async (id, payload) => {
+        updateCalls.push({
+          id,
+          payload,
+        });
+
+        return createPricingItem({
+          id,
+          priceLabel: payload.priceLabel ?? null,
+          isActive: payload.isActive ?? true,
+          displayOrder: payload.displayOrder ?? 1,
+          updatedAt: "2026-05-15T13:00:00.000Z",
+        });
+      },
+      writeAuditLog: async (_req, input) => {
+        auditCalls.push(input as Record<string, unknown>);
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/1",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        priceLabel: null,
+        isActive: false,
+        displayOrder: 7,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      pricingItem: {
+        id: 1,
+        category: "CITOLOGÍAS",
+        studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+        priceLabel: null,
+        displayOrder: 7,
+        isActive: false,
+        updatedAt: "2026-05-15T13:00:00.000Z",
+      },
+    });
+
+    assert.equal(updateCalls.length, 1);
+    assert.equal(updateCalls[0].id, 1);
+    assert.deepEqual(updateCalls[0].payload, {
+      priceLabel: null,
+      isActive: false,
+      displayOrder: 7,
+      now: new Date(Date.UTC(2026, 4, 15, 12, 0, 0)),
+    });
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(updateCalls[0].payload, "category"),
+      false,
+    );
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(updateCalls[0].payload, "studyName"),
+      false,
+    );
+
+    assert.equal(auditCalls.length, 1);
+    assert.equal(auditCalls[0].event, "admin.pricing.update");
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin pricing mantiene error 500 seguro cuando falla persistencia", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      listAdminPricingItems: async () => [createPricingItem()],
+      updatePricingItem: async () => {
+        throw new Error("db unavailable");
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/1",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        isActive: false,
+      },
+    });
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Error interno del servidor",
+    });
+  } finally {
+    await app.close();
+  }
+});

--- a/test/admin-pricing-api.test.ts
+++ b/test/admin-pricing-api.test.ts
@@ -212,7 +212,7 @@ test("admin pricing PATCH valida payload y bloquea edición de category/study_na
       cookie: `${ENV.adminCookieName}=admin-session-token`,
     };
 
-    const cases: Array<{ payload: unknown; label: string }> = [
+    const cases: Array<{ payload: Record<string, unknown>; label: string }> = [
       { payload: {}, label: "empty body" },
       { payload: { category: "X" }, label: "category forbidden" },
       { payload: { studyName: "X" }, label: "studyName forbidden" },

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -13,6 +13,7 @@ test("AUDIT_EVENTS conserva los eventos públicos esperados", () => {
     ADMIN_LOGIN_SUCCEEDED: "auth.admin.login.succeeded",
     CLINIC_LOGIN_SUCCEEDED: "auth.clinic.login.succeeded",
     CLINIC_USER_ROLE_CHANGED: "clinic_user.role.changed",
+    ADMIN_PRICING_UPDATED: "admin.pricing.update",
     REPORT_STATUS_CHANGED: "report.status.changed",
     REPORT_UPLOADED: "report.uploaded",
     STUDY_TRACKING_CASE_CREATED: "study_tracking.case.created",

--- a/test/pricing-migration.test.ts
+++ b/test/pricing-migration.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const migrationPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "0023_pricing_items.sql",
+);
+const journalPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "meta",
+  "_journal.json",
+);
+const schemaPath = resolve(process.cwd(), "drizzle", "schema.ts");
+
+function readText(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const INITIAL_STUDIES = [
+  "UNA LESIÓN (VARIOS VIDRIOS)",
+  "REPETICIÓN (DENTRO DE 15 DÍAS)",
+  "LESIÓN ADICIONAL (SOBRE SU VALOR)",
+  "MÉDULA ÓSEA",
+  "CITOLOGIA VAGINAL (PAP)",
+  "ZIEHL-NEELSEN",
+  "FROTIS CAPILAR",
+  "PIEZAS HASTA 10 CM",
+  "PIEZAS MÁS DE 10 CM",
+  "DERMATOPATOLOGÍA",
+  "LÍNEA MAMARIA COMPLETA",
+  "PIEZAS CON HUESO",
+  "PIEZA ADICIONAL (SOBRE SU VALOR)",
+  "TINCIONES ESPECIALES",
+  "URGENTES (ADICIONAL)",
+] as const;
+
+test("pricing_items migration exists with expected table columns index and seed", () => {
+  assert.ok(existsSync(migrationPath), "missing 0023_pricing_items.sql");
+
+  const source = readText(migrationPath);
+
+  assert.match(source, /CREATE TABLE IF NOT EXISTS "pricing_items"/);
+  assert.match(source, /"category" varchar\(80\) NOT NULL/);
+  assert.match(source, /"study_name" varchar\(160\) NOT NULL/);
+  assert.match(source, /"price_label" varchar\(80\)/);
+  assert.match(source, /"display_order" integer NOT NULL/);
+  assert.match(source, /"is_active" boolean NOT NULL DEFAULT true/);
+  assert.match(source, /"updated_at" timestamp NOT NULL DEFAULT now\(\)/);
+  assert.match(source, /pricing_items_active_category_display_order_idx/);
+
+  assert.match(source, /'CITOLOGÍAS'/);
+  assert.match(source, /'HISTOPATOLOGÍAS'/);
+
+  for (const studyName of INITIAL_STUDIES) {
+    assert.match(
+      source,
+      new RegExp(escapeRegex(`'${studyName}'`)),
+      `migration must include seeded study ${studyName}`,
+    );
+  }
+});
+
+test("pricing_items migration is registered in drizzle journal", () => {
+  const journal = JSON.parse(readText(journalPath)) as {
+    entries?: Array<{ tag?: string }>;
+  };
+  const tags = new Set((journal.entries ?? []).map((entry) => entry.tag));
+
+  assert.ok(tags.has("0023_pricing_items"), "journal missing 0023_pricing_items");
+});
+
+test("drizzle schema keeps pricing_items table contract", () => {
+  const schemaSource = readText(schemaPath);
+
+  assert.match(schemaSource, /pgTable\(\s*"pricing_items"/);
+  assert.match(schemaSource, /studyName:\s+varchar\("study_name"/);
+  assert.match(schemaSource, /priceLabel:\s+varchar\("price_label"/);
+  assert.match(schemaSource, /displayOrder:\s+integer\("display_order"\)/);
+  assert.match(schemaSource, /isActive:\s+boolean\("is_active"\)/);
+});

--- a/test/public-pricing-api.test.ts
+++ b/test/public-pricing-api.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+const { publicPricingNativeRoutes } = await import(
+  "../server/routes/public-pricing.fastify.ts"
+);
+
+type PublicPricingNativeRoutesOptions = import(
+  "../server/routes/public-pricing.fastify.ts"
+).PublicPricingNativeRoutesOptions;
+
+function createPricingItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    category: "CITOLOGÍAS",
+    studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+    priceLabel: null,
+    displayOrder: 1,
+    isActive: true,
+    updatedAt: "2026-05-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function buildDeps(
+  overrides: Partial<PublicPricingNativeRoutesOptions> = {},
+): PublicPricingNativeRoutesOptions {
+  return {
+    listPublicPricingItems: async () => [],
+    ...overrides,
+  };
+}
+
+test("public pricing expone GET /api/public/pricing con contrato agrupado", async () => {
+  const app = Fastify();
+
+  await app.register(
+    publicPricingNativeRoutes,
+    buildDeps({
+      listPublicPricingItems: async () => [
+        createPricingItem({
+          id: 1,
+          category: "CITOLOGÍAS",
+          studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+          priceLabel: null,
+          displayOrder: 1,
+        }),
+        createPricingItem({
+          id: 2,
+          category: "CITOLOGÍAS",
+          studyName: "REPETICIÓN (DENTRO DE 15 DÍAS)",
+          priceLabel: "$ 0",
+          displayOrder: 2,
+        }),
+        createPricingItem({
+          id: 8,
+          category: "HISTOPATOLOGÍAS",
+          studyName: "PIEZAS HASTA 10 CM",
+          priceLabel: null,
+          displayOrder: 1,
+        }),
+      ],
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      categories: [
+        {
+          category: "CITOLOGÍAS",
+          items: [
+            {
+              id: 1,
+              studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+              priceLabel: null,
+              displayOrder: 1,
+            },
+            {
+              id: 2,
+              studyName: "REPETICIÓN (DENTRO DE 15 DÍAS)",
+              priceLabel: "$ 0",
+              displayOrder: 2,
+            },
+          ],
+        },
+        {
+          category: "HISTOPATOLOGÍAS",
+          items: [
+            {
+              id: 8,
+              studyName: "PIEZAS HASTA 10 CM",
+              priceLabel: null,
+              displayOrder: 1,
+            },
+          ],
+        },
+      ],
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("public pricing devuelve categories vacías cuando no hay items activos", async () => {
+  const app = Fastify();
+
+  await app.register(
+    publicPricingNativeRoutes,
+    buildDeps({
+      listPublicPricingItems: async () => [],
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      categories: [],
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("public pricing no usa fallback mock silencioso y responde 500 seguro ante falla DB", async () => {
+  const app = Fastify();
+
+  await app.register(
+    publicPricingNativeRoutes,
+    buildDeps({
+      listPublicPricingItems: async () => {
+        throw new Error("db down");
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Error interno del servidor",
+    });
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary
- Add persistent `pricing_items` storage with the initial VETNEB price-list categories and studies, without inventing prices.
- Add public pricing API and admin pricing API for manual price updates.
- Register pricing routes and admin audit event coverage for pricing updates.

## Validation
- `pnpm test -- test/pricing-migration.test.ts test/public-pricing-api.test.ts test/admin-pricing-api.test.ts`
- `pnpm test` -> 1403 tests pass
- `pnpm build` -> OK
- `pnpm db:migrate` -> OK
- `GET /api/public/pricing` -> 200
- `GET /api/admin/pricing` -> 200
- `PATCH /api/admin/pricing/:id` -> 200
- public pricing reflects updated `priceLabel` after admin PATCH