### PR TITLE
style(public): add public motion policy presets

### DIFF
--- a/frontend/src/components/public/PublicScrollReveal.tsx
+++ b/frontend/src/components/public/PublicScrollReveal.tsx
@@ -5,11 +5,50 @@ import { type ReactNode, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 type PublicScrollRevealTag = "div" | "section" | "article";
+export type PublicScrollRevealVariant = "section" | "cards" | "minimal";
+
+type PublicScrollRevealPreset = {
+  fromOpacity: number;
+  fromY: number;
+  duration: number;
+  ease: "power2.out";
+  start: string;
+  stagger?: number;
+};
+
+const PUBLIC_MOTION_POLICY_PRESETS: Record<
+  PublicScrollRevealVariant,
+  PublicScrollRevealPreset
+> = {
+  section: {
+    fromOpacity: 0.96,
+    fromY: 14,
+    duration: 0.75,
+    ease: "power2.out",
+    start: "top 86%",
+  },
+  cards: {
+    fromOpacity: 0.96,
+    fromY: 16,
+    duration: 0.72,
+    ease: "power2.out",
+    start: "top 84%",
+    stagger: 0.07,
+  },
+  minimal: {
+    fromOpacity: 0.98,
+    fromY: 8,
+    duration: 0.55,
+    ease: "power2.out",
+    start: "top 88%",
+  },
+};
 
 export type PublicScrollRevealProps = {
   children: ReactNode;
   className?: string;
   as?: PublicScrollRevealTag;
+  variant?: PublicScrollRevealVariant;
   staggerChildren?: boolean;
   childSelector?: string;
 };
@@ -18,16 +57,20 @@ export function PublicScrollReveal({
   children,
   className,
   as = "div",
+  variant,
   staggerChildren = false,
   childSelector = "[data-scroll-reveal-item]",
 }: PublicScrollRevealProps) {
   const rootRef = useRef<HTMLElement | null>(null);
+  const resolvedVariant: PublicScrollRevealVariant =
+    variant ?? (staggerChildren ? "cards" : "section");
 
   useEffect(() => {
     const rootElement = rootRef.current;
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
+    const preset = PUBLIC_MOTION_POLICY_PRESETS[resolvedVariant];
 
     if (!rootElement || prefersReducedMotion) {
       return;
@@ -51,20 +94,24 @@ export function PublicScrollReveal({
       ctx = gsap.context(() => {
         if (staggerChildren) {
           const childElements = rootRef.current?.querySelectorAll(childSelector);
+          const staggerValue =
+            preset.stagger ??
+            PUBLIC_MOTION_POLICY_PRESETS.cards.stagger ??
+            0.07;
 
           if (childElements && childElements.length > 0) {
             gsap.fromTo(
               childElements,
-              { opacity: 0.96, y: 16 },
+              { opacity: preset.fromOpacity, y: preset.fromY },
               {
                 opacity: 1,
                 y: 0,
-                duration: 0.72,
-                ease: "power2.out",
-                stagger: 0.07,
+                duration: preset.duration,
+                ease: preset.ease,
+                stagger: staggerValue,
                 scrollTrigger: {
                   trigger: rootRef.current,
-                  start: "top 84%",
+                  start: preset.start,
                   once: true,
                 },
               },
@@ -76,15 +123,15 @@ export function PublicScrollReveal({
 
         gsap.fromTo(
           rootRef.current,
-          { opacity: 0.96, y: 14 },
+          { opacity: preset.fromOpacity, y: preset.fromY },
           {
             opacity: 1,
             y: 0,
-            duration: 0.75,
-            ease: "power2.out",
+            duration: preset.duration,
+            ease: preset.ease,
             scrollTrigger: {
               trigger: rootRef.current,
-              start: "top 86%",
+              start: preset.start,
               once: true,
             },
           },
@@ -98,7 +145,7 @@ export function PublicScrollReveal({
       isDisposed = true;
       ctx?.revert();
     };
-  }, [childSelector, staggerChildren]);
+  }, [childSelector, resolvedVariant, staggerChildren]);
 
   if (as === "section") {
     return (

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -6,12 +6,22 @@ import test from "node:test";
 const COMPONENT_PATH = "frontend/src/components/public/PublicScrollReveal.tsx";
 const FRONTEND_PACKAGE_PATH = "frontend/package.json";
 const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
-const SCROLL_REVEAL_FORBIDDEN_TERMS = ["lenis", "pinspacing", "scrub", "parallax"];
+const SCROLL_REVEAL_FORBIDDEN_TERMS = [
+  "lenis",
+  "pinspacing",
+  "pin:",
+  "scrub",
+  "parallax",
+];
 
 const PUBLIC_FILES_WITHOUT_USAGE = [
   "frontend/src/app/servicios/page.tsx",
   "frontend/src/app/clinicas/page.tsx",
+  "frontend/src/app/profesionales/page.tsx",
+  "frontend/src/app/particulares/page.tsx",
+  "frontend/src/app/contacto/page.tsx",
   "frontend/src/app/precios/page.tsx",
+  "frontend/src/app/login/page.tsx",
   "frontend/src/components/public/ContactoContent.tsx",
   "frontend/src/components/public/ParticularesContent.tsx",
   "frontend/src/components/public/ProfesionalesSearchContent.tsx",
@@ -21,7 +31,11 @@ const PUBLIC_FILES_WITHOUT_GSAP_IMPORT = [
   "frontend/src/app/page.tsx",
   "frontend/src/app/servicios/page.tsx",
   "frontend/src/app/clinicas/page.tsx",
+  "frontend/src/app/profesionales/page.tsx",
+  "frontend/src/app/particulares/page.tsx",
+  "frontend/src/app/contacto/page.tsx",
   "frontend/src/app/precios/page.tsx",
+  "frontend/src/app/login/page.tsx",
   "frontend/src/components/public/ContactoContent.tsx",
   "frontend/src/components/public/ParticularesContent.tsx",
   "frontend/src/components/public/ProfesionalesSearchContent.tsx",
@@ -49,14 +63,29 @@ test("public scroll reveal infrastructure is client-only and uses safe gsap prim
   assert.ok(source.includes("prefers-reduced-motion"));
   assert.ok(source.includes("matchMedia"));
   assert.ok(source.includes("revert()"));
+  assert.ok(source.includes("PublicScrollRevealVariant"));
+  assert.ok(source.includes('"section" | "cards" | "minimal"'));
+  assert.ok(source.includes("variant?: PublicScrollRevealVariant"));
+  assert.ok(source.includes("PUBLIC_MOTION_POLICY_PRESETS"));
+  assert.ok(source.includes("section: {"));
+  assert.ok(source.includes("cards: {"));
+  assert.ok(source.includes("minimal: {"));
+  assert.ok(source.includes("fromOpacity: 0.98"));
+  assert.ok(source.includes("fromOpacity: 0.96"));
+  assert.ok(source.includes("fromY: 14"));
+  assert.ok(source.includes("fromY: 16"));
+  assert.ok(source.includes("fromY: 8"));
+  assert.ok(source.includes("duration: 0.75"));
+  assert.ok(source.includes("duration: 0.72"));
+  assert.ok(source.includes("duration: 0.55"));
+  assert.ok(source.includes('start: "top 86%"'));
+  assert.ok(source.includes('start: "top 84%"'));
+  assert.ok(source.includes('start: "top 88%"'));
   assert.ok(source.includes("staggerChildren?: boolean"));
   assert.ok(source.includes("childSelector?: string"));
   assert.ok(source.includes('[data-scroll-reveal-item]'));
   assert.ok(source.includes("stagger: 0.07"));
-  assert.ok(source.includes("opacity: 0.96"));
   assert.ok(source.includes("opacity: 1"));
-  assert.ok(source.includes("y: 14"));
-  assert.ok(source.includes("y: 16"));
   assert.ok(source.includes("y: 0"));
   assert.ok(source.includes("once: true"));
 });


### PR DESCRIPTION
## Summary
- adds closed public motion policy presets to PublicScrollReveal
- keeps GSAP usage centralized and client-only
- preserves reduced-motion behavior and cleanup guarantees
- does not apply new animations to additional pages yet
- adds tests for the global public motion policy

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build