### PR TITLE
style(public): add technical line treatment to buttons

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -809,125 +809,137 @@
   .public-cta-outline,
   .public-cta-on-hero {
     letter-spacing: 0.01em;
-    transition-property: background-image, background-color, border-color, box-shadow, transform;
+    transition-property: background-image, background-color, border-color, box-shadow, color, transform;
     transition-duration: 300ms;
     transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
   }
 
   .public-cta-primary {
     @apply font-semibold text-primary-foreground;
-    border: 1px solid rgba(170, 205, 226, 0.28);
+    border: 1px solid rgba(190, 224, 242, 0.34);
     background-image: linear-gradient(135deg, #071F35 0%, #123E63 52%, #185A7C 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.18),
-      inset 0 -1px 0 rgba(4, 16, 28, 0.34),
+      inset 0 1px 0 rgba(255, 255, 255, 0.24),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.38),
       0 14px 34px rgba(7, 31, 53, 0.24);
   }
 
   .public-cta-primary:hover {
-    border-color: rgba(190, 224, 242, 0.36);
+    border-color: rgba(218, 239, 248, 0.48);
     background-image: linear-gradient(135deg, #092942 0%, #164D78 52%, #1F6F94 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.22),
-      inset 0 -1px 0 rgba(4, 16, 28, 0.36),
+      inset 0 1px 0 rgba(255, 255, 255, 0.30),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.42),
       0 18px 40px rgba(7, 31, 53, 0.28);
     transform: translateY(-0.5px);
   }
 
   .public-cta-primary:active {
+    border-color: rgba(198, 228, 243, 0.44);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.16),
-      inset 0 -1px 0 rgba(4, 16, 28, 0.38),
-      0 12px 28px rgba(7, 31, 53, 0.22);
+      inset 0 1px 0 rgba(255, 255, 255, 0.20),
+      inset 0 -1px 0 rgba(4, 16, 28, 0.44),
+      0 11px 25px rgba(7, 31, 53, 0.22);
     transform: translateY(0);
   }
 
   .public-cta-secondary {
     @apply font-semibold text-vetneb-navy;
-    border: 1px solid rgba(118, 156, 182, 0.34);
+    border: 1px solid rgba(124, 163, 189, 0.42);
     background-image: linear-gradient(135deg, rgba(236, 245, 251, 0.98) 0%, rgba(224, 238, 248, 0.95) 52%, rgba(211, 230, 242, 0.92) 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.42),
-      inset 0 -1px 0 rgba(74, 108, 132, 0.16),
+      inset 0 1px 0 rgba(255, 255, 255, 0.52),
+      inset 0 -1px 0 rgba(68, 101, 124, 0.22),
       0 10px 24px rgba(12, 40, 64, 0.12);
   }
 
   .public-cta-secondary:hover {
-    border-color: rgba(106, 151, 180, 0.42);
+    border-color: rgba(142, 182, 206, 0.52);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.5),
-      inset 0 -1px 0 rgba(66, 101, 126, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.62),
+      inset 0 -1px 0 rgba(61, 94, 117, 0.28),
       0 13px 28px rgba(12, 40, 64, 0.16);
