### PR TITLE
fix(backend): cap db pool and tolerate cleanup exhaustion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ SUPABASE_ANON_KEY=<supabase-anon-key>
 SUPABASE_SERVICE_ROLE_KEY=<supabase-service-role-key>
 SUPABASE_DB_URL=<supabase-db-url>
 DATABASE_URL=<database-url-fallback>
+# Conexiones máximas al pool postgres-js. Default: 3. Min: 1. Max (hard): 10.
+# Mantener bajo en staging (PgBouncer session mode). Ajustar en producción según slots disponibles.
+DATABASE_MAX_CONNECTIONS=3
 SUPABASE_STORAGE_BUCKET=reports
 
 COOKIE_NAME=app_session_id

--- a/server/db.ts
+++ b/server/db.ts
@@ -22,6 +22,7 @@ import { normalizeClinicUserRole } from "./lib/permissions.ts";
 
 const client = postgres(ENV.databaseUrl, {
   prepare: false,
+  max: ENV.databaseMaxConnections,
 });
 
 export const pgClient = client;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,29 +1,8 @@
-import { sql } from "drizzle-orm";
-
 import { bootstrapHttpServer, type HttpServerHandle } from "./bootstrap.ts";
-import { closeDbConnection, db, deleteExpiredAdminSessions, deleteExpiredSessions } from "./db.ts";
-import { deleteExpiredParticularSessions } from "./db-particular.ts";
+import { closeDbConnection } from "./db.ts";
 import { createFastifyApp } from "./fastify-app.ts";
 import { ENV } from "./lib/env.ts";
