### PR TITLE
ops(release): add backup restore rollback runbook

### DIFF
--- a/docs/ops/BACKUP_RESTORE_ROLLBACK.md
+++ b/docs/ops/BACKUP_RESTORE_ROLLBACK.md
@@ -1,0 +1,220 @@
+# Backup, restore y rollback — Portal VETNEB
+
+Runbook operativo formal para release readiness. Documento obligatorio para
+salidas productivas con impacto potencial en datos, storage, runtime o
+configuracion.
+
+## 1. Estado y decision
+
+- Este runbook es obligatorio antes de GO produccion.
+- Ningun deploy productivo con cambios de DB/storage debe avanzar sin backup
+  vigente.
+- Si restore o rollback no fueron probados, la decision operativa debe ser
+  **NO-GO**.
+
+## 2. Alcance
+
+Este runbook cubre:
+
+- Supabase Postgres.
+- Supabase Storage (buckets de informes/avatar, si aplica).
+- Render backend.
+- Render frontend.
+- Variables de entorno.
+- DNS/dominio, si aplica al release.
+
+## 3. Datos que nunca deben exponerse
+
+No pegar en issues/chats/PRs/capturas/logs:
+
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `DATABASE_URL`
+- `SUPABASE_DB_URL`
+- `SMTP_PASS`
+- `GMAIL_API_REFRESH_TOKEN`
+- cookies de sesion
+- passwords
+- tokens particulares
+- signed URLs completas
+- backups completos descargables
+- connection strings
+
+## 4. Evidencia sanitizada permitida
+
+| Tipo | Permitido | Prohibido | Responsable |
+|---|---|---|---|
+| backup DB | fecha UTC, estado, tamano aproximado, operador | dump completo, URL de conexion, credenciales | DBA/DevOps |
+| backup storage | bucket, privacidad, conteo aproximado, fecha | archivos sensibles, signed URLs completas | Backend/DevOps |
+| restore test | acta de entorno no productivo, resultado smoke, timestamp | restore en produccion sin control, datos sensibles crudos | DBA/Tech lead |
+| rollback app | deploy IDs sanitizados, hora, resultado health | env vars con valor, tokens, capturas con secretos | DevOps |
+| rollback DB | decision documentada, metodo, ventana, resultado | comandos destructivos sin aprobacion, dumps en PR | DBA/Tech lead |
+| rollback env vars | listado de nombres revertidos, fecha, operador | valores reales de variables | DevOps |
+| smoke post-restore | resumen pass/fail por check | passwords, cookies, tokens, signed URLs completas | QA/Tech lead |
+| smoke post-rollback | resumen pass/fail y estado final | logs crudos con secretos | QA/Tech lead |
+
+## 5. Preflight antes de release
+
+- [ ] `main` limpio.
+- [ ] PRs abiertos: ninguno.
+- [ ] CI verde.
+- [ ] `pnpm validate:local:schema`.
+- [ ] `pnpm smoke:staging`.
+- [ ] `pnpm smoke:upload` con credenciales staging, si corresponde.
+- [ ] backup DB reciente.
+- [ ] backup storage reciente.
+- [ ] restore probado.
+- [ ] rollback documentado.
+- [ ] responsables tecnico y negocio asignados.
+
+## 6. Backup DB Supabase
+
+Pasos operativos:
+
+1. Confirmar proyecto Supabase correcto (`<supabase-project-id>` /
+   `<supabase-project-name>`).
+2. Registrar fecha/hora UTC de inicio de backup.
+3. Ejecutar backup/snapshot/export usando panel Supabase o tooling autorizado
+   por el equipo.
+4. Verificar estado final (`success`) y tamano aproximado del backup.
+5. Registrar evidencia sanitizada en tracker operativo.
+6. Confirmar que no se pego dump completo ni connection string en ningun canal.
+
+Nota: si no hay CLI oficial configurada en este repo para backup, ejecutar el
+procedimiento desde panel Supabase o herramienta autorizada por la organizacion.
+
+## 7. Backup Supabase Storage
+
+Pasos operativos:
+
+1. Identificar buckets relevantes (`<reports-bucket>`, `<clinic-avatars-bucket>`,
+   u otros del release).
+2. Validar que los buckets usados por runtime sean privados.
+3. Registrar conteo aproximado de objetos, fecha UTC y tamano aproximado (si
+   la consola lo permite).
+4. No descargar ni adjuntar archivos sensibles en PRs/issues/chats.
+5. Adjuntar solo evidencia permitida: nombre de bucket, conteo aproximado,
+   estado privado y fecha.
+
+## 8. Restore test en staging/no productivo
+
+Reglas:
+
+- Restore debe probarse fuera de produccion.
+- Usar entorno no productivo controlado (`<staging-restore-env>`).
+
+Pasos minimos:
+
+1. Ejecutar restore de DB en entorno no productivo.
+2. Validar esquema y conectividad.
+3. Validar login basico.
+4. Ejecutar `pnpm smoke:staging`.
+5. Ejecutar `pnpm smoke:upload` si hay credenciales de smoke.
+6. Registrar resultado final (pass/fail), hora UTC y responsables.
+
+## 9. Rollback app Render
+
+Pasos operativos:
+
+1. Identificar deploy anterior estable para backend
+   (`<backend-deploy-id-previo>`).
+2. Identificar deploy anterior estable para frontend
+   (`<frontend-deploy-id-previo>`).
+3. Ejecutar rollback backend en Render.
+4. Ejecutar rollback frontend en Render.
+5. Verificar `GET /health` y `GET /api/health`.
+6. Verificar CORS/cookies y login basico.
+7. Registrar deploy IDs sanitizados, hora UTC y resultado.
+
+No pegar valores reales de env vars en evidencia.
+
+## 10. Rollback DB
+
+Reglas:
+
+- Preferir migraciones backward-compatible.
+- Si hay migracion irreversible, el release debe quedar en NO-GO hasta tener
+  plan explicito aprobado.
+- Rollback DB puede requerir restore desde backup.
+- No ejecutar rollback destructivo sin aprobacion de responsable tecnico y
+  responsable negocio.
+
+Registrar siempre:
+
+- motivo de rollback DB
+- estrategia aplicada
+- impacto esperado
+- resultado y decision final
+
+## 11. Rollback env vars
+
+Pasos operativos:
+
+1. Capturar estado previo de nombres de variables (sin valores).
+2. Revertir cambios desde panel Render/Supabase segun corresponda.
+3. No pegar valores en PRs/issues/chats/capturas.
+4. Ejecutar smoke posterior.
+5. Registrar evidencia sanitizada.
+
+## 12. Criterios de rollback inmediato
+
+Disparar rollback inmediato ante cualquiera de estos casos:
+
+- `/health` falla.
+- DB/storage no `up`.
+- login admin/clinic falla.
+- CORS/cookies falla.
+- upload/download falla.
+- schema health `degraded`.
+- errores 5xx repetidos.
+- fuga de token/signed URL/secreto en logs.
+- contacto/email critico falla si esta dentro del release.
+- dominio HTTPS falla.
+
+## 13. Secuencia de rollback
+
+1. Congelar deploys.
+2. Preservar evidencia sanitizada.
+3. Notificar responsables tecnico y negocio.
+4. Rollback app.
+5. Rollback env vars si aplica.
+6. Restore DB si corresponde.
+7. Restore storage si corresponde.
+8. Ejecutar smoke post-rollback.
+9. Registrar decision final.
+
+## 14. Smoke posterior a restore/rollback
+
+Comandos PowerShell seguros (placeholders):
+
+```powershell
+cd C:\PORTAL-VETNEB
+pnpm validate:local:schema
+pnpm smoke:staging
+
+$env:SMOKE_BASE_URL = "https://<backend-staging-or-production>"
+$env:SMOKE_USERNAME = "<clinic-user>"
+$env:SMOKE_PASSWORD = Read-Host "Clinic password"
+# Opcional:
+# $env:SMOKE_UPLOAD_FILE = "C:\path\to\portal-vetneb-smoke-upload.pdf"
+
+pnpm smoke:upload
+
+Remove-Item Env:\SMOKE_PASSWORD -ErrorAction SilentlyContinue
+Remove-Item Env:\SMOKE_UPLOAD_FILE -ErrorAction SilentlyContinue
+```
+
+Checks manuales complementarios (si aplica): admin, clinic, particular.
+
+## 15. Registro operativo
+
+| Fecha UTC | Entorno | Accion | Commit/deploy | Responsable tecnico | Responsable negocio | Evidencia sanitizada | Resultado |
+|---|---|---|---|---|---|---|---|
+|  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |
+
+## 16. Decision go/no-go
+
+- GO solo si hay backup vigente + restore probado + rollback app/DB documentado.
+- NO-GO si falta backup, restore o rollback.
+- GO condicionado solo si no quedan P0 abiertos.

