### PR TITLE
fix(contact): clear stale form feedback on edits

### DIFF
--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -53,6 +53,12 @@ export function ContactoContent() {
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  function clearFeedbackMessages() {
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setWarningMessage(null);
+  }
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -60,9 +66,7 @@ export function ContactoContent() {
       return;
     }
 
-    setErrorMessage(null);
-    setSuccessMessage(null);
-    setWarningMessage(null);
+    clearFeedbackMessages();
     setIsSubmitting(true);
 
     try {
@@ -79,14 +83,14 @@ export function ContactoContent() {
 
       if (response.sent === false || response.reason === "smtp_disabled") {
         setWarningMessage(response.message);
-      } else {
+      } else if (response.sent === true) {
         setSuccessMessage(response.message);
+        setNombre("");
+        setApellido("");
+        setEmail("");
+        setClinica("");
+        setMensaje("");
       }
-      setNombre("");
-      setApellido("");
-      setEmail("");
-      setClinica("");
-      setMensaje("");
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -158,7 +162,10 @@ export function ContactoContent() {
                         autoComplete="given-name"
                         required
                         value={nombre}
-                        onChange={(event) => setNombre(event.target.value)}
+                        onChange={(event) => {
+                          clearFeedbackMessages();
+                          setNombre(event.target.value);
+                        }}
                         disabled={isSubmitting}
                         className="pl-10"
                       />
@@ -177,7 +184,10 @@ export function ContactoContent() {
                       placeholder="Su apellido"
                       autoComplete="family-name"
                       value={apellido}
-                      onChange={(event) => setApellido(event.target.value)}
+                      onChange={(event) => {
+                        clearFeedbackMessages();
+                        setApellido(event.target.value);
+                      }}
                       disabled={isSubmitting}
                     />
                   </div>
@@ -198,7 +208,10 @@ export function ContactoContent() {
                       autoComplete="email"
                       required
                       value={email}
-                      onChange={(event) => setEmail(event.target.value)}
+                      onChange={(event) => {
+                        clearFeedbackMessages();
+                        setEmail(event.target.value);
+                      }}
                       disabled={isSubmitting}
                       className="pl-10"
                     />
@@ -219,7 +232,10 @@ export function ContactoContent() {
                       placeholder="Clínica Veterinaria..."
                       autoComplete="organization"
                       value={clinica}
-                      onChange={(event) => setClinica(event.target.value)}
+                      onChange={(event) => {
+                        clearFeedbackMessages();
+                        setClinica(event.target.value);
+                      }}
                       disabled={isSubmitting}
                       className="pl-10"
                     />
@@ -240,7 +256,10 @@ export function ContactoContent() {
                     required
                     minLength={10}
                     value={mensaje}
-                    onChange={(event) => setMensaje(event.target.value)}
+                    onChange={(event) => {
+                      clearFeedbackMessages();
+                      setMensaje(event.target.value);
+                    }}
                     disabled={isSubmitting}
                   />
                 </div>

--- a/test/frontend-contact-form-integration.test.ts
+++ b/test/frontend-contact-form-integration.test.ts
@@ -29,25 +29,71 @@ test("contact public page submits messages through the API client", () => {
   assert.ok(source.includes("onSubmit={handleSubmit}"));
 });
 
-test("contact public page handles loading, success, error and reset states", () => {
+test("contact public page handles loading, feedback cleanup and conditional reset states", () => {
   const source = read(CONTACTO_CONTENT_PATH);
 
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
   assert.ok(source.includes("const [successMessage, setSuccessMessage]"));
   assert.ok(source.includes("const [warningMessage, setWarningMessage]"));
   assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes("function clearFeedbackMessages()"));
+  assert.ok(source.includes("setErrorMessage(null);"));
+  assert.ok(source.includes("setSuccessMessage(null);"));
   assert.ok(source.includes("if (isSubmitting)"));
+  assert.ok(source.includes("clearFeedbackMessages();"));
   assert.ok(source.includes("setIsSubmitting(true);"));
-  assert.ok(source.includes("setWarningMessage(null);"));
   assert.ok(source.includes('response.reason === "smtp_disabled"'));
   assert.ok(source.includes("setWarningMessage(response.message);"));
   assert.ok(source.includes("setSuccessMessage(response.message);"));
   assert.ok(source.includes("clinical-alert-warning"));
-  assert.ok(source.includes('setNombre("");'));
-  assert.ok(source.includes('setApellido("");'));
-  assert.ok(source.includes('setEmail("");'));
-  assert.ok(source.includes('setClinica("");'));
-  assert.ok(source.includes('setMensaje("");'));
+  assert.ok(
+    /onChange=\{\(event\) => \{\s*clearFeedbackMessages\(\);\s*setNombre\(event\.target\.value\);\s*\}\}/.test(
+      source,
+    ),
+  );
+  assert.ok(
+    /onChange=\{\(event\) => \{\s*clearFeedbackMessages\(\);\s*setApellido\(event\.target\.value\);\s*\}\}/.test(
+      source,
+    ),
+  );
+  assert.ok(
+    /onChange=\{\(event\) => \{\s*clearFeedbackMessages\(\);\s*setEmail\(event\.target\.value\);\s*\}\}/.test(
+      source,
+    ),
+  );
+  assert.ok(
+    /onChange=\{\(event\) => \{\s*clearFeedbackMessages\(\);\s*setClinica\(event\.target\.value\);\s*\}\}/.test(
+      source,
+    ),
+  );
+  assert.ok(
+    /onChange=\{\(event\) => \{\s*clearFeedbackMessages\(\);\s*setMensaje\(event\.target\.value\);\s*\}\}/.test(
+      source,
+    ),
+  );
+
+  const warningBranchMatch = source.match(
+    /if \(response\.sent === false \|\| response\.reason === "smtp_disabled"\) \{([\s\S]*?)\}\s*else if \(response\.sent === true\)/,
+  );
+  assert.ok(warningBranchMatch);
+  assert.ok(warningBranchMatch[1]?.includes("setWarningMessage(response.message);"));
+  assert.equal(
+    /setNombre\(""\)|setApellido\(""\)|setEmail\(""\)|setClinica\(""\)|setMensaje\(""\)/.test(
+      warningBranchMatch[1] ?? "",
+    ),
+    false,
+  );
+
+  const successBranchMatch = source.match(
+    /else if \(response\.sent === true\) \{([\s\S]*?)\n\s*\}/,
+  );
+  assert.ok(successBranchMatch);
+  assert.ok(successBranchMatch[1]?.includes("setSuccessMessage(response.message);"));
+  assert.ok(successBranchMatch[1]?.includes('setNombre("");'));
+  assert.ok(successBranchMatch[1]?.includes('setApellido("");'));
+  assert.ok(successBranchMatch[1]?.includes('setEmail("");'));
+  assert.ok(successBranchMatch[1]?.includes('setClinica("");'));
+  assert.ok(successBranchMatch[1]?.includes('setMensaje("");'));
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("disabled={isSubmitting}"));
   assert.ok(source.includes('isSubmitting ? "Enviando mensaje..." : "Enviar mensaje"'));


### PR DESCRIPTION
## Summary
- clear stale contact form feedback when users edit fields
- preserve form data when SMTP delivery is degraded
- keep successful submissions clearing the form

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build