### PR TITLE
style(public): refine public cta visual depth

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -776,25 +776,146 @@
     @apply mt-1 text-sm leading-relaxed text-primary-foreground/76;
   }
 
+  .public-cta-primary,
+  .public-cta-secondary,
+  .public-cta-outline,
+  .public-cta-on-hero {
+    letter-spacing: 0.01em;
+    transition-property: background-image, background-color, border-color, box-shadow, transform;
+    transition-duration: 300ms;
+    transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
   .public-cta-primary {
-    @apply font-semibold text-primary-foreground shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] hover:shadow-[0_18px_44px_hsl(var(--vetneb-navy)/0.26)];
-    background-image: linear-gradient(135deg, #0E3556 0%, #2B5B88 52%, #3F7EA2 100%);
+    @apply font-semibold text-primary-foreground;
+    border: 1px solid rgba(170, 205, 226, 0.28);
+    background-image: linear-gradient(135deg, #071F35 0%, #123E63 52%, #185A7C 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.18),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.34),
+      0 14px 34px rgba(7, 31, 53, 0.24);
   }
 
   .public-cta-primary:hover {
-    background-image: linear-gradient(135deg, #0E3556 0%, #2B5B88 52%, #3F7EA2 100%);
+    border-color: rgba(190, 224, 242, 0.36);
+    background-image: linear-gradient(135deg, #092942 0%, #164D78 52%, #1F6F94 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.22),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.36),
+      0 18px 40px rgba(7, 31, 53, 0.28);
+    transform: translateY(-0.5px);
+  }
+
+  .public-cta-primary:active {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.16),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.38),
+      0 12px 28px rgba(7, 31, 53, 0.22);
+    transform: translateY(0);
   }
 
   .public-cta-secondary {
-    @apply border border-vetneb-line/90 bg-vetneb-surface-muted/70 font-semibold text-vetneb-ink shadow-sm hover:bg-vetneb-surface-muted;
+    @apply font-semibold text-vetneb-navy;
+    border: 1px solid rgba(118, 156, 182, 0.34);
+    background-image: linear-gradient(135deg, rgba(236, 245, 251, 0.98) 0%, rgba(224, 238, 248, 0.95) 52%, rgba(211, 230, 242, 0.92) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.42),
+      inset 0 -1px 0 rgba(74, 108, 132, 0.16),
+      0 10px 24px rgba(12, 40, 64, 0.12);
+  }
+
+  .public-cta-secondary:hover {
+    border-color: rgba(106, 151, 180, 0.42);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.5),
+      inset 0 -1px 0 rgba(66, 101, 126, 0.2),
+      0 13px 28px rgba(12, 40, 64, 0.16);
   }
 
   .public-cta-outline {
-    @apply border border-vetneb-line/90 bg-card/95 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy;
+    @apply font-semibold text-vetneb-navy;
+    border: 1px solid rgba(122, 161, 187, 0.4);
+    background-color: rgba(241, 248, 253, 0.98);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.44),
+      inset 0 -1px 0 rgba(82, 116, 141, 0.14),
+      0 10px 22px rgba(12, 40, 64, 0.11);
+  }
+
+  .public-cta-outline:hover {
+    border-color: rgba(114, 158, 186, 0.48);
+    background-color: rgba(248, 252, 255, 1);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.54),
+      inset 0 -1px 0 rgba(74, 107, 132, 0.18),
+      0 13px 28px rgba(12, 40, 64, 0.14);
   }
 
   .public-cta-on-hero {
-    @apply border border-white/55 bg-card/95 font-semibold text-vetneb-navy shadow-[0_12px_34px_rgba(5,28,42,0.16)] hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy;
+    @apply font-semibold text-vetneb-navy;
+    border: 1px solid rgba(228, 242, 252, 0.78);
+    background-image: linear-gradient(135deg, rgba(244, 250, 255, 0.98) 0%, rgba(232, 243, 251, 0.95) 52%, rgba(220, 236, 247, 0.92) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.5),
+      inset 0 -1px 0 rgba(74, 108, 132, 0.18),
+      0 14px 32px rgba(5, 28, 42, 0.24);
+  }
+
+  .public-cta-on-hero:hover {
+    border-color: rgba(236, 248, 255, 0.92);
+    background-image: linear-gradient(135deg, rgba(248, 253, 255, 1) 0%, rgba(236, 246, 253, 0.96) 52%, rgba(223, 238, 248, 0.93) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.58),
+      inset 0 -1px 0 rgba(67, 101, 124, 0.2),
+      0 18px 36px rgba(5, 28, 42, 0.27);
+    transform: translateY(-0.5px);
+  }
+
+  .public-cta-primary:active {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.14),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.4),
+      0 10px 22px rgba(7, 31, 53, 0.2);
+    transform: translateY(0);
+  }
+
+  .public-cta-secondary:active {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.38),
+      inset 0 -1px 0 rgba(66, 100, 124, 0.2),
+      0 7px 18px rgba(12, 40, 64, 0.12);
+    transform: translateY(0);
+  }
+
+  .public-cta-outline:active {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.4),
+      inset 0 -1px 0 rgba(74, 106, 130, 0.18),
+      0 7px 18px rgba(12, 40, 64, 0.11);
+    transform: translateY(0);
+  }
+
+  .public-cta-on-hero:active {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.42),
+      inset 0 -1px 0 rgba(67, 101, 124, 0.2),
+      0 10px 22px rgba(5, 28, 42, 0.2);
+    transform: translateY(0);
+  }
+
+  .public-cta-primary:disabled,
+  .public-cta-primary[aria-busy="true"],
+  .public-cta-secondary:disabled,
+  .public-cta-secondary[aria-busy="true"],
+  .public-cta-outline:disabled,
+  .public-cta-outline[aria-busy="true"],
+  .public-cta-on-hero:disabled,
+  .public-cta-on-hero[aria-busy="true"] {
+    transform: none;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.24),
+      inset 0 -1px 0 rgba(7, 23, 39, 0.18),
+      0 8px 18px rgba(7, 31, 53, 0.14);
   }
 }
 /* public-secondary-hero-surface:start */

