### PR TITLE
style(frontend): standardize clinical feedback states

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -225,7 +225,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
         </div>
 
         {error ? (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="clinical-alert-error">
             {error}
           </div>
         ) : null}
@@ -278,7 +278,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
                 <TableRow>
                   <TableCell
                     colSpan={7}
-                    className="py-8 text-center text-sm text-gray-400"
+                    className="clinical-table-state"
                   >
                     {isPending
                       ? "Cargando intentos fallidos..."

--- a/frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx
@@ -122,7 +122,7 @@ export function AdminMaintenanceDryRunCard() {
 
       <CardContent className="space-y-4">
         {error ? (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="clinical-alert-error">
             {error}
           </div>
         ) : null}

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -480,7 +480,7 @@ export function AdminParticularTokensCard() {
 
           {errorMessage ? (
             <p
-              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              className="clinical-alert-error px-3 py-2"
               role="alert"
             >
               {errorMessage}
@@ -488,7 +488,7 @@ export function AdminParticularTokensCard() {
           ) : null}
 
           {statusMessage ? (
-            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+            <p className="clinical-alert-success px-3 py-2">
               {statusMessage}
             </p>
           ) : null}

--- a/frontend/src/app/dashboard/admin/AdminPricingEditorCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminPricingEditorCard.tsx
@@ -326,7 +326,7 @@ export function AdminPricingEditorCard() {
         {loadError ? (
           <p
             role="alert"
-            className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+            className="clinical-alert-warning"
           >
             {LOAD_ERROR_MESSAGE}
           </p>
@@ -474,13 +474,13 @@ export function AdminPricingEditorCard() {
                         <div className="mt-4 flex flex-col gap-3 border-t border-vetneb-line pt-4 sm:flex-row sm:items-center sm:justify-between">
                           <div className="min-h-5">
                             {formState.errorMessage ? (
-                              <p className="text-sm text-red-700" role="alert">
+                              <p className="clinical-alert-error px-3 py-2" role="alert">
                                 {formState.errorMessage}
                               </p>
                             ) : null}
 
                             {formState.statusMessage ? (
-                              <p className="text-sm text-green-700">
+                              <p className="clinical-alert-success px-3 py-2">
                                 {formState.statusMessage}
                               </p>
                             ) : null}

--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -215,7 +215,7 @@ export function AdminSessionsReadOnlyCard() {
         </div>
 
         {error ? (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="clinical-alert-error">
             {error}
           </div>
         ) : null}
@@ -287,7 +287,7 @@ export function AdminSessionsReadOnlyCard() {
                 <TableRow>
                   <TableCell
                     colSpan={7}
-                    className="py-8 text-center text-sm text-gray-400"
+                    className="clinical-table-state"
                   >
                     {isPending
                       ? "Cargando sesiones..."

--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -284,13 +284,13 @@ export function AdminUsersRolesReadOnlyCard() {
         </div>
 
         {error ? (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="clinical-alert-error">
             {error}
           </div>
         ) : null}
 
         {roleChangeMessage ? (
-          <div className="rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          <div className="clinical-alert-success">
             {roleChangeMessage}
           </div>
         ) : null}
@@ -318,7 +318,7 @@ export function AdminUsersRolesReadOnlyCard() {
                   return (
                     <TableRow
                       key={userKey}
-                      className={wasChanged ? "bg-green-50/60" : undefined}
+                      className={wasChanged ? "bg-vetneb-teal/10" : undefined}
                     >
                       <TableCell>
                         <div className="flex flex-col gap-1">
@@ -329,7 +329,7 @@ export function AdminUsersRolesReadOnlyCard() {
                             #{user.userId}
                           </span>
                           {wasChanged ? (
-                            <span className="text-xs font-medium text-green-700">
+                            <span className="text-xs font-medium text-vetneb-teal">
                               Actualizado
                             </span>
                           ) : null}
@@ -379,7 +379,7 @@ export function AdminUsersRolesReadOnlyCard() {
                 <TableRow>
                   <TableCell
                     colSpan={7}
-                    className="py-8 text-center text-sm text-gray-400"
+                    className="clinical-table-state"
                   >
                     {isPending
                       ? "Cargando usuarios y roles..."

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -399,7 +399,7 @@ export default async function AdminPage({
             {hasSystemHealthFetchError ? (
               <div
                 role="alert"
-                className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+                className="mb-4 clinical-alert-warning"
               >
                 No se pudo consultar el estado del sistema. Los valores de salud
                 operacional se muestran como desconocidos hasta recuperar la lectura.
@@ -581,7 +581,7 @@ export default async function AdminPage({
                     <TableCell
                       colSpan={7}
                       role="alert"
-                      className="py-8 text-center text-sm text-amber-700"
+                      className="clinical-table-state clinical-alert-warning"
                     >
                       No se pudieron cargar los eventos de auditoría. Intente nuevamente.
                     </TableCell>
@@ -620,7 +620,7 @@ export default async function AdminPage({
                   <TableRow>
                     <TableCell
                       colSpan={7}
-                      className="py-8 text-center text-sm text-gray-400"
+                      className="clinical-table-state"
                     >
                       {hasActiveAuditFilters
                         ? "No hay eventos para los filtros seleccionados."

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -174,7 +174,7 @@ export default async function InformesPage({
                     <TableCell
                       colSpan={7}
                       role="alert"
-                      className="px-6 py-10 text-center text-sm text-amber-700"
+                      className="clinical-table-state clinical-alert-warning"
                     >
                       No se pudieron cargar los informes. Intente nuevamente.
                     </TableCell>
@@ -214,7 +214,7 @@ export default async function InformesPage({
                   <TableRow>
                     <TableCell
                       colSpan={7}
-                      className="px-6 py-10 text-center text-sm text-gray-500"
+                      className="clinical-table-state"
                     >
                       No hay informes disponibles.
                     </TableCell>

--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -153,11 +153,11 @@ export default async function MetricasPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             {routePlansLoadError ? (
-              <div role="alert" className="surface-empty text-amber-700">
+              <div role="alert" className="clinical-alert-warning">
                 No se pudieron cargar los planes de ruta para métricas. Intente nuevamente.
               </div>
             ) : routeMetricsLoadError ? (
-              <div role="alert" className="surface-empty text-amber-700">
+              <div role="alert" className="clinical-alert-warning">
                 No se pudieron cargar las métricas de ruta. Intente nuevamente.
               </div>
             ) : routeMetrics.length ? (

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -171,7 +171,7 @@ export default async function LogisticaPage() {
           </CardHeader>
           <CardContent className="space-y-3">
             {fieldVisitsLoadError ? (
-              <p role="alert" className="surface-empty text-amber-700">
+              <p role="alert" className="clinical-alert-warning">
                 No se pudieron cargar las visitas recientes. Intente nuevamente.
               </p>
             ) : fieldVisits.length ? (
@@ -214,7 +214,7 @@ export default async function LogisticaPage() {
           </CardHeader>
           <CardContent className="space-y-3">
             {routePlansLoadError ? (
-              <p role="alert" className="surface-empty text-amber-700">
+              <p role="alert" className="clinical-alert-warning">
                 No se pudieron cargar los planes de ruta recientes. Intente nuevamente.
               </p>
             ) : routePlans.length ? (

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -96,7 +96,7 @@ export default async function RutasPage() {
                     <TableCell
                       colSpan={6}
                       role="alert"
-                      className="px-6 py-10 text-center text-sm text-amber-700"
+                      className="clinical-table-state clinical-alert-warning"
                     >
                       No se pudieron cargar los planes de ruta. Intente nuevamente.
                     </TableCell>
@@ -152,7 +152,7 @@ export default async function RutasPage() {
                   <TableRow>
                     <TableCell
                       colSpan={6}
-                      className="px-6 py-10 text-center text-sm text-gray-500"
+                      className="clinical-table-state"
                     >
                       No hay planes de ruta disponibles.
                     </TableCell>

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -98,7 +98,7 @@ export default async function VisitasPage() {
                     <TableCell
                       colSpan={7}
                       role="alert"
-                      className="px-6 py-10 text-center text-sm text-amber-700"
+                      className="clinical-table-state clinical-alert-warning"
                     >
                       No se pudieron cargar las visitas de campo. Intente nuevamente.
                     </TableCell>
@@ -137,7 +137,7 @@ export default async function VisitasPage() {
                   <TableRow>
                     <TableCell
                       colSpan={7}
-                      className="px-6 py-10 text-center text-sm text-gray-500"
+                      className="clinical-table-state"
                     >
                       No hay visitas de campo disponibles.
                     </TableCell>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -121,7 +121,7 @@ export default async function DashboardPage() {
             Vista rápida de informes, pendientes y actividad logística del día.
           </p>
           {statsLoadError ? (
-            <p role="alert" className="mt-3 surface-empty text-amber-700">
+            <p role="alert" className="mt-3 clinical-alert-warning">
               No se pudieron cargar las métricas operativas. Intente nuevamente.
             </p>
           ) : null}
@@ -145,7 +145,7 @@ export default async function DashboardPage() {
             </CardHeader>
             <CardContent className="space-y-1.5">
               {reportsLoadError ? (
-                <p role="alert" className="surface-empty text-amber-700">
+                <p role="alert" className="clinical-alert-warning">
                   No se pudieron cargar los informes recientes. Intente nuevamente.
                 </p>
               ) : recentReports.length ? (
@@ -192,7 +192,7 @@ export default async function DashboardPage() {
             </CardHeader>
             <CardContent className="space-y-1.5">
               {visitsLoadError ? (
-                <p role="alert" className="surface-empty text-amber-700">
+                <p role="alert" className="clinical-alert-warning">
                   No se pudieron cargar las visitas de campo recientes. Intente nuevamente.
                 </p>
               ) : recentVisits.length ? (

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -211,6 +211,22 @@
     @apply px-6 py-10 text-center text-sm text-muted-foreground;
   }
 
+  .clinical-table-state.clinical-alert-error {
+    @apply text-destructive;
+  }
+
+  .clinical-table-state.clinical-alert-success {
+    @apply text-vetneb-teal;
+  }
+
+  .clinical-table-state.clinical-alert-warning {
+    @apply text-amber-800;
+  }
+
+  .clinical-table-state.clinical-alert-info {
+    @apply text-vetneb-navy;
+  }
+
   .dashboard-metric-card {
     @apply rounded-lg border border-vetneb-line/80 bg-card/95 p-4 shadow-[0_12px_34px_rgba(15,45,62,0.08)];
   }

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -448,7 +448,7 @@ export function ClinicParticularTokensCard() {
 
           {errorMessage ? (
             <p
-              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              className="clinical-alert-error px-3 py-2"
               role="alert"
             >
               {errorMessage}
@@ -456,7 +456,7 @@ export function ClinicParticularTokensCard() {
           ) : null}
 
           {statusMessage ? (
-            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+            <p className="clinical-alert-success px-3 py-2">
               {statusMessage}
             </p>
           ) : null}

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -362,21 +362,21 @@ export function ClinicPublicProfileCard() {
           </label>
 
           {missingRequiredFields.length ? (
-            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            <div className="clinical-alert-warning px-3 py-2">
               <p className="font-semibold">Campos obligatorios pendientes:</p>
               <p>{missingRequiredFields.map(getFieldLabel).join(", ")}</p>
             </div>
           ) : null}
 
           {missingRecommendedFields.length ? (
-            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+            <div className="clinical-alert-info px-3 py-2">
               <p className="font-semibold">Recomendados para mejorar calidad:</p>
               <p>{missingRecommendedFields.map(getFieldLabel).join(", ")}</p>
             </div>
           ) : null}
 
           {publicationErrors.length ? (
-            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            <div className="clinical-alert-error px-3 py-2">
               {publicationErrors.map((error) => (
                 <p key={error}>{error}</p>
               ))}
@@ -385,7 +385,7 @@ export function ClinicPublicProfileCard() {
 
           {errorMessage ? (
             <p
-              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              className="clinical-alert-error px-3 py-2"
               role="alert"
             >
               {errorMessage}
@@ -393,7 +393,7 @@ export function ClinicPublicProfileCard() {
           ) : null}
 
           {statusMessage ? (
-            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+            <p className="clinical-alert-success px-3 py-2">
               {statusMessage}
             </p>
           ) : null}

--- a/frontend/src/components/dashboard/UploadReportModal.tsx
+++ b/frontend/src/components/dashboard/UploadReportModal.tsx
@@ -490,7 +490,7 @@ export function UploadReportModal() {
 
             {clinicLoadError ? (
               <p
-                className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                className="mt-2 clinical-alert-error px-3 py-2"
                 role="alert"
               >
                 {clinicLoadError}
@@ -503,13 +503,13 @@ export function UploadReportModal() {
               aria-label="Clínicas registradas"
             >
               {isLoadingClinics ? (
-                <p className="px-3 py-2 text-sm text-gray-500">
+                <p className="surface-empty m-2 py-3">
                   Cargando clínicas registradas...
                 </p>
               ) : null}
 
               {!isLoadingClinics && filteredClinicOptions.length === 0 ? (
-                <p className="px-3 py-2 text-sm text-gray-500">
+                <p className="surface-empty m-2 py-3">
                   No hay clínicas registradas que coincidan con la búsqueda.
                 </p>
               ) : null}
@@ -578,14 +578,14 @@ export function UploadReportModal() {
             </p>
 
             {isLoadingParticularTokens ? (
-              <p className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-gray-500">
+              <p className="mt-2 surface-empty py-3">
                 Cargando tokens particulares...
               </p>
             ) : null}
 
             {particularTokenLoadError ? (
               <p
-                className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                className="mt-2 clinical-alert-error px-3 py-2"
                 role="alert"
               >
                 {particularTokenLoadError}
@@ -596,7 +596,7 @@ export function UploadReportModal() {
             !isLoadingParticularTokens &&
             !particularTokenLoadError &&
             particularTokens.length === 0 ? (
-              <p className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+              <p className="mt-2 clinical-alert-warning px-3 py-2">
                 Esta clínica no tiene tokens particulares disponibles.
               </p>
             ) : null}
@@ -687,7 +687,7 @@ export function UploadReportModal() {
 
           {errorMessage ? (
             <p
-              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              className="clinical-alert-error px-3 py-2"
               role="alert"
             >
               {errorMessage}
@@ -695,7 +695,7 @@ export function UploadReportModal() {
           ) : null}
 
           {successMessage ? (
-            <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+            <p className="clinical-alert-success px-3 py-2">
               {successMessage}
             </p>
           ) : null}

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -237,7 +237,7 @@ export function ContactoContent() {
 
                 {errorMessage ? (
                   <p
-                    className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2"
+                    className="clinical-alert-error px-3 py-2"
                     role="alert"
                   >
                     {errorMessage}
@@ -245,7 +245,7 @@ export function ContactoContent() {
                 ) : null}
 
                 {successMessage ? (
-                  <p className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-md px-3 py-2">
+                  <p className="clinical-alert-success px-3 py-2">
                     {successMessage}
                   </p>
                 ) : null}

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -346,7 +346,7 @@ export function ParticularesContent() {
                       </div>
                     </div>
                   ) : (
-                    <div className="rounded-lg border border-vetneb-amber/35 bg-vetneb-amber/10 p-4 text-sm text-amber-900 shadow-sm">
+                    <div className="clinical-alert-warning p-4">
                       El caso todavía no tiene un informe vinculado. El estudio
                       continúa en evaluación profesional y se habilitará cuando
                       finalice la validación diagnóstica.
@@ -355,7 +355,7 @@ export function ParticularesContent() {
 
                   {errorMessage ? (
                     <p
-                      className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                      className="clinical-alert-error px-3 py-2"
                       role="alert"
                     >
                       {errorMessage}
@@ -404,7 +404,7 @@ export function ParticularesContent() {
 
                   {errorMessage ? (
                     <p
-                      className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                      className="clinical-alert-error px-3 py-2"
                       role="alert"
                     >
                       {errorMessage}

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -166,26 +166,26 @@ export function ProfesionalesSearchContent() {
 
             <div className="mt-8" aria-live="polite">
               {!currentQuery ? (
-                <div className="premium-card-muted p-6 text-sm text-gray-500">
+                <div className="surface-empty p-6">
                   Realice una búsqueda para consultar el banco público y
                   coordinar contacto profesional.
                 </div>
               ) : null}
 
               {state.status === "loading" ? (
-                <div className="clinical-muted-band rounded-lg p-6 text-sm text-vetneb-navy shadow-sm">
+                <div className="clinical-alert-info p-6">
                   Buscando profesionales vinculados a VETNEB...
                 </div>
               ) : null}
 
               {state.status === "error" ? (
-                <div className="rounded-2xl border border-red-100 bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+                <div className="clinical-alert-error p-6">
                   No se pudo realizar la búsqueda. Intente nuevamente.
                 </div>
               ) : null}
 
               {state.status === "success" && state.professionals.length === 0 ? (
-                <div className="premium-card-muted p-6 text-sm text-gray-500">
+                <div className="surface-empty p-6">
                   No se encontraron profesionales para “{currentQuery}”. Revise
                   la ortografía o pruebe otro dato de búsqueda.
                 </div>

--- a/test/frontend-admin-users-roles-card.test.ts
+++ b/test/frontend-admin-users-roles-card.test.ts
@@ -168,7 +168,7 @@ test("admin users roles card renders rows editable clinic actions and admin non-
   assert.ok(source.includes("const userKey = getUserKey(user);"));
   assert.ok(source.includes("const isChanging = changingUserKey === userKey;"));
   assert.ok(source.includes("const wasChanged = changedUserKey === userKey;"));
-  assert.ok(source.includes('className={wasChanged ? "bg-green-50/60" : undefined}'));
+  assert.ok(source.includes('className={wasChanged ? "bg-vetneb-teal/10" : undefined}'));
   assert.ok(source.includes("{user.username}"));
   assert.ok(source.includes("#{user.userId}"));
   assert.ok(source.includes("Actualizado"));


### PR DESCRIPTION
## Summary
- Standardizes visual feedback states across public, dashboard, and admin surfaces using clinical alert and table-state utilities.
- Replaces repeated red/green/amber state class clusters with `clinical-alert-*`, `surface-empty`, and `clinical-table-state` where the change is purely visual.
- Preserves existing text, roles, aria behavior, handlers, fetch logic, and API contracts.

## Validation
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`
- `pnpm -C frontend build`