### PR TITLE
fix(auth): constrain clinic login next redirect

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -18,11 +18,31 @@ import { loginClinic } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 
 function getSafeNextPath(nextPath: string | null): string {
-  if (!nextPath?.startsWith("/dashboard")) {
+  const candidate = nextPath?.trim();
+
+  if (!candidate) {
     return ROUTES.dashboard;
   }
 
-  return nextPath;
+  if (candidate === ROUTES.dashboard) {
+    return candidate;
+  }
+
+  if (
+    candidate === ROUTES.dashboardAdmin ||
+    candidate.startsWith(`${ROUTES.dashboardAdmin}/`)
+  ) {
+    return ROUTES.dashboard;
+  }
+
+  if (
+    candidate.startsWith(`${ROUTES.dashboard}/`) ||
+    candidate.startsWith(`${ROUTES.dashboard}?`)
+  ) {
+    return candidate;
+  }
+
+  return ROUTES.dashboard;
 }
 
 export function LoginContent() {

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -28,7 +28,11 @@ test("frontend login content preserves dashboard next path safely", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
-  assert.ok(source.includes('nextPath?.startsWith("/dashboard")'));
+  assert.ok(source.includes("candidate === ROUTES.dashboard"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
+  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
   assert.ok(source.includes("return ROUTES.dashboard"));
 });
 

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -31,9 +31,13 @@ test("login public page redirects safely after successful authentication", () =>
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
-  assert.ok(source.includes('if (!nextPath?.startsWith("/dashboard"))'));
+  assert.ok(source.includes("candidate === ROUTES.dashboard"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
+  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
   assert.ok(source.includes("return ROUTES.dashboard;"));
-  assert.ok(source.includes("return nextPath;"));
+  assert.equal(source.includes("return nextPath;"), false);
   assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
   assert.ok(source.includes("router.refresh();"));
 });

--- a/test/frontend-login-next-redirect-boundary.test.ts
+++ b/test/frontend-login-next-redirect-boundary.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const LOGIN_CONTENT_PATH = "frontend/src/components/public/LoginContent.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("login next redirect helper keeps strict dashboard boundary checks", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
+  assert.ok(source.includes("return ROUTES.dashboard;"));
+  assert.ok(source.includes("candidate === ROUTES.dashboard"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
+  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.equal(source.includes('if (!nextPath?.startsWith("/dashboard"))'), false);
+  assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
+  assert.ok(source.includes('requestedSurface === "particular"'));
+  assert.ok(source.includes("router.replace(ROUTES.particulares);"));
+});

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -58,7 +58,11 @@ test("login content keeps safe dashboard redirect and error handling", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
-  assert.ok(source.includes('if (!nextPath?.startsWith("/dashboard"))'));
+  assert.ok(source.includes("candidate === ROUTES.dashboard"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
+  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
   assert.ok(source.includes("return ROUTES.dashboard;"));
   assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
   assert.ok(source.includes("router.refresh();"));
@@ -78,6 +82,4 @@ test("login content exposes public navigation affordances without direct fetch",
   assert.equal(source.includes('"/api"'), false);
   assert.equal(source.includes("fetch("), false);
 });
-
-
 


### PR DESCRIPTION
## Summary
- constrain clinic login next redirects to valid clinic dashboard paths
- reject admin dashboard and dashboard-like paths from clinic login redirect handling
- update frontend login contracts for the stricter redirect boundary

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build