### PR TITLE
fix(communication): add safe smtp failure diagnostics

### DIFF
--- a/server/routes/contact.fastify.ts
+++ b/server/routes/contact.fastify.ts
@@ -18,6 +18,17 @@ type ContactMessageInput = {
   message: string;
 };
 
+type SafeContactEmailErrorDiagnostics = {
+  errorName: string;
+  errorCode?: string;
+  errorCommand?: string;
+  errorResponseCode?: number;
+  errorSyscall?: string;
+  errorHostname?: string;
+  errorPort?: number;
+  errorAddress?: string;
+};
+
 export type ContactNativeRoutesOptions = {
   sendContactMessageEmail?: (
     input: ContactMessageInput,
@@ -184,6 +195,102 @@ function normalizeOptionalText(value: string | null | undefined) {
   return trimmed ? trimmed : null;
 }
 
+function getKnownErrorProperty(error: unknown, propertyName: string): unknown {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  return (error as Record<string, unknown>)[propertyName];
+}
+
+function toSafeNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toSafeNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractSafeContactEmailErrorDiagnostics(
+  error: unknown,
+): SafeContactEmailErrorDiagnostics {
+  const diagnostics: SafeContactEmailErrorDiagnostics = {
+    errorName:
+      toSafeNonEmptyString(error instanceof Error ? error.name : undefined) ??
+      "unknown_error",
+  };
+
+  const errorCode = toSafeNonEmptyString(getKnownErrorProperty(error, "code"));
+  const errorCommand = toSafeNonEmptyString(
+    getKnownErrorProperty(error, "command"),
+  );
+  const errorResponseCode = toSafeNumber(
+    getKnownErrorProperty(error, "responseCode"),
+  );
+  const errorSyscall = toSafeNonEmptyString(
+    getKnownErrorProperty(error, "syscall"),
+  );
+  const errorHostname = toSafeNonEmptyString(
+    getKnownErrorProperty(error, "hostname"),
+  );
+  const errorPort = toSafeNumber(getKnownErrorProperty(error, "port"));
+  const errorAddress = toSafeNonEmptyString(
+    getKnownErrorProperty(error, "address"),
+  );
+
+  if (errorCode) {
+    diagnostics.errorCode = errorCode;
+  }
+
+  if (errorCommand) {
+    diagnostics.errorCommand = errorCommand;
+  }
+
+  if (typeof errorResponseCode === "number") {
+    diagnostics.errorResponseCode = errorResponseCode;
+  }
+
+  if (errorSyscall) {
+    diagnostics.errorSyscall = errorSyscall;
+  }
+
+  if (errorHostname) {
+    diagnostics.errorHostname = errorHostname;
+  }
+
+  if (typeof errorPort === "number") {
+    diagnostics.errorPort = errorPort;
+  }
+
+  if (errorAddress) {
+    diagnostics.errorAddress = errorAddress;
+  }
+
+  return diagnostics;
+}
+
 export const contactNativeRoutes: FastifyPluginAsync<
   ContactNativeRoutesOptions
 > = async (app, options) => {
@@ -250,20 +357,17 @@ export const contactNativeRoutes: FastifyPluginAsync<
         message: parsed.data.message,
       });
     } catch (error) {
-      const errorCode =
-        error && typeof error === "object" && "code" in error
-          ? String((error as { code?: unknown }).code ?? "")
-          : undefined;
+      const diagnostics = extractSafeContactEmailErrorDiagnostics(error);
 
       console.error("[EMAIL] contact_message failed", {
         email: parsed.data.email,
         clinicName: normalizedClinicName,
-        errorName: error instanceof Error ? error.name : "unknown_error",
-        errorCode: errorCode && errorCode.trim().length > 0 ? errorCode : undefined,
+        ...diagnostics,
       });
 
       return reply.code(502).send({
         success: false,
+        reason: "email_delivery_failed",
         error:
           "No se pudo enviar el mensaje en este momento. Intente nuevamente más tarde.",
       });

--- a/test/contact-route.test.ts
+++ b/test/contact-route.test.ts
@@ -206,10 +206,43 @@ test("contact endpoint accepts message when smtp is disabled", async () => {
   }
 });
 
