### PR TITLE
ops(smoke): add upload storage signed-url evidence mode

### DIFF
--- a/docs/production-readiness-evidence.md
+++ b/docs/production-readiness-evidence.md
@@ -38,9 +38,9 @@ criterios formales de salida.
 | P0-005 | Config produccion | P0 | Abierto | Variables Render produccion configuradas y sanitizadas | Verificacion manual en Render (captura con valores ocultos) | Variables requeridas presentes, sin secretos expuestos |
 | P0-006 | DB staging | P0 | Abierto | DB staging migrada + `schema:verify` OK | `pnpm schema:verify` sobre entorno staging controlado | Migraciones aplicadas y verify en verde |
 | P0-007 | DB produccion | P0 | Abierto | Backup previo antes de migrar | Evidencia de backup previo con fecha/hora | No se migra sin backup confirmado del mismo dia |
-| P0-008 | Storage | P0 | Abierto | Supabase Storage privado verificado | Revisión en dashboard + prueba de acceso autenticado | Bucket privado, sin lectura publica no autorizada |
-| P0-009 | Upload PDF | P0 | Abierto | Upload PDF funcional en staging | `pnpm smoke:staging` o runbook upload | PDF sube, persiste y queda trazable |
-| P0-010 | Signed URL | P0 | Abierto | Signed URL staging sin exposicion en logs | Descarga controlada + revision de logs sanitizados | URLs firmadas no aparecen completas en logs |
+| P0-008 | Storage | P0 | Abierto | Supabase Storage privado verificado + evidencia de `storagePath/storage_path` | `pnpm smoke:upload` + revision dashboard storage (sanitizada) | Bucket privado, sin lectura publica no autorizada; evidencia runtime/staging pendiente |
+| P0-009 | Upload PDF | P0 | Abierto | Upload PDF funcional en staging con reporte persistido | `pnpm smoke:upload` | Login clinic + upload OK + `reportId` trazable; evidencia runtime/staging pendiente |
+| P0-010 | Signed URL | P0 | Abierto | Signed URL staging validada sin exposicion en logs | `pnpm smoke:upload` (esperar `signedUrl=present`) + revision de logs sanitizados | URLs firmadas no aparecen completas en logs; evidencia runtime/staging pendiente |
 | P0-011 | Avatar/logo | P0 | Abierto | Upload de avatar/logo funcional en staging | Ejecutar flujo manual de avatar/logo en staging | Upload/update/delete correcto por permisos esperados |
 | P0-012 | Contacto/email | P0 | Abierto | Contacto/email staging E2E o exclusion formal de release | Smoke manual de `/contacto` + decision documentada | Envio confirmado o fuera de alcance aprobado |
 | P0-013 | CORS staging | P0 | Abierto | CORS exacto en staging (preflight OPTIONS) | `pnpm smoke:staging` (check `OPTIONS /api/auth/login` con `Origin=$FrontendUrl`) | `Access-Control-Allow-Origin` coincide con frontend staging y `Access-Control-Allow-Credentials=true`; evidencia runtime/staging pendiente |

