### PR TITLE
chore(frontend): align css editor diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "css.lint.unknownAtRules": "ignore",
+  "scss.lint.unknownAtRules": "ignore",
+  "less.lint.unknownAtRules": "ignore"
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -360,9 +360,6 @@
     text-wrap: pretty;
   }
 
-  .render-gpu-soft {
-  }
-
   .diagnostic-field {
     position: absolute;
     inset: 0;
@@ -648,10 +645,6 @@
       animation: none;
     }
 
-    .render-card:hover,
-    .premium-card:hover,
-    [data-services-polished="true"] > [id]:hover {
-    }
   }
 }
 @keyframes clinical-skeleton-pulse {


### PR DESCRIPTION
## Summary
- Removes empty CSS rulesets from the frontend global stylesheet.
- Adds VS Code workspace settings to ignore Tailwind at-rules in CSS diagnostics.
- Preserves the existing Tailwind directives and global user-select behavior.

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build