### PR TITLE
fix(frontend): make login particulares CTA native link and harden password toggle contract

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -102,11 +102,6 @@ export function LoginContent() {
     }
   }
 
-  function openParticularAccess() {
-    setErrorMessage(null);
-    router.push(ROUTES.particulares);
-  }
-
   const clinicSubmitLabel = isSubmitting ? "Iniciando sesión..." : "Iniciar sesión";
 
   return (
@@ -153,18 +148,18 @@ export function LoginContent() {
                 className="rounded-md border border-vetneb-teal/30 bg-card px-3 py-2 text-sm font-medium text-vetneb-ink shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
                 disabled={isSubmitting}
                 aria-pressed="true"
+                data-auth-clinic-access-tab="true"
               >
                 Clínicas
               </button>
-              <button
-                type="button"
+              <Link
+                href={ROUTES.particulares}
                 className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
-                onClick={openParticularAccess}
-                disabled={isSubmitting}
                 aria-pressed="false"
+                data-auth-particular-access-link="true"
               >
                 Particulares
-              </button>
+              </Link>
             </div>
 
             <form
@@ -199,6 +194,7 @@ export function LoginContent() {
                     id="password"
                     name="password"
                     type={isPasswordVisible ? "text" : "password"}
+                    data-auth-password-input="true"
                     placeholder="••••••••"
                     autoComplete="current-password"
                     required
@@ -214,6 +210,8 @@ export function LoginContent() {
                     disabled={isSubmitting}
                     aria-label={isPasswordVisible ? "Ocultar contraseña" : "Mostrar contraseña"}
                     aria-pressed={isPasswordVisible}
+                    aria-controls="password"
+                    data-auth-password-visibility-toggle="true"
                   >
                     {isPasswordVisible ? (
                       <EyeOff className="h-4 w-4" aria-hidden="true" />

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -75,8 +75,12 @@ test("frontend login content keeps particular token entry on the dedicated publi
   assert.equal(source.includes("Token de acceso"), false);
   assert.equal(source.includes("Ingresar con token"), false);
   assert.equal(source.includes("Ingrese el token recibido"), false);
-  assert.ok(source.includes("router.push(ROUTES.particulares);"));
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
+  assert.ok(source.includes("<Link"));
+  assert.ok(source.includes("href={ROUTES.particulares}"));
+  assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.equal(source.includes("openParticularAccess"), false);
+  assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
 });
 test("frontend login content allows toggling clinic password visibility", () => {
   const source = read(LOGIN_CONTENT_PATH);
@@ -84,8 +88,12 @@ test("frontend login content allows toggling clinic password visibility", () => 
   assert.ok(source.includes('import { Eye, EyeOff, ShieldCheck } from "lucide-react"'));
   assert.ok(source.includes('const [isPasswordVisible, setIsPasswordVisible] = useState(false)'));
   assert.ok(source.includes('type={isPasswordVisible ? "text" : "password"}'));
+  assert.ok(source.includes('data-auth-password-input="true"'));
   assert.ok(source.includes('className="h-12 rounded-lg pr-12"'));
   assert.ok(source.includes('onClick={() => setIsPasswordVisible((current) => !current)}'));
   assert.ok(source.includes('aria-label={isPasswordVisible ? "Ocultar contraseña" : "Mostrar contraseña"}'));
   assert.ok(source.includes('aria-pressed={isPasswordVisible}'));
+  assert.ok(source.includes('aria-controls="password"'));
+  assert.ok(source.includes('data-auth-password-visibility-toggle="true"'));
+  assert.ok(source.includes('data-auth-clinic-access-tab="true"'));
 });

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -61,6 +61,16 @@ test("login public page handles loading and error states", () => {
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("disabled={isSubmitting}"));
   assert.ok(source.includes('isSubmitting ? "Iniciando sesión..." : "Iniciar sesión"'));
+  assert.ok(source.includes('data-auth-clinic-access-tab="true"'));
+  assert.ok(source.includes('data-auth-password-input="true"'));
+  assert.ok(source.includes('data-auth-password-visibility-toggle="true"'));
+  assert.ok(source.includes('aria-controls="password"'));
+  assert.ok(
+    source.includes(
+      'aria-label={isPasswordVisible ? "Ocultar contraseña" : "Mostrar contraseña"}',
+    ),
+  );
+  assert.ok(source.includes("aria-pressed={isPasswordVisible}"));
 });
 
 test("API client exposes clinic login contract against backend auth endpoint", () => {
@@ -82,5 +92,9 @@ test("login public page routes particular access away from the clinic login form
   assert.ok(source.includes('const requestedSurface = searchParams.get("tipo") ?? searchParams.get("surface");'));
   assert.ok(source.includes('if (requestedSurface === "particular")'));
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
-  assert.ok(source.includes("router.push(ROUTES.particulares);"));
+  assert.ok(source.includes("<Link"));
+  assert.ok(source.includes("href={ROUTES.particulares}"));
+  assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.equal(source.includes("openParticularAccess"), false);
+  assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
 });

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -78,11 +78,14 @@ test("login content exposes public navigation affordances without direct fetch",
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("href={ROUTES.home}"));
+  assert.ok(source.includes("href={ROUTES.particulares}"));
+  assert.ok(source.includes('data-auth-particular-access-link="true"'));
   assert.ok(source.includes('aria-label="PORTAL VETNEB — Inicio"'));
   assert.ok(source.includes("¿Su clínica no tiene acceso?"));
   assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicite acceso"));
   assert.ok(source.includes("← Volver al sitio público"));
+  assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
   assert.equal(source.includes('"/api"'), false);
   assert.equal(source.includes("fetch("), false);
 });

--- a/test/frontend-login-password-visibility-contract.test.ts
+++ b/test/frontend-login-password-visibility-contract.test.ts
@@ -21,6 +21,7 @@ test("login password visibility starts hidden and toggles input type safely", ()
     ),
   );
   assert.ok(source.includes('type={isPasswordVisible ? "text" : "password"}'));
+  assert.ok(source.includes('data-auth-password-input="true"'));
 });
 
 test("login password visibility toggle uses explicit button semantics", () => {
@@ -30,6 +31,8 @@ test("login password visibility toggle uses explicit button semantics", () => {
   assert.ok(
     source.includes("onClick={() => setIsPasswordVisible((current) => !current)}"),
   );
+  assert.ok(source.includes('aria-controls="password"'));
+  assert.ok(source.includes('data-auth-password-visibility-toggle="true"'));
 });
 
 test("login password visibility exposes accessible label and pressed state", () => {
@@ -60,10 +63,13 @@ test("login redirects particular surface requests to the dedicated public route"
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
 });
 
-test("login particular button delegates to openParticularAccess handler", () => {
+test("login particular access uses native Link navigation contract", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
-  assert.ok(source.includes("onClick={openParticularAccess}"));
-  assert.ok(source.includes("function openParticularAccess() {"));
-  assert.ok(source.includes("router.push(ROUTES.particulares);"));
+  assert.ok(source.includes("<Link"));
+  assert.ok(source.includes("href={ROUTES.particulares}"));
+  assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.ok(source.includes('aria-pressed="false"'));
+  assert.equal(source.includes("openParticularAccess"), false);
+  assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
 });

--- a/test/frontend-public-button-contrast-contract.test.ts
+++ b/test/frontend-public-button-contrast-contract.test.ts
@@ -124,7 +124,9 @@ test("login and particulares submit CTAs keep loading semantics and contract cla
   assert.ok(login.includes("aria-busy={isSubmitting}"));
   assert.ok(login.includes('aria-pressed="true"'));
   assert.ok(login.includes('aria-pressed="false"'));
-  assert.ok(login.includes("router.push(ROUTES.particulares);"));
+  assert.ok(login.includes("href={ROUTES.particulares}"));
+  assert.ok(login.includes('data-auth-particular-access-link="true"'));
+  assert.equal(login.includes("router.push(ROUTES.particulares);"), false);
 
   assert.ok(particulares.includes("public-cta-primary w-full"));
   assert.ok(particulares.includes("aria-busy={isSubmitting}"));


### PR DESCRIPTION
## Resumen
- cambia el CTA **Particulares** en `LoginContent` de `button + onClick/router.push` a `Link` nativo con `href={ROUTES.particulares}`
- agrega atributos de contrato QA/a11y para login:
  - `data-auth-clinic-access-tab="true"`
  - `data-auth-password-input="true"`
  - `data-auth-password-visibility-toggle="true"`
  - `aria-controls="password"` en toggle de visibilidad
- conserva redirecciones existentes:
  - `router.replace(ROUTES.particulares)` cuando `requestedSurface === "particular"`
  - `router.replace(getSafeNextPath(searchParams.get("next")))` en login clínico
- actualiza tests de contrato de login para reflejar navegación nativa y atributos nuevos

## Validación
- `git diff --check`
- `pnpm test`
- `pnpm build`
- `pnpm -C frontend build`

## Notas
- no se tocaron backend, DB, dashboard, auth server, ni estilos globales
- sin nuevas dependencias