### PR TITLE
fix(admin): serialize clinic timestamps from raw SQL

### DIFF
--- a/server/db-admin-clinics.ts
+++ b/server/db-admin-clinics.ts
@@ -177,8 +177,18 @@ async function reserveNextClinicId(tx: DbTransaction): Promise<number> {
   return reserved.clinicId;
 }
 
-function toIsoDate(value: Date) {
-  return value.toISOString();
+function toIsoDate(value: Date | string | number) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Fecha inválida recibida desde DB.");
+  }
+
+  return date.toISOString();
 }
 
 function serializeClinic(row: ClinicRow): AdminClinicSummary {

--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -187,3 +187,24 @@ test("journal de migraciones incluye 0026 como última entrada", () => {
   );
   assert.equal(last?.idx, 26, "idx de la última migración debe ser 26");
 });
+
+test("toIsoDate acepta Date o string devuelto por raw SQL postgres-js", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  const toIsoDateStart = source.indexOf("function toIsoDate(");
+  const toIsoDateEnd = source.indexOf("function serializeClinic(");
+  const toIsoDateFn = source.slice(toIsoDateStart, toIsoDateEnd);
+
+  assert.ok(
+    toIsoDateFn.includes("value instanceof Date"),
+    "toIsoDate debe manejar Date nativo",
+  );
+  assert.ok(
+    toIsoDateFn.includes("new Date(value)"),
+    "toIsoDate debe aceptar string/number devuelto por raw SQL",
+  );
+  assert.ok(
+    toIsoDateFn.includes("Number.isNaN(date.getTime())"),
+    "toIsoDate debe validar fechas inválidas",
+  );
+});


### PR DESCRIPTION
## Problema
- POST /api/admin/clinics llega correctamente al backend pero devuelve 500.
- Render logs muestran value.toISOString is not a function en serializeClinic/toIsoDate.
- En el branch legacy con raw SQL, postgres-js puede devolver timestamptz como string en lugar de Date.

## Fix
- toIsoDate ahora acepta Date | string | number.
- Convierte strings devueltos por raw SQL con new Date(value).
- Valida fechas inválidas antes de serializar.

## Tests
- Agrega contrato para Date/string/number en toIsoDate.

## No-alcance
- Sin cambios frontend.
- Sin cambios CORS/PWA.
- Sin cambios DB/migrations.

## Validación
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local