### PR TITLE
feat(admin): add schema health status card

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminSchemaHealthStatusCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSchemaHealthStatusCard.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getAdminSchemaHealth } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type { AdminSchemaHealthSnapshot } from "@/types";
+
+function getSchemaStatusVariant(
+  status: AdminSchemaHealthSnapshot["status"],
+): "default" | "secondary" | "destructive" | "outline" {
+  return status === "ok" ? "default" : "secondary";
+}
+
+function formatSchemaStatusLabel(
+  status: AdminSchemaHealthSnapshot["status"],
+) {
+  return status === "ok" ? "Esquema compatible" : "Faltan columnas críticas";
+}
+
+function formatGeneratedAt(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return formatDateTime(date.toISOString());
+}
+
+function sanitizeSchemaHealthError(error: unknown) {
+  const fallbackMessage =
+    "No se pudo consultar el estado del esquema. Reintentá en unos segundos.";
+
+  if (!(error instanceof Error)) {
+    return fallbackMessage;
+  }
+
+  const message = error.message.trim();
+  if (!message) {
+    return fallbackMessage;
+  }
+
+  if (message.startsWith("HTTP ")) {
+    return fallbackMessage;
+  }
+
+  return message;
+}
+
+export function AdminSchemaHealthStatusCard() {
+  const [snapshot, setSnapshot] = useState<AdminSchemaHealthSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function loadSchemaHealth() {
+    setError(null);
+
+    startTransition(() => {
+      void (async () => {
+        try {
+          const result = await getAdminSchemaHealth();
+          setSnapshot(result);
+        } catch (fetchError) {
+          setSnapshot(null);
+          setError(sanitizeSchemaHealthError(fetchError));
+        } finally {
+          setHasLoadedOnce(true);
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    loadSchemaHealth();
+  }, []);
+
+  const showLoadingState = !hasLoadedOnce && !snapshot && !error;
+  const showDegradedState = snapshot?.status === "degraded";
+
+  return (
+    <Card id="admin-schema-health" className="dashboard-surface">
+      <CardHeader className="flex flex-col gap-3 border-b border-vetneb-line/70 md:flex-row md:items-start md:justify-between">
+        <div>
+          <CardTitle className="text-base">Estado de esquema</CardTitle>
+          <CardDescription>
+            Validación de columnas críticas requeridas por el backend.
+          </CardDescription>
+        </div>
+        <Button type="button" variant="outline" onClick={loadSchemaHealth} disabled={isPending}>
+          {isPending ? "Consultando..." : "Reintentar"}
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-4 pt-6">
+        {showLoadingState ? (
+          <div className="surface-empty">
+            Consultando estado de esquema...
+          </div>
+        ) : null}
+
+        {error ? (
+          <div role="alert" className="clinical-alert-error">
+            {error}
+          </div>
+        ) : null}
+
+        {snapshot ? (
+          <>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Estado</p>
+                <div className="mt-2">
+                  <Badge variant={getSchemaStatusVariant(snapshot.status)}>
+                    {formatSchemaStatusLabel(snapshot.status)}
+                  </Badge>
+                </div>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Generado</p>
+                <p className="mt-1 text-sm font-semibold text-vetneb-ink">
+                  {formatGeneratedAt(snapshot.generatedAt)}
+                </p>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Revisado por</p>
+                <p className="mt-1 text-sm font-semibold text-vetneb-ink">
+                  {snapshot.checkedBy
+                    ? `${snapshot.checkedBy.username} #${snapshot.checkedBy.adminUserId}`
+                    : "—"}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Tablas requeridas</p>
+                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                  {snapshot.summary.requiredTables}
+                </p>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Columnas requeridas</p>
+                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                  {snapshot.summary.requiredColumns}
+                </p>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Columnas presentes</p>
+                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                  {snapshot.summary.presentColumns}
+                </p>
+              </div>
+              <div className="surface-soft">
+                <p className="text-xs text-muted-foreground">Columnas faltantes</p>
+                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                  {snapshot.summary.missingColumns}
+                </p>
+              </div>
+            </div>
+
+            {showDegradedState ? (
+              <div className="clinical-alert-warning">
+                <p className="font-semibold">Faltan columnas críticas.</p>
+                {snapshot.missing.length ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+                    {snapshot.missing.map((missingColumn) => (
+                      <li
+                        key={`${missingColumn.schema}.${missingColumn.table}.${missingColumn.column}`}
+                        className="font-mono"
+                      >
+                        {missingColumn.schema}.{missingColumn.table}.{missingColumn.column}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-sm">
+                    No se recibió detalle de columnas faltantes.
+                  </p>
+                )}
+              </div>
+            ) : null}
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -23,6 +23,7 @@ import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsRead
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminParticularTokensCard } from "./AdminParticularTokensCard";
 import { AdminPricingEditorCard } from "./AdminPricingEditorCard";
+import { AdminSchemaHealthStatusCard } from "./AdminSchemaHealthStatusCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
 import { AdminReportWorkflowViewerCard } from "@/components/dashboard/AdminReportWorkflowViewerCard";
@@ -602,6 +603,9 @@ export default async function AdminPage({
             </div>
           </CardContent>
         </Card>
+        <section id="admin-schema-health">
+          <AdminSchemaHealthStatusCard />
+        </section>
         <section id="admin-maintenance">
           <AdminMaintenanceDryRunCard />
         </section>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   ParticularLoginCredentials,
   DashboardStats,
   SystemHealth,
+  AdminSchemaHealthSnapshot,
   MaintenancePurgeDryRunSnapshot,
   AdminSessionsQuery,
   AdminSessionsSnapshot,
@@ -52,6 +53,8 @@ export const BACKEND_CONNECTION_ERROR_MESSAGE =
   "No se pudo conectar con el backend. Verifique sesión admin, CORS y despliegue backend/frontend.";
 export const BACKEND_OPERATION_ERROR_MESSAGE =
   "El backend no pudo completar la operación. Reintentá y, si persiste, revisá estado del sistema y logs de backend.";
+export const ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE =
+  "Sesión admin no autenticada o inválida. Iniciá sesión nuevamente.";
 
 function isLocalOrLanHostname(hostname: string): boolean {
   const normalizedHost = hostname.trim().toLowerCase();
@@ -1015,6 +1018,87 @@ export async function getAdminSystemHealth(
     warnApiFallback("getAdminSystemHealth", error);
     return null;
   }
+}
+
+function readBackendMessageFromBody(body: unknown): string | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const bodyRecord = body as Record<string, unknown>;
+  const errorValue = bodyRecord.error;
+  const messageValue = bodyRecord.message;
+
+  if (typeof errorValue === "string" && errorValue.trim()) {
+    return errorValue;
+  }
+
+  if (typeof messageValue === "string" && messageValue.trim()) {
+    return messageValue;
+  }
+
+  return null;
+}
+
+export async function getAdminSchemaHealth(
+  options?: RequestInit,
+): Promise<AdminSchemaHealthSnapshot> {
+  const apiBaseUrl = resolveApiBaseUrlForRuntime();
+  const headers = new Headers(options?.headers);
+
+  let res: Response;
+
+  try {
+    res = await fetch(`${apiBaseUrl}/api/admin/system/schema-health`, {
+      ...options,
+      credentials: options?.credentials ?? "include",
+      headers,
+    });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      const errorDetail =
+        error instanceof Error ? error.message : String(error);
+      console.warn(`[API] /api/admin/system/schema-health: ${errorDetail}`);
+    }
+
+    if (error instanceof TypeError) {
+      throw new Error(BACKEND_CONNECTION_ERROR_MESSAGE);
+    }
+
+    throw error;
+  }
+
+  const body = (await res.json().catch(() => null)) as unknown;
+  const backendMessage = readBackendMessageFromBody(body);
+
+  if (res.status === 401) {
+    throw new Error(ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE);
+  }
+
+  const parsedSnapshot =
+    body && typeof body === "object"
+      ? (body as Partial<AdminSchemaHealthSnapshot>)
+      : null;
+  const parsedStatus = parsedSnapshot?.status;
+  const hasValidSchemaHealthStatus =
+    parsedStatus === "ok" || parsedStatus === "degraded";
+
+  if (
+    (res.status === 200 || res.status === 503) &&
+    hasValidSchemaHealthStatus
+  ) {
+    return parsedSnapshot as AdminSchemaHealthSnapshot;
+  }
+
+  if (backendMessage) {
+    throw new Error(backendMessage);
+  }
+
+  if (res.status >= 500) {
+    throw new Error(BACKEND_OPERATION_ERROR_MESSAGE);
+  }
+
+  throw new Error(`HTTP ${res.status}`);
 }
 
 export async function getAdminUsersRoles(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -507,3 +507,49 @@ export type SystemHealth = {
   };
   health?: Record<string, unknown>;
 };
+
+export type AdminSchemaHealthStatus = "ok" | "degraded";
+
+export type AdminSchemaHealthCheckedBy = {
+  adminUserId: string | number;
+  username: string;
+};
+
+export type AdminSchemaHealthSummary = {
+  requiredTables: number;
+  requiredColumns: number;
+  presentColumns: number;
+  missingColumns: number;
+};
+
+export type AdminSchemaHealthColumn = {
+  name: string;
+  present: boolean;
+};
+
+export type AdminSchemaHealthTable = {
+  schema: string;
+  table: string;
+  status: AdminSchemaHealthStatus;
+  requiredColumns: number;
+  presentColumns: number;
+  missingColumns: number;
+  columns: AdminSchemaHealthColumn[];
+  missingColumnNames: string[];
+};
+
+export type AdminSchemaHealthMissingColumn = {
+  schema: string;
+  table: string;
+  column: string;
+};
+
+export type AdminSchemaHealthSnapshot = {
+  success: boolean;
+  checkedBy?: AdminSchemaHealthCheckedBy;
+  status: AdminSchemaHealthStatus;
+  generatedAt: string;
+  summary: AdminSchemaHealthSummary;
+  tables: AdminSchemaHealthTable[];
+  missing: AdminSchemaHealthMissingColumn[];
+};


### PR DESCRIPTION
## Summary
- Add Admin card for DB schema health status.
- Consume GET /api/admin/system/schema-health from frontend.
- Handle loading, ok, degraded, 401, and sanitized API/network errors.
- Treat HTTP 503 with degraded body as operational status, not generic failure.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Notes
- pnpm --dir frontend e2e was attempted locally but could not run because Playwright Chromium is not installed in the local environment.