### PR TITLE
style(public): remove contact clinic integration link

### DIFF
--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -2,7 +2,6 @@
 
 import { FormEvent, useState } from "react";
 import {
-  ArrowRight,
   Building2,
   Mail,
   MapPin,
@@ -310,10 +309,6 @@ export function ContactoContent() {
                   configurar su acceso y explicarle el proceso de integración,
                   trazabilidad y seguimiento de informes.
                 </p>
-                <div className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary">
-                  Solicitar integración clínica
-                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                </div>
               </div>
             </div>
           </div>

--- a/test/frontend-contacto-page.test.ts
+++ b/test/frontend-contacto-page.test.ts
@@ -66,6 +66,8 @@ test("contacto content keeps clinic onboarding guidance visible", () => {
   assert.ok(source.includes("configurar su acceso"));
   assert.ok(source.includes("Nombre de la clínica (opcional)"));
   assert.ok(source.includes("Describa su consulta o solicitud de acceso"));
+  assert.equal(source.includes("Solicitar integración clínica"), false);
+  assert.equal(source.includes("ArrowRight"), false);
 });
 
 test("contacto page remains public and does not expose private route literals", () => {


### PR DESCRIPTION
## Summary
- removes the unused clinic integration link from the contact page
- removes the associated arrow icon when no longer needed
- keeps the clinic contact information card intact
- preserves layout, routes, handlers, auth, backend, motion and typography behavior

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build