--- a/docs/staging-smoke-runbook.md
+++ b/docs/staging-smoke-runbook.md
@@ -44,6 +44,26 @@ Remove-Item Env:\SMOKE_CLINIC_PASSWORD -ErrorAction SilentlyContinue
 Remove-Item Env:\SMOKE_PARTICULAR_TOKEN -ErrorAction SilentlyContinue
 ```
 
+## 1.2 Smoke de Storage/upload y signed URL (`pnpm smoke:upload`)
+
+Este smoke valida login clinic, upload PDF, evidencia de `storagePath` y
+obtencion de signed URL sin exponer secretos ni URLs firmadas completas.
+La salida esperada debe mostrar `signedUrl=present` y nunca la URL completa.
+
+```powershell
+$env:SMOKE_BASE_URL = "https://<backend-staging-or-production>"
+$env:SMOKE_USERNAME = "<clinic-user>"
+$env:SMOKE_PASSWORD = Read-Host "Clinic password"
+$env:SMOKE_TMP_DIR = "$env:TEMP\portal-vetneb-smoke"
+# Opcional:
+# $env:SMOKE_UPLOAD_FILE = "C:\path\to\portal-vetneb-smoke-upload.pdf"
+
+pnpm smoke:upload
+
+Remove-Item Env:\SMOKE_PASSWORD -ErrorAction SilentlyContinue
+Remove-Item Env:\SMOKE_UPLOAD_FILE -ErrorAction SilentlyContinue
+```
+
 ### Preflight Render para comunicaciones
 
 Antes del smoke del formulario de contacto, confirmar en Render que quedaron

--- a/scripts/smoke/smoke-upload.mjs
+++ b/scripts/smoke/smoke-upload.mjs
@@ -5,9 +5,9 @@ import path from "node:path";
 
 const BASE_URL = process.env.SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
 const USERNAME = process.env.SMOKE_USERNAME ?? "admin";
-const PASSWORD = requiredEnv("SMOKE_PASSWORD");
 const TMP_DIR = process.env.SMOKE_TMP_DIR ?? path.join(os.tmpdir(), "portal-vetneb-smoke");
 const PDF_PATH = path.join(TMP_DIR, "smoke-test.pdf");
+const UPLOAD_FILE_ENV = process.env.SMOKE_UPLOAD_FILE;
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -21,10 +21,10 @@ function requiredEnv(name) {
 
 function fail(message, error) {
   console.error("SMOKE UPLOAD FALLO");
-  console.error(message);
+  console.error(sanitizeText(message));
 
   if (error) {
-    console.error(error);
+    console.error(`ERROR: ${sanitizeError(error)}`);
   }
 
   process.exit(1);
@@ -60,7 +60,103 @@ async function fetchOrExplain(url, options = {}) {
   }
 }
 
-function ensureTmpPdf() {
+function sanitizeText(text) {
+  if (typeof text !== "string") {
+    return "valor no textual";
+  }
+
+  const noNewlines = text.replace(/\r?\n/g, " ").trim();
+  const redactedUrls = noNewlines.replace(/https?:\/\/[^\s"']+/gi, "[url-redacted]");
+  const redactedTokens = redactedUrls.replace(
+    /((?:token|password|cookie|authorization)[^=\s:]*)[:=][^\s,;]+/gi,
+    "$1=[redacted]"
+  );
+
+  return redactedTokens.length > 300
+    ? `${redactedTokens.slice(0, 300)}...`
+    : redactedTokens;
+}
+
+function sanitizeError(error) {
+  if (!error) {
+    return "sin detalle";
+  }
+
+  if (typeof error === "string") {
+    return sanitizeText(error);
+  }
+
+  if (error instanceof Error) {
+    return sanitizeText(error.message);
+  }
+
+  return sanitizeText(String(error));
+}
+
+function hasCookieFlag(setCookieHeader, flag) {
+  return new RegExp(`(?:^|;)\\s*${flag}(?:;|$)`, "i").test(setCookieHeader);
+}
+
+function summarizeStoragePath(storagePath) {
+  if (typeof storagePath !== "string" || storagePath.trim() === "") {
+    return "missing";
+  }
+
+  if (/^https?:\/\//i.test(storagePath)) {
+    return "url-redacted";
+  }
+
+  if (/[?&](?:token|sig|signature|x-amz-signature|x-amz-security-token)=/i.test(storagePath)) {
+    return "sanitized";
+  }
+
+  return storagePath;
+}
+
+function resolveSignedUrl(payload) {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+
+  return (
+    payload.signedUrl ??
+    payload.downloadUrl ??
+    payload.url ??
+    payload.previewUrl ??
+    payload.data?.signedUrl ??
+    ""
+  );
+}
+
+function resolveStoragePath(payload) {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+
+  return (
+    payload?.report?.storagePath ??
+    payload?.report?.storage_path ??
+    payload?.storagePath ??
+    payload?.storage_path ??
+    ""
+  );
+}
+
+function resolveReportId(payload) {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+
+  return (
+    payload?.report?.id ??
+    payload?.reportId ??
+    payload?.id ??
+    payload?.report?.reportId ??
+    ""
+  );
+}
+
+function ensureTmpPdf(targetPath = PDF_PATH) {
   fs.mkdirSync(TMP_DIR, { recursive: true });
 
   const pdfContent = `%PDF-1.1
