### PR TITLE
chore(frontend): improve dev fallback API warning diagnostics

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,6 +39,41 @@ import type {
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
+function warnApiFallback(functionName: string, error: unknown): void {
+  switch (functionName) {
+    case "getReports":
+      console.warn("[API] getReports: endpoint no disponible");
+      break;
+    case "searchReports":
+      console.warn("[API] searchReports: endpoint no disponible");
+      break;
+    case "getLogisticsFieldVisits":
+      console.warn("[API] getLogisticsFieldVisits: endpoint no disponible");
+      break;
+    case "getRoutePlans":
+      console.warn("[API] getRoutePlans: endpoint no disponible");
+      break;
+    case "getRoutePlanMetrics":
+      console.warn("[API] getRoutePlanMetrics: endpoint no disponible");
+      break;
+    case "getAuditEntries":
+      console.warn("[API] getAuditEntries: endpoint no disponible");
+      break;
+    case "getAdminSystemHealth":
+      console.warn("[API] getAdminSystemHealth: endpoint no disponible");
+      break;
+    default:
+      console.warn(`[API] ${functionName}: endpoint no disponible`);
+      break;
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    const errorDetail =
+      error instanceof Error ? error.message : String(error);
+    console.warn(`[API] ${functionName}: ${errorDetail}`);
+  }
+}
+
 async function apiFetch<T>(
   path: string,
   options: RequestInit = {},
@@ -183,7 +218,7 @@ export async function getReports(
     );
     return res.reports ?? [];
   } catch (error) {
-    console.warn("[API] getReports: endpoint no disponible");
+    warnApiFallback("getReports", error);
     if (readOptions.throwOnError) {
       throw error;
     }
@@ -213,7 +248,7 @@ export async function searchReports(
     );
     return res.reports ?? [];
   } catch (error) {
-    console.warn("[API] searchReports: endpoint no disponible");
+    warnApiFallback("searchReports", error);
     if (readOptions.throwOnError) {
       throw error;
     }
@@ -585,7 +620,7 @@ export async function getLogisticsFieldVisits(
     );
     return res.visits ?? [];
   } catch (error) {
-    console.warn("[API] getLogisticsFieldVisits: endpoint no disponible");
+    warnApiFallback("getLogisticsFieldVisits", error);
     if (readOptions.throwOnError) {
       throw error;
     }
@@ -605,7 +640,7 @@ export async function getRoutePlans(
     );
     return res.plans ?? [];
   } catch (error) {
-    console.warn("[API] getRoutePlans: endpoint no disponible");
+    warnApiFallback("getRoutePlans", error);
     if (readOptions.throwOnError) {
       throw error;
     }
@@ -627,7 +662,7 @@ export async function getRoutePlanMetrics(
       );
       return res.metrics ? [res.metrics] : [];
     } catch (error) {
-      console.warn("[API] getRoutePlanMetrics: endpoint no disponible");
+      warnApiFallback("getRoutePlanMetrics", error);
       if (readOptions.throwOnError) {
         throw error;
       }
@@ -655,7 +690,7 @@ export async function getAuditEntries(
     );
     return res.entries ?? [];
   } catch (error) {
-    console.warn("[API] getAuditEntries: endpoint no disponible");
+    warnApiFallback("getAuditEntries", error);
     if (readOptions.throwOnError) {
       throw error;
     }
@@ -770,8 +805,8 @@ export async function getAdminSystemHealth(
       "/api/admin/system/health",
       options,
     );
-  } catch {
-    console.warn("[API] getAdminSystemHealth: endpoint no disponible");
+  } catch (error) {
+    warnApiFallback("getAdminSystemHealth", error);
     return null;
   }
 }

--- a/test/frontend-api-dev-error-details.test.ts
+++ b/test/frontend-api-dev-error-details.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function getBetween(
+  source: string,
+  startToken: string,
+  endToken: string,
+): string {
+  const start = source.indexOf(startToken);
+  const end = source.indexOf(endToken, start + startToken.length);
+
+  if (start === -1 || end === -1 || end <= start) {
+    return "";
+  }
+
+  return source.slice(start, end);
+}
+
+test("frontend API dev fallback helper keeps endpoint warning and development details", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("function warnApiFallback(functionName: string, error: unknown): void"));
+  assert.ok(source.includes("endpoint no disponible"));
+  assert.ok(source.includes("error instanceof Error ? error.message : String(error)"));
+  assert.ok(source.includes('warnApiFallback("getReports", error);'));
+  assert.ok(source.includes('warnApiFallback("getLogisticsFieldVisits", error);'));
+  assert.ok(source.includes('warnApiFallback("getRoutePlans", error);'));
+  assert.ok(source.includes('credentials: options.credentials ?? "include",'));
+});
+
+test("frontend API dev fallback helper avoids cookie/header leakage markers", () => {
+  const source = read(API_CLIENT_PATH);
+  const helper = getBetween(
+    source,
+    "function warnApiFallback(functionName: string, error: unknown): void {",
+    "async function apiFetch<T>(",
+  );
+
+  assert.ok(helper.length > 0);
+  assert.equal(helper.includes("headers.cookie"), false);
+  assert.equal(helper.includes("Cookie"), false);
+});


### PR DESCRIPTION
## Resumen
- agrega helper `warnApiFallback(functionName, error)` en `frontend/src/lib/api.ts`
- mantiene mensaje compatible `endpoint no disponible`
- en `development` agrega detalle con `error instanceof Error ? error.message : String(error)`
- mantiene `console.warn`, fallbacks y flujos `throwOnError` existentes
- no cambia `credentials: options.credentials ?? "include"`

## Wrappers actualizados
- `getReports`
- `searchReports`
- `getLogisticsFieldVisits`
- `getRoutePlans`
- `getRoutePlanMetrics` (solo catch fallback del endpoint real)
- `getAuditEntries`
- `getAdminSystemHealth`

## Test
- nuevo: `test/frontend-api-dev-error-details.test.ts`
  - valida existencia de `warnApiFallback`
  - valida uso en `getReports`, `getLogisticsFieldVisits`, `getRoutePlans`
  - valida presencia de `endpoint no disponible`
  - valida ausencia de `headers.cookie` y `Cookie` dentro del helper
  - valida que `apiFetch` mantiene `credentials: options.credentials ?? "include"`

## Validación ejecutada
- `git diff --check`
- `pnpm test`
- `pnpm build`
- `pnpm -C frontend build`