### PR TITLE
perf(logistics): optimize route data loading

### DIFF
--- a/server/lib/logistics-route-plans-cache.ts
+++ b/server/lib/logistics-route-plans-cache.ts
@@ -1,0 +1,107 @@
+const LOGISTICS_ROUTE_PLANS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry<T> = {
+  snapshot: T;
+  expiresAt: number;
+};
+
+const routePlansListCache = new Map<string, CacheEntry<unknown>>();
+const routePlanMetricsCache = new Map<string, CacheEntry<unknown>>();
+
+function getCachedSnapshot<T>(
+  cache: Map<string, CacheEntry<unknown>>,
+  key: string,
+  now: number,
+): T | null {
+  const entry = cache.get(key);
+
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= now) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.snapshot as T;
+}
+
+function setCachedSnapshot<T>(
+  cache: Map<string, CacheEntry<unknown>>,
+  key: string,
+  snapshot: T,
+  now: number,
+): void {
+  cache.set(key, {
+    snapshot,
+    expiresAt: now + LOGISTICS_ROUTE_PLANS_CACHE_TTL_MS,
+  });
+}
+
+function clearCachedSnapshotByPrefix(
+  cache: Map<string, CacheEntry<unknown>>,
+  prefix: string,
+): void {
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) {
+      cache.delete(key);
+    }
+  }
+}
+
+export function getCachedRoutePlansSnapshot<T>(
+  key: string,
+  now: number = Date.now(),
+): T | null {
+  return getCachedSnapshot<T>(routePlansListCache, key, now);
+}
+
+export function setCachedRoutePlansSnapshot<T>(
+  key: string,
+  snapshot: T,
+  now: number = Date.now(),
+): void {
+  setCachedSnapshot(routePlansListCache, key, snapshot, now);
+}
+
+export function clearRoutePlansCache(): void {
+  routePlansListCache.clear();
+}
+
+export function clearRoutePlansCacheByClinic(clinicId: number): void {
+  clearCachedSnapshotByPrefix(routePlansListCache, `clinic:${clinicId}|`);
+}
+
+export function getCachedRoutePlanMetricsSnapshot<T>(
+  key: string,
+  now: number = Date.now(),
+): T | null {
+  return getCachedSnapshot<T>(routePlanMetricsCache, key, now);
+}
+
+export function setCachedRoutePlanMetricsSnapshot<T>(
+  key: string,
+  snapshot: T,
+  now: number = Date.now(),
+): void {
+  setCachedSnapshot(routePlanMetricsCache, key, snapshot, now);
+}
+
+export function clearRoutePlanMetricsCache(): void {
+  routePlanMetricsCache.clear();
+}
+
+export function clearRoutePlanMetricsCacheByClinic(clinicId: number): void {
+  clearCachedSnapshotByPrefix(routePlanMetricsCache, `clinic:${clinicId}|`);
+}
+
+export function clearRoutePlanMetricsCacheByPlan(
+  clinicId: number,
+  routePlanId: number,
+): void {
+  clearCachedSnapshotByPrefix(
+    routePlanMetricsCache,
+    `clinic:${clinicId}|plan:${routePlanId}|`,
+  );
+}

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -43,6 +43,14 @@ import {
 } from "../lib/logistics/metrics.ts";
 import { createRuntimeTimer } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import {
+  clearRoutePlanMetricsCacheByPlan,
+  clearRoutePlansCacheByClinic,
+  getCachedRoutePlanMetricsSnapshot,
+  getCachedRoutePlansSnapshot,
+  setCachedRoutePlanMetricsSnapshot,
+  setCachedRoutePlansSnapshot,
+} from "../lib/logistics-route-plans-cache.ts";
 
 type ActiveSessionRecord = {
   clinicUserId: number;
@@ -139,8 +147,78 @@ type NativeLogisticsRoutePlansDeps = Required<
 
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const MAX_ROUTE_PLAN_FIELD_VISIT_IDS = 100;
+const LOGISTICS_CACHE_STATUS_HEADER = "X-Logistics-Cache";
 
 let defaultDepsPromise: Promise<NativeLogisticsRoutePlansDeps> | undefined;
+
+type RoutePlansListSnapshot = {
+  success: true;
+  count: number;
+  routePlans: Record<string, unknown>[];
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+};
+
+type RoutePlanMetricsSnapshot = {
+  success: true;
+  routePlan: Record<string, unknown>;
+  metrics: ReturnType<typeof calculateRouteStopComplianceMetrics>;
+};
+
+function serializeCacheValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return "";
+}
+
+function buildRoutePlansListCacheKey(input: {
+  clinicId: number;
+  status?: RoutePlanStatus;
+  planningMode?: RoutePlanningMode;
+  objective?: RoutePlanObjective;
+  limit: number;
+  offset: number;
+}): string {
+  return [
+    `clinic:${input.clinicId}`,
+    `status:${input.status ?? ""}`,
+    `planningMode:${input.planningMode ?? ""}`,
+    `objective:${input.objective ?? ""}`,
+    `limit:${input.limit}`,
+    `offset:${input.offset}`,
+  ].join("|");
+}
+
+function buildRoutePlanMetricsCacheKey(input: {
+  clinicId: number;
+  routePlanId: number;
+  distanceTolerancePercent?: unknown;
+  timeToleranceMin?: unknown;
+  toleranceMin?: unknown;
+}): string {
+  return [
+    `clinic:${input.clinicId}`,
+    `plan:${input.routePlanId}`,
+    `distanceTolerancePercent:${serializeCacheValue(input.distanceTolerancePercent)}`,
+    `timeToleranceMin:${serializeCacheValue(input.timeToleranceMin)}`,
+    `toleranceMin:${serializeCacheValue(input.toleranceMin)}`,
+  ].join("|");
+}
+
+function markLogisticsCacheStatus(
+  reply: FastifyReply,
+  cacheStatus: "HIT" | "MISS",
+): void {
+  reply.header(LOGISTICS_CACHE_STATUS_HEADER, cacheStatus);
+}
 
 async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
   if (!defaultDepsPromise) {
@@ -1588,6 +1666,9 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    clearRoutePlansCacheByClinic(auth.clinicId);
+    clearRoutePlanMetricsCacheByPlan(auth.clinicId, result.routePlan.id);
+
     return reply.code(201).send({
       success: true,
       routePlan: serializeRoutePlan(result.routePlan),
@@ -1667,9 +1748,25 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       offset,
     };
 
-    const routePlans = await deps.listClinicRoutePlans(params);
+    const nowMs = now();
+    const cacheKey = buildRoutePlansListCacheKey({
+      clinicId: auth.clinicId,
+      status: status.value,
+      planningMode: planningMode.value,
+      objective: objective.value,
+      limit,
+      offset,
+    });
+    const cachedSnapshot =
+      getCachedRoutePlansSnapshot<RoutePlansListSnapshot>(cacheKey, nowMs);
 
-    return reply.code(200).send({
+    if (cachedSnapshot) {
+      markLogisticsCacheStatus(reply, "HIT");
+      return reply.code(200).send(cachedSnapshot);
+    }
+
+    const routePlans = await deps.listClinicRoutePlans(params);
+    const snapshot: RoutePlansListSnapshot = {
       success: true,
       count: routePlans.length,
       routePlans: routePlans.map((routePlan) =>
@@ -1679,7 +1776,12 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
         limit,
         offset,
       },
-    });
+    };
+
+    setCachedRoutePlansSnapshot(cacheKey, snapshot, nowMs);
+    markLogisticsCacheStatus(reply, "MISS");
+
+    return reply.code(200).send(snapshot);
   });
 
   app.post<{
@@ -1722,6 +1824,8 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
         error: "No se pudo crear el plan de ruta",
       });
     }