--- a/docs/production-readiness-evidence.md
+++ b/docs/production-readiness-evidence.md
@@ -46,10 +46,10 @@ criterios formales de salida.
 | P0-013 | CORS staging | P0 | Abierto | CORS exacto en staging (preflight OPTIONS) | `pnpm smoke:staging` (check `OPTIONS /api/auth/login` con `Origin=$FrontendUrl`) | `Access-Control-Allow-Origin` coincide con frontend staging y `Access-Control-Allow-Credentials=true`; evidencia runtime/staging pendiente |
 | P0-014 | Cookies staging | P0 | Abierto | Cookies `Secure` y `SameSite=None` en staging HTTPS | `pnpm smoke:staging` (logins autenticados opcionales admin/clinic validan flags de cookie) | Flags correctas en cookies de sesion; evidencia runtime/staging pendiente |
 | P0-015 | Seguridad | P0 | Abierto | Smoke cross-tenant / IDOR minimo + contrato `test/security-cross-tenant-idor-contract.test.ts` | `pnpm test` (guardrail) + pruebas manuales con sesiones separadas en staging/produccion | Sin acceso a recursos de otro tenant; evidencia runtime/staging pendiente |
-| P0-016 | Backup | P0 | Abierto | Backup productivo reciente | Evidencia de backup con fecha, tamano y estado | Backup vigente dentro de ventana acordada |
-| P0-017 | Restore | P0 | Abierto | Restore probado en staging/no productivo | Acta de restore de prueba (sanitizada) | Restore validado y documentado |
-| P0-018 | Rollback app | P0 | Abierto | Rollback app Render documentado | Runbook de rollback con pasos y responsables | Procedimiento repetible validado |
-| P0-019 | Rollback DB | P0 | Abierto | Rollback DB documentado | Runbook DB con precondiciones y riesgos | Procedimiento aprobado por responsable tecnico |
+| P0-016 | Backup | P0 | Abierto | Backup productivo reciente (DB y storage) | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` + evidencia de backup con fecha, tamano y estado (sanitizada) | Backup vigente dentro de ventana acordada |
+| P0-017 | Restore | P0 | Abierto | Restore probado en staging/no productivo | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` + acta de restore de prueba (sanitizada) | Restore validado y documentado |
+| P0-018 | Rollback app | P0 | Abierto | Rollback app Render documentado | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` (pasos, responsables y evidencia sanitizada) | Procedimiento repetible validado |
+| P0-019 | Rollback DB | P0 | Abierto | Rollback DB documentado | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` (criterio NO-GO, restore y decision registrada) | Procedimiento aprobado por responsable tecnico |
 | P0-020 | Dominio/HTTPS | P0 | Abierto | Dominio HTTPS productivo operativo | `Invoke-WebRequest "$FrontendUrl"` y certificados validos | Frontend/back con HTTPS valido y sin mixed content critico |
 | P0-021 | CORS/cookies prod | P0 | Abierto | CORS y cookies correctas en produccion | `OPTIONS` login + inspeccion de cookies en prod | Login/sesion funcional y politicas correctas |
 | P0-022 | Smoke prod | P0 | Abierto | Smoke produccion post-deploy | Runbook productivo ejecutado y firmado | Smoke minimo verde tras deploy |

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -502,6 +502,9 @@ Remove-Variable ParticularToken
 
 ## 9. Observabilidad, backups y rollback
 
