### PR TITLE
style(public): refine public hero ctas and section labels

### DIFF
--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -118,8 +118,9 @@ export default function ClinicasPage() {
           <div className="mt-8 flex flex-col gap-4 sm:flex-row">
             <Button
               asChild
+              variant="outline"
               size="lg"
-              className="bg-card font-semibold text-vetneb-navy shadow-[0_18px_45px_rgba(255,255,255,0.18)] hover:bg-card/92"
+              className="w-full border-vetneb-line/90 bg-card/95 px-7 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto"
             >
               <Link href={ROUTES.login}>
                 Acceder al portal
@@ -141,9 +142,6 @@ export default function ClinicasPage() {
       <section className="py-16 md:py-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mx-auto mb-10 max-w-3xl text-center">
-            <p className="mb-3 inline-flex clinical-pill px-3 py-1 text-[0.66rem]">
-              Operación clínica
-            </p>
             <h2 className="text-2xl font-bold text-vetneb-ink md:text-3xl">
               Todo lo que necesita su clínica
             </h2>
@@ -176,9 +174,6 @@ export default function ClinicasPage() {
       <section className="py-16 md:py-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mx-auto mb-10 max-w-3xl text-center">
-            <p className="mb-3 inline-flex clinical-pill px-3 py-1 text-[0.66rem]">
-              Implementación guiada
-            </p>
             <h2 className="text-2xl font-bold text-vetneb-ink md:text-3xl">
               Cómo comenzar
             </h2>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -121,6 +121,7 @@ export default function HomePage() {
               <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
                 <Button
                   asChild
+                  variant="outline"
                   size="lg"
                   className="w-full border border-vetneb-line/90 bg-card/95 px-7 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto"
                 >

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -142,9 +142,6 @@ export default function ServiciosPage() {
       <section className="py-16 md:py-20">
         <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto mb-10 max-w-4xl">
-            <p className="mb-3 inline-flex clinical-pill px-3 py-1 text-[0.66rem]">
-              Laboratorio VETNEB
-            </p>
             <h2 className="text-2xl font-bold text-vetneb-ink md:text-3xl">
               Estudios diagnósticos con criterio clínico-patológico
             </h2>

--- a/test/frontend-clinicas-page-content.test.ts
+++ b/test/frontend-clinicas-page-content.test.ts
@@ -37,14 +37,14 @@ test("clinicas page exposes hero content and primary CTAs", () => {
   assert.ok(source.includes("Solicitar acceso"));
 });
 
-test("clinicas page keeps solicitar acceso CTA visible on blue hero background", () => {
+test("clinicas page keeps hero CTAs visible on blue hero background", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
   assert.ok(source.includes("border border-white/60"));
   assert.ok(source.includes("bg-white/10"));
   assert.ok(source.includes("font-semibold text-white"));
   assert.ok(source.includes("hover:bg-white/16"));
-  assert.equal(source.includes('variant="outline"'), false);
+  assert.ok(source.includes('variant="outline"'));
 });
 
 test("clinicas page lists operational feature cards", () => {
@@ -87,4 +87,5 @@ test("clinicas page keeps one continuous soft canvas below hero", () => {
   assert.equal(source.includes('className="bg-white py-16 md:py-20"'), false);
   assert.equal(source.includes('className="public-soft-canvas py-16 md:py-20"'), false);
 });
+
 


### PR DESCRIPTION
## Summary
- Use outline light treatment for public hero primary CTAs.
- Remove decorative clinical pill labels from public sections.
- Update visual contract test for the intentional clinics CTA treatment.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build