### PR TITLE
feat(frontend): show public pricing list

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import { PublicLayout } from "@/components/layout/PublicLayout";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";
 import { createPageMetadata, getOrganizationJsonLd, SITE_URL } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -67,8 +68,31 @@ const benefits = [
   },
 ];
 
-export default function HomePage() {
+function normalizePriceLabel(priceLabel: string | null | undefined): string {
+  const normalizedPriceLabel = priceLabel?.trim();
+
+  return normalizedPriceLabel ? normalizedPriceLabel : "Consultar";
+}
+
+function hasPricingItems(categories: PublicPricingCategory[]): boolean {
+  return categories.some((category) => category.items.length > 0);
+}
+
+export default async function HomePage() {
   const jsonLd = getOrganizationJsonLd();
+  let pricingCategories: PublicPricingCategory[] = [];
+  let pricingLoadError = false;
+
+  try {
+    const pricingSnapshot = await getPublicPricing(
+      { cache: "no-store" },
+      { throwOnError: true },
+    );
+
+    pricingCategories = pricingSnapshot.categories;
+  } catch {
+    pricingLoadError = true;
+  }
 
   return (
     <PublicLayout>
@@ -184,6 +208,52 @@ export default function HomePage() {
                 <Link href={ROUTES.servicios}>Ver todos los servicios</Link>
               </Button>
             </div>
+          </div>
+        </section>
+
+        <section className="py-16 md:py-20" aria-labelledby="pricing-heading">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center mb-12">
+              <h2
+                id="pricing-heading"
+                className="text-3xl md:text-4xl font-bold text-gray-950 mb-4"
+              >
+                Lista de precios
+              </h2>
+            </div>
+
+            {pricingLoadError ? (
+              <p role="alert" className="surface-empty text-amber-700">
+                No se pudieron cargar los precios. Intente nuevamente.
+              </p>
+            ) : hasPricingItems(pricingCategories) ? (
+              <div className="space-y-6">
+                {pricingCategories.map((category) => (
+                  <Card key={category.category} className="border-vetneb-line/80">
+                    <CardHeader className="pb-3">
+                      <CardTitle className="text-xl">{category.category}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                      {category.items.map((item) => (
+                        <div
+                          key={item.id}
+                          className="flex flex-col gap-1 rounded-lg border border-slate-100 bg-white/90 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <p className="text-sm font-medium text-gray-900">
+                            {item.studyName}
+                          </p>
+                          <p className="text-sm font-semibold text-vetneb-navy">
+                            {normalizePriceLabel(item.priceLabel)}
+                          </p>
+                        </div>
+                      ))}
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            ) : (
+              <p className="surface-empty">No hay precios disponibles.</p>
+            )}
           </div>
         </section>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -933,6 +933,49 @@ export async function getDashboardStats(
     ).length,
   };
 }
+
+export type PublicPricingItem = {
+  id: number;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+};
+
+export type PublicPricingCategory = {
+  category: string;
+  items: PublicPricingItem[];
+};
+
+export type PublicPricingSnapshot = {
+  success: true;
+  categories: PublicPricingCategory[];
+};
+
+type PublicPricingReadOptions = {
+  throwOnError?: boolean;
+};
+
+export async function getPublicPricing(
+  options?: RequestInit,
+  readOptions: PublicPricingReadOptions = {},
+): Promise<PublicPricingSnapshot> {
+  try {
+    return await apiFetch<PublicPricingSnapshot>(
+      "/api/public/pricing",
+      options,
+    );
+  } catch (error) {
+    if (readOptions.throwOnError ?? true) {
+      throw error;
+    }
+
+    return {
+      success: true,
+      categories: [],
+    };
+  }
+}
+
 export type PublicProfessional = {
   clinicId: number;
   displayName: string;

--- a/test/frontend-home-pricing-list.test.ts
+++ b/test/frontend-home-pricing-list.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("home page requests public pricing from backend API", () => {
+  const source = read(HOME_PAGE_PATH);
+
+  assert.ok(source.includes('import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";'));
+  assert.ok(source.includes("export default async function HomePage()"));
+  assert.ok(source.includes("await getPublicPricing("));
+  assert.ok(source.includes('{ cache: "no-store" }'));
+  assert.ok(source.includes("{ throwOnError: true },"));
+});
+
+test("home page shows public pricing section and normalized label fallback", () => {
+  const source = read(HOME_PAGE_PATH);
+
+  assert.ok(source.includes("Lista de precios"));
+  assert.ok(source.includes("normalizePriceLabel(priceLabel: string | null | undefined): string"));
+  assert.ok(source.includes('return normalizedPriceLabel ? normalizedPriceLabel : "Consultar";'));
+  assert.ok(source.includes("{item.studyName}"));
+  assert.ok(source.includes("{normalizePriceLabel(item.priceLabel)}"));
+});
+
+test("home page distinguishes pricing API error and empty states", () => {
+  const source = read(HOME_PAGE_PATH);
+
+  assert.ok(source.includes("pricingLoadError ?"));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("No se pudieron cargar los precios. Intente nuevamente."));
+  assert.ok(source.includes("No hay precios disponibles."));
+  assert.ok(source.includes("hasPricingItems(pricingCategories)"));
+});

--- a/test/frontend-public-pricing-api.test.ts
+++ b/test/frontend-public-pricing-api.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function extractFunction(source: string, functionName: string): string {
+  const signature = `export async function ${functionName}(`;
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `${functionName} declaration must exist`);
+
+  const nextExport = source.indexOf("\nexport ", start + signature.length);
+  return nextExport === -1 ? source.slice(start) : source.slice(start, nextExport);
+}
+
+test("public pricing API client defines frontend contract types", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export type PublicPricingItem = {"));
+  assert.ok(source.includes("export type PublicPricingCategory = {"));
+  assert.ok(source.includes("export type PublicPricingSnapshot = {"));
+  assert.ok(source.includes("priceLabel: string | null;"));
+  assert.ok(source.includes("categories: PublicPricingCategory[];"));
+});
+
+test("public pricing API client reads the real pricing endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = extractFunction(source, "getPublicPricing");
+
+  assert.ok(functionSource.includes("options?: RequestInit,"));
+  assert.ok(functionSource.includes("readOptions: PublicPricingReadOptions = {},"));
+  assert.ok(functionSource.includes("apiFetch<PublicPricingSnapshot>("));
+  assert.ok(functionSource.includes("\"/api/public/pricing\","));
+});
+
+test("public pricing API client preserves API errors by default", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = extractFunction(source, "getPublicPricing");
+
+  assert.ok(functionSource.includes("if (readOptions.throwOnError ?? true) {"));
+  assert.ok(functionSource.includes("throw error;"));
+  assert.ok(functionSource.includes("categories: [],"));
+});
+
+test("public pricing API client does not use mock pricing fallback", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = extractFunction(source, "getPublicPricing");
+
+  assert.equal(source.includes('from "@/lib/mock-data"'), false);
+  assert.equal(source.includes("MOCK_"), false);
+  assert.equal(functionSource.includes("@/lib/mock-data"), false);
+  assert.equal(functionSource.includes("MOCK_"), false);
+});


### PR DESCRIPTION
## Summary
- Add frontend API client support for public pricing.
- Render the public price list using GET /api/public/pricing.
- Show "Consultar" when priceLabel is empty and explicit error/empty states.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build