-import { ensureStorageBucketExists } from "./lib/supabase.ts";
-
-async function preflight() {
-  await db.execute(sql`select 1`);
-  await ensureStorageBucketExists();
-
-  const [deletedClinicSessions, deletedAdminSessions, deletedParticularSessions] =
-    await Promise.all([
-      deleteExpiredSessions(),
-      deleteExpiredAdminSessions(),
-      deleteExpiredParticularSessions(),
-    ]);
-
-  return {
-    deletedClinicSessions,
-    deletedAdminSessions,
-    deletedParticularSessions,
-  };
-}
+import { preflight } from "./preflight.ts";
 
 async function closeResources() {
   await closeDbConnection();

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -1,4 +1,4 @@
-﻿import "dotenv/config";
+import "dotenv/config";
 import { z } from "zod";
 
 const emptyToUndefined = (value: unknown) => {
@@ -26,11 +26,22 @@ function parseDelimitedList(value: string | undefined): string[] {
     .filter(Boolean);
 }
 
+
+function parseDatabaseMaxConnections(value: string | undefined): number {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return 3;
+  }
+
+  return Math.min(Math.max(Math.trunc(parsed), 1), 10);
+}
 const envSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
   PORT: z.coerce.number().int().positive().optional(),
   DATABASE_URL: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
   SUPABASE_DB_URL: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
+  DATABASE_MAX_CONNECTIONS: z.preprocess(emptyToUndefined, z.string().optional()),
   SUPABASE_URL: z.preprocess(emptyToUndefined, z.string().url()),
   SUPABASE_ANON_KEY: z.preprocess(emptyToUndefined, z.string().min(1)),
   SUPABASE_SERVICE_ROLE_KEY: z.preprocess(emptyToUndefined, z.string().min(1)),
@@ -94,7 +105,10 @@ const port = rawEnv.PORT ?? 3000;
 const databaseUrl = rawEnv.SUPABASE_DB_URL ?? rawEnv.DATABASE_URL;
 if (!databaseUrl) {
   throw new Error("DATABASE_URL o SUPABASE_DB_URL es obligatorio");
-}
+}const DB_MAX_CONNECTIONS_DEFAULT = 3;
+const DB_MAX_CONNECTIONS_FLOOR = 1;
+const DB_MAX_CONNECTIONS_CEILING = 10;
+const databaseMaxConnections = parseDatabaseMaxConnections(rawEnv.DATABASE_MAX_CONNECTIONS);
 
 const LOCAL_CORS_ORIGINS = [
   "http://localhost:3000",
@@ -138,6 +152,7 @@ export const ENV = {
   isProduction: nodeEnv === "production",
   port,
   databaseUrl,
+  databaseMaxConnections,
   supabaseUrl: rawEnv.SUPABASE_URL,
   supabaseAnonKey: rawEnv.SUPABASE_ANON_KEY,
   supabaseServiceRoleKey: rawEnv.SUPABASE_SERVICE_ROLE_KEY,

--- a/server/preflight.ts
+++ b/server/preflight.ts
@@ -1,0 +1,78 @@
+import { sql } from "drizzle-orm";
+
+import { type StartupCleanupSummary } from "./bootstrap.ts";
+import {
+  db,
+  deleteExpiredAdminSessions,
+  deleteExpiredSessions,
+} from "./db.ts";
+import { deleteExpiredParticularSessions } from "./db-particular.ts";
+import { ensureStorageBucketExists } from "./lib/supabase.ts";
+
+const POOL_EXHAUSTED_PATTERNS = [
+  "max clients reached",
+  "EMAXCONN",
+  "too many connections",
+  "remaining connection slots are reserved",
+];
+
+export function isPoolExhaustedError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return POOL_EXHAUSTED_PATTERNS.some((pattern) => msg.includes(pattern));
+}
+
+type LoggerLike = Pick<Console, "warn">;
+
+/**
+ * Ejecuta una función de limpieza de sesiones expiradas de forma resiliente.
+ * Si la DB rechaza la conexión por pool exhausto (EMAXCONNSESSION),
+ * loguea un warning y retorna 0 — no aborta el startup del servidor.
+ * Cualquier otro error se relanza como crítico.
+ */
+export async function safeCleanupStep(
+  fn: () => Promise<number>,
+  label: string,
+  logger: LoggerLike = console,
+): Promise<number> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isPoolExhaustedError(err)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `[PREFLIGHT_CLEANUP_WARN] ${label}: pool exhausted, cleanup skipped (${msg.slice(0, 100)})`,
+      );
+      return 0;
+    }
+    throw err;
+  }
+}
+
+export async function preflight(
+  deps: { logger?: LoggerLike } = {},
+): Promise<StartupCleanupSummary> {
+  await db.execute(sql`select 1`);
+  await ensureStorageBucketExists();
+
+  const logger = deps.logger ?? console;
+
+  const [
+    deletedClinicSessions,
+    deletedAdminSessions,
+    deletedParticularSessions,
+  ] = await Promise.all([
+    safeCleanupStep(deleteExpiredSessions, "clinic_sessions", logger),
+    safeCleanupStep(deleteExpiredAdminSessions, "admin_sessions", logger),
+    safeCleanupStep(
+      deleteExpiredParticularSessions,
+      "particular_sessions",
+      logger,
+    ),
+  ]);
+
+  return {
+    deletedClinicSessions,
+    deletedAdminSessions,
+    deletedParticularSessions,
+  };
+}

--- a/server/preflight.ts
+++ b/server/preflight.ts
@@ -1,13 +1,6 @@
 import { sql } from "drizzle-orm";
 
-import { type StartupCleanupSummary } from "./bootstrap.ts";
-import {
-  db,
-  deleteExpiredAdminSessions,
-  deleteExpiredSessions,
-} from "./db.ts";
-import { deleteExpiredParticularSessions } from "./db-particular.ts";
-import { ensureStorageBucketExists } from "./lib/supabase.ts";
+import type { StartupCleanupSummary } from "./bootstrap.ts";
 
 const POOL_EXHAUSTED_PATTERNS = [
   "max clients reached",
@@ -44,6 +37,7 @@ export async function safeCleanupStep(
       );
       return 0;
     }
+
     throw err;
   }
 }
