### PR TITLE
fix(auth): normalize clinic login next redirect target

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -17,6 +17,8 @@ import { Input } from "@/components/ui/input";
 import { loginClinic } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 
+const SAFE_LOGIN_REDIRECT_ORIGIN = "https://portal.vetneb.local";
+
 function getSafeNextPath(nextPath: string | null): string {
   const candidate = nextPath?.trim();
 
@@ -24,22 +26,36 @@ function getSafeNextPath(nextPath: string | null): string {
     return ROUTES.dashboard;
   }
 
-  if (candidate === ROUTES.dashboard) {
-    return candidate;
+  if (candidate.startsWith("//")) {
+    return ROUTES.dashboard;
   }
 
+  let parsedNextPath: URL;
+
+  try {
+    parsedNextPath = new URL(candidate, SAFE_LOGIN_REDIRECT_ORIGIN);
+  } catch {
+    return ROUTES.dashboard;
+  }
+
+  if (parsedNextPath.origin !== SAFE_LOGIN_REDIRECT_ORIGIN) {
+    return ROUTES.dashboard;
+  }
+
+  const pathname = parsedNextPath.pathname;
+
   if (
-    candidate === ROUTES.dashboardAdmin ||
-    candidate.startsWith(`${ROUTES.dashboardAdmin}/`)
+    parsedNextPath.pathname === ROUTES.dashboardAdmin ||
+    parsedNextPath.pathname.startsWith(`${ROUTES.dashboardAdmin}/`)
   ) {
     return ROUTES.dashboard;
   }
 
   if (
-    candidate.startsWith(`${ROUTES.dashboard}/`) ||
-    candidate.startsWith(`${ROUTES.dashboard}?`)
+    pathname === ROUTES.dashboard ||
+    pathname.startsWith(`${ROUTES.dashboard}/`)
   ) {
-    return candidate;
+    return `${pathname}${parsedNextPath.search}`;
   }
 
   return ROUTES.dashboard;

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -28,11 +28,16 @@ test("frontend login content preserves dashboard next path safely", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
-  assert.ok(source.includes("candidate === ROUTES.dashboard"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
-  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("new URL(candidate, SAFE_LOGIN_REDIRECT_ORIGIN)"));
+  assert.ok(source.includes("const pathname = parsedNextPath.pathname;"));
+  assert.ok(source.includes("parsedNextPath.pathname === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("parsedNextPath.pathname.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("pathname === ROUTES.dashboard"));
+  assert.ok(source.includes("pathname.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("return `${pathname}${parsedNextPath.search}`;"));
+  assert.equal(source.includes("safePath === ROUTES.dashboardAdmin"), false);
+  assert.equal(source.includes("safePath.startsWith(`${ROUTES.dashboardAdmin}/`)"), false);
+  assert.equal(source.includes("return candidate;"), false);
   assert.ok(source.includes("return ROUTES.dashboard"));
 });
 

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -31,13 +31,18 @@ test("login public page redirects safely after successful authentication", () =>
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
-  assert.ok(source.includes("candidate === ROUTES.dashboard"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
-  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("new URL(candidate, SAFE_LOGIN_REDIRECT_ORIGIN)"));
+  assert.ok(source.includes("const pathname = parsedNextPath.pathname;"));
+  assert.ok(source.includes("parsedNextPath.pathname === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("parsedNextPath.pathname.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("pathname === ROUTES.dashboard"));
+  assert.ok(source.includes("pathname.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("return `${pathname}${parsedNextPath.search}`;"));
+  assert.equal(source.includes("safePath === ROUTES.dashboardAdmin"), false);
+  assert.equal(source.includes("safePath.startsWith(`${ROUTES.dashboardAdmin}/`)"), false);
   assert.ok(source.includes("return ROUTES.dashboard;"));
   assert.equal(source.includes("return nextPath;"), false);
+  assert.equal(source.includes("return candidate;"), false);
   assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
   assert.ok(source.includes("router.refresh();"));
 });

--- a/test/frontend-login-next-redirect-boundary.test.ts
+++ b/test/frontend-login-next-redirect-boundary.test.ts
@@ -16,12 +16,21 @@ test("login next redirect helper keeps strict dashboard boundary checks", () => 
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
+  assert.ok(source.includes('const SAFE_LOGIN_REDIRECT_ORIGIN = "https://portal.vetneb.local";'));
+  assert.ok(source.includes("new URL(candidate, SAFE_LOGIN_REDIRECT_ORIGIN)"));
+  assert.ok(source.includes("parsedNextPath.origin !== SAFE_LOGIN_REDIRECT_ORIGIN"));
+  assert.ok(source.includes('candidate.startsWith("//")'));
+  assert.ok(source.includes("const pathname = parsedNextPath.pathname;"));
+  assert.ok(source.includes("parsedNextPath.pathname === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("parsedNextPath.pathname.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("parsedNextPath.search"));
+  assert.equal(source.includes("return candidate;"), false);
   assert.ok(source.includes("return ROUTES.dashboard;"));
-  assert.ok(source.includes("candidate === ROUTES.dashboard"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
-  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("pathname === ROUTES.dashboard"));
+  assert.ok(source.includes("pathname.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("return `${pathname}${parsedNextPath.search}`;"));
+  assert.equal(source.includes("safePath === ROUTES.dashboardAdmin"), false);
+  assert.equal(source.includes("safePath.startsWith(`${ROUTES.dashboardAdmin}/`)"), false);
   assert.equal(source.includes('if (!nextPath?.startsWith("/dashboard"))'), false);
   assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
   assert.ok(source.includes('requestedSurface === "particular"'));

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -58,11 +58,15 @@ test("login content keeps safe dashboard redirect and error handling", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("function getSafeNextPath(nextPath: string | null): string"));
-  assert.ok(source.includes("candidate === ROUTES.dashboard"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}/`)"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboard}?`)"));
-  assert.ok(source.includes("candidate === ROUTES.dashboardAdmin"));
-  assert.ok(source.includes("candidate.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("new URL(candidate, SAFE_LOGIN_REDIRECT_ORIGIN)"));
+  assert.ok(source.includes("const pathname = parsedNextPath.pathname;"));
+  assert.ok(source.includes("parsedNextPath.pathname === ROUTES.dashboardAdmin"));
+  assert.ok(source.includes("parsedNextPath.pathname.startsWith(`${ROUTES.dashboardAdmin}/`)"));
+  assert.ok(source.includes("pathname === ROUTES.dashboard"));
+  assert.ok(source.includes("pathname.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.ok(source.includes("return `${pathname}${parsedNextPath.search}`;"));
+  assert.equal(source.includes("safePath === ROUTES.dashboardAdmin"), false);
+  assert.equal(source.includes("safePath.startsWith(`${ROUTES.dashboardAdmin}/`)"), false);
   assert.ok(source.includes("return ROUTES.dashboard;"));
   assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
   assert.ok(source.includes("router.refresh();"));
@@ -82,4 +86,3 @@ test("login content exposes public navigation affordances without direct fetch",
   assert.equal(source.includes('"/api"'), false);
   assert.equal(source.includes("fetch("), false);
 });
-


### PR DESCRIPTION
## Summary
- normalize clinic login next redirect targets before validating them
- reject external, protocol-relative, admin and normalized dashboard-admin redirects
- update frontend login contracts for parsed pathname/search redirect handling

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build