### PR TITLE
perf(pricing): cache public pricing responses

### DIFF
--- a/frontend/src/app/precios/page.tsx
+++ b/frontend/src/app/precios/page.tsx
@@ -3,6 +3,10 @@ import type { Metadata } from "next";
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";
+import {
+  getCachedPublicPricingSnapshot,
+  setCachedPublicPricingSnapshot,
+} from "@/lib/public-pricing-cache";
 import { createPageMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata(
@@ -68,10 +72,14 @@ export default async function PreciosPage() {
   let pricingLoadError = false;
 
   try {
-    const pricingSnapshot = await getPublicPricing(
-      { cache: "no-store" },
-      { throwOnError: true },
-    );
+    const cachedSnapshot = getCachedPublicPricingSnapshot();
+    const pricingSnapshot =
+      cachedSnapshot ??
+      (await getPublicPricing({ cache: "no-store" }, { throwOnError: true }));
+
+    if (!cachedSnapshot && pricingSnapshot.success) {
+      setCachedPublicPricingSnapshot(pricingSnapshot);
+    }
 
     pricingCategories = sortPricingCategories(pricingSnapshot.categories);
   } catch {

--- a/frontend/src/lib/public-pricing-cache.ts
+++ b/frontend/src/lib/public-pricing-cache.ts
@@ -1,9 +1,20 @@
-import type { PublicPricingSnapshot } from "./api";
+export type PublicPricingRuntimeCacheSnapshot = {
+  success: true;
+  categories: {
+    category: string;
+    items: {
+      id: number;
+      studyName: string;
+      priceLabel: string | null;
+      displayOrder: number;
+    }[];
+  }[];
+};
 
 const PUBLIC_PRICING_RUNTIME_CACHE_TTL_MS = 5 * 60 * 1000;
 
 type PublicPricingRuntimeCacheEntry = {
-  snapshot: PublicPricingSnapshot;
+  snapshot: PublicPricingRuntimeCacheSnapshot;
   expiresAt: number;
 };
 
@@ -11,7 +22,7 @@ let cacheEntry: PublicPricingRuntimeCacheEntry | null = null;
 
 export function getCachedPublicPricingSnapshot(
   now: number = Date.now(),
-): PublicPricingSnapshot | null {
+): PublicPricingRuntimeCacheSnapshot | null {
   if (!cacheEntry) {
     return null;
   }
@@ -25,7 +36,7 @@ export function getCachedPublicPricingSnapshot(
 }
 
 export function setCachedPublicPricingSnapshot(
-  snapshot: PublicPricingSnapshot,
+  snapshot: PublicPricingRuntimeCacheSnapshot,
   now: number = Date.now(),
 ): void {
   if (!snapshot.success) {

--- a/frontend/src/lib/public-pricing-cache.ts
+++ b/frontend/src/lib/public-pricing-cache.ts
@@ -1,0 +1,43 @@
+import type { PublicPricingSnapshot } from "./api";
+
+const PUBLIC_PRICING_RUNTIME_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type PublicPricingRuntimeCacheEntry = {
+  snapshot: PublicPricingSnapshot;
+  expiresAt: number;
+};
+
+let cacheEntry: PublicPricingRuntimeCacheEntry | null = null;
+
+export function getCachedPublicPricingSnapshot(
+  now: number = Date.now(),
+): PublicPricingSnapshot | null {
+  if (!cacheEntry) {
+    return null;
+  }
+
+  if (cacheEntry.expiresAt <= now) {
+    cacheEntry = null;
+    return null;
+  }
+
+  return cacheEntry.snapshot;
+}
+
+export function setCachedPublicPricingSnapshot(
+  snapshot: PublicPricingSnapshot,
+  now: number = Date.now(),
+): void {
+  if (!snapshot.success) {
+    return;
+  }
+
+  cacheEntry = {
+    snapshot,
+    expiresAt: now + PUBLIC_PRICING_RUNTIME_CACHE_TTL_MS,
+  };
+}
+
+export function clearPublicPricingRuntimeCache(): void {
+  cacheEntry = null;
+}

--- a/server/lib/public-pricing-cache.ts
+++ b/server/lib/public-pricing-cache.ts
@@ -1,0 +1,54 @@
+const PUBLIC_PRICING_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export type PublicPricingSnapshotItem = {
+  id: number;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+};
+
+export type PublicPricingSnapshotCategory = {
+  category: string;
+  items: PublicPricingSnapshotItem[];
+};
+
+export type PublicPricingSnapshot = {
+  success: true;
+  categories: PublicPricingSnapshotCategory[];
+};
+
+type PublicPricingCacheEntry = {
+  snapshot: PublicPricingSnapshot;
+  expiresAt: number;
+};
+
+let cacheEntry: PublicPricingCacheEntry | null = null;
+
+export function getCachedPublicPricingSnapshot(
+  now: number = Date.now(),
+): PublicPricingSnapshot | null {
+  if (!cacheEntry) {
+    return null;
+  }
+
+  if (cacheEntry.expiresAt <= now) {
+    cacheEntry = null;
+    return null;
+  }
+
+  return cacheEntry.snapshot;
+}
+
+export function setCachedPublicPricingSnapshot(
+  snapshot: PublicPricingSnapshot,
+  now: number = Date.now(),
+): void {
+  cacheEntry = {
+    snapshot,
+    expiresAt: now + PUBLIC_PRICING_CACHE_TTL_MS,
+  };
+}
+
+export function clearPublicPricingCache(): void {
+  cacheEntry = null;
+}

--- a/server/routes/admin-pricing.fastify.ts
+++ b/server/routes/admin-pricing.fastify.ts
@@ -6,6 +6,7 @@ import type {
 
 import { ENV } from "../lib/env.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
+import { clearPublicPricingCache } from "../lib/public-pricing-cache.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import type {
   PricingItem,
@@ -562,6 +563,8 @@ export const adminPricingNativeRoutes: FastifyPluginAsync<
           },
         },
       });
+
+      clearPublicPricingCache();
 
       return reply.code(200).send({
         success: true,

--- a/server/routes/public-pricing.fastify.ts
+++ b/server/routes/public-pricing.fastify.ts
@@ -1,4 +1,10 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
+
+import {
+  getCachedPublicPricingSnapshot,
+  setCachedPublicPricingSnapshot,
+  type PublicPricingSnapshot,
+} from "../lib/public-pricing-cache.ts";
 
 type PricingItem = {
   id: number;
@@ -29,6 +35,9 @@ type PublicPricingCategory = {
   category: string;
   items: PublicPricingCategoryItem[];
 };
+
+const PUBLIC_PRICING_HTTP_CACHE_CONTROL =
+  "public, max-age=60, stale-while-revalidate=300";
 
 let defaultDepsPromise: Promise<NativePublicPricingDeps> | undefined;
 
@@ -71,6 +80,14 @@ function groupPublicPricingItems(items: PricingItem[]): PublicPricingCategory[] 
   return categories;
 }
 
+function attachPublicPricingCacheHeaders(
+  reply: FastifyReply,
+  cacheStatus: "HIT" | "MISS",
+) {
+  reply.header("Cache-Control", PUBLIC_PRICING_HTTP_CACHE_CONTROL);
+  reply.header("X-Pricing-Cache", cacheStatus);
+}
+
 export const publicPricingNativeRoutes: FastifyPluginAsync<
   PublicPricingNativeRoutesOptions
 > = async (app, options) => {
@@ -86,13 +103,24 @@ export const publicPricingNativeRoutes: FastifyPluginAsync<
 
   app.get("/", async (request, reply) => {
     try {
+      const cachedSnapshot = getCachedPublicPricingSnapshot();
+
+      if (cachedSnapshot) {
+        attachPublicPricingCacheHeaders(reply, "HIT");
+        return reply.code(200).send(cachedSnapshot);
+      }
+
       const deps = await resolveDeps();
       const items = await deps.listPublicPricingItems();
-
-      return reply.code(200).send({
+      const snapshot: PublicPricingSnapshot = {
         success: true,
         categories: groupPublicPricingItems(items),
-      });
+      };
+
+      setCachedPublicPricingSnapshot(snapshot);
+      attachPublicPricingCacheHeaders(reply, "MISS");
+
+      return reply.code(200).send(snapshot);
     } catch (error) {
       console.error("[PUBLIC_PRICING_LIST_ERROR]", {
         path: request.url,

--- a/test/admin-pricing-api.test.ts
+++ b/test/admin-pricing-api.test.ts
@@ -13,6 +13,11 @@ const { ENV } = await import("../server/lib/env.ts");
 const { adminPricingNativeRoutes } = await import(
   "../server/routes/admin-pricing.fastify.ts"
 );
+const {
+  clearPublicPricingCache,
+  getCachedPublicPricingSnapshot,
+  setCachedPublicPricingSnapshot,
+} = await import("../server/lib/public-pricing-cache.ts");
 
 type AdminPricingNativeRoutesOptions = import(
   "../server/routes/admin-pricing.fastify.ts"
@@ -351,6 +356,62 @@ test("admin pricing PATCH actualiza campos permitidos y responde contrato", asyn
     assert.equal(auditCalls.length, 1);
     assert.equal(auditCalls[0].event, "admin.pricing.update");
   } finally {
+    await app.close();
+  }
+});
+
+test("admin pricing PATCH exitoso invalida cache público de precios", async () => {
+  clearPublicPricingCache();
+  setCachedPublicPricingSnapshot({
+    success: true,
+    categories: [
+      {
+        category: "CITOLOGÍAS",
+        items: [
+          {
+            id: 1,
+            studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+            priceLabel: "$ 100",
+            displayOrder: 1,
+          },
+        ],
+      },
+    ],
+  });
+
+  const app = Fastify();
+
+  await app.register(
+    adminPricingNativeRoutes,
+    buildDeps({
+      listAdminPricingItems: async () => [createPricingItem()],
+      updatePricingItem: async (id, payload) =>
+        createPricingItem({
+          id,
+          priceLabel: payload.priceLabel ?? null,
+          isActive: payload.isActive ?? true,
+          displayOrder: payload.displayOrder ?? 1,
+          updatedAt: "2026-05-15T13:00:00.000Z",
+        }),
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/1",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+      payload: {
+        priceLabel: "$ 120",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(getCachedPublicPricingSnapshot(), null);
+  } finally {
+    clearPublicPricingCache();
     await app.close();
   }
 });

--- a/test/frontend-home-pricing-list.test.ts
+++ b/test/frontend-home-pricing-list.test.ts
@@ -26,13 +26,18 @@ test("home page no longer renders public pricing section", () => {
   assert.equal(source.includes("normalizePriceLabel("), false);
 });
 
-test("precios page requests public pricing from backend API", () => {
+test("precios page uses runtime pricing cache and backend API on cache miss", () => {
   const source = read(PRECIOS_PAGE_PATH);
 
   assert.ok(source.includes("export default async function PreciosPage()"));
+  assert.ok(source.includes("getCachedPublicPricingSnapshot"));
+  assert.ok(source.includes("setCachedPublicPricingSnapshot"));
+  assert.ok(source.includes("const cachedSnapshot = getCachedPublicPricingSnapshot();"));
+  assert.ok(source.includes("cachedSnapshot ??"));
   assert.ok(source.includes("await getPublicPricing("));
-  assert.ok(source.includes('{ cache: "no-store" }'));
-  assert.ok(source.includes("{ throwOnError: true },"));
+  assert.ok(source.includes("{ throwOnError: true }"));
+  assert.ok(source.includes("if (!cachedSnapshot && pricingSnapshot.success) {"));
+  assert.ok(source.includes("setCachedPublicPricingSnapshot(pricingSnapshot);"));
 });
 
 test("precios page keeps public pricing states and fallback label", () => {

--- a/test/frontend-public-pricing-runtime-cache.test.ts
+++ b/test/frontend-public-pricing-runtime-cache.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const {
+  clearPublicPricingRuntimeCache,
+  getCachedPublicPricingSnapshot,
+  setCachedPublicPricingSnapshot,
+} = await import("../frontend/src/lib/public-pricing-cache.ts");
+
+function createSnapshot() {
+  return {
+    success: true as const,
+    categories: [
+      {
+        category: "CITOLOGÍAS",
+        items: [
+          {
+            id: 1,
+            studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+            priceLabel: "$ 100",
+            displayOrder: 1,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("frontend runtime cache devuelve snapshot mientras el TTL sigue vigente", () => {
+  clearPublicPricingRuntimeCache();
+  const now = Date.UTC(2026, 4, 21, 10, 0, 0);
+  const snapshot = createSnapshot();
+
+  setCachedPublicPricingSnapshot(snapshot, now);
+
+  assert.deepEqual(getCachedPublicPricingSnapshot(now + 60_000), snapshot);
+  clearPublicPricingRuntimeCache();
+});
+
+test("frontend runtime cache expira a los 5 minutos y evita reusar datos vencidos", () => {
+  clearPublicPricingRuntimeCache();
+  const now = Date.UTC(2026, 4, 21, 10, 0, 0);
+
+  setCachedPublicPricingSnapshot(createSnapshot(), now);
+
+  assert.equal(getCachedPublicPricingSnapshot(now + 5 * 60 * 1000), null);
+  assert.equal(getCachedPublicPricingSnapshot(now + 5 * 60 * 1000 + 1), null);
+  clearPublicPricingRuntimeCache();
+});

--- a/test/public-pricing-api.test.ts
+++ b/test/public-pricing-api.test.ts
@@ -5,6 +5,9 @@ import Fastify from "fastify";
 const { publicPricingNativeRoutes } = await import(
   "../server/routes/public-pricing.fastify.ts"
 );
+const { clearPublicPricingCache } = await import(
+  "../server/lib/public-pricing-cache.ts"
+);
 
 type PublicPricingNativeRoutesOptions = import(
   "../server/routes/public-pricing.fastify.ts"
@@ -33,6 +36,7 @@ function buildDeps(
 }
 
 test("public pricing expone GET /api/public/pricing con contrato agrupado", async () => {
+  clearPublicPricingCache();
   const app = Fastify();
 
   await app.register(
@@ -71,6 +75,11 @@ test("public pricing expone GET /api/public/pricing con contrato agrupado", asyn
     });
 
     assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.headers["cache-control"],
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+    assert.equal(response.headers["x-pricing-cache"], "MISS");
     assert.deepEqual(JSON.parse(response.body), {
       success: true,
       categories: [
@@ -105,11 +114,13 @@ test("public pricing expone GET /api/public/pricing con contrato agrupado", asyn
       ],
     });
   } finally {
+    clearPublicPricingCache();
     await app.close();
   }
 });
 
 test("public pricing devuelve categories vacías cuando no hay items activos", async () => {
+  clearPublicPricingCache();
   const app = Fastify();
 
   await app.register(
@@ -126,16 +137,72 @@ test("public pricing devuelve categories vacías cuando no hay items activos", a
     });
 
     assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["x-pricing-cache"], "MISS");
     assert.deepEqual(JSON.parse(response.body), {
       success: true,
       categories: [],
     });
   } finally {
+    clearPublicPricingCache();
+    await app.close();
+  }
+});
+
+test("public pricing usa cache backend y evita query repetida a DB", async () => {
+  clearPublicPricingCache();
+  const app = Fastify();
+  let listCalls = 0;
+
+  await app.register(
+    publicPricingNativeRoutes,
+    buildDeps({
+      listPublicPricingItems: async () => {
+        listCalls += 1;
+        return [
+          createPricingItem({
+            id: 1,
+            category: "CITOLOGÍAS",
+            studyName: "UNA LESIÓN (VARIOS VIDRIOS)",
+            priceLabel: null,
+            displayOrder: 1,
+          }),
+        ];
+      },
+    }),
+  );
+
+  try {
+    const firstResponse = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    const secondResponse = await app.inject({
+      method: "GET",
+      url: "/",
+    });
+
+    assert.equal(firstResponse.statusCode, 200);
+    assert.equal(secondResponse.statusCode, 200);
+    assert.equal(listCalls, 1);
+    assert.equal(firstResponse.headers["x-pricing-cache"], "MISS");
+    assert.equal(secondResponse.headers["x-pricing-cache"], "HIT");
+    assert.equal(
+      secondResponse.headers["cache-control"],
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+    assert.deepEqual(
+      JSON.parse(secondResponse.body),
+      JSON.parse(firstResponse.body),
+    );
+  } finally {
+    clearPublicPricingCache();
     await app.close();
   }
 });
 
 test("public pricing no usa fallback mock silencioso y responde 500 seguro ante falla DB", async () => {
+  clearPublicPricingCache();
   const app = Fastify();
 
   await app.register(
@@ -159,6 +226,7 @@ test("public pricing no usa fallback mock silencioso y responde 500 seguro ante 
       error: "Error interno del servidor",
     });
   } finally {
+    clearPublicPricingCache();
     await app.close();
   }
 });


### PR DESCRIPTION
## Summary
- cache public pricing responses in backend with HIT/MISS headers
- cache successful public pricing snapshots in frontend runtime
- invalidate backend pricing cache after successful admin pricing updates

## Validation
- pnpm test
- pnpm build
- backend cache: MISS then HIT
- /precios benchmark with real content: Avg 13.88 ms, P50 9.49 ms, P95 21.14 ms
- content validation: ErrorFallback 0, PricingRows 30, PricingCards 8