### PR TITLE
style(public): fix home final cta contrast

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -277,10 +277,11 @@ export default function HomePage() {
               >
                 <Link href={ROUTES.login}>Ingresar al portal de informes</Link>
               </Button>
-              <Button
+                            <Button
                 asChild
+                variant="outline"
                 size="lg"
-                className="w-full border border-vetneb-line/90 bg-card/90 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-accent/60 sm:w-auto"
+                className="w-full border-vetneb-line/90 bg-card/95 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto"
               >
                 <Link href={ROUTES.contacto}>Coordinar muestras y consultas</Link>
               </Button>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -89,9 +89,10 @@ test("home page exposes final conversion CTA without private route metadata", ()
   assert.ok(source.includes("Ingresar al portal de informes"));
   assert.ok(source.includes("Coordinar muestras y consultas"));
   assert.ok(source.includes("clinical-primary-gradient clinical-primary-gradient-hover"));
-  assert.ok(source.includes("border border-vetneb-line/90 bg-card/90"));
+  assert.ok(source.includes('variant="outline"'));
+  assert.ok(source.includes("border-vetneb-line/90 bg-card/95"));
   assert.ok(source.includes("font-semibold text-vetneb-navy shadow-sm"));
-  assert.ok(source.includes("hover:border-vetneb-teal/45 hover:bg-accent/60"));
+  assert.ok(source.includes("hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy"));
   assert.equal(source.includes("bg-primary py-16 text-white md:py-20"), false);
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes('"/api"'), false);


### PR DESCRIPTION
## Summary
- Fixes the final home secondary CTA contrast.
- Uses the outline button variant so Coordinar muestras y consultas remains readable.
- Preserves copy, routes, handlers and behavior.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build