### PR TITLE
fix(frontend): add admin pricing sidebar link

### DIFF
--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -1,8 +1,8 @@
 import {
   Activity,
   ClipboardPlus,
-  FileText,
   KeyRound,
+  ReceiptText,
   ScrollText,
   Settings2,
   ShieldCheck,
@@ -38,6 +38,11 @@ const adminNavItems: DashboardNavItem[] = [
     icon: TicketCheck,
   },
   {
+    label: "Precios",
+    href: `${ROUTES.dashboardAdmin}#admin-pricing`,
+    icon: ReceiptText,
+  },
+  {
     label: "Sesiones",
     href: `${ROUTES.dashboardAdmin}#admin-sessions`,
     icon: KeyRound,
@@ -67,6 +72,3 @@ export function AdminDashboardSidebar() {
     />
   );
 }
-
-
-

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -87,17 +87,16 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.ok(source.includes('label: "Administración"'));
   assert.ok(source.includes('label: "Subir informe"'));
   assert.ok(source.includes('label: "Estado"'));
-  assert.ok(source.includes('label: "Sesiones"'));
   assert.ok(source.includes('label: "Tokens particulares"'));
+  assert.ok(source.includes('label: "Precios"'));
+  assert.ok(source.includes('label: "Sesiones"'));
   assert.ok(source.includes('label: "Roles clínica"'));
   assert.ok(source.includes('label: "Auditoría"'));
   assert.ok(source.includes('label: "Mantenimiento"'));
   assert.ok(source.includes("ROUTES.dashboardAdmin"));
+  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}#admin-pricing`'));
   assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}#admin-users-roles`'));
   assert.equal(source.includes('href: `${ROUTES.dashboardAdmin}#audit-role-changes`'), false);
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);
 });
-
-
-


### PR DESCRIPTION
## Summary
- Add a Precios item to the admin dashboard sidebar.
- Link the sidebar item to the existing #admin-pricing section.

## Validation
- pnpm test -- test/frontend-dashboard-shell.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build