### PR TITLE
ops(smoke): extend staging smoke authenticated flows

### DIFF
--- a/docs/production-readiness-evidence.md
+++ b/docs/production-readiness-evidence.md
@@ -32,8 +32,8 @@ criterios formales de salida.
 | ID | Grupo | Severidad | Estado | Evidencia requerida | Comando PowerShell / accion | Criterio de cierre |
 |---|---|---|---|---|---|---|
 | P0-001 | CI | P0 | Abierto | Backend y frontend verdes en commit candidato | Revisar runs CI del commit (`gh run list --commit a65a43e`) o panel CI | Ambos pipelines exitosos, sin jobs requeridos en rojo |
-| P0-002 | Staging smoke | P0 | Abierto | Smoke autenticado admin/clinic/particular | `pnpm smoke:staging` + evidencia manual sanitizada | Flujos core de los 3 perfiles completan sin error |
-| P0-003 | Schema health | P0 | Abierto | Estado de esquema admin en staging | `Invoke-RestMethod "$BackendUrl/api/admin/system/schema-health"` (con sesion valida) | Resultado consistente y sin drift bloqueante |
+| P0-002 | Staging smoke | P0 | Abierto | Smoke autenticado admin/clinic/particular | `pnpm smoke:staging` (modo autenticado opcional con `SMOKE_*`) + evidencia manual sanitizada | Flujos core de los 3 perfiles completan sin error; si faltan credenciales, checks autenticados quedan en SKIP |
+| P0-003 | Schema health | P0 | Abierto | Estado de esquema admin en staging (smoke autenticado) | `pnpm smoke:staging` con `SMOKE_ADMIN_USERNAME` y `SMOKE_ADMIN_PASSWORD` (check `/api/admin/system/schema-health`) | `status=ok` para cierre; `status=degraded` mantiene P0 Abierto y evidencia runtime/staging pendiente |
 | P0-004 | Config staging | P0 | Abierto | Variables Render staging configuradas y sanitizadas | Verificacion manual en Render (captura con valores ocultos) | Variables requeridas presentes, sin secretos expuestos |
 | P0-005 | Config produccion | P0 | Abierto | Variables Render produccion configuradas y sanitizadas | Verificacion manual en Render (captura con valores ocultos) | Variables requeridas presentes, sin secretos expuestos |
 | P0-006 | DB staging | P0 | Abierto | DB staging migrada + `schema:verify` OK | `pnpm schema:verify` sobre entorno staging controlado | Migraciones aplicadas y verify en verde |
@@ -43,8 +43,8 @@ criterios formales de salida.
 | P0-010 | Signed URL | P0 | Abierto | Signed URL staging sin exposicion en logs | Descarga controlada + revision de logs sanitizados | URLs firmadas no aparecen completas en logs |
 | P0-011 | Avatar/logo | P0 | Abierto | Upload de avatar/logo funcional en staging | Ejecutar flujo manual de avatar/logo en staging | Upload/update/delete correcto por permisos esperados |
 | P0-012 | Contacto/email | P0 | Abierto | Contacto/email staging E2E o exclusion formal de release | Smoke manual de `/contacto` + decision documentada | Envio confirmado o fuera de alcance aprobado |
-| P0-013 | CORS staging | P0 | Abierto | CORS exacto en staging | `Invoke-WebRequest -Method Options "$BackendUrl/api/auth/login" -Headers @{Origin=$Origin;"Access-Control-Request-Method"="POST"}` | Header `Access-Control-Allow-Origin` coincide con frontend staging |
-| P0-014 | Cookies staging | P0 | Abierto | Cookies `Secure` y `SameSite=None` en staging HTTPS | Inspeccion de `Set-Cookie` en login staging | Flags correctas en cookies de sesion |
+| P0-013 | CORS staging | P0 | Abierto | CORS exacto en staging (preflight OPTIONS) | `pnpm smoke:staging` (check `OPTIONS /api/auth/login` con `Origin=$FrontendUrl`) | `Access-Control-Allow-Origin` coincide con frontend staging y `Access-Control-Allow-Credentials=true`; evidencia runtime/staging pendiente |
+| P0-014 | Cookies staging | P0 | Abierto | Cookies `Secure` y `SameSite=None` en staging HTTPS | `pnpm smoke:staging` (logins autenticados opcionales admin/clinic validan flags de cookie) | Flags correctas en cookies de sesion; evidencia runtime/staging pendiente |
 | P0-015 | Seguridad | P0 | Abierto | Smoke cross-tenant / IDOR minimo + contrato `test/security-cross-tenant-idor-contract.test.ts` | `pnpm test` (guardrail) + pruebas manuales con sesiones separadas en staging/produccion | Sin acceso a recursos de otro tenant; evidencia runtime/staging pendiente |
 | P0-016 | Backup | P0 | Abierto | Backup productivo reciente | Evidencia de backup con fecha, tamano y estado | Backup vigente dentro de ventana acordada |
 | P0-017 | Restore | P0 | Abierto | Restore probado en staging/no productivo | Acta de restore de prueba (sanitizada) | Restore validado y documentado |

