### PR TITLE
style(public): lighten home hero primary cta

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -122,7 +122,7 @@ export default function HomePage() {
                 <Button
                   asChild
                   size="lg"
-                  className="w-full clinical-primary-gradient clinical-primary-gradient-hover px-7 text-primary-foreground shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] sm:w-auto"
+                  className="w-full border border-vetneb-line/90 bg-card/95 px-7 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto"
                 >
                   <Link href={ROUTES.login}>Acceder a informes y trazabilidad</Link>
                 </Button>


### PR DESCRIPTION
## Summary
- Lighten the home hero primary CTA background.
- Align the CTA with the existing light institutional button treatment.
- Preserve copy, route, layout, and behavior.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build