### PR TITLE
fix(ci): pin pnpm action setup version

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 10.8.1
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 10.8.1
 

--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -99,7 +99,7 @@ test("Frontend CI define toolchain y cache de pnpm esperados", () => {
   const source = readWorkflow();
 
   assertContains(source, "timeout-minutes: 20");
-  assertContains(source, "uses: pnpm/action-setup@v6");
+  assertContains(source, "uses: pnpm/action-setup@v4");
   assertContains(source, "version: 10.8.1");
   assertContains(source, "uses: actions/setup-node@v6");
   assertContains(source, "node-version: 24");

--- a/test/toolchain-contract.test.ts
+++ b/test/toolchain-contract.test.ts
@@ -50,7 +50,7 @@ test("Backend CI uses the pinned pnpm and Node toolchain", () => {
     "concurrency:\n  group: backend-ci-${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true",
   );
   assertContains(workflow, "uses: actions/checkout@v6");
-  assertContains(workflow, "uses: pnpm/action-setup@v6");
+  assertContains(workflow, "uses: pnpm/action-setup@v4");
   assertContains(workflow, "version: 10.8.1");
   assertContains(workflow, "uses: actions/setup-node@v6");
   assertContains(workflow, "node-version: 24");
@@ -63,7 +63,7 @@ test("Backend CI installs dependencies after toolchain setup", () => {
   const workflow = readTextFile(".github", "workflows", "backend-ci.yml");
 
   assertOrdered(workflow, [
-    "      - name: Setup pnpm\n        uses: pnpm/action-setup@v6",
+    "      - name: Setup pnpm\n        uses: pnpm/action-setup@v4",
     "      - name: Setup Node.js\n        uses: actions/setup-node@v6",
     "      - name: Install dependencies\n        run: pnpm install --frozen-lockfile",
   ]);


### PR DESCRIPTION
Pins pnpm/action-setup to v4 after CI failed before running project code while downloading pnpm/action-setup@v6.