### PR TITLE
style(public): unify secondary hero surfaces

### DIFF
--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -20,7 +20,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { AmbientOrbs, VisualIcon } from "@/components/public/VisualAccents";
+import { VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -106,7 +106,6 @@ export default function ClinicasPage() {
   return (
     <PublicLayout>
       <section className="public-secondary-hero-surface py-16 text-white md:py-20">
-        <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="mb-5 max-w-4xl text-4xl font-bold md:text-5xl">
             Portal para clínicas veterinarias

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -105,7 +105,7 @@ const steps = [
 export default function ClinicasPage() {
   return (
     <PublicLayout>
-      <section className="public-hero-depth py-16 text-white md:py-20">
+      <section className="public-secondary-hero-surface py-16 text-white md:py-20">
         <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="mb-5 max-w-4xl text-4xl font-bold md:text-5xl">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -787,4 +787,49 @@
     @apply mt-1 text-sm leading-relaxed text-primary-foreground/76;
   }
 }
+/* public-secondary-hero-surface:start */
+@layer components {
+  .public-secondary-hero-surface {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    color: hsl(var(--primary-foreground));
+    background:
+      radial-gradient(1000px 420px at -8% 8%, hsl(var(--vetneb-cyan) / 0.20), transparent 62%),
+      radial-gradient(900px 360px at 108% -8%, hsl(var(--vetneb-teal) / 0.24), transparent 58%),
+      linear-gradient(135deg, hsl(209 74% 17%) 0%, hsl(201 66% 21%) 46%, hsl(178 61% 26%) 100%);
+    box-shadow:
+      inset 0 1px 0 hsl(var(--primary-foreground) / 0.10),
+      inset 0 -1px 0 hsl(var(--primary-foreground) / 0.16);
+  }
 
+  .public-secondary-hero-surface::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(90deg, hsl(var(--primary-foreground) / 0.07) 1px, transparent 1px),
+      linear-gradient(180deg, hsl(var(--primary-foreground) / 0.05) 1px, transparent 1px);
+    background-size: 72px 72px;
+    opacity: 0.34;
+    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0.20));
+  }
+
+  .public-secondary-hero-surface::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(116deg, transparent 0 45%, hsl(var(--vetneb-teal) / 0.16) 45% 46%, transparent 46% 100%),
+      linear-gradient(180deg, hsl(var(--primary-foreground) / 0.07), transparent 50%);
+    opacity: 0.92;
+  }
+
+  .public-secondary-hero-surface > * {
+    position: relative;
+    z-index: 1;
+  }
+}
+/* public-secondary-hero-surface:end */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -794,42 +794,7 @@
     isolation: isolate;
     overflow: hidden;
     color: hsl(var(--primary-foreground));
-    background:
-      radial-gradient(1000px 420px at -8% 8%, hsl(var(--vetneb-cyan) / 0.20), transparent 62%),
-      radial-gradient(900px 360px at 108% -8%, hsl(var(--vetneb-teal) / 0.24), transparent 58%),
-      linear-gradient(135deg, hsl(209 74% 17%) 0%, hsl(201 66% 21%) 46%, hsl(178 61% 26%) 100%);
-    box-shadow:
-      inset 0 1px 0 hsl(var(--primary-foreground) / 0.10),
-      inset 0 -1px 0 hsl(var(--primary-foreground) / 0.16);
-  }
-
-  .public-secondary-hero-surface::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background:
-      linear-gradient(90deg, hsl(var(--primary-foreground) / 0.07) 1px, transparent 1px),
-      linear-gradient(180deg, hsl(var(--primary-foreground) / 0.05) 1px, transparent 1px);
-    background-size: 72px 72px;
-    opacity: 0.34;
-    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0.20));
-  }
-
-  .public-secondary-hero-surface::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background:
-      linear-gradient(116deg, transparent 0 45%, hsl(var(--vetneb-teal) / 0.16) 45% 46%, transparent 46% 100%),
-      linear-gradient(180deg, hsl(var(--primary-foreground) / 0.07), transparent 50%);
-    opacity: 0.92;
-  }
-
-  .public-secondary-hero-surface > * {
-    position: relative;
-    z-index: 1;
+    background: linear-gradient(135deg, #2B5B88 0%, #5992B1 48%, #97C1C9 100%);
   }
 }
 /* public-secondary-hero-surface:end */

