### PR TITLE
style(public): add services scroll reveal

### DIFF
--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import {
   Card,
   CardContent,
@@ -135,161 +136,190 @@ export default function ServiciosPage() {
         </div>
       </section>
       <div className="public-soft-canvas">
-      <section className="py-16 md:py-20">
-        <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-          <div className="mx-auto mb-10 max-w-4xl">
-            <h2 className="text-2xl font-bold text-vetneb-ink md:text-3xl">
-              Estudios diagnósticos con criterio clínico-patológico
-            </h2>
-            <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
-              Unificamos histopatología, citología, técnicas complementarias e
-              informes trazables para acompañar decisiones clínicas en cada
-              etapa del caso.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8" data-services-polished="true">
-            {serviceCategories.map((service) => (
-              <div
-                key={service.id}
-                className={
-                  serviceCategories.length % 2 === 1 &&
-                  service.id === serviceCategories[serviceCategories.length - 1]?.id
-                    ? "lg:col-span-2 lg:mx-auto lg:w-full lg:max-w-[calc((100%-2rem)/2)]"
-                    : ""
-                }
-              >
-                <Card id={service.id} className="premium-card h-full">
-                  <CardHeader>
-                    <VisualIcon icon={service.icon} tone={service.tone} className="mb-2" />
-                    <CardTitle className="text-xl text-vetneb-ink">
-                      {service.title}
-                    </CardTitle>
-                    <CardDescription className="public-copy-tight text-sm text-muted-foreground">
-                      {service.description}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <ul className="space-y-2.5">
-                      {service.features.map((feature) => (
-                        <li key={feature} className="flex items-start gap-2">
-                          <span
-                            className="mt-0.5 text-primary font-bold text-xs"
-                            aria-hidden="true"
-                          >
-                            →
-                          </span>
-                          <span className="text-sm text-muted-foreground">{feature}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                </Card>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
-          <div className="premium-card p-8">
-            <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
-              Coordinación diagnóstica para clínicas y profesionales
-            </h2>
-            <p className="public-copy text-muted-foreground mb-8">
-              Coordinamos recepción de muestras, priorización por complejidad y
-              entrega de informes trazables. Los tiempos se ajustan al criterio
-              diagnóstico y a las necesidades clínicas de cada caso.
-            </p>
-            <div className="flex flex-col justify-center gap-3 sm:flex-row">
-              <Button
-                asChild
-                size="lg"
-                className="public-cta-primary w-full sm:w-auto"
-              >
-                <Link href={ROUTES.contacto}>
-                  Solicitar coordinación diagnóstica
-                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                </Link>
-              </Button>
-              <Button
-                asChild
-                size="lg"
-                variant="outline"
-                className="public-cta-outline w-full sm:w-auto"
-              >
-                <Link href={ROUTES.clinicas}>Conocer solución para clínicas</Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-          <div className="premium-card-muted p-6">
-            <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
-              Diagnóstico integral para medicina veterinaria
-            </h2>
-            <p className="public-copy text-muted-foreground mb-4">
-              El diagnóstico anatomopatológico veterinario requiere integrar no
-              sólo el análisis de tejido y citología, sino también el
-              conocimiento clínico global de cada paciente. Esta articulación
-              permite enriquecer la lectura diagnóstica junto con otras áreas de
-              práctica veterinaria.
-            </p>
-            <p className="public-copy text-muted-foreground">
-              Nuestro objetivo es colaborar de forma permanente con equipos
-              quirúrgicos y clínicos, estudiando tejidos extirpados y muestras de
-              punción para construir diagnósticos específicos y apoyar planes de
-              tratamiento personalizados.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
-          <div className="premium-card-muted p-6">
-            <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
-              Para tener en cuenta
-            </h2>
-            <p className="public-copy text-muted-foreground mb-4">
-              El estudio anatomopatológico requiere integrar datos clínicos con la
-              evaluación histológica y citológica realizada por el médico
-              veterinario patólogo en microscopía.
-            </p>
-            <p className="public-copy text-muted-foreground">
-              No se trata de un diagnóstico automatizado, por lo que los tiempos
-              son variables según complejidad y técnicas complementarias
-              requeridas. En ciertos casos se requiere interconsulta profesional
-              para alcanzar mayor precisión diagnóstica.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-          <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
-            <div className="flex items-start gap-3">
-              <VisualIcon icon={ClipboardCheck} tone="emerald" className="h-11 w-11 shrink-0 rounded-xl" />
-              <div>
-                <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
-                  Valores que guían el servicio
+        <section className="py-16 md:py-20">
+          <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="mx-auto mb-10 max-w-4xl">
+                <h2 className="text-2xl font-bold text-vetneb-ink md:text-3xl">
+                  Estudios diagnósticos con criterio clínico-patológico
                 </h2>
-                <p className="public-copy text-muted-foreground">
-                  Basamos nuestro trabajo en compromiso, seriedad, respeto,
-                  responsabilidad, confianza, diálogo, trabajo en equipo, empatía y
-                  capacitación constante para sostener un servicio patológico
-                  veterinario confiable.
+                <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
+                  Unificamos histopatología, citología, técnicas complementarias e
+                  informes trazables para acompañar decisiones clínicas en cada
+                  etapa del caso.
                 </p>
               </div>
-            </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal variant="cards" staggerChildren>
+              <div
+                className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"
+                data-services-polished="true"
+              >
+                {serviceCategories.map((service) => (
+                  <div
+                    key={service.id}
+                    data-scroll-reveal-item
+                    className={
+                      serviceCategories.length % 2 === 1 &&
+                      service.id === serviceCategories[serviceCategories.length - 1]?.id
+                        ? "lg:col-span-2 lg:mx-auto lg:w-full lg:max-w-[calc((100%-2rem)/2)]"
+                        : ""
+                    }
+                  >
+                    <Card id={service.id} className="premium-card h-full">
+                      <CardHeader>
+                        <VisualIcon
+                          icon={service.icon}
+                          tone={service.tone}
+                          className="mb-2"
+                        />
+                        <CardTitle className="text-xl text-vetneb-ink">
+                          {service.title}
+                        </CardTitle>
+                        <CardDescription className="public-copy-tight text-sm text-muted-foreground">
+                          {service.description}
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <ul className="space-y-2.5">
+                          {service.features.map((feature) => (
+                            <li key={feature} className="flex items-start gap-2">
+                              <span
+                                className="mt-0.5 text-primary font-bold text-xs"
+                                aria-hidden="true"
+                              >
+                                →
+                              </span>
+                              <span className="text-sm text-muted-foreground">
+                                {feature}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </CardContent>
+                    </Card>
+                  </div>
+                ))}
+              </div>
+            </PublicScrollReveal>
           </div>
-        </div>
-      </section>
+        </section>
+
+        <section className="py-16">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
+            <PublicScrollReveal variant="minimal">
+              <div className="premium-card p-8">
+                <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
+                  Coordinación diagnóstica para clínicas y profesionales
+                </h2>
+                <p className="public-copy text-muted-foreground mb-8">
+                  Coordinamos recepción de muestras, priorización por complejidad y
+                  entrega de informes trazables. Los tiempos se ajustan al criterio
+                  diagnóstico y a las necesidades clínicas de cada caso.
+                </p>
+                <div className="flex flex-col justify-center gap-3 sm:flex-row">
+                  <Button
+                    asChild
+                    size="lg"
+                    className="public-cta-primary w-full sm:w-auto"
+                  >
+                    <Link href={ROUTES.contacto}>
+                      Solicitar coordinación diagnóstica
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </Link>
+                  </Button>
+                  <Button
+                    asChild
+                    size="lg"
+                    variant="outline"
+                    className="public-cta-outline w-full sm:w-auto"
+                  >
+                    <Link href={ROUTES.clinicas}>
+                      Conocer solución para clínicas
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
+            <PublicScrollReveal variant="section">
+              <div className="premium-card-muted p-6">
+                <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
+                  Diagnóstico integral para medicina veterinaria
+                </h2>
+                <p className="public-copy text-muted-foreground mb-4">
+                  El diagnóstico anatomopatológico veterinario requiere integrar no
+                  sólo el análisis de tejido y citología, sino también el
+                  conocimiento clínico global de cada paciente. Esta articulación
+                  permite enriquecer la lectura diagnóstica junto con otras áreas
+                  de práctica veterinaria.
+                </p>
+                <p className="public-copy text-muted-foreground">
+                  Nuestro objetivo es colaborar de forma permanente con equipos
+                  quirúrgicos y clínicos, estudiando tejidos extirpados y muestras
+                  de punción para construir diagnósticos específicos y apoyar
+                  planes de tratamiento personalizados.
+                </p>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
+            <PublicScrollReveal variant="section">
+              <div className="premium-card-muted p-6">
+                <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
+                  Para tener en cuenta
+                </h2>
+                <p className="public-copy text-muted-foreground mb-4">
+                  El estudio anatomopatológico requiere integrar datos clínicos con
+                  la evaluación histológica y citológica realizada por el médico
+                  veterinario patólogo en microscopía.
+                </p>
+                <p className="public-copy text-muted-foreground">
+                  No se trata de un diagnóstico automatizado, por lo que los
+                  tiempos son variables según complejidad y técnicas
+                  complementarias requeridas. En ciertos casos se requiere
+                  interconsulta profesional para alcanzar mayor precisión
+                  diagnóstica.
+                </p>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
+            <PublicScrollReveal variant="minimal">
+              <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
+                <div className="flex items-start gap-3">
+                  <VisualIcon
+                    icon={ClipboardCheck}
+                    tone="emerald"
+                    className="h-11 w-11 shrink-0 rounded-xl"
+                  />
+                  <div>
+                    <h2 className="text-2xl font-bold text-vetneb-ink mb-4">
+                      Valores que guían el servicio
+                    </h2>
+                    <p className="public-copy text-muted-foreground">
+                      Basamos nuestro trabajo en compromiso, seriedad, respeto,
+                      responsabilidad, confianza, diálogo, trabajo en equipo,
+                      empatía y capacitación constante para sostener un servicio
+                      patológico veterinario confiable.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
       </div>
     </PublicLayout>
   );

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 const COMPONENT_PATH = "frontend/src/components/public/PublicScrollReveal.tsx";
 const FRONTEND_PACKAGE_PATH = "frontend/package.json";
 const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+const SERVICES_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
 const SCROLL_REVEAL_FORBIDDEN_TERMS = [
   "lenis",
   "pinspacing",
@@ -15,7 +16,6 @@ const SCROLL_REVEAL_FORBIDDEN_TERMS = [
 ];
 
 const PUBLIC_FILES_WITHOUT_USAGE = [
-  "frontend/src/app/servicios/page.tsx",
   "frontend/src/app/clinicas/page.tsx",
   "frontend/src/app/profesionales/page.tsx",
   "frontend/src/app/particulares/page.tsx",
@@ -104,8 +104,35 @@ test("home page imports and uses PublicScrollReveal with card stagger rollout", 
   assert.ok(source.includes("staggerChildren"));
 });
 
+test("services page imports and uses PublicScrollReveal for controlled rollout", () => {
+  const source = read(SERVICES_PAGE_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";',
+    ),
+  );
+  assert.ok(source.includes("<PublicScrollReveal"));
+  assert.ok(source.includes('variant="section"'));
+  assert.ok(source.includes('variant="cards"'));
+  assert.ok(source.includes('variant="minimal"'));
+  assert.ok(source.includes("staggerChildren"));
+  assert.ok(source.includes("data-scroll-reveal-item"));
+});
+
 test("home page does not import gsap or ScrollTrigger directly", () => {
   const source = read(HOME_PAGE_PATH);
+
+  assert.equal(
+    source.includes('from "gsap"') || source.includes("from 'gsap'"),
+    false,
+  );
+  assert.equal(source.includes('from "gsap/ScrollTrigger"'), false);
+  assert.equal(source.includes("from 'gsap/ScrollTrigger'"), false);
+});
+
+test("services page does not import gsap or ScrollTrigger directly", () => {
+  const source = read(SERVICES_PAGE_PATH);
 
   assert.equal(
     source.includes('from "gsap"') || source.includes("from 'gsap'"),
@@ -132,8 +159,9 @@ test("home keeps hero and hero image untouched by PublicScrollReveal", () => {
   );
 });
 
-test("home and reveal infrastructure do not include advanced scroll effects", () => {
-  const combinedSource = `${read(COMPONENT_PATH)}\n${read(HOME_PAGE_PATH)}`.toLowerCase();
+test("home, services and reveal infrastructure do not include advanced scroll effects", () => {
+  const combinedSource =
+    `${read(COMPONENT_PATH)}\n${read(HOME_PAGE_PATH)}\n${read(SERVICES_PAGE_PATH)}`.toLowerCase();
 
   for (const forbiddenTerm of SCROLL_REVEAL_FORBIDDEN_TERMS) {
     assert.equal(
@@ -156,7 +184,7 @@ test("public pages and public content do not use PublicScrollReveal yet", () => 
   }
 });
 
-test("staggerChildren is only used in home rollout", () => {
+test("staggerChildren is only used in home and services rollout", () => {
   for (const path of PUBLIC_FILES_WITHOUT_USAGE) {
     const source = read(path);
 


### PR DESCRIPTION
## Summary
- applies the public motion policy to the Services page
- uses PublicScrollReveal presets without direct GSAP imports in the page
- keeps hero, copy, layout, routes, handlers, auth and backend behavior unchanged
- updates scroll reveal tests for the controlled Services rollout

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build