### PR TITLE
fix(admin): mark current session as non-revocable

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -238,6 +238,10 @@ export function AdminSessionsReadOnlyCard() {
                 snapshot.sessions.map((session) => {
                   const sessionKey = `${session.sessionType}-${session.sessionId}`;
                   const isRevoking = revokingSessionKey === sessionKey;
+                  const isCurrentAdminSession =
+                    session.sessionType === "admin" &&
+                    typeof snapshot.currentAdminSessionId === "number" &&
+                    session.sessionId === snapshot.currentAdminSessionId;
 
                   return (
                     <TableRow key={sessionKey}>
@@ -274,10 +278,14 @@ export function AdminSessionsReadOnlyCard() {
                         <Button
                           type="button"
                           variant="outline"
-                          disabled={isRevoking}
+                          disabled={isRevoking || isCurrentAdminSession}
                           onClick={() => void handleRevokeSession(session)}
                         >
-                          {isRevoking ? "Revocando..." : "Revocar"}
+                          {isCurrentAdminSession
+                            ? "Sesión actual"
+                            : isRevoking
+                              ? "Revocando..."
+                              : "Revocar"}
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -395,6 +395,7 @@ export type AdminSessionsSnapshot = {
   total: number;
   limit: number;
   offset: number;
+  currentAdminSessionId?: number;
   checkedBy?: {
     adminUserId: number;
     username: string;

--- a/server/routes/admin-sessions.fastify.ts
+++ b/server/routes/admin-sessions.fastify.ts
@@ -574,6 +574,7 @@ export const adminSessionsNativeRoutes: FastifyPluginAsync<
 
       return reply.code(200).send({
         ...snapshot,
+        currentAdminSessionId: admin.sessionId,
         checkedBy: {
           adminUserId: admin.id,
           username: admin.username,

--- a/test/admin-sessions.fastify.test.ts
+++ b/test/admin-sessions.fastify.test.ts
@@ -390,3 +390,81 @@ test("admin sessions revoke bloquea origin no permitido", async () => {
     await app.close();
   }
 });
+
+test("admin sessions GET expone currentAdminSessionId igual al sessionId autenticado", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      getAdminSessionsSnapshot: async (): Promise<AdminSessionsSnapshot> => ({
+        success: true,
+        sessions: [],
+        total: 0,
+        limit: 50,
+        offset: 0,
+      }),
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(typeof body.currentAdminSessionId, "number");
+    assert.equal(body.currentAdminSessionId, 99);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin sessions GET no expone token, cookie, hash ni sessionToken en currentAdminSessionId", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      getAdminSessionsSnapshot: async (): Promise<AdminSessionsSnapshot> => ({
+        success: true,
+        sessions: [],
+        total: 0,
+        limit: 50,
+        offset: 0,
+      }),
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+    const serialized = JSON.stringify(body);
+
+    assert.equal(typeof body.currentAdminSessionId, "number");
+    assert.equal(body.sessionToken, undefined);
+    assert.equal(body.tokenHash, undefined);
+    assert.equal(body.cookie, undefined);
+    assert.equal(serialized.includes("admin-session-token"), false);
+    assert.equal(serialized.includes("hash:"), false);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/frontend-admin-sessions-card.test.ts
+++ b/test/frontend-admin-sessions-card.test.ts
@@ -131,7 +131,8 @@ test("admin sessions card renders rows actions empty state and pagination", () =
   assert.ok(source.includes("formatOptionalDate(session.lastAccess)"));
   assert.ok(source.includes("formatOptionalDate(session.expiresAt)"));
   assert.ok(source.includes("onClick={() => void handleRevokeSession(session)}"));
-  assert.ok(source.includes('isRevoking ? "Revocando..." : "Revocar"'));
+  assert.ok(source.includes('"Revocando..."'));
+  assert.ok(source.includes('"Revocar"'));
   assert.ok(
     source.includes(
       'isPending\n                      ? "Cargando sesiones..."\n                      : error',
@@ -158,4 +159,28 @@ test("admin sessions card keeps session helpers and avoids technical endpoint co
   assert.equal(source.includes("password"), false);
   assert.equal(source.includes("sessionToken"), false);
   assert.equal(source.includes("tokenHash"), false);
+});
+
+test("admin sessions card detecta sesión actual via currentAdminSessionId y deshabilita Revocar", () => {
+  const source = read(ADMIN_SESSIONS_CARD_PATH);
+
+  assert.ok(source.includes("isCurrentAdminSession"));
+  assert.ok(source.includes('session.sessionType === "admin"'));
+  assert.ok(source.includes("snapshot.currentAdminSessionId"));
+  assert.ok(source.includes("session.sessionId === snapshot.currentAdminSessionId"));
+  assert.ok(source.includes("disabled={isRevoking || isCurrentAdminSession}"));
+});
+
+test("admin sessions card muestra texto Sesión actual para sesión admin propia", () => {
+  const source = read(ADMIN_SESSIONS_CARD_PATH);
+
+  assert.ok(source.includes('"Sesión actual"'));
+});
+
+test("admin sessions card no expone token, cookie ni hash en UI", () => {
+  const source = read(ADMIN_SESSIONS_CARD_PATH);
+
+  assert.equal(source.includes("sessionToken"), false);
+  assert.equal(source.includes("tokenHash"), false);
+  assert.equal(source.includes("password"), false);
 });


### PR DESCRIPTION
## Resumen
- Expone de forma segura currentAdminSessionId en el snapshot de sesiones admin.
- Deshabilita Revocar para la sesión admin actual y muestra Sesión actual.
- Mantiene la revocación real para sesiones revocables.
- No expone tokens, cookies ni hashes.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local