### PR TITLE
style(public): add gsap scroll reveal infrastructure

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
+    "gsap": "^3.15.0",
     "lucide-react": "^0.462.0",
     "next": "^15.1.0",
     "react": "^19.0.0",

--- a/frontend/src/components/public/PublicScrollReveal.tsx
+++ b/frontend/src/components/public/PublicScrollReveal.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { type ReactNode, useEffect, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PublicScrollRevealTag = "div" | "section" | "article";
+
+export type PublicScrollRevealProps = {
+  children: ReactNode;
+  className?: string;
+  as?: PublicScrollRevealTag;
+};
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function PublicScrollReveal({
+  children,
+  className,
+  as = "div",
+}: PublicScrollRevealProps) {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const rootElement = rootRef.current;
+
+    if (!rootElement || prefersReducedMotion()) {
+      return;
+    }
+
+    let isDisposed = false;
+    let context: { revert: () => void } | null = null;
+
+    const initialize = async () => {
+      const [{ gsap }, { ScrollTrigger }] = await Promise.all([
+        import("gsap"),
+        import("gsap/ScrollTrigger"),
+      ]);
+
+      if (isDisposed || !rootRef.current) {
+        return;
+      }
+
+      gsap.registerPlugin(ScrollTrigger);
+
+      context = gsap.context(() => {
+        gsap.fromTo(
+          rootRef.current,
+          { opacity: 0, y: 18 },
+          {
+            opacity: 1,
+            y: 0,
+            duration: 0.8,
+            ease: "power2.out",
+            scrollTrigger: {
+              trigger: rootRef.current,
+              start: "top 86%",
+              once: true,
+            },
+          },
+        );
+      }, rootRef);
+    };
+
+    void initialize();
+
+    return () => {
+      isDisposed = true;
+      context?.revert();
+    };
+  }, []);
+
+  if (as === "section") {
+    return (
+      <section
+        ref={(node) => {
+          rootRef.current = node;
+        }}
+        className={cn(className)}
+      >
+        {children}
+      </section>
+    );
+  }
+
+  if (as === "article") {
+    return (
+      <article
+        ref={(node) => {
+          rootRef.current = node;
+        }}
+        className={cn(className)}
+      >
+        {children}
+      </article>
+    );
+  }
+
+  return (
+    <div
+      ref={(node) => {
+        rootRef.current = node;
+      }}
+      className={cn(className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/public/PublicScrollReveal.tsx
+++ b/frontend/src/components/public/PublicScrollReveal.tsx
@@ -12,14 +12,6 @@ export type PublicScrollRevealProps = {
   as?: PublicScrollRevealTag;
 };
 
-function prefersReducedMotion(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-}
-
 export function PublicScrollReveal({
   children,
   className,
@@ -29,13 +21,16 @@ export function PublicScrollReveal({
 
   useEffect(() => {
     const rootElement = rootRef.current;
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
 
-    if (!rootElement || prefersReducedMotion()) {
+    if (!rootElement || prefersReducedMotion) {
       return;
     }
 
     let isDisposed = false;
-    let context: { revert: () => void } | null = null;
+    let ctx: { revert: () => void } | null = null;
 
     const initialize = async () => {
       const [{ gsap }, { ScrollTrigger }] = await Promise.all([
@@ -49,14 +44,14 @@ export function PublicScrollReveal({
 
       gsap.registerPlugin(ScrollTrigger);
 
-      context = gsap.context(() => {
+      ctx = gsap.context(() => {
         gsap.fromTo(
           rootRef.current,
-          { opacity: 0, y: 18 },
+          { opacity: 0.96, y: 14 },
           {
             opacity: 1,
             y: 0,
-            duration: 0.8,
+            duration: 0.75,
             ease: "power2.out",
             scrollTrigger: {
               trigger: rootRef.current,
@@ -72,7 +67,7 @@ export function PublicScrollReveal({
 
     return () => {
       isDisposed = true;
-      context?.revert();
+      ctx?.revert();
     };
   }, []);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       echarts-for-react:
         specifier: ^3.0.6
         version: 3.0.6(echarts@6.0.0)(react@19.2.5)
+      gsap:
+        specifier: ^3.15.0
+        version: 3.15.0
       lucide-react:
         specifier: ^0.462.0
         version: 0.462.0(react@19.2.5)
@@ -2580,6 +2583,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5922,6 +5928,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gsap@3.15.0: {}
 
   has-bigints@1.1.0: {}
 

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const COMPONENT_PATH = "frontend/src/components/public/PublicScrollReveal.tsx";
+const FRONTEND_PACKAGE_PATH = "frontend/package.json";
+
+const PUBLIC_FILES_WITHOUT_USAGE = [
+  "frontend/src/app/page.tsx",
+  "frontend/src/app/servicios/page.tsx",
+  "frontend/src/app/clinicas/page.tsx",
+  "frontend/src/app/precios/page.tsx",
+  "frontend/src/components/public/ContactoContent.tsx",
+  "frontend/src/components/public/ParticularesContent.tsx",
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx",
+];
+
+const PUBLIC_SERVER_PAGES = [
+  "frontend/src/app/page.tsx",
+  "frontend/src/app/servicios/page.tsx",
+  "frontend/src/app/clinicas/page.tsx",
+  "frontend/src/app/precios/page.tsx",
+];
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("public scroll reveal infrastructure file exists", () => {
+  assert.equal(existsSync(resolve(process.cwd(), COMPONENT_PATH)), true);
+});
+
+test("public scroll reveal infrastructure is client-only and uses safe gsap primitives", () => {
+  const source = read(COMPONENT_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes('import("gsap")'));
+  assert.ok(source.includes("ScrollTrigger"));
+  assert.ok(source.includes("gsap.context"));
+  assert.ok(source.includes("prefers-reduced-motion"));
+  assert.ok(source.includes("matchMedia"));
+  assert.ok(source.includes("revert()"));
+  assert.ok(source.includes("opacity: 0"));
+  assert.ok(source.includes("opacity: 1"));
+  assert.ok(source.includes("y: 18"));
+  assert.ok(source.includes("y: 0"));
+});
+
+test("public pages and public content do not use PublicScrollReveal yet", () => {
+  for (const path of PUBLIC_FILES_WITHOUT_USAGE) {
+    const source = read(path);
+
+    assert.equal(
+      source.includes("PublicScrollReveal"),
+      false,
+      `${path} should not reference PublicScrollReveal yet`,
+    );
+  }
+});
+
+test("public server pages do not import gsap directly", () => {
+  for (const path of PUBLIC_SERVER_PAGES) {
+    const source = read(path);
+
+    assert.equal(
+      source.includes('from "gsap"') || source.includes("from 'gsap'"),
+      false,
+      `${path} should not import gsap directly`,
+    );
+    assert.equal(
+      source.includes("ScrollTrigger"),
+      false,
+      `${path} should not reference ScrollTrigger directly`,
+    );
+  }
+});
+
+test("frontend package declares gsap dependency", () => {
+  const source = read(FRONTEND_PACKAGE_PATH);
+
+  assert.match(source, /"gsap"\s*:/);
+});

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -16,11 +16,14 @@ const PUBLIC_FILES_WITHOUT_USAGE = [
   "frontend/src/components/public/ProfesionalesSearchContent.tsx",
 ];
 
-const PUBLIC_SERVER_PAGES = [
+const PUBLIC_FILES_WITHOUT_GSAP_IMPORT = [
   "frontend/src/app/page.tsx",
   "frontend/src/app/servicios/page.tsx",
   "frontend/src/app/clinicas/page.tsx",
   "frontend/src/app/precios/page.tsx",
+  "frontend/src/components/public/ContactoContent.tsx",
+  "frontend/src/components/public/ParticularesContent.tsx",
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx",
 ];
 
 function read(relativePath: string): string {
@@ -44,10 +47,11 @@ test("public scroll reveal infrastructure is client-only and uses safe gsap prim
   assert.ok(source.includes("prefers-reduced-motion"));
   assert.ok(source.includes("matchMedia"));
   assert.ok(source.includes("revert()"));
-  assert.ok(source.includes("opacity: 0"));
+  assert.ok(source.includes("opacity: 0.96"));
   assert.ok(source.includes("opacity: 1"));
-  assert.ok(source.includes("y: 18"));
+  assert.ok(source.includes("y: 14"));
   assert.ok(source.includes("y: 0"));
+  assert.ok(source.includes("once: true"));
 });
 
 test("public pages and public content do not use PublicScrollReveal yet", () => {
@@ -62,8 +66,8 @@ test("public pages and public content do not use PublicScrollReveal yet", () => 
   }
 });
 
-test("public server pages do not import gsap directly", () => {
-  for (const path of PUBLIC_SERVER_PAGES) {
+test("public pages and content do not import gsap directly", () => {
+  for (const path of PUBLIC_FILES_WITHOUT_GSAP_IMPORT) {
     const source = read(path);
 
     assert.equal(


### PR DESCRIPTION
## Summary
- adds GSAP as a frontend dependency for future public scroll animations
- introduces a safe client-only PublicScrollReveal infrastructure component
- respects prefers-reduced-motion and cleans up GSAP context correctly
- adds tests to prevent GSAP usage in public server pages before rollout
- does not apply visual animations to public pages yet

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build