### PR TITLE
fix(admin): surface study tracking notifications

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -284,6 +284,10 @@ export default async function AdminPage({
     (entry) => entry.event === "clinic_user.role.changed",
   );
   const lastRoleChangeAuditEntry = roleChangeAuditEntries[0];
+  const notificationAuditEntries = auditEntries.filter(
+    (entry) => entry.event === "study_tracking.notification.created",
+  );
+  const lastNotificationAuditEntry = notificationAuditEntries[0];
   const auditEventOptions = Object.keys(eventCounts).sort();
   const actorTypeOptions = Array.from(
     new Set(auditEntries.map((entry) => entry.actorType)),
@@ -475,6 +479,40 @@ export default async function AdminPage({
         <section id="admin-users-roles">
           <AdminUsersRolesReadOnlyCard />
         </section>
+        <Card id="admin-notifications" className="dashboard-surface">
+          <CardHeader>
+            <CardTitle className="text-base">Notificaciones</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Registradas</p>
+                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                  {notificationAuditEntries.length}
+                </p>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Última notificación</p>
+                <p className="mt-1 text-sm font-semibold text-vetneb-ink">
+                  {lastNotificationAuditEntry
+                    ? formatDateTime(lastNotificationAuditEntry.createdAt)
+                    : "—"}
+                </p>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Auditoría</p>
+                <Link
+                  href={buildAdminAuditFilterHref({
+                    event: "study_tracking.notification.created",
+                  })}
+                  className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                >
+                  Ver notificaciones
+                </Link>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
         <Card id="audit-role-changes" className="dashboard-surface">
           <CardHeader>
             <CardTitle className="text-base">

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -216,6 +216,21 @@ test("dashboard admin surfaces system health fetch failures", () => {
   assert.ok(source.includes("formatSystemStatusDetail(serviceChecks)"));
 });
 
+test("dashboard admin surfaces study tracking notifications", () => {
+  const source = read(ADMIN_PAGE_PATH);
+
+  assert.ok(source.includes("const notificationAuditEntries = auditEntries.filter("));
+  assert.ok(source.includes('(entry) => entry.event === "study_tracking.notification.created",'));
+  assert.ok(source.includes("const lastNotificationAuditEntry = notificationAuditEntries[0];"));
+  assert.ok(source.includes('id="admin-notifications"'));
+  assert.ok(source.includes('<CardTitle className="text-base">Notificaciones</CardTitle>'));
+  assert.ok(source.includes("notificationAuditEntries.length"));
+  assert.ok(source.includes("lastNotificationAuditEntry"));
+  assert.ok(source.includes("formatDateTime(lastNotificationAuditEntry.createdAt)"));
+  assert.ok(source.includes('event: "study_tracking.notification.created",'));
+  assert.ok(source.includes("Ver notificaciones"));
+});
+
 test("dashboard admin renders role-change audit and audit log table", () => {
   const source = read(ADMIN_PAGE_PATH);
 
@@ -252,7 +267,10 @@ test("dashboard admin distinguishes audit log load failures from empty states", 
 test("dashboard admin avoids duplicate section ids in navigation anchors", () => {
   const source = read(ADMIN_PAGE_PATH);
   const adminHealthIdMatches = source.match(/id="admin-health"/g) ?? [];
+  const adminNotificationsIdMatches =
+    source.match(/id="admin-notifications"/g) ?? [];
 
   assert.equal(adminHealthIdMatches.length, 1);
+  assert.equal(adminNotificationsIdMatches.length, 1);
   assert.equal(source.includes('id="admin-event-summary"'), true);
 });


### PR DESCRIPTION
## Summary
- surface study tracking notifications in the admin dashboard
- add audit-log shortcut for notification events
- cover visibility contract with frontend admin test

## Validation
- pnpm test
- pnpm build