### PR TITLE
revert(public): restore services and professionals visuals

### DIFF
--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -10,8 +11,6 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
-import { PublicAction } from "@/components/public/PublicAction";
-import { PublicHero } from "@/components/public/PublicHero";
 import {
   Card,
   CardContent,
@@ -19,7 +18,8 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { VisualIcon } from "@/components/public/VisualAccents";
+import { Button } from "@/components/ui/button";
+import { AmbientOrbs, VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -122,17 +122,22 @@ export default function ServiciosPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      <PublicHero
-        variant="editorial"
-        title="Servicio patológico veterinario"
-        description={
-          <>
+      <section
+        className="clinical-primary-gradient py-16 text-white md:py-20"
+        data-public-hero-depth="true"
+      >
+        <AmbientOrbs variant="dark" />
+        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="mb-4 max-w-4xl text-4xl font-bold leading-tight md:text-5xl">
+            Servicio patológico veterinario
+          </h1>
+          <p className="max-w-2xl public-copy text-lg text-primary-foreground/92 md:text-xl">
             La anatomía patológica veterinaria integra evaluación microscópica,
             trazabilidad de muestras e informes clínicos para orientar
             decisiones diagnósticas con respaldo profesional.
-          </>
-        }
-      />
+          </p>
+        </div>
+      </section>
       <div className="public-soft-canvas">
       <section className="py-16 md:py-20">
         <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
@@ -202,20 +207,24 @@ export default function ServiciosPage() {
               diagnóstico y a las necesidades clínicas de cada caso.
             </p>
             <div className="flex flex-col justify-center gap-3 sm:flex-row">
-              <PublicAction
-                href={ROUTES.contacto}
-                variant="primaryDark"
-                icon={<ArrowRight className="h-4 w-4" aria-hidden="true" />}
+              <Button
+                asChild
+                size="lg"
+                className="w-full clinical-primary-gradient clinical-primary-gradient-hover shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] sm:w-auto"
               >
-                Solicitar coordinación diagnóstica
-              </PublicAction>
-              <PublicAction
-                href={ROUTES.clinicas}
-                variant="textLink"
-                className="justify-center px-2 py-3"
+                <Link href={ROUTES.contacto}>
+                  Solicitar coordinación diagnóstica
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="w-full border border-vetneb-line/90 bg-card/90 text-vetneb-navy hover:border-vetneb-teal/45 hover:bg-accent/60 sm:w-auto"
               >
-                Conocer solución para clínicas
-              </PublicAction>
+                <Link href={ROUTES.clinicas}>Conocer solución para clínicas</Link>
+              </Button>
             </div>
           </div>
         </div>
@@ -289,5 +298,4 @@ export default function ServiciosPage() {
     </PublicLayout>
   );
 }
-
 

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -12,8 +12,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
-import { PublicHero } from "@/components/public/PublicHero";
-import { VisualIcon } from "@/components/public/VisualAccents";
+import { AmbientOrbs, VisualIcon } from "@/components/public/VisualAccents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -103,6 +102,7 @@ export function ProfesionalesSearchContent() {
   return (
     <PublicLayout>
       <section className="public-hero-depth py-16 text-white md:py-20">
+        <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
 <h1 className="mb-4 max-w-4xl text-4xl font-bold md:text-5xl">
             Red de profesionales veterinarios
@@ -308,4 +308,3 @@ export function ProfesionalesSearchContent() {
     </PublicLayout>
   );
 }
-

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -32,8 +32,8 @@ test("profesionales public page exposes search instead of conversion CTAs", () =
 test("servicios public page exposes conversion CTAs", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes('import { PublicAction } from "@/components/public/PublicAction";'));
-  assert.ok(source.includes('variant="primaryDark"'));
+  assert.ok(source.includes('import Link from "next/link"'));
+  assert.ok(source.includes('import { Button } from "@/components/ui/button"'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
   assert.ok(source.includes("Coordinación diagnóstica para clínicas y profesionales"));
   assert.ok(source.includes("Solicitar coordinación diagnóstica"));
@@ -41,4 +41,3 @@ test("servicios public page exposes conversion CTAs", () => {
   assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("href={ROUTES.clinicas}"));
 });
-

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -16,8 +16,7 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import { PublicAction } from "@/components/public/PublicAction";'));
-  assert.ok(source.includes('import { PublicHero } from "@/components/public/PublicHero";'));
+  assert.ok(source.includes('import Link from "next/link";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes('import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
@@ -93,4 +92,3 @@ test("servicios page keeps one continuous soft canvas through middle sections", 
   assert.equal(source.includes('className="bg-gray-50 py-16"'), false);
   assert.equal(source.includes('data-public-soft-canvas="true"'), false);
 });
-

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -165,7 +165,7 @@ test("servicios page keeps professional section/card structure and responsive la
   assertMatchesAll(
     source,
     [
-      /<PublicHero[\s\S]*variant="editorial"/,
+      /className="clinical-primary-gradient py-16 text-white md:py-20"/,
       /className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"/,
       /className="premium-card h-full"/,
       /className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center"/,
@@ -445,4 +445,3 @@ test("public pages use one single shared canvas background", () => {
   assert.equal(globals.includes("public-page-canvas-drift"), false);
   assert.ok(login.includes("min-h-screen public-page-canvas flex items-center justify-center p-4"));
 });
-


### PR DESCRIPTION
## Summary
- Revert PR #572 public services/professionals visual migration.
- Restore services and professionals to the previous main visual state.
- Keep PR #571 public primitives available for later controlled migration.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build