### PR TITLE
fix(frontend): improve mobile public navigation

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Microscope } from "lucide-react";
+import { ArrowRight, ChevronDown, Microscope } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
@@ -13,13 +13,45 @@ const navLinks = [
   { label: "Precios", href: ROUTES.precios },
 ];
 
+const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];
+
 export function Navbar() {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-vetneb-line/80 bg-card/96 shadow-[0_10px_28px_rgba(15,45,62,0.08)]">
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="relative lg:hidden">
+          <details className="group">
+            <summary
+              className="flex h-9 cursor-pointer list-none items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-bold text-primary-foreground shadow-[0_10px_26px_hsl(var(--vetneb-navy)/0.20)] ring-1 ring-vetneb-teal/30 transition-[background-color,box-shadow,border-color] hover:shadow-[0_12px_30px_hsl(var(--vetneb-navy)/0.24)] [&::-webkit-details-marker]:hidden"
+              aria-label="Abrir navegación VETNEB"
+            >
+              <Microscope className="h-4 w-4" aria-hidden="true" />
+              <span>VETNEB</span>
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            </summary>
+            <nav
+              className="absolute left-0 top-full z-50 mt-2 w-72 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-vetneb-line/80 bg-card p-2 shadow-[0_18px_45px_rgba(15,45,62,0.16)]"
+              aria-label="Navegación mobile"
+            >
+              <ul className="flex flex-col gap-1">
+                {mobileNavLinks.map((link) => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      className="block rounded-md px-3 py-2.5 text-sm font-medium text-vetneb-ink/85 transition-colors hover:bg-accent/70 hover:text-vetneb-ink"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </details>
+        </div>
+
         <Link
           href={ROUTES.home}
-          className="group flex items-center gap-2.5"
+          className="group hidden items-center gap-2.5 lg:flex"
           aria-label="VETNEB — Inicio"
         >
           <span className="flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-bold text-primary-foreground shadow-[0_10px_26px_hsl(var(--vetneb-navy)/0.20)] ring-1 ring-vetneb-teal/30 transition-[background-color,box-shadow,border-color] group-hover:shadow-[0_12px_30px_hsl(var(--vetneb-navy)/0.24)]">
@@ -46,15 +78,7 @@ export function Navbar() {
           ))}
         </nav>
 
-        <div className="flex items-center gap-3">
-          <Button
-            asChild
-            variant="outline"
-            size="sm"
-            className="public-cta-outline lg:hidden"
-          >
-            <Link href={ROUTES.profesionales}>Profesionales</Link>
-          </Button>
+        <div className="flex items-center gap-2 sm:gap-3">
           <Button asChild variant="outline" size="sm" className="public-cta-outline">
             <Link href={ROUTES.login}>Iniciar sesión</Link>
           </Button>

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -32,6 +32,7 @@ test("navbar uses centralized public routes for primary navigation", () => {
 
   assert.ok(source.includes('import Link from "next/link";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
+  assert.ok(source.includes('const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];'));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
   assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
@@ -41,7 +42,7 @@ test("navbar uses centralized public routes for primary navigation", () => {
   assert.ok(source.includes('aria-label="Navegación principal"'));
 });
 
-test("navbar keeps full navigation desktop-only and exposes compact professionals link", () => {
+test("navbar keeps full navigation desktop-only and exposes mobile dropdown", () => {
   const source = read(NAVBAR_PATH);
 
   assert.ok(
@@ -50,9 +51,26 @@ test("navbar keeps full navigation desktop-only and exposes compact professional
     ),
   );
   assert.equal(source.includes("p-1 md:flex"), false);
-  assert.ok(source.includes('className="public-cta-outline lg:hidden"'));
-  assert.ok(source.includes("<Link href={ROUTES.profesionales}>Profesionales</Link>"));
+  assert.ok(source.includes('className="relative lg:hidden"'));
+  assert.ok(source.includes("<details"));
+  assert.ok(source.includes("<summary"));
+  assert.ok(source.includes('aria-label="Navegación mobile"'));
+  assert.ok(source.includes("{mobileNavLinks.map((link) => ("));
+  assert.equal(source.includes('className="public-cta-outline lg:hidden"'), false);
+  assert.equal(source.includes("<Link href={ROUTES.profesionales}>Profesionales</Link>"), false);
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
+});
+
+test("navbar mobile dropdown includes expected public links", () => {
+  const source = read(NAVBAR_PATH);
+
+  assert.ok(source.includes('const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];'));
+  assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
+  assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
+  assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
+  assert.ok(source.includes('{ label: "Particulares", href: ROUTES.particulares }'));
+  assert.ok(source.includes('{ label: "Contacto", href: ROUTES.contacto }'));
+  assert.ok(source.includes('{ label: "Precios", href: ROUTES.precios }'));
 });
 
 test("navbar keeps expected public link order including precios", () => {


### PR DESCRIPTION
## Summary
- Removes the compact mobile-only Profesionales CTA from the public header.
- Adds a mobile navigation dropdown from the VETNEB brand control without converting Navbar to a client component.
- Preserves desktop navigation and keeps Iniciar sesión visible in the mobile header.
- Updates public navigation tests to cover the mobile dropdown contract.

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build