+    transform: translateY(-0.5px);
   }
 
   .public-cta-outline {
     @apply font-semibold text-vetneb-navy;
-    border: 1px solid rgba(122, 161, 187, 0.4);
-    background-color: rgba(241, 248, 253, 0.98);
+    border: 1px solid rgba(126, 166, 192, 0.44);
+    background-image: linear-gradient(135deg, rgba(244, 250, 254, 0.98) 0%, rgba(236, 246, 252, 0.96) 54%, rgba(229, 241, 249, 0.94) 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.44),
-      inset 0 -1px 0 rgba(82, 116, 141, 0.14),
+      inset 0 1px 0 rgba(255, 255, 255, 0.56),
+      inset 0 -1px 0 rgba(71, 104, 128, 0.20),
       0 10px 22px rgba(12, 40, 64, 0.11);
   }
 
   .public-cta-outline:hover {
-    border-color: rgba(114, 158, 186, 0.48);
-    background-color: rgba(248, 252, 255, 1);
+    border-color: rgba(148, 186, 209, 0.54);
+    background-image: linear-gradient(135deg, rgba(248, 253, 255, 1) 0%, rgba(240, 248, 253, 0.98) 56%, rgba(233, 244, 251, 0.95) 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.54),
-      inset 0 -1px 0 rgba(74, 107, 132, 0.18),
+      inset 0 1px 0 rgba(255, 255, 255, 0.66),
+      inset 0 -1px 0 rgba(64, 98, 122, 0.26),
       0 13px 28px rgba(12, 40, 64, 0.14);
+    transform: translateY(-0.5px);
   }
 
   .public-cta-on-hero {
     @apply font-semibold text-vetneb-navy;
-    border: 1px solid rgba(228, 242, 252, 0.78);
+    border: 1px solid rgba(232, 244, 252, 0.84);
     background-image: linear-gradient(135deg, rgba(244, 250, 255, 0.98) 0%, rgba(232, 243, 251, 0.95) 52%, rgba(220, 236, 247, 0.92) 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.5),
-      inset 0 -1px 0 rgba(74, 108, 132, 0.18),
+      inset 0 1px 0 rgba(255, 255, 255, 0.56),
+      inset 0 -1px 0 rgba(66, 100, 124, 0.22),
       0 14px 32px rgba(5, 28, 42, 0.24);
   }
 
   .public-cta-on-hero:hover {
-    border-color: rgba(236, 248, 255, 0.92);
+    border-color: rgba(245, 252, 255, 0.98);
     background-image: linear-gradient(135deg, rgba(248, 253, 255, 1) 0%, rgba(236, 246, 253, 0.96) 52%, rgba(223, 238, 248, 0.93) 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.58),
-      inset 0 -1px 0 rgba(67, 101, 124, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.66),
+      inset 0 -1px 0 rgba(58, 92, 116, 0.26),
       0 18px 36px rgba(5, 28, 42, 0.27);
     transform: translateY(-0.5px);
   }
 
-  .public-cta-primary:active {
+  .public-cta-primary:focus-visible,
+  .public-cta-secondary:focus-visible,
+  .public-cta-outline:focus-visible,
+  .public-cta-on-hero:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.14),
-      inset 0 -1px 0 rgba(4, 16, 28, 0.4),
-      0 10px 22px rgba(7, 31, 53, 0.2);
-    transform: translateY(0);
+      inset 0 1px 0 rgba(255, 255, 255, 0.34),
+      inset 0 -1px 0 rgba(7, 23, 39, 0.34),
+      0 0 0 3px hsl(var(--ring) / 0.2),
+      0 14px 32px rgba(7, 31, 53, 0.20);
+    transform: translateY(-0.5px);
   }
 
   .public-cta-secondary:active {
+    border-color: rgba(132, 171, 196, 0.48);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.38),
-      inset 0 -1px 0 rgba(66, 100, 124, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.48),
+      inset 0 -1px 0 rgba(61, 95, 118, 0.30),
       0 7px 18px rgba(12, 40, 64, 0.12);
     transform: translateY(0);
   }
 
   .public-cta-outline:active {
+    border-color: rgba(136, 175, 199, 0.50);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.4),
-      inset 0 -1px 0 rgba(74, 106, 130, 0.18),
+      inset 0 1px 0 rgba(255, 255, 255, 0.50),
+      inset 0 -1px 0 rgba(60, 94, 118, 0.28),
       0 7px 18px rgba(12, 40, 64, 0.11);
     transform: translateY(0);
   }
 
   .public-cta-on-hero:active {
+    border-color: rgba(235, 246, 253, 0.90);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.42),
-      inset 0 -1px 0 rgba(67, 101, 124, 0.2),
-      0 10px 22px rgba(5, 28, 42, 0.2);
+      inset 0 1px 0 rgba(255, 255, 255, 0.52),
+      inset 0 -1px 0 rgba(58, 92, 116, 0.30),
+      0 10px 22px rgba(5, 28, 42, 0.20);
     transform: translateY(0);
   }
 