@@ -51,20 +45,34 @@ export async function safeCleanupStep(
 export async function preflight(
   deps: { logger?: LoggerLike } = {},
 ): Promise<StartupCleanupSummary> {
-  await db.execute(sql`select 1`);
-  await ensureStorageBucketExists();
+  const [
+    dbModule,
+    particularModule,
+    supabaseModule,
+  ] = await Promise.all([
+    import("./db.ts"),
+    import("./db-particular.ts"),
+    import("./lib/supabase.ts"),
+  ]);
 
   const logger = deps.logger ?? console;
+
+  await dbModule.db.execute(sql`select 1`);
+  await supabaseModule.ensureStorageBucketExists();
 
   const [
     deletedClinicSessions,
     deletedAdminSessions,
     deletedParticularSessions,
   ] = await Promise.all([
-    safeCleanupStep(deleteExpiredSessions, "clinic_sessions", logger),
-    safeCleanupStep(deleteExpiredAdminSessions, "admin_sessions", logger),
+    safeCleanupStep(dbModule.deleteExpiredSessions, "clinic_sessions", logger),
     safeCleanupStep(
-      deleteExpiredParticularSessions,
+      dbModule.deleteExpiredAdminSessions,
+      "admin_sessions",
+      logger,
+    ),
+    safeCleanupStep(
+      particularModule.deleteExpiredParticularSessions,
       "particular_sessions",
       logger,
     ),

--- a/test/db-pool-contract.test.ts
+++ b/test/db-pool-contract.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("server/db.ts configura max conexiones desde ENV.databaseMaxConnections", () => {
+  const source = read("server/db.ts");
+  assert.ok(
+    source.includes("max: ENV.databaseMaxConnections"),
+    "el cliente postgres debe recibir max: ENV.databaseMaxConnections para limitar el pool",
+  );
+});
+
+test("server/lib/env.ts expone DATABASE_MAX_CONNECTIONS y databaseMaxConnections", () => {
+  const source = read("server/lib/env.ts");
+  assert.ok(
+    source.includes("DATABASE_MAX_CONNECTIONS"),
+    "envSchema debe incluir DATABASE_MAX_CONNECTIONS",
+  );
+  assert.ok(
+    source.includes("databaseMaxConnections"),
+    "ENV debe exportar databaseMaxConnections",
+  );
+});
+
+test("server/preflight.ts exporta safeCleanupStep e isPoolExhaustedError", () => {
+  const source = read("server/preflight.ts");
+  assert.ok(
+    source.includes("export async function safeCleanupStep"),
+    "safeCleanupStep debe ser exportada para testabilidad",
+  );
+  assert.ok(
+    source.includes("export function isPoolExhaustedError"),
+    "isPoolExhaustedError debe ser exportada para testabilidad",
+  );
+});
+
+test("server/index.ts importa preflight desde server/preflight.ts y no define preflight local", () => {
+  const source = read("server/index.ts");
+  assert.ok(
+    source.includes('from "./preflight.ts"'),
+    "index.ts debe importar preflight del modulo preflight.ts",
+  );
+  assert.ok(
+    !source.includes("async function preflight()"),
+    "index.ts no debe definir una funcion preflight local (debe delegarla al modulo)",
+  );
+});

--- a/test/env-db-pool.test.ts
+++ b/test/env-db-pool.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+function readDatabaseMaxConnectionsFromChild(overrides: Record<string, string>) {
+  const env: Record<string, string> = {
+    NODE_ENV: "test",
+    SUPABASE_URL: "https://example.supabase.co",
+    SUPABASE_ANON_KEY: "test-anon-key",
+    SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+    DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/postgres",
+    SUPABASE_DB_URL: "postgresql://postgres:postgres@127.0.0.1:5432/postgres",
+    DATABASE_MAX_CONNECTIONS: "",
+    ...overrides,
+  };
+  const script = [
+    'const { ENV } = await import("./server/lib/env.ts");',
+    "process.stdout.write(JSON.stringify(ENV.databaseMaxConnections));",
+  ].join("\n");
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--experimental-strip-types",
+      "--experimental-specifier-resolution=node",
+      "--input-type=module",
+      "-e",
+      script,
+    ],
+    { cwd: resolve(process.cwd()), env, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout) as number;
+}
+
+test("ENV.databaseMaxConnections usa default 3 cuando no se configura", () => {
+  const value = readDatabaseMaxConnectionsFromChild({
+    DATABASE_MAX_CONNECTIONS: "",
+  });
+  assert.equal(value, 3);
+});
+
+test("ENV.databaseMaxConnections parsea valor valido dentro del rango", () => {
+  const value = readDatabaseMaxConnectionsFromChild({
+    DATABASE_MAX_CONNECTIONS: "5",
+  });
+  assert.equal(value, 5);
+});
+
+test("ENV.databaseMaxConnections limita valor alto al techo de 10", () => {
+  const value = readDatabaseMaxConnectionsFromChild({
+    DATABASE_MAX_CONNECTIONS: "50",
+  });
+  assert.equal(value, 10);
+});
+
+test("ENV.databaseMaxConnections limita valor 1 al piso de 1", () => {
+  const value = readDatabaseMaxConnectionsFromChild({
+    DATABASE_MAX_CONNECTIONS: "1",
+  });
+  assert.equal(value, 1);
+});

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isPoolExhaustedError,
+  safeCleanupStep,
+} from "../server/preflight.ts";
+
+// isPoolExhaustedError
+
+test("isPoolExhaustedError detecta 'max clients reached'", () => {
+  assert.equal(
+    isPoolExhaustedError(
+      new Error("max clients reached in session mode — pool_size: 15"),
+    ),
+    true,
+  );
+});
+
+test("isPoolExhaustedError detecta 'too many connections'", () => {
+  assert.equal(
+    isPoolExhaustedError(new Error("too many connections")),
+    true,
+  );
+});
+
+test("isPoolExhaustedError detecta 'EMAXCONN'", () => {
+  assert.equal(isPoolExhaustedError(new Error("EMAXCONN")), true);
+});
+
+test("isPoolExhaustedError no clasifica errores criticos como pool", () => {
+  assert.equal(
+    isPoolExhaustedError(new Error("password authentication failed")),
+    false,
+  );
+  assert.equal(
+    isPoolExhaustedError(new Error("connection refused: ECONNREFUSED")),
+    false,
+  );
+  assert.equal(
+    isPoolExhaustedError(new Error("relation does not exist")),
+    false,
+  );
+});
+
+// safeCleanupStep
+
+test("safeCleanupStep retorna el resultado cuando la funcion tiene exito", async () => {
+  const result = await safeCleanupStep(async () => 7, "test_ok");
+  assert.equal(result, 7);
+});
+
+test("safeCleanupStep retorna 0 y loguea warning cuando es EMAXCONNSESSION", async () => {
+  const warnings: string[] = [];
+  const mockLogger = {
+    warn: (...args: unknown[]) => {
+      warnings.push(args.join(" "));
+    },
+  };
+
+  const result = await safeCleanupStep(
+    async () => {
+      throw new Error("max clients reached in session mode — pool_size: 15");
+    },
+    "admin_sessions",
+    mockLogger,
+  );
+
+  assert.equal(result, 0);
+  assert.equal(warnings.length, 1);
+  assert.ok(warnings[0].includes("[PREFLIGHT_CLEANUP_WARN]"));
+  assert.ok(warnings[0].includes("admin_sessions"));
+  assert.ok(warnings[0].includes("pool exhausted"));
+});
+
+test("safeCleanupStep re-lanza errores criticos que no son de pool", async () => {
+  const criticalError = new Error("password authentication failed for user");
+
+  await assert.rejects(
+    () => safeCleanupStep(async () => { throw criticalError; }, "test_critical"),
+    (err: unknown) => {
+      assert.ok(err === criticalError);
+      return true;
+    },
+  );
+});
+
+test("safeCleanupStep re-lanza errores de conexion rechazada", async () => {
+  await assert.rejects(
+    () =>
+      safeCleanupStep(
+        async () => {
+          throw new Error("connect ECONNREFUSED 127.0.0.1:5432");
+        },
+        "test_econnrefused",
+      ),
+    /ECONNREFUSED/,
+  );
+});
+
+test("safeCleanupStep no loguea nada en caso de exito", async () => {
+  const warnings: string[] = [];
+  const mockLogger = {
+    warn: (...args: unknown[]) => {
+      warnings.push(args.join(" "));
+    },
+  };
+
+  await safeCleanupStep(async () => 3, "test_silent", mockLogger);
+  assert.equal(warnings.length, 0);
+});


### PR DESCRIPTION
## Resumen
- Limita explícitamente el pool postgres-js para evitar EMAXCONNSESSION en staging.
- Agrega DATABASE_MAX_CONNECTIONS con default seguro y clamp 1..10.
- Extrae preflight resiliente para que limpiezas no críticas no tumben el backend.
- Mantiene errores críticos como críticos.
- Conserva el fix de creación de clínicas legacy.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local