### PR TITLE
fix(public): hide redundant related service links

### DIFF
--- a/frontend/src/app/informes-veterinarios/page.tsx
+++ b/frontend/src/app/informes-veterinarios/page.tsx
@@ -279,20 +279,6 @@ export default function InformesVeterinariosPage() {
                       citología y técnicas complementarias según la pregunta
                       diagnóstica del caso.
                     </p>
-                    <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-                      <Link
-                        href="/servicios"
-                        className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
-                      >
-                        Ver servicios diagnósticos
-                      </Link>
-                      <Link
-                        href="/laboratorio-patologico-veterinario"
-                        className="text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"
-                      >
-                        Ver laboratorio patológico veterinario
-                      </Link>
-                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
+++ b/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
@@ -261,9 +261,6 @@ export default function LaboratorioPatologicoVeterinarioPage() {
                         según la muestra recibida y la pregunta diagnóstica del
                         caso.
                       </p>
-                      <div className="mt-5 text-sm font-semibold text-primary underline underline-offset-4">
-                        <span aria-hidden="true">Ver más</span>
-                      </div>
                     </div>
                   </div>
                 </div>

--- a/test/frontend-diagnostic-reports-landing-page.test.ts
+++ b/test/frontend-diagnostic-reports-landing-page.test.ts
@@ -124,3 +124,9 @@ test("veterinary diagnostic reports landing page avoids unverifiable claims", ()
   assert.equal(source.includes("from \"gsap\""), false);
   assert.equal(source.includes("from 'gsap'"), false);
 });
+test("veterinary diagnostic reports hides redundant visible related service links", () => {
+  const source = read(DIAGNOSTIC_REPORTS_PAGE_PATH);
+
+  assert.equal(source.includes("Ver servicios diagnósticos"), false);
+  assert.equal(source.includes("Ver laboratorio patológico veterinario"), false);
+});

--- a/test/frontend-pathology-laboratory-landing-page.test.ts
+++ b/test/frontend-pathology-laboratory-landing-page.test.ts
@@ -109,7 +109,7 @@ test("veterinary pathology laboratory related services card links to public serv
   assert.ok(source.includes('className="sr-only"'));
   assert.ok(source.includes("Ver citología veterinaria"));
   assert.ok(source.includes("Ver servicio patológico veterinario"));
-  assert.ok(source.includes('<span aria-hidden="true">Ver más</span>'));
+  assert.equal(source.includes('<span aria-hidden="true">Ver más</span>'), false);
   assert.ok(source.includes("group-hover:bg-sky-50"));
   assert.ok(source.includes("group-hover:border-sky-300"));
   assert.ok(source.includes("group-hover:shadow-xl"));
@@ -117,4 +117,9 @@ test("veterinary pathology laboratory related services card links to public serv
     source.includes("text-sm font-semibold text-primary underline underline-offset-4 hover:text-vetneb-teal"),
     false,
   );
+});
+test("veterinary pathology laboratory hides redundant visible related services teaser", () => {
+  const source = read(PATHOLOGY_LAB_PAGE_PATH);
+
+  assert.equal(source.includes('<span aria-hidden="true">Ver más</span>'), false);
 });


### PR DESCRIPTION
## Summary
- hide redundant visible related-service links on public diagnostic pages
- keep existing section copy and primary CTAs unchanged
- keep backend, dashboard, auth, SEO infrastructure and layout behavior unchanged

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build