@@ -940,10 +952,11 @@
   .public-cta-on-hero:disabled,
   .public-cta-on-hero[aria-busy="true"] {
     transform: none;
+    border-color: rgba(146, 174, 194, 0.34);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.24),
-      inset 0 -1px 0 rgba(7, 23, 39, 0.18),
-      0 8px 18px rgba(7, 31, 53, 0.14);
+      inset 0 -1px 0 rgba(7, 23, 39, 0.26),
+      0 8px 18px rgba(7, 31, 53, 0.12);
   }
 }
 /* public-secondary-hero-surface:start */

--- a/test/frontend-public-button-contrast-contract.test.ts
+++ b/test/frontend-public-button-contrast-contract.test.ts
@@ -24,19 +24,58 @@ function read(relativePath: string): string {
 
 test("globals css defines public CTA contract classes", () => {
   const source = read(GLOBALS_CSS_PATH);
+  const ctaContractStart = source.indexOf(
+    ".public-cta-primary,\n  .public-cta-secondary,\n  .public-cta-outline,\n  .public-cta-on-hero {\n    letter-spacing: 0.01em;",
+  );
+  const ctaContractEnd = source.indexOf("/* public-secondary-hero-surface:start */");
+  const hasValidCtaContractRange =
+    ctaContractStart !== -1 &&
+    ctaContractEnd !== -1 &&
+    ctaContractEnd > ctaContractStart;
 
   assert.ok(source.includes(".public-cta-primary"));
   assert.ok(source.includes(".public-cta-secondary"));
   assert.ok(source.includes(".public-cta-outline"));
   assert.ok(source.includes(".public-cta-on-hero"));
+  assert.ok(hasValidCtaContractRange, "public CTA contract block must exist");
+
+  const ctaContract = source.slice(ctaContractStart, ctaContractEnd);
+
+  assert.ok(ctaContract.includes("inset 0 1px 0"));
+  assert.ok(ctaContract.includes("inset 0 -1px 0"));
+  assert.ok(
+    ctaContract.includes(
+      "transition-property: background-image, background-color, border-color, box-shadow, color, transform;",
+    ),
+  );
   assert.ok(source.includes("transition-duration: 300ms"));
   assert.ok(source.includes("cubic-bezier(0.2, 0.8, 0.2, 1)"));
+  assert.ok(ctaContract.includes("transform: translateY(-0.5px)"));
+  assert.ok(ctaContract.includes("transform: translateY(0)"));
+  assert.ok(ctaContract.includes(":focus-visible"));
   assert.ok(source.includes("background-image: linear-gradient(135deg, #071F35 0%, #123E63 52%, #185A7C 100%)"));
   assert.ok(source.includes("background-image: linear-gradient(135deg, #092942 0%, #164D78 52%, #1F6F94 100%)"));
-  assert.ok(source.includes("inset 0 1px 0"));
-  assert.ok(source.includes("box-shadow"));
-  assert.equal(source.includes("backdrop-filter"), false);
-  assert.equal(source.includes("-webkit-backdrop-filter"), false);
+  assert.ok(ctaContract.includes("box-shadow"));
+
+  for (const forbiddenMarker of [
+    "backdrop-filter",
+    "-webkit-backdrop-filter",
+    "hard-shadow",
+    "text-shadow",
+    "@keyframes",
+    "animation:",
+    "translateY(-1px)",
+    "Lenis",
+    "gsap",
+    "ScrollTrigger",
+  ]) {
+    assert.equal(
+      ctaContract.includes(forbiddenMarker),
+      false,
+      `public CTA contract must not contain ${forbiddenMarker}`,
+    );
+  }
+
   assert.equal(source.includes(".public-cta-primary::before"), false);
   assert.equal(source.includes(".public-cta-primary::after"), false);
   assert.equal(source.includes(".public-cta-on-hero::before"), false);


### PR DESCRIPTION
## Summary
- adds a subtle technical line treatment to public CTA buttons
- uses inset borders and controlled shadows to improve visual definition
- adds restrained luminous hover/focus/active states without hard-shadow or glass effects
- preserves copy, layout, routes, handlers, auth, backend, motion and typography behavior

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build