### PR TITLE
seo(public): add technical seo foundation

### DIFF
--- a/frontend/src/app/particulares/page.tsx
+++ b/frontend/src/app/particulares/page.tsx
@@ -4,11 +4,17 @@ import { PublicLayout } from "@/components/layout/PublicLayout";
 import { ParticularesContent } from "@/components/public/ParticularesContent";
 import { createPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = createPageMetadata(
-  "Acceso para particulares",
-  "Ingreso seguro por token para consultar datos de casos particulares vinculados a VETNEB.",
-  "/particulares",
-);
+export const metadata: Metadata = {
+  ...createPageMetadata(
+    "Acceso para particulares",
+    "Ingreso seguro por token para consultar datos de casos particulares vinculados a VETNEB.",
+    "/particulares",
+  ),
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 export default function ParticularesPage() {
   return (

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -6,8 +6,15 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: ["/", "/servicios", "/profesionales", "/clinicas", "/contacto"],
-        disallow: ["/dashboard/", "/login", "/api/"],
+        allow: [
+          "/",
+          "/servicios",
+          "/clinicas",
+          "/profesionales",
+          "/contacto",
+          "/precios",
+        ],
+        disallow: ["/dashboard", "/api"],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -18,28 +18,28 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/clinicas`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.85,
+    },
+    {
       url: `${SITE_URL}/profesionales`,
       lastModified: now,
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: `${SITE_URL}/clinicas`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${SITE_URL}/particulares`,
+      url: `${SITE_URL}/contacto`,
       lastModified: now,
       changeFrequency: "monthly",
       priority: 0.7,
     },
     {
-      url: `${SITE_URL}/contacto`,
+      url: `${SITE_URL}/precios`,
       lastModified: now,
-      changeFrequency: "yearly",
-      priority: 0.6,
+      changeFrequency: "monthly",
+      priority: 0.65,
     },
   ];
 }

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -8,16 +8,30 @@ import type { Metadata } from "next";
 // ─── Configuración base ───────────────────────────────────────────────────────
 
 export const SITE_NAME = "Portal VETNEB";
-export const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com";
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com"
+).replace(/\/+$/, "");
 export const SITE_DESCRIPTION =
   "La anatomía patológica veterinaria estudia los motivos, el desarrollo y las consecuencias de distintas enfermedades mediante el análisis de tejidos, órganos y muestras celulares. Servicio patológico veterinario con histopatología, citología, citopatología, hematología, diagnóstico hematológico y hemoparásitos.";
 export const SITE_LOCALE = "es_AR";