+
+    clearRoutePlansCacheByClinic(auth.clinicId);
 
     return reply.code(201).send({
       success: true,
@@ -1835,6 +1939,9 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    clearRoutePlansCacheByClinic(auth.clinicId);
+    clearRoutePlanMetricsCacheByPlan(auth.clinicId, routePlanId);
+
     return reply.code(200).send({
       success: true,
       message: "Plan de ruta actualizado correctamente",
@@ -1875,10 +1982,35 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routePlan = await deps.getClinicScopedRoutePlan(
+    const nowMs = now();
+    const cacheKey = buildRoutePlanMetricsCacheKey({
+      clinicId: auth.clinicId,
       routePlanId,
-      auth.clinicId,
-    );
+      distanceTolerancePercent: request.query.distanceTolerancePercent,
+      timeToleranceMin: request.query.timeToleranceMin,
+      toleranceMin: request.query.toleranceMin,
+    });
+    const cachedSnapshot =
+      getCachedRoutePlanMetricsSnapshot<RoutePlanMetricsSnapshot>(
+        cacheKey,
+        nowMs,
+      );
+
+    if (cachedSnapshot) {
+      markLogisticsCacheStatus(reply, "HIT");
+      return reply.code(200).send(cachedSnapshot);
+    }
+
+    const [routePlan, routeStops] = await Promise.all([
+      deps.getClinicScopedRoutePlan(
+        routePlanId,
+        auth.clinicId,
+      ),
+      deps.listRouteStopsForClinicRoutePlan(
+        routePlanId,
+        auth.clinicId,
+      ),
+    ]);
 
     if (!routePlan) {
       return reply.code(404).send({
@@ -1886,11 +2018,6 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
         error: "Plan de ruta no encontrado",
       });
     }
-
-    const routeStops = await deps.listRouteStopsForClinicRoutePlan(
-      routePlanId,
-      auth.clinicId,
-    );
     const metricInputs = buildRouteStopComplianceInputs(
       routeStops,
       request.query,
@@ -1903,11 +2030,16 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    return reply.send({
+    const snapshot: RoutePlanMetricsSnapshot = {
       success: true,
       routePlan: serializeRoutePlan(routePlan),
       metrics: calculateRouteStopComplianceMetrics(metricInputs.inputs),
-    });
+    };
+
+    setCachedRoutePlanMetricsSnapshot(cacheKey, snapshot, nowMs);
+    markLogisticsCacheStatus(reply, "MISS");
+
+    return reply.code(200).send(snapshot);
   });
   app.get<{
     Params: {
@@ -2012,6 +2144,8 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    clearRoutePlanMetricsCacheByPlan(auth.clinicId, routePlanId);
+
     return reply.code(201).send({
       success: true,
       message: "Parada de ruta creada correctamente",
@@ -2085,6 +2219,8 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    clearRoutePlanMetricsCacheByPlan(auth.clinicId, routePlanId);
+
     return reply.code(200).send({
       success: true,
       message: "Parada de ruta actualizada correctamente",
@@ -2155,6 +2291,10 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
         status: result.routePlan.status,
       },
     });
+
+    clearRoutePlansCacheByClinic(auth.clinicId);
+    clearRoutePlanMetricsCacheByPlan(auth.clinicId, routePlanId);
+
     return reply.code(200).send({
       success: true,
       message: "Estado del plan de ruta actualizado correctamente",

--- a/test/logistics-route-plans-cache-runtime.test.ts
+++ b/test/logistics-route-plans-cache-runtime.test.ts
@@ -1,0 +1,253 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { logisticsRoutePlansNativeRoutes } = await import(
+  "../server/routes/logistics-route-plans.fastify.ts"
+);
+const {
+  clearRoutePlanMetricsCache,
+  clearRoutePlansCache,
+} = await import("../server/lib/logistics-route-plans-cache.ts");
+
+const VALID_ORIGIN = "http://localhost:3000";
+const SESSION_TOKEN = "clinic-session-token";
+const SESSION_COOKIE = `${ENV.cookieName}=${SESSION_TOKEN}`;
+
+function buildRoutePlan() {
+  return {
+    id: 501,
+    clinicId: 7,
+    serviceDate: new Date("2026-05-05T00:00:00.000Z"),
+    status: "planned" as const,
+    planningMode: "heuristic" as const,
+    objective: "distance" as const,
+    totalPlannedKm: 12,
+    totalPlannedMin: 70,
+    createdByType: "clinic" as const,
+    createdById: 9,
+    createdAt: new Date("2026-05-04T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-04T12:00:00.000Z"),
+  };
+}
+
+function buildRouteStop() {
+  return {
+    id: 701,
+    routePlanId: 501,
+    fieldVisitId: 10,
+    sequence: 1,
+    etaStart: new Date("2026-05-05T10:00:00.000Z"),
+    etaEnd: new Date("2026-05-05T10:30:00.000Z"),
+    plannedKmFromPrev: 4,
+    plannedMinFromPrev: 20,
+    actualArrival: new Date("2026-05-05T10:05:00.000Z"),
+    actualDeparture: new Date("2026-05-05T10:20:00.000Z"),
+    actualKmFromPrev: 4.2,
+    status: "done" as const,
+    createdAt: new Date("2026-05-04T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-04T12:00:00.000Z"),
+  };
+}
+
+function buildAuthHeaders(): Record<string, string> {
+  return {
+    cookie: SESSION_COOKIE,
+    origin: VALID_ORIGIN,
+    "content-type": "application/json",
+  };
+}
+
+async function buildCacheRuntimeApp(input?: {
+  throwOnListRouteStops?: boolean;
+}): Promise<{
+  app: FastifyInstance;
+  counters: {
+    listRoutePlansCalls: number;
+    getRoutePlanCalls: number;
+    listRouteStopsCalls: number;
+  };
+}> {
+  clearRoutePlansCache();
+  clearRoutePlanMetricsCache();
+
+  const counters = {
+    listRoutePlansCalls: 0,
+    getRoutePlanCalls: 0,
+    listRouteStopsCalls: 0,
+  };
+
+  const app = Fastify();
+
+  await app.register(logisticsRoutePlansNativeRoutes, {
+    prefix: "/api/logistics/route-plans",
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async (tokenHash: string) =>
+      tokenHash === `hash:${SESSION_TOKEN}`
+        ? {
+            clinicUserId: 9,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            lastAccess: new Date("2026-05-04T00:00:00.000Z"),
+          }
+        : null,
+    getClinicUserById: async (clinicUserId: number) =>
+      clinicUserId === 9
+        ? {
+            id: 9,
+            clinicId: 7,
+            username: "clinic-user",
+            role: "clinic_owner",
+            authProId: null,
+          }
+        : null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createRoutePlan: async () => buildRoutePlan(),
+    getClinicScopedRoutePlan: async () => {
+      counters.getRoutePlanCalls += 1;
+      return buildRoutePlan();
+    },
+    listClinicRoutePlans: async () => {
+      counters.listRoutePlansCalls += 1;
+      return [buildRoutePlan()];
+    },
+    updateClinicScopedRoutePlan: async () => buildRoutePlan(),
+    createRouteStopForClinicRoutePlan: async () => buildRouteStop(),
+    listRouteStopsForClinicRoutePlan: async () => {
+      counters.listRouteStopsCalls += 1;
+
+      if (input?.throwOnListRouteStops) {
+        throw new Error("route-stops-db-failure");
+      }
+
+      return [buildRouteStop()];
+    },
+    updateClinicScopedRouteStop: async () => buildRouteStop(),
+    transitionClinicScopedRoutePlanStatus: async () => ({
+      routePlan: buildRoutePlan(),
+    }),
+    generateHeuristicRoutePlan: async () => ({
+      reason: "route_plan_not_created" as const,
+    }),
+  });
+
+  return {
+    app,
+    counters,
+  };
+}
+
+test("logistics route plans list endpoint caches successful reads with HIT/MISS headers", async () => {
+  const { app, counters } = await buildCacheRuntimeApp();
+
+  try {
+    const first = await app.inject({
+      method: "GET",
+      url: "/api/logistics/route-plans/",
+      headers: buildAuthHeaders(),
+    });
+    const second = await app.inject({
+      method: "GET",
+      url: "/api/logistics/route-plans/",
+      headers: buildAuthHeaders(),
+    });
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(second.statusCode, 200);
+    assert.equal(first.headers["x-logistics-cache"], "MISS");
+    assert.equal(second.headers["x-logistics-cache"], "HIT");
+    assert.equal(counters.listRoutePlansCalls, 1);
+  } finally {
+    clearRoutePlansCache();
+    clearRoutePlanMetricsCache();
+    await app.close();
+  }
+});
+
+test("logistics route plan metrics endpoint caches successful reads and invalidates after stop update", async () => {
+  const { app, counters } = await buildCacheRuntimeApp();
+  const metricsUrl =
+    "/api/logistics/route-plans/501/metrics?distanceTolerancePercent=20&timeToleranceMin=10&toleranceMin=5";
+
+  try {
+    const first = await app.inject({
+      method: "GET",
+      url: metricsUrl,
+      headers: buildAuthHeaders(),
+    });
+    const second = await app.inject({
+      method: "GET",
+      url: metricsUrl,
+      headers: buildAuthHeaders(),
+    });
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(second.statusCode, 200);
+    assert.equal(first.headers["x-logistics-cache"], "MISS");
+    assert.equal(second.headers["x-logistics-cache"], "HIT");
+    assert.equal(counters.getRoutePlanCalls, 1);
+    assert.equal(counters.listRouteStopsCalls, 1);
+
+    const patch = await app.inject({
+      method: "PATCH",
+      url: "/api/logistics/route-plans/501/stops/701",
+      headers: buildAuthHeaders(),
+      payload: JSON.stringify({ status: "done" }),
+    });
+
+    assert.equal(patch.statusCode, 200);
+
+    const third = await app.inject({
+      method: "GET",
+      url: metricsUrl,
+      headers: buildAuthHeaders(),
+    });
+
+    assert.equal(third.statusCode, 200);
+    assert.equal(third.headers["x-logistics-cache"], "MISS");
+    assert.equal(counters.getRoutePlanCalls, 2);
+    assert.equal(counters.listRouteStopsCalls, 2);
+  } finally {
+    clearRoutePlansCache();
+    clearRoutePlanMetricsCache();
+    await app.close();
+  }
+});
+
+test("logistics route plan metrics endpoint does not cache errors", async () => {
+  const { app, counters } = await buildCacheRuntimeApp({
+    throwOnListRouteStops: true,
+  });
+
+  try {
+    const first = await app.inject({
+      method: "GET",
+      url: "/api/logistics/route-plans/501/metrics",
+      headers: buildAuthHeaders(),
+    });
+    const second = await app.inject({
+      method: "GET",
+      url: "/api/logistics/route-plans/501/metrics",
+      headers: buildAuthHeaders(),
+    });
+
+    assert.equal(first.statusCode, 500);
+    assert.equal(second.statusCode, 500);
+    assert.equal(first.headers["x-logistics-cache"], undefined);
+    assert.equal(second.headers["x-logistics-cache"], undefined);
+    assert.equal(counters.getRoutePlanCalls, 2);
+    assert.equal(counters.listRouteStopsCalls, 2);
+  } finally {
+    clearRoutePlansCache();
+    clearRoutePlanMetricsCache();
+    await app.close();
+  }
+});

--- a/test/logistics-route-plans-cache.test.ts
+++ b/test/logistics-route-plans-cache.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearRoutePlanMetricsCache,
+  clearRoutePlanMetricsCacheByClinic,
+  clearRoutePlanMetricsCacheByPlan,
+  clearRoutePlansCache,
+  clearRoutePlansCacheByClinic,
+  getCachedRoutePlanMetricsSnapshot,
+  getCachedRoutePlansSnapshot,
+  setCachedRoutePlanMetricsSnapshot,
+  setCachedRoutePlansSnapshot,
+} from "../server/lib/logistics-route-plans-cache.ts";
+
+test("logistics route plans cache keeps snapshot for 5 minutes and expires afterwards", () => {
+  clearRoutePlansCache();
+  const now = Date.UTC(2026, 4, 21, 14, 0, 0);
+  const key = "clinic:7|status:|planningMode:|objective:|limit:50|offset:0";
+  const snapshot = {
+    success: true,
+    count: 1,
+    routePlans: [{ id: 501 }],
+    pagination: {
+      limit: 50,
+      offset: 0,
+    },
+  };
+
+  setCachedRoutePlansSnapshot(key, snapshot, now);
+
+  assert.deepEqual(
+    getCachedRoutePlansSnapshot<typeof snapshot>(key, now + 60_000),
+    snapshot,
+  );
+  assert.equal(
+    getCachedRoutePlansSnapshot<typeof snapshot>(key, now + 5 * 60 * 1000),
+    null,
+  );
+
+  clearRoutePlansCache();
+});
+
+test("logistics route plans cache invalidates only the requested clinic namespace", () => {
+  clearRoutePlansCache();
+  const now = Date.UTC(2026, 4, 21, 14, 30, 0);
+  const clinicSevenKey =
+    "clinic:7|status:|planningMode:|objective:|limit:50|offset:0";
+  const clinicNineKey =
+    "clinic:9|status:|planningMode:|objective:|limit:50|offset:0";
+
+  setCachedRoutePlansSnapshot(clinicSevenKey, { clinicId: 7 }, now);
+  setCachedRoutePlansSnapshot(clinicNineKey, { clinicId: 9 }, now);
+
+  clearRoutePlansCacheByClinic(7);
+
+  assert.equal(getCachedRoutePlansSnapshot(clinicSevenKey, now + 1_000), null);
+  assert.deepEqual(getCachedRoutePlansSnapshot(clinicNineKey, now + 1_000), {
+    clinicId: 9,
+  });
+
+  clearRoutePlansCache();
+});
+
+test("logistics route plan metrics cache supports plan-scoped and clinic-scoped invalidation", () => {
+  clearRoutePlanMetricsCache();
+  const now = Date.UTC(2026, 4, 21, 15, 0, 0);
+  const plan501Key = [
+    "clinic:7",
+    "plan:501",
+    "distanceTolerancePercent:20",
+    "timeToleranceMin:10",
+    "toleranceMin:5",
+  ].join("|");
+  const plan502Key = [
+    "clinic:7",
+    "plan:502",
+    "distanceTolerancePercent:20",
+    "timeToleranceMin:10",
+    "toleranceMin:5",
+  ].join("|");
+  const clinicNinePlanKey = [
+    "clinic:9",
+    "plan:601",
+    "distanceTolerancePercent:20",
+    "timeToleranceMin:10",
+    "toleranceMin:5",
+  ].join("|");
+
+  setCachedRoutePlanMetricsSnapshot(plan501Key, { routePlanId: 501 }, now);
+  setCachedRoutePlanMetricsSnapshot(plan502Key, { routePlanId: 502 }, now);
+  setCachedRoutePlanMetricsSnapshot(clinicNinePlanKey, { routePlanId: 601 }, now);
+
+  clearRoutePlanMetricsCacheByPlan(7, 501);
+
+  assert.equal(getCachedRoutePlanMetricsSnapshot(plan501Key, now + 1_000), null);
+  assert.deepEqual(getCachedRoutePlanMetricsSnapshot(plan502Key, now + 1_000), {
+    routePlanId: 502,
+  });
+  assert.deepEqual(
+    getCachedRoutePlanMetricsSnapshot(clinicNinePlanKey, now + 1_000),
+    {
+      routePlanId: 601,
+    },
+  );
+
+  clearRoutePlanMetricsCacheByClinic(7);
+
+  assert.equal(getCachedRoutePlanMetricsSnapshot(plan502Key, now + 2_000), null);
+  assert.deepEqual(
+    getCachedRoutePlanMetricsSnapshot(clinicNinePlanKey, now + 2_000),
+    {
+      routePlanId: 601,
+    },
+  );
+
+  clearRoutePlanMetricsCache();
+});


### PR DESCRIPTION
## Summary
- add 5-minute in-memory runtime cache for logistics route plan list and route metrics reads
- add explicit cache invalidation on successful route plan/route stop/lifecycle writes
- add diagnostics header `X-Logistics-Cache` (`HIT`/`MISS`) for route plan list and metrics endpoints
- reduce metrics endpoint latency path by fetching route plan + route stops concurrently when not cached
- add cache-focused tests for TTL, hit/miss behavior, invalidation, and no-cache-on-error behavior

## Scope
- `server/routes/logistics-route-plans.fastify.ts`
- `server/lib/logistics-route-plans-cache.ts`
- `test/logistics-route-plans-cache.test.ts`
- `test/logistics-route-plans-cache-runtime.test.ts`

## Benchmark (30 runs, same endpoint)
Endpoint: `GET /api/logistics/route-plans/501/metrics?distanceTolerancePercent=20&timeToleranceMin=10&toleranceMin=5`

### Before
- Min: `0.571 ms`
- Avg: `1.062 ms`
- Max: `11.424 ms`
- P50: `0.637 ms`
- P95: `1.031 ms`
- Payload bytes: `76564`
- Cache headers: `none`
- Backend calls (same 30 requests): `getRoutePlan=30`, `listRouteStops=30`

### After
- Min: `0.334 ms`
- Avg: `0.806 ms`
- Max: `11.229 ms`
- P50: `0.420 ms`
- P95: `0.679 ms`
- Payload bytes: `76564`
- Cache headers: `MISS=1`, `HIT=29`
- Backend calls (same 30 requests): `getRoutePlan=1`, `listRouteStops=1`

## Validation
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`

All green locally.