### PR TITLE
style(public): fit home hero contact band to content

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -135,7 +135,7 @@ export default function HomePage() {
                 </Button>
               </div>
 
-              <div className="clinical-muted-band mt-7 rounded-lg px-4 py-3 text-vetneb-navy">
+              <div className="clinical-muted-band mt-7 w-fit max-w-full rounded-lg px-4 py-3 text-vetneb-navy">
                 <p className="text-sm font-semibold">
                   Consultá los resultados de sus informes las 24 hs.
                 </p>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -39,6 +39,7 @@ test("home page exposes accessible hero and primary CTAs", () => {
   assert.ok(source.includes("Dr. BARBÉ, NICOLÁS E."));
   assert.ok(source.includes("Acceder a informes y trazabilidad"));
   assert.ok(source.includes("Consultá los resultados de sus informes las 24 hs."));
+  assert.ok(source.includes("clinical-muted-band mt-7 w-fit max-w-full"));
   assert.equal(source.includes("inline-flex w-fit flex-col rounded-md border border-white/30"), false);
   assert.equal(source.includes("text-[0.62rem]"), false);
   assert.equal(source.includes("border-t border-white/35"), false);


### PR DESCRIPTION
## Summary
- Fits the home hero contact band to its text content.
- Keeps the band responsive with max-w-full.
- Preserves hero copy, CTAs, routes, image and behavior.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build