### PR TITLE
fix(study-tracking): notify stage changes from admin

### DIFF
--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -72,6 +72,23 @@ type StudyTrackingEmailInput = Pick<
   | "notes"
 >;
 
+function getStudyTrackingStageLabel(value: unknown): string {
+  switch (value) {
+    case "reception":
+      return "Recepción";
+    case "processing":
+      return "Procesamiento";
+    case "evaluation":
+      return "Evaluación";
+    case "report_development":
+      return "Desarrollo de informe";
+    case "delivered":
+      return "Entregado";
+    default:
+      return String(value);
+  }
+}
+
 export type AdminStudyTrackingNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
   getAdminSessionByToken?: (
@@ -1112,7 +1129,11 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
           ? undefined
           : parsed.data.deliveredAt,
     });
+    const stageChanged =
+      typeof parsed.data.currentStage !== "undefined" &&
+      parsed.data.currentStage !== current.currentStage;
     let updateNotification: StudyTrackingNotification | null = null;
+    let stageChangeNotification: StudyTrackingNotification | null = null;
 
     const updated = await deps.updateStudyTrackingCase(trackingCaseId, {
       reportId:
@@ -1202,6 +1223,20 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       await notifySpecialStainByEmail(finalCase, deps);
     }
 
+    if (stageChanged) {
+      stageChangeNotification = await deps.createStudyTrackingNotification({
+        studyTrackingCaseId: finalCase.id,
+        clinicId: finalCase.clinicId,
+        reportId: finalCase.reportId ?? null,
+        particularTokenId: finalCase.particularTokenId ?? null,
+        type: "stage_changed",
+        title: "Estado de estudio actualizado",
+        message: `El estudio cambió de estado: ${getStudyTrackingStageLabel(current.currentStage)} → ${getStudyTrackingStageLabel(finalCase.currentStage)}.`,
+        isRead: false,
+        readAt: null,
+      });
+    }
+
     await deps.writeAuditLog(createAuditRequestLike(request, admin), {
       event: AUDIT_EVENTS.STUDY_TRACKING_CASE_UPDATED,
       clinicId: finalCase.clinicId,
@@ -1233,6 +1268,24 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    if (stageChangeNotification) {
+      await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+        event: AUDIT_EVENTS.STUDY_TRACKING_NOTIFICATION_CREATED,
+        clinicId: stageChangeNotification.clinicId,
+        reportId: stageChangeNotification.reportId ?? null,
+        metadata: {
+          trackingCaseId: stageChangeNotification.studyTrackingCaseId,
+          notificationId: stageChangeNotification.id,
+          particularTokenId: stageChangeNotification.particularTokenId ?? null,
+          type: stageChangeNotification.type,
+          title: stageChangeNotification.title,
+          fromStage: current.currentStage,
+          toStage: finalCase.currentStage,
+          createdVia: "admin",
+        },
+      });
+    }
+
     return reply.code(200).send({
       success: true,
       message: "Seguimiento actualizado correctamente",
@@ -1240,4 +1293,3 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
     });
   });
 };
-

--- a/test/admin-study-tracking.fastify.test.ts
+++ b/test/admin-study-tracking.fastify.test.ts
@@ -385,6 +385,154 @@ test("adminStudyTrackingNativeRoutes expone GET /:trackingCaseId con detalle glo
   }
 });
 
