### PR TITLE
feat(ops): wire schema verify into local validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "smoke:staging": "powershell -ExecutionPolicy Bypass -File scripts/dev/smoke-staging.ps1",
     "test": "node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts",
     "schema:verify": "node scripts/schema-verify.mjs",
-    "validate:local": "pnpm typecheck && pnpm typecheck:test && pnpm test && pnpm build"
+    "validate:local": "pnpm typecheck && pnpm typecheck:test && pnpm test && pnpm build",
+    "validate:local:schema": "pnpm validate:local && pnpm schema:verify"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.106.1",


### PR DESCRIPTION
## Summary
- Add validate:local:schema to run the existing local validation flow plus schema verification.
- Keep validate:local unchanged because package script guardrails assert its contract.
- Avoid wiring schema verification into CI or workflows.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm schema:verify
- pnpm validate:local:schema

## Schema verification
- schema:verify returned status ok
- requiredTables: 3
- totalMissing: 0