--- a/docs/staging-smoke-runbook.md
+++ b/docs/staging-smoke-runbook.md
@@ -24,6 +24,26 @@ if ($BackendUrl.EndsWith("/") -or $FrontendUrl.EndsWith("/")) {
 }
 ```
 
+## 1.1 Smoke autenticado opcional (`pnpm smoke:staging`)
+
+Si estan disponibles credenciales de smoke, `pnpm smoke:staging` ejecuta checks
+autenticados de admin, clinic y particular. Si faltan, esos checks quedan en
+`SKIP` sin exponer secretos.
+
+```powershell
+$env:SMOKE_ADMIN_USERNAME = "<admin-user>"
+$env:SMOKE_ADMIN_PASSWORD = Read-Host "Admin password"
+$env:SMOKE_CLINIC_USERNAME = "<clinic-user>"
+$env:SMOKE_CLINIC_PASSWORD = Read-Host "Clinic password"
+$env:SMOKE_PARTICULAR_TOKEN = Read-Host "Particular token"
+
+pnpm smoke:staging
+
+Remove-Item Env:\SMOKE_ADMIN_PASSWORD -ErrorAction SilentlyContinue
+Remove-Item Env:\SMOKE_CLINIC_PASSWORD -ErrorAction SilentlyContinue
+Remove-Item Env:\SMOKE_PARTICULAR_TOKEN -ErrorAction SilentlyContinue
+```
+
 ### Preflight Render para comunicaciones
 
 Antes del smoke del formulario de contacto, confirmar en Render que quedaron

--- a/scripts/dev/smoke-staging.ps1
+++ b/scripts/dev/smoke-staging.ps1
@@ -49,71 +49,186 @@ function Get-StatusCodeFromException {
   return $null
 }
 
-function Invoke-GetWithRetry {
+function Get-HeadersFromException {
+  param([System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+  try {
+    if ($null -ne $ErrorRecord.Exception.Response -and $null -ne $ErrorRecord.Exception.Response.Headers) {
+      return $ErrorRecord.Exception.Response.Headers
+    }
+  } catch {
+  }
+
+  return @{}
+}
+
+function Get-BodyFromException {
+  param([System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+  try {
+    if ($null -ne $ErrorRecord.ErrorDetails -and -not [string]::IsNullOrWhiteSpace($ErrorRecord.ErrorDetails.Message)) {
+      return [string]$ErrorRecord.ErrorDetails.Message
+    }
+  } catch {
+  }
+
+  try {
+    if ($null -ne $ErrorRecord.Exception -and -not [string]::IsNullOrWhiteSpace($ErrorRecord.Exception.Message)) {
+      return [string]$ErrorRecord.Exception.Message
+    }
+  } catch {
+  }
+
+  return ""
+}
+
+function Try-ParseJson {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return $null
+  }
+
+  try {
+    return $Text | ConvertFrom-Json -ErrorAction Stop
+  } catch {
+    return $null
+  }
+}
+
+function Get-HeaderValue {
   param(
+    $Headers,
+    [string]$Name
+  )
+
+  if ($null -eq $Headers) {
+    return ""
+  }
+
+  try {
+    $value = $Headers[$Name]
+    if ($null -eq $value) {
+      return ""
+    }
+    if ($value -is [System.Array]) {
+      return [string]($value -join ",")
+    }
+    return [string]$value
+  } catch {
+    return ""
+  }
+}
+
+function Get-CookieFlagsFromHeaders {
+  param($Headers)
+
+  $setCookie = Get-HeaderValue -Headers $Headers -Name "Set-Cookie"
+  if ([string]::IsNullOrWhiteSpace($setCookie)) {
+    return [pscustomobject]@{
+      HasSetCookie = $false
+      HasSecure = $false
+      HasSameSiteNone = $false
+    }
+  }
+
+  return [pscustomobject]@{
+    HasSetCookie = $true
+    HasSecure = [bool]($setCookie -match "(?i)\bSecure\b")
+    HasSameSiteNone = [bool]($setCookie -match "(?i)SameSite=None")
+  }
+}
+
+function Invoke-SmokeRequest {
+  param(
+    [string]$Method,
     [string]$Url,
     [int]$TimeoutSec,
     [int]$Retries,
-    [int]$MinAcceptedStatus,
-    [int]$MaxAcceptedStatus
+    [int[]]$ExpectedStatusCodes,
+    [hashtable]$RequestHeaders = @{},
+    [object]$BodyObject = $null,
+    [Microsoft.PowerShell.Commands.WebRequestSession]$WebSession = $null
   )
 
   $lastStatusCode = $null
   $lastError = ""
-  $lastContentLength = $null
+  $lastHeaders = @{}
+  $lastBody = ""
 
   for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+    $statusCode = $null
+    $responseHeaders = @{}
+    $body = ""
+
     try {
-      $response = Invoke-WebRequest `
-        -UseBasicParsing `
-        -Method Get `
-        -Uri $Url `
-        -TimeoutSec $TimeoutSec `
-        -MaximumRedirection 5
+      $params = @{
+        UseBasicParsing = $true
+        Method = $Method
+        Uri = $Url
+        TimeoutSec = $TimeoutSec
+        MaximumRedirection = 5
+        ErrorAction = "Stop"
+      }
 
