### PR TITLE
fix(public): point service CTAs to services page

### DIFF
--- a/frontend/src/app/citologia-veterinaria/page.tsx
+++ b/frontend/src/app/citologia-veterinaria/page.tsx
@@ -106,7 +106,7 @@ export default function CitologiaVeterinariaPage() {
               </Link>
             </Button>
             <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver todos los servicios</Link>
+              <Link href="/servicios">VER MAS SERVICIOS</Link>
             </Button>
           </div>
         </div>
@@ -225,9 +225,7 @@ export default function CitologiaVeterinariaPage() {
                     <Link href="/contacto">Coordinar envío de muestras</Link>
                   </Button>
                   <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/histopatologia-veterinaria">
-                      Ver histopatología veterinaria
-                    </Link>
+                    <Link href="/servicios">VER MAS SERVICIOS</Link>
                   </Button>
                 </div>
               </div>

--- a/frontend/src/app/histopatologia-veterinaria/page.tsx
+++ b/frontend/src/app/histopatologia-veterinaria/page.tsx
@@ -106,7 +106,7 @@ export default function HistopatologiaVeterinariaPage() {
               </Link>
             </Button>
             <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver todos los servicios</Link>
+              <Link href="/servicios">VER MAS SERVICIOS</Link>
             </Button>
           </div>
         </div>
@@ -226,9 +226,7 @@ export default function HistopatologiaVeterinariaPage() {
                     <Link href="/contacto">Coordinar envío de muestras</Link>
                   </Button>
                   <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/citologia-veterinaria">
-                      Ver citología veterinaria
-                    </Link>
+                    <Link href="/servicios">VER MAS SERVICIOS</Link>
                   </Button>
                 </div>
               </div>

--- a/frontend/src/app/informes-veterinarios/page.tsx
+++ b/frontend/src/app/informes-veterinarios/page.tsx
@@ -125,7 +125,7 @@ export default function InformesVeterinariosPage() {
               </Link>
             </Button>
             <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver servicios diagnósticos</Link>
+              <Link href="/servicios">VER MAS SERVICIOS</Link>
             </Button>
           </div>
         </div>
@@ -252,9 +252,7 @@ export default function InformesVeterinariosPage() {
                     <Link href="/contacto">Consultar por un caso</Link>
                   </Button>
                   <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/laboratorio-patologico-veterinario">
-                      Ver laboratorio patológico veterinario
-                    </Link>
+                    <Link href="/servicios">VER MAS SERVICIOS</Link>
                   </Button>
                 </div>
               </div>

--- a/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
+++ b/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
@@ -109,7 +109,7 @@ export default function LaboratorioPatologicoVeterinarioPage() {
               </Link>
             </Button>
             <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver todos los servicios</Link>
+              <Link href="/servicios">VER MAS SERVICIOS</Link>
             </Button>
           </div>
         </div>
@@ -229,9 +229,7 @@ export default function LaboratorioPatologicoVeterinarioPage() {
                     <Link href="/contacto">Coordinar envío de muestras</Link>
                   </Button>
                   <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/histopatologia-veterinaria">
-                      Ver histopatología veterinaria
-                    </Link>
+                    <Link href="/servicios">VER MAS SERVICIOS</Link>
                   </Button>
                 </div>
               </div>

--- a/test/frontend-diagnostic-reports-landing-page.test.ts
+++ b/test/frontend-diagnostic-reports-landing-page.test.ts
@@ -79,9 +79,8 @@ test("veterinary diagnostic reports landing page keeps public editorial navigati
   assert.ok(source.includes('href="/contacto"'));
   assert.ok(source.includes("Consultar por informes"));
   assert.ok(source.includes('href="/servicios"'));
-  assert.ok(source.includes("Ver servicios diagnósticos"));
-  assert.ok(source.includes('href="/laboratorio-patologico-veterinario"'));
-  assert.ok(source.includes("Ver laboratorio patológico veterinario"));
+  assert.ok(source.includes("VER MAS SERVICIOS"));
+  assert.ok(source.includes('href="/servicios"'));
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes('href="/dashboard"'), false);
   assert.equal(source.includes('"/api"'), false);

--- a/test/frontend-diagnostic-service-landing-pages.test.ts
+++ b/test/frontend-diagnostic-service-landing-pages.test.ts
@@ -37,7 +37,8 @@ test("histopathology landing page targets transactional veterinary service inten
   assert.ok(source.includes("criterio clínico-patológico"));
   assert.ok(source.includes("const jsonLd = getDiagnosticServiceJsonLd({"));
   assert.ok(source.includes('type="application/ld+json"'));
-  assert.ok(source.includes('href="/citologia-veterinaria"'));
+  assert.ok(source.includes('href="/servicios"'));
+  assert.ok(source.includes("VER MAS SERVICIOS"));
   assert.ok(source.includes('href="/contacto"'));
 });
 
@@ -55,7 +56,8 @@ test("cytology landing page targets transactional veterinary service intent", ()
   assert.ok(source.includes("criterio clínico-patológico"));
   assert.ok(source.includes("const jsonLd = getDiagnosticServiceJsonLd({"));
   assert.ok(source.includes('type="application/ld+json"'));
-  assert.ok(source.includes('href="/histopatologia-veterinaria"'));
+  assert.ok(source.includes('href="/servicios"'));
+  assert.ok(source.includes("VER MAS SERVICIOS"));
   assert.ok(source.includes('href="/contacto"'));
 });
 

--- a/test/frontend-pathology-laboratory-landing-page.test.ts
+++ b/test/frontend-pathology-laboratory-landing-page.test.ts
@@ -62,11 +62,8 @@ test("veterinary pathology laboratory landing page keeps public diagnostic navig
   assert.ok(source.includes('href="/contacto"'));
   assert.ok(source.includes("Solicitar coordinación diagnóstica"));
   assert.ok(source.includes('href="/servicios"'));
-  assert.ok(source.includes("Ver todos los servicios"));
-  assert.ok(source.includes('href="/histopatologia-veterinaria"'));
-  assert.ok(source.includes("Ver histopatología veterinaria"));
-  assert.ok(source.includes('href="/citologia-veterinaria"'));
-  assert.ok(source.includes("Ver citología veterinaria"));
+  assert.ok(source.includes("VER MAS SERVICIOS"));
+  assert.ok(source.includes('href="/servicios"'));
 });
 
 test("veterinary pathology laboratory landing page is included in sitemap", () => {


### PR DESCRIPTION
## Summary
- update affected public service CTAs to show VER MAS SERVICIOS
- point the updated CTAs to /servicios
- keep layout, styling, backend, dashboard, auth and SEO infrastructure unchanged

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build