### PR TITLE
ci(deps): add Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary
- add Dependabot coverage for GitHub Actions
- keep existing PNPM dependency audit gate in Backend CI
- avoid duplicating audit workflow

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm audit --prod
- pnpm audit