### PR TITLE
style(public): simplify home hero brand composition

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -97,18 +97,13 @@ export default function HomePage() {
           aria-hidden="true"
         />
         <div className="relative container mx-auto flex min-h-[calc(100vh-4.5rem)] items-center px-4 py-16 sm:px-6 lg:px-8">
-          <div className="grid w-full items-center gap-10 lg:grid-cols-[1.08fr_0.92fr]">
-            <div className="max-w-3xl">
-              <h1
+          <div className="grid w-full items-center gap-10">
+            <div className="max-w-5xl">
+                            <h1
                 id="hero-heading"
-                className="mt-2 text-5xl font-semibold leading-[0.94] text-white sm:text-6xl lg:text-6xl"
+                className="mt-2 max-w-none text-[clamp(1.85rem,4.6vw,3.75rem)] font-bold uppercase leading-[0.94] tracking-[0.045em] text-primary-foreground"
               >
-                <span className="block text-[0.58em] tracking-[0.10em] text-primary-foreground/92">
-                  SERVICIO PATOLÓGICO
-                </span>
-                <span className="mt-2 block border-t border-white/35 pt-2 font-bold tracking-[0.14em] text-primary-foreground">
-                  VETNEB
-                </span>
+                SERVICIO PATOLÓGICO VETNEB
               </h1>
               <p className="mt-6 max-w-2xl text-xl font-medium leading-tight text-primary-foreground/94 md:text-2xl lg:text-3xl">
                 Diagnóstico patológico veterinario con criterio clínico y
@@ -160,42 +155,6 @@ export default function HomePage() {
               </div>
             </div>
 
-            <div className="premium-card p-6">
-              <h2 className="text-base font-semibold text-vetneb-ink sm:text-lg">
-                Superficies clínicas orientadas a confianza operativa
-              </h2>
-              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                Diseñadas para sostener decisiones diagnósticas con mayor
-                claridad comercial y continuidad entre laboratorio, clínica y
-                tutor.
-              </p>
-              <div className="mt-5 grid grid-cols-1 gap-2.5">
-                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                  <p className="clinical-pill px-2 py-0.5 text-[0.65rem] tracking-[0.07em]">
-                    Trazabilidad
-                  </p>
-                  <p className="mt-1.5 text-xs text-vetneb-ink">
-                    Seguimiento de estudios e informes durante todo el circuito.
-                  </p>
-                </div>
-                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                  <p className="clinical-pill px-2 py-0.5 text-[0.65rem] tracking-[0.07em]">
-                    Integración
-                  </p>
-                  <p className="mt-1.5 text-xs text-vetneb-ink">
-                    Coordinación clínica y apoyo técnico en decisiones de caso.
-                  </p>
-                </div>
-                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                  <p className="clinical-pill px-2 py-0.5 text-[0.65rem] tracking-[0.07em]">
-                    Disponibilidad
-                  </p>
-                  <p className="mt-1.5 text-xs text-vetneb-ink">
-                    Acceso seguro para clínicas y token particular 24 hs.
-                  </p>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </section>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -32,7 +32,7 @@ test("home page exposes accessible hero and primary CTAs", () => {
   assert.ok(source.includes('id="hero-heading"'));
   assert.ok(source.includes('src="/images/hero-microscope-vetneb.jpg"'));
   assert.ok(source.includes('import Image from "next/image";'));
-  assert.ok(source.includes("SERVICIO PATOLÓGICO"));
+  assert.ok(source.includes("SERVICIO PATOLÓGICO VETNEB"));
   assert.ok(source.includes("VETNEB"));
   assert.ok(source.includes("Diagnóstico patológico veterinario con criterio clínico y"));
   assert.ok(source.includes("trazabilidad integral"));
@@ -41,6 +41,8 @@ test("home page exposes accessible hero and primary CTAs", () => {
   assert.ok(source.includes("Consultá los resultados de sus informes las 24 hs."));
   assert.equal(source.includes("inline-flex w-fit flex-col rounded-md border border-white/30"), false);
   assert.equal(source.includes("text-[0.62rem]"), false);
+  assert.equal(source.includes("border-t border-white/35"), false);
+  assert.equal(source.includes("premium-card p-6"), false);
   assert.ok(source.includes("Horario de atención Lunes a viernes de 8 a 17hs"));
   assert.ok(source.includes("Whatsapp: 3534138946"));
   assert.ok(source.includes('href="https://wa.me/5493534138946"'));

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -132,7 +132,7 @@ test("public home page keeps polished visual hierarchy and responsive sections",
     [
       /className="relative isolate overflow-hidden text-white"/,
       /className="relative container mx-auto flex min-h-\[calc\(100vh-4\.5rem\)\] items-center px-4 py-16 sm:px-6 lg:px-8"/,
-      /className="mt-2 text-5xl font-semibold leading-\[0\.94\] text-white sm:text-6xl lg:text-6xl"/,
+      /className=\"mt-2 max-w-none text-\[clamp\(1\.85rem,4\.6vw,3\.75rem\)\] font-bold uppercase leading-\[0\.94\] tracking-\[0\.045em\] text-primary-foreground\"/,
       /className="mt-6 max-w-2xl text-xl font-medium leading-tight text-primary-foreground\/94 md:text-2xl lg:text-3xl"/,
       /className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center"/,
       /className="public-soft-canvas"/,


### PR DESCRIPTION
## Summary
- Makes SERVICIO PATOLÓGICO VETNEB a contiguous primary hero title.
- Removes the right-side hero information card that overlapped the visual composition.
- Removes the divider between SERVICIO PATOLÓGICO and VETNEB while preserving CTAs, image, routes and behavior.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build