--- a/frontend/src/app/precios/page.tsx
+++ b/frontend/src/app/precios/page.tsx
@@ -70,21 +70,21 @@ export default async function PreciosPage() {
   return (
     <PublicLayout>
       <section
-        className="public-page-canvas py-16 md:py-20"
+        className="public-secondary-hero-surface py-16 text-white md:py-20"
         aria-labelledby="pricing-page-title"
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mx-auto mb-12 max-w-3xl text-center">
-            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/90">
               Valores de referencia
             </p>
             <h1
               id="pricing-page-title"
-              className="text-3xl font-bold text-vetneb-ink md:text-4xl"
+              className="text-3xl font-bold text-primary-foreground md:text-4xl"
             >
               Lista de precios
             </h1>
-            <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
+            <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-primary-foreground/88 md:text-base">
               Referencia orientativa para la coordinación administrativa. Los
               valores sin definición vigente se muestran como “Consultar”.
             </p>

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -122,10 +122,7 @@ export default function ServiciosPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      <section
-        className="clinical-primary-gradient py-16 text-white md:py-20"
-        data-public-hero-depth="true"
-      >
+      <section className="public-secondary-hero-surface py-16 text-white md:py-20">
         <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="mb-4 max-w-4xl text-4xl font-bold leading-tight md:text-5xl">

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -19,7 +19,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { AmbientOrbs, VisualIcon } from "@/components/public/VisualAccents";
+import { VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -123,7 +123,6 @@ export default function ServiciosPage() {
       />
 
       <section className="public-secondary-hero-surface py-16 text-white md:py-20">
-        <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="mb-4 max-w-4xl text-4xl font-bold leading-tight md:text-5xl">
             Servicio patológico veterinario

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -95,7 +95,7 @@ export function ContactoContent() {
 
   return (
     <PublicLayout>
-      <section className="public-hero-depth py-16 text-white md:py-20">
+      <section className="public-secondary-hero-surface py-16 text-white md:py-20">
         <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
 <h1 className="mb-4 text-4xl font-bold md:text-5xl">

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
-import { AmbientOrbs, VisualIcon } from "@/components/public/VisualAccents";
+import { VisualIcon } from "@/components/public/VisualAccents";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -96,7 +96,6 @@ export function ContactoContent() {
   return (
     <PublicLayout>
       <section className="public-secondary-hero-surface py-16 text-white md:py-20">
-        <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
 <h1 className="mb-4 text-4xl font-bold md:text-5xl">
             Contacto

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -172,14 +172,14 @@ export function ParticularesContent() {
   }
 
   return (
-    <section className="relative overflow-hidden public-soft-canvas py-16 md:py-20">
+    <section className="public-secondary-hero-surface py-16 md:py-20">
       <AmbientOrbs />
       <div className="container relative z-10 mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 lg:grid-cols-[1fr_0.95fr] lg:px-8">
         <div>
-<h1 className="max-w-3xl text-4xl font-bold text-vetneb-ink md:text-5xl">
+<h1 className="max-w-3xl text-4xl font-bold text-primary-foreground md:text-5xl">
             Acceda al seguimiento y al informe de su caso con token seguro
           </h1>
-          <p className="mt-5 max-w-2xl public-copy text-lg text-muted-foreground">
+          <p className="mt-5 max-w-2xl public-copy text-lg text-primary-foreground/88">
             El acceso particular está limitado al caso vinculado al token.
             Permite consultar estado, fechas e informe sin exponer información
             de clínicas, rutas internas, profesionales ni otros estudios.

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -33,7 +33,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  AmbientOrbs,
   PremiumPanel,
   VisualIcon,
 } from "@/components/public/VisualAccents";
@@ -173,7 +172,6 @@ export function ParticularesContent() {
 
   return (
     <section className="public-secondary-hero-surface py-16 md:py-20">
-      <AmbientOrbs />
       <div className="container relative z-10 mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 lg:grid-cols-[1fr_0.95fr] lg:px-8">
         <div>
 <h1 className="max-w-3xl text-4xl font-bold text-primary-foreground md:text-5xl">

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -101,7 +101,7 @@ export function ProfesionalesSearchContent() {
 
   return (
     <PublicLayout>
-      <section className="public-hero-depth py-16 text-white md:py-20">
+      <section className="public-secondary-hero-surface py-16 text-white md:py-20">
         <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
 <h1 className="mb-4 max-w-4xl text-4xl font-bold md:text-5xl">

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
-import { AmbientOrbs, VisualIcon } from "@/components/public/VisualAccents";
+import { VisualIcon } from "@/components/public/VisualAccents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -102,7 +102,6 @@ export function ProfesionalesSearchContent() {
   return (
     <PublicLayout>
       <section className="public-secondary-hero-surface py-16 text-white md:py-20">
-        <AmbientOrbs variant="dark" />
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
 <h1 className="mb-4 max-w-4xl text-4xl font-bold md:text-5xl">
             Red de profesionales veterinarios

--- a/test/frontend-public-secondary-hero-surface.test.ts
+++ b/test/frontend-public-secondary-hero-surface.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+
+const SECONDARY_HERO_FILES = [
+  "frontend/src/app/servicios/page.tsx",
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx",
+  "frontend/src/app/clinicas/page.tsx",
+  "frontend/src/components/public/ContactoContent.tsx",
+  "frontend/src/components/public/ParticularesContent.tsx",
+];
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function getSecondaryHeroSurfaceBlock(source: string): string {
+  const startMarker = "/* public-secondary-hero-surface:start */";
+  const endMarker = "/* public-secondary-hero-surface:end */";
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  assert.ok(end > start);
+
+  return source.slice(start, end + endMarker.length);
+}
+
+test("public secondary hero surface defines the shared visual surface", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const block = getSecondaryHeroSurfaceBlock(source);
+
+  assert.ok(block.includes(".public-secondary-hero-surface"));
+  assert.ok(block.includes(".public-secondary-hero-surface::before"));
+  assert.ok(block.includes(".public-secondary-hero-surface::after"));
+  assert.ok(block.includes("radial-gradient"));
+  assert.ok(block.includes("linear-gradient(135deg"));
+  assert.ok(!block.includes("!important"));
+});
+
+test("secondary public heroes use public-secondary-hero-surface", () => {
+  for (const filePath of SECONDARY_HERO_FILES) {
+    assert.ok(
+      read(filePath).includes("public-secondary-hero-surface"),
+      `${filePath} should use public-secondary-hero-surface`,
+    );
+  }
+});
+
+test("services hero no longer uses the legacy hero-depth attribute", () => {
+  const source = read("frontend/src/app/servicios/page.tsx");
+
+  assert.ok(!source.includes('data-public-hero-depth="true"'));
+  assert.ok(
+    !source.includes('className="clinical-primary-gradient py-16 text-white md:py-20"'),
+  );
+});
+
+test("home and pricing do not use the secondary hero surface", () => {
+  assert.ok(!read("frontend/src/app/page.tsx").includes("public-secondary-hero-surface"));
+  assert.ok(!read("frontend/src/app/precios/page.tsx").includes("public-secondary-hero-surface"));
+});

--- a/test/frontend-public-secondary-hero-surface.test.ts
+++ b/test/frontend-public-secondary-hero-surface.test.ts
@@ -11,6 +11,7 @@ const SECONDARY_HERO_FILES = [
   "frontend/src/app/clinicas/page.tsx",
   "frontend/src/components/public/ContactoContent.tsx",
   "frontend/src/components/public/ParticularesContent.tsx",
+  "frontend/src/app/precios/page.tsx",
 ];
 
 function read(relativePath: string): string {
@@ -38,10 +39,17 @@ test("public secondary hero surface defines the shared visual surface", () => {
   const block = getSecondaryHeroSurfaceBlock(source);
 
   assert.ok(block.includes(".public-secondary-hero-surface"));
-  assert.ok(block.includes(".public-secondary-hero-surface::before"));
-  assert.ok(block.includes(".public-secondary-hero-surface::after"));
-  assert.ok(block.includes("radial-gradient"));
-  assert.ok(block.includes("linear-gradient(135deg"));
+  assert.ok(
+    block.includes(
+      "linear-gradient(135deg, #2B5B88 0%, #5992B1 48%, #97C1C9 100%)",
+    ),
+  );
+  assert.ok(!block.includes(".public-secondary-hero-surface::before"));
+  assert.ok(!block.includes(".public-secondary-hero-surface::after"));
+  assert.ok(!block.includes("linear-gradient(90deg"));
+  assert.ok(!block.includes("linear-gradient(116deg"));
+  assert.ok(!block.includes("background-size: 72px 72px"));
+  assert.ok(!block.includes("mask-image"));
   assert.ok(!block.includes("!important"));
 });
 
@@ -63,7 +71,6 @@ test("services hero no longer uses the legacy hero-depth attribute", () => {
   );
 });
 
-test("home and pricing do not use the secondary hero surface", () => {
+test("home does not use the secondary hero surface", () => {
   assert.ok(!read("frontend/src/app/page.tsx").includes("public-secondary-hero-surface"));
-  assert.ok(!read("frontend/src/app/precios/page.tsx").includes("public-secondary-hero-surface"));
 });

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -165,7 +165,7 @@ test("servicios page keeps professional section/card structure and responsive la
   assertMatchesAll(
     source,
     [
-      /className="clinical-primary-gradient py-16 text-white md:py-20"/,
+      /className="public-secondary-hero-surface py-16 text-white md:py-20"/,
       /className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"/,
       /className="premium-card h-full"/,
       /className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center"/,


### PR DESCRIPTION
## Summary
- adds a shared public secondary hero surface
- applies the shared clean gradient surface to secondary public heroes
- includes pricing in the secondary public hero surface contract
- removes decorative grid and diagonal overlay from the secondary hero surface
- removes the conflicting hero-depth data attribute from services
- updates visual consistency tests for the new secondary hero contract
- keeps Home untouched

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build