### PR TITLE
perf(public): defer scroll reveal initialization

### DIFF
--- a/frontend/src/components/public/PublicScrollReveal.tsx
+++ b/frontend/src/components/public/PublicScrollReveal.tsx
@@ -16,6 +16,14 @@ type PublicScrollRevealPreset = {
   stagger?: number;
 };
 
+type PublicMotionSchedulerWindow = Window & {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout?: number },
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
 const PUBLIC_MOTION_POLICY_PRESETS: Record<
   PublicScrollRevealVariant,
   PublicScrollRevealPreset
@@ -43,6 +51,25 @@ const PUBLIC_MOTION_POLICY_PRESETS: Record<
     start: "top 88%",
   },
 };
+
+function schedulePublicMotionInitialization(callback: () => void) {
+  const motionWindow = window as PublicMotionSchedulerWindow;
+
+  if (
+    typeof motionWindow.requestIdleCallback === "function" &&
+    typeof motionWindow.cancelIdleCallback === "function"
+  ) {
+    const idleCallbackId = motionWindow.requestIdleCallback(callback, {
+      timeout: 1200,
+    });
+
+    return () => motionWindow.cancelIdleCallback?.(idleCallbackId);
+  }
+
+  const timeoutId = window.setTimeout(callback, 160);
+
+  return () => window.clearTimeout(timeoutId);
+}
 
 export type PublicScrollRevealProps = {
   children: ReactNode;
@@ -78,6 +105,8 @@ export function PublicScrollReveal({
 
     let isDisposed = false;
     let ctx: { revert: () => void } | null = null;
+    let observer: IntersectionObserver | null = null;
+    let cancelIdleInitialization: (() => void) | null = null;
 
     const initialize = async () => {
       const [{ gsap }, { ScrollTrigger }] = await Promise.all([
@@ -139,10 +168,44 @@ export function PublicScrollReveal({
       }, rootRef);
     };
 
-    void initialize();
+    const scheduleInitialize = () => {
+      if (isDisposed || cancelIdleInitialization) {
+        return;
+      }
+
+      cancelIdleInitialization = schedulePublicMotionInitialization(() => {
+        cancelIdleInitialization = null;
+
+        if (!isDisposed) {
+          void initialize();
+        }
+      });
+    };
+
+    if ("IntersectionObserver" in window) {
+      observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) {
+            observer?.disconnect();
+            observer = null;
+            scheduleInitialize();
+          }
+        },
+        {
+          rootMargin: "240px 0px",
+          threshold: 0.01,
+        },
+      );
+
+      observer.observe(rootElement);
+    } else {
+      scheduleInitialize();
+    }
 
     return () => {
       isDisposed = true;
+      cancelIdleInitialization?.();
+      observer?.disconnect();
       ctx?.revert();
     };
   }, [childSelector, resolvedVariant, staggerChildren]);

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -76,6 +76,15 @@ test("public scroll reveal infrastructure is client-only and uses safe gsap prim
   assert.ok(source.includes("prefers-reduced-motion"));
   assert.ok(source.includes("matchMedia"));
   assert.ok(source.includes("revert()"));
+  assert.ok(source.includes("IntersectionObserver"));
+  assert.ok(source.includes('rootMargin: "240px 0px"'));
+  assert.ok(source.includes("threshold: 0.01"));
+  assert.ok(source.includes("requestIdleCallback"));
+  assert.ok(source.includes("cancelIdleCallback"));
+  assert.ok(source.includes("setTimeout(callback, 160)"));
+  assert.ok(source.includes("clearTimeout(timeoutId)"));
+  assert.ok(source.includes("timeout: 1200"));
+  assert.ok(source.includes("disconnect()"));
   assert.ok(source.includes("PublicScrollRevealVariant"));
   assert.ok(source.includes('"section" | "cards" | "minimal"'));
   assert.ok(source.includes("variant?: PublicScrollRevealVariant"));


### PR DESCRIPTION
## Summary
- defer public scroll reveal initialization until elements approach the viewport
- schedule GSAP/ScrollTrigger setup during idle time with a timeout fallback
- keep reduced-motion handling, cleanup, and visual presets unchanged

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build