@@ -100,107 +196,196 @@ startxref
 413
 %%EOF`;
 
-  fs.writeFileSync(PDF_PATH, pdfContent, "utf8");
-  return PDF_PATH;
+  fs.writeFileSync(targetPath, pdfContent, "utf8");
+  return targetPath;
+}
+
+function resolveUploadFile() {
+  if (UPLOAD_FILE_ENV && UPLOAD_FILE_ENV.trim() !== "") {
+    const providedPath = path.resolve(UPLOAD_FILE_ENV);
+    if (!fs.existsSync(providedPath)) {
+      throw new Error(
+        "SMOKE_UPLOAD_FILE fue provisto pero el archivo no existe. Ajusta la ruta o elimina la variable para usar PDF temporal."
+      );
+    }
+
+    return {
+      filePath: providedPath,
+      generatedTemporaryFile: false,
+    };
+  }
+
+  return {
+    filePath: ensureTmpPdf(PDF_PATH),
+    generatedTemporaryFile: true,
+  };
+}
+
+async function assertStatus(response, expectedStatuses, label) {
+  if (!expectedStatuses.includes(response.status)) {
+    throw new Error(
+      `${label} fallo. Esperado HTTP ${expectedStatuses.join(" o ")}, recibido HTTP ${response.status}`
+    );
+  }
 }
 
 async function run() {
+  requiredEnv("SMOKE_BASE_URL");
+  requiredEnv("SMOKE_USERNAME");
+  let password = requiredEnv("SMOKE_PASSWORD");
+
   console.log("INICIANDO SMOKE UPLOAD...");
   console.log(`BASE URL: ${BASE_URL}`);
   console.log(`USUARIO: ${USERNAME}`);
 
-  const filePath = ensureTmpPdf();
-  console.log(`PDF DE PRUEBA: ${filePath}`);
-
-  const loginRes = await fetchOrExplain(`${BASE_URL}/api/auth/login`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      username: USERNAME,
-      password: PASSWORD,
-    }),
-  });
-
-  const loginJson = await readJson(loginRes);
-  assert(
-    loginRes.ok,
-    `LOGIN FALLO: ${loginRes.status} ${JSON.stringify(loginJson, null, 2)}`
+  const uploadFile = resolveUploadFile();
+  const filePath = uploadFile.filePath;
+  console.log(
+    `PDF DE PRUEBA: ${filePath} (temporal=${uploadFile.generatedTemporaryFile ? "yes" : "no"})`
   );
 
-  const setCookie = loginRes.headers.get("set-cookie");
-  assert(setCookie, "NO SE RECIBIO COOKIE DE SESION");
-  console.log("OK /api/auth/login");
+  let setCookie = "";
+  let loggedIn = false;
 
-  const form = new FormData();
-  const fileBuffer = fs.readFileSync(filePath);
-  const blob = new Blob([fileBuffer], { type: "application/pdf" });
+  try {
+    const loginRes = await fetchOrExplain(`${BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: USERNAME,
+        password,
+      }),
+    });
 
-  form.append("file", blob, "smoke-test.pdf");
-  form.append("patientName", "SMOKE TEST");
-  form.append("studyType", "PDF_PRUEBA");
-  form.append("uploadDate", "2026-04-07");
+    await assertStatus(loginRes, [200], "LOGIN");
+    const loginJson = await readJson(loginRes);
+    assert(loginJson?.success === true, "LOGIN no devolvio success=true");
 
-  const uploadRes = await fetchOrExplain(`${BASE_URL}/api/admin/reports/upload`, {
-    method: "POST",
-    headers: {
-      Cookie: setCookie,
-    },
-    body: form,
-  });
+    setCookie = loginRes.headers.get("set-cookie") ?? "";
+    assert(setCookie, "NO SE RECIBIO COOKIE DE SESION");
+    loggedIn = true;
 
