### PR TITLE
fix(public): align particular token form options

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -42,8 +42,8 @@ const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
   petName: "",
   petAge: "",
   petBreed: "",
-  petSex: "",
-  petSpecies: "",
+  petSex: "Macho",
+  petSpecies: "Caninos",
   sampleLocation: "",
   sampleEvolution: "",
   detailsLesion: "",
@@ -70,18 +70,20 @@ const REQUIRED_FIELD_LABELS: Array<{
 ];
 
 const PET_SEX_OPTIONS = [
-  { value: "", label: "Seleccionar sexo" },
   { value: "Macho", label: "Macho" },
   { value: "Hembra", label: "Hembra" },
-  { value: "No informado", label: "No informado" },
 ];
 
 const PET_SPECIES_OPTIONS = [
-  { value: "", label: "Seleccionar especie" },
-  { value: "Canina", label: "Canina" },
-  { value: "Felina", label: "Felina" },
-  { value: "Equina", label: "Equina" },
-  { value: "Otra", label: "Otra" },
+  { value: "Caninos", label: "Caninos" },
+  { value: "Felinos", label: "Felinos" },
+  { value: "Exóticos", label: "Exóticos" },
+  { value: "Bovinos", label: "Bovinos" },
+  { value: "Equinos", label: "Equinos" },
+  { value: "Porcinos", label: "Porcinos" },
+  { value: "Ovinos", label: "Ovinos" },
+  { value: "Caprinos", label: "Caprinos" },
+  { value: "Aves", label: "Aves" },
 ];
 
 function toIsoDate(value: string): string {

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -35,8 +35,8 @@ const INITIAL_FORM_STATE: ClinicParticularTokenFormState = {
   petName: "",
   petAge: "",
   petBreed: "",
-  petSex: "",
-  petSpecies: "",
+  petSex: "Macho",
+  petSpecies: "Caninos",
   sampleLocation: "",
   sampleEvolution: "",
   detailsLesion: "",
@@ -62,18 +62,20 @@ const REQUIRED_FIELD_LABELS: Array<{
 ];
 
 const PET_SEX_OPTIONS = [
-  { value: "", label: "Seleccionar sexo" },
   { value: "Macho", label: "Macho" },
   { value: "Hembra", label: "Hembra" },
-  { value: "No informado", label: "No informado" },
 ];
 
 const PET_SPECIES_OPTIONS = [
-  { value: "", label: "Seleccionar especie" },
-  { value: "Canina", label: "Canina" },
-  { value: "Felina", label: "Felina" },
-  { value: "Equina", label: "Equina" },
-  { value: "Otra", label: "Otra" },
+  { value: "Caninos", label: "Caninos" },
+  { value: "Felinos", label: "Felinos" },
+  { value: "Exóticos", label: "Exóticos" },
+  { value: "Bovinos", label: "Bovinos" },
+  { value: "Equinos", label: "Equinos" },
+  { value: "Porcinos", label: "Porcinos" },
+  { value: "Ovinos", label: "Ovinos" },
+  { value: "Caprinos", label: "Caprinos" },
+  { value: "Aves", label: "Aves" },
 ];
 
 function toIsoDate(value: string): string {

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -250,11 +250,6 @@ export function ParticularesContent() {
               ) : session ? (
                 <div className="space-y-5">
                   <div className="clinical-muted-band rounded-lg p-4">
-                    <div className="mb-3">
-                      <span className="clinical-pill px-2 py-0.5 text-[0.65rem] tracking-[0.08em]">
-                        Resumen de caso
-                      </span>
-                    </div>
                     <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
                       <div className="surface-soft px-3 py-2.5">
                         <dt className="flex items-center gap-1.5 font-medium text-muted-foreground">
@@ -367,9 +362,9 @@ export function ParticularesContent() {
 
                   <Button
                     type="button"
-                    variant="secondary"
+                    variant="outline"
                     onClick={handleLogout}
-                    className="public-cta-secondary"
+                    className="public-cta-outline"
                   >
                     <LogOut className="h-4 w-4" aria-hidden="true" />
                     Cerrar sesión particular

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -11,6 +11,17 @@ const ADMIN_SIDEBAR_PATH =
 const API_PATH = "frontend/src/lib/api.ts";
 const CLINIC_CARD_PATH =
   "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
+const EXPECTED_SPECIES_OPTIONS = [
+  "Caninos",
+  "Felinos",
+  "Exóticos",
+  "Bovinos",
+  "Equinos",
+  "Porcinos",
+  "Ovinos",
+  "Caprinos",
+  "Aves",
+] as const;
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -81,4 +92,51 @@ test("clinic token generator remains clinic-scoped and separate from admin gener
   assert.ok(admin.includes("createAdminParticularToken"));
   assert.ok(admin.includes("getAdminParticularTokens"));
   assert.equal(admin.includes("createClinicParticularToken"), false);
+});
+
+test("admin and clinic token forms keep normalized sex and species options", () => {
+  const admin = read(ADMIN_CARD_PATH);
+  const clinic = read(CLINIC_CARD_PATH);
+
+  for (const [context, source] of [
+    ["admin", admin],
+    ["clinic", clinic],
+  ] as const) {
+    assert.equal(
+      source.includes('value: "", label: "Seleccionar sexo"'),
+      false,
+      `${context} form must not include selectable sex placeholder`,
+    );
+    assert.equal(
+      source.includes('value: "No informado", label: "No informado"'),
+      false,
+      `${context} form must not include "No informado" sex option`,
+    );
+    assert.equal(
+      source.includes('value: "", label: "Seleccionar especie"'),
+      false,
+      `${context} form must not include selectable species placeholder`,
+    );
+    assert.equal(source.includes('value: "Canina", label: "Canina"'), false);
+    assert.equal(source.includes('value: "Felina", label: "Felina"'), false);
+    assert.equal(source.includes('value: "Equina", label: "Equina"'), false);
+    assert.equal(source.includes('value: "Otra", label: "Otra"'), false);
+
+    assert.ok(source.includes('value: "Macho", label: "Macho"'));
+    assert.ok(source.includes('value: "Hembra", label: "Hembra"'));
+    assert.ok(source.includes('petSex: "Macho"'));
+    assert.ok(source.includes('petSpecies: "Caninos"'));
+
+    let previousIndex = -1;
+    for (const species of EXPECTED_SPECIES_OPTIONS) {
+      const marker = `value: "${species}", label: "${species}"`;
+      const index = source.indexOf(marker);
+      assert.ok(index !== -1, `${context} form must include ${species}`);
+      assert.ok(
+        index > previousIndex,
+        `${context} form must keep species order for ${species}`,
+      );
+      previousIndex = index;
+    }
+  }
 });

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -36,3 +36,14 @@ test("particulares content surfaces refreshSession fetch failures instead of sil
   assert.ok(source.includes("setIsCheckingSession(false);"));
   assert.ok(source.includes('role="alert"'));
 });
+
+test("particulares content keeps neutral logout control and removes resumen label", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("Cerrar sesión particular"));
+  assert.ok(source.includes("variant=\"outline\""));
+  assert.ok(source.includes("className=\"public-cta-outline\""));
+  assert.equal(source.includes("variant=\"secondary\""), false);
+  assert.equal(source.includes("className=\"public-cta-secondary\""), false);
+  assert.equal(source.includes("Resumen de caso"), false);
+});


### PR DESCRIPTION
## Summary
- restricts particular token sex options to Macho and Hembra
- normalizes species options and ordering for admin and clinic token forms
- makes the particular logout button visually neutral while preserving behavior
- removes the “Resumen de caso” label from the particular view
- updates tests for the token option and particular view contracts

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build