### PR TITLE
seo(content): add veterinary diagnostic service landing pages

### DIFF
--- a/frontend/src/app/citologia-veterinaria/page.tsx
+++ b/frontend/src/app/citologia-veterinaria/page.tsx
@@ -1,0 +1,265 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  ClipboardCheck,
+  FlaskConical,
+  Network,
+  SearchCheck,
+} from "lucide-react";
+
+import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
+import { VisualIcon } from "@/components/public/VisualAccents";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  createPageMetadata,
+  getDiagnosticServiceJsonLd,
+} from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata(
+  "Citología Veterinaria | Servicio Citológico y Citopatológico Veterinario",
+  "Servicio de citología veterinaria y citopatología veterinaria para estudio citológico de muestras, líquidos y punciones con criterio clínico-patológico.",
+  "/citologia-veterinaria",
+);
+
+const sampleTypes = [
+  "Punciones con aguja fina",
+  "Líquidos y muestras citológicas",
+  "Lesiones cutáneas o subcutáneas",
+  "Material de aspiración o impronta",
+  "Evaluación celular orientada a diagnóstico",
+  "Correlación con antecedentes clínicos",
+];
+
+const processSteps = [
+  {
+    title: "Recepción de la muestra",
+    description:
+      "El material se interpreta junto con datos clínicos, localización, evolución y motivo de consulta para orientar la lectura citológica.",
+  },
+  {
+    title: "Evaluación celular",
+    description:
+      "Se valoran poblaciones celulares, patrones inflamatorios, criterios de atipia y hallazgos compatibles con diagnósticos diferenciales.",
+  },
+  {
+    title: "Integración clínico-patológica",
+    description:
+      "El informe relaciona los hallazgos citológicos con el contexto del paciente y la sospecha clínica indicada por el profesional.",
+  },
+  {
+    title: "Conclusión profesional",
+    description:
+      "La interpretación citológica aporta orientación diagnóstica, recomendaciones de seguimiento o necesidad de estudios complementarios.",
+  },
+];
+
+export default function CitologiaVeterinariaPage() {
+  const jsonLd = getDiagnosticServiceJsonLd({
+    path: "/citologia-veterinaria",
+    name: "Citología veterinaria",
+    serviceType: "Servicio citológico veterinario",
+    description:
+      "Servicio de citología veterinaria y citopatología veterinaria para estudio citológico de muestras, líquidos y punciones con criterio clínico-patológico.",
+    knowsAbout: [
+      "citología veterinaria",
+      "servicio citológico veterinario",
+      "citopatología veterinaria",
+      "servicio citopatológico veterinario",
+      "diagnóstico citológico veterinario",
+    ],
+  });
+
+  return (
+    <PublicLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <section
+        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        aria-labelledby="cytology-page-title"
+      >
+        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88">
+            Servicio citológico veterinario
+          </p>
+          <h1
+            id="cytology-page-title"
+            className="mb-4 max-w-4xl text-4xl font-bold leading-tight md:text-5xl"
+          >
+            Citología veterinaria
+          </h1>
+          <p className="max-w-3xl public-copy text-lg text-primary-foreground/92 md:text-xl">
+            Estudio citológico y citopatológico de muestras, líquidos y
+            punciones para evaluar alteraciones celulares, orientar diagnósticos
+            diferenciales y acompañar decisiones clínicas veterinarias.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button asChild size="lg" className="public-cta-primary w-full sm:w-auto">
+              <Link href="/contacto">
+                Solicitar coordinación diagnóstica
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
+              <Link href="/servicios">Ver todos los servicios</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <div className="public-soft-canvas">
+        <section className="py-16 md:py-20" aria-labelledby="cytology-samples-heading">
+          <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="mx-auto mb-10 max-w-4xl">
+                <h2
+                  id="cytology-samples-heading"
+                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
+                >
+                  Qué permite evaluar la citología veterinaria
+                </h2>
+                <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
+                  La citología veterinaria permite valorar muestras celulares de
+                  forma orientativa y rápida, integrando hallazgos microscópicos
+                  con antecedentes clínicos y evolución del caso.
+                </p>
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal variant="cards" staggerChildren>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                {sampleTypes.map((sampleType) => (
+                  <article
+                    key={sampleType}
+                    data-scroll-reveal-item
+                    className="premium-card-muted p-5"
+                  >
+                    <div className="flex items-start gap-3">
+                      <VisualIcon
+                        icon={SearchCheck}
+                        tone="emerald"
+                        className="h-10 w-10 shrink-0 rounded-xl"
+                      />
+                      <p className="text-sm leading-relaxed text-muted-foreground">
+                        {sampleType}
+                      </p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16" aria-labelledby="cytology-process-heading">
+          <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="mx-auto mb-10 max-w-4xl">
+                <h2
+                  id="cytology-process-heading"
+                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
+                >
+                  Proceso del servicio citológico veterinario
+                </h2>
+                <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
+                  La lectura citológica se orienta a interpretar alteraciones
+                  celulares dentro del contexto clínico del paciente.
+                </p>
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal variant="cards" staggerChildren>
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+                {processSteps.map((step) => (
+                  <article key={step.title} data-scroll-reveal-item>
+                    <Card className="premium-card h-full">
+                      <CardHeader>
+                        <VisualIcon
+                          icon={ClipboardCheck}
+                          tone="blue"
+                          className="mb-2"
+                        />
+                        <CardTitle className="text-lg text-vetneb-ink">
+                          {step.title}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <p className="text-sm leading-relaxed text-muted-foreground">
+                          {step.description}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  </article>
+                ))}
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16" aria-labelledby="cytology-value-heading">
+          <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="minimal">
+              <div className="premium-card p-8">
+                <div className="mb-4 flex items-center gap-3">
+                  <VisualIcon icon={FlaskConical} tone="emerald" />
+                  <h2
+                    id="cytology-value-heading"
+                    className="text-2xl font-bold text-vetneb-ink"
+                  >
+                    Citopatología veterinaria con orientación clínica
+                  </h2>
+                </div>
+                <p className="public-copy text-muted-foreground">
+                  El servicio citopatológico veterinario aporta información
+                  celular relevante para orientar diagnósticos diferenciales,
+                  definir seguimiento y decidir si corresponde complementar con
+                  histopatología u otras técnicas diagnósticas.
+                </p>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                  <Button asChild className="public-cta-primary w-full sm:w-auto">
+                    <Link href="/contacto">Coordinar envío de muestras</Link>
+                  </Button>
+                  <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
+                    <Link href="/histopatologia-veterinaria">
+                      Ver histopatología veterinaria
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16" aria-labelledby="cytology-related-heading">
+          <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="minimal">
+              <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
+                <div className="flex items-start gap-3">
+                  <VisualIcon icon={Network} tone="slate" className="h-11 w-11 shrink-0 rounded-xl" />
+                  <div>
+                    <h2
+                      id="cytology-related-heading"
+                      className="mb-3 text-xl font-bold text-vetneb-ink"
+                    >
+                      Complemento diagnóstico interdisciplinario
+                    </h2>
+                    <p className="public-copy-tight text-sm text-muted-foreground">
+                      La citología puede orientar decisiones iniciales y, según la
+                      complejidad del caso, complementarse con histopatología,
+                      tinciones especiales o interconsulta profesional.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+      </div>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/app/histopatologia-veterinaria/page.tsx
+++ b/frontend/src/app/histopatologia-veterinaria/page.tsx
@@ -1,0 +1,266 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  ClipboardCheck,
+  Microscope,
+  Network,
+  SearchCheck,
+} from "lucide-react";
+
+import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
+import { VisualIcon } from "@/components/public/VisualAccents";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  createPageMetadata,
+  getDiagnosticServiceJsonLd,
+} from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata(
+  "Histopatología Veterinaria | Servicio Histopatológico Veterinario",
+  "Servicio de histopatología veterinaria para estudio anatomopatológico de tejidos, biopsias y órganos con interpretación microscópica y criterio clínico-patológico.",
+  "/histopatologia-veterinaria",
+);
+
+const processSteps = [
+  {
+    title: "Recepción de tejidos y antecedentes",
+    description:
+      "La muestra se interpreta junto con la información clínica, localización anatómica, evolución y sospecha diagnóstica informada por el profesional.",
+  },
+  {
+    title: "Procesamiento histológico",
+    description:
+      "El tejido se procesa para evaluación microscópica, preservando trazabilidad de la muestra y consistencia diagnóstica durante el circuito.",
+  },
+  {
+    title: "Lectura anatomopatológica",
+    description:
+      "El análisis permite caracterizar lesiones, patrones inflamatorios, proliferativos o degenerativos y aportar hallazgos relevantes para el caso.",
+  },
+  {
+    title: "Informe diagnóstico",
+    description:
+      "El resultado integra observaciones microscópicas con criterio clínico-patológico para orientar decisiones terapéuticas o interconsultas.",
+  },
+];
+
+const useCases = [
+  "Biopsias de piel y tejidos blandos",
+  "Evaluación de órganos y lesiones quirúrgicas",
+  "Caracterización microscópica de procesos inflamatorios",
+  "Apoyo diagnóstico en lesiones proliferativas",
+  "Correlación con antecedentes clínicos e imagenológicos",
+  "Definición de diagnósticos diferenciales",
+];
+
+export default function HistopatologiaVeterinariaPage() {
+  const jsonLd = getDiagnosticServiceJsonLd({
+    path: "/histopatologia-veterinaria",
+    name: "Histopatología veterinaria",
+    serviceType: "Servicio histopatológico veterinario",
+    description:
+      "Servicio de histopatología veterinaria para estudio anatomopatológico de tejidos, biopsias y órganos con interpretación microscópica y criterio clínico-patológico.",
+    knowsAbout: [
+      "histopatología veterinaria",
+      "servicio histopatológico veterinario",
+      "estudio anatomopatológico veterinario",
+      "biopsias veterinarias",
+      "patología veterinaria",
+    ],
+  });
+
+  return (
+    <PublicLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <section
+        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        aria-labelledby="histopathology-page-title"
+      >
+        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88">
+            Servicio histopatológico veterinario
+          </p>
+          <h1
+            id="histopathology-page-title"
+            className="mb-4 max-w-4xl text-4xl font-bold leading-tight md:text-5xl"
+          >
+            Histopatología veterinaria
+          </h1>
+          <p className="max-w-3xl public-copy text-lg text-primary-foreground/92 md:text-xl">
+            Estudio anatomopatológico de tejidos, biopsias y órganos para
+            caracterizar lesiones, integrar antecedentes clínicos y aportar
+            precisión diagnóstica en medicina veterinaria.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button asChild size="lg" className="public-cta-primary w-full sm:w-auto">
+              <Link href="/contacto">
+                Solicitar coordinación diagnóstica
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
+              <Link href="/servicios">Ver todos los servicios</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <div className="public-soft-canvas">
+        <section className="py-16 md:py-20" aria-labelledby="histopathology-when-heading">
+          <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="mx-auto mb-10 max-w-4xl">
+                <h2
+                  id="histopathology-when-heading"
+                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
+                >
+                  Cuándo solicitar histopatología veterinaria
+                </h2>
+                <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
+                  La histopatología veterinaria es indicada cuando se requiere
+                  estudiar tejidos u órganos para comprender la naturaleza de una
+                  lesión, confirmar diagnósticos diferenciales o acompañar una
+                  decisión clínica con evidencia microscópica.
+                </p>
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal variant="cards" staggerChildren>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                {useCases.map((useCase) => (
+                  <article
+                    key={useCase}
+                    data-scroll-reveal-item
+                    className="premium-card-muted p-5"
+                  >
+                    <div className="flex items-start gap-3">
+                      <VisualIcon
+                        icon={SearchCheck}
+                        tone="blue"
+                        className="h-10 w-10 shrink-0 rounded-xl"
+                      />
+                      <p className="text-sm leading-relaxed text-muted-foreground">
+                        {useCase}
+                      </p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16" aria-labelledby="histopathology-process-heading">
+          <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="mx-auto mb-10 max-w-4xl">
+                <h2
+                  id="histopathology-process-heading"
+                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
+                >
+                  Proceso del servicio histopatológico veterinario
+                </h2>
+                <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
+                  El circuito prioriza trazabilidad, interpretación profesional e
+                  integración con el contexto clínico de cada paciente.
+                </p>
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal variant="cards" staggerChildren>
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+                {processSteps.map((step) => (
+                  <article key={step.title} data-scroll-reveal-item>
+                    <Card className="premium-card h-full">
+                      <CardHeader>
+                        <VisualIcon
+                          icon={ClipboardCheck}
+                          tone="emerald"
+                          className="mb-2"
+                        />
+                        <CardTitle className="text-lg text-vetneb-ink">
+                          {step.title}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <p className="text-sm leading-relaxed text-muted-foreground">
+                          {step.description}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  </article>
+                ))}
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16" aria-labelledby="histopathology-value-heading">
+          <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="minimal">
+              <div className="premium-card p-8">
+                <div className="mb-4 flex items-center gap-3">
+                  <VisualIcon icon={Microscope} tone="blue" />
+                  <h2
+                    id="histopathology-value-heading"
+                    className="text-2xl font-bold text-vetneb-ink"
+                  >
+                    Diagnóstico anatomopatológico con criterio clínico
+                  </h2>
+                </div>
+                <p className="public-copy text-muted-foreground">
+                  El estudio histopatológico veterinario no es un proceso
+                  automatizado. Requiere lectura microscópica, correlación con los
+                  antecedentes y comunicación profesional para construir una
+                  conclusión diagnóstica útil para el equipo tratante.
+                </p>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                  <Button asChild className="public-cta-primary w-full sm:w-auto">
+                    <Link href="/contacto">Coordinar envío de muestras</Link>
+                  </Button>
+                  <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
+                    <Link href="/citologia-veterinaria">
+                      Ver citología veterinaria
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section className="py-16" aria-labelledby="histopathology-related-heading">
+          <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="minimal">
+              <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
+                <div className="flex items-start gap-3">
+                  <VisualIcon icon={Network} tone="slate" className="h-11 w-11 shrink-0 rounded-xl" />
+                  <div>
+                    <h2
+                      id="histopathology-related-heading"
+                      className="mb-3 text-xl font-bold text-vetneb-ink"
+                    >
+                      Integración con otros estudios diagnósticos
+                    </h2>
+                    <p className="public-copy-tight text-sm text-muted-foreground">
+                      La histopatología puede complementarse con citología,
+                      tinciones especiales, antecedentes clínicos e interconsulta
+                      profesional cuando la complejidad del caso lo requiere.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+      </div>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -160,6 +160,20 @@ export default function ServiciosPage() {
                   informes trazables para acompañar decisiones clínicas en cada
                   etapa del caso.
                 </p>
+                <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                  <Link
+                    href="/histopatologia-veterinaria"
+                    className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
+                  >
+                    Ver histopatología veterinaria
+                  </Link>
+                  <Link
+                    href="/citologia-veterinaria"
+                    className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
+                  >
+                    Ver citología veterinaria
+                  </Link>
+                </div>
               </div>
             </PublicScrollReveal>
 

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -18,6 +18,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/histopatologia-veterinaria`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.88,
+    },
+    {
+      url: `${SITE_URL}/citologia-veterinaria`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.88,
+    },
+    {
       url: `${SITE_URL}/clinicas`,
       lastModified: now,
       changeFrequency: "monthly",
@@ -43,3 +55,4 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 }
+

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -239,6 +239,84 @@ export function getServicesJsonLd() {
   };
 }
 
+
+// ─── JSON-LD para landing de servicio diagnóstico ────────────────────────────
+
+export type DiagnosticServiceJsonLdInput = {
+  path: string;
+  name: string;
+  serviceType: string;
+  description: string;
+  knowsAbout: string[];
+};
+
+export function getDiagnosticServiceJsonLd({
+  path,
+  name,
+  serviceType,
+  description,
+  knowsAbout,
+}: DiagnosticServiceJsonLdInput) {
+  const pageUrl = buildCanonicalUrl(path);
+  const organizationId = `${SITE_URL}/#organization`;
+  const websiteId = `${SITE_URL}/#website`;
+  const breadcrumbId = `${pageUrl}#breadcrumb`;
+  const serviceId = `${pageUrl}#service`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Inicio",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Servicios",
+            item: buildCanonicalUrl("/servicios"),
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name,
+            item: pageUrl,
+          },
+        ],
+      },
+      {
+        "@type": "Service",
+        "@id": serviceId,
+        name,
+        serviceType,
+        description,
+        url: pageUrl,
+        inLanguage: "es-AR",
+        areaServed: {
+          "@type": "Country",
+          name: "Argentina",
+        },
+        provider: {
+          "@id": organizationId,
+        },
+        isPartOf: {
+          "@id": websiteId,
+        },
+        breadcrumb: {
+          "@id": breadcrumbId,
+        },
+        knowsAbout,
+      },
+    ],
+  };
+}
+
 // ─── JSON-LD para página pública de profesionales ────────────────────────────
 
 export function getProfessionalsPageJsonLd() {
@@ -305,3 +383,4 @@ export function getProfessionalsPageJsonLd() {
     ],
   };
 }
+

--- a/test/frontend-diagnostic-service-landing-pages.test.ts
+++ b/test/frontend-diagnostic-service-landing-pages.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const HISTOPATHOLOGY_PAGE_PATH =
+  "frontend/src/app/histopatologia-veterinaria/page.tsx";
+const CYTOLOGY_PAGE_PATH =
+  "frontend/src/app/citologia-veterinaria/page.tsx";
+const SERVICES_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
+const SEO_PATH = "frontend/src/lib/seo.ts";
+const SITEMAP_PATH = "frontend/src/app/sitemap.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("diagnostic service landing pages exist", () => {
+  assert.equal(existsSync(resolve(process.cwd(), HISTOPATHOLOGY_PAGE_PATH)), true);
+  assert.equal(existsSync(resolve(process.cwd(), CYTOLOGY_PAGE_PATH)), true);
+});
+
+test("histopathology landing page targets transactional veterinary service intent", () => {
+  const source = read(HISTOPATHOLOGY_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
+  assert.ok(source.includes('"Histopatología Veterinaria | Servicio Histopatológico Veterinario"'));
+  assert.ok(source.includes('"/histopatologia-veterinaria"'));
+  assert.ok(source.includes("Histopatología veterinaria"));
+  assert.ok(source.includes("Servicio histopatológico veterinario"));
+  assert.ok(source.includes("estudio anatomopatológico"));
+  assert.ok(source.includes("biopsias"));
+  assert.ok(source.includes("criterio clínico-patológico"));
+  assert.ok(source.includes("const jsonLd = getDiagnosticServiceJsonLd({"));
+  assert.ok(source.includes('type="application/ld+json"'));
+  assert.ok(source.includes('href="/citologia-veterinaria"'));
+  assert.ok(source.includes('href="/contacto"'));
+});
+
+test("cytology landing page targets transactional veterinary service intent", () => {
+  const source = read(CYTOLOGY_PAGE_PATH);
+
+  assert.ok(source.includes('import type { Metadata } from "next";'));
+  assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
+  assert.ok(source.includes('"Citología Veterinaria | Servicio Citológico y Citopatológico Veterinario"'));
+  assert.ok(source.includes('"/citologia-veterinaria"'));
+  assert.ok(source.includes("Citología veterinaria"));
+  assert.ok(source.includes("Servicio citológico veterinario"));
+  assert.ok(source.includes("citopatología veterinaria"));
+  assert.ok(source.includes("diagnóstico citológico veterinario"));
+  assert.ok(source.includes("criterio clínico-patológico"));
+  assert.ok(source.includes("const jsonLd = getDiagnosticServiceJsonLd({"));
+  assert.ok(source.includes('type="application/ld+json"'));
+  assert.ok(source.includes('href="/histopatologia-veterinaria"'));
+  assert.ok(source.includes('href="/contacto"'));
+});
+
+test("diagnostic service structured data is centralized and verifiable", () => {
+  const source = read(SEO_PATH);
+
+  assert.ok(source.includes("export type DiagnosticServiceJsonLdInput = {"));
+  assert.ok(source.includes("export function getDiagnosticServiceJsonLd({"));
+  assert.ok(source.includes('"@type": "BreadcrumbList"'));
+  assert.ok(source.includes('"@type": "Service"'));
+  assert.ok(source.includes("serviceType"));
+  assert.ok(source.includes("areaServed"));
+  assert.ok(source.includes('"@type": "Country"'));
+  assert.ok(source.includes('name: "Argentina"'));
+  assert.ok(source.includes('"@id": organizationId'));
+  assert.ok(source.includes('"@id": websiteId'));
+  assert.ok(source.includes('"@id": breadcrumbId'));
+});
+
+test("diagnostic service landing pages are included in sitemap", () => {
+  const source = read(SITEMAP_PATH);
+
+  assert.ok(source.includes("url: `${SITE_URL}/histopatologia-veterinaria`,"));
+  assert.ok(source.includes("url: `${SITE_URL}/citologia-veterinaria`,"));
+  assert.ok(source.includes("priority: 0.88,"));
+});
+
+test("services page links to transactional diagnostic landing pages", () => {
+  const source = read(SERVICES_PAGE_PATH);
+
+  assert.ok(source.includes('href="/histopatologia-veterinaria"'));
+  assert.ok(source.includes("Ver histopatología veterinaria"));
+  assert.ok(source.includes('href="/citologia-veterinaria"'));
+  assert.ok(source.includes("Ver citología veterinaria"));
+});
+
+test("diagnostic service pages remain public and avoid backend calls", () => {
+  const combined = `${read(HISTOPATHOLOGY_PAGE_PATH)}\n${read(CYTOLOGY_PAGE_PATH)}`;
+
+  assert.equal(combined.includes('"/dashboard"'), false);
+  assert.equal(combined.includes('"/api"'), false);
+  assert.equal(combined.includes("fetch("), false);
+  assert.equal(combined.includes("AggregateRating"), false);
+  assert.equal(combined.includes('"@type": "Review"'), false);
+  assert.equal(combined.includes("openingHours"), false);
+  assert.equal(combined.includes("GeoCoordinates"), false);
+  assert.equal(combined.includes("PostalAddress"), false);
+});


### PR DESCRIPTION
## Summary
- add transactional SEO landing pages for histopathology and cytology veterinary services
- add verifiable Service JSON-LD helper for diagnostic service pages
- include both public routes in sitemap and link them from /servicios

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build