+Runbook operativo obligatorio:
+`docs/ops/BACKUP_RESTORE_ROLLBACK.md`.
+
 - [ ] `[BLOCKER]` `/health` productivo responde `200` y reporta DB y Storage
   `up`.
 - [ ] `[BLOCKER]` `/api/admin/system/health` visible para admin productivo y sin
@@ -551,6 +554,8 @@ Invoke-RestMethod "$BaseUrl/api/health"
 
 Referencia de evidencia formal para decision de salida:
 `docs/production-readiness-evidence.md`.
+Referencia de procedimiento operativo de backup/restore/rollback:
+`docs/ops/BACKUP_RESTORE_ROLLBACK.md`.
 
 ### Go
 


### PR DESCRIPTION
## Summary
- Add mandatory backup, restore, and rollback runbook for Portal VETNEB production readiness.
- Cover Supabase DB, Supabase Storage, Render backend/frontend rollback, env var rollback, smoke after restore/rollback, and go/no-go rules.
- Reference the runbook from production readiness evidence P0-016/P0-017/P0-018/P0-019.
- Reference the runbook from release readiness backup/rollback and go/no-go sections.

## Validation
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Notes
- Documentation-only PR.
- No backend/frontend runtime, scripts, tests, workflows, migrations, package, or lockfile changes.
- No secrets, DB URLs, service role keys, tokens, cookies, signed URLs, or downloadable backups included.