+export const SITE_OG_IMAGE_PATH = "/images/hero-microscope-vetneb.webp";
+export const SITE_OG_IMAGE_URL = `${SITE_URL}${SITE_OG_IMAGE_PATH}`;
+
+export function buildCanonicalUrl(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (normalizedPath === "/") {
+    return SITE_URL;
+  }
+
+  return `${SITE_URL}${normalizedPath}`;
+}
 
 // ─── Metadata base ────────────────────────────────────────────────────────────
 
 export const baseMetadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  applicationName: SITE_NAME,
   title: {
     default: SITE_NAME,
     template: `%s | ${SITE_NAME}`,
@@ -68,9 +82,7 @@ export const baseMetadata: Metadata = {
     description: SITE_DESCRIPTION,
     images: [
       {
-        url: `${SITE_URL}/og-image.png`,
-        width: 1200,
-        height: 630,
+        url: SITE_OG_IMAGE_URL,
         alt: "Portal VETNEB — Laboratorio patológico veterinario, histopatología, citología y hematología",
       },
     ],
@@ -79,7 +91,7 @@ export const baseMetadata: Metadata = {
     card: "summary_large_image",
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
-    images: [`${SITE_URL}/og-image.png`],
+    images: [SITE_OG_IMAGE_URL],
   },
   alternates: {
     canonical: SITE_URL,
@@ -93,21 +105,33 @@ export function createPageMetadata(
   description: string,
   path: string,
 ): Metadata {
-  const url = `${SITE_URL}${path}`;
+  const canonicalUrl = buildCanonicalUrl(path);
+
   return {
     title,
     description,
     openGraph: {
+      type: "website",
+      locale: SITE_LOCALE,
+      siteName: SITE_NAME,
       title,
       description,
-      url,
+      url: canonicalUrl,
+      images: [
+        {
+          url: SITE_OG_IMAGE_URL,
+          alt: "Portal VETNEB — Laboratorio patológico veterinario, histopatología, citología y hematología",
+        },
+      ],
     },
     twitter: {
+      card: "summary_large_image",
       title,
       description,
+      images: [SITE_OG_IMAGE_URL],
     },
     alternates: {
-      canonical: url,
+      canonical: canonicalUrl,
     },
   };
 }
@@ -115,34 +139,46 @@ export function createPageMetadata(
 // ─── JSON-LD para organización ────────────────────────────────────────────────
 
 export function getOrganizationJsonLd() {
+  const organizationId = `${SITE_URL}/#organization`;
+  const websiteId = `${SITE_URL}/#website`;
+
   return {
     "@context": "https://schema.org",
-    "@type": "MedicalOrganization",
-    name: "VETNEB",
-    description:
-      "Laboratorio patológico veterinario orientado a diagnóstico integral mediante estudio anatomopatológico, citológico y tinciones especiales para clínicas y profesionales.",
-    url: SITE_URL,
-    logo: `${SITE_URL}/logo.png`,
-    contactPoint: {
-      "@type": "ContactPoint",
-      contactType: "customer service",
-      availableLanguage: "Spanish",
-    },
-    areaServed: {
-      "@type": "Country",
-      name: "Argentina",
-    },
-    medicalSpecialty: "Veterinary",
-    knowsAbout: [
-      "laboratorio patológico veterinario",
-      "servicio patológico veterinario",
-      "histopatología veterinaria",
-      "citología veterinaria",
-      "citopatología veterinaria",
-      "hematología veterinaria",
-      "diagnóstico hematológico veterinario",
-      "hemoparásitos veterinarios",
-      "anatomía patológica veterinaria",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": organizationId,
+        name: "VETNEB",
+        description:
+          "Laboratorio patológico veterinario orientado a diagnóstico integral mediante estudio anatomopatológico, citológico y tinciones especiales para clínicas y profesionales.",
+        url: SITE_URL,
+        areaServed: {
+          "@type": "Country",
+          name: "Argentina",
+        },
+        knowsAbout: [
+          "laboratorio patológico veterinario",
+          "servicio patológico veterinario",
+          "histopatología veterinaria",
+          "citología veterinaria",
+          "citopatología veterinaria",
+          "hematología veterinaria",
+          "diagnóstico hematológico veterinario",
+          "hemoparásitos veterinarios",
+          "anatomía patológica veterinaria",
+        ],
+      },
+      {
+        "@type": "WebSite",
+        "@id": websiteId,
+        url: SITE_URL,
+        name: SITE_NAME,
+        description: SITE_DESCRIPTION,
+        inLanguage: "es-AR",
+        publisher: {
+          "@id": organizationId,
+        },
+      },
     ],
   };
 }
@@ -155,7 +191,7 @@ export function getServicesJsonLd() {
     "@type": "Service",
     serviceType: "Laboratorio patológico veterinario",
     provider: {
-      "@type": "MedicalOrganization",
+      "@type": "Organization",
       name: "VETNEB",
       url: SITE_URL,
     },

--- a/test/frontend-public-seo-contract.test.ts
+++ b/test/frontend-public-seo-contract.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const SEO_PATH = "frontend/src/lib/seo.ts";
+const LAYOUT_PATH = "frontend/src/app/layout.tsx";
+const ROBOTS_PATH = "frontend/src/app/robots.ts";
+const SITEMAP_PATH = "frontend/src/app/sitemap.ts";
+const HOME_PATH = "frontend/src/app/page.tsx";
+const SERVICIOS_PATH = "frontend/src/app/servicios/page.tsx";
+const CLINICAS_PATH = "frontend/src/app/clinicas/page.tsx";
+const PROFESIONALES_PATH = "frontend/src/app/profesionales/page.tsx";
+const CONTACTO_PATH = "frontend/src/app/contacto/page.tsx";
+const PRECIOS_PATH = "frontend/src/app/precios/page.tsx";
+const PARTICULARES_PATH = "frontend/src/app/particulares/page.tsx";
+const LOGIN_PATH = "frontend/src/app/login/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("public SEO base keeps controlled site URL and canonical metadata helpers", () => {
+  const source = read(SEO_PATH);
+
+  assert.ok(source.includes("export const SITE_URL = ("));
+  assert.ok(
+    source.includes('process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com"'),
+  );
+  assert.ok(source.includes("metadataBase: new URL(SITE_URL),"));
+  assert.ok(source.includes("alternates: {"));
+  assert.ok(source.includes("canonical: SITE_URL,"));
+  assert.ok(source.includes("export function buildCanonicalUrl(path: string): string {"));
+  assert.ok(source.includes("const canonicalUrl = buildCanonicalUrl(path);"));
+  assert.ok(source.includes("canonical: canonicalUrl,"));
+  assert.equal(source.includes("localhost"), false);
+});
+
+test("root layout embeds institutional JSON-LD script", () => {
+  const source = read(LAYOUT_PATH);
+
+  assert.ok(source.includes("const orgJsonLd = getOrganizationJsonLd();"));
+  assert.ok(source.includes('type="application/ld+json"'));
+  assert.ok(
+    source.includes(
+      "dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}",
+    ),
+  );
+});
+
+test("robots policy blocks dashboard and api while exposing sitemap", () => {
+  const source = read(ROBOTS_PATH);
+
+  assert.ok(source.includes('disallow: ["/dashboard", "/api"]'));
+  assert.ok(source.includes("sitemap: `${SITE_URL}/sitemap.xml`,"));
+});
+
+test("sitemap includes only public indexable institutional routes", () => {
+  const source = read(SITEMAP_PATH);
+
+  assert.ok(source.includes("url: SITE_URL,"));
+  assert.ok(source.includes("url: `${SITE_URL}/servicios`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/clinicas`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/profesionales`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/contacto`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/precios`,"));
+  assert.ok(source.includes("priority: 1,"));
+  assert.ok(source.includes("priority: 0.9,"));
+  assert.ok(source.includes("priority: 0.85,"));
+  assert.ok(source.includes("priority: 0.8,"));
+  assert.ok(source.includes("priority: 0.7,"));
+  assert.ok(source.includes("priority: 0.65,"));
+  assert.equal(source.includes("/dashboard"), false);
+  assert.equal(source.includes("/api"), false);
+  assert.equal(source.includes("/login"), false);
+  assert.equal(source.includes("/particulares"), false);
+});
+
+test("public pages use metadata helper with stable canonical routes", () => {
+  const homeSource = read(HOME_PATH);
+  const serviciosSource = read(SERVICIOS_PATH);
+  const clinicasSource = read(CLINICAS_PATH);
+  const profesionalesSource = read(PROFESIONALES_PATH);
+  const contactoSource = read(CONTACTO_PATH);
+  const preciosSource = read(PRECIOS_PATH);
+  const particularesSource = read(PARTICULARES_PATH);
+  const loginSource = read(LOGIN_PATH);
+
+  assert.ok(homeSource.includes('"/",'));
+  assert.ok(serviciosSource.includes('"/servicios"'));
+  assert.ok(clinicasSource.includes('"/clinicas"'));
+  assert.ok(profesionalesSource.includes('"/profesionales"'));
+  assert.ok(contactoSource.includes('"/contacto"'));
+  assert.ok(preciosSource.includes('"/precios"'));
+  assert.ok(particularesSource.includes('"/particulares"'));
+  assert.ok(loginSource.includes('"/login"'));
+  assert.ok(particularesSource.includes("robots: {"));
+  assert.ok(particularesSource.includes("index: false,"));
+  assert.ok(particularesSource.includes("follow: false,"));
+  assert.ok(loginSource.includes("robots: { index: false, follow: false },"));
+});
+
+test("institutional JSON-LD avoids fake rating/review schema", () => {
+  const source = read(SEO_PATH);
+
+  assert.equal(source.includes("AggregateRating"), false);
+  assert.equal(source.includes('"@type": "Review"'), false);
+  assert.ok(source.includes('"@type": "Organization"'));
+  assert.ok(source.includes('"@type": "WebSite"'));
+});
+
+test("server SEO files avoid client-only window/document usage", () => {
+  const combined = [
+    read(SEO_PATH),
+    read(LAYOUT_PATH),
+    read(ROBOTS_PATH),
+    read(SITEMAP_PATH),
+  ].join("\n");
+
+  assert.equal(combined.includes("window."), false);
+  assert.equal(combined.includes("document."), false);
+});

--- a/test/frontend-seo-metadata.test.ts
+++ b/test/frontend-seo-metadata.test.ts
@@ -19,11 +19,19 @@ test("frontend root layout wires base metadata and organization JSON-LD", () => 
   const source = read(ROOT_LAYOUT_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";'));
+  assert.ok(
+    source.includes(
+      'import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";',
+    ),
+  );
   assert.ok(source.includes("export const metadata: Metadata = baseMetadata;"));
   assert.ok(source.includes("const orgJsonLd = getOrganizationJsonLd();"));
   assert.ok(source.includes('type="application/ld+json"'));
-  assert.ok(source.includes("dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}"));
+  assert.ok(
+    source.includes(
+      "dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}",
+    ),
+  );
   assert.ok(source.includes('<html lang="es"'));
 });
 
@@ -31,10 +39,14 @@ test("frontend SEO base metadata defines canonical brand and indexable robots", 
   const source = read(SEO_PATH);
 
   assert.ok(source.includes('export const SITE_NAME = "Portal VETNEB";'));
-  assert.ok(source.includes('process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com";'));
+  assert.ok(
+    source.includes('process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.vetneb.com"'),
+  );
+  assert.ok(source.includes(").replace(/\\/+$/, \"\");"));
   assert.ok(source.includes('export const SITE_LOCALE = "es_AR";'));
   assert.ok(source.includes("export const baseMetadata: Metadata = {"));
   assert.ok(source.includes("metadataBase: new URL(SITE_URL),"));
+  assert.ok(source.includes("applicationName: SITE_NAME,"));
   assert.ok(source.includes("template: `%s | ${SITE_NAME}`,"));
   assert.ok(source.includes("index: true,"));
   assert.ok(source.includes("follow: true,"));
@@ -44,46 +56,49 @@ test("frontend SEO base metadata defines canonical brand and indexable robots", 
 test("frontend SEO metadata exposes Open Graph and Twitter cards", () => {
   const source = read(SEO_PATH);
 
+  assert.ok(source.includes("export const SITE_OG_IMAGE_PATH ="));
+  assert.ok(source.includes("export const SITE_OG_IMAGE_URL ="));
   assert.ok(source.includes("openGraph: {"));
   assert.ok(source.includes('type: "website",'));
   assert.ok(source.includes("locale: SITE_LOCALE,"));
   assert.ok(source.includes("siteName: SITE_NAME,"));
-  assert.ok(source.includes("`${SITE_URL}/og-image.png`"));
+  assert.ok(source.includes("url: SITE_OG_IMAGE_URL,"));
   assert.ok(source.includes("twitter: {"));
   assert.ok(source.includes('card: "summary_large_image",'));
+  assert.ok(source.includes("images: [SITE_OG_IMAGE_URL],"));
   assert.ok(source.includes("alternates: {"));
   assert.ok(source.includes("canonical: SITE_URL,"));
 });
 
-test("frontend SEO helpers create page metadata and organization JSON-LD", () => {
+test("frontend SEO helpers create page metadata and organization JSON-LD graph", () => {
   const source = read(SEO_PATH);
 
-  assert.ok(source.includes("export function createPageMetadata("));
-  assert.ok(source.includes("const url = `${SITE_URL}${path}`;"));
-  assert.ok(source.includes("canonical: url,"));
+  assert.ok(source.includes("export function buildCanonicalUrl(path: string): string {"));
+  assert.ok(source.includes("const canonicalUrl = buildCanonicalUrl(path);"));
+  assert.ok(source.includes("canonical: canonicalUrl,"));
   assert.ok(source.includes("export function getOrganizationJsonLd()"));
   assert.ok(source.includes('"@context": "https://schema.org"'));
-  assert.ok(source.includes('"@type": "MedicalOrganization"'));
-  assert.ok(source.includes('medicalSpecialty: "Veterinary"'));
-  assert.ok(source.includes('"laboratorio patológico veterinario"'));
-  assert.ok(source.includes('"servicio patológico veterinario"'));
-  assert.ok(source.includes('"histopatología veterinaria"'));
-  assert.ok(source.includes('"citología veterinaria"'));
-  assert.ok(source.includes('"citopatología veterinaria"'));
-  assert.ok(source.includes('"hematología veterinaria"'));
-  assert.ok(source.includes('"diagnóstico hematológico veterinario"'));
-  assert.ok(source.includes('"hemoparásitos veterinarios"'));
+  assert.ok(source.includes('"@graph": ['));
+  assert.ok(source.includes('"@type": "Organization"'));
+  assert.ok(source.includes('"@type": "WebSite"'));
   assert.ok(source.includes("knowsAbout: ["));
+  assert.ok(source.includes('"@type": "Service"'));
   assert.ok(source.includes("hasOfferCatalog: {"));
+  assert.equal(source.includes("AggregateRating"), false);
+  assert.equal(source.includes('"@type": "Review"'), false);
 });
 
-test("frontend robots allows public pages and blocks private/API surfaces", () => {
+test("frontend robots allows public institutional pages and blocks private/API surfaces", () => {
   const source = read(ROBOTS_PATH);
 
   assert.ok(source.includes('import { SITE_URL } from "@/lib/seo";'));
   assert.ok(source.includes('userAgent: "*"'));
-  assert.ok(source.includes('allow: ["/", "/servicios", "/profesionales", "/clinicas", "/contacto"]'));
-  assert.ok(source.includes('disallow: ["/dashboard/", "/login", "/api/"]'));
+  assert.ok(source.includes('"/servicios"'));
+  assert.ok(source.includes('"/clinicas"'));
+  assert.ok(source.includes('"/profesionales"'));
+  assert.ok(source.includes('"/contacto"'));
+  assert.ok(source.includes('"/precios"'));
+  assert.ok(source.includes('disallow: ["/dashboard", "/api"]'));
   assert.ok(source.includes("sitemap: `${SITE_URL}/sitemap.xml`,"));
 });
 
@@ -94,9 +109,12 @@ test("frontend sitemap lists public indexable pages only", () => {
   assert.ok(source.includes("const now = new Date();"));
   assert.ok(source.includes("url: SITE_URL,"));
   assert.ok(source.includes("url: `${SITE_URL}/servicios`,"));
-  assert.ok(source.includes("url: `${SITE_URL}/profesionales`,"));
   assert.ok(source.includes("url: `${SITE_URL}/clinicas`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/profesionales`,"));
   assert.ok(source.includes("url: `${SITE_URL}/contacto`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/precios`,"));
   assert.equal(source.includes("/dashboard"), false);
+  assert.equal(source.includes("/api"), false);
   assert.equal(source.includes("/login"), false);
+  assert.equal(source.includes("/particulares"), false);
 });


### PR DESCRIPTION
## Summary
- strengthens public technical SEO metadata, canonical rules and robots/sitemap behavior
- keeps institutional pages indexable and excludes private/token/dashboard routes
- improves JSON-LD foundation without inventing business facts
- preserves rendering, layout, auth, backend, dashboard and public UI behavior

## Validation
- git diff --check
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm -C frontend build