### PR TITLE
style(public): add home card stagger reveal

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -167,8 +167,8 @@ export default function HomePage() {
           className="py-16 md:py-20"
           aria-labelledby="services-heading"
         >
-          <PublicScrollReveal>
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal>
               <div className="text-center mb-12">
                 <h2
                   id="services-heading"
@@ -182,10 +182,14 @@ export default function HomePage() {
                   sostener decisiones con mayor confianza.
                 </p>
               </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal staggerChildren>
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
                 {services.map((service) => (
                   <Card
                     key={service.title}
+                    data-scroll-reveal-item
                     className="premium-card h-full"
                   >
                     <CardHeader>
@@ -200,13 +204,16 @@ export default function HomePage() {
                   </Card>
                 ))}
               </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal>
               <div className="mt-10 text-center">
                 <Button asChild variant="outline">
                   <Link href={ROUTES.servicios}>Ver todos los servicios</Link>
                 </Button>
               </div>
-            </div>
-          </PublicScrollReveal>
+            </PublicScrollReveal>
+          </div>
         </section>
 
         {/* Beneficios */}
@@ -214,8 +221,8 @@ export default function HomePage() {
           className="py-16 md:py-20"
           aria-labelledby="benefits-heading"
         >
-          <PublicScrollReveal>
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal>
               <div className="text-center mb-12">
                 <h2
                   id="benefits-heading"
@@ -229,9 +236,16 @@ export default function HomePage() {
                   diagnóstica antes de definir conductas de tratamiento.
                 </p>
               </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal staggerChildren>
               <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
                 {benefits.map((benefit) => (
-                  <Card key={benefit.title} className="premium-card h-full">
+                  <Card
+                    key={benefit.title}
+                    data-scroll-reveal-item
+                    className="premium-card h-full"
+                  >
                     <CardHeader>
                       <CardTitle className="text-xl">{benefit.title}</CardTitle>
                     </CardHeader>
@@ -253,8 +267,8 @@ export default function HomePage() {
                   </Card>
                 ))}
               </div>
-            </div>
-          </PublicScrollReveal>
+            </PublicScrollReveal>
+          </div>
         </section>
 
         {/* CTA final */}

--- a/frontend/src/components/public/PublicScrollReveal.tsx
+++ b/frontend/src/components/public/PublicScrollReveal.tsx
@@ -10,12 +10,16 @@ export type PublicScrollRevealProps = {
   children: ReactNode;
   className?: string;
   as?: PublicScrollRevealTag;
+  staggerChildren?: boolean;
+  childSelector?: string;
 };
 
 export function PublicScrollReveal({
   children,
   className,
   as = "div",
+  staggerChildren = false,
+  childSelector = "[data-scroll-reveal-item]",
 }: PublicScrollRevealProps) {
   const rootRef = useRef<HTMLElement | null>(null);
 
@@ -45,6 +49,31 @@ export function PublicScrollReveal({
       gsap.registerPlugin(ScrollTrigger);
 
       ctx = gsap.context(() => {
+        if (staggerChildren) {
+          const childElements = rootRef.current?.querySelectorAll(childSelector);
+
+          if (childElements && childElements.length > 0) {
+            gsap.fromTo(
+              childElements,
+              { opacity: 0.96, y: 16 },
+              {
+                opacity: 1,
+                y: 0,
+                duration: 0.72,
+                ease: "power2.out",
+                stagger: 0.07,
+                scrollTrigger: {
+                  trigger: rootRef.current,
+                  start: "top 84%",
+                  once: true,
+                },
+              },
+            );
+
+            return;
+          }
+        }
+
         gsap.fromTo(
           rootRef.current,
           { opacity: 0.96, y: 14 },
@@ -69,7 +98,7 @@ export function PublicScrollReveal({
       isDisposed = true;
       ctx?.revert();
     };
-  }, []);
+  }, [childSelector, staggerChildren]);
 
   if (as === "section") {
     return (

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 const COMPONENT_PATH = "frontend/src/components/public/PublicScrollReveal.tsx";
 const FRONTEND_PACKAGE_PATH = "frontend/package.json";
 const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+const SCROLL_REVEAL_FORBIDDEN_TERMS = ["lenis", "pinspacing", "scrub", "parallax"];
 
 const PUBLIC_FILES_WITHOUT_USAGE = [
   "frontend/src/app/servicios/page.tsx",
@@ -43,18 +44,24 @@ test("public scroll reveal infrastructure is client-only and uses safe gsap prim
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import("gsap")'));
   assert.ok(source.includes("ScrollTrigger"));
+  assert.ok(source.includes("registerPlugin(ScrollTrigger)"));
   assert.ok(source.includes("gsap.context"));
   assert.ok(source.includes("prefers-reduced-motion"));
   assert.ok(source.includes("matchMedia"));
   assert.ok(source.includes("revert()"));
+  assert.ok(source.includes("staggerChildren?: boolean"));
+  assert.ok(source.includes("childSelector?: string"));
+  assert.ok(source.includes('[data-scroll-reveal-item]'));
+  assert.ok(source.includes("stagger: 0.07"));
   assert.ok(source.includes("opacity: 0.96"));
   assert.ok(source.includes("opacity: 1"));
   assert.ok(source.includes("y: 14"));
+  assert.ok(source.includes("y: 16"));
   assert.ok(source.includes("y: 0"));
   assert.ok(source.includes("once: true"));
 });
 
-test("home page imports and uses PublicScrollReveal for the first rollout", () => {
+test("home page imports and uses PublicScrollReveal with card stagger rollout", () => {
   const source = read(HOME_PAGE_PATH);
 
   assert.ok(
@@ -63,6 +70,9 @@ test("home page imports and uses PublicScrollReveal for the first rollout", () =
     ),
   );
   assert.ok(source.includes("<PublicScrollReveal>"));
+  assert.ok(source.includes("<PublicScrollReveal staggerChildren>"));
+  assert.ok(source.includes("data-scroll-reveal-item"));
+  assert.ok(source.includes("staggerChildren"));
 });
 
 test("home page does not import gsap or ScrollTrigger directly", () => {
@@ -93,6 +103,18 @@ test("home keeps hero and hero image untouched by PublicScrollReveal", () => {
   );
 });
 
+test("home and reveal infrastructure do not include advanced scroll effects", () => {
+  const combinedSource = `${read(COMPONENT_PATH)}\n${read(HOME_PAGE_PATH)}`.toLowerCase();
+
+  for (const forbiddenTerm of SCROLL_REVEAL_FORBIDDEN_TERMS) {
+    assert.equal(
+      combinedSource.includes(forbiddenTerm),
+      false,
+      `scroll reveal rollout should not include ${forbiddenTerm}`,
+    );
+  }
+});
+
 test("public pages and public content do not use PublicScrollReveal yet", () => {
   for (const path of PUBLIC_FILES_WITHOUT_USAGE) {
     const source = read(path);
@@ -101,6 +123,18 @@ test("public pages and public content do not use PublicScrollReveal yet", () => 
       source.includes("PublicScrollReveal"),
       false,
       `${path} should not reference PublicScrollReveal yet`,
+    );
+  }
+});
+
+test("staggerChildren is only used in home rollout", () => {
+  for (const path of PUBLIC_FILES_WITHOUT_USAGE) {
+    const source = read(path);
+
+    assert.equal(
+      source.includes("staggerChildren"),
+      false,
+      `${path} should not reference staggerChildren`,
     );
   }
 });


### PR DESCRIPTION
## Summary
- extends PublicScrollReveal with optional staggered child reveals
- applies subtle stagger reveal to Home card groups only
- keeps the Home hero, hero image and navbar untouched
- preserves copy, layout, routes, handlers, auth and backend behavior
- updates scroll reveal tests for the card stagger rollout

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build