### PR TITLE
ux(public): hide service card link labels

### DIFF
--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -173,25 +173,25 @@ export default function ServiciosPage() {
                 <div className="mt-5 flex flex-col gap-3 sm:flex-row">
                   <Link
                     href="/laboratorio-patologico-veterinario"
-                    className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
+                    className="sr-only"
                   >
                     Ver laboratorio patológico veterinario
                   </Link>
                   <Link
                     href="/histopatologia-veterinaria"
-                    className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
+                    className="sr-only"
                   >
                     Ver histopatología veterinaria
                   </Link>
                   <Link
                     href="/citologia-veterinaria"
-                    className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
+                    className="sr-only"
                   >
                     Ver citología veterinaria
                   </Link>
                   <Link
                     href="/informes-veterinarios"
-                    className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
+                    className="sr-only"
                   >
                     Ver informes veterinarios
                   </Link>
@@ -221,7 +221,7 @@ export default function ServiciosPage() {
                     >
                       <Link
                         href={service.href}
-                        className="group block h-full rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                        className="group block h-full rounded-lg transition duration-200 [&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                         aria-labelledby={serviceHeadingId}
                       >
                         <Card
@@ -257,7 +257,7 @@ export default function ServiciosPage() {
                                 </li>
                               ))}
                             </ul>
-                            <div className="mt-5 text-sm font-semibold text-primary underline underline-offset-4 transition group-hover:text-vetneb-teal">
+                            <div className="mt-5 text-sm font-semibold text-primary underline underline-offset-4 transition ">
                               {service.linkLabel}
                             </div>
                           </CardContent>

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -92,3 +92,18 @@ test("servicios page keeps one continuous soft canvas through middle sections", 
   assert.equal(source.includes('className="bg-gray-50 py-16"'), false);
   assert.equal(source.includes('data-public-soft-canvas="true"'), false);
 });
+
+test("servicios page hides service link typography while keeping link semantics", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  assert.ok(source.includes('href="/laboratorio-patologico-veterinario"'));
+  assert.ok(source.includes('href="/histopatologia-veterinaria"'));
+  assert.ok(source.includes('href="/citologia-veterinaria"'));
+  assert.ok(source.includes('href="/informes-veterinarios"'));
+  assert.ok(source.includes('className="sr-only"'));
+  assert.ok(source.includes("<span"));
+  assert.ok(source.includes("{service.linkLabel}"));
+  assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
+  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-200"));
+  assert.equal(source.includes("group-hover:text-vetneb-teal"), false);
+});


### PR DESCRIPTION
## Summary
- Hide visible service link typography while preserving public link semantics
- Keep SEO/internal route anchors available as screen-reader-only links
- Add light blue hover state to clickable service cards
- Extend services page content test coverage

## Validation
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-servicios-page-content.test.ts test/frontend-diagnostic-reports-landing-page.test.ts test/frontend-visual-consistency.test.ts
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build