+      if ($RequestHeaders.Count -gt 0) {
+        $params.Headers = $RequestHeaders
+      }
+
+      if ($null -ne $BodyObject) {
+        $params.ContentType = "application/json"
+        $params.Body = ($BodyObject | ConvertTo-Json -Depth 10 -Compress)
+      }
+
+      if ($null -ne $WebSession) {
+        $params.WebSession = $WebSession
+      }
+
+      $response = Invoke-WebRequest @params
       $statusCode = [int]$response.StatusCode
+      $responseHeaders = $response.Headers
+      $body = if ($null -ne $response.Content) { [string]$response.Content } else { "" }
+
       $lastStatusCode = $statusCode
+      $lastHeaders = $responseHeaders
+      $lastBody = $body
 
-      $contentLength = $null
-      if ($null -ne $response.Headers -and $null -ne $response.Headers["Content-Length"]) {
-        $parsedLength = 0
-        if ([int]::TryParse([string]$response.Headers["Content-Length"], [ref]$parsedLength)) {
-          $contentLength = $parsedLength
-        }
-      }
-      if ($null -eq $contentLength -and $null -ne $response.Content) {
-        $contentLength = $response.Content.Length
-      }
-      $lastContentLength = $contentLength
-
-      if ($statusCode -ge $MinAcceptedStatus -and $statusCode -le $MaxAcceptedStatus) {
+      if ($ExpectedStatusCodes -contains $statusCode) {
         return [pscustomobject]@{
           Success = $true
           StatusCode = $statusCode
-          ContentLength = $contentLength
+          Headers = $responseHeaders
+          Body = $body
+          Json = (Try-ParseJson -Text $body)
           Attempts = $attempt
           Error = ""
         }
       }
 
-      $lastError = "HTTP $statusCode fuera de rango aceptado ($MinAcceptedStatus-$MaxAcceptedStatus)"
+      $lastError = "HTTP $statusCode fuera de codigos esperados ($($ExpectedStatusCodes -join ','))"
     } catch {
       $statusFromException = Get-StatusCodeFromException -ErrorRecord $_
       if ($null -ne $statusFromException) {
         $lastStatusCode = $statusFromException
       }
+      $responseHeaders = Get-HeadersFromException -ErrorRecord $_
+      $body = Get-BodyFromException -ErrorRecord $_
+      $lastHeaders = $responseHeaders
+      $lastBody = $body
 
-      if ($null -ne $statusFromException -and $statusFromException -ge $MinAcceptedStatus -and $statusFromException -le $MaxAcceptedStatus) {
+      if ($null -ne $statusFromException -and ($ExpectedStatusCodes -contains $statusFromException)) {
         return [pscustomobject]@{
           Success = $true
           StatusCode = $statusFromException
-          ContentLength = $null
+          Headers = $responseHeaders
+          Body = $body
+          Json = (Try-ParseJson -Text $body)
           Attempts = $attempt
           Error = ""
         }
       }
 
-      $message = Sanitize-Text -Text $_.Exception.Message
+      $message = Sanitize-Text -Text (Get-BodyFromException -ErrorRecord $_)
       $lastError = if ($null -ne $statusFromException) {
         "HTTP $statusFromException - $message"
       } else {
@@ -131,14 +246,44 @@ function Invoke-GetWithRetry {
   return [pscustomobject]@{
     Success = $false
     StatusCode = $lastStatusCode
-    ContentLength = $lastContentLength
+    Headers = $lastHeaders
+    Body = $lastBody
+    Json = (Try-ParseJson -Text $lastBody)
     Attempts = $Retries
     Error = (Sanitize-Text -Text $lastError)
   }
 }
 
+function Add-CheckResult {
+  param(
+    [string]$Name,
+    [string]$Status,
+    [bool]$Required,
+    [string]$Detail
+  )
+
+  $results.Add([pscustomobject]@{
+    Name = $Name
+    Status = $Status
+    Required = $Required
+    Detail = (Sanitize-Text -Text $Detail)
+  })
+}
+
+function Mark-CredentialCheckSkipSet {
+  param(
+    [string[]]$CheckNames,
+    [string]$MissingReason
+  )
+
+  foreach ($checkName in $CheckNames) {
+    Add-CheckResult -Name $checkName -Status "SKIP" -Required $false -Detail ("SKIP - " + $MissingReason)
+  }
+}
+
 $BackendUrl = Normalize-Url -Url $BackendUrl
 $FrontendUrl = Normalize-Url -Url $FrontendUrl
+$ExpectedSecureCookieFlags = $BackendUrl.StartsWith("https://")
 
 if ([string]::IsNullOrWhiteSpace($BackendUrl)) {
   Write-Host "BackendUrl es requerido." -ForegroundColor Red
@@ -163,22 +308,6 @@ if ($Retries -lt 1) {
 $startedAt = Get-Date
 $results = [System.Collections.Generic.List[object]]::new()
 
-function Add-CheckResult {
-  param(
-    [string]$Name,
-    [string]$Status,
-    [bool]$Required,
-    [string]$Detail
-  )
-
-  $results.Add([pscustomobject]@{
-    Name = $Name
-    Status = $Status
-    Required = $Required
-    Detail = (Sanitize-Text -Text $Detail)
-  })
-}
-
 Write-Host ""
 Write-Host "=== STAGING SMOKE CHECK ===" -ForegroundColor Cyan
 Write-Host "BackendUrl : $BackendUrl"
@@ -198,12 +327,12 @@ $backendErrors = [System.Collections.Generic.List[string]]::new()
 
 foreach ($candidate in $backendCandidates) {
   Write-Host ("Probing backend: {0}" -f $candidate.Label) -ForegroundColor DarkGray
-  $probe = Invoke-GetWithRetry `
+  $probe = Invoke-SmokeRequest `
+    -Method "GET" `
     -Url $candidate.Url `
     -TimeoutSec $TimeoutSec `
     -Retries $Retries `
-    -MinAcceptedStatus 200 `
-    -MaxAcceptedStatus 299
+    -ExpectedStatusCodes @(200)
 
   if ($probe.Success) {
     $backendSuccess = [pscustomobject]@{
@@ -233,20 +362,31 @@ if ($null -ne $backendSuccess) {
 }
 
 Write-Host "Probing frontend: GET /" -ForegroundColor DarkGray
-$frontendProbe = Invoke-GetWithRetry `
+$frontendProbe = Invoke-SmokeRequest `
+  -Method "GET" `
   -Url "$FrontendUrl/" `
   -TimeoutSec $TimeoutSec `
   -Retries $Retries `
-  -MinAcceptedStatus 200 `
-  -MaxAcceptedStatus 399
+  -ExpectedStatusCodes @(200, 301, 302, 303, 307, 308)
 
 if ($frontendProbe.Success) {
-  $hasNonEmptyContent = ($null -eq $frontendProbe.ContentLength) -or ($frontendProbe.ContentLength -gt 0)
+  $contentLength = $null
+  $contentLengthHeader = Get-HeaderValue -Headers $frontendProbe.Headers -Name "Content-Length"
+  if (-not [string]::IsNullOrWhiteSpace($contentLengthHeader)) {
+    $parsedLength = 0
+    if ([int]::TryParse($contentLengthHeader, [ref]$parsedLength)) {
+      $contentLength = $parsedLength
+    }
+  } elseif (-not [string]::IsNullOrWhiteSpace($frontendProbe.Body)) {
+    $contentLength = $frontendProbe.Body.Length
+  }
+
+  $hasNonEmptyContent = ($null -eq $contentLength) -or ($contentLength -gt 0)
   if ($hasNonEmptyContent) {
-    $contentPart = if ($null -eq $frontendProbe.ContentLength) {
+    $contentPart = if ($null -eq $contentLength) {
       "contentLength=n/a"
     } else {
-      "contentLength=$($frontendProbe.ContentLength)"
+      "contentLength=$contentLength"
     }
 
     Add-CheckResult `
@@ -269,11 +409,281 @@ if ($frontendProbe.Success) {
     -Detail ("GET / fallo. " + $frontendProbe.Error)
 }
 
-Add-CheckResult `
-  -Name "Backend schema health (admin)" `
-  -Status "SKIP" `
-  -Required $false `
-  -Detail "SKIP - requiere admin session (/api/admin/system/schema-health)"
+$corsHeaders = @{
+  Origin = $FrontendUrl
+  "Access-Control-Request-Method" = "POST"
+}
+
+$corsPreflight = Invoke-SmokeRequest `
+  -Method "OPTIONS" `
+  -Url "$BackendUrl/api/auth/login" `
+  -TimeoutSec $TimeoutSec `
+  -Retries $Retries `
+  -ExpectedStatusCodes @(204) `
+  -RequestHeaders $corsHeaders
+
+if (-not $corsPreflight.Success) {
+  Add-CheckResult `
+    -Name "CORS preflight /api/auth/login (frontend origin)" `
+    -Status "FAIL" `
+    -Required $true `
+    -Detail ("Esperado HTTP 204. " + $corsPreflight.Error)
+} else {
+  $allowOrigin = Get-HeaderValue -Headers $corsPreflight.Headers -Name "Access-Control-Allow-Origin"
+  $allowCredentials = Get-HeaderValue -Headers $corsPreflight.Headers -Name "Access-Control-Allow-Credentials"
+
+  if (($allowOrigin -ne $FrontendUrl) -or ($allowCredentials -ne "true")) {
+    Add-CheckResult `
+      -Name "CORS preflight /api/auth/login (frontend origin)" `
+      -Status "FAIL" `
+      -Required $true `
+      -Detail ("Header mismatch allow-origin=$allowOrigin allow-credentials=$allowCredentials")
+  } else {
+    Add-CheckResult `
+      -Name "CORS preflight /api/auth/login (frontend origin)" `
+      -Status "OK" `
+      -Required $true `
+      -Detail ("HTTP 204 allow-origin=$allowOrigin allow-credentials=$allowCredentials")
+  }
+}
+
+$badOriginCheck = Invoke-SmokeRequest `
+  -Method "POST" `
+  -Url "$BackendUrl/api/auth/logout" `
+  -TimeoutSec $TimeoutSec `
+  -Retries $Retries `
+  -ExpectedStatusCodes @(403) `
+  -RequestHeaders @{ Origin = "https://example.invalid" } `
+  -BodyObject @{}
+
+if ($badOriginCheck.Success) {
+  Add-CheckResult `
+    -Name "Unsafe bad origin blocked (/api/auth/logout)" `
+    -Status "OK" `
+    -Required $true `
+    -Detail "HTTP 403 para origin no permitido"
+} else {
+  Add-CheckResult `
+    -Name "Unsafe bad origin blocked (/api/auth/logout)" `
+    -Status "FAIL" `
+    -Required $true `
+    -Detail ("Esperado HTTP 403. " + $badOriginCheck.Error)
+}
+
+$adminUser = [Environment]::GetEnvironmentVariable("SMOKE_ADMIN_USERNAME")
+$adminPassword = [Environment]::GetEnvironmentVariable("SMOKE_ADMIN_PASSWORD")
+$hasAdminCreds = -not [string]::IsNullOrWhiteSpace($adminUser) -and -not [string]::IsNullOrWhiteSpace($adminPassword)
+
+if ($hasAdminCreds) {
+  $adminSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+  $adminLogin = Invoke-SmokeRequest `
+    -Method "POST" `
+    -Url "$BackendUrl/api/admin/auth/login" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -BodyObject @{
+      username = $adminUser
+      password = $adminPassword
+    } `
+    -WebSession $adminSession
+
+  if (-not $adminLogin.Success) {
+    Add-CheckResult -Name "Admin login (/api/admin/auth/login)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200. " + $adminLogin.Error)
+  } else {
+    $cookieFlags = Get-CookieFlagsFromHeaders -Headers $adminLogin.Headers
+    $cookieDetail = "setCookie=" + ($(if ($cookieFlags.HasSetCookie) { "present" } else { "missing" })) + " secure=" + ($(if ($cookieFlags.HasSecure) { "yes" } else { "no" })) + " sameSiteNone=" + ($(if ($cookieFlags.HasSameSiteNone) { "yes" } else { "no" }))
+    $cookieFlagsValid = (-not $ExpectedSecureCookieFlags) -or ($cookieFlags.HasSecure -and $cookieFlags.HasSameSiteNone)
+
+    if (-not $cookieFlagsValid) {
+      Add-CheckResult -Name "Admin login (/api/admin/auth/login)" -Status "FAIL" -Required $true -Detail ("HTTP 200 pero flags de cookie invalidos ($cookieDetail)")
+    } else {
+      Add-CheckResult -Name "Admin login (/api/admin/auth/login)" -Status "OK" -Required $true -Detail ("HTTP 200 ($cookieDetail)")
+    }
+  }
+
+  $adminMe = Invoke-SmokeRequest `
+    -Method "GET" `
+    -Url "$BackendUrl/api/admin/auth/me" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -WebSession $adminSession
+
+  Add-CheckResult -Name "Admin me (/api/admin/auth/me)" -Status ($(if ($adminMe.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($adminMe.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $adminMe.Error }))
+
+  $adminSystemHealth = Invoke-SmokeRequest `
+    -Method "GET" `
+    -Url "$BackendUrl/api/admin/system/health" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -WebSession $adminSession
+
+  Add-CheckResult -Name "Admin system health (/api/admin/system/health)" -Status ($(if ($adminSystemHealth.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($adminSystemHealth.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $adminSystemHealth.Error }))
+
+  $adminSchemaHealth = Invoke-SmokeRequest `
+    -Method "GET" `
+    -Url "$BackendUrl/api/admin/system/schema-health" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200, 503) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -WebSession $adminSession
+
+  if (-not $adminSchemaHealth.Success) {
+    Add-CheckResult -Name "Admin schema health (/api/admin/system/schema-health)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200 o 503. " + $adminSchemaHealth.Error)
+  } else {
+    $schemaStatus = ""
+    if ($null -ne $adminSchemaHealth.Json -and $null -ne $adminSchemaHealth.Json.status) {
+      $schemaStatus = [string]$adminSchemaHealth.Json.status
+    }
+
+    if ($adminSchemaHealth.StatusCode -eq 200 -and $schemaStatus -eq "ok") {
+      Add-CheckResult -Name "Admin schema health (/api/admin/system/schema-health)" -Status "OK" -Required $true -Detail "HTTP 200 status=ok"
+    } elseif ($adminSchemaHealth.StatusCode -eq 503 -and $schemaStatus -eq "degraded") {
+      Add-CheckResult -Name "Admin schema health (/api/admin/system/schema-health)" -Status "FAIL" -Required $true -Detail "HTTP 503 status=degraded (bloquea readiness de staging)"
+    } else {
+      Add-CheckResult -Name "Admin schema health (/api/admin/system/schema-health)" -Status "FAIL" -Required $true -Detail ("HTTP " + $adminSchemaHealth.StatusCode + " status=" + $schemaStatus + " (resultado no aceptable)")
+    }
+  }
+
+  $adminLogout = Invoke-SmokeRequest `
+    -Method "POST" `
+    -Url "$BackendUrl/api/admin/auth/logout" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -WebSession $adminSession
+
+  Add-CheckResult -Name "Admin logout (/api/admin/auth/logout)" -Status ($(if ($adminLogout.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($adminLogout.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $adminLogout.Error }))
+} else {
+  Mark-CredentialCheckSkipSet -CheckNames @(
+    "Admin login (/api/admin/auth/login)",
+    "Admin me (/api/admin/auth/me)",
+    "Admin system health (/api/admin/system/health)",
+    "Admin schema health (/api/admin/system/schema-health)",
+    "Admin logout (/api/admin/auth/logout)"
+  ) -MissingReason "faltan env vars SMOKE_ADMIN_USERNAME/SMOKE_ADMIN_PASSWORD"
+}
+
+$clinicUser = [Environment]::GetEnvironmentVariable("SMOKE_CLINIC_USERNAME")
+$clinicPassword = [Environment]::GetEnvironmentVariable("SMOKE_CLINIC_PASSWORD")
+$hasClinicCreds = -not [string]::IsNullOrWhiteSpace($clinicUser) -and -not [string]::IsNullOrWhiteSpace($clinicPassword)
+
+if ($hasClinicCreds) {
+  $clinicSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+  $clinicLogin = Invoke-SmokeRequest `
+    -Method "POST" `
+    -Url "$BackendUrl/api/auth/login" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -BodyObject @{
+      username = $clinicUser
+      password = $clinicPassword
+    } `
+    -WebSession $clinicSession
+
+  if (-not $clinicLogin.Success) {
+    Add-CheckResult -Name "Clinic login (/api/auth/login)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200. " + $clinicLogin.Error)
+  } else {
+    $clinicCookieFlags = Get-CookieFlagsFromHeaders -Headers $clinicLogin.Headers
+    $clinicCookieDetail = "setCookie=" + ($(if ($clinicCookieFlags.HasSetCookie) { "present" } else { "missing" })) + " secure=" + ($(if ($clinicCookieFlags.HasSecure) { "yes" } else { "no" })) + " sameSiteNone=" + ($(if ($clinicCookieFlags.HasSameSiteNone) { "yes" } else { "no" }))
+    $clinicCookieFlagsValid = (-not $ExpectedSecureCookieFlags) -or ($clinicCookieFlags.HasSecure -and $clinicCookieFlags.HasSameSiteNone)
+
+    if (-not $clinicCookieFlagsValid) {
+      Add-CheckResult -Name "Clinic login (/api/auth/login)" -Status "FAIL" -Required $true -Detail ("HTTP 200 pero flags de cookie invalidos ($clinicCookieDetail)")
+    } else {
+      Add-CheckResult -Name "Clinic login (/api/auth/login)" -Status "OK" -Required $true -Detail ("HTTP 200 ($clinicCookieDetail)")
+    }
+  }
+
+  $clinicMe = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/auth/me" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
+  Add-CheckResult -Name "Clinic me (/api/auth/me)" -Status ($(if ($clinicMe.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicMe.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicMe.Error }))
+
+  $clinicReports = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/reports?limit=10&offset=0" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
+  Add-CheckResult -Name "Clinic reports list (/api/reports?limit=10&offset=0)" -Status ($(if ($clinicReports.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicReports.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicReports.Error }))
+
+  $clinicProfile = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/clinic/profile" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
+  Add-CheckResult -Name "Clinic profile (/api/clinic/profile)" -Status ($(if ($clinicProfile.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicProfile.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicProfile.Error }))
+
+  $clinicParticularTokens = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular-tokens?limit=10&offset=0" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
+  Add-CheckResult -Name "Clinic particular tokens list (/api/particular-tokens?limit=10&offset=0)" -Status ($(if ($clinicParticularTokens.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicParticularTokens.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicParticularTokens.Error }))
+
+  $clinicLogout = Invoke-SmokeRequest -Method "POST" -Url "$BackendUrl/api/auth/logout" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
+  Add-CheckResult -Name "Clinic logout (/api/auth/logout)" -Status ($(if ($clinicLogout.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicLogout.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicLogout.Error }))
+} else {
+  Mark-CredentialCheckSkipSet -CheckNames @(
+    "Clinic login (/api/auth/login)",
+    "Clinic me (/api/auth/me)",
+    "Clinic reports list (/api/reports?limit=10&offset=0)",
+    "Clinic profile (/api/clinic/profile)",
+    "Clinic particular tokens list (/api/particular-tokens?limit=10&offset=0)",
+    "Clinic logout (/api/auth/logout)"
+  ) -MissingReason "faltan env vars SMOKE_CLINIC_USERNAME/SMOKE_CLINIC_PASSWORD"
+}
+
+$particularToken = [Environment]::GetEnvironmentVariable("SMOKE_PARTICULAR_TOKEN")
+$hasParticularToken = -not [string]::IsNullOrWhiteSpace($particularToken)
+
+if ($hasParticularToken) {
+  $particularSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+  $particularLogin = Invoke-SmokeRequest `
+    -Method "POST" `
+    -Url "$BackendUrl/api/particular/auth/login" `
+    -TimeoutSec $TimeoutSec `
+    -Retries $Retries `
+    -ExpectedStatusCodes @(200) `
+    -RequestHeaders @{ Origin = $FrontendUrl } `
+    -BodyObject @{
+      token = $particularToken
+    } `
+    -WebSession $particularSession
+
+  Add-CheckResult -Name "Particular login (/api/particular/auth/login)" -Status ($(if ($particularLogin.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($particularLogin.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $particularLogin.Error }))
+
+  $particularMe = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/me" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  Add-CheckResult -Name "Particular me (/api/particular/auth/me)" -Status ($(if ($particularMe.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($particularMe.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $particularMe.Error }))
+
+  $particularPreviewUrl = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/report/preview-url" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  if (-not $particularPreviewUrl.Success) {
+    Add-CheckResult -Name "Particular report preview (/api/particular/auth/report/preview-url)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200. " + $particularPreviewUrl.Error)
+  } else {
+    $previewPresent = $false
+    if ($null -ne $particularPreviewUrl.Json -and $null -ne $particularPreviewUrl.Json.previewUrl) {
+      $previewPresent = -not [string]::IsNullOrWhiteSpace([string]$particularPreviewUrl.Json.previewUrl)
+    }
+    Add-CheckResult -Name "Particular report preview (/api/particular/auth/report/preview-url)" -Status "OK" -Required $true -Detail ("HTTP 200 signedUrl=" + ($(if ($previewPresent) { "present" } else { "missing" })))
+  }
+
+  $particularDownloadUrl = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/report/download-url" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  if (-not $particularDownloadUrl.Success) {
+    Add-CheckResult -Name "Particular report download (/api/particular/auth/report/download-url)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200. " + $particularDownloadUrl.Error)
+  } else {
+    $downloadPresent = $false
+    if ($null -ne $particularDownloadUrl.Json -and $null -ne $particularDownloadUrl.Json.downloadUrl) {
+      $downloadPresent = -not [string]::IsNullOrWhiteSpace([string]$particularDownloadUrl.Json.downloadUrl)
+    }
+    Add-CheckResult -Name "Particular report download (/api/particular/auth/report/download-url)" -Status "OK" -Required $true -Detail ("HTTP 200 signedUrl=" + ($(if ($downloadPresent) { "present" } else { "missing" })))
+  }
+
+  $particularLogout = Invoke-SmokeRequest -Method "POST" -Url "$BackendUrl/api/particular/auth/logout" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  Add-CheckResult -Name "Particular logout (/api/particular/auth/logout)" -Status ($(if ($particularLogout.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($particularLogout.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $particularLogout.Error }))
+} else {
+  Mark-CredentialCheckSkipSet -CheckNames @(
+    "Particular login (/api/particular/auth/login)",
+    "Particular me (/api/particular/auth/me)",
+    "Particular report preview (/api/particular/auth/report/preview-url)",
+    "Particular report download (/api/particular/auth/report/download-url)",
+    "Particular logout (/api/particular/auth/logout)"
+  ) -MissingReason "falta env var SMOKE_PARTICULAR_TOKEN"
+}
 
 Write-Host ""
 Write-Host "=== CHECKS ===" -ForegroundColor Cyan

--- a/test/smoke-staging-script-contract.test.ts
+++ b/test/smoke-staging-script-contract.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const SCRIPT_PATH = resolve(REPO_ROOT, "scripts/dev/smoke-staging.ps1");
+
+function readSource(path: string): string {
+  return readFileSync(path, "utf8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+}
+
+function assertContains(source: string, marker: string, context: string): void {
+  assert.ok(source.includes(marker), `${context} must contain: ${marker}`);
+}
+
+function assertNotContains(source: string, marker: string, context: string): void {
+  assert.equal(source.includes(marker), false, `${context} must not contain: ${marker}`);
+}
+
+test("staging smoke script defines required optional env vars", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "SMOKE_ADMIN_USERNAME",
+    "SMOKE_ADMIN_PASSWORD",
+    "SMOKE_CLINIC_USERNAME",
+    "SMOKE_CLINIC_PASSWORD",
+    "SMOKE_PARTICULAR_TOKEN",
+  ]) {
+    assertContains(source, marker, "smoke staging script env vars");
+  }
+});
+
+test("staging smoke script contains authenticated endpoints", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "/api/admin/auth/login",
+    "/api/admin/auth/me",
+    "/api/admin/system/health",
+    "/api/admin/system/schema-health",
+    "/api/auth/login",
+    "/api/auth/me",
+    "/api/reports?limit=10&offset=0",
+    "/api/clinic/profile",
+    "/api/particular-tokens?limit=10&offset=0",
+    "/api/particular/auth/login",
+    "/api/particular/auth/me",
+    "/api/particular/auth/report/preview-url",
+    "/api/particular/auth/report/download-url",
+  ]) {
+    assertContains(source, marker, "smoke staging script authenticated endpoints");
+  }
+});
+
+test("staging smoke script validates bad origin rejection", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assertContains(source, "https://example.invalid", "smoke staging script bad origin");
+  assertContains(source, "Unsafe bad origin blocked", "smoke staging script bad origin check");
+});
+
+test("staging smoke script checks secure cookie flags", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assertContains(source, "Secure", "smoke staging script secure cookie marker");
+  assertContains(source, "SameSite=None", "smoke staging script sameSite marker");
+  assertContains(source, "Get-CookieFlagsFromHeaders", "smoke staging cookie flags helper");
+});
+
+test("staging smoke script uses SKIP checks when optional credentials are missing", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assertContains(source, 'Status "SKIP"', "smoke staging script skip status");
+  assertContains(source, "Mark-CredentialCheckSkipSet", "smoke staging script skip helper");
+  assertContains(
+    source,
+    "faltan env vars SMOKE_ADMIN_USERNAME/SMOKE_ADMIN_PASSWORD",
+    "smoke staging script admin skip reason",
+  );
+  assertContains(
+    source,
+    "faltan env vars SMOKE_CLINIC_USERNAME/SMOKE_CLINIC_PASSWORD",
+    "smoke staging script clinic skip reason",
+  );
+  assertContains(
+    source,
+    "falta env var SMOKE_PARTICULAR_TOKEN",
+    "smoke staging script particular skip reason",
+  );
+});
+
+test("staging smoke script does not contain real secrets or unsafe placeholders", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "SUPABASE_SERVICE_ROLE_KEY=",
+    "DATABASE_URL=",
+    "SMTP_PASS=",
+    "password real",
+    "token real",
+  ]) {
+    assertNotContains(source, marker, "smoke staging script forbidden secret marker");
+  }
+});
+
+test("staging smoke script avoids direct printing of sensitive values", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  const forbiddenPatterns = [
+    /Write-Host\s+\$env:SMOKE_ADMIN_PASSWORD/i,
+    /Write-Host\s+\$env:SMOKE_CLINIC_PASSWORD/i,
+    /Write-Host\s+\$env:SMOKE_PARTICULAR_TOKEN/i,
+    /Write-Host\s+\$SetCookie\b/i,
+  ];
+
+  for (const pattern of forbiddenPatterns) {
+    assert.equal(
+      pattern.test(source),
+      false,
+      `smoke staging script must avoid direct sensitive log pattern ${pattern}`,
+    );
+  }
+});
+
+test("smoke staging script contract source stays ascii only", () => {
+  const source = readSource(resolve(REPO_ROOT, "test/smoke-staging-script-contract.test.ts"));
+  const replacementCharacter = String.fromCharCode(0xfffd);
+
+  assert.equal(
+    source.includes(replacementCharacter),
+    false,
+    "smoke staging script contract source must not contain replacement characters",
+  );
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `smoke staging script contract source must stay ascii-only at index ${index}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Extend staging smoke checks with optional authenticated Admin, Clinic, and Particular flows using SMOKE_* environment variables.
- Keep unauthenticated compatibility: missing credentials produce SKIP instead of FAIL.
- Add CORS and bad-origin checks, cookie flag validation, sanitized output, and contract tests.
- Document authenticated smoke usage and production readiness evidence references.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm smoke:staging

## Notes
- Smoke/test/docs-only PR.
- No backend/frontend runtime, workflow, migration, package, or lockfile changes.
- Authenticated checks require env vars and remain SKIP when credentials are absent.