### PR TITLE
fix(communication): harden contact email readiness

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -68,7 +68,9 @@ function getServiceVariant(
   value: unknown,
 ): "default" | "secondary" | "destructive" | "outline" {
   if (value === "up") return "default";
+  if (value === "configured") return "default";
   if (value === "down") return "outline";
+  if (value === "not_configured") return "outline";
   if (value === "unknown" || value === undefined || value === null) {
     return "outline";
   }
@@ -77,7 +79,9 @@ function getServiceVariant(
 
 function formatServiceStatus(value: unknown) {
   if (value === "up") return "Activo";
+  if (value === "configured") return "Configurado";
   if (value === "down") return "Caído";
+  if (value === "not_configured") return "No configurado";
   if (value === "unknown" || value === undefined || value === null) {
     return "Desconocido";
   }
@@ -110,7 +114,7 @@ function getSystemStatusIndicatorClass(status: string) {
 function formatSystemStatusDetail(services: Record<string, unknown>) {
   return `Base de datos: ${formatServiceStatus(services.database)} · Almacenamiento: ${formatServiceStatus(
     services.storage,
-  )}`;
+  )} · Correo SMTP: ${formatServiceStatus(services.smtp)}`;
 }
 
 function formatUptime(totalSeconds: number | undefined) {
@@ -420,6 +424,12 @@ export default async function AdminPage({
                 <p className="mb-2 text-xs text-muted-foreground">Almacenamiento</p>
                 <Badge variant={getServiceVariant(serviceChecks.storage)}>
                   {formatServiceStatus(serviceChecks.storage)}
+                </Badge>
+              </div>
+              <div className="surface-soft">
+                <p className="mb-2 text-xs text-muted-foreground">Correo SMTP</p>
+                <Badge variant={getServiceVariant(serviceChecks.smtp)}>
+                  {formatServiceStatus(serviceChecks.smtp)}
                 </Badge>
               </div>
               <div className="surface-soft">

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -50,6 +50,7 @@ export function ContactoContent() {
   const [mensaje, setMensaje] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -61,6 +62,7 @@ export function ContactoContent() {
 
     setErrorMessage(null);
     setSuccessMessage(null);
+    setWarningMessage(null);
     setIsSubmitting(true);
 
     try {
@@ -75,7 +77,11 @@ export function ContactoContent() {
         message: mensaje.trim(),
       });
 
-      setSuccessMessage(response.message);
+      if (response.sent === false || response.reason === "smtp_disabled") {
+        setWarningMessage(response.message);
+      } else {
+        setSuccessMessage(response.message);
+      }
       setNombre("");
       setApellido("");
       setEmail("");
@@ -251,6 +257,16 @@ export function ContactoContent() {
                 {successMessage ? (
                   <p className="clinical-alert-success px-3 py-2">
                     {successMessage}
+                  </p>
+                ) : null}
+
+                {warningMessage ? (
+                  <p
+                    className="clinical-alert-warning px-3 py-2"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {warningMessage}
                   </p>
                 ) : null}
 

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -2,6 +2,7 @@ import nodemailer, { type Transporter } from "nodemailer";
 import { ENV } from "./env.ts";
 
 let cachedTransporter: Transporter | null = null;
+let cachedTransporterKey: string | null = null;
 
 function isLikelyEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
@@ -35,7 +36,14 @@ function getTransporter(): Transporter | null {
     return null;
   }
 
-  if (cachedTransporter) {
+  const transporterKey = JSON.stringify([
+    ENV.smtp.host,
+    ENV.smtp.port,
+    ENV.smtp.secure,
+    ENV.smtp.user,
+  ]);
+
+  if (cachedTransporter && cachedTransporterKey === transporterKey) {
     return cachedTransporter;
   }
 
@@ -48,6 +56,7 @@ function getTransporter(): Transporter | null {
       pass: ENV.smtp.pass,
     },
   });
+  cachedTransporterKey = transporterKey;
 
   return cachedTransporter;
 }
@@ -74,10 +83,10 @@ function buildSpecialStainRequiredText(input: {
   const lines = [
     `Hola,`,
     ``,
-    `Te informamos que el estudio #${input.trackingCaseId} de la clÃƒÂ­nica ${input.clinicName} requiere tinciÃƒÂ³n especial.`,
+    `Te informamos que el estudio #${input.trackingCaseId} de la clínica ${input.clinicName} requiere tinción especial.`,
     ``,
     `Estado actual: ${input.currentStage}`,
-    `RecepciÃƒÂ³n de muestra: ${formatDateTime(input.receptionAt)}`,
+    `Recepción de muestra: ${formatDateTime(input.receptionAt)}`,
     `Fecha estimada de entrega: ${formatDateTime(input.estimatedDeliveryAt)}`,
   ];
 
@@ -94,12 +103,12 @@ function buildSpecialStainRequiredText(input: {
   }
 
   if (input.adminContactPhone) {
-    lines.push(`TelÃƒÂ©fono de contacto administrativo: ${input.adminContactPhone}`);
+    lines.push(`Teléfono de contacto administrativo: ${input.adminContactPhone}`);
   }
 
   lines.push(
     ``,
-    `IngresÃƒÂ¡ al portal para revisar el seguimiento y continuar la gestiÃƒÂ³n.`,
+    `Ingresá al portal para revisar el seguimiento y continuar la gestión.`,
     ``,
     `Equipo VETNEB`,
   );
@@ -119,7 +128,7 @@ function buildContactMessageText(input: {
     "",
     `Nombre: ${input.name}`,
     `Email: ${input.email}`,
-    `Clinica: ${input.clinicName ?? "No informada"}`,
+    `Clínica: ${input.clinicName ?? "No informada"}`,
     "",
     "Mensaje:",
     input.message,
@@ -137,11 +146,13 @@ export async function sendContactMessageEmail(input: {
   | { sent: false; reason: "smtp_disabled" }
   | { sent: true; messageId: string }
 > {
-  const recipient = normalizeRecipients([ENV.smtp.from])[0];
+  const recipients = normalizeRecipients(
+    ENV.contactTo.length > 0 ? ENV.contactTo : [ENV.smtp.from],
+  );
 
   const transporter = getTransporter();
 
-  if (!transporter || !recipient) {
+  if (!transporter || recipients.length === 0) {
     console.info("[EMAIL] contact_message skipped: smtp disabled", {
       email: input.email,
       clinicName: input.clinicName,
@@ -152,7 +163,7 @@ export async function sendContactMessageEmail(input: {
 
   const info = await transporter.sendMail({
     from: ENV.smtp.from,
-    to: recipient,
+    to: recipients.join(", "),
     replyTo: input.email,
     subject: `[VETNEB] Contacto web: ${input.name}`,
     text: buildContactMessageText(input),
@@ -205,7 +216,7 @@ export async function sendSpecialStainRequiredEmail(input: {
   const info = await transporter.sendMail({
     from: ENV.smtp.from,
     to: recipients.join(", "),
-    subject: `[VETNEB] Estudio #${input.trackingCaseId}: requiere tinciÃƒÂ³n especial`,
+    subject: `[VETNEB] Estudio #${input.trackingCaseId}: requiere tinción especial`,
     text: buildSpecialStainRequiredText(input),
   });
 
@@ -220,4 +231,3 @@ export async function sendSpecialStainRequiredEmail(input: {
     messageId: info.messageId,
   };
 }
-

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -18,10 +18,10 @@ const parseBooleanishEnv = (value: unknown) => {
   return value;
 };
 
-function parseCsvList(value: string | undefined): string[] {
+function parseDelimitedList(value: string | undefined): string[] {
   if (!value) return [];
   return value
-    .split(",")
+    .split(/[;,]/g)
     .map((item) => item.trim())
     .filter(Boolean);
 }
@@ -67,6 +67,7 @@ const envSchema = z.object({
   SMTP_USER: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
   SMTP_PASS: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
   SMTP_FROM: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
+  CONTACT_TO: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
 });
 
 const rawEnv = envSchema.parse(process.env);
@@ -79,7 +80,7 @@ if (!databaseUrl) {
   throw new Error("DATABASE_URL o SUPABASE_DB_URL es obligatorio");
 }
 
-const corsOrigins = parseCsvList(rawEnv.CORS_ORIGIN);
+const corsOrigins = parseDelimitedList(rawEnv.CORS_ORIGIN);
 
 const smtpEnabled = Boolean(
   rawEnv.SMTP_HOST &&
@@ -110,7 +111,8 @@ export const ENV = {
     | "none"
     | "lax",
   ownerOpenId: rawEnv.OWNER_OPEN_ID ?? "",
-  labUploadUsernames: parseCsvList(rawEnv.LAB_UPLOAD_USERNAMES),
+  labUploadUsernames: parseDelimitedList(rawEnv.LAB_UPLOAD_USERNAMES),
+  contactTo: parseDelimitedList(rawEnv.CONTACT_TO),
   maxUploadFileSizeMb: rawEnv.MAX_UPLOAD_FILE_SIZE_MB ?? 20,
   signedUrlExpiresInSeconds:
     rawEnv.SUPABASE_SIGNED_URL_EXPIRES_IN_SECONDS ?? 60 * 15,
@@ -125,4 +127,3 @@ export const ENV = {
     from: rawEnv.SMTP_FROM ?? "",
   },
 } as const;
-

--- a/server/routes/admin-system-health.fastify.ts
+++ b/server/routes/admin-system-health.fastify.ts
@@ -248,6 +248,18 @@ function buildRuntimePayload() {
   };
 }
 
+function buildServiceChecksPayload(checks: unknown) {
+  const baseChecks =
+    checks && typeof checks === "object" && !Array.isArray(checks)
+      ? (checks as Record<string, unknown>)
+      : {};
+
+  return {
+    ...baseChecks,
+    smtp: ENV.smtp.enabled ? "configured" : "not_configured",
+  };
+}
+
 export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
   AdminSystemHealthNativeRoutesOptions
 > = async (app, options) => {
@@ -291,6 +303,7 @@ export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
 
     const health = await deps.getSystemHealthSnapshot();
     const healthPayload = health.payload;
+    const serviceChecks = buildServiceChecksPayload(healthPayload.checks);
 
     const status =
       typeof healthPayload.status === "string" ? healthPayload.status : "unknown";
@@ -303,7 +316,7 @@ export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
         adminUserId: admin.id,
         username: admin.username,
       },
-      services: healthPayload.checks ?? {},
+      services: serviceChecks,
       runtime: buildRuntimePayload(),
       health: healthPayload,
     });

--- a/server/routes/contact.fastify.ts
+++ b/server/routes/contact.fastify.ts
@@ -251,7 +251,7 @@ export const contactNativeRoutes: FastifyPluginAsync<
       reason: result.sent ? undefined : result.reason,
       message: result.sent
         ? "Mensaje enviado correctamente"
-        : "Mensaje recibido. SMTP no configurado para envío inmediato.",
+        : "Mensaje recibido, pero el envío automático de correo no está configurado. Contacte a VETNEB por los canales oficiales si requiere respuesta inmediata.",
     });
   });
 };

--- a/test/admin-system-health.fastify.test.ts
+++ b/test/admin-system-health.fastify.test.ts
@@ -109,6 +109,7 @@ test("admin system health expone servicios, runtime y versión para admin autent
     assert.deepEqual(body.services, {
       database: "up",
       storage: "up",
+      smtp: ENV.smtp.enabled ? "configured" : "not_configured",
     });
     assert.deepEqual(body.checkedBy, {
       adminUserId: 1,

--- a/test/contact-route.test.ts
+++ b/test/contact-route.test.ts
@@ -146,11 +146,16 @@ test("contact endpoint accepts message when smtp is disabled", async () => {
       success: boolean;
       sent: boolean;
       reason: string;
+      message: string;
     };
 
     assert.equal(body.success, true);
     assert.equal(body.sent, false);
     assert.equal(body.reason, "smtp_disabled");
+    assert.equal(
+      body.message,
+      "Mensaje recibido, pero el envío automático de correo no está configurado. Contacte a VETNEB por los canales oficiales si requiere respuesta inmediata.",
+    );
   } finally {
     await app.close();
   }

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -31,6 +31,7 @@ test("ENV expone un contrato base consistente", () => {
 test("ENV expone colecciones limpias y strings no vacíos donde corresponde", () => {
   assert.equal(Array.isArray(ENV.corsOrigins), true);
   assert.equal(Array.isArray(ENV.labUploadUsernames), true);
+  assert.equal(Array.isArray(ENV.contactTo), true);
 
   for (const origin of ENV.corsOrigins) {
     assert.equal(typeof origin, "string");
@@ -42,6 +43,12 @@ test("ENV expone colecciones limpias y strings no vacíos donde corresponde", ()
     assert.equal(typeof username, "string");
     assert.equal(username.trim(), username);
     assert.equal(username.length > 0, true);
+  }
+
+  for (const recipient of ENV.contactTo) {
+    assert.equal(typeof recipient, "string");
+    assert.equal(recipient.trim(), recipient);
+    assert.equal(recipient.length > 0, true);
   }
 
   assert.equal(typeof ENV.cookieName, "string");
@@ -72,4 +79,3 @@ test("ENV.smtp mantiene tipos e invariantes esperadas", () => {
     assert.equal(ENV.smtp.from.length > 0, true);
   }
 });
-

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -2339,6 +2339,7 @@ test(
       assert.deepEqual(body.services, {
         database: "up",
         storage: "up",
+        smtp: ENV.smtp.enabled ? "configured" : "not_configured",
       });
     } finally {
       await app.close();

--- a/test/frontend-contact-form-integration.test.ts
+++ b/test/frontend-contact-form-integration.test.ts
@@ -34,10 +34,15 @@ test("contact public page handles loading, success, error and reset states", () 
 
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
   assert.ok(source.includes("const [successMessage, setSuccessMessage]"));
+  assert.ok(source.includes("const [warningMessage, setWarningMessage]"));
   assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
   assert.ok(source.includes("if (isSubmitting)"));
   assert.ok(source.includes("setIsSubmitting(true);"));
+  assert.ok(source.includes("setWarningMessage(null);"));
+  assert.ok(source.includes('response.reason === "smtp_disabled"'));
+  assert.ok(source.includes("setWarningMessage(response.message);"));
   assert.ok(source.includes("setSuccessMessage(response.message);"));
+  assert.ok(source.includes("clinical-alert-warning"));
   assert.ok(source.includes('setNombre("");'));
   assert.ok(source.includes('setApellido("");'));
   assert.ok(source.includes('setEmail("");'));

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -70,7 +70,9 @@ test("dashboard admin keeps status and service formatting helpers", () => {
   assert.ok(source.includes('if (value === "down") return "outline";'));
   assert.ok(source.includes("function formatServiceStatus(value: unknown)"));
   assert.ok(source.includes('if (value === "up") return "Activo";'));
+  assert.ok(source.includes('if (value === "configured") return "Configurado";'));
   assert.ok(source.includes('if (value === "down") return "Caído";'));
+  assert.ok(source.includes('if (value === "not_configured") return "No configurado";'));
   assert.ok(source.includes("function getSystemStatusVariant("));
   assert.ok(source.includes("function formatSystemStatus(status: string)"));
   assert.ok(source.includes("function getSystemStatusIndicatorClass(status: string)"));
@@ -140,6 +142,8 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes('id="admin-users-roles"'));
   assert.ok(source.includes('id="admin-event-summary"'));
   assert.ok(source.includes("Estado y mantenimiento"));
+  assert.ok(source.includes("Correo SMTP"));
+  assert.ok(source.includes("serviceChecks.smtp"));
   assert.equal(source.includes("Health & Maintenance"), false);
   assert.equal(source.includes("AdminSourceContractMarkers"), false);
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);

--- a/test/logger-and-email.test.ts
+++ b/test/logger-and-email.test.ts
@@ -1,5 +1,8 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import nodemailer from "nodemailer";
 import {
   logError,
   logInfo,
@@ -14,7 +17,7 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { ENV } = await import("../server/lib/env.ts");
-const { sendSpecialStainRequiredEmail } = await import("../server/lib/email.ts");
+const { sendContactMessageEmail, sendSpecialStainRequiredEmail } = await import("../server/lib/email.ts");
 
 test("logInfo agrega prefijo [INFO]", () => {
   const original = console.log;
@@ -88,6 +91,111 @@ test("serializeError deja intactos valores no Error", () => {
   assert.equal(serializeError(payload), payload);
   assert.equal(serializeError("texto"), "texto");
   assert.equal(serializeError(null), null);
+});
+
+test("sendContactMessageEmail usa CONTACT_TO y fallback SMTP_FROM sin loguear secretos", async () => {
+  const originalInfo = console.info;
+  const originalCreateTransport = nodemailer.createTransport;
+  const originalEnv = {
+    contactTo: ENV.contactTo,
+    smtp: {
+      enabled: ENV.smtp.enabled,
+      host: ENV.smtp.host,
+      port: ENV.smtp.port,
+      secure: ENV.smtp.secure,
+      user: ENV.smtp.user,
+      pass: ENV.smtp.pass,
+      from: ENV.smtp.from,
+    },
+  };
+  const infoCalls: unknown[][] = [];
+  const sendMailCalls: Array<Record<string, unknown>> = [];
+
+  console.info = (...args: unknown[]) => {
+    infoCalls.push(args);
+  };
+
+  (ENV as any).contactTo = ["contacto@vetneb.com", "ops@vetneb.com"];
+  (ENV.smtp as any).enabled = true;
+  (ENV.smtp as any).host = "smtp.contact.example";
+  (ENV.smtp as any).port = 587;
+  (ENV.smtp as any).secure = false;
+  (ENV.smtp as any).user = "smtp-user-contact";
+  (ENV.smtp as any).pass = "smtp-pass-contact";
+  (ENV.smtp as any).from = "fallback@vetneb.com";
+
+  (nodemailer as any).createTransport = () => ({
+    sendMail: async (payload: Record<string, unknown>) => {
+      sendMailCalls.push(payload);
+      return { messageId: `contact-${sendMailCalls.length}` };
+    },
+  });
+
+  try {
+    const contactToResult = await sendContactMessageEmail({
+      name: "Maria Gomez",
+      email: "maria@example.com",
+      clinicName: "Clínica Sur",
+      message: "Necesito coordinar una consulta clínica.",
+    });
+
+    (ENV as any).contactTo = [];
+
+    const fallbackResult = await sendContactMessageEmail({
+      name: "Juan Perez",
+      email: "juan@example.com",
+      clinicName: null,
+      message: "Necesito registrar mi clínica en el portal.",
+    });
+
+    assert.deepEqual(contactToResult, {
+      sent: true,
+      messageId: "contact-1",
+    });
+    assert.deepEqual(fallbackResult, {
+      sent: true,
+      messageId: "contact-2",
+    });
+  } finally {
+    console.info = originalInfo;
+    (nodemailer as any).createTransport = originalCreateTransport;
+    (ENV as any).contactTo = originalEnv.contactTo;
+    (ENV.smtp as any).enabled = originalEnv.smtp.enabled;
+    (ENV.smtp as any).host = originalEnv.smtp.host;
+    (ENV.smtp as any).port = originalEnv.smtp.port;
+    (ENV.smtp as any).secure = originalEnv.smtp.secure;
+    (ENV.smtp as any).user = originalEnv.smtp.user;
+    (ENV.smtp as any).pass = originalEnv.smtp.pass;
+    (ENV.smtp as any).from = originalEnv.smtp.from;
+  }
+
+  assert.equal(sendMailCalls.length, 2);
+  assert.equal(sendMailCalls[0].to, "contacto@vetneb.com, ops@vetneb.com");
+  assert.equal(sendMailCalls[0].replyTo, "maria@example.com");
+  assert.equal(sendMailCalls[1].to, "fallback@vetneb.com");
+  assert.equal(sendMailCalls[1].replyTo, "juan@example.com");
+  assert.equal(JSON.stringify(infoCalls).includes("smtp-pass-contact"), false);
+});
+
+test("templates de email no tienen mojibake visible", () => {
+  const source = readFileSync(
+    resolve(process.cwd(), "server/lib/email.ts"),
+    "utf8",
+  );
+
+  for (const expected of [
+    "clínica",
+    "tinción",
+    "Recepción",
+    "Teléfono",
+    "Ingresá",
+    "gestión",
+    "Clínica",
+  ]) {
+    assert.ok(source.includes(expected), `email.ts debe incluir ${expected}`);
+  }
+
+  assert.doesNotMatch(source, /Ã|Â|�/);
 });
 
 test("sendSpecialStainRequiredEmail omite envío cuando no hay destinatarios válidos", async () => {


### PR DESCRIPTION
## Summary
- add CONTACT_TO for contact email delivery with SMTP_FROM fallback
- show smtp-disabled contact submissions as warnings
- expose SMTP readiness in admin health
- fix visible email template encoding issues

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build