### PR TITLE
fix(routes): constrain dashboard route predicate

### DIFF
--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -50,5 +50,8 @@ export const DASHBOARD_ROUTES: AppRoute[] = [
 ];
 
 export function isDashboardRoute(pathname: string): boolean {
-  return pathname.startsWith("/dashboard");
+  return (
+    pathname === ROUTES.dashboard ||
+    pathname.startsWith(`${ROUTES.dashboard}/`)
+  );
 }

--- a/test/frontend-route-registry.test.ts
+++ b/test/frontend-route-registry.test.ts
@@ -67,9 +67,12 @@ test("frontend route registry keeps dashboard route allowlist explicit", () => {
   assert.ok(source.includes("ROUTES.dashboardAdmin,"));
 });
 
-test("frontend route registry identifies dashboard paths by prefix", () => {
+test("frontend route registry identifies only real dashboard routes", () => {
   const source = read(ROUTES_PATH);
 
   assert.ok(source.includes("export function isDashboardRoute(pathname: string): boolean"));
-  assert.ok(source.includes('return pathname.startsWith("/dashboard");'));
+  assert.ok(source.includes("pathname === ROUTES.dashboard"));
+  assert.ok(source.includes("pathname.startsWith(`${ROUTES.dashboard}/`)"));
+  assert.equal(source.includes('pathname.startsWith("/dashboard")'), false);
+  assert.equal(source.includes('return pathname.startsWith("/dashboard");'), false);
 });


### PR DESCRIPTION
## Summary
- constrain isDashboardRoute to /dashboard and real dashboard subroutes
- reject dashboard-like public paths such as /dashboard-admin and /dashboard.evil
- update frontend route registry contracts for the stricter predicate

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build