### PR TITLE
fix(admin): set backend launcher cookie for cross-origin fetch

### DIFF
--- a/docs/staging-smoke-runbook.md
+++ b/docs/staging-smoke-runbook.md
@@ -323,6 +323,11 @@ cd C:\PORTAL-VETNEB
 powershell -ExecutionPolicy Bypass -File scripts/dev/open-admin-dashboard.ps1
 ```
 
+El launcher inicia sesion admin contra backend e inyecta la cookie
+`admin_session_id` tanto para frontend como para backend. Para staging
+cross-origin, la cookie backend se inyecta con `SameSite=None` y `Secure` para
+habilitar operaciones admin desde frontend con `credentials: "include"`.
+
 2. Iniciar sesion admin en el navegador si el script lo solicita.
 3. Abrir `$FrontendUrl/dashboard/admin`.
 4. En la seccion `Clínicas`, crear una clinica nueva desde `Alta de clínica`:

--- a/scripts/dev/open-admin-dashboard.ps1
+++ b/scripts/dev/open-admin-dashboard.ps1
@@ -155,7 +155,9 @@ try {
       value = $adminCookie.Value
       url = $BackendUrl
       path = "/"
-      sameSite = "Lax"
+      # Required for cross-origin fetch(..., { credentials: "include" }) from frontend staging.
+      sameSite = "None"
+      secure = $true
     }
 
   Send-CDP `

--- a/test/admin-dashboard-launcher.test.ts
+++ b/test/admin-dashboard-launcher.test.ts
@@ -44,3 +44,41 @@ test("local admin dashboard launcher does not hardcode admin password", () => {
   assert.equal(source.includes('"password":"'), false);
   assert.equal(source.includes("'password':'"), false);
 });
+
+test("local admin dashboard launcher configures frontend/backend cookies for cross-origin admin calls", () => {
+  const source = read(ADMIN_LAUNCHER_PATH);
+
+  const frontendCookieStart = source.indexOf("-Id 3");
+  const backendCookieStart = source.indexOf("-Id 4");
+  const navigateStart = source.indexOf("-Id 5");
+
+  assert.ok(frontendCookieStart >= 0);
+  assert.ok(backendCookieStart > frontendCookieStart);
+  assert.ok(navigateStart > backendCookieStart);
+
+  const frontendCookieBlock = source.slice(frontendCookieStart, backendCookieStart);
+  const backendCookieBlock = source.slice(backendCookieStart, navigateStart);
+
+  assert.ok(frontendCookieBlock.includes("url = $FrontendUrl"));
+  assert.ok(frontendCookieBlock.includes('sameSite = "Lax"'));
+
+  assert.ok(backendCookieBlock.includes("url = $BackendUrl"));
+  assert.ok(backendCookieBlock.includes('sameSite = "None"'));
+  assert.ok(backendCookieBlock.includes("secure = $true"));
+});
+
+test("local admin dashboard launcher never prints admin cookie value", () => {
+  const source = read(ADMIN_LAUNCHER_PATH);
+
+  const sensitiveOutputPatterns = [
+    /\bWrite-Host\b[^\n]*\$adminCookie\.Value/,
+    /\bWrite-Output\b[^\n]*\$adminCookie\.Value/,
+    /\becho\b[^\n]*\$adminCookie\.Value/,
+    /\bWrite-Verbose\b[^\n]*\$adminCookie\.Value/,
+    /\bWrite-Debug\b[^\n]*\$adminCookie\.Value/,
+  ];
+
+  for (const pattern of sensitiveOutputPatterns) {
+    assert.equal(pattern.test(source), false);
+  }
+});


### PR DESCRIPTION
## Summary
- Keep frontend admin launcher cookie as SameSite=Lax
- Set backend admin launcher cookie as SameSite=None and Secure for cross-origin fetch credentials
- Cover launcher cookie behavior with tests
- Update staging smoke runbook

## Validation
- pnpm test
- pnpm build