### PR TITLE
fix(auth): throttle clinic session last-access updates

### DIFF
--- a/server/middlewares/admin-auth.ts
+++ b/server/middlewares/admin-auth.ts
@@ -1,13 +1,13 @@
 ﻿import type { NextFunction, Request, Response } from "../lib/http-types.ts";
 
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+
 type AuthenticatedAdmin = {
   id: number;
   username: string;
   sessionToken: string;
 };
 
-
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
 
 type AdminSessionRecord = {
   adminUserId: number;
@@ -44,17 +44,6 @@ function getAdminSessionToken(
 
   const trimmed = raw.trim();
   return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
 }
 
 let defaultDepsPromise: Promise<AdminAuthDeps> | null = null;
@@ -169,4 +158,3 @@ export function createRequireAdminAuth(
 }
 
 export const requireAdminAuth = createRequireAdminAuth();
-

--- a/server/middlewares/auth.ts
+++ b/server/middlewares/auth.ts
@@ -2,6 +2,7 @@
 import type { ClinicUserRole } from "../../drizzle/schema";
 import type { ClinicPermissions } from "../lib/permissions.ts";
 
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import { getClinicPermissions, normalizeClinicUserRole } from "../lib/permissions.ts";
 
 export type AuthenticatedUser = {
@@ -19,6 +20,7 @@ export type AuthenticatedUser = {
 type ActiveSessionRecord = {
   clinicUserId: number;
   expiresAt: Date | null;
+  lastAccess?: Date | null;
 };
 
 type ClinicUserRecord = {
@@ -144,7 +146,9 @@ export function createRequireAuth(
         });
       }
 
-      await deps.updateSessionLastAccess(tokenHash);
+      if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, deps.now())) {
+        await deps.updateSessionLastAccess(tokenHash);
+      }
 
       const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
       const permissions = getClinicPermissions(role);
@@ -169,5 +173,4 @@ export function createRequireAuth(
 }
 
 export const requireAuth = createRequireAuth();
-
 

--- a/server/middlewares/particular-auth.ts
+++ b/server/middlewares/particular-auth.ts
@@ -1,6 +1,6 @@
 ﻿import type { NextFunction, Request, Response } from "../lib/http-types.ts";
 
-const SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS = 10 * 60 * 1000;
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 
 type ParticularSessionRecord = {
   particularTokenId: number;
@@ -43,17 +43,6 @@ function getParticularSessionToken(
 
   const trimmed = raw.trim();
   return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function shouldRefreshSessionLastAccess(
-  lastAccess: Date | null | undefined,
-  nowMs: number,
-) {
-  if (!(lastAccess instanceof Date)) {
-    return true;
-  }
-
-  return nowMs - lastAccess.getTime() >= SESSION_LAST_ACCESS_UPDATE_INTERVAL_MS;
 }
 
 let defaultDepsPromise: Promise<ParticularAuthDeps> | null = null;
@@ -171,4 +160,3 @@ export function createRequireParticularAuth(
 }
 
 export const requireParticularAuth = createRequireParticularAuth();
-

--- a/test/auth-middleware.test.ts
+++ b/test/auth-middleware.test.ts
@@ -227,13 +227,14 @@ test("requireAuth elimina sesión cuando el usuario clinic no existe", async () 
   assert.equal(nextCalls.length, 0);
 });
 
-test("requireAuth autentica owner y actualiza lastAccess", async () => {
+test("requireAuth autentica owner y actualiza lastAccess si lastAccess es null", async () => {
   const { deps, calls } = createDeps({
     getActiveSessionByToken: async (tokenHash: string) => {
       calls.getActiveSessionByToken.push(tokenHash);
       return {
         clinicUserId: 99,
         expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+        lastAccess: null,
       };
     },
     getClinicUserById: async (id: number) => {
@@ -287,6 +288,111 @@ test("requireAuth autentica owner y actualiza lastAccess", async () => {
   });
   assert.equal(res.statusCode, 200);
   assert.equal(res.jsonPayload, undefined);
+  assert.deepEqual(nextCalls, [undefined]);
+});
+
+test("requireAuth autentica sin actualizar lastAccess si aún no corresponde", async () => {
+  const { deps, calls } = createDeps({
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return {
+        clinicUserId: 55,
+        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+        lastAccess: new Date("2026-04-21T11:55:00.000Z"),
+      };
+    },
+    getClinicUserById: async (id: number) => {
+      calls.getClinicUserById.push(id);
+      return {
+        id,
+        clinicId: 8,
+        username: "fresh-user",
+        authProId: null,
+        role: "clinic_staff",
+      };
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req: any = {
+    cookies: {
+      clinic_session: "token-fresco",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.updateSessionLastAccess, []);
+  assert.deepEqual(req.auth, {
+    id: 55,
+    clinicId: 8,
+    username: "fresh-user",
+    authProId: null,
+    role: "clinic_staff",
+    permissions: {
+      canUploadReports: false,
+      canManageClinicUsers: false,
+      canViewLogistics: true,
+      canManageLogisticsFieldVisits: false,
+      canManageLogisticsRoutePlans: false,
+      canManageLogisticsRouteEvents: false,
+      canViewLogisticsSla: true,
+    },
+    canUploadReports: false,
+    canManageClinicUsers: false,
+    sessionToken: "token-fresco",
+  });
+  assert.deepEqual(nextCalls, [undefined]);
+});
+
+test("requireAuth actualiza lastAccess si el intervalo expiró", async () => {
+  const { deps, calls } = createDeps({
+    getActiveSessionByToken: async (tokenHash: string) => {
+      calls.getActiveSessionByToken.push(tokenHash);
+      return {
+        clinicUserId: 66,
+        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+        lastAccess: new Date("2026-04-21T11:50:00.000Z"),
+      };
+    },
+    getClinicUserById: async (id: number) => {
+      calls.getClinicUserById.push(id);
+      return {
+        id,
+        clinicId: 9,
+        username: "stale-user",
+        authProId: null,
+        role: "clinic_staff",
+      };
+    },
+  });
+
+  const middleware = createRequireAuth(deps as any);
+
+  const req: any = {
+    cookies: {
+      clinic_session: "token-vencido",
+    },
+  };
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  await middleware(
+    req,
+    res as any,
+    ((error?: unknown) => nextCalls.push(error)) as any,
+  );
+
+  assert.deepEqual(calls.updateSessionLastAccess, ["hashed:token-vencido"]);
   assert.deepEqual(nextCalls, [undefined]);
 });
 


### PR DESCRIPTION
## Summary
- aplica throttle compartido a updateSessionLastAccess en clinic auth
- elimina duplicación inline de shouldRefreshSessionLastAccess en admin y particular auth
- agrega cobertura para lastAccess reciente, null y expirado

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build