### PR TITLE
fix(routes): remove legacy particular token aliases

### DIFF
--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -325,11 +325,6 @@ export async function createFastifyApp(
     ...(options.adminParticularTokensRoutes ?? {}),
   });
 
-  await app.register(adminParticularTokensNativeRoutes, {
-    prefix: "/api/admin/particular/tokens",
-    ...(options.adminParticularTokensRoutes ?? {}),
-  });
-
   await app.register(adminReportsNativeRoutes, {
     prefix: "/api/admin/reports",
     ...(options.adminReportsRoutes ?? {}),
@@ -405,11 +400,6 @@ export async function createFastifyApp(
     ...(options.particularTokensRoutes ?? {}),
   });
 
-  await app.register(particularTokensNativeRoutes, {
-    prefix: "/api/particular/tokens",
-    ...(options.particularTokensRoutes ?? {}),
-  });
-
   await app.register(publicProfessionalsNativeRoutes, {
     prefix: "/api/public/professionals",
     ...(options.publicProfessionalsRoutes ?? {}),
@@ -467,5 +457,4 @@ export async function createFastifyApp(
 
   return app;
 }
-
 

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -1950,65 +1950,6 @@ test(
 
 
 test(
-  "createFastifyApp despacha aliases legacy de particular tokens al router nativo",
-  async () => {
-    const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
-      publicProfessionalsRoutes: {
-        searchPublicProfessionals: async () => ({
-          rows: [],
-          total: 0,
-          limit: 20,
-          offset: 0,
-        }),
-        getPublicProfessionalByClinicId: async () => null,
-        createSignedStorageUrl: async (path: string) => `signed:${path}`,
-      },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
-    });
-
-    try {
-      const adminAliasResponse = await app.inject({
-        method: "GET",
-        url: "/api/admin/particular/tokens",
-      });
-
-      assert.equal(adminAliasResponse.headers["x-legacy-bridge"], undefined);
-      assert.notEqual(adminAliasResponse.statusCode, 418);
-      assert.equal(adminAliasResponse.statusCode, 401);
-
-      const clinicAliasResponse = await app.inject({
-        method: "GET",
-        url: "/api/particular/tokens",
-      });
-
-      assert.equal(clinicAliasResponse.headers["x-legacy-bridge"], undefined);
-      assert.notEqual(clinicAliasResponse.statusCode, 418);
-      assert.equal(clinicAliasResponse.statusCode, 401);
-    } finally {
-      await app.close();
-    }
-  },
-);
-
-
-test(
   "createFastifyApp despacha rutas nativas restantes al router nativo",
   async () => {
     const app = await createFastifyApp(buildFastifyDispatchRouteStubs());


### PR DESCRIPTION
## Summary
- elimina alias legacy /api/admin/particular/tokens
- elimina alias legacy /api/particular/tokens
- mantiene rutas canónicas /api/admin/particular-tokens y /api/particular-tokens

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build