### PR TITLE
fix(admin): add CORS OPTIONS handlers to audit-log and system-health routes

### DIFF
--- a/server/routes/admin-audit.fastify.ts
+++ b/server/routes/admin-audit.fastify.ts
@@ -261,6 +261,97 @@ async function authenticateAdminUser(
   };
 }
 
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
 export const adminAuditNativeRoutes: FastifyPluginAsync<
   AdminAuditNativeRoutesOptions
 > = async (app, options) => {
@@ -301,6 +392,11 @@ export const adminAuditNativeRoutes: FastifyPluginAsync<
   };
 
   const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    applyCorsHeaders(request, reply, allowedOrigins);
+  });
 
   app.addHook("onRequest", async (request) => {
     (request as AdminAuditFastifyRequest)[REQUEST_TIMER_KEY] =
@@ -308,6 +404,34 @@ export const adminAuditNativeRoutes: FastifyPluginAsync<
 
     return undefined;
   });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+  app.options("/export.csv", optionsHandler);
 
   app.addHook("onResponse", async (request, reply) => {
     const timer =

--- a/server/routes/admin-system-health.fastify.ts
+++ b/server/routes/admin-system-health.fastify.ts
@@ -361,6 +361,97 @@ function buildServiceChecksPayload(checks: unknown) {
   };
 }
 
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
 export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
   AdminSystemHealthNativeRoutesOptions
 > = async (app, options) => {
@@ -394,6 +485,38 @@ export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
   };
 
   const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    applyCorsHeaders(request, reply, allowedOrigins);
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
 
   app.get("/", async (request, reply) => {
     const admin = await authenticateAdminUser(request, reply, deps, now);

--- a/test/admin-audit.fastify.test.ts
+++ b/test/admin-audit.fastify.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 
@@ -8,6 +8,7 @@ process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.CORS_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 
 const { ENV } = await import("../server/lib/env.ts");
 const {
@@ -281,3 +282,144 @@ test(
     }
   },
 );
+
+
+const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
+
+test("CORS: preflight OPTIONS / devuelve 204 con headers correctos", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/admin/audit-log/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+    assert.equal(
+      response.headers["access-control-allow-methods"],
+      "GET,OPTIONS",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: preflight OPTIONS /export.csv devuelve 204 con headers correctos", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/api/admin/audit-log/export.csv",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+    assert.equal(
+      response.headers["access-control-allow-methods"],
+      "GET,OPTIONS",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: GET / origin permitido devuelve access-control-allow-origin", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/audit-log/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: origin no permitido no recibe access-control-allow-origin", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/audit-log/",
+      headers: {
+        origin: "https://evil.example.com",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      undefined,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: 401 sin sesion mantiene CORS header para origin permitido", async () => {
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/audit-log/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=bad-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/test/admin-system-health.fastify.test.ts
+++ b/test/admin-system-health.fastify.test.ts
@@ -8,6 +8,7 @@ process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.CORS_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 
 const { ENV } = await import("../server/lib/env.ts");
 const { adminSystemHealthNativeRoutes } = await import(
@@ -197,6 +198,144 @@ test("admin system health expone servicios, runtime y versión para admin autent
     assert.equal(typeof body.runtime.memory.rssMb, "number");
     assert.equal(body.health.status, "ok");
     assert.equal(updatedLastAccess, true);
+  } finally {
+    await app.close();
+  }
+});
+
+
+const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
+
+function buildHealthDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({ id: 1, username: "VETNEB" }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSystemHealthSnapshot: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+        checks: { database: "up", storage: "up" },
+      },
+    }),
+    getBackendVersion: () => "test-version",
+    ...overrides,
+  };
+}
+
+test("CORS: preflight OPTIONS / en system-health devuelve 204 con headers correctos", async () => {
+  const app = Fastify();
+  await app.register(adminSystemHealthNativeRoutes, buildHealthDeps());
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+    assert.equal(
+      response.headers["access-control-allow-methods"],
+      "GET,OPTIONS",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: GET / en system-health con origin permitido devuelve access-control-allow-origin", async () => {
+  const app = Fastify();
+  await app.register(adminSystemHealthNativeRoutes, buildHealthDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: 401 sin sesion en system-health mantiene CORS header para origin permitido", async () => {
+  const app = Fastify();
+  await app.register(
+    adminSystemHealthNativeRoutes,
+    buildHealthDeps({ getAdminSessionByToken: async () => null }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=bad-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: origin no permitido en system-health no recibe access-control-allow-origin", async () => {
+  const app = Fastify();
+  await app.register(adminSystemHealthNativeRoutes, buildHealthDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        origin: "https://evil.example.com",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      undefined,
+    );
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Problema
- /api/admin/audit-log y /api/admin/system/health no tenían handlers CORS preflight.
- OPTIONS devolvía 404 en staging, bloqueando fetch con credentials: include desde Admin Dashboard.

## Causa raíz
- Ambos plugins Fastify omitían el bloque CORS autónomo usado por otras rutas admin.

## Fix
- Agrega helpers CORS, hook onRequest y handlers OPTIONS.
- Cubre /api/admin/audit-log, /api/admin/audit-log/export.csv y /api/admin/system/health.

## Tests
- 5 tests CORS nuevos en test/admin-audit.fastify.test.ts.
- 4 tests CORS nuevos en test/admin-system-health.fastify.test.ts.
- Los tests fuerzan CORS_ORIGIN staging antes de importar ENV.

## No-alcance
- Sin cambios en DB, migrations, frontend ni otras rutas.

## Validación
- pnpm validate:local