+test("adminStudyTrackingNativeRoutes notifica cambio de etapa en PATCH /:trackingCaseId", async () => {
+  const notificationCalls: Array<Record<string, unknown>> = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
+  const current = createTrackingCaseFixture({ currentStage: "processing" });
+  const updated = createTrackingCaseFixture({ currentStage: "evaluation" });
+
+  const app = await createTestApp({
+    getClinicScopedStudyTrackingCase: async () => current,
+    updateStudyTrackingCase: async (
+      trackingCaseId: number,
+      input: Record<string, unknown>,
+    ) => {
+      assert.equal(trackingCaseId, 11);
+      assert.equal(input.currentStage, "evaluation");
+      return updated;
+    },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture({ id: 31, ...input });
+    },
+    writeAuditLog: async (_request: unknown, input: Record<string, unknown>) => {
+      auditCalls.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/11",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        currentStage: "evaluation",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(notificationCalls.length, 1);
+
+    const notification = notificationCalls[0];
+    assert.equal(notification.studyTrackingCaseId, 11);
+    assert.equal(notification.clinicId, 3);
+    assert.equal(notification.reportId, 55);
+    assert.equal(notification.particularTokenId, 7);
+    assert.equal(notification.type, "stage_changed");
+    assert.equal(notification.title, "Estado de estudio actualizado");
+    assert.equal(
+      notification.message,
+      "El estudio cambió de estado: Procesamiento → Evaluación.",
+    );
+    assert.equal(notification.isRead, false);
+    assert.equal(notification.readAt, null);
+
+    const notificationAudit = auditCalls.find((call) => {
+      const metadata = call.metadata as Record<string, unknown> | undefined;
+      return (
+        call.event === "study_tracking.notification.created" &&
+        metadata?.type === "stage_changed"
+      );
+    });
+
+    assert.ok(notificationAudit);
+    const metadata = notificationAudit.metadata as Record<string, unknown>;
+    assert.equal(metadata.trackingCaseId, 11);
+    assert.equal(metadata.notificationId, 31);
+    assert.equal(metadata.particularTokenId, 7);
+    assert.equal(metadata.type, "stage_changed");
+    assert.equal(metadata.title, "Estado de estudio actualizado");
+    assert.equal(metadata.fromStage, "processing");
+    assert.equal(metadata.toStage, "evaluation");
+    assert.equal(metadata.createdVia, "admin");
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes no notifica stage_changed si currentStage no cambia", async () => {
+  const withoutStageCalls: Array<Record<string, unknown>> = [];
+  const current = createTrackingCaseFixture({ currentStage: "evaluation" });
+
+  const appWithoutStage = await createTestApp({
+    getClinicScopedStudyTrackingCase: async () => current,
+    updateStudyTrackingCase: async () =>
+      createTrackingCaseFixture({ currentStage: "evaluation" }),
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      withoutStageCalls.push(input);
+      return createNotificationFixture({ ...input });
+    },
+  });
+
+  try {
+    const response = await appWithoutStage.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/11",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        notes: "Actualización administrativa",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(withoutStageCalls.length, 0);
+  } finally {
+    await appWithoutStage.close();
+  }
+
+  const sameStageCalls: Array<Record<string, unknown>> = [];
+  const appSameStage = await createTestApp({
+    getClinicScopedStudyTrackingCase: async () => current,
+    updateStudyTrackingCase: async () =>
+      createTrackingCaseFixture({ currentStage: "evaluation" }),
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      sameStageCalls.push(input);
+      return createNotificationFixture({ ...input });
+    },
+  });
+
+  try {
+    const response = await appSameStage.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/11",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        currentStage: "evaluation",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(sameStageCalls.length, 0);
+  } finally {
+    await appSameStage.close();
+  }
+});
+
 test("adminStudyTrackingNativeRoutes actualiza PATCH /:trackingCaseId y notifica tinción especial", async () => {
   const updateCalls: Array<Record<string, unknown>> = [];
   const notificationCalls: Array<Record<string, unknown>> = [];
@@ -452,8 +600,18 @@ test("adminStudyTrackingNativeRoutes actualiza PATCH /:trackingCaseId y notifica
     assert.equal(updateCalls[0].currentStage, "evaluation");
     assert.equal(updateCalls[0].specialStainRequired, true);
     assert.deepEqual(updateCalls[1], { specialStainNotifiedAt: notifiedAt });
-    assert.equal(notificationCalls.length, 1);
-    assert.equal(notificationCalls[0].type, "special_stain_required");
+    assert.equal(notificationCalls.length, 2);
+    assert.ok(
+      notificationCalls.find((call) => call.type === "special_stain_required"),
+    );
+    const stageNotification = notificationCalls.find(
+      (call) => call.type === "stage_changed",
+    );
+    assert.ok(stageNotification);
+    assert.equal(
+      stageNotification.message,
+      "El estudio cambió de estado: Recepción → Evaluación.",
+    );
     assert.equal(emailCalls.length, 1);
 
     const body = JSON.parse(response.body);
@@ -465,6 +623,5 @@ test("adminStudyTrackingNativeRoutes actualiza PATCH /:trackingCaseId y notifica
     await app.close();
   }
 });
-
 
 

--- a/test/particular-study-tracking.fastify.test.ts
+++ b/test/particular-study-tracking.fastify.test.ts
@@ -156,7 +156,13 @@ test("particularStudyTrackingNativeRoutes expone GET /notifications con filtro p
   const app = await createTestApp({
     listStudyTrackingNotifications: async (params: Record<string, unknown>) => {
       listCalls.push(params);
-      return [createNotificationFixture()];
+      return [
+        createNotificationFixture({
+          type: "stage_changed",
+          title: "Estado de estudio actualizado",
+          message: "El estudio cambió de estado: Recepción → Procesamiento.",
+        }),
+      ];
     },
   });
 
@@ -183,7 +189,9 @@ test("particularStudyTrackingNativeRoutes expone GET /notifications con filtro p
     assert.equal(body.success, true);
     assert.equal(body.count, 1);
     assert.equal(body.notifications[0].id, 21);
+    assert.equal(body.notifications[0].clinicId, 3);
     assert.equal(body.notifications[0].particularTokenId, 7);
+    assert.equal(body.notifications[0].type, "stage_changed");
     assert.equal(body.pagination.limit, 5);
     assert.equal(body.pagination.offset, 2);
   } finally {

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -183,7 +183,13 @@ test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async 
   const app = await createTestApp({
     listStudyTrackingNotifications: async (params: Record<string, unknown>) => {
       listCalls.push(params);
-      return [createNotificationFixture()];
+      return [
+        createNotificationFixture({
+          type: "stage_changed",
+          title: "Estado de estudio actualizado",
+          message: "El estudio cambió de estado: Recepción → Procesamiento.",
+        }),
+      ];
     },
   });
 
@@ -211,6 +217,8 @@ test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async 
     assert.equal(body.count, 1);
     assert.equal(body.notifications[0].id, 21);
     assert.equal(body.notifications[0].clinicId, 3);
+    assert.equal(body.notifications[0].particularTokenId, 7);
+    assert.equal(body.notifications[0].type, "stage_changed");
     assert.equal(body.pagination.limit, 5);
     assert.equal(body.pagination.offset, 2);
   } finally {


### PR DESCRIPTION
## Summary
- create study tracking notifications for admin stage changes
- expose stage-change alerts to clinic and particular notification feeds
- keep special stain notifications intact

## Validation
- pnpm test
- pnpm build