### PR TITLE
fix(frontend): move public pricing to dedicated page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,6 @@ import { PublicLayout } from "@/components/layout/PublicLayout";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";
 import { createPageMetadata, getOrganizationJsonLd, SITE_URL } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -68,31 +67,8 @@ const benefits = [
   },
 ];
 
-function normalizePriceLabel(priceLabel: string | null | undefined): string {
-  const normalizedPriceLabel = priceLabel?.trim();
-
-  return normalizedPriceLabel ? normalizedPriceLabel : "Consultar";
-}
-
-function hasPricingItems(categories: PublicPricingCategory[]): boolean {
-  return categories.some((category) => category.items.length > 0);
-}
-
-export default async function HomePage() {
+export default function HomePage() {
   const jsonLd = getOrganizationJsonLd();
-  let pricingCategories: PublicPricingCategory[] = [];
-  let pricingLoadError = false;
-
-  try {
-    const pricingSnapshot = await getPublicPricing(
-      { cache: "no-store" },
-      { throwOnError: true },
-    );
-
-    pricingCategories = pricingSnapshot.categories;
-  } catch {
-    pricingLoadError = true;
-  }
 
   return (
     <PublicLayout>
@@ -208,52 +184,6 @@ export default async function HomePage() {
                 <Link href={ROUTES.servicios}>Ver todos los servicios</Link>
               </Button>
             </div>
-          </div>
-        </section>
-
-        <section className="py-16 md:py-20" aria-labelledby="pricing-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="text-center mb-12">
-              <h2
-                id="pricing-heading"
-                className="text-3xl md:text-4xl font-bold text-gray-950 mb-4"
-              >
-                Lista de precios
-              </h2>
-            </div>
-
-            {pricingLoadError ? (
-              <p role="alert" className="surface-empty text-amber-700">
-                No se pudieron cargar los precios. Intente nuevamente.
-              </p>
-            ) : hasPricingItems(pricingCategories) ? (
-              <div className="space-y-6">
-                {pricingCategories.map((category) => (
-                  <Card key={category.category} className="border-vetneb-line/80">
-                    <CardHeader className="pb-3">
-                      <CardTitle className="text-xl">{category.category}</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-2">
-                      {category.items.map((item) => (
-                        <div
-                          key={item.id}
-                          className="flex flex-col gap-1 rounded-lg border border-slate-100 bg-white/90 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
-                        >
-                          <p className="text-sm font-medium text-gray-900">
-                            {item.studyName}
-                          </p>
-                          <p className="text-sm font-semibold text-vetneb-navy">
-                            {normalizePriceLabel(item.priceLabel)}
-                          </p>
-                        </div>
-                      ))}
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            ) : (
-              <p className="surface-empty">No hay precios disponibles.</p>
-            )}
           </div>
         </section>
 

--- a/frontend/src/app/precios/page.tsx
+++ b/frontend/src/app/precios/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+
+import { PublicLayout } from "@/components/layout/PublicLayout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";
+import { createPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata(
+  "Lista de precios",
+  "Listado público de estudios de citologías e histopatologías con sus valores de referencia y estado vigente.",
+  "/precios",
+);
+
+const CATEGORY_PRIORITY = new Map<string, number>([
+  ["CITOLOGÍAS", 0],
+  ["HISTOPATOLOGÍAS", 1],
+]);
+
+function normalizePriceLabel(priceLabel: string | null | undefined): string {
+  const normalizedPriceLabel = priceLabel?.trim();
+
+  return normalizedPriceLabel ? normalizedPriceLabel : "Consultar";
+}
+
+function hasPricingItems(categories: PublicPricingCategory[]): boolean {
+  return categories.some((category) => category.items.length > 0);
+}
+
+function sortPricingCategories(
+  categories: PublicPricingCategory[],
+): PublicPricingCategory[] {
+  return categories
+    .map((category, index) => ({ category, index }))
+    .sort((a, b) => {
+      const aPriority = CATEGORY_PRIORITY.get(a.category.category);
+      const bPriority = CATEGORY_PRIORITY.get(b.category.category);
+
+      if (aPriority !== undefined && bPriority !== undefined) {
+        return aPriority - bPriority;
+      }
+
+      if (aPriority !== undefined) {
+        return -1;
+      }
+
+      if (bPriority !== undefined) {
+        return 1;
+      }
+
+      return a.index - b.index;
+    })
+    .map((entry) => entry.category);
+}
+
+export default async function PreciosPage() {
+  let pricingCategories: PublicPricingCategory[] = [];
+  let pricingLoadError = false;
+
+  try {
+    const pricingSnapshot = await getPublicPricing(
+      { cache: "no-store" },
+      { throwOnError: true },
+    );
+
+    pricingCategories = sortPricingCategories(pricingSnapshot.categories);
+  } catch {
+    pricingLoadError = true;
+  }
+
+  return (
+    <PublicLayout>
+      <section className="public-soft-canvas py-16 md:py-20" aria-labelledby="pricing-page-title">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-10 text-center">
+            <h1
+              id="pricing-page-title"
+              className="text-3xl font-bold text-vetneb-ink md:text-4xl"
+            >
+              Lista de precios
+            </h1>
+          </div>
+
+          {pricingLoadError ? (
+            <p role="alert" className="surface-empty text-amber-700">
+              No se pudieron cargar los precios. Intente nuevamente.
+            </p>
+          ) : hasPricingItems(pricingCategories) ? (
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {pricingCategories.map((category) => (
+                <Card
+                  key={category.category}
+                  className="border-vetneb-line bg-vetneb-surface-raised/80"
+                >
+                  <CardHeader className="border-b border-vetneb-line bg-primary py-4 text-center">
+                    <CardTitle className="text-center text-lg font-semibold text-primary-foreground">
+                      {category.category}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-0 p-0">
+                    {category.items.map((item, index) => (
+                      <div
+                        key={item.id}
+                        className={`flex items-start justify-between gap-4 px-4 py-3 ${
+                          index < category.items.length - 1
+                            ? "border-b border-vetneb-line/70"
+                            : ""
+                        }`}
+                      >
+                        <p className="text-sm font-medium text-vetneb-ink">
+                          {item.studyName}
+                        </p>
+                        <p className="shrink-0 text-sm font-semibold text-vetneb-ink">
+                          {normalizePriceLabel(item.priceLabel)}
+                        </p>
+                      </div>
+                    ))}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <p className="surface-empty">No hay precios disponibles.</p>
+          )}
+        </div>
+      </section>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -10,6 +10,7 @@ const navLinks = [
   { label: "Clínicas", href: ROUTES.clinicas },
   { label: "Particulares", href: ROUTES.particulares },
   { label: "Contacto", href: ROUTES.contacto },
+  { label: "Precios", href: ROUTES.precios },
 ];
 
 export function Navbar() {

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   clinicas: "/clinicas",
   particulares: "/particulares",
   contacto: "/contacto",
+  precios: "/precios",
   login: "/login",
 
   // Dashboard (privado)
@@ -33,6 +34,7 @@ export const PUBLIC_ROUTES: AppRoute[] = [
   ROUTES.clinicas,
   ROUTES.particulares,
   ROUTES.contacto,
+  ROUTES.precios,
   ROUTES.login,
 ];
 

--- a/test/frontend-home-pricing-list.test.ts
+++ b/test/frontend-home-pricing-list.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+const PRECIOS_PAGE_PATH = "frontend/src/app/precios/page.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -12,32 +13,37 @@ function read(relativePath: string): string {
   );
 }
 
-test("home page requests public pricing from backend API", () => {
+test("home page no longer renders public pricing section", () => {
   const source = read(HOME_PAGE_PATH);
 
-  assert.ok(source.includes('import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";'));
-  assert.ok(source.includes("export default async function HomePage()"));
+  assert.equal(source.includes("Lista de precios"), false);
+  assert.equal(source.includes("getPublicPricing("), false);
+  assert.equal(
+    source.includes("No se pudieron cargar los precios. Intente nuevamente."),
+    false,
+  );
+  assert.equal(source.includes("No hay precios disponibles."), false);
+  assert.equal(source.includes("normalizePriceLabel("), false);
+});
+
+test("precios page requests public pricing from backend API", () => {
+  const source = read(PRECIOS_PAGE_PATH);
+
+  assert.ok(source.includes("export default async function PreciosPage()"));
   assert.ok(source.includes("await getPublicPricing("));
   assert.ok(source.includes('{ cache: "no-store" }'));
   assert.ok(source.includes("{ throwOnError: true },"));
 });
 
-test("home page shows public pricing section and normalized label fallback", () => {
-  const source = read(HOME_PAGE_PATH);
+test("precios page keeps public pricing states and fallback label", () => {
+  const source = read(PRECIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Lista de precios"));
-  assert.ok(source.includes("normalizePriceLabel(priceLabel: string | null | undefined): string"));
+  assert.ok(source.includes("function normalizePriceLabel(priceLabel: string | null | undefined): string"));
   assert.ok(source.includes('return normalizedPriceLabel ? normalizedPriceLabel : "Consultar";'));
-  assert.ok(source.includes("{item.studyName}"));
+  assert.ok(source.includes("Lista de precios"));
   assert.ok(source.includes("{normalizePriceLabel(item.priceLabel)}"));
-});
-
-test("home page distinguishes pricing API error and empty states", () => {
-  const source = read(HOME_PAGE_PATH);
-
-  assert.ok(source.includes("pricingLoadError ?"));
-  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("{item.studyName}"));
   assert.ok(source.includes("No se pudieron cargar los precios. Intente nuevamente."));
   assert.ok(source.includes("No hay precios disponibles."));
-  assert.ok(source.includes("hasPricingItems(pricingCategories)"));
+  assert.ok(source.includes('role="alert"'));
 });

--- a/test/frontend-precios-page-content.test.ts
+++ b/test/frontend-precios-page-content.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PRECIOS_PAGE_PATH = "frontend/src/app/precios/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("precios page defines public metadata and layout", () => {
+  const source = read(PRECIOS_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
+  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
+  assert.ok(source.includes('"Lista de precios"'));
+  assert.ok(source.includes('"/precios"'));
+  assert.ok(source.includes("<PublicLayout>"));
+});
+
+test("precios page keeps category priority with citologías then histopatologías", () => {
+  const source = read(PRECIOS_PAGE_PATH);
+  const citologiasIndex = source.indexOf('"CITOLOGÍAS"');
+  const histopatologiasIndex = source.indexOf('"HISTOPATOLOGÍAS"');
+
+  assert.ok(source.includes("const CATEGORY_PRIORITY = new Map<string, number>(["));
+  assert.ok(citologiasIndex !== -1);
+  assert.ok(histopatologiasIndex !== -1);
+  assert.ok(citologiasIndex < histopatologiasIndex);
+  assert.ok(source.includes("function sortPricingCategories("));
+});
+
+test("precios page renders responsive side-by-side category cards", () => {
+  const source = read(PRECIOS_PAGE_PATH);
+
+  assert.ok(source.includes("grid grid-cols-1 gap-6 lg:grid-cols-2"));
+  assert.ok(source.includes("border-vetneb-line bg-vetneb-surface-raised/80"));
+  assert.ok(source.includes("bg-primary py-4 text-center"));
+  assert.ok(source.includes("text-center text-lg font-semibold text-primary-foreground"));
+  assert.ok(source.includes("flex items-start justify-between gap-4"));
+  assert.ok(source.includes("text-sm font-medium text-vetneb-ink"));
+  assert.ok(source.includes("text-sm font-semibold text-vetneb-ink"));
+});
+
+test("precios page preserves fallback labels and error/empty states", () => {
+  const source = read(PRECIOS_PAGE_PATH);
+
+  assert.ok(source.includes("return normalizedPriceLabel ? normalizedPriceLabel : \"Consultar\";"));
+  assert.ok(source.includes("No se pudieron cargar los precios. Intente nuevamente."));
+  assert.ok(source.includes("No hay precios disponibles."));
+  assert.ok(source.includes("hasPricingItems(pricingCategories)"));
+  assert.ok(source.includes('role="alert"'));
+});

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -35,8 +35,27 @@ test("navbar uses centralized public routes for primary navigation", () => {
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
   assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
+  assert.ok(source.includes('{ label: "Particulares", href: ROUTES.particulares }'));
   assert.ok(source.includes('{ label: "Contacto", href: ROUTES.contacto }'));
+  assert.ok(source.includes('{ label: "Precios", href: ROUTES.precios }'));
   assert.ok(source.includes('aria-label="Navegación principal"'));
+});
+
+test("navbar keeps expected public link order including precios", () => {
+  const source = read(NAVBAR_PATH);
+
+  const serviciosIndex = source.indexOf('{ label: "Servicios", href: ROUTES.servicios }');
+  const profesionalesIndex = source.indexOf('{ label: "Profesionales", href: ROUTES.profesionales }');
+  const clinicasIndex = source.indexOf('{ label: "Clínicas", href: ROUTES.clinicas }');
+  const particularesIndex = source.indexOf('{ label: "Particulares", href: ROUTES.particulares }');
+  const contactoIndex = source.indexOf('{ label: "Contacto", href: ROUTES.contacto }');
+  const preciosIndex = source.indexOf('{ label: "Precios", href: ROUTES.precios }');
+
+  assert.ok(serviciosIndex < profesionalesIndex);
+  assert.ok(profesionalesIndex < clinicasIndex);
+  assert.ok(clinicasIndex < particularesIndex);
+  assert.ok(particularesIndex < contactoIndex);
+  assert.ok(contactoIndex < preciosIndex);
 });
 
 test("navbar exposes home login and access CTAs with VETNEB brand", () => {
@@ -81,4 +100,3 @@ test("footer exposes access links and legal copy without redundant brand block",
   assert.equal(source.includes("Laboratorio veterinario digital. Informes, estudios y gestión"), false);
   assert.equal(source.includes("rounded-md bg-primary px-3"), false);
 });
-

--- a/test/frontend-route-registry.test.ts
+++ b/test/frontend-route-registry.test.ts
@@ -20,7 +20,9 @@ test("frontend route registry defines public routes centrally", () => {
   assert.ok(source.includes('servicios: "/servicios",'));
   assert.ok(source.includes('profesionales: "/profesionales",'));
   assert.ok(source.includes('clinicas: "/clinicas",'));
+  assert.ok(source.includes('particulares: "/particulares",'));
   assert.ok(source.includes('contacto: "/contacto",'));
+  assert.ok(source.includes('precios: "/precios",'));
   assert.ok(source.includes('login: "/login",'));
   assert.ok(source.includes("} as const;"));
   assert.ok(source.includes("export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];"));
@@ -34,7 +36,9 @@ test("frontend route registry keeps public route allowlist explicit", () => {
   assert.ok(source.includes("ROUTES.servicios,"));
   assert.ok(source.includes("ROUTES.profesionales,"));
   assert.ok(source.includes("ROUTES.clinicas,"));
+  assert.ok(source.includes("ROUTES.particulares,"));
   assert.ok(source.includes("ROUTES.contacto,"));
+  assert.ok(source.includes("ROUTES.precios,"));
   assert.ok(source.includes("ROUTES.login,"));
 });
 


### PR DESCRIPTION
## Summary
- Move the public pricing list from Home to a dedicated /precios page.
- Add the Precios route to public routes and the main navbar.
- Render pricing categories in side-by-side cards with Citologías left and Histopatologías right, using existing visual styles.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
