### PR TITLE
feat(auth): add login password visibility toggle

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -153,7 +153,8 @@ export function LoginContent() {
                   disabled={isSubmitting}
                   className="h-12 rounded-lg"
                 />
-              </div>              <div>
+              </div>
+              <div>
                 <label htmlFor="password" className="field-label">
                   Contraseña
                 </label>

--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -31,6 +31,7 @@ export function LoginContent() {
   const requestedSurface = searchParams.get("tipo") ?? searchParams.get("surface");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -152,23 +153,38 @@ export function LoginContent() {
                   disabled={isSubmitting}
                   className="h-12 rounded-lg"
                 />
-              </div>
-              <div>
+              </div>              <div>
                 <label htmlFor="password" className="field-label">
                   Contraseña
                 </label>
-                <Input
-                  id="password"
-                  name="password"
-                  type="password"
-                  placeholder="••••••••"
-                  autoComplete="current-password"
-                  required
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  disabled={isSubmitting}
-                  className="h-12 rounded-lg"
-                />
+                <div className="relative">
+                  <Input
+                    id="password"
+                    name="password"
+                    type={isPasswordVisible ? "text" : "password"}
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                    required
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    disabled={isSubmitting}
+                    className="h-12 rounded-lg pr-12"
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
+                    onClick={() => setIsPasswordVisible((current) => !current)}
+                    disabled={isSubmitting}
+                    aria-label={isPasswordVisible ? "Ocultar contraseña" : "Mostrar contraseña"}
+                    aria-pressed={isPasswordVisible}
+                  >
+                    {isPasswordVisible ? (
+                      <EyeOff className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                      <Eye className="h-4 w-4" aria-hidden="true" />
+                    )}
+                  </button>
+                </div>
               </div>
 
               {errorMessage ? (

--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -3,7 +3,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ShieldCheck } from "lucide-react";
+import { Eye, EyeOff, ShieldCheck } from "lucide-react";
 
 import {
   Card,

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -69,3 +69,14 @@ test("frontend login content keeps particular token entry on the dedicated publi
   assert.ok(source.includes("router.push(ROUTES.particulares);"));
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
 });
+test("frontend login content allows toggling clinic password visibility", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes('import { Eye, EyeOff, ShieldCheck } from "lucide-react"'));
+  assert.ok(source.includes('const [isPasswordVisible, setIsPasswordVisible] = useState(false)'));
+  assert.ok(source.includes('type={isPasswordVisible ? "text" : "password"}'));
+  assert.ok(source.includes('className="h-12 rounded-lg pr-12"'));
+  assert.ok(source.includes('onClick={() => setIsPasswordVisible((current) => !current)}'));
+  assert.ok(source.includes('aria-label={isPasswordVisible ? "Ocultar contraseña" : "Mostrar contraseña"}'));
+  assert.ok(source.includes('aria-pressed={isPasswordVisible}'));
+});


### PR DESCRIPTION
## Summary
- add a show/hide password toggle to the clinic login form
- preserve existing clinic authentication behavior
- keep backend, dashboard, API and particular token access unchanged

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build