### PR TITLE
fix(public): surface professionals network on mobile

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -162,6 +162,35 @@ export default function HomePage() {
       </section>
 
       <div className="public-soft-canvas">
+        <section
+          className="border-b border-vetneb-line/80 bg-card/72 py-8 md:py-10 lg:hidden"
+          aria-labelledby="mobile-professionals-heading"
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-center md:gap-6">
+              <div>
+                <h2
+                  id="mobile-professionals-heading"
+                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
+                >
+                  Red de profesionales veterinarios
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+                  Buscá profesionales vinculados a VETNEB para derivaciones,
+                  interconsultas y coordinación clínica.
+                </p>
+              </div>
+              <Button
+                asChild
+                size="lg"
+                className="public-cta-primary w-full sm:w-auto"
+              >
+                <Link href={ROUTES.profesionales}>Buscar profesionales</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+
         {/* Servicios principales */}
         <section
           className="py-16 md:py-20"

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
         </Link>
 
         <nav
-          className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 md:flex"
+          className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 lg:flex"
           aria-label="Navegación principal"
         >
           {navLinks.map((link) => (
@@ -47,6 +47,14 @@ export function Navbar() {
         </nav>
 
         <div className="flex items-center gap-3">
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="public-cta-outline lg:hidden"
+          >
+            <Link href={ROUTES.profesionales}>Profesionales</Link>
+          </Button>
           <Button asChild variant="outline" size="sm" className="public-cta-outline">
             <Link href={ROUTES.login}>Iniciar sesión</Link>
           </Button>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -52,6 +52,29 @@ test("home page exposes accessible hero and primary CTAs", () => {
   assert.ok(source.includes('href={ROUTES.login}'));
 });
 
+test("home page exposes mobile professionals block before services", () => {
+  const source = read(HOME_PAGE_PATH);
+  const professionalsIndex = source.indexOf("Red de profesionales veterinarios");
+  const servicesIndex = source.indexOf(
+    "Servicios del laboratorio patológico veterinario",
+  );
+
+  assert.ok(professionalsIndex !== -1);
+  assert.ok(servicesIndex !== -1);
+  assert.ok(professionalsIndex < servicesIndex);
+  assert.ok(source.includes('aria-labelledby="mobile-professionals-heading"'));
+  assert.ok(source.includes('id="mobile-professionals-heading"'));
+  assert.ok(
+    source.includes(
+      'className="border-b border-vetneb-line/80 bg-card/72 py-8 md:py-10 lg:hidden"',
+    ),
+  );
+  assert.ok(source.includes("Buscá profesionales vinculados a VETNEB para derivaciones,"));
+  assert.ok(source.includes("interconsultas y coordinación clínica."));
+  assert.ok(source.includes('className="public-cta-primary w-full sm:w-auto"'));
+  assert.ok(source.includes("<Link href={ROUTES.profesionales}>Buscar profesionales</Link>"));
+});
+
 test("home page lists core laboratory services and services route CTA", () => {
   const source = read(HOME_PAGE_PATH);
 

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -41,6 +41,20 @@ test("navbar uses centralized public routes for primary navigation", () => {
   assert.ok(source.includes('aria-label="Navegación principal"'));
 });
 
+test("navbar keeps full navigation desktop-only and exposes compact professionals link", () => {
+  const source = read(NAVBAR_PATH);
+
+  assert.ok(
+    source.includes(
+      'className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 lg:flex"',
+    ),
+  );
+  assert.equal(source.includes("p-1 md:flex"), false);
+  assert.ok(source.includes('className="public-cta-outline lg:hidden"'));
+  assert.ok(source.includes("<Link href={ROUTES.profesionales}>Profesionales</Link>"));
+  assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
+});
+
 test("navbar keeps expected public link order including precios", () => {
   const source = read(NAVBAR_PATH);
 


### PR DESCRIPTION
## Summary
- surface the professionals network earlier on mobile/tablet home
- expose a compact professionals access in mobile/tablet header
- keep desktop experience unchanged

## Validation
- pnpm test
- pnpm build