### PR TITLE
fix(db): ensure report workflow columns

### DIFF
--- a/drizzle/migrations/0028_ensure_report_workflow_columns.sql
+++ b/drizzle/migrations/0028_ensure_report_workflow_columns.sql
@@ -1,0 +1,8 @@
+-- Ensure report workflow columns exist even if 0027 was already journaled.
+-- Safe/idempotent for staging and production.
+
+ALTER TABLE "reports"
+  ADD COLUMN IF NOT EXISTS "workflow_stage" text NOT NULL DEFAULT 'sample_received',
+  ADD COLUMN IF NOT EXISTS "special_stain_requested" boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "special_stain_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "workflow_updated_at" timestamp with time zone;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
                         "when":  1777118400000,
                         "tag":  "0027_report_workflow",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  28,
+                        "version":  "7",
+                        "when":  1777122000000,
+                        "tag":  "0028_ensure_report_workflow_columns",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -172,7 +172,7 @@ test("migración 0026 existe y añade contact_email y contact_phone con ADD COLU
   );
 });
 
-test("journal de migraciones conserva 0026 y deja 0027 como última entrada", () => {
+test("journal de migraciones conserva 0026 y deja 0028 como última entrada", () => {
   const raw = read("drizzle/migrations/meta/_journal.json");
   const journal = JSON.parse(raw) as {
     entries: Array<{ idx: number; tag: string }>;
@@ -190,10 +190,10 @@ test("journal de migraciones conserva 0026 y deja 0027 como última entrada", ()
   );
   assert.equal(
     last?.tag,
-    "0027_report_workflow",
-    "la última entrada del journal debe ser 0027_report_workflow",
+    "0028_ensure_report_workflow_columns",
+    "la última entrada del journal debe ser 0028_ensure_report_workflow_columns",
   );
-  assert.equal(last?.idx, 27, "idx de la última migración debe ser 27");
+  assert.equal(last?.idx, 28, "idx de la última migración debe ser 28");
 });
 
 test("toIsoDate acepta Date o string devuelto por raw SQL postgres-js", () => {


### PR DESCRIPTION
Adds an idempotent corrective migration to ensure report workflow columns exist when 0027 has already been journaled but the runtime database is missing the columns.