### PR TITLE
fix(auth): persist login rate-limit counters

### DIFF
--- a/drizzle/migrations/0025_login_rate_limits.sql
+++ b/drizzle/migrations/0025_login_rate_limits.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "login_rate_limits" (
+  "key_hash" text PRIMARY KEY NOT NULL,
+  "count" integer NOT NULL,
+  "reset_at" timestamp NOT NULL,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "updated_at" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "login_rate_limits_reset_at_idx"
+  ON "login_rate_limits" ("reset_at");

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
                         "when":  1777107600000,
                         "tag":  "0024_clinic_public_profile_avatar_map",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  25,
+                        "version":  "7",
+                        "when":  1777111200000,
+                        "tag":  "0025_login_rate_limits",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -438,6 +438,20 @@ export const loginFailedAttempts = pgTable(
   }),
 );
 
+export const loginRateLimits = pgTable(
+  "login_rate_limits",
+  {
+    keyHash: text("key_hash").primaryKey(),
+    count: integer("count").notNull(),
+    resetAt: timestamp("reset_at", { mode: "date" }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (table) => ({
+    resetAtIdx: index("login_rate_limits_reset_at_idx").on(table.resetAt),
+  }),
+);
+
 export const pricingItems = pgTable(
   "pricing_items",
   {
@@ -1088,6 +1102,9 @@ export type NewReportAccessToken = InferInsertModel<typeof reportAccessTokens>;
 
 export type AuditLog = InferSelectModel<typeof auditLog>;
 export type NewAuditLog = InferInsertModel<typeof auditLog>;
+
+export type LoginRateLimit = InferSelectModel<typeof loginRateLimits>;
+export type NewLoginRateLimit = InferInsertModel<typeof loginRateLimits>;
 
 export type ActiveSession = InferSelectModel<typeof activeSessions>;
 export type NewActiveSession = InferInsertModel<typeof activeSessions>;

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,7 +1,7 @@
 import { getReportStudyTypes as getCanonicalReportStudyTypes, REPORT_STUDY_TYPE_LABELS } from "./lib/report-study-types.ts";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { and, desc, eq, ilike, isNotNull, lte, or, sql } from "drizzle-orm";
+import { and, desc, eq, ilike, isNotNull, lt, lte, or, sql } from "drizzle-orm";
 import {
   activeSessions,
   adminSessions,
@@ -9,6 +9,7 @@ import {
   clinicUsers,
   clinics,
   loginFailedAttempts,
+  loginRateLimits,
   reports,
   reportStatusHistory,
   type ClinicUserRole,
@@ -144,6 +145,99 @@ export async function recordLoginFailedAttempt(input: {
     .returning();
 
   return result[0];
+}
+
+/* ========================= LOGIN RATE LIMITS ========================= */
+
+export async function getLoginRateLimitEntry(keyHash: string) {
+  const result = await db
+    .select({
+      count: loginRateLimits.count,
+      resetAt: loginRateLimits.resetAt,
+    })
+    .from(loginRateLimits)
+    .where(eq(loginRateLimits.keyHash, keyHash))
+    .limit(1);
+
+  return result[0];
+}
+
+export async function setLoginRateLimitEntry(input: {
+  keyHash: string;
+  count: number;
+  resetAt: Date;
+  now: Date;
+}) {
+  const result = await db
+    .insert(loginRateLimits)
+    .values({
+      keyHash: input.keyHash,
+      count: input.count,
+      resetAt: input.resetAt,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoUpdate({
+      target: loginRateLimits.keyHash,
+      set: {
+        count: input.count,
+        resetAt: input.resetAt,
+        updatedAt: input.now,
+      },
+    })
+    .returning({
+      count: loginRateLimits.count,
+      resetAt: loginRateLimits.resetAt,
+    });
+
+  return result[0];
+}
+
+export async function incrementLoginRateLimitEntry(input: {
+  keyHash: string;
+  count: number;
+  resetAt: Date;
+  now: Date;
+}) {
+  const result = await db
+    .insert(loginRateLimits)
+    .values({
+      keyHash: input.keyHash,
+      count: input.count,
+      resetAt: input.resetAt,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoUpdate({
+      target: loginRateLimits.keyHash,
+      set: {
+        count: sql<number>`
+          CASE
+            WHEN ${loginRateLimits.resetAt} <= ${input.now} THEN ${input.count}
+            ELSE ${loginRateLimits.count} + 1
+          END
+        `,
+        resetAt: sql<Date>`
+          CASE
+            WHEN ${loginRateLimits.resetAt} <= ${input.now} THEN ${input.resetAt}
+            ELSE ${loginRateLimits.resetAt}
+          END
+        `,
+        updatedAt: input.now,
+      },
+    })
+    .returning({
+      count: loginRateLimits.count,
+      resetAt: loginRateLimits.resetAt,
+    });
+
+  return result[0];
+}
+
+export async function deleteExpiredLoginRateLimitEntries(now: Date) {
+  await db
+    .delete(loginRateLimits)
+    .where(lt(loginRateLimits.resetAt, now));
 }
 
 /* ========================= CLINIC SESSIONS ========================= */
@@ -561,5 +655,3 @@ export async function getReportStudyTypes(_clinicId: number) {
 }
 
 export const getStudyTypes = getReportStudyTypes;
-
-

--- a/server/lib/rate-limit-store.ts
+++ b/server/lib/rate-limit-store.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export type RateLimitEntry = {
   count: number;
   resetAt: number;
@@ -6,6 +8,39 @@ export type RateLimitEntry = {
 export type RateLimitStore = {
   get: (key: string) => RateLimitEntry | undefined | Promise<RateLimitEntry | undefined>;
   set: (key: string, entry: RateLimitEntry) => void | Promise<void>;
+  increment?: (
+    key: string,
+    entry: RateLimitEntry,
+    now?: number,
+  ) => RateLimitEntry | Promise<RateLimitEntry>;
+};
+
+export type PersistentRateLimitRecord = {
+  count: number;
+  resetAt: Date;
+};
+
+export type PersistentRateLimitStoreAdapter = {
+  get: (
+    keyHash: string,
+  ) => PersistentRateLimitRecord | undefined | Promise<PersistentRateLimitRecord | undefined>;
+  set: (input: {
+    keyHash: string;
+    count: number;
+    resetAt: Date;
+    now: Date;
+  }) => PersistentRateLimitRecord | undefined | Promise<PersistentRateLimitRecord | undefined>;
+  increment: (input: {
+    keyHash: string;
+    count: number;
+    resetAt: Date;
+    now: Date;
+  }) => PersistentRateLimitRecord | Promise<PersistentRateLimitRecord>;
+  cleanupExpired?: (now: Date) => void | Promise<void>;
+};
+
+export type PersistentRateLimitStoreOptions = {
+  now?: () => number;
 };
 
 export function createMemoryRateLimitStore(): RateLimitStore {
@@ -15,6 +50,79 @@ export function createMemoryRateLimitStore(): RateLimitStore {
     get: (key) => entries.get(key),
     set: (key, entry) => {
       entries.set(key, entry);
+    },
+  };
+}
+
+export function hashRateLimitKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+function toPersistentDate(ms: number): Date {
+  return new Date(ms);
+}
+
+function toRateLimitEntry(record: PersistentRateLimitRecord): RateLimitEntry {
+  return {
+    count: record.count,
+    resetAt: record.resetAt.getTime(),
+  };
+}
+
+async function cleanupExpiredBestEffort(
+  adapter: PersistentRateLimitStoreAdapter,
+  now: number,
+) {
+  if (!adapter.cleanupExpired) {
+    return;
+  }
+
+  try {
+    await adapter.cleanupExpired(toPersistentDate(now));
+  } catch {
+    return;
+  }
+}
+
+export function createPersistentRateLimitStore(
+  adapter: PersistentRateLimitStoreAdapter,
+  options: PersistentRateLimitStoreOptions = {},
+): RateLimitStore {
+  const getNow = options.now ?? (() => Date.now());
+
+  return {
+    get: async (key) => {
+      const now = getNow();
+
+      await cleanupExpiredBestEffort(adapter, now);
+
+      const record = await adapter.get(hashRateLimitKey(key));
+
+      return record ? toRateLimitEntry(record) : undefined;
+    },
+    set: async (key, entry) => {
+      const now = getNow();
+
+      await cleanupExpiredBestEffort(adapter, now);
+
+      await adapter.set({
+        keyHash: hashRateLimitKey(key),
+        count: entry.count,
+        resetAt: toPersistentDate(entry.resetAt),
+        now: toPersistentDate(now),
+      });
+    },
+    increment: async (key, entry, now = getNow()) => {
+      await cleanupExpiredBestEffort(adapter, now);
+
+      return toRateLimitEntry(
+        await adapter.increment({
+          keyHash: hashRateLimitKey(key),
+          count: entry.count + 1,
+          resetAt: toPersistentDate(entry.resetAt),
+          now: toPersistentDate(now),
+        }),
+      );
     },
   };
 }
@@ -45,7 +153,12 @@ export async function incrementRateLimitEntry(
   store: RateLimitStore,
   key: string,
   entry: RateLimitEntry,
+  now?: number,
 ): Promise<RateLimitEntry> {
+  if (store.increment) {
+    return store.increment(key, entry, now);
+  }
+
   const updated = {
     count: entry.count + 1,
     resetAt: entry.resetAt,

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/login-rate-limit.ts";
 import {
   createMemoryRateLimitStore,
+  createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
   type RateLimitStore,
@@ -160,10 +161,13 @@ type NativeAuthDeps = Required<
     | "recordLoginFailedAttempt"
   >
 >;
+type NativeAuthDefaultDeps = NativeAuthDeps & {
+  loginRateLimitStore: RateLimitStore;
+};
 
-let defaultDepsPromise: Promise<NativeAuthDeps> | undefined;
+let defaultDepsPromise: Promise<NativeAuthDefaultDeps> | undefined;
 
-async function loadDefaultDeps(): Promise<NativeAuthDeps> {
+async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
@@ -187,6 +191,12 @@ async function loadDefaultDeps(): Promise<NativeAuthDeps> {
           input: AuditWriteInput,
         ) => Promise<void>,
         recordLoginFailedAttempt: db.recordLoginFailedAttempt,
+        loginRateLimitStore: createPersistentRateLimitStore({
+          get: db.getLoginRateLimitEntry,
+          set: db.setLoginRateLimitEntry,
+          increment: db.incrementLoginRateLimitEntry,
+          cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+        }),
       };
     })();
   }
@@ -574,8 +584,12 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
   const loginRateLimitMaxAttempts =
     options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
-  const loginRateLimitStore =
+  const memoryLoginRateLimitStore =
     options.loginRateLimitStore ?? createMemoryRateLimitStore();
+  const loginRateLimitStore =
+    options.loginRateLimitStore ??
+    defaultDeps?.loginRateLimitStore ??
+    memoryLoginRateLimitStore;
 
   app.addHook("onRequest", async (request, reply) => {
     (request as AuthFastifyRequest)[REQUEST_TIMER_KEY] =
@@ -708,6 +722,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         loginRateLimitStore,
         rateLimitKey,
         failureEntry,
+        currentTime,
       );
 
       failureEntry.count = updatedEntry.count;
@@ -883,4 +898,3 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     });
   });
 };
-

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -15,6 +15,10 @@ const {
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
 } = await import("../server/lib/login-rate-limit.ts");
 const {
+  createPersistentRateLimitStore,
+  hashRateLimitKey,
+} = await import("../server/lib/rate-limit-store.ts");
+const {
   getClinicPermissions,
 } = await import("../server/lib/permissions.ts");
 const {
@@ -46,6 +50,71 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
   });
 
   return app;
+}
+
+type PersistentRateLimitRow = {
+  count: number;
+  resetAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function createPersistentRateLimitStoreHarness(input?: {
+  rows?: Map<string, PersistentRateLimitRow>;
+  now?: () => number;
+}) {
+  const rows = input?.rows ?? new Map<string, PersistentRateLimitRow>();
+
+  const store = createPersistentRateLimitStore(
+    {
+      get: async (keyHash) => rows.get(keyHash),
+      set: async ({ keyHash, count, resetAt, now }) => {
+        const existing = rows.get(keyHash);
+        const row = {
+          count,
+          resetAt,
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        };
+
+        rows.set(keyHash, row);
+
+        return row;
+      },
+      increment: async ({ keyHash, count, resetAt, now }) => {
+        const existing = rows.get(keyHash);
+        const row =
+          !existing || existing.resetAt.getTime() <= now.getTime()
+            ? {
+                count,
+                resetAt,
+                createdAt: existing?.createdAt ?? now,
+                updatedAt: now,
+              }
+            : {
+                ...existing,
+                count: existing.count + 1,
+                updatedAt: now,
+              };
+
+        rows.set(keyHash, row);
+
+        return row;
+      },
+      cleanupExpired: async (now) => {
+        for (const [keyHash, row] of rows) {
+          if (row.resetAt.getTime() < now.getTime()) {
+            rows.delete(keyHash);
+          }
+        }
+      },
+    },
+    {
+      now: input?.now,
+    },
+  );
+
+  return { rows, store };
 }
 
 function getSetCookieHeader(response: { headers: Record<string, unknown> }) {
@@ -434,6 +503,242 @@ test("clinicAuthNativeRoutes responde 401 para password inválida", async () => 
     });
   } finally {
     await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes login fallido incrementa store persistente", async () => {
+  const currentTime = Date.UTC(2026, 4, 8, 0, 0, 0);
+  const { rows, store } = createPersistentRateLimitStoreHarness({
+    now: () => currentTime,
+  });
+
+  const app = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: store,
+    getClinicUserByUsername: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.50",
+      payload: {
+        username: "vetneb",
+        password: "incorrecta",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(rows.get(hashRateLimitKey("203.0.113.50"))?.count, 1);
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes bloquea login al superar límite persistente", async () => {
+  const currentTime = Date.UTC(2026, 4, 8, 0, 0, 0);
+  const { store } = createPersistentRateLimitStoreHarness({
+    now: () => currentTime,
+  });
+
+  const app = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: store,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 2,
+    getClinicUserByUsername: async () => null,
+  });
+
+  try {
+    const first = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.51",
+      payload: {
+        username: "vetneb",
+        password: "bad-1",
+      },
+    });
+    const second = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.51",
+      payload: {
+        username: "vetneb",
+        password: "bad-2",
+      },
+    });
+    const third = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.51",
+      payload: {
+        username: "vetneb",
+        password: "bad-3",
+      },
+    });
+
+    assert.equal(first.statusCode, 401);
+    assert.equal(second.statusCode, 401);
+    assert.equal(third.statusCode, 429);
+    assert.deepEqual(JSON.parse(third.body), {
+      success: false,
+      error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+    });
+    assert.equal(third.headers["ratelimit-limit"], "2");
+    assert.equal(third.headers["ratelimit-remaining"], "0");
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes recrea app y store persistente sin resetear contador", async () => {
+  const currentTime = Date.UTC(2026, 4, 8, 0, 0, 0);
+  const rows = new Map<string, PersistentRateLimitRow>();
+  const firstHarness = createPersistentRateLimitStoreHarness({
+    rows,
+    now: () => currentTime,
+  });
+  const firstApp = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: firstHarness.store,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 1,
+    getClinicUserByUsername: async () => null,
+  });
+
+  try {
+    const first = await firstApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.52",
+      payload: {
+        username: "vetneb",
+        password: "bad-1",
+      },
+    });
+
+    assert.equal(first.statusCode, 401);
+  } finally {
+    await firstApp.close();
+  }
+
+  const secondHarness = createPersistentRateLimitStoreHarness({
+    rows,
+    now: () => currentTime,
+  });
+  const secondApp = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: secondHarness.store,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 1,
+    getClinicUserByUsername: async () => {
+      throw new Error("rate limited request must not query clinic user");
+    },
+  });
+
+  try {
+    const second = await secondApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.52",
+      payload: {
+        username: "vetneb",
+        password: "bad-2",
+      },
+    });
+
+    assert.equal(second.statusCode, 429);
+  } finally {
+    await secondApp.close();
+  }
+});
+
+test("clinicAuthNativeRoutes reinicia ventana persistente cuando resetAt venció", async () => {
+  let currentTime = Date.UTC(2026, 4, 8, 0, 0, 0);
+  const rows = new Map<string, PersistentRateLimitRow>();
+  const firstHarness = createPersistentRateLimitStoreHarness({
+    rows,
+    now: () => currentTime,
+  });
+  const firstApp = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: firstHarness.store,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 1,
+    getClinicUserByUsername: async () => null,
+  });
+
+  try {
+    const first = await firstApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.53",
+      payload: {
+        username: "vetneb",
+        password: "bad-1",
+      },
+    });
+
+    assert.equal(first.statusCode, 401);
+  } finally {
+    await firstApp.close();
+  }
+
+  currentTime += 61_000;
+
+  const secondHarness = createPersistentRateLimitStoreHarness({
+    rows,
+    now: () => currentTime,
+  });
+  const secondApp = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: secondHarness.store,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 1,
+    getClinicUserByUsername: async () => null,
+  });
+
+  try {
+    const second = await secondApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.53",
+      payload: {
+        username: "vetneb",
+        password: "bad-2",
+      },
+    });
+
+    assert.equal(second.statusCode, 401);
+    assert.equal(rows.get(hashRateLimitKey("203.0.113.53"))?.count, 1);
+  } finally {
+    await secondApp.close();
   }
 });
 

