### PR TITLE
fix(db): reconcile current public profile columns

### DIFF
--- a/scripts/db/reconcile-public-profile-db.mjs
+++ b/scripts/db/reconcile-public-profile-db.mjs
@@ -40,12 +40,24 @@ try {
         services_text text,
         email varchar(255),
         phone varchar(50),
+        public_address varchar(160),
+        map_link varchar(2048),
         locality varchar(255),
         country varchar(255),
         is_public boolean NOT NULL DEFAULT false,
         created_at timestamp NOT NULL DEFAULT now(),
         updated_at timestamp NOT NULL DEFAULT now()
       );
+    `);
+
+    await tx.unsafe(`
+      ALTER TABLE clinic_public_profiles
+      ADD COLUMN IF NOT EXISTS public_address varchar(160);
+    `);
+
+    await tx.unsafe(`
+      ALTER TABLE clinic_public_profiles
+      ADD COLUMN IF NOT EXISTS map_link varchar(2048);
     `);
 
     await tx.unsafe(`
@@ -73,12 +85,24 @@ try {
         services_text text,
         email varchar(255),
         phone varchar(50),
+        public_address varchar(160),
+        map_link varchar(2048),
         locality varchar(255),
         country varchar(255),
         is_public boolean NOT NULL DEFAULT false,
         search_text text NOT NULL,
         updated_at timestamp NOT NULL DEFAULT now()
       );
+    `);
+
+    await tx.unsafe(`
+      ALTER TABLE clinic_public_search
+      ADD COLUMN IF NOT EXISTS public_address varchar(160);
+    `);
+
+    await tx.unsafe(`
+      ALTER TABLE clinic_public_search
+      ADD COLUMN IF NOT EXISTS map_link varchar(2048);
     `);
 
     await tx.unsafe(`
@@ -163,6 +187,8 @@ try {
         services_text,
         email,
         phone,
+        public_address,
+        map_link,
         locality,
         country,
         is_public,
@@ -181,6 +207,8 @@ try {
         NULL,
         c.contact_email,
         c.contact_phone,
+        NULL,
+        NULL,
         NULL,
         NULL,
         false,
@@ -281,16 +309,29 @@ try {
 
   const checks = await sql.unsafe(`
     SELECT
+      table_name,
       column_name
     FROM information_schema.columns
     WHERE table_schema = 'public'
-      AND table_name = 'clinic_public_search'
-      AND column_name IN (
-        'has_required_public_fields',
-        'is_search_eligible',
-        'profile_quality_score'
+      AND (
+        (
+          table_name = 'clinic_public_search'
+          AND column_name IN (
+            'has_required_public_fields',
+            'is_search_eligible',
+            'profile_quality_score',
+            'public_address',
+            'map_link'
+          )
+        ) OR (
+          table_name = 'clinic_public_profiles'
+          AND column_name IN (
+            'public_address',
+            'map_link'
+          )
+        )
       )
-    ORDER BY column_name;
+    ORDER BY table_name, column_name;
   `);
 
   const tables = await sql.unsafe(`

--- a/test/reconcile-public-profile-db-contract.test.ts
+++ b/test/reconcile-public-profile-db-contract.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const SCRIPT_PATH = "scripts/db/reconcile-public-profile-db.mjs";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("public profile reconciliation script keeps required table and extension contracts", () => {
+  const source = read(SCRIPT_PATH);
+  const normalized = source.replace(/\s+/g, " ");
+
+  assert.ok(
+    normalized.includes("CREATE EXTENSION IF NOT EXISTS unaccent"),
+    "El script debe mantener CREATE EXTENSION IF NOT EXISTS unaccent.",
+  );
+  assert.ok(
+    normalized.includes("CREATE EXTENSION IF NOT EXISTS pg_trgm"),
+    "El script debe mantener CREATE EXTENSION IF NOT EXISTS pg_trgm.",
+  );
+  assert.ok(
+    normalized.includes("CREATE TABLE IF NOT EXISTS clinic_public_profiles"),
+    "El script debe mantener CREATE TABLE IF NOT EXISTS clinic_public_profiles.",
+  );
+  assert.ok(
+    normalized.includes("CREATE TABLE IF NOT EXISTS clinic_public_search"),
+    "El script debe mantener CREATE TABLE IF NOT EXISTS clinic_public_search.",
+  );
+});
+
+test("public profile reconciliation script enforces address and map columns in both public tables", () => {
+  const source = read(SCRIPT_PATH);
+  const normalized = source.replace(/\s+/g, " ");
+
+  assert.ok(
+    normalized.includes(
+      "ALTER TABLE clinic_public_profiles ADD COLUMN IF NOT EXISTS public_address varchar(160)",
+    ),
+    "El script debe agregar public_address en clinic_public_profiles con ALTER TABLE IF NOT EXISTS.",
+  );
+  assert.ok(
+    normalized.includes(
+      "ALTER TABLE clinic_public_profiles ADD COLUMN IF NOT EXISTS map_link varchar(2048)",
+    ),
+    "El script debe agregar map_link en clinic_public_profiles con ALTER TABLE IF NOT EXISTS.",
+  );
+  assert.ok(
+    normalized.includes(
+      "ALTER TABLE clinic_public_search ADD COLUMN IF NOT EXISTS public_address varchar(160)",
+    ),
+    "El script debe agregar public_address en clinic_public_search con ALTER TABLE IF NOT EXISTS.",
+  );
+  assert.ok(
+    normalized.includes(
+      "ALTER TABLE clinic_public_search ADD COLUMN IF NOT EXISTS map_link varchar(2048)",
+    ),
+    "El script debe agregar map_link en clinic_public_search con ALTER TABLE IF NOT EXISTS.",
+  );
+});
+
+test("public profile reconciliation script seeds new columns in clinic_public_search", () => {
+  const source = read(SCRIPT_PATH);
+  const normalized = source.replace(/\s+/g, " ");
+
+  assert.ok(
+    normalized.includes(
+      "INSERT INTO clinic_public_search ( clinic_id, display_name, avatar_storage_path, about_text, specialty_text, services_text, email, phone, public_address, map_link, locality, country, is_public, has_required_public_fields, is_search_eligible, profile_quality_score, search_text, updated_at )",
+    ),
+    "El INSERT INTO clinic_public_search debe incluir public_address y map_link.",
+  );
+  assert.ok(
+    normalized.includes("c.contact_phone, NULL, NULL, NULL, NULL, false"),
+    "El SELECT del INSERT debe incluir NULL, NULL para public_address y map_link.",
+  );
+});
+
+test("public profile reconciliation script verifies new columns in information_schema checks", () => {
+  const source = read(SCRIPT_PATH);
+  const normalized = source.replace(/\s+/g, " ");
+
+  assert.ok(
+    normalized.includes(
+      "table_name = 'clinic_public_search' AND column_name IN ( 'has_required_public_fields', 'is_search_eligible', 'profile_quality_score', 'public_address', 'map_link' )",
+    ),
+    "El check final debe contemplar public_address y map_link en clinic_public_search.",
+  );
+  assert.ok(
+    normalized.includes(
+      "table_name = 'clinic_public_profiles' AND column_name IN ( 'public_address', 'map_link' )",
+    ),
+    "El check final debe contemplar public_address y map_link en clinic_public_profiles.",
+  );
+});


### PR DESCRIPTION
## Summary
- reconcile public profile address and map-link columns in the DB helper script
- keep local DB reconciliation idempotent for existing databases
- add a contract test for current public profile schema columns

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build