-  const uploadJson = await readJson(uploadRes);
+    if (BASE_URL.startsWith("https://")) {
+      const hasSecure = hasCookieFlag(setCookie, "Secure");
+      const hasSameSiteNone = /;\s*SameSite=None(?:;|$)/i.test(setCookie);
+      console.log(
+        `cookieFlags secure=${hasSecure ? "yes" : "no"} sameSiteNone=${hasSameSiteNone ? "yes" : "no"}`
+      );
+    }
 
-  if (uploadRes.status !== 201) {
-    console.error("DETALLE DE RESPUESTA UPLOAD:");
-    console.error(JSON.stringify(uploadJson, null, 2));
+    console.log("OK /api/auth/login");
+
+    const form = new FormData();
+    const fileBuffer = fs.readFileSync(filePath);
+    const blob = new Blob([fileBuffer], { type: "application/pdf" });
+
+    form.append("file", blob, "smoke-test.pdf");
+    form.append("patientName", "SMOKE TEST");
+    form.append("studyType", "PDF_PRUEBA");
+    form.append("uploadDate", "2026-04-07");
+
+    const uploadRes = await fetchOrExplain(`${BASE_URL}/api/admin/reports/upload`, {
+      method: "POST",
+      headers: {
+        Cookie: setCookie,
+      },
+      body: form,
+    });
+
+    const uploadJson = await readJson(uploadRes);
+    const uploadAcceptedStatus = uploadRes.status === 200 || uploadRes.status === 201;
+    const uploadCreatedStatus = uploadRes.status === 201;
+    void uploadCreatedStatus;
+    assert(
+      uploadAcceptedStatus,
+      `UPLOAD FALLO: ${uploadRes.status} bodyKeys=${Object.keys(uploadJson ?? {}).join(",")}`
+    );
+
+    assert(uploadJson?.success === true, "UPLOAD NO DEVOLVIO success=true");
+    assert(uploadJson?.report?.id, "UPLOAD NO DEVOLVIO report.id");
+    assert(
+      uploadJson?.report?.storagePath || uploadJson?.report?.storage_path,
+      "UPLOAD NO DEVOLVIO report.storagePath"
+    );
+    assert(
+      uploadJson?.report?.previewUrl || uploadJson?.previewUrl,
+      "UPLOAD NO DEVOLVIO previewUrl"
+    );
+    assert(
+      uploadJson?.report?.downloadUrl || uploadJson?.downloadUrl,
+      "UPLOAD NO DEVOLVIO downloadUrl"
+    );
+
+    const reportId = resolveReportId(uploadJson);
+    const storagePath = resolveStoragePath(uploadJson);
+
+    assert(reportId, "UPLOAD NO DEVOLVIO reportId equivalente");
+    assert(storagePath, "UPLOAD NO DEVOLVIO storagePath/storage_path equivalente");
+
+    console.log("OK /api/admin/reports/upload");
+    console.log(`reportId=${reportId}`);
+    console.log(`storagePath=${summarizeStoragePath(storagePath)}`);
+
+    const reportDownloadUrlRes = await fetchOrExplain(
+      `${BASE_URL}/api/reports/${reportId}/download-url`,
+      {
+        method: "GET",
+        headers: {
+          Cookie: setCookie,
+        },
+      }
+    );
+    const reportDownloadUrlJson = await readJson(reportDownloadUrlRes);
+    await assertStatus(reportDownloadUrlRes, [200], "REPORT DOWNLOAD URL");
+
+    const signedUrl = resolveSignedUrl(reportDownloadUrlJson);
+    assert(
+      typeof signedUrl === "string" && signedUrl.trim().length > 0,
+      "REPORT DOWNLOAD URL no devolvio signed URL"
+    );
+    console.log(`OK /api/reports/${reportId}/download-url signedUrl=present`);
+
+    const reportsRes = await fetchOrExplain(`${BASE_URL}/api/reports`, {
+      headers: {
+        Cookie: setCookie,
+      },
+    });
+    const reportsJson = await readJson(reportsRes);
+    await assertStatus(reportsRes, [200], "REPORTS");
+    assert(Array.isArray(reportsJson?.reports), "REPORTS NO DEVOLVIO ARRAY");
+    console.log("OK /api/reports");
+
+    const logoutRes = await fetchOrExplain(`${BASE_URL}/api/auth/logout`, {
+      method: "POST",
+      headers: {
+        Cookie: setCookie,
+      },
+    });
+    await assertStatus(logoutRes, [200], "LOGOUT");
+    console.log("OK /api/auth/logout");
+    loggedIn = false;
+
+    console.log("SMOKE UPLOAD COMPLETO OK");
+  } finally {
+    if (loggedIn && setCookie) {
+      try {
+        await fetchOrExplain(`${BASE_URL}/api/auth/logout`, {
+          method: "POST",
+          headers: {
+            Cookie: setCookie,
+          },
+        });
+      } catch {
+        // Logout best-effort for cleanup; main failure is handled by the check flow.
+      }
+    }
+
+    password = "";
+    setCookie = "";
+    delete process.env.SMOKE_PASSWORD;
   }
