### PR TITLE
feat(ops): add backend schema health check

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "smoke:test": "node scripts/smoke/smoke-test.mjs",
     "smoke:upload": "node scripts/smoke/smoke-upload.mjs",
     "test": "node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts",
+    "schema:verify": "node scripts/schema-verify.mjs",
     "validate:local": "pnpm typecheck && pnpm typecheck:test && pnpm test && pnpm build"
   },
   "dependencies": {

--- a/scripts/schema-verify.mjs
+++ b/scripts/schema-verify.mjs
@@ -1,0 +1,122 @@
+import "dotenv/config";
+import postgres from "postgres";
+
+const databaseUrl = process.env.SUPABASE_DB_URL || process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  console.error("Error: Falta SUPABASE_DB_URL o DATABASE_URL en .env");
+  process.exit(1);
+}
+
+const CRITICAL_SCHEMA_COLUMNS = {
+  "public.reports": [
+    "id",
+    "clinic_id",
+    "upload_date",
+    "study_type",
+    "patient_name",
+    "file_name",
+    "storage_path",
+    "current_status",
+    "status_changed_at",
+    "workflow_stage",
+    "special_stain_requested",
+    "special_stain_at",
+    "workflow_updated_at",
+    "created_at",
+    "updated_at",
+  ],
+  "public.report_status_history": [
+    "id",
+    "report_id",
+    "from_status",
+    "to_status",
+    "changed_by_clinic_user_id",
+    "changed_by_admin_user_id",
+    "note",
+    "created_at",
+  ],
+  "public.report_access_tokens": [
+    "id",
+    "clinic_id",
+    "report_id",
+    "token_hash",
+    "token_last4",
+    "access_count",
+    "last_access_at",
+    "expires_at",
+    "revoked_at",
+    "created_at",
+    "updated_at",
+  ],
+};
+
+const sql = postgres(databaseUrl, { prepare: false });
+
+try {
+  const rows = await sql`
+    SELECT table_schema, table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name IN ('reports', 'report_status_history', 'report_access_tokens')
+  `;
+
+  const presentSet = new Set(
+    rows.map((r) => `${r.table_schema}.${r.table_name}.${r.column_name}`),
+  );
+
+  let totalMissing = 0;
+  const tableResults = [];
+
+  for (const [tableKey, cols] of Object.entries(CRITICAL_SCHEMA_COLUMNS)) {
+    const [schema, table] = tableKey.split(".");
+    const missingCols = cols.filter(
+      (col) => !presentSet.has(`${schema}.${table}.${col}`),
+    );
+
+    tableResults.push({
+      table: tableKey,
+      required: cols.length,
+      present: cols.length - missingCols.length,
+      missing: missingCols.length,
+      missingColumns: missingCols,
+    });
+
+    totalMissing += missingCols.length;
+  }
+
+  const status = totalMissing === 0 ? "ok" : "degraded";
+
+  console.log(
+    JSON.stringify(
+      {
+        status,
+        generatedAt: new Date().toISOString(),
+        summary: {
+          requiredTables: tableResults.length,
+          totalMissing,
+        },
+        tables: tableResults,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (status !== "ok") {
+    console.error(
+      `\nSchema DEGRADED: faltan ${totalMissing} columna(s) critica(s).`,
+    );
+    process.exit(1);
+  }
+
+  console.log("\nSchema OK: todas las columnas criticas presentes.");
+} catch (err) {
+  console.error(
+    "Error al consultar el esquema:",
+    err instanceof Error ? err.message : String(err),
+  );
+  process.exit(1);
+} finally {
+  await sql.end();
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -61,6 +61,10 @@ import {
   type AdminSystemMaintenanceNativeRoutesOptions,
 } from "./routes/admin-system-maintenance.fastify.ts";
 import {
+  adminSystemSchemaHealthNativeRoutes,
+  type AdminSystemSchemaHealthNativeRoutesOptions,
+} from "./routes/admin-system-schema-health.fastify.ts";
+import {
   clinicAuthNativeRoutes,
   type AuthNativeRoutesOptions,
 } from "./routes/auth.fastify.ts";
@@ -216,6 +220,7 @@ export type CreateFastifyAppOptions = {
   adminStudyTrackingRoutes?: AdminStudyTrackingNativeRoutesOptions;
   adminSystemHealthRoutes?: AdminSystemHealthNativeRoutesOptions;
   adminSystemMaintenanceRoutes?: AdminSystemMaintenanceNativeRoutesOptions;
+  adminSystemSchemaHealthRoutes?: AdminSystemSchemaHealthNativeRoutesOptions;
   adminUsersRolesRoutes?: AdminUsersRolesNativeRoutesOptions;
   clinicAuthRoutes?: AuthNativeRoutesOptions;
   contactRoutes?: ContactNativeRoutesOptions;
@@ -373,6 +378,11 @@ export async function createFastifyApp(
   await app.register(adminSystemMaintenanceNativeRoutes, {
     prefix: "/api/admin/system/maintenance",
     ...(options.adminSystemMaintenanceRoutes ?? {}),
+  });
+
+  await app.register(adminSystemSchemaHealthNativeRoutes, {
+    prefix: "/api/admin/system/schema-health",
+    ...(options.adminSystemSchemaHealthRoutes ?? {}),
   });
 
   await app.register(adminUsersRolesNativeRoutes, {

--- a/server/lib/schema-health.ts
+++ b/server/lib/schema-health.ts
@@ -151,12 +151,18 @@ export function buildSchemaHealthSnapshotFromRows(
 }
 
 export async function getSchemaHealthSnapshot(): Promise<SchemaHealthSnapshot> {
-  const rows = await pgClient`
+  const result = await pgClient`
     SELECT table_schema, table_name, column_name
     FROM information_schema.columns
     WHERE table_schema = 'public'
     AND table_name IN ('reports', 'report_status_history', 'report_access_tokens')
   `;
+
+  const rows = Array.from(result).map((row) => ({
+    table_schema: String(row.table_schema),
+    table_name: String(row.table_name),
+    column_name: String(row.column_name),
+  }));
 
   return buildSchemaHealthSnapshotFromRows(rows, new Date().toISOString());
 }

--- a/server/lib/schema-health.ts
+++ b/server/lib/schema-health.ts
@@ -1,0 +1,162 @@
+import { pgClient } from "../db.ts";
+
+export type SchemaHealthStatus = "ok" | "degraded";
+
+export type SchemaHealthColumnCheck = {
+  name: string;
+  present: boolean;
+};
+
+export type SchemaHealthTableCheck = {
+  schema: "public";
+  table: string;
+  status: SchemaHealthStatus;
+  requiredColumns: number;
+  presentColumns: number;
+  missingColumns: number;
+  columns: SchemaHealthColumnCheck[];
+  missingColumnNames: string[];
+};
+
+export type SchemaHealthMissingColumn = {
+  schema: "public";
+  table: string;
+  column: string;
+};
+
+export type SchemaHealthSnapshot = {
+  success: boolean;
+  status: SchemaHealthStatus;
+  generatedAt: string;
+  summary: {
+    requiredTables: number;
+    requiredColumns: number;
+    presentColumns: number;
+    missingColumns: number;
+  };
+  tables: SchemaHealthTableCheck[];
+  missing: SchemaHealthMissingColumn[];
+};
+
+export const CRITICAL_SCHEMA_COLUMNS: Readonly<Record<string, readonly string[]>> = {
+  "public.reports": [
+    "id",
+    "clinic_id",
+    "upload_date",
+    "study_type",
+    "patient_name",
+    "file_name",
+    "storage_path",
+    "current_status",
+    "status_changed_at",
+    "workflow_stage",
+    "special_stain_requested",
+    "special_stain_at",
+    "workflow_updated_at",
+    "created_at",
+    "updated_at",
+  ],
+  "public.report_status_history": [
+    "id",
+    "report_id",
+    "from_status",
+    "to_status",
+    "changed_by_clinic_user_id",
+    "changed_by_admin_user_id",
+    "note",
+    "created_at",
+  ],
+  "public.report_access_tokens": [
+    "id",
+    "clinic_id",
+    "report_id",
+    "token_hash",
+    "token_last4",
+    "access_count",
+    "last_access_at",
+    "expires_at",
+    "revoked_at",
+    "created_at",
+    "updated_at",
+  ],
+};
+
+export function buildSchemaHealthSnapshotFromRows(
+  rows: Array<{ table_schema: unknown; table_name: unknown; column_name: unknown }>,
+  generatedAt?: string,
+): SchemaHealthSnapshot {
+  const timestamp = generatedAt ?? new Date().toISOString();
+
+  const presentSet = new Set<string>(
+    rows.map(
+      (r) =>
+        `${String(r.table_schema)}.${String(r.table_name)}.${String(r.column_name)}`,
+    ),
+  );
+
+  const tableChecks: SchemaHealthTableCheck[] = [];
+  const allMissing: SchemaHealthMissingColumn[] = [];
+
+  for (const [tableKey, requiredCols] of Object.entries(CRITICAL_SCHEMA_COLUMNS)) {
+    const dotIndex = tableKey.indexOf(".");
+    const schema = tableKey.slice(0, dotIndex) as "public";
+    const table = tableKey.slice(dotIndex + 1);
+
+    const columns: SchemaHealthColumnCheck[] = requiredCols.map((col) => ({
+      name: col,
+      present: presentSet.has(`${schema}.${table}.${col}`),
+    }));
+
+    const missingColumnNames = columns.filter((c) => !c.present).map((c) => c.name);
+    const presentCount = columns.filter((c) => c.present).length;
+    const missingCount = missingColumnNames.length;
+
+    for (const col of missingColumnNames) {
+      allMissing.push({ schema, table, column: col });
+    }
+
+    tableChecks.push({
+      schema,
+      table,
+      status: missingCount === 0 ? "ok" : "degraded",
+      requiredColumns: requiredCols.length,
+      presentColumns: presentCount,
+      missingColumns: missingCount,
+      columns,
+      missingColumnNames,
+    });
+  }
+
+  const totalRequired = Object.values(CRITICAL_SCHEMA_COLUMNS).reduce(
+    (sum, cols) => sum + cols.length,
+    0,
+  );
+  const totalPresent = tableChecks.reduce((sum, t) => sum + t.presentColumns, 0);
+  const totalMissing = allMissing.length;
+  const overallStatus: SchemaHealthStatus = totalMissing === 0 ? "ok" : "degraded";
+
+  return {
+    success: overallStatus === "ok",
+    status: overallStatus,
+    generatedAt: timestamp,
+    summary: {
+      requiredTables: tableChecks.length,
+      requiredColumns: totalRequired,
+      presentColumns: totalPresent,
+      missingColumns: totalMissing,
+    },
+    tables: tableChecks,
+    missing: allMissing,
+  };
+}
+
+export async function getSchemaHealthSnapshot(): Promise<SchemaHealthSnapshot> {
+  const rows = await pgClient`
+    SELECT table_schema, table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name IN ('reports', 'report_status_history', 'report_access_tokens')
+  `;
+
+  return buildSchemaHealthSnapshotFromRows(rows, new Date().toISOString());
+}

--- a/server/routes/admin-system-schema-health.fastify.ts
+++ b/server/routes/admin-system-schema-health.fastify.ts
@@ -1,0 +1,410 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+
+import { ENV } from "../lib/env.ts";
+import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import type { SchemaHealthSnapshot } from "../lib/schema-health.ts";
+
+type AdminSessionRecord = {
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AuthenticatedAdminUser = {
+  id: number;
+  username: string;
+  sessionToken: string;
+};
+
+export type AdminSystemSchemaHealthNativeRoutesOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionRecord | null>;
+  getAdminUserById?: (
+    adminUserId: number,
+  ) => Promise<SessionAdminUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getSchemaHealthSnapshot?: () => Promise<SchemaHealthSnapshot>;
+  now?: () => number;
+};
+
+type NativeAdminSystemSchemaHealthDeps = Required<
+  Pick<
+    AdminSystemSchemaHealthNativeRoutesOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionByToken"
+    | "getAdminUserById"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getSchemaHealthSnapshot"
+  >
+>;
+
+let defaultDepsPromise: Promise<NativeAdminSystemSchemaHealthDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminSystemSchemaHealthDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const db = await import("../db.ts");
+      const authSecurity = await import("../lib/auth-security.ts");
+      const schemaHealth = await import("../lib/schema-health.ts");
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionByToken: db.getAdminSessionByToken,
+        getAdminUserById: db.getAdminUserById,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getSchemaHealthSnapshot: schemaHealth.getSchemaHealthSnapshot,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+function parseCookies(cookieHeader: string | undefined) {
+  const result: Record<string, string> = {};
+
+  if (!cookieHeader) {
+    return result;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.split("=");
+
+    if (!rawName) {
+      continue;
+    }
+
+    const name = rawName.trim();
+
+    if (!name) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join("=").trim();
+
+    try {
+      result[name] = decodeURIComponent(rawValue);
+    } catch {
+      result[name] = rawValue;
+    }
+  }
+
+  return result;
+}
+
+function getAdminSessionToken(request: FastifyRequest) {
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
+
+  const cookies = parseCookies(cookieHeader);
+  const raw = cookies[ENV.adminCookieName];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function serializeCookie(input: {
+  name: string;
+  value: string;
+  maxAgeSeconds?: number;
+  expires?: string;
+}) {
+  const parts = [
+    `${input.name}=${encodeURIComponent(input.value)}`,
+    "Path=/",
+    "HttpOnly",
+    `SameSite=${ENV.cookieSameSite}`,
+  ];
+
+  if (ENV.cookieSecure) {
+    parts.push("Secure");
+  }
+
+  if (typeof input.maxAgeSeconds === "number") {
+    parts.push(`Max-Age=${input.maxAgeSeconds}`);
+  }
+
+  if (input.expires) {
+    parts.push(`Expires=${input.expires}`);
+  }
+
+  return parts.join("; ");
+}
+
+function buildClearAdminSessionCookie() {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: "",
+    maxAgeSeconds: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 GMT",
+  });
+}
+
+async function authenticateAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: NativeAdminSystemSchemaHealthDeps,
+  now: () => number,
+): Promise<AuthenticatedAdminUser | null> {
+  const token = getAdminSessionToken(request);
+
+  if (!token) {
+    reply.code(401).send({
+      success: false,
+      error: "Admin no autenticado",
+    });
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(token);
+  const session = await deps.getAdminSessionByToken(tokenHash);
+
+  if (!session) {
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin inválida",
+    });
+    return null;
+  }
+
+  if (session.expiresAt && session.expiresAt.getTime() <= now()) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Sesión admin expirada",
+    });
+    return null;
+  }
+
+  const adminUser = await deps.getAdminUserById(session.adminUserId);
+
+  if (!adminUser) {
+    await deps.deleteAdminSession(tokenHash);
+
+    reply.header("set-cookie", buildClearAdminSessionCookie());
+    reply.code(401).send({
+      success: false,
+      error: "Usuario admin de sesión no encontrado",
+    });
+    return null;
+  }
+
+  if (shouldRefreshSessionLastAccess(session.lastAccess ?? null, now())) {
+    await deps.updateAdminSessionLastAccess(tokenHash);
+  }
+
+  return {
+    id: adminUser.id,
+    username: adminUser.username,
+    sessionToken: token,
+  };
+}
+
+function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getOriginHeader(request: FastifyRequest) {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+function applyCorsHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  const allowedOrigin = getAllowedOriginForCors(request, allowedOrigins);
+
+  if (!allowedOrigin) {
+    return;
+  }
+
+  reply.header("vary", "Origin");
+  reply.header("access-control-allow-origin", allowedOrigin);
+  reply.header("access-control-allow-credentials", "true");
+}
+
+export const adminSystemSchemaHealthNativeRoutes: FastifyPluginAsync<
+  AdminSystemSchemaHealthNativeRoutesOptions
+> = async (app, options) => {
+  const hasAllInjectedDeps =
+    !!options.deleteAdminSession &&
+    !!options.getAdminSessionByToken &&
+    !!options.getAdminUserById &&
+    !!options.updateAdminSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getSchemaHealthSnapshot;
+
+  const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
+
+  const deps: NativeAdminSystemSchemaHealthDeps = {
+    deleteAdminSession:
+      options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+    getAdminSessionByToken:
+      options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
+    getAdminUserById: options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+    updateAdminSessionLastAccess:
+      options.updateAdminSessionLastAccess ??
+      defaultDeps!.updateAdminSessionLastAccess,
+    hashSessionToken: options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+    getSchemaHealthSnapshot:
+      options.getSchemaHealthSnapshot ?? defaultDeps!.getSchemaHealthSnapshot,
+  };
+
+  const now = options.now ?? (() => Date.now());
+  const allowedOrigins = new Set(getAllowedOrigins());
+
+  app.addHook("onRequest", async (request, reply) => {
+    applyCorsHeaders(request, reply, allowedOrigins);
+  });
+
+  const optionsHandler = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const requestOrigin = getRequestOrigin(request);
+
+    if (requestOrigin && !allowedOrigins.has(requestOrigin)) {
+      return reply.code(403).send({
+        success: false,
+        error: "Origen no permitido",
+      });
+    }
+
+    applyCorsHeaders(request, reply, allowedOrigins);
+    reply.header("access-control-allow-methods", "GET,OPTIONS");
+
+    const requestedHeaders =
+      typeof request.headers["access-control-request-headers"] === "string"
+        ? request.headers["access-control-request-headers"]
+        : "content-type";
+
+    reply.header("access-control-allow-headers", requestedHeaders);
+    return reply.code(204).send();
+  };
+
+  app.options("/", optionsHandler);
+
+  app.get("/", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    let snapshot: SchemaHealthSnapshot;
+
+    try {
+      snapshot = await deps.getSchemaHealthSnapshot();
+    } catch {
+      return reply.code(500).send({
+        success: false,
+        error: "Error al consultar el esquema de base de datos",
+      });
+    }
+
+    const statusCode = snapshot.status === "ok" ? 200 : 503;
+
+    return reply.code(statusCode).send({
+      success: snapshot.success,
+      checkedBy: {
+        adminUserId: admin.id,
+        username: admin.username,
+      },
+      status: snapshot.status,
+      generatedAt: snapshot.generatedAt,
+      summary: snapshot.summary,
+      tables: snapshot.tables,
+      missing: snapshot.missing,
+    });
+  });
+};

--- a/test/admin-system-schema-health.fastify.test.ts
+++ b/test/admin-system-schema-health.fastify.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.CORS_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
+
+const { ENV } = await import("../server/lib/env.ts");
+const { adminSystemSchemaHealthNativeRoutes } = await import(
+  "../server/routes/admin-system-schema-health.fastify.ts"
+);
+
+const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
+
+const okSnapshot = {
+  success: true,
+  status: "ok" as const,
+  generatedAt: "2026-05-27T00:00:00.000Z",
+  summary: {
+    requiredTables: 3,
+    requiredColumns: 34,
+    presentColumns: 34,
+    missingColumns: 0,
+  },
+  tables: [],
+  missing: [],
+};
+
+const degradedSnapshot = {
+  success: false,
+  status: "degraded" as const,
+  generatedAt: "2026-05-27T00:00:00.000Z",
+  summary: {
+    requiredTables: 3,
+    requiredColumns: 34,
+    presentColumns: 33,
+    missingColumns: 1,
+  },
+  tables: [],
+  missing: [
+    { schema: "public" as const, table: "reports", column: "workflow_stage" },
+  ],
+};
+
+function buildDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({ id: 1, username: "VETNEB" }),
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSchemaHealthSnapshot: async () => okSnapshot,
+    ...overrides,
+  };
+}
+
+test("admin schema health 401 sin cookie", async () => {
+  const app = Fastify();
+  await app.register(adminSystemSchemaHealthNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({ method: "GET", url: "/" });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin schema health 200 con admin valido y schema ok", async () => {
+  const app = Fastify();
+  await app.register(adminSystemSchemaHealthNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: { cookie: `${ENV.adminCookieName}=admin-session-token` },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.status, "ok");
+    assert.deepEqual(body.checkedBy, { adminUserId: 1, username: "VETNEB" });
+    assert.equal(body.generatedAt, okSnapshot.generatedAt);
+    assert.deepEqual(body.summary, okSnapshot.summary);
+    assert.deepEqual(body.missing, []);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin schema health 503 con admin valido y schema degraded", async () => {
+  const app = Fastify();
+  await app.register(
+    adminSystemSchemaHealthNativeRoutes,
+    buildDeps({ getSchemaHealthSnapshot: async () => degradedSnapshot }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: { cookie: `${ENV.adminCookieName}=admin-session-token` },
+    });
+
+    assert.equal(response.statusCode, 503);
+
+    const body = JSON.parse(response.body);
+
+    assert.equal(body.success, false);
+    assert.equal(body.status, "degraded");
+    assert.equal(body.summary.missingColumns, 1);
+    assert.deepEqual(body.missing, degradedSnapshot.missing);
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: OPTIONS con origin permitido devuelve 204 en schema-health", async () => {
+  const app = Fastify();
+  await app.register(adminSystemSchemaHealthNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+    assert.equal(
+      response.headers["access-control-allow-methods"],
+      "GET,OPTIONS",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: GET con origin permitido devuelve access-control-allow-origin en schema-health", async () => {
+  const app = Fastify();
+  await app.register(adminSystemSchemaHealthNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        origin: STAGING_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(
+      response.headers["access-control-allow-credentials"],
+      "true",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: origin no permitido no recibe access-control-allow-origin en schema-health", async () => {
+  const app = Fastify();
+  await app.register(adminSystemSchemaHealthNativeRoutes, buildDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/",
+      headers: {
+        origin: "https://evil.example.com",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      undefined,
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/test/schema-health.lib.test.ts
+++ b/test/schema-health.lib.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+
+const { CRITICAL_SCHEMA_COLUMNS, buildSchemaHealthSnapshotFromRows } =
+  await import("../server/lib/schema-health.ts");
+
+function allPresentRows() {
+  const rows: Array<{
+    table_schema: string;
+    table_name: string;
+    column_name: string;
+  }> = [];
+
+  for (const [key, cols] of Object.entries(CRITICAL_SCHEMA_COLUMNS)) {
+    const dotIndex = key.indexOf(".");
+    const schema = key.slice(0, dotIndex);
+    const table = key.slice(dotIndex + 1);
+
+    for (const col of cols) {
+      rows.push({ table_schema: schema, table_name: table, column_name: col });
+    }
+  }
+
+  return rows;
+}
+
+function rowsWithout(tableName: string, column: string) {
+  return allPresentRows().filter(
+    (r) => !(r.table_name === tableName && r.column_name === column),
+  );
+}
+
+test("CRITICAL_SCHEMA_COLUMNS includes reports.workflow_stage", () => {
+  assert.ok(
+    CRITICAL_SCHEMA_COLUMNS["public.reports"].includes("workflow_stage"),
+  );
+});
+
+test("CRITICAL_SCHEMA_COLUMNS includes reports.special_stain_requested", () => {
+  assert.ok(
+    CRITICAL_SCHEMA_COLUMNS["public.reports"].includes(
+      "special_stain_requested",
+    ),
+  );
+});
+
+test("CRITICAL_SCHEMA_COLUMNS includes reports.special_stain_at", () => {
+  assert.ok(
+    CRITICAL_SCHEMA_COLUMNS["public.reports"].includes("special_stain_at"),
+  );
+});
+
+test("CRITICAL_SCHEMA_COLUMNS includes reports.workflow_updated_at", () => {
+  assert.ok(
+    CRITICAL_SCHEMA_COLUMNS["public.reports"].includes("workflow_updated_at"),
+  );
+});
+
+test("buildSchemaHealthSnapshotFromRows marca ok cuando todas las columnas estan presentes", () => {
+  const snapshot = buildSchemaHealthSnapshotFromRows(
+    allPresentRows(),
+    "2026-05-27T00:00:00.000Z",
+  );
+
+  assert.equal(snapshot.status, "ok");
+  assert.equal(snapshot.success, true);
+  assert.equal(snapshot.missing.length, 0);
+  assert.equal(snapshot.generatedAt, "2026-05-27T00:00:00.000Z");
+
+  for (const table of snapshot.tables) {
+    assert.equal(table.status, "ok");
+    assert.equal(table.missingColumns, 0);
+    assert.deepEqual(table.missingColumnNames, []);
+  }
+});
+
+test("buildSchemaHealthSnapshotFromRows marca degraded si falta reports.workflow_stage", () => {
+  const rows = rowsWithout("reports", "workflow_stage");
+  const snapshot = buildSchemaHealthSnapshotFromRows(
+    rows,
+    "2026-05-27T00:00:00.000Z",
+  );
+
+  assert.equal(snapshot.status, "degraded");
+  assert.equal(snapshot.success, false);
+  assert.equal(snapshot.missing.length, 1);
+  assert.deepEqual(snapshot.missing[0], {
+    schema: "public",
+    table: "reports",
+    column: "workflow_stage",
+  });
+
+  const reportsTable = snapshot.tables.find((t) => t.table === "reports");
+  assert.ok(reportsTable);
+  assert.equal(reportsTable.status, "degraded");
+  assert.ok(reportsTable.missingColumnNames.includes("workflow_stage"));
+});
+
+test("buildSchemaHealthSnapshotFromRows marca degraded si falta reports.special_stain_requested", () => {
+  const rows = rowsWithout("reports", "special_stain_requested");
+  const snapshot = buildSchemaHealthSnapshotFromRows(
+    rows,
+    "2026-05-27T00:00:00.000Z",
+  );
+
+  assert.equal(snapshot.status, "degraded");
+  assert.equal(snapshot.success, false);
+
+  const reportsTable = snapshot.tables.find((t) => t.table === "reports");
+  assert.ok(reportsTable);
+  assert.equal(reportsTable.status, "degraded");
+  assert.ok(
+    reportsTable.missingColumnNames.includes("special_stain_requested"),
+  );
+});
+
+test("buildSchemaHealthSnapshotFromRows summary cuenta correctamente requiredColumns presentColumns y missingColumns", () => {
+  const rows = rowsWithout("reports", "workflow_stage");
+  const snapshot = buildSchemaHealthSnapshotFromRows(rows);
+
+  const totalRequired = Object.values(CRITICAL_SCHEMA_COLUMNS).reduce(
+    (sum, cols) => sum + cols.length,
+    0,
+  );
+
+  assert.equal(snapshot.summary.requiredTables, 3);
+  assert.equal(snapshot.summary.requiredColumns, totalRequired);
+  assert.equal(snapshot.summary.presentColumns, totalRequired - 1);
+  assert.equal(snapshot.summary.missingColumns, 1);
+});

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -55,6 +55,8 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           'prefix: "/api/admin/system/health"',
           "adminSystemMaintenanceNativeRoutes",
           'prefix: "/api/admin/system/maintenance"',
+          "adminSystemSchemaHealthNativeRoutes",
+          'prefix: "/api/admin/system/schema-health"',
           "adminUsersRolesNativeRoutes",
           'prefix: "/api/admin/users-roles"',
         ],
@@ -101,6 +103,10 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
       },
       {
         path: "server/routes/admin-system-maintenance.fastify.ts",
+        markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
+      },
+      {
+        path: "server/routes/admin-system-schema-health.fastify.ts",
         markers: ["cookies[ENV.adminCookieName]", "name: ENV.adminCookieName"],
       },
       {

--- a/test/security-cross-auth-surface-boundaries.test.ts
+++ b/test/security-cross-auth-surface-boundaries.test.ts
@@ -29,6 +29,7 @@ const adminFiles = [
   "server/routes/admin-study-tracking.fastify.ts",
   "server/routes/admin-system-health.fastify.ts",
   "server/routes/admin-system-maintenance.fastify.ts",
+  "server/routes/admin-system-schema-health.fastify.ts",
   "server/routes/admin-users-roles.fastify.ts",
 ] as const;
 
@@ -136,6 +137,7 @@ test("cross auth surface registry keeps every protected route family explicit", 
       "server/routes/admin-study-tracking.fastify.ts",
       "server/routes/admin-system-health.fastify.ts",
       "server/routes/admin-system-maintenance.fastify.ts",
+      "server/routes/admin-system-schema-health.fastify.ts",
       "server/routes/admin-users-roles.fastify.ts",
       "server/routes/particular-audit.fastify.ts",
       "server/routes/particular-auth.fastify.ts",

--- a/test/security-session-cookie-boundaries.test.ts
+++ b/test/security-session-cookie-boundaries.test.ts
@@ -44,6 +44,7 @@ const ADMIN_SESSION_FILES = [
   "server/routes/admin-study-tracking.fastify.ts",
   "server/routes/admin-system-health.fastify.ts",
   "server/routes/admin-system-maintenance.fastify.ts",
+  "server/routes/admin-system-schema-health.fastify.ts",
   "server/routes/admin-users-roles.fastify.ts",
 ] as const;
 


### PR DESCRIPTION
## Summary
- Add backend schema health snapshot for critical DB columns.
- Add protected admin endpoint GET /api/admin/system/schema-health.
- Add standalone pnpm schema:verify CLI.
- Add backend tests and security guardrail registry entries.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm schema:verify

## Schema verification
schema:verify returned status ok with 0 missing critical columns.