### PR TITLE
fix(admin): create clinics with legacy timestamp params

### DIFF
--- a/server/db-admin-clinics.ts
+++ b/server/db-admin-clinics.ts
@@ -343,8 +343,8 @@ export async function createAdminClinicWithUser(
               ${input.clinicName.trim()},
               ${input.contactEmail.trim()},
               ${input.contactPhone?.trim() || null},
-              ${now},
-              ${now}
+              ${now.toISOString()}::timestamptz,
+              ${now.toISOString()}::timestamptz
             )
             returning
               "id" as "clinicId",

--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -15,8 +15,8 @@ test("admin clinics create soporta clinic_id legacy requerido en DB real", () =>
 
   assert.ok(source.includes("column_name = 'clinic_id'"));
   assert.ok(source.includes("buildLegacyClinicExternalId"));
-  assert.ok(source.includes("insert into \"clinics\""));
-  assert.ok(source.includes("\"clinic_id\""));
+  assert.ok(source.includes('insert into "clinics"'));
+  assert.ok(source.includes('"clinic_id"'));
   assert.ok(source.includes("reserveNextClinicId"));
 });
 
@@ -30,4 +30,119 @@ test("admin clinics delete limpia report_access_tokens antes de borrar clinics",
 
   assert.ok(deleteReportAccessTokensIndex >= 0);
   assert.ok(deleteClinicsIndex > deleteReportAccessTokensIndex);
+});
+
+test("branch legacy usa toISOString() para timestamps, no Date crudo en raw SQL", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  // La corrección debe estar presente: ISO string + cast explícito de timestamptz
+  const isoOccurrences = (source.match(/now\.toISOString\(\)/g) ?? []).length;
+  assert.ok(
+    isoOccurrences >= 2,
+    "debe haber al menos 2 llamadas a now.toISOString() (created_at y updated_at), encontradas: " +
+      String(isoOccurrences),
+  );
+
+  assert.ok(
+    source.includes("::timestamptz"),
+    "el cast ::timestamptz debe estar presente en el insert legacy",
+  );
+
+  // El insert raw SQL nunca debe pasar ${now} sin conversión a string.
+  // Extraemos el bloque del insert legacy y verificamos que no hay Date crudo.
+  const legacyInsertStart = source.indexOf('insert into "clinics"');
+  const legacyInsertEnd = source.indexOf("returning", legacyInsertStart) + 9;
+  const legacyInsertBlock = source.slice(legacyInsertStart, legacyInsertEnd);
+
+  assert.ok(
+    !legacyInsertBlock.includes("${now},") &&
+      !legacyInsertBlock.includes("${now}\n"),
+    "el insert legacy no debe contener ${now} sin .toISOString() como parametro de timestamp",
+  );
+});
+
+test("buildLegacyClinicExternalId genera clinic-{id} y se usa con el id reservado", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  // La función genera el formato clinic-{id}
+  assert.ok(
+    source.includes("`clinic-${clinicId}`"),
+    "buildLegacyClinicExternalId debe retornar template clinic-${clinicId}",
+  );
+
+  // Se usa correctamente con el id reservado
+  assert.ok(
+    source.includes("buildLegacyClinicExternalId(reservedClinicId)"),
+    "debe llamarse con reservedClinicId, no con otro valor",
+  );
+
+  // El id reservado proviene de la secuencia de la DB, no de un autoincremento
+  assert.ok(
+    source.includes("pg_get_serial_sequence"),
+    "la reserva del id debe usar pg_get_serial_sequence para evitar conflictos",
+  );
+});
+
+test("serializeClinic serializa createdAt y updatedAt como ISO string, no expone passwordHash", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  const serializeClinicStart = source.indexOf("function serializeClinic(");
+  const serializeClinicEnd = source.indexOf("function serializeClinicUser(");
+  const serializeClinicFn = source.slice(serializeClinicStart, serializeClinicEnd);
+
+  assert.ok(
+    serializeClinicFn.includes("toIsoDate(row.createdAt)"),
+    "serializeClinic debe llamar toIsoDate(row.createdAt)",
+  );
+  assert.ok(
+    serializeClinicFn.includes("toIsoDate(row.updatedAt)"),
+    "serializeClinic debe llamar toIsoDate(row.updatedAt)",
+  );
+  assert.ok(
+    !serializeClinicFn.includes("passwordHash"),
+    "serializeClinic no debe exponer passwordHash",
+  );
+  assert.ok(
+    !serializeClinicFn.includes("password"),
+    "serializeClinic no debe exponer password",
+  );
+
+  // toIsoDate usa toISOString()
+  const toIsoDateStart = source.indexOf("function toIsoDate(");
+  const toIsoDateEnd = source.indexOf("function serializeClinic(");
+  const toIsoDateFn = source.slice(toIsoDateStart, toIsoDateEnd);
+
+  assert.ok(
+    toIsoDateFn.includes(".toISOString()"),
+    "toIsoDate debe usar .toISOString()",
+  );
+});
+
+test("serializeClinicUser no expone passwordHash, authProId ni campos sensibles", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  const serializeUserStart = source.indexOf("function serializeClinicUser(");
+  const serializeUserEnd = source.indexOf("async function getClinicUserRow(");
+  const serializeUserFn = source.slice(serializeUserStart, serializeUserEnd);
+
+  assert.ok(
+    !serializeUserFn.includes("passwordHash"),
+    "serializeClinicUser no debe incluir passwordHash",
+  );
+  assert.ok(
+    !serializeUserFn.includes("password"),
+    "serializeClinicUser no debe incluir password",
+  );
+  assert.ok(
+    !serializeUserFn.includes("authProId"),
+    "serializeClinicUser no debe exponer authProId",
+  );
+  assert.ok(
+    serializeUserFn.includes("toIsoDate(row.createdAt)"),
+    "serializeClinicUser debe serializar createdAt como ISO",
+  );
+  assert.ok(
+    serializeUserFn.includes("toIsoDate(row.updatedAt)"),
+    "serializeClinicUser debe serializar updatedAt como ISO",
+  );
 });


### PR DESCRIPTION
## Resumen
- Corrige creación de clínicas en DB legacy evitando pasar Date crudo al raw SQL.
- Usa timestamps ISO casteados a timestamptz en el insert legacy con clinic_id requerido.
- Mantiene el branch normal Drizzle sin cambios.
- Agrega contrato para el branch legacy, clinic_id externo y sanitización.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local