### PR TITLE
ci(review): add PR governance templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,1 @@
-* lab.vetneb@gmail.com
-
-/server/** lab.vetneb@gmail.com
-/frontend/** lab.vetneb@gmail.com
-/.github/workflows/** lab.vetneb@gmail.com
-/drizzle/migrations/** lab.vetneb@gmail.com
-/drizzle/schema.ts lab.vetneb@gmail.com
-/drizzle/relations.ts lab.vetneb@gmail.com
-/drizzle.config.ts lab.vetneb@gmail.com
+* @LABVETNEB

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
 ## Summary
 - Change type:
-- Scope:
-  - [ ] backend
-  - [ ] frontend
-  - [ ] workflows/ci
-  - [ ] migrations/schema
-  - [ ] docs
 - Context / issue:
+- What changed:
+
+## Scope
+- [ ] backend runtime
+- [ ] frontend runtime
+- [ ] workflows/ci
+- [ ] migrations/schema
+- [ ] docs
+- [ ] dependencies
 
 ## Validation
 - [ ] `pnpm typecheck`
@@ -18,15 +21,14 @@
 - [ ] `pnpm --dir frontend build` (if frontend affected)
 - [ ] `pnpm audit --prod` (if dependencies affected)
 - [ ] `pnpm audit` (if dependencies affected)
+- [ ] Relevant CI checks passed (`Backend CI`, `Frontend CI` when applicable)
 
-## Security
+## Security / Regression Checklist
 - [ ] No secret/token exposure in code, logs, or config.
-- [ ] AuthZ/AuthN and data-access impact reviewed.
+- [ ] AuthN/AuthZ and data-access impact reviewed.
 - [ ] Dependency and supply-chain impact reviewed.
-
-## Migrations / Schema
-- [ ] No migration/schema changes.
-- [ ] If applies: migration + backward-compatibility notes included.
+- [ ] No unintended regression in out-of-scope domains.
+- [ ] Migration/schema impact documented or explicitly not applicable.
 
 ## Rollback
 - Trigger:

--- a/docs/review-governance.md
+++ b/docs/review-governance.md
@@ -1,20 +1,28 @@
 # Review Governance
 
 ## Required PR content
-- Clear scope and context.
+- Clear summary and context.
+- Explicit scope (backend runtime, frontend runtime, workflows/ci, migrations/schema, docs, dependencies).
 - Validation checklist completed with commands run.
-- Security review notes.
-- Migration/schema impact stated (or explicit "no changes").
+- Security/regression checklist completed.
 - Rollback trigger, steps, and data impact.
 
-## Review routing
-- CODEOWNERS defines required reviewers for:
-  - backend (`/server/**`)
-  - frontend (`/frontend/**`)
-  - workflows (`/.github/workflows/**`)
-  - migrations/schema (`/drizzle/**`, `drizzle.config.ts`)
+## Expected checks
+- Backend scope: `pnpm typecheck`, `pnpm typecheck:test`, `pnpm test`, `pnpm build` (`Backend CI`).
+- Frontend scope: `pnpm --dir frontend lint`, `pnpm --dir frontend typecheck`, `pnpm --dir frontend build` (`Frontend CI`).
+- Dependency scope: `pnpm audit --prod`, `pnpm audit`.
 
-## Merge criteria
-- Required validations pass for the PR scope.
-- Security-impacting changes are explicitly reviewed.
-- Any migration/schema change includes compatibility and rollback notes.
+## Review routing
+- CODEOWNERS at `.github/CODEOWNERS` defines default reviewers for the repository.
+
+## Scope discipline
+- Keep PR scope strict and avoid unrelated runtime, migration, schema, deploy, or credential changes.
+- If scope expands, split into a separate PR whenever possible.
+
+## Rollback expectation
+- Every PR must define rollback trigger, rollback steps, and data impact.
+- Any migration/schema change must include backward-compatibility and rollback notes.
+
+## Branch protection
+- Branch protection rules are external repository settings in GitHub.
+- Do not attempt to configure branch protection through repository code changes.


### PR DESCRIPTION
## Summary
- simplify CODEOWNERS to a global repository owner rule
- update PR template with scope, validation, security/regression and rollback checklist
- document review governance and external branch protection expectations

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build