### PR TITLE
fix(db): add missing contact_email/contact_phone columns to clinics table

### DIFF
--- a/drizzle/migrations/0026_clinics_contact_columns_reconciliation.sql
+++ b/drizzle/migrations/0026_clinics_contact_columns_reconciliation.sql
@@ -1,0 +1,12 @@
+-- 0026_clinics_contact_columns_reconciliation.sql
+-- CONTEXTO: La migración 0010 usó CREATE TABLE IF NOT EXISTS "clinics", que fue
+-- un no-op en entornos donde la tabla ya existía (migración 0000). Como resultado,
+-- las columnas contact_email y contact_phone nunca se añadieron a la tabla real.
+-- Toda consulta que las referencia falla (listAdminClinics GET, legacy INSERT POST).
+-- Este script las añade de forma segura e idempotente.
+
+ALTER TABLE "clinics"
+  ADD COLUMN IF NOT EXISTS "contact_email" varchar(255);
+
+ALTER TABLE "clinics"
+  ADD COLUMN IF NOT EXISTS "contact_phone" varchar(50);

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
                         "when":  1777111200000,
                         "tag":  "0025_login_rate_limits",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  26,
+                        "version":  "7",
+                        "when":  1777114800000,
+                        "tag":  "0026_clinics_contact_columns_reconciliation",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -146,3 +146,44 @@ test("serializeClinicUser no expone passwordHash, authProId ni campos sensibles"
     "serializeClinicUser debe serializar updatedAt como ISO",
   );
 });
+
+test("migración 0026 existe y añade contact_email y contact_phone con ADD COLUMN IF NOT EXISTS", () => {
+  const source = read("drizzle/migrations/0026_clinics_contact_columns_reconciliation.sql");
+
+  assert.ok(
+    source.includes('ADD COLUMN IF NOT EXISTS "contact_email"'),
+    "la migración debe añadir contact_email con IF NOT EXISTS",
+  );
+  assert.ok(
+    source.includes('ADD COLUMN IF NOT EXISTS "contact_phone"'),
+    "la migración debe añadir contact_phone con IF NOT EXISTS",
+  );
+  assert.ok(
+    source.includes("varchar(255)"),
+    "contact_email debe ser varchar(255)",
+  );
+  assert.ok(
+    source.includes("varchar(50)"),
+    "contact_phone debe ser varchar(50)",
+  );
+  assert.ok(
+    !source.includes("NOT NULL"),
+    "las columnas nuevas no deben tener NOT NULL (son opcionales)",
+  );
+});
+
+test("journal de migraciones incluye 0026 como última entrada", () => {
+  const raw = read("drizzle/migrations/meta/_journal.json");
+  const journal = JSON.parse(raw) as {
+    entries: Array<{ idx: number; tag: string }>;
+  };
+
+  const last = journal.entries[journal.entries.length - 1];
+
+  assert.equal(
+    last?.tag,
+    "0026_clinics_contact_columns_reconciliation",
+    "la última entrada del journal debe ser 0026_clinics_contact_columns_reconciliation",
+  );
+  assert.equal(last?.idx, 26, "idx de la última migración debe ser 26");
+});


### PR DESCRIPTION
## Problema
- La migración 0010 usó `CREATE TABLE IF NOT EXISTS "clinics"` con el schema nuevo.
- En staging, la tabla clinics ya existía desde la migración inicial, por lo que 0010 fue no-op.
- Las columnas `contact_email` y `contact_phone` nunca quedaron creadas en la DB real.
- Síntoma: GET/POST `/api/admin/clinics` devuelve 500.

## Fix
- Agrega migración 0026 idempotente con `ALTER TABLE ADD COLUMN IF NOT EXISTS` para `contact_email` y `contact_phone`.
- Actualiza `drizzle/migrations/meta/_journal.json`.
- Agrega tests de contrato para validar migración y journal.

## No-alcance
- Sin cambios frontend.
- Sin cambios en rutas admin.
- Sin cambios en auth/CORS/PWA.

## Validación
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`
- `pnpm validate:local`

## Post-merge
- Aplicar migración en staging con `pnpm db:migrate`.
- Revalidar Admin > Clínicas create/list/delete.