### PR TITLE
fix(public): hide diagnostic hero eyebrows

### DIFF
--- a/frontend/src/app/citologia-veterinaria/page.tsx
+++ b/frontend/src/app/citologia-veterinaria/page.tsx
@@ -84,7 +84,7 @@ export default function CitologiaVeterinariaPage() {
         aria-labelledby="cytology-page-title"
       >
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88">
+          <p className="sr-only">
             Servicio citológico veterinario
           </p>
           <h1

--- a/frontend/src/app/histopatologia-veterinaria/page.tsx
+++ b/frontend/src/app/histopatologia-veterinaria/page.tsx
@@ -84,7 +84,7 @@ export default function HistopatologiaVeterinariaPage() {
         aria-labelledby="histopathology-page-title"
       >
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88">
+          <p className="sr-only">
             Servicio histopatológico veterinario
           </p>
           <h1

--- a/frontend/src/app/informes-veterinarios/page.tsx
+++ b/frontend/src/app/informes-veterinarios/page.tsx
@@ -103,7 +103,7 @@ export default function InformesVeterinariosPage() {
         aria-labelledby="diagnostic-reports-page-title"
       >
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88">
+          <p className="sr-only">
             Consulta de informes veterinarios
           </p>
           <h1

--- a/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
+++ b/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
@@ -87,7 +87,7 @@ export default function LaboratorioPatologicoVeterinarioPage() {
         aria-labelledby="pathology-lab-page-title"
       >
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88">
+          <p className="sr-only">
             Anatomía patológica veterinaria
           </p>
           <h1

--- a/test/frontend-diagnostic-service-landing-pages.test.ts
+++ b/test/frontend-diagnostic-service-landing-pages.test.ts
@@ -106,3 +106,19 @@ test("diagnostic service pages remain public and avoid backend calls", () => {
   assert.equal(combined.includes("GeoCoordinates"), false);
   assert.equal(combined.includes("PostalAddress"), false);
 });
+test("diagnostic service hero eyebrows remain visually hidden", () => {
+  const pages = [
+    read(HISTOPATHOLOGY_PAGE_PATH),
+    read(CYTOLOGY_PAGE_PATH),
+    read("frontend/src/app/laboratorio-patologico-veterinario/page.tsx"),
+    read("frontend/src/app/informes-veterinarios/page.tsx"),
+  ];
+
+  for (const source of pages) {
+    assert.ok(source.includes('className="sr-only"'));
+    assert.equal(
+      source.includes('className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/88"'),
+      false,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- hide visible eyebrow labels in diagnostic public page heroes
- preserve the labels as screen-reader-only text
- keep layout, backend, dashboard, auth and SEO infrastructure unchanged

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build