### PR TITLE
chore(frontend): ignore false empty css diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "css.lint.unknownAtRules": "ignore",
   "scss.lint.unknownAtRules": "ignore",
-  "less.lint.unknownAtRules": "ignore"
+  "less.lint.unknownAtRules": "ignore",
+  "css.lint.emptyRules": "ignore",
+  "scss.lint.emptyRules": "ignore",
+  "less.lint.emptyRules": "ignore"
 }


### PR DESCRIPTION
## Summary
- Keeps existing VS Code settings for Tailwind at-rules.
- Ignores false empty CSS ruleset diagnostics for CSS, SCSS, and Less.
- Does not change frontend CSS or production behavior.

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm -C frontend build