### PR TITLE
fix(frontend): constrain public card links to CTAs

### DIFF
--- a/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
+++ b/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
@@ -237,9 +237,8 @@ export default function LaboratorioPatologicoVeterinarioPage() {
         <section className="py-16" aria-labelledby="pathology-lab-related-heading">
           <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="minimal">
-              <Link
-                href="/servicios"
-                className="group block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              <div
+                className="group rounded-lg"
                 aria-labelledby="pathology-lab-related-heading"
               >
                 <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow transition-colors duration-200 group-hover:bg-sky-50 group-hover:border-sky-300 group-hover:shadow-xl">
@@ -258,10 +257,17 @@ export default function LaboratorioPatologicoVeterinarioPage() {
                         según la muestra recibida y la pregunta diagnóstica del
                         caso.
                       </p>
+                      <Link
+                        href="/servicios"
+                        className="mt-5 inline-flex w-fit items-center gap-2 rounded-md text-sm font-semibold text-primary underline underline-offset-4 transition hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                      >
+                        Ver servicios relacionados
+                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                      </Link>
                     </div>
                   </div>
                 </div>
-              </Link>
+              </div>
             </PublicScrollReveal>
           </div>
         </section>

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -10,6 +10,8 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import { cn } from "@/lib/utils";
+
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import {
@@ -186,60 +188,58 @@ export default function ServiciosPage() {
                       key={service.id}
                       data-scroll-reveal-item
                       aria-labelledby={serviceHeadingId}
-                      className={
+                      className={cn(
+                        "[&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-300 hover:[&_.premium-card]:shadow-xl",
                         serviceCategories.length % 2 === 1 &&
                         service.id === serviceCategories[serviceCategories.length - 1]?.id
                           ? "lg:col-span-2 lg:mx-auto lg:w-full lg:max-w-[calc((100%-2rem)/2)]"
-                          : ""
-                      }
+                          : "",
+                      )}
                     >
-                      <Link
-                        href={service.href}
-                        className="group block h-full rounded-lg transition duration-200 [&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-300 hover:[&_.premium-card]:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-                        aria-labelledby={serviceHeadingId}
+                      <Card
+                        id={service.id}
+                        className="premium-card h-full"
                       >
-                        <Card
-                          id={service.id}
-                          className="premium-card h-full"
-                        >
-                          <CardHeader>
-                            <VisualIcon
-                              icon={service.icon}
-                              tone={service.tone}
-                              className="mb-2"
-                            />
-                            <CardTitle id={serviceHeadingId} className="text-xl text-vetneb-ink">
-                              {service.title}
-                            </CardTitle>
-                            <CardDescription className="public-copy-tight text-sm text-muted-foreground">
-                              {service.description}
-                            </CardDescription>
-                          </CardHeader>
-                          <CardContent>
-                            <ul className="space-y-2.5">
-                              {service.features.map((feature) => (
-                                <li key={feature} className="flex items-start gap-2">
-                                  <span
-                                    className="mt-0.5 text-primary font-bold text-xs"
-                                    aria-hidden="true"
-                                  >
-                                    →
-                                  </span>
-                                  <span className="text-sm text-muted-foreground">
-                                    {feature}
-                                  </span>
-                                </li>
-                              ))}
-                            </ul>
-                            <div className="mt-5 text-sm font-semibold text-primary underline underline-offset-4">
-                              <span className="sr-only">
-                                {service.linkLabel}
-                              </span>
-                              <span aria-hidden="true">Ver más</span>
-                            </div>
-                          </CardContent>
-                        </Card>
-                      </Link>                    </article>
+                        <CardHeader>
+                          <VisualIcon
+                            icon={service.icon}
+                            tone={service.tone}
+                            className="mb-2"
+                          />
+                          <CardTitle id={serviceHeadingId} className="text-xl text-vetneb-ink">
+                            {service.title}
+                          </CardTitle>
+                          <CardDescription className="public-copy-tight text-sm text-muted-foreground">
+                            {service.description}
+                          </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                          <ul className="space-y-2.5">
+                            {service.features.map((feature) => (
+                              <li key={feature} className="flex items-start gap-2">
+                                <span
+                                  className="mt-0.5 text-primary font-bold text-xs"
+                                  aria-hidden="true"
+                                >
+                                  →
+                                </span>
+                                <span className="text-sm text-muted-foreground">
+                                  {feature}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                          <Link
+                            href={service.href}
+                            className="mt-5 inline-flex w-fit items-center gap-2 rounded-md text-sm font-semibold text-primary underline underline-offset-4 transition hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                          >
+                            <span className="sr-only">{service.linkLabel}</span>
+                            <span aria-hidden="true">Ver más</span>
+                            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                          </Link>
+                        </CardContent>
+                      </Card>
+                    </article>
                   );
                 })}
               </div>

--- a/frontend/src/components/public/PublicAction.tsx
+++ b/frontend/src/components/public/PublicAction.tsx
@@ -61,23 +61,27 @@ export function PublicAction({
 
   if (variant === "contactCard") {
     return (
-      <Link
-        href={href}
+      <div
         className={cn(
-          "group flex items-center justify-between gap-4 rounded-lg border border-vetneb-line/85 bg-card/95 px-4 py-3 text-left shadow-sm transition hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised",
+          "group flex items-center justify-between gap-4 rounded-lg border border-vetneb-line/85 bg-card/95 px-4 py-3 shadow-sm transition hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised",
           className,
         )}
-        rel={rel}
-        target={target}
-        {...props}
       >
         <span className="text-sm font-semibold text-vetneb-navy">{children}</span>
-        {icon ? (
-          <span className="text-vetneb-teal transition group-hover:translate-x-0.5">
-            {icon}
+        <Link
+          href={href}
+          rel={rel}
+          target={target}
+          className="inline-flex shrink-0 text-vetneb-teal transition group-hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+          tabIndex={0}
+          {...props}
+        >
+          <span className="sr-only">
+            {typeof children === "string" ? children : "Ver"}
           </span>
-        ) : null}
-      </Link>
+          {icon ? <span aria-hidden="true">{icon}</span> : null}
+        </Link>
+      </div>
     );
   }
 

--- a/test/frontend-pathology-laboratory-landing-page.test.ts
+++ b/test/frontend-pathology-laboratory-landing-page.test.ts
@@ -125,3 +125,18 @@ test("veterinary pathology laboratory hides redundant visible related services t
 
   assert.equal(source.includes('<span aria-hidden="true">Ver más</span>'), false);
 });
+
+test("veterinary pathology laboratory related services section does not use link as full surface wrapper", () => {
+  const source = read(PATHOLOGY_LAB_PAGE_PATH);
+
+  // Outer container of related-services band must not be a block Link
+  assert.equal(source.includes('"group block rounded-lg'), false);
+  // No absolute overlay link trick
+  assert.equal(source.includes("absolute inset-0"), false);
+  // Explicit CTA still navigates to /servicios
+  assert.ok(source.includes('href="/servicios"'));
+  // Hover effects preserved on inner container via group parent
+  assert.ok(source.includes("group-hover:bg-sky-50"));
+  assert.ok(source.includes("group-hover:border-sky-300"));
+  assert.ok(source.includes("group-hover:shadow-xl"));
+});

--- a/test/frontend-public-visual-primitives.test.ts
+++ b/test/frontend-public-visual-primitives.test.ts
@@ -53,3 +53,15 @@ test("public hero primitive separates dark conversion heroes from editorial surf
   assert.ok(source.includes('const isDark = variant === "brand" || variant === "conversion";'));
   assert.ok(source.includes('<AmbientOrbs variant="dark" />'));
 });
+
+test("public action contactCard variant renders non-interactive div container not Link wrapper", () => {
+  const source = read(PUBLIC_ACTION_PATH);
+
+  assert.ok(source.includes('"contactCard"'));
+  // contactCard container must be a div not a Link wrapping the whole card
+  assert.ok(source.includes("group flex items-center justify-between gap-4 rounded-lg"));
+  // No absolute inset-0 overlay trick
+  assert.equal(source.includes("absolute inset-0"), false);
+  // Explicit constrained Link CTA inside the contactCard branch
+  assert.ok(source.includes("inline-flex shrink-0"));
+});

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -123,3 +123,16 @@ test("servicios page shows unified card CTA while preserving hidden SEO labels",
   assert.equal(source.includes("Ver citología veterinaria</div>"), false);
   assert.equal(source.includes("Ver informes veterinarios</div>"), false);
 });
+
+test("servicios page card links are constrained to explicit CTAs not full card wrappers", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  // No Link wrapping the full card surface
+  assert.equal(source.includes("group block h-full"), false);
+  assert.equal(source.includes('"group block'), false);
+  // No absolute overlay link trick
+  assert.equal(source.includes("absolute inset-0"), false);
+  // Explicit constrained CTA exists inside card
+  assert.ok(source.includes("inline-flex w-fit"));
+  assert.ok(source.includes("href={service.href}"));
+});


### PR DESCRIPTION
## Summary
- replaces public full-card Link wrappers with non-interactive card containers plus explicit CTAs
- constrains the pathology laboratory related-services card to an explicit CTA
- refactors PublicAction contactCard so only the CTA is a real link
- adds frontend contract tests for public card/link surface regressions

## Validation
- pnpm test
  - tests 1780
  - pass 1779
  - fail 0
  - skipped 1
- pnpm build
- pnpm -C frontend build

## Scope
- frontend public UI only
- no backend changes
- no lockfile changes
- no GitHub Actions changes
- no Supabase/Render/env changes