-test("contact endpoint returns controlled error when smtp sender fails", async () => {
+test("contact endpoint returns controlled smtp error and logs only safe diagnostics", async () => {
+  const originalConsoleError = console.error;
+  const errorCalls: unknown[][] = [];
+  const sensitivePass = "smtp-pass-super-secret";
+  const sensitiveUser = "smtp-user-sensitive@example.com";
+  const sensitiveAccessToken = "sensitive-access-token";
+  const sensitiveRefreshToken = "sensitive-refresh-token";
+
+  console.error = (...args: unknown[]) => {
+    errorCalls.push(args);
+  };
+
   const app = await createContactTestApp({
     sendContactMessageEmail: async () => {
-      throw new Error("SMTP transport failure");
+      throw Object.assign(
+        new Error(
+          `SMTP auth failure for ${sensitiveUser} using pass ${sensitivePass}`,
+        ),
+        {
+          code: "ESOCKET",
+          command: "CONN",
+          syscall: "connect",
+          hostname: "smtp.gmail.com",
+          port: 587,
+          responseCode: 421,
+          address: "74.125.140.108",
+          pass: sensitivePass,
+          password: sensitivePass,
+          auth: {
+            user: sensitiveUser,
+            pass: sensitivePass,
+          },
+          SMTP_PASS: sensitivePass,
+          accessToken: sensitiveAccessToken,
+          refreshToken: sensitiveRefreshToken,
+        },
+      );
     },
   });
 
@@ -220,6 +253,7 @@ test("contact endpoint returns controlled error when smtp sender fails", async (
       payload: {
         name: "Maria Gomez",
         email: "maria@example.com",
+        clinicName: "Clinica Sur",
         message: "Necesito confirmar una recepción de muestras.",
       },
     });
@@ -228,17 +262,52 @@ test("contact endpoint returns controlled error when smtp sender fails", async (
 
     const body = response.json() as {
       success: boolean;
+      reason: string;
       error: string;
     };
 
     assert.equal(body.success, false);
+    assert.equal(body.reason, "email_delivery_failed");
     assert.equal(
       body.error,
       "No se pudo enviar el mensaje en este momento. Intente nuevamente más tarde.",
     );
   } finally {
+    console.error = originalConsoleError;
     await app.close();
   }
+
+  assert.equal(errorCalls.length, 1);
+  assert.equal(errorCalls[0]?.[0], "[EMAIL] contact_message failed");
+
+  const payload = errorCalls[0]?.[1] as Record<string, unknown>;
+  assert.equal(payload.email, "maria@example.com");
+  assert.equal(payload.clinicName, "Clinica Sur");
+  assert.equal(payload.errorName, "Error");
+  assert.equal(payload.errorCode, "ESOCKET");
+  assert.equal(payload.errorCommand, "CONN");
+  assert.equal(payload.errorSyscall, "connect");
+  assert.equal(payload.errorHostname, "smtp.gmail.com");
+  assert.equal(payload.errorPort, 587);
+  assert.equal(payload.errorResponseCode, 421);
+  assert.equal(payload.errorAddress, "74.125.140.108");
+
+  for (const forbiddenKey of [
+    "pass",
+    "password",
+    "auth",
+    "SMTP_PASS",
+    "accessToken",
+    "refreshToken",
+  ]) {
+    assert.equal(forbiddenKey in payload, false);
+  }
+
+  const serializedPayload = JSON.stringify(payload);
+  assert.equal(serializedPayload.includes(sensitivePass), false);
+  assert.equal(serializedPayload.includes(sensitiveUser), false);
+  assert.equal(serializedPayload.includes(sensitiveAccessToken), false);
+  assert.equal(serializedPayload.includes(sensitiveRefreshToken), false);
 });
 
 test("contact endpoint rejects untrusted unsafe origins", async () => {

--- a/test/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/security-sensitive-log-redaction-boundaries.test.ts
@@ -188,6 +188,49 @@ test("environment secret names are parsed but not logged directly", () => {
   assertNotContains(envSource, "console.error", "env module direct console.error");
 });
 
+test("contact smtp failure logging keeps diagnostics allowlist and avoids secret fields", () => {
+  const contactRouteSource = readSource("server/routes/contact.fastify.ts");
+
+  assertContains(
+    contactRouteSource,
+    "extractSafeContactEmailErrorDiagnostics",
+    "contact route smtp diagnostics helper",
+  );
+  assertContains(
+    contactRouteSource,
+    'reason: "email_delivery_failed"',
+    "contact route public smtp failure reason",
+  );
+  assertContains(
+    contactRouteSource,
+    'console.error("[EMAIL] contact_message failed", {',
+    "contact route smtp error logging",
+  );
+
+  for (const marker of [
+    'getKnownErrorProperty(error, "code")',
+    'getKnownErrorProperty(error, "command")',
+    'getKnownErrorProperty(error, "responseCode")',
+    'getKnownErrorProperty(error, "syscall")',
+    'getKnownErrorProperty(error, "hostname")',
+    'getKnownErrorProperty(error, "port")',
+    'getKnownErrorProperty(error, "address")',
+  ]) {
+    assertContains(contactRouteSource, marker, "contact route smtp diagnostics allowlist");
+  }
+
+  for (const forbidden of [
+    'getKnownErrorProperty(error, "message")',
+    "SMTP_PASS",
+    "accessToken",
+    "refreshToken",
+    "password",
+    "auth:",
+  ]) {
+    assertNotContains(contactRouteSource, forbidden, "contact route smtp diagnostics forbidden fields");
+  }
+});
+
 test("runtime tests remain explicit for redaction and secret-safe logging", () => {
   const requestLoggerTests = readSource("test/request-logger.test.ts");
   const requestLoggerEdgeTests = readSource("test/request-logger-edge.test.ts");


### PR DESCRIPTION
## Summary
- add non-sensitive SMTP failure reason for public contact 502 responses
- log safe SMTP diagnostics for Render delivery failures
- protect secrets from SMTP error logging

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build