### PR TITLE
seo(public): add professionals structured data

### DIFF
--- a/frontend/src/app/profesionales/page.tsx
+++ b/frontend/src/app/profesionales/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 
 import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSearchContent";
 import { createPageMetadata } from "@/lib/seo";
+import { getProfessionalsPageJsonLd } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata(
   "Red de Profesionales Veterinarios",
@@ -11,9 +12,20 @@ export const metadata: Metadata = createPageMetadata(
 );
 
 export default function ProfesionalesPage() {
+  const professionalsPageJsonLd = getProfessionalsPageJsonLd();
+
   return (
-    <Suspense fallback={null}>
-      <ProfesionalesSearchContent />
-    </Suspense>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(professionalsPageJsonLd),
+        }}
+      />
+      <Suspense fallback={null}>
+        <ProfesionalesSearchContent />
+      </Suspense>
+    </>
   );
 }
+

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -238,3 +238,61 @@ export function getServicesJsonLd() {
     },
   };
 }
+
+// ─── JSON-LD para página pública de profesionales ────────────────────────────
+
+export function getProfessionalsPageJsonLd() {
+  const pageUrl = buildCanonicalUrl("/profesionales");
+  const organizationId = `${SITE_URL}/#organization`;
+  const websiteId = `${SITE_URL}/#website`;
+  const breadcrumbId = `${pageUrl}#breadcrumb`;
+  const searchPageId = `${pageUrl}#search-results-page`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Inicio",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Profesionales",
+            item: pageUrl,
+          },
+        ],
+      },
+      {
+        "@type": "SearchResultsPage",
+        "@id": searchPageId,
+        url: pageUrl,
+        name: "Red de Profesionales Veterinarios",
+        description:
+          "Banco público de profesionales vinculados a VETNEB con búsqueda por texto libre y coincidencias aproximadas.",
+        inLanguage: "es-AR",
+        isPartOf: {
+          "@id": websiteId,
+        },
+        publisher: {
+          "@id": organizationId,
+        },
+        breadcrumb: {
+          "@id": breadcrumbId,
+        },
+        about: [
+          "profesionales veterinarios",
+          "clínicas veterinarias",
+          "laboratorio patológico veterinario",
+          "diagnóstico veterinario",
+        ],
+      },
+    ],
+  };
+}

--- a/test/frontend-public-seo-contract.test.ts
+++ b/test/frontend-public-seo-contract.test.ts
@@ -103,6 +103,55 @@ test("public pages use metadata helper with stable canonical routes", () => {
   assert.ok(loginSource.includes("robots: { index: false, follow: false },"));
 });
 
+test("professionals public page exposes verifiable structured data", () => {
+  const seoSource = read(SEO_PATH);
+  const profesionalesSource = read(PROFESIONALES_PATH);
+
+  assert.ok(seoSource.includes("export function getProfessionalsPageJsonLd()"));
+  assert.ok(seoSource.includes('"@type": "BreadcrumbList"'));
+  assert.ok(seoSource.includes('"@type": "SearchResultsPage"'));
+  assert.ok(seoSource.includes('const pageUrl = buildCanonicalUrl("/profesionales");'));
+  assert.ok(seoSource.includes("const breadcrumbId = `${pageUrl}#breadcrumb`;"));
+  assert.ok(seoSource.includes("const searchPageId = `${pageUrl}#search-results-page`;"));
+  assert.ok(seoSource.includes('name: "Inicio"'));
+  assert.ok(seoSource.includes('name: "Profesionales"'));
+  assert.ok(seoSource.includes("item: SITE_URL"));
+  assert.ok(seoSource.includes("item: pageUrl"));
+  assert.ok(seoSource.includes('"@id": websiteId'));
+  assert.ok(seoSource.includes('"@id": organizationId'));
+  assert.ok(seoSource.includes('"@id": breadcrumbId'));
+
+  assert.ok(
+    profesionalesSource.includes(
+      'import { getProfessionalsPageJsonLd } from "@/lib/seo";',
+    ),
+  );
+  assert.ok(
+    profesionalesSource.includes(
+      "const professionalsPageJsonLd = getProfessionalsPageJsonLd();",
+    ),
+  );
+  assert.ok(profesionalesSource.includes('type="application/ld+json"'));
+  assert.ok(
+    profesionalesSource.includes(
+      "__html: JSON.stringify(professionalsPageJsonLd),",
+    ),
+  );
+});
+
+test("professionals structured data avoids unverifiable result entities", () => {
+  const seoSource = read(SEO_PATH);
+  const profesionalesSource = read(PROFESIONALES_PATH);
+  const combined = `${seoSource}\n${profesionalesSource}`;
+
+  assert.equal(combined.includes('"@type": "ItemList"'), false);
+  assert.equal(combined.includes("AggregateRating"), false);
+  assert.equal(combined.includes('"@type": "Review"'), false);
+  assert.equal(combined.includes("openingHours"), false);
+  assert.equal(combined.includes("GeoCoordinates"), false);
+  assert.equal(combined.includes("PostalAddress"), false);
+});
+
 test("institutional JSON-LD avoids fake rating/review schema", () => {
   const source = read(SEO_PATH);
 
@@ -123,3 +172,4 @@ test("server SEO files avoid client-only window/document usage", () => {
   assert.equal(combined.includes("window."), false);
   assert.equal(combined.includes("document."), false);
 });
+


### PR DESCRIPTION
## Summary
- add verifiable JSON-LD for the public professionals page
- include BreadcrumbList and SearchResultsPage schema
- avoid unverifiable ItemList, ratings, reviews, opening hours, geo, and address data

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build