### PR TITLE
style(public): introduce visual hero and action primitives

### DIFF
--- a/frontend/src/components/public/PublicAction.tsx
+++ b/frontend/src/components/public/PublicAction.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type PublicActionVariant =
+  | "primaryLight"
+  | "primaryDark"
+  | "secondaryOutline"
+  | "textLink"
+  | "contactCard";
+
+type PublicActionProps = {
+  href: string;
+  children: ReactNode;
+  variant?: PublicActionVariant;
+  className?: string;
+  icon?: ReactNode;
+  external?: boolean;
+} & Omit<ComponentPropsWithoutRef<typeof Link>, "href" | "children" | "className">;
+
+const actionClasses: Record<Exclude<PublicActionVariant, "textLink" | "contactCard">, string> = {
+  primaryLight:
+    "w-full border-vetneb-line/90 bg-card/95 px-7 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto",
+  primaryDark:
+    "w-full clinical-primary-gradient clinical-primary-gradient-hover px-7 font-semibold text-primary-foreground shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] sm:w-auto",
+  secondaryOutline:
+    "w-full border border-white/60 bg-white/10 px-7 font-semibold text-white shadow-sm hover:bg-white/16 sm:w-auto",
+};
+
+export function PublicAction({
+  href,
+  children,
+  variant = "primaryLight",
+  className,
+  icon,
+  external = false,
+  ...props
+}: PublicActionProps) {
+  const rel = external ? "noopener noreferrer" : props.rel;
+  const target = external ? "_blank" : props.target;
+
+  if (variant === "textLink") {
+    return (
+      <Link
+        href={href}
+        className={cn(
+          "inline-flex items-center gap-2 text-sm font-semibold text-vetneb-navy underline-offset-4 transition hover:text-vetneb-teal hover:underline",
+          className,
+        )}
+        rel={rel}
+        target={target}
+        {...props}
+      >
+        <span>{children}</span>
+        {icon}
+      </Link>
+    );
+  }
+
+  if (variant === "contactCard") {
+    return (
+      <Link
+        href={href}
+        className={cn(
+          "group flex items-center justify-between gap-4 rounded-lg border border-vetneb-line/85 bg-card/95 px-4 py-3 text-left shadow-sm transition hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised",
+          className,
+        )}
+        rel={rel}
+        target={target}
+        {...props}
+      >
+        <span className="text-sm font-semibold text-vetneb-navy">{children}</span>
+        {icon ? (
+          <span className="text-vetneb-teal transition group-hover:translate-x-0.5">
+            {icon}
+          </span>
+        ) : null}
+      </Link>
+    );
+  }
+
+  return (
+    <Button
+      asChild
+      variant={variant === "primaryDark" ? "default" : "outline"}
+      size="lg"
+      className={cn(actionClasses[variant], className)}
+    >
+      <Link href={href} rel={rel} target={target} {...props}>
+        <span>{children}</span>
+        {icon}
+      </Link>
+    </Button>
+  );
+}