-
-  assert(
-    uploadRes.status === 201,
-    `UPLOAD FALLO: ${uploadRes.status} ${JSON.stringify(uploadJson, null, 2)}`
-  );
-
-  assert(uploadJson?.success === true, "UPLOAD NO DEVOLVIO success=true");
-  assert(uploadJson?.report?.id, "UPLOAD NO DEVOLVIO report.id");
-  assert(uploadJson?.report?.storagePath, "UPLOAD NO DEVOLVIO report.storagePath");
-  assert(uploadJson?.report?.previewUrl, "UPLOAD NO DEVOLVIO previewUrl");
-  assert(uploadJson?.report?.downloadUrl, "UPLOAD NO DEVOLVIO downloadUrl");
-
-  console.log("OK /api/admin/reports/upload");
-  console.log(`REPORT ID: ${uploadJson.report.id}`);
-
-  const reportsRes = await fetchOrExplain(`${BASE_URL}/api/reports`, {
-    headers: {
-      Cookie: setCookie,
-    },
-  });
-
-  const reportsJson = await readJson(reportsRes);
-
-  assert(
-    reportsRes.ok,
-    `REPORTS FALLO: ${reportsRes.status} ${JSON.stringify(reportsJson, null, 2)}`
-  );
-  assert(Array.isArray(reportsJson?.reports), "REPORTS NO DEVOLVIO ARRAY");
-  console.log("OK /api/reports");
-
-  const logoutRes = await fetchOrExplain(`${BASE_URL}/api/auth/logout`, {
-    method: "POST",
-    headers: {
-      Cookie: setCookie,
-    },
-  });
-
-  const logoutJson = await readJson(logoutRes);
-  assert(
-    logoutRes.ok,
-    `LOGOUT FALLO: ${logoutRes.status} ${JSON.stringify(logoutJson, null, 2)}`
-  );
-  console.log("OK /api/auth/logout");
-
-  console.log("SMOKE UPLOAD COMPLETO OK");
 }
 
 run().catch((error) => {

--- a/test/smoke-upload-script-contract.test.ts
+++ b/test/smoke-upload-script-contract.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const SCRIPT_PATH = resolve(REPO_ROOT, "scripts/smoke/smoke-upload.mjs");
+
+function readSource(path: string): string {
+  return readFileSync(path, "utf8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+}
+
+function assertContains(source: string, marker: string, context: string): void {
+  assert.ok(source.includes(marker), `${context} must contain: ${marker}`);
+}
+
+function assertNotContains(source: string, marker: string, context: string): void {
+  assert.equal(source.includes(marker), false, `${context} must not contain: ${marker}`);
+}
+
+test("smoke upload script references expected env vars", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "SMOKE_BASE_URL",
+    "SMOKE_USERNAME",
+    "SMOKE_PASSWORD",
+    "SMOKE_TMP_DIR",
+    "SMOKE_UPLOAD_FILE",
+  ]) {
+    assertContains(source, marker, "smoke upload script env vars");
+  }
+});
+
+test("smoke upload script includes login, upload, download-url and logout surfaces", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "/api/auth/login",
+    "/api/auth/logout",
+    "/api/reports/",
+    "download-url",
+    "/api/admin/reports/upload",
+  ]) {
+    assertContains(source, marker, "smoke upload script endpoint registry");
+  }
+});
+
+test("smoke upload script enforces signed URL evidence without full URL disclosure", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assertContains(source, "signedUrl=present", "smoke upload script signed URL marker");
+
+  for (const pattern of [
+    /console\.log\(\s*process\.env\.SMOKE_PASSWORD/i,
+    /console\.log\(\s*setCookie\b/i,
+    /console\.log\(\s*signedUrl\b/i,
+    /console\.log\(\s*downloadUrl\b/i,
+    /console\.log\(\s*url\b/i,
+  ]) {
+    assert.equal(
+      pattern.test(source),
+      false,
+      `smoke upload script must avoid direct sensitive output pattern ${pattern}`,
+    );
+  }
+});
+
+test("smoke upload script creates a temporary PDF when SMOKE_UPLOAD_FILE is missing", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assertContains(source, "function ensureTmpPdf", "smoke upload script temp PDF helper");
+  assertContains(source, "%PDF-1.1", "smoke upload script pdf signature");
+  assertContains(source, "resolveUploadFile", "smoke upload script file resolver");
+  assertContains(source, "generatedTemporaryFile: true", "smoke upload script temp flag");
+  assertContains(source, "SMOKE_UPLOAD_FILE fue provisto pero el archivo no existe", "smoke upload script safe missing file message");
+});
+
+test("smoke upload script uses multipart form upload contract", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "new FormData()",
+    'form.append("file"',
+    'form.append("patientName"',
+    'form.append("studyType"',
+    'form.append("uploadDate"',
+  ]) {
+    assertContains(source, marker, "smoke upload script multipart markers");
+  }
+});
+
+test("smoke upload script does not include real secrets or unsafe placeholders", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const marker of [
+    "SUPABASE_SERVICE_ROLE_KEY=",
+    "DATABASE_URL=",
+    "SMTP_PASS=",
+    "password real",
+    "token real",
+  ]) {
+    assertNotContains(source, marker, "smoke upload script forbidden secret marker");
+  }
+});
+
+test("smoke upload script avoids direct logging of sensitive env vars and cookies", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  for (const pattern of [
+    /Write-Host\s+\$env:SMOKE_ADMIN_PASSWORD/i,
+    /Write-Host\s+\$env:SMOKE_CLINIC_PASSWORD/i,
+    /Write-Host\s+\$env:SMOKE_PARTICULAR_TOKEN/i,
+    /console\.log\(\s*process\.env\.SMOKE_PASSWORD/i,
+    /console\.log\(\s*process\.env\.SMOKE_USERNAME/i,
+    /console\.log\(\s*set-cookie\b/i,
+    /console\.log\(\s*cookie\b/i,
+  ]) {
+    assert.equal(
+      pattern.test(source),
+      false,
+      `smoke upload script must avoid direct sensitive pattern ${pattern}`,
+    );
+  }
+});
+
+test("smoke upload script contract source stays ascii only", () => {
+  const source = readSource(resolve(REPO_ROOT, "test/smoke-upload-script-contract.test.ts"));
+  const replacementCharacter = String.fromCharCode(0xfffd);
+
+  assert.equal(
+    source.includes(replacementCharacter),
+    false,
+    "smoke upload script contract source must not contain replacement characters",
+  );
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `smoke upload script contract source must stay ascii-only at index ${index}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Extend smoke upload evidence mode for clinic login, PDF upload, report payload validation, storage path detection, signed/download URL presence, and logout.
- Create a temporary smoke PDF when SMOKE_UPLOAD_FILE is not provided.
- Sanitize output so passwords, cookies, headers, tokens, and signed URLs are not printed.
- Add contract tests for env vars, endpoints, multipart upload, temporary PDF creation, signed URL sanitization, and forbidden secret patterns.
- Update staging smoke runbook and production readiness evidence for storage/upload/signed URL P0 items.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Smoke upload
- pnpm smoke:upload was attempted without credentials and failed safely as expected:
  - SMOKE_BASE_URL is required.

## Notes
- Smoke/test/docs-only PR.
- No backend/frontend runtime, workflow, migration, package, or lockfile changes.
- Real smoke upload requires SMOKE_BASE_URL, SMOKE_USERNAME, and SMOKE_PASSWORD.