### PR TITLE
chore: remove dead route imports

### DIFF
--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -7,7 +7,6 @@ import type {
 import { ENV } from "../lib/env.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
-import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import type {
   AdminClinicUserRoleChangeInput,
   AdminClinicUserRoleChangeResult,

--- a/server/routes/clinic-public-profile.fastify.ts
+++ b/server/routes/clinic-public-profile.fastify.ts
@@ -4,7 +4,6 @@ import type {
   FastifyRequest,
 } from "fastify";
 import multer from "multer";
-import type { Multer } from "multer";
 
 import { ENV } from "../lib/env.ts";
 import {


### PR DESCRIPTION
## Resumen
- Elimina imports muertos seguros en rutas backend.
- Mantiene rutas, middleware, PWA y comportamiento funcional sin cambios.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local