### PR TITLE
fix(admin): add save all pricing action

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminPricingEditorCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminPricingEditorCard.tsx
@@ -163,11 +163,47 @@ export function AdminPricingEditorCard() {
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [savingItemId, setSavingItemId] = useState<number | null>(null);
+  const [isSavingAll, setIsSavingAll] = useState(false);
 
   const hasPricingItems = useMemo(
     () => categories.some((category) => category.items.length > 0),
     [categories],
   );
+
+  const { pendingItemIds, hasPendingValidationErrors } = useMemo(() => {
+    const ids: number[] = [];
+    let hasErrors = false;
+
+    for (const id of Object.keys(formStateById).map(Number)) {
+      const original = originalItemsById[id];
+      const form = formStateById[id];
+
+      if (!original || !form) {
+        continue;
+      }
+
+      const nextDisplayOrder = parseDisplayOrder(form.displayOrder);
+
+      if (nextDisplayOrder === null) {
+        ids.push(id);
+        hasErrors = true;
+        continue;
+      }
+
+      const nextPriceLabel = normalizePriceLabelForPayload(form.priceLabel);
+      const prevPriceLabel = normalizePriceLabelForPayload(original.priceLabel ?? "");
+
+      if (
+        nextPriceLabel !== prevPriceLabel ||
+        form.isActive !== original.isActive ||
+        nextDisplayOrder !== original.displayOrder
+      ) {
+        ids.push(id);
+      }
+    }
+
+    return { pendingItemIds: ids, hasPendingValidationErrors: hasErrors };
+  }, [formStateById, originalItemsById]);
 
   async function loadPricing() {
     setIsLoading(true);
@@ -259,8 +295,52 @@ export function AdminPricingEditorCard() {
     return { payload, errorMessage: null };
   }
 
+  async function handleSaveAll() {
+    if (savingItemId !== null || isSavingAll || pendingItemIds.length === 0 || hasPendingValidationErrors) {
+      return;
+    }
+
+    setIsSavingAll(true);
+
+    const toSave = pendingItemIds
+      .map((id) => ({ id, ...getUpdatePayload(id) }))
+      .filter(
+        (item): item is typeof item & { payload: AdminPricingUpdatePayload } =>
+          item.payload !== null && item.errorMessage === null,
+      );
+
+    for (const { id, payload } of toSave) {
+      try {
+        const response = await updateAdminPricingItem(id, payload);
+        const updatedItem = response.pricingItem;
+
+        setCategories((current) => applyUpdatedItem(current, updatedItem));
+        setOriginalItemsById((current) => ({
+          ...current,
+          [updatedItem.id]: updatedItem,
+        }));
+        setFormStateById((current) => ({
+          ...current,
+          [updatedItem.id]: {
+            ...toFormState(updatedItem),
+            statusMessage: SAVE_SUCCESS_MESSAGE,
+            errorMessage: null,
+          },
+        }));
+      } catch (error) {
+        updateItemFormState(id, (current) => ({
+          ...current,
+          statusMessage: null,
+          errorMessage: formatAdminPricingError(error, SAVE_ERROR_MESSAGE),
+        }));
+      }
+    }
+
+    setIsSavingAll(false);
+  }
+
   async function handleSaveItem(itemId: number) {
-    if (savingItemId !== null) {
+    if (savingItemId !== null || isSavingAll) {
       return;
     }
 
@@ -329,13 +409,34 @@ export function AdminPricingEditorCard() {
             Gestión manual de etiquetas de precio por estudio.
           </CardDescription>
         </div>
-        <Button
-          type="button"
-          onClick={() => void loadPricing()}
-          disabled={isLoading || savingItemId !== null}
-        >
-          {isLoading ? "Actualizando..." : "Actualizar"}
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void handleSaveAll()}
+            disabled={
+              isLoading ||
+              savingItemId !== null ||
+              isSavingAll ||
+              pendingItemIds.length === 0 ||
+              hasPendingValidationErrors
+            }
+            data-save-all
+          >
+            {isSavingAll
+              ? "Guardando todos..."
+              : pendingItemIds.length > 0
+                ? `Guardar todos (${pendingItemIds.length})`
+                : "Guardar todos"}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void loadPricing()}
+            disabled={isLoading || savingItemId !== null || isSavingAll}
+          >
+            {isLoading ? "Actualizando..." : "Actualizar"}
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="space-y-4 pt-6">
         {loadError ? (
@@ -391,7 +492,7 @@ export function AdminPricingEditorCard() {
                       >
                         <fieldset
                           className="grid grid-cols-1 gap-3 lg:grid-cols-2"
-                          disabled={isSaving}
+                          disabled={isSaving || isSavingAll}
                         >
                           <label className="space-y-2">
                             <span className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
@@ -501,7 +602,7 @@ export function AdminPricingEditorCard() {
                             ) : null}
                           </div>
 
-                          <Button type="submit" disabled={isSaving}>
+                          <Button type="submit" disabled={isSaving || isSavingAll}>
                             {isSaving ? "Guardando..." : "Guardar precio"}
                           </Button>
                         </div>

--- a/test/frontend-admin-pricing-card.test.ts
+++ b/test/frontend-admin-pricing-card.test.ts
@@ -74,6 +74,67 @@ test("admin pricing card supports display order and active state updates", () =>
   assert.ok(source.includes('isActive: event.target.value === "active"'));
 });
 
+test("admin pricing card contains Guardar todos button with save-all marker", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(source.includes("data-save-all"));
+  assert.ok(source.includes("Guardar todos"));
+  assert.ok(source.includes("Guardando todos..."));
+});
+
+test("admin pricing card detects pending changes via pendingItemIds useMemo", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(source.includes("pendingItemIds"));
+  assert.ok(source.includes("hasPendingValidationErrors"));
+  assert.ok(source.includes("normalizePriceLabelForPayload(original.priceLabel ?? \"\")"));
+  assert.ok(source.includes("normalizePriceLabelForPayload(form.priceLabel)"));
+  assert.ok(source.includes("form.isActive !== original.isActive"));
+  assert.ok(source.includes("nextDisplayOrder !== original.displayOrder"));
+});
+
+test("admin pricing card does not send unchanged items in save-all", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(source.includes("item.payload !== null && item.errorMessage === null"));
+  assert.ok(source.includes("for (const { id, payload } of toSave)"));
+});
+
+test("admin pricing card disables Guardar todos when no changes or saving", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(source.includes("pendingItemIds.length === 0"));
+  assert.ok(source.includes("hasPendingValidationErrors"));
+  assert.ok(source.includes("isSavingAll"));
+  assert.ok(source.includes("savingItemId !== null || isSavingAll"));
+});
+
+test("admin pricing card handles per-item error in save-all without false success", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(source.includes("for (const { id, payload } of toSave)"));
+  assert.ok(source.includes("formatAdminPricingError(error, SAVE_ERROR_MESSAGE)"));
+  assert.ok(source.includes("setIsSavingAll(false)"));
+});
+
+test("admin pricing card preserves individual Guardar precio intact", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(source.includes('type="submit"'));
+  assert.ok(source.includes("handleSaveItem"));
+  assert.ok(source.includes("isSaving ? \"Guardando...\" : \"Guardar precio\""));
+  assert.ok(source.includes("disabled={isSaving || isSavingAll}"));
+});
+
+test("admin pricing card does not contain passwords, hashes, tokens or cookies in source", () => {
+  const source = read(ADMIN_PRICING_CARD_PATH);
+
+  assert.ok(!source.toLowerCase().includes("password"));
+  assert.ok(!source.toLowerCase().includes("hash"));
+  assert.ok(!source.toLowerCase().includes("token"));
+  assert.ok(!source.toLowerCase().includes("cookie"));
+});
+
 test("dashboard admin mounts pricing card in dedicated section", () => {
   const source = read(ADMIN_PAGE_PATH);
 


### PR DESCRIPTION
## Resumen
- Agrega acción Guardar todos en Admin > Precios para persistir todos los ítems modificados.
- Mantiene Guardar precio individual.
- No envía ítems sin cambios.
- Conserva errores por ítem y evita éxito simulado.
- No toca backend ni rutas públicas; cada PATCH existente invalida cache público de precios.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local