--- a/test/frontend-public-button-contrast-contract.test.ts
+++ b/test/frontend-public-button-contrast-contract.test.ts
@@ -29,7 +29,18 @@ test("globals css defines public CTA contract classes", () => {
   assert.ok(source.includes(".public-cta-secondary"));
   assert.ok(source.includes(".public-cta-outline"));
   assert.ok(source.includes(".public-cta-on-hero"));
-  assert.ok(source.includes("clinical-primary-gradient"));
+  assert.ok(source.includes("transition-duration: 300ms"));
+  assert.ok(source.includes("cubic-bezier(0.2, 0.8, 0.2, 1)"));
+  assert.ok(source.includes("background-image: linear-gradient(135deg, #071F35 0%, #123E63 52%, #185A7C 100%)"));
+  assert.ok(source.includes("background-image: linear-gradient(135deg, #092942 0%, #164D78 52%, #1F6F94 100%)"));
+  assert.ok(source.includes("inset 0 1px 0"));
+  assert.ok(source.includes("box-shadow"));
+  assert.equal(source.includes("backdrop-filter"), false);
+  assert.equal(source.includes("-webkit-backdrop-filter"), false);
+  assert.equal(source.includes(".public-cta-primary::before"), false);
+  assert.equal(source.includes(".public-cta-primary::after"), false);
+  assert.equal(source.includes(".public-cta-on-hero::before"), false);
+  assert.equal(source.includes(".public-cta-on-hero::after"), false);
   assert.equal(source.includes('[data-auth-login-submit="true"]'), false);
 });
 


### PR DESCRIPTION
## Summary
- refines public CTA button gradients to improve visual hierarchy
- differentiates link and login buttons from public hero backgrounds
- adds restrained hover/focus depth for a more institutional interaction model
- preserves copy, routes, handlers, auth and backend behavior

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build