--- a/test/rate-limit-store.test.ts
+++ b/test/rate-limit-store.test.ts
@@ -3,10 +3,84 @@ import assert from "node:assert/strict";
 
 import {
   createMemoryRateLimitStore,
+  createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
+  hashRateLimitKey,
   incrementRateLimitEntry,
+  type PersistentRateLimitRecord,
   type RateLimitStore,
 } from "../server/lib/rate-limit-store.ts";
+
+type PersistentHarnessRow = PersistentRateLimitRecord & {
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function createPersistentHarness(input?: {
+  rows?: Map<string, PersistentHarnessRow>;
+  now?: () => number;
+  failCleanup?: boolean;
+}) {
+  const rows = input?.rows ?? new Map<string, PersistentHarnessRow>();
+  const cleanupCalls: Date[] = [];
+
+  const store = createPersistentRateLimitStore(
+    {
+      get: async (keyHash) => rows.get(keyHash),
+      set: async ({ keyHash, count, resetAt, now }) => {
+        const existing = rows.get(keyHash);
+        const row = {
+          count,
+          resetAt,
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        };
+
+        rows.set(keyHash, row);
+
+        return row;
+      },
+      increment: async ({ keyHash, count, resetAt, now }) => {
+        const existing = rows.get(keyHash);
+        const row =
+          !existing || existing.resetAt.getTime() <= now.getTime()
+            ? {
+                count,
+                resetAt,
+                createdAt: existing?.createdAt ?? now,
+                updatedAt: now,
+              }
+            : {
+                ...existing,
+                count: existing.count + 1,
+                updatedAt: now,
+              };
+
+        rows.set(keyHash, row);
+
+        return row;
+      },
+      cleanupExpired: async (now) => {
+        cleanupCalls.push(now);
+
+        if (input?.failCleanup) {
+          throw new Error("cleanup failed");
+        }
+
+        for (const [keyHash, row] of rows) {
+          if (row.resetAt.getTime() < now.getTime()) {
+            rows.delete(keyHash);
+          }
+        }
+      },
+    },
+    {
+      now: input?.now,
+    },
+  );
+
+  return { rows, store, cleanupCalls };
+}
 
 test("rate limit memory store creates and reuses active entries", async () => {
   const store = createMemoryRateLimitStore();
@@ -70,4 +144,133 @@ test("rate limit helpers support injected async stores", async () => {
     "set:ip:async:1:600",
     "get:ip:async",
   ]);
+});
+
+test("rate limit persistent store hashes keys and creates counters", async () => {
+  const { rows, store } = createPersistentHarness({
+    now: () => 10,
+  });
+
+  const entry = await getOrCreateRateLimitEntry(store, "ip:raw", 1000, 10);
+  const updated = await incrementRateLimitEntry(store, "ip:raw", entry, 10);
+  const keyHash = hashRateLimitKey("ip:raw");
+
+  assert.deepEqual(entry, {
+    count: 0,
+    resetAt: 1010,
+  });
+  assert.deepEqual(updated, {
+    count: 1,
+    resetAt: 1010,
+  });
+  assert.equal(rows.has("ip:raw"), false);
+  assert.equal(rows.has(keyHash), true);
+});
+
+test("rate limit persistent store increments active counters", async () => {
+  const { store } = createPersistentHarness({
+    now: () => 100,
+  });
+
+  const first = await getOrCreateRateLimitEntry(store, "ip:1", 500, 100);
+  const firstUpdated = await incrementRateLimitEntry(store, "ip:1", first, 100);
+  const second = await getOrCreateRateLimitEntry(store, "ip:1", 500, 101);
+  const secondUpdated = await incrementRateLimitEntry(
+    store,
+    "ip:1",
+    second,
+    101,
+  );
+
+  assert.deepEqual(firstUpdated, {
+    count: 1,
+    resetAt: 600,
+  });
+  assert.deepEqual(secondUpdated, {
+    count: 2,
+    resetAt: 600,
+  });
+});
+
+test("rate limit persistent store survives reconstruction with same adapter data", async () => {
+  const rows = new Map<string, PersistentHarnessRow>();
+  const firstHarness = createPersistentHarness({
+    rows,
+    now: () => 100,
+  });
+
+  const first = await getOrCreateRateLimitEntry(
+    firstHarness.store,
+    "ip:persist",
+    1000,
+    100,
+  );
+  await incrementRateLimitEntry(firstHarness.store, "ip:persist", first, 100);
+
+  const secondHarness = createPersistentHarness({
+    rows,
+    now: () => 200,
+  });
+  const restored = await getOrCreateRateLimitEntry(
+    secondHarness.store,
+    "ip:persist",
+    1000,
+    200,
+  );
+
+  assert.deepEqual(restored, {
+    count: 1,
+    resetAt: 1100,
+  });
+});
+
+test("rate limit persistent store exposes rate-limited state at the same threshold", async () => {
+  const maxAttempts = 2;
+  const { store } = createPersistentHarness({
+    now: () => 100,
+  });
+
+  const first = await getOrCreateRateLimitEntry(store, "ip:limited", 1000, 100);
+  await incrementRateLimitEntry(store, "ip:limited", first, 100);
+
+  const second = await getOrCreateRateLimitEntry(store, "ip:limited", 1000, 101);
+  const secondUpdated = await incrementRateLimitEntry(
+    store,
+    "ip:limited",
+    second,
+    101,
+  );
+
+  assert.equal(secondUpdated.count >= maxAttempts, true);
+});
+
+test("rate limit persistent store resets expired windows", async () => {
+  const { store } = createPersistentHarness({
+    now: () => 100,
+  });
+
+  const first = await getOrCreateRateLimitEntry(store, "ip:reset", 500, 100);
+  await incrementRateLimitEntry(store, "ip:reset", first, 100);
+
+  const reset = await getOrCreateRateLimitEntry(store, "ip:reset", 500, 601);
+
+  assert.deepEqual(reset, {
+    count: 0,
+    resetAt: 1101,
+  });
+});
+
+test("rate limit persistent store ignores expired cleanup failures", async () => {
+  const { store } = createPersistentHarness({
+    now: () => 100,
+    failCleanup: true,
+  });
+
+  const entry = await getOrCreateRateLimitEntry(store, "ip:cleanup", 500, 100);
+  const updated = await incrementRateLimitEntry(store, "ip:cleanup", entry, 100);
+
+  assert.deepEqual(updated, {
+    count: 1,
+    resetAt: 600,
+  });
 });


### PR DESCRIPTION
## Summary
- agrega store persistente para rate-limit de login
- mantiene memory store para tests/fallback
- persiste contadores en login_rate_limits usando key hash
- preserva contadores tras reconstruir app/store
- cubre incremento, bloqueo, reset de ventana y cleanup best-effort

## Migration
- drizzle/migrations/0025_login_rate_limits.sql

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build