### PR TITLE
style(public): add modern typography foundation

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -45,6 +45,9 @@
     --sidebar-accent-foreground: 190 38% 96%;
     --sidebar-border: 202 41% 26%;
     --sidebar-ring: 181 65% 43%;
+    --font-heading: var(--font-inter);
+    --font-body: var(--font-source-sans-3);
+    --font-ui: var(--font-inter);
   }
 
   .dark {
@@ -86,12 +89,37 @@
   body {
     @apply bg-background text-foreground;
     min-height: 100vh;
+    font-family: var(--font-body), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-feature-settings:
       "cv02" 1,
       "cv03" 1,
       "cv04" 1,
       "cv11" 1;
     text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .font-heading,
+  .public-heading {
+    font-family: var(--font-heading), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  button,
+  input,
+  select,
+  textarea,
+  .public-cta-primary,
+  .public-cta-secondary,
+  .public-cta-outline,
+  .public-cta-on-hero {
+    font-family: var(--font-ui), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 
   ::selection {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Source_Sans_3 } from "next/font/google";
 import "./globals.css";
 
 import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";
@@ -8,6 +8,14 @@ const inter = Inter({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-inter",
+  weight: ["400", "500", "600", "700"],
+});
+
+const sourceSans = Source_Sans_3({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-source-sans-3",
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = baseMetadata;
@@ -20,14 +28,14 @@ export default function RootLayout({
   const orgJsonLd = getOrganizationJsonLd();
 
   return (
-    <html lang="es" className={inter.variable}>
+    <html lang="es" className={`${inter.variable} ${sourceSans.variable}`}>
       <head>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
         />
       </head>
-      <body className="min-h-screen bg-background font-sans antialiased">
+      <body className="min-h-screen bg-background antialiased">
         {children}
       </body>
     </html>

--- a/test/frontend-public-typography-contract.test.ts
+++ b/test/frontend-public-typography-contract.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const LAYOUT_PATH = "frontend/src/app/layout.tsx";
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("root layout loads Inter and Source Sans 3 via next/font and exposes both css variables", () => {
+  const source = read(LAYOUT_PATH);
+
+  assert.match(
+    source,
+    /import\s+\{\s*Inter\s*,\s*Source_Sans_3\s*\}\s+from\s+"next\/font\/google";/,
+  );
+  assert.ok(source.includes('variable: "--font-inter"'));
+  assert.ok(source.includes('variable: "--font-source-sans-3"'));
+  assert.ok(source.includes('weight: ["400", "500", "600", "700"]'));
+  assert.match(
+    source,
+    /<html[^>]*className=\{`\$\{inter\.variable\}\s+\$\{sourceSans\.variable\}`\}/,
+  );
+});
+
+test("globals css defines typography tokens and applies them to body headings and ui controls", () => {
+  const source = read(GLOBALS_CSS_PATH);
+
+  assert.ok(source.includes("--font-heading: var(--font-inter);"));
+  assert.ok(source.includes("--font-body: var(--font-source-sans-3);"));
+  assert.ok(source.includes("--font-ui: var(--font-inter);"));
+
+  assert.match(
+    source,
+    /body\s*\{[\s\S]*font-family:\s*var\(--font-body\),\s*system-ui,\s*-apple-system,\s*BlinkMacSystemFont,\s*"Segoe UI",\s*sans-serif;/,
+  );
+  assert.match(
+    source,
+    /h1,[\s\S]*h6,[\s\S]*\.font-heading,[\s\S]*\.public-heading\s*\{[\s\S]*font-family:\s*var\(--font-heading\),\s*system-ui,\s*-apple-system,\s*BlinkMacSystemFont,\s*"Segoe UI",\s*sans-serif;/,
+  );
+  assert.match(
+    source,
+    /button,[\s\S]*textarea,[\s\S]*\.public-cta-on-hero\s*\{[\s\S]*font-family:\s*var\(--font-ui\),\s*system-ui,\s*-apple-system,\s*BlinkMacSystemFont,\s*"Segoe UI",\s*sans-serif;/,
+  );
+
+  assert.ok(source.includes("-webkit-font-smoothing: antialiased;"));
+  assert.ok(source.includes("-moz-osx-font-smoothing: grayscale;"));
+});
+
+test("typography foundation does not introduce motion or serif policy regressions", () => {
+  const layout = read(LAYOUT_PATH);
+  const globals = read(GLOBALS_CSS_PATH);
+  const combined = `${layout}\n${globals}`;
+
+  for (const forbiddenMotionMarker of [
+    "gsap",
+    "ScrollTrigger",
+    "PublicScrollReveal",
+    "staggerChildren",
+    "data-scroll-reveal-item",
+    "Lenis",
+    "pinSpacing",
+    "scrub",
+    "parallax",
+  ]) {
+    assert.equal(
+      combined.includes(forbiddenMotionMarker),
+      false,
+      `typography foundation must not include ${forbiddenMotionMarker}`,
+    );
+  }
+
+  for (const forbiddenSerifMarker of [
+    "Source Serif",
+    "Merriweather",
+    "Georgia",
+    "\"Times New Roman\"",
+  ]) {
+    assert.equal(
+      combined.includes(forbiddenSerifMarker),
+      false,
+      `typography foundation must not include ${forbiddenSerifMarker}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- adds Inter and Source Sans 3 as the public typography foundation with next/font
- defines global typography tokens for headings, body copy and UI controls
- keeps existing proportions with only minimal legibility-oriented foundation changes
- preserves copy, layout, routes, handlers, auth, backend and motion behavior

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build