### PR TITLE
fix(communication): force smtp ipv4 on render

### DIFF
--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -1,4 +1,5 @@
 import nodemailer, { type Transporter } from "nodemailer";
+import type SMTPTransport from "nodemailer/lib/smtp-transport";
 import { ENV } from "./env.ts";
 
 let cachedTransporter: Transporter | null = null;
@@ -47,15 +48,21 @@ function getTransporter(): Transporter | null {
     return cachedTransporter;
   }
 
-  cachedTransporter = nodemailer.createTransport({
+  const transportOptions: SMTPTransport.Options = {
     host: ENV.smtp.host,
     port: ENV.smtp.port,
     secure: ENV.smtp.secure,
+    family: 4,
+    tls: {
+      servername: ENV.smtp.host,
+    },
     auth: {
       user: ENV.smtp.user,
       pass: ENV.smtp.pass,
     },
-  });
+  };
+
+  cachedTransporter = nodemailer.createTransport(transportOptions);
   cachedTransporterKey = transporterKey;
 
   return cachedTransporter;

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -1,9 +1,16 @@
 import nodemailer, { type Transporter } from "nodemailer";
-import type SMTPTransport from "nodemailer/lib/smtp-transport";
 import { ENV } from "./env.ts";
 
 let cachedTransporter: Transporter | null = null;
 let cachedTransporterKey: string | null = null;
+
+type VetnebSmtpTransportOptions =
+  Parameters<typeof nodemailer.createTransport>[0] & {
+    family: 4;
+    tls: {
+      servername: string;
+    };
+  };
 
 function isLikelyEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
@@ -48,21 +55,21 @@ function getTransporter(): Transporter | null {
     return cachedTransporter;
   }
 
-  const transportOptions: SMTPTransport.Options = {
+  const transporterOptions = {
     host: ENV.smtp.host,
     port: ENV.smtp.port,
     secure: ENV.smtp.secure,
-    family: 4,
-    tls: {
-      servername: ENV.smtp.host,
-    },
     auth: {
       user: ENV.smtp.user,
       pass: ENV.smtp.pass,
     },
-  };
+    family: 4,
+    tls: {
+      servername: ENV.smtp.host,
+    },
+  } as VetnebSmtpTransportOptions;
 
-  cachedTransporter = nodemailer.createTransport(transportOptions);
+  cachedTransporter = nodemailer.createTransport(transporterOptions);
   cachedTransporterKey = transporterKey;
 
   return cachedTransporter;
@@ -122,7 +129,6 @@ function buildSpecialStainRequiredText(input: {
 
   return lines.join("\n");
 }
-
 
 function buildContactMessageText(input: {
   name: string;
@@ -199,6 +205,7 @@ export async function sendContactMessageEmail(input: {
     messageId: info.messageId,
   };
 }
+
 export async function sendSpecialStainRequiredEmail(input: {
   to: Array<string | null | undefined>;
   clinicName: string;

--- a/test/email-success.test.ts
+++ b/test/email-success.test.ts
@@ -91,6 +91,10 @@ test("sendSpecialStainRequiredEmail envia correo con payload esperado cuando SMT
     host: "smtp.example.com",
     port: 587,
     secure: false,
+    family: 4,
+    tls: {
+      servername: "smtp.example.com",
+    },
     auth: {
       user: "smtp-user",
       pass: "smtp-pass",

--- a/test/logger-and-email.test.ts
+++ b/test/logger-and-email.test.ts
@@ -110,6 +110,7 @@ test("sendContactMessageEmail usa CONTACT_TO y fallback SMTP_FROM sin loguear se
   };
   const infoCalls: unknown[][] = [];
   const sendMailCalls: Array<Record<string, unknown>> = [];
+  const transportCalls: unknown[] = [];
 
   console.info = (...args: unknown[]) => {
     infoCalls.push(args);
@@ -119,19 +120,23 @@ test("sendContactMessageEmail usa CONTACT_TO y fallback SMTP_FROM sin loguear se
     "contacto@vetneb.com; ops@vetneb.com, CONTACTO@vetneb.com",
   ];
   (ENV.smtp as any).enabled = true;
-  (ENV.smtp as any).host = "smtp.contact.example";
+  (ENV.smtp as any).host = "smtp.gmail.com";
   (ENV.smtp as any).port = 587;
   (ENV.smtp as any).secure = false;
   (ENV.smtp as any).user = "smtp-user-contact";
   (ENV.smtp as any).pass = "smtp-pass-contact";
   (ENV.smtp as any).from = "fallback@vetneb.com";
 
-  (nodemailer as any).createTransport = () => ({
+  (nodemailer as any).createTransport = (options: unknown) => {
+    transportCalls.push(options);
+
+    return {
     sendMail: async (payload: Record<string, unknown>) => {
       sendMailCalls.push(payload);
       return { messageId: `contact-${sendMailCalls.length}` };
     },
-  });
+  };
+  };
 
   try {
     const contactToResult = await sendContactMessageEmail({
@@ -176,7 +181,27 @@ test("sendContactMessageEmail usa CONTACT_TO y fallback SMTP_FROM sin loguear se
   assert.equal(sendMailCalls[0].replyTo, "maria@example.com");
   assert.equal(sendMailCalls[1].to, "fallback@vetneb.com");
   assert.equal(sendMailCalls[1].replyTo, "juan@example.com");
+  assert.equal(transportCalls.length, 1);
+  const transport = transportCalls[0] as {
+    family?: unknown;
+    host?: unknown;
+    port?: unknown;
+    secure?: unknown;
+    tls?: { servername?: unknown };
+    auth?: { user?: unknown; pass?: unknown };
+  };
+  assert.equal(transport.family, 4);
+  assert.equal(transport.host, "smtp.gmail.com");
+  assert.equal(transport.port, 587);
+  assert.equal(transport.secure, false);
+  assert.deepEqual(transport.tls, {
+    servername: "smtp.gmail.com",
+  });
+  assert.equal(transport.auth?.user, "smtp-user-contact");
+  assert.equal(transport.auth?.pass, "smtp-pass-contact");
   assert.equal(JSON.stringify(infoCalls).includes("smtp-pass-contact"), false);
+  assert.equal(JSON.stringify(infoCalls).includes("smtp-user-contact"), false);
+  assert.equal(JSON.stringify(infoCalls).toLowerCase().includes("auth"), false);
 });
 
 test("sendContactMessageEmail exige CONTACT_TO explícito en entorno público", async () => {

--- a/test/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/security-sensitive-log-redaction-boundaries.test.ts
@@ -188,6 +188,15 @@ test("environment secret names are parsed but not logged directly", () => {
   assertNotContains(envSource, "console.error", "env module direct console.error");
 });
 
+test("smtp transport uses ipv4 and tls servername without logging smtp secrets", () => {
+  const emailSource = readSource("server/lib/email.ts");
+
+  assertContains(emailSource, "family: 4", "smtp transport ipv4 enforcement");
+  assertContains(emailSource, "servername: ENV.smtp.host", "smtp transport tls servername");
+  assertNotContains(emailSource, "SMTP_PASS", "smtp module source");
+  assertNoDirectSecretLogging(emailSource, "smtp module");
+});
+
 test("contact smtp failure logging keeps diagnostics allowlist and avoids secret fields", () => {
   const contactRouteSource = readSource("server/routes/contact.fastify.ts");
 


### PR DESCRIPTION
## Summary
- force Nodemailer SMTP connections to IPv4 for Render
- preserve Gmail STARTTLS configuration
- cover transporter config without exposing secrets

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build