### PR TITLE
fix(admin): restore failed login alerts cors

### DIFF
--- a/server/routes/admin-failed-login-alerts.fastify.ts
+++ b/server/routes/admin-failed-login-alerts.fastify.ts
@@ -378,10 +378,134 @@ function parseFailedLoginAlertsQuery(
   };
 }
 
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
 export const adminFailedLoginAlertsNativeRoutes: FastifyPluginAsync<
   AdminFailedLoginAlertsNativeRoutesOptions
 > = async (app, options) => {
   const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    applyCorsHeaders(request, reply, allowedOrigins);
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/export.csv", optionsHandler);
 
   async function resolveDeps(): Promise<NativeAdminFailedLoginAlertsDeps> {
     const hasAllInjectedDeps =

--- a/test/admin-failed-login-alerts.fastify.test.ts
+++ b/test/admin-failed-login-alerts.fastify.test.ts
@@ -8,6 +8,10 @@ process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.CORS_ORIGIN ??=
+  "https://portal-vetneb-frontend-staging.onrender.com";
+
+const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 
 const { ENV } = await import("../server/lib/env.ts");
 const { adminFailedLoginAlertsNativeRoutes } = await import(
@@ -76,7 +80,7 @@ function buildDeps(
   };
 }
 
-test("admin failed-login alerts requiere sesión admin", async () => {
+test("admin failed-login alerts requiere sesion admin", async () => {
   const app = Fastify();
 
   await app.register(
@@ -186,7 +190,7 @@ test("admin failed-login alerts devuelve intentos sanitizados", async () => {
   }
 });
 
-test("admin failed-login alerts rechaza filtros inválidos", async () => {
+test("admin failed-login alerts rechaza filtros invalidos", async () => {
   const app = Fastify();
   let listCalled = false;
 
@@ -228,7 +232,6 @@ test("admin failed-login alerts rechaza filtros inválidos", async () => {
     await app.close();
   }
 });
-
 
 test("admin failed-login alerts exporta CSV sanitizado", async () => {
   const app = Fastify();
@@ -287,10 +290,7 @@ test("admin failed-login alerts exporta CSV sanitizado", async () => {
     });
 
     assert.equal(response.statusCode, 200);
-    assert.equal(
-      response.headers["content-type"],
-      "text/csv; charset=utf-8",
-    );
+    assert.equal(response.headers["content-type"], "text/csv; charset=utf-8");
     assert.equal(
       response.headers["content-disposition"],
       'attachment; filename="admin-failed-login-alerts-test.csv"',
@@ -302,15 +302,13 @@ test("admin failed-login alerts exporta CSV sanitizado", async () => {
       offset: 0,
     });
 
-    assert.equal(
-      response.body,
-      [
-        "id,surface,username,reason,ipAddress,userAgent,createdAt",
-        "20,clinic,clinic-user,invalid_credentials,203.0.113.20,csv-test-agent,2026-05-08T00:02:00.000Z",
-        "21,particular,,rate_limited,203.0.113.21,csv-test-agent-2,2026-05-08T00:03:00.000Z",
-      ].join("\n"),
-    );
+    const expectedCsv = [
+      "id,surface,username,reason,ipAddress,userAgent,createdAt",
+      "20,clinic,clinic-user,invalid_credentials,203.0.113.20,csv-test-agent,2026-05-08T00:02:00.000Z",
+      "21,particular,,rate_limited,203.0.113.21,csv-test-agent-2,2026-05-08T00:03:00.000Z",
+    ].join("\n");
 
+    assert.equal(response.body, expectedCsv);
     assert.equal(response.body.includes("tokenHash"), false);
     assert.equal(response.body.includes("hash:"), false);
     assert.equal(response.body.includes("password"), false);
@@ -320,7 +318,7 @@ test("admin failed-login alerts exporta CSV sanitizado", async () => {
   }
 });
 
-test("admin failed-login alerts export rechaza filtros inválidos", async () => {
+test("admin failed-login alerts export rechaza filtros invalidos", async () => {
   const app = Fastify();
   let listCalled = false;
 
@@ -358,6 +356,187 @@ test("admin failed-login alerts export rechaza filtros inválidos", async () => 
     assert.equal(response.statusCode, 400);
     assert.equal(JSON.parse(response.body).success, false);
     assert.equal(listCalled, false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: GET / origin permitido devuelve access-control-allow-origin exacto", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?limit=25&offset=0",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["access-control-allow-origin"], STAGING_ORIGIN);
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: GET / origin permitido devuelve access-control-allow-credentials true", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?limit=25&offset=0",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: GET /export.csv origin permitido devuelve CORS correcto", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/export.csv",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["access-control-allow-origin"], STAGING_ORIGIN);
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: preflight OPTIONS / devuelve 204 con headers correctos", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.headers["access-control-allow-origin"], STAGING_ORIGIN);
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+    assert.equal(response.headers["access-control-allow-methods"], "GET,OPTIONS");
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: preflight OPTIONS /export.csv devuelve 204 con headers correctos", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/export.csv",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.headers["access-control-allow-origin"], STAGING_ORIGIN);
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+    assert.equal(response.headers["access-control-allow-methods"], "GET,OPTIONS");
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: origin no permitido no recibe access-control-allow-origin", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?limit=25&offset=0",
+      headers: {
+        origin: "https://evil.example.com",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: 401 sesion invalida mantiene CORS header para origin permitido", async () => {
+  const app = Fastify();
+  await app.register(
+    adminFailedLoginAlertsNativeRoutes,
+    buildDeps({ getAdminSessionByToken: async () => null }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?limit=25&offset=0",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=bad-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(response.headers["access-control-allow-origin"], STAGING_ORIGIN);
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: respuesta no expone token cookie hash ni password", async () => {
+  const app = Fastify();
+  await app.register(adminFailedLoginAlertsNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/?limit=25&offset=0",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body.includes("sessionToken"), false);
+    assert.equal(response.body.includes("tokenHash"), false);
+    assert.equal(response.body.includes("hash:"), false);
+    assert.equal(response.body.includes("password"), false);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Resumen
- Agrega CORS autónomo a Admin > Intentos fallidos de login siguiendo el patrón de rutas admin existentes.
- Cubre GET /api/admin/failed-login-alerts y GET /api/admin/failed-login-alerts/export.csv.
- Agrega OPTIONS para ambos endpoints con métodos GET,OPTIONS.
- Mantiene credenciales admin, sanitización y bloqueo de origins no permitidos.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local