### PR TITLE
ux(public): unify service card CTA hover

### DIFF
--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -221,7 +221,7 @@ export default function ServiciosPage() {
                     >
                       <Link
                         href={service.href}
-                        className="group block h-full rounded-lg transition duration-200 [&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                        className="group block h-full rounded-lg transition duration-200 [&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-300 hover:[&_.premium-card]:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                         aria-labelledby={serviceHeadingId}
                       >
                         <Card
@@ -257,8 +257,11 @@ export default function ServiciosPage() {
                                 </li>
                               ))}
                             </ul>
-                            <div className="mt-5 text-sm font-semibold text-primary underline underline-offset-4 transition ">
-                              {service.linkLabel}
+                            <div className="mt-5 text-sm font-semibold text-primary underline underline-offset-4">
+                              <span className="sr-only">
+                                {service.linkLabel}
+                              </span>
+                              <span aria-hidden="true">Ver más</span>
                             </div>
                           </CardContent>
                         </Card>

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -104,6 +104,22 @@ test("servicios page hides service link typography while keeping link semantics"
   assert.ok(source.includes("<span"));
   assert.ok(source.includes("{service.linkLabel}"));
   assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
-  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-200"));
+  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-300"));
+  assert.ok(source.includes("hover:[&_.premium-card]:shadow-xl"));
   assert.equal(source.includes("group-hover:text-vetneb-teal"), false);
+});
+
+test("servicios page shows unified card CTA while preserving hidden SEO labels", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  assert.ok(source.includes("<span aria-hidden=\"true\">Ver más</span>"));
+  assert.ok(source.includes("{service.linkLabel}"));
+  assert.ok(source.includes('className="sr-only"'));
+  assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
+  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-300"));
+  assert.ok(source.includes("hover:[&_.premium-card]:shadow-xl"));
+  assert.equal(source.includes("Ver laboratorio patológico veterinario</div>"), false);
+  assert.equal(source.includes("Ver histopatología veterinaria</div>"), false);
+  assert.equal(source.includes("Ver citología veterinaria</div>"), false);
+  assert.equal(source.includes("Ver informes veterinarios</div>"), false);
 });


### PR DESCRIPTION
## Summary
- Replace visible per-service card labels with a unified Ver más CTA
- Preserve hidden service-specific labels for semantics and SEO continuity
- Strengthen light blue hover state on clickable service cards
- Extend services page content test coverage

## Validation
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-servicios-page-content.test.ts test/frontend-diagnostic-reports-landing-page.test.ts test/frontend-visual-consistency.test.ts
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build