--- a/frontend/src/components/public/PublicHero.tsx
+++ b/frontend/src/components/public/PublicHero.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+
+import { AmbientOrbs } from "@/components/public/VisualAccents";
+import { cn } from "@/lib/utils";
+
+export type PublicHeroVariant =
+  | "brand"
+  | "editorial"
+  | "directory"
+  | "conversion"
+  | "compact"
+  | "none";
+
+type PublicHeroProps = {
+  title: string;
+  description?: ReactNode;
+  eyebrow?: string;
+  actions?: ReactNode;
+  children?: ReactNode;
+  variant?: PublicHeroVariant;
+  className?: string;
+};
+
+const heroShellClasses: Record<Exclude<PublicHeroVariant, "none">, string> = {
+  brand: "relative isolate overflow-hidden text-white",
+  editorial: "public-soft-canvas border-b border-vetneb-line/70 py-14 md:py-16",
+  directory: "public-soft-canvas border-b border-vetneb-line/70 py-12 md:py-14",
+  conversion: "public-hero-depth py-16 text-white md:py-20",
+  compact: "public-soft-canvas border-b border-vetneb-line/70 py-10 md:py-12",
+};
+
+const contentClasses: Record<Exclude<PublicHeroVariant, "none">, string> = {
+  brand: "container relative z-10 mx-auto px-4 sm:px-6 lg:px-8",
+  editorial: "container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8",
+  directory: "container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8",
+  conversion: "container relative z-10 mx-auto px-4 sm:px-6 lg:px-8",
+  compact: "container mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8",
+};
+
+const titleClasses: Record<Exclude<PublicHeroVariant, "none">, string> = {
+  brand: "max-w-5xl text-[clamp(1.85rem,4.6vw,3.75rem)] font-bold uppercase leading-[0.94] tracking-[0.045em] text-primary-foreground",
+  editorial: "max-w-4xl text-3xl font-bold leading-tight text-vetneb-ink md:text-4xl",
+  directory: "max-w-4xl text-3xl font-bold leading-tight text-vetneb-ink md:text-4xl",
+  conversion: "max-w-4xl text-4xl font-bold leading-tight text-primary-foreground md:text-5xl",
+  compact: "text-3xl font-bold leading-tight text-vetneb-ink md:text-4xl",
+};
+
+const descriptionClasses: Record<Exclude<PublicHeroVariant, "none">, string> = {
+  brand: "mt-6 max-w-2xl text-xl font-medium leading-tight text-primary-foreground/94 md:text-2xl lg:text-3xl",
+  editorial: "mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg",
+  directory: "mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg",
+  conversion: "mt-5 max-w-2xl text-xl leading-relaxed text-primary-foreground/92",
+  compact: "mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base",
+};
+
+export function PublicHero({
+  title,
+  description,
+  eyebrow,
+  actions,
+  children,
+  variant = "editorial",
+  className,
+}: PublicHeroProps) {
+  if (variant === "none") {
+    return <>{children}</>;
+  }
+
+  const isDark = variant === "brand" || variant === "conversion";
+
+  return (
+    <section className={cn(heroShellClasses[variant], className)}>
+      {isDark ? <AmbientOrbs variant="dark" /> : null}
+      <div className={contentClasses[variant]}>
+        {eyebrow ? (
+          <p
+            className={cn(
+              "mb-3 text-xs font-semibold uppercase tracking-[0.22em]",
+              isDark ? "text-primary-foreground/72" : "text-vetneb-navy/70",
+            )}
+          >
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className={titleClasses[variant]}>{title}</h1>
+        {description ? (
+          <div className={descriptionClasses[variant]}>{description}</div>
+        ) : null}
+        {actions ? (
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+            {actions}
+          </div>
+        ) : null}
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/test/frontend-public-visual-primitives.test.ts
+++ b/test/frontend-public-visual-primitives.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PUBLIC_ACTION_PATH = "frontend/src/components/public/PublicAction.tsx";
+const PUBLIC_HERO_PATH = "frontend/src/components/public/PublicHero.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("public action primitive defines intentional action variants", () => {
+  const source = read(PUBLIC_ACTION_PATH);
+
+  assert.ok(source.includes("export type PublicActionVariant"));
+  assert.ok(source.includes('"primaryLight"'));
+  assert.ok(source.includes('"primaryDark"'));
+  assert.ok(source.includes('"secondaryOutline"'));
+  assert.ok(source.includes('"textLink"'));
+  assert.ok(source.includes('"contactCard"'));
+});
+
+test("public action primitive avoids accidental default gradient on light CTAs", () => {
+  const source = read(PUBLIC_ACTION_PATH);
+
+  assert.ok(source.includes('variant={variant === "primaryDark" ? "default" : "outline"}'));
+  assert.ok(source.includes("bg-card/95"));
+  assert.ok(source.includes("text-vetneb-navy"));
+  assert.ok(source.includes("clinical-primary-gradient"));
+});
+
+test("public hero primitive defines page-intent variants", () => {
+  const source = read(PUBLIC_HERO_PATH);
+
+  assert.ok(source.includes("export type PublicHeroVariant"));
+  assert.ok(source.includes('"brand"'));
+  assert.ok(source.includes('"editorial"'));
+  assert.ok(source.includes('"directory"'));
+  assert.ok(source.includes('"conversion"'));
+  assert.ok(source.includes('"compact"'));
+  assert.ok(source.includes('"none"'));
+});
+
+test("public hero primitive separates dark conversion heroes from editorial surfaces", () => {
+  const source = read(PUBLIC_HERO_PATH);
+
+  assert.ok(source.includes("public-hero-depth py-16 text-white md:py-20"));
+  assert.ok(source.includes("public-soft-canvas border-b border-vetneb-line/70"));
+  assert.ok(source.includes('const isDark = variant === "brand" || variant === "conversion";'));
+  assert.ok(source.includes('<AmbientOrbs variant="dark" />'));
+});


### PR DESCRIPTION
## Summary
- Add PublicHero primitive with page-intent variants.
- Add PublicAction primitive with controlled CTA/link treatments.
- Add visual contract tests for public primitives.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build