### PR TITLE
fix(frontend): eliminate native link previews sitewide

### DIFF
--- a/frontend/src/app/citologia-veterinaria/page.tsx
+++ b/frontend/src/app/citologia-veterinaria/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -9,9 +8,9 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   createPageMetadata,
@@ -96,15 +95,21 @@ export default function CitologiaVeterinariaPage() {
             diferenciales y acompañar decisiones clínicas veterinarias.
           </p>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <Button asChild size="lg" className="public-cta-primary w-full sm:w-auto">
-              <Link href="/contacto">
-                Solicitar coordinación diagnóstica
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </Button>
-            <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver más servicios</Link>
-            </Button>
+            <PublicRouteControl
+              href="/contacto"
+              variant="primaryDark"
+              className="public-cta-primary w-full sm:w-auto"
+            >
+              Solicitar coordinación diagnóstica
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </PublicRouteControl>
+            <PublicRouteControl
+              href="/servicios"
+              variant="secondaryOutline"
+              className="public-cta-on-hero w-full sm:w-auto"
+            >
+              Ver más servicios
+            </PublicRouteControl>
           </div>
         </div>
       </section>
@@ -218,12 +223,20 @@ export default function CitologiaVeterinariaPage() {
                   histopatología u otras técnicas diagnósticas.
                 </p>
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                  <Button asChild className="public-cta-primary w-full sm:w-auto">
-                    <Link href="/contacto">Coordinar envío de muestras</Link>
-                  </Button>
-                  <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/servicios">Ver más servicios</Link>
-                  </Button>
+                  <PublicRouteControl
+                    href="/contacto"
+                    variant="primaryDark"
+                    className="public-cta-primary w-full sm:w-auto"
+                  >
+                    Coordinar envío de muestras
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href="/servicios"
+                    variant="primaryLight"
+                    className="public-cta-outline w-full sm:w-auto"
+                  >
+                    Ver más servicios
+                  </PublicRouteControl>
                 </div>
               </div>
             </PublicScrollReveal>

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -12,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import {
   Card,
@@ -20,7 +20,6 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
@@ -122,24 +121,21 @@ export default function ClinicasPage() {
             clínica veterinaria. Acceso seguro, trazable y disponible las 24 hs.
           </p>
           <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-            <Button
-              asChild
-              size="lg"
+            <PublicRouteControl
+              href={ROUTES.login}
+              variant="primaryDark"
               className="public-cta-primary w-full sm:w-auto"
             >
-              <Link href={ROUTES.login}>
-                Acceder al portal
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              size="lg"
+              Acceder al portal
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </PublicRouteControl>
+            <PublicRouteControl
+              href={ROUTES.contacto}
+              variant="secondaryOutline"
               className="public-cta-on-hero w-full sm:w-auto"
             >
-              <Link href={ROUTES.contacto}>Solicitar acceso</Link>
-            </Button>
+              Solicitar acceso
+            </PublicRouteControl>
           </div>
         </div>
       </section>
@@ -267,9 +263,13 @@ export default function ClinicasPage() {
                       </p>
                     </div>
                   </div>
-                  <Button asChild className="public-cta-primary">
-                    <Link href={ROUTES.login}>Ingresar</Link>
-                  </Button>
+                  <PublicRouteControl
+                    href={ROUTES.login}
+                    variant="primaryDark"
+                    className="public-cta-primary"
+                  >
+                    Ingresar
+                  </PublicRouteControl>
                 </div>
               </section>
             </PublicScrollReveal>

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, useTransition } from "react";
+import { PublicExternalControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -147,13 +148,13 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           >
             Limpiar filtros
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            asChild
+          <PublicExternalControl
+            href={csvUrl}
+            target="_self"
+            className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-card/95 px-4 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-55"
           >
-            <a href={csvUrl}>Exportar CSV</a>
-          </Button>
+            Exportar CSV
+          </PublicExternalControl>
           <Button
             type="button"
             onClick={loadFailedLoginAlerts}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -645,14 +645,15 @@ export default async function AdminPage({
               </div>
               <div className="surface-soft">
                 <p className="text-xs text-muted-foreground">Auditoría</p>
-                <Link
+                <PublicRouteControl
                   href={buildAdminAuditFilterHref({
                     event: "study_tracking.notification.created",
                   })}
+                  variant="textLink"
                   className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
                 >
                   Ver notificaciones
-                </Link>
+                </PublicRouteControl>
               </div>
             </div>
           </CardContent>
@@ -681,14 +682,15 @@ export default async function AdminPage({
               </div>
               <div className="surface-soft">
                 <p className="text-xs text-muted-foreground">Filtro audit</p>
-                <Link
+                <PublicRouteControl
                   href={buildAdminAuditFilterHref({
                     event: "clinic_user.role.changed",
                   })}
+                  variant="textLink"
                   className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
                 >
                   Ver cambios de rol
-                </Link>
+                </PublicRouteControl>
               </div>
             </div>
           </CardContent>
@@ -737,12 +739,14 @@ export default async function AdminPage({
                 <span>
                   Mostrando {filteredAuditEntries.length} de {auditEntries.length} eventos.
                 </span>
-                <Link
+                <PublicRouteControl
                   href="/dashboard/admin#audit-log"
+                  replace
+                  variant="textLink"
                   className="font-semibold text-vetneb-navy hover:text-vetneb-teal"
                 >
                   Limpiar filtros
-                </Link>
+                </PublicRouteControl>
               </div>
             ) : null}
             <Table>
@@ -809,12 +813,14 @@ export default async function AdminPage({
                         : "No hay eventos de auditoría disponibles."}
                       {hasActiveAuditFilters ? (
                         <div className="mt-2">
-                          <Link
+                          <PublicRouteControl
                             href="/dashboard/admin#audit-log"
+                            replace
+                            variant="textLink"
                             className="font-semibold text-vetneb-navy hover:text-vetneb-teal"
                           >
                             Limpiar filtros
-                          </Link>
+                          </PublicRouteControl>
                         </div>
                       ) : null}
                     </TableCell>

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -141,9 +142,14 @@ export default async function InformesPage({
                 <Button type="submit" size="sm">
                   Filtrar
                 </Button>
-                <Button size="sm" variant="ghost" asChild>
-                  <a href="/dashboard/informes">Limpiar</a>
-                </Button>
+                <PublicRouteControl
+                  href="/dashboard/informes"
+                  replace
+                  variant="bare"
+                  className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+                >
+                  Limpiar
+                </PublicRouteControl>
               </div>
             </form>
           </CardContent>

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import Link from "next/link";
 import {
   BarChart3,
   MapPinned,
@@ -8,9 +7,9 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
 import {
   getLogisticsFieldVisits,
@@ -172,9 +171,13 @@ export default async function LogisticaPage() {
                       {module.count}
                     </p>
                   )}
-                  <Button asChild variant="outline" size="sm" className="w-full">
-                    <Link href={module.href}>Ver módulo</Link>
-                  </Button>
+                  <PublicRouteControl
+                    href={module.href}
+                    variant="bare"
+                    className="inline-flex h-9 w-full items-center justify-center rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground"
+                  >
+                    Ver módulo
+                  </PublicRouteControl>
                 </CardContent>
               </Card>
             );
@@ -184,9 +187,13 @@ export default async function LogisticaPage() {
         <Card className="dashboard-surface">
           <CardHeader className="flex flex-row items-center justify-between pb-4">
             <CardTitle className="text-base">Visitas recientes</CardTitle>
-            <Button asChild variant="ghost" size="sm">
-              <Link href={ROUTES.dashboardLogisticaVisitas}>Ver todas</Link>
-            </Button>
+            <PublicRouteControl
+              href={ROUTES.dashboardLogisticaVisitas}
+              variant="bare"
+              className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+            >
+              Ver todas
+            </PublicRouteControl>
           </CardHeader>
           <CardContent className="space-y-3">
             {fieldVisitsLoadError ? (
@@ -227,9 +234,13 @@ export default async function LogisticaPage() {
         <Card className="dashboard-surface">
           <CardHeader className="flex flex-row items-center justify-between pb-4">
             <CardTitle className="text-base">Planes de ruta</CardTitle>
-            <Button asChild variant="ghost" size="sm">
-              <Link href={ROUTES.dashboardLogisticaRutas}>Ver todos</Link>
-            </Button>
+            <PublicRouteControl
+              href={ROUTES.dashboardLogisticaRutas}
+              variant="bare"
+              className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+            >
+              Ver todos
+            </PublicRouteControl>
           </CardHeader>
           <CardContent className="space-y-3">
             {routePlansLoadError ? (

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import Link from "next/link";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { StatsCards } from "@/components/dashboard/StatsCards";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
 import {
   getDashboardStats,
@@ -139,9 +138,13 @@ export default async function DashboardPage() {
                   Últimos estudios cargados y su estado actual.
                 </p>
               </div>
-              <Button asChild variant="ghost" size="sm">
-                <Link href={ROUTES.dashboardInformes}>Ver todos</Link>
-              </Button>
+              <PublicRouteControl
+                href={ROUTES.dashboardInformes}
+                variant="bare"
+                className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+              >
+                Ver todos
+              </PublicRouteControl>
             </CardHeader>
             <CardContent className="space-y-1.5">
               {reportsLoadError ? (
@@ -186,9 +189,13 @@ export default async function DashboardPage() {
                   Programación logística con seguimiento en curso.
                 </p>
               </div>
-              <Button asChild variant="ghost" size="sm">
-                <Link href={ROUTES.dashboardLogisticaVisitas}>Ver todas</Link>
-              </Button>
+              <PublicRouteControl
+                href={ROUTES.dashboardLogisticaVisitas}
+                variant="bare"
+                className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+              >
+                Ver todas
+              </PublicRouteControl>
             </CardHeader>
             <CardContent className="space-y-1.5">
               {visitsLoadError ? (

--- a/frontend/src/app/histopatologia-veterinaria/page.tsx
+++ b/frontend/src/app/histopatologia-veterinaria/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -9,9 +8,9 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   createPageMetadata,
@@ -96,15 +95,21 @@ export default function HistopatologiaVeterinariaPage() {
             precisión diagnóstica en medicina veterinaria.
           </p>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <Button asChild size="lg" className="public-cta-primary w-full sm:w-auto">
-              <Link href="/contacto">
-                Solicitar coordinación diagnóstica
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </Button>
-            <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver más servicios</Link>
-            </Button>
+            <PublicRouteControl
+              href="/contacto"
+              variant="primaryDark"
+              className="public-cta-primary w-full sm:w-auto"
+            >
+              Solicitar coordinación diagnóstica
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </PublicRouteControl>
+            <PublicRouteControl
+              href="/servicios"
+              variant="secondaryOutline"
+              className="public-cta-on-hero w-full sm:w-auto"
+            >
+              Ver más servicios
+            </PublicRouteControl>
           </div>
         </div>
       </section>
@@ -219,12 +224,20 @@ export default function HistopatologiaVeterinariaPage() {
                   conclusión diagnóstica útil para el equipo tratante.
                 </p>
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                  <Button asChild className="public-cta-primary w-full sm:w-auto">
-                    <Link href="/contacto">Coordinar envío de muestras</Link>
-                  </Button>
-                  <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/servicios">Ver más servicios</Link>
-                  </Button>
+                  <PublicRouteControl
+                    href="/contacto"
+                    variant="primaryDark"
+                    className="public-cta-primary w-full sm:w-auto"
+                  >
+                    Coordinar envío de muestras
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href="/servicios"
+                    variant="primaryLight"
+                    className="public-cta-outline w-full sm:w-auto"
+                  >
+                    Ver más servicios
+                  </PublicRouteControl>
                 </div>
               </div>
             </PublicScrollReveal>

--- a/frontend/src/app/informes-veterinarios/page.tsx
+++ b/frontend/src/app/informes-veterinarios/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -11,9 +10,9 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   createPageMetadata,
@@ -115,15 +114,21 @@ export default function InformesVeterinariosPage() {
             resguardo de la información clínica de cada caso.
           </p>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <Button asChild size="lg" className="public-cta-primary w-full sm:w-auto">
-              <Link href="/contacto">
-                Consultar por informes
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </Button>
-            <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver más servicios</Link>
-            </Button>
+            <PublicRouteControl
+              href="/contacto"
+              variant="primaryDark"
+              className="public-cta-primary w-full sm:w-auto"
+            >
+              Consultar por informes
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </PublicRouteControl>
+            <PublicRouteControl
+              href="/servicios"
+              variant="secondaryOutline"
+              className="public-cta-on-hero w-full sm:w-auto"
+            >
+              Ver más servicios
+            </PublicRouteControl>
           </div>
         </div>
       </section>
@@ -245,12 +250,20 @@ export default function InformesVeterinariosPage() {
                   para todos los casos.
                 </p>
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                  <Button asChild className="public-cta-primary w-full sm:w-auto">
-                    <Link href="/contacto">Consultar por un caso</Link>
-                  </Button>
-                  <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/servicios">Ver más servicios</Link>
-                  </Button>
+                  <PublicRouteControl
+                    href="/contacto"
+                    variant="primaryDark"
+                    className="public-cta-primary w-full sm:w-auto"
+                  >
+                    Consultar por un caso
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href="/servicios"
+                    variant="primaryLight"
+                    className="public-cta-outline w-full sm:w-auto"
+                  >
+                    Ver más servicios
+                  </PublicRouteControl>
                 </div>
               </div>
             </PublicScrollReveal>

--- a/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
+++ b/frontend/src/app/laboratorio-patologico-veterinario/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -9,9 +8,9 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   createPageMetadata,
@@ -99,15 +98,21 @@ export default function LaboratorioPatologicoVeterinarioPage() {
             clínico-patológico.
           </p>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <Button asChild size="lg" className="public-cta-primary w-full sm:w-auto">
-              <Link href="/contacto">
-                Solicitar coordinación diagnóstica
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </Button>
-            <Button asChild size="lg" variant="outline" className="public-cta-on-hero w-full sm:w-auto">
-              <Link href="/servicios">Ver más servicios</Link>
-            </Button>
+            <PublicRouteControl
+              href="/contacto"
+              variant="primaryDark"
+              className="public-cta-primary w-full sm:w-auto"
+            >
+              Solicitar coordinación diagnóstica
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </PublicRouteControl>
+            <PublicRouteControl
+              href="/servicios"
+              variant="secondaryOutline"
+              className="public-cta-on-hero w-full sm:w-auto"
+            >
+              Ver más servicios
+            </PublicRouteControl>
           </div>
         </div>
       </section>
@@ -222,12 +227,20 @@ export default function LaboratorioPatologicoVeterinarioPage() {
                   para decisiones terapéuticas responsables.
                 </p>
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                  <Button asChild className="public-cta-primary w-full sm:w-auto">
-                    <Link href="/contacto">Coordinar envío de muestras</Link>
-                  </Button>
-                  <Button asChild variant="outline" className="public-cta-outline w-full sm:w-auto">
-                    <Link href="/servicios">Ver más servicios</Link>
-                  </Button>
+                  <PublicRouteControl
+                    href="/contacto"
+                    variant="primaryDark"
+                    className="public-cta-primary w-full sm:w-auto"
+                  >
+                    Coordinar envío de muestras
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href="/servicios"
+                    variant="primaryLight"
+                    className="public-cta-outline w-full sm:w-auto"
+                  >
+                    Ver más servicios
+                  </PublicRouteControl>
                 </div>
               </div>
             </PublicScrollReveal>
@@ -257,13 +270,14 @@ export default function LaboratorioPatologicoVeterinarioPage() {
                         según la muestra recibida y la pregunta diagnóstica del
                         caso.
                       </p>
-                      <Link
+                      <PublicRouteControl
                         href="/servicios"
+                        variant="bare"
                         className="mt-5 inline-flex w-fit items-center gap-2 rounded-md text-sm font-semibold text-primary underline underline-offset-4 transition hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                       >
                         Ver servicios relacionados
                         <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                      </Link>
+                      </PublicRouteControl>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import Link from "next/link";
 import { ClipboardCheck, FlaskConical, Microscope, Network } from "lucide-react";
+
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { createPageMetadata } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
@@ -93,7 +93,7 @@ export default function HomePage() {
         <div className="relative container mx-auto flex min-h-[calc(100vh-4.5rem)] items-center px-4 py-16 sm:px-6 lg:px-8">
           <div className="grid w-full items-center gap-10">
             <div className="max-w-5xl">
-                            <h1
+              <h1
                 id="hero-heading"
                 className="mt-2 max-w-none text-[clamp(1.85rem,4.6vw,3.75rem)] font-bold uppercase leading-[0.94] tracking-[0.045em] text-primary-foreground"
               >
@@ -113,21 +113,20 @@ export default function HomePage() {
               </p>
 
               <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
-                <Button
-                  asChild
-                  size="lg"
+                <PublicRouteControl
+                  href={ROUTES.login}
+                  variant="primaryDark"
                   className="public-cta-primary w-full sm:w-auto"
                 >
-                  <Link href={ROUTES.login}>Acceder a informes y trazabilidad</Link>
-                </Button>
-                <Button
-                  asChild
-                  variant="outline"
-                  size="lg"
+                  Acceder a informes y trazabilidad
+                </PublicRouteControl>
+                <PublicRouteControl
+                  href={ROUTES.particulares}
+                  variant="secondaryOutline"
                   className="public-cta-on-hero w-full sm:w-auto"
                 >
-                  <Link href={ROUTES.particulares}>Consultar informes 24 hs</Link>
-                </Button>
+                  Consultar informes 24 hs
+                </PublicRouteControl>
               </div>
 
               <div className="clinical-muted-band mt-7 w-fit max-w-full rounded-lg px-4 py-3 text-vetneb-navy">
@@ -173,13 +172,13 @@ export default function HomePage() {
                   interconsultas y coordinación clínica.
                 </p>
               </div>
-              <Button
-                asChild
-                size="lg"
+              <PublicRouteControl
+                href={ROUTES.profesionales}
+                variant="primaryDark"
                 className="public-cta-primary w-full sm:w-auto"
               >
-                <Link href={ROUTES.profesionales}>Buscar profesionales</Link>
-              </Button>
+                Buscar profesionales
+              </PublicRouteControl>
             </div>
           </div>
         </section>
@@ -238,9 +237,13 @@ export default function HomePage() {
 
             <PublicScrollReveal>
               <div className="mt-10 text-center">
-                <Button asChild variant="outline">
-                  <Link href={ROUTES.servicios}>Ver todos los servicios</Link>
-                </Button>
+                <PublicRouteControl
+                  href={ROUTES.servicios}
+                  variant="secondaryOutline"
+                  className="border-vetneb-line/80 bg-transparent text-vetneb-ink hover:bg-accent/60 hover:border-vetneb-teal/45"
+                >
+                  Ver todos los servicios
+                </PublicRouteControl>
               </div>
             </PublicScrollReveal>
           </div>
@@ -329,21 +332,20 @@ export default function HomePage() {
                 claridad.
               </p>
               <div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
-                <Button
-                  asChild
-                  size="lg"
+                <PublicRouteControl
+                  href={ROUTES.login}
+                  variant="primaryDark"
                   className="public-cta-primary w-full sm:w-auto"
                 >
-                  <Link href={ROUTES.login}>Ingresar al portal de informes</Link>
-                </Button>
-                <Button
-                  asChild
-                  variant="outline"
-                  size="lg"
+                  Ingresar al portal de informes
+                </PublicRouteControl>
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="primaryLight"
                   className="public-cta-outline w-full sm:w-auto"
                 >
-                  <Link href={ROUTES.contacto}>Coordinar muestras y consultas</Link>
-                </Button>
+                  Coordinar muestras y consultas
+                </PublicRouteControl>
               </div>
             </div>
           </PublicScrollReveal>

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   ArrowRight,
   ClipboardCheck,
@@ -14,6 +13,7 @@ import { cn } from "@/lib/utils";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import {
   Card,
   CardContent,
@@ -21,7 +21,6 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
@@ -153,6 +152,7 @@ export default function ServiciosPage() {
           </p>
         </div>
       </section>
+
       <div className="public-soft-canvas">
         <section
           className="py-16 md:py-20"
@@ -229,14 +229,15 @@ export default function ServiciosPage() {
                               </li>
                             ))}
                           </ul>
-                          <Link
+                          <PublicRouteControl
                             href={service.href}
+                            variant="bare"
                             className="mt-5 inline-flex w-fit items-center gap-2 rounded-md text-sm font-semibold text-primary underline underline-offset-4 transition hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                           >
                             <span className="sr-only">{service.linkLabel}</span>
                             <span aria-hidden="true">Ver más</span>
                             <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                          </Link>
+                          </PublicRouteControl>
                         </CardContent>
                       </Card>
                     </article>
@@ -263,26 +264,21 @@ export default function ServiciosPage() {
                   diagnóstico y a las necesidades clínicas de cada caso.
                 </p>
                 <div className="flex flex-col justify-center gap-3 sm:flex-row">
-                  <Button
-                    asChild
-                    size="lg"
+                  <PublicRouteControl
+                    href={ROUTES.contacto}
+                    variant="primaryDark"
                     className="public-cta-primary w-full sm:w-auto"
                   >
-                    <Link href={ROUTES.contacto}>
-                      Solicitar coordinación diagnóstica
-                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                    </Link>
-                  </Button>
-                  <Button
-                    asChild
-                    size="lg"
-                    variant="outline"
+                    Solicitar coordinación diagnóstica
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href={ROUTES.clinicas}
+                    variant="primaryLight"
                     className="public-cta-outline w-full sm:w-auto"
                   >
-                    <Link href={ROUTES.clinicas}>
-                      Conocer solución para clínicas
-                    </Link>
-                  </Button>
+                    Conocer solución para clínicas
+                  </PublicRouteControl>
                 </div>
               </div>
             </PublicScrollReveal>
@@ -363,9 +359,11 @@ export default function ServiciosPage() {
                     </h2>
                     <p className="public-copy text-muted-foreground">
                       Basamos nuestro trabajo en compromiso, seriedad, respeto,
-                      responsabilidad, confianza, diálogo, trabajo en equipo,
-                      empatía y capacitación constante para sostener un servicio
-                      patológico veterinario confiable.
+                      responsabilidad, confianza, diálogo, criterio clínico y ética
+                      profesional. Queremos ser un laboratorio de anatomía
+                      patológica veterinaria confiable, comprometido con la calidad
+                      diagnóstica y con el bienestar animal en cada caso que
+                      recibimos.
                     </p>
                   </div>
                 </div>
@@ -377,4 +375,3 @@ export default function ServiciosPage() {
     </PublicLayout>
   );
 }
-

--- a/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
 import { ArrowLeft, Microscope } from "lucide-react";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
@@ -65,8 +65,9 @@ export function DashboardSidebarFrame({
       <nav className="flex-1 space-y-1 px-2 py-4 sm:px-3" aria-label="Menú principal">
         {navItems.map((item) => (
           <div key={item.href}>
-            <Link
+            <PublicRouteControl
               href={item.href}
+              variant="bare"
               className={cn(
                 "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors sm:justify-start sm:px-3",
                 isActive(item.href, item.exact)
@@ -77,25 +78,26 @@ export function DashboardSidebarFrame({
             >
               <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
               <span className="hidden sm:inline">{item.label}</span>
-            </Link>
+            </PublicRouteControl>
 
             {item.children && isActive(item.href) && (
               <div className="ml-6 mt-1 hidden space-y-1 sm:block">
                 {item.children.map((child) => (
-                  <Link
+                  <PublicRouteControl
                     key={child.href}
                     href={child.href}
-                      className={cn(
-                        "flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
-                        pathname === child.href
-                          ? "bg-sidebar-accent/80 text-sidebar-accent-foreground ring-1 ring-white/10"
-                          : "text-sidebar-foreground/62 hover:bg-sidebar-accent/38 hover:text-sidebar-foreground",
-                      )}
-                      aria-current={pathname === child.href ? "page" : undefined}
-                    >
+                    variant="bare"
+                    className={cn(
+                      "flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                      pathname === child.href
+                        ? "bg-sidebar-accent/80 text-sidebar-accent-foreground ring-1 ring-white/10"
+                        : "text-sidebar-foreground/62 hover:bg-sidebar-accent/38 hover:text-sidebar-foreground",
+                    )}
+                    aria-current={pathname === child.href ? "page" : undefined}
+                  >
                     <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true" />
                     {child.label}
-                  </Link>
+                  </PublicRouteControl>
                 ))}
               </div>
             )}
@@ -104,13 +106,14 @@ export function DashboardSidebarFrame({
       </nav>
 
       <div className="border-t border-sidebar-border px-2 py-4 sm:px-3">
-        <Link
+        <PublicRouteControl
           href={ROUTES.home}
+          variant="bare"
           className="flex items-center justify-center gap-2 rounded-md px-2 py-2 text-xs text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground sm:justify-start sm:px-3"
         >
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
           <span className="hidden sm:inline">Volver al sitio público</span>
-        </Link>
+        </PublicRouteControl>
       </div>
     </aside>
   );

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 
 interface DashboardTopbarProps {
@@ -37,9 +36,13 @@ export function DashboardTopbar({ title, subtitle }: DashboardTopbarProps) {
       </div>
 
       <div className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3">
-        <Button asChild variant="outline" size="sm">
-          <Link href={ROUTES.login}>Cerrar sesión</Link>
-        </Button>
+        <PublicRouteControl
+          href={ROUTES.login}
+          variant="bare"
+          className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground"
+        >
+          Cerrar sesión
+        </PublicRouteControl>
       </div>
     </header>
   );

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,4 +1,6 @@
-import Link from "next/link";
+"use client";
+
+import { useRouter } from "next/navigation";
 import {
   ChevronDown,
   Mail,
@@ -83,6 +85,7 @@ export function FooterFaq() {
 }
 
 export function Footer() {
+  const router = useRouter();
   const year = new Date().getFullYear();
 
   return (
@@ -147,12 +150,13 @@ export function Footer() {
             <ul className="space-y-3">
               {footerLinks.map((link) => (
                 <li key={link.href}>
-                  <Link
-                    href={link.href}
-                    className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal"
+                  <button
+                    type="button"
+                    onClick={() => router.push(link.href)}
+                    className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                   >
                     {link.label}
-                  </Link>
+                  </button>
                 </li>
               ))}
             </ul>
@@ -164,29 +168,32 @@ export function Footer() {
             </h3>
             <ul className="space-y-3">
               <li>
-                <Link
-                  href={ROUTES.login}
-                  className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal"
+                <button
+                  type="button"
+                  onClick={() => router.push(ROUTES.login)}
+                  className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                 >
                   Iniciar sesión
-                </Link>
+                </button>
               </li>
               <li>
-                <Link
-                  href={ROUTES.particulares}
-                  className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal"
+                <button
+                  type="button"
+                  onClick={() => router.push(ROUTES.particulares)}
+                  className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                 >
                   Acceso particulares
-                </Link>
+                </button>
               </li>
               <li>
-                <Link
-                  href={ROUTES.contacto}
-                  className="inline-flex items-center gap-2 rounded-md border border-white/15 bg-white/8 px-3 py-1.5 text-sm text-white shadow-sm transition-colors hover:bg-white/14"
+                <button
+                  type="button"
+                  onClick={() => router.push(ROUTES.contacto)}
+                  className="inline-flex items-center gap-2 rounded-md border border-white/15 bg-white/8 px-3 py-1.5 text-sm text-white shadow-sm transition-colors hover:bg-white/14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                 >
                   <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
                   Solicitar acceso
-                </Link>
+                </button>
               </li>
             </ul>
           </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,4 +1,6 @@
-import Link from "next/link";
+"use client";
+
+import { useRouter } from "next/navigation";
 import { ArrowRight, ChevronDown, Microscope } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -16,6 +18,8 @@ const navLinks = [
 const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];
 
 export function Navbar() {
+  const router = useRouter();
+
   return (
     <header className="sticky top-0 z-50 w-full border-b border-vetneb-line/80 bg-card/96 shadow-[0_10px_28px_rgba(15,45,62,0.08)]">
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
@@ -36,12 +40,13 @@ export function Navbar() {
               <ul className="flex flex-col gap-1">
                 {mobileNavLinks.map((link) => (
                   <li key={link.href}>
-                    <Link
-                      href={link.href}
-                      className="block rounded-md px-3 py-2.5 text-sm font-medium text-vetneb-ink/85 transition-colors hover:bg-accent/70 hover:text-vetneb-ink"
+                    <button
+                      type="button"
+                      onClick={() => router.push(link.href)}
+                      className="block w-full rounded-md px-3 py-2.5 text-left text-sm font-medium text-vetneb-ink/85 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                     >
                       {link.label}
-                    </Link>
+                    </button>
                   </li>
                 ))}
               </ul>
@@ -49,10 +54,11 @@ export function Navbar() {
           </details>
         </div>
 
-        <Link
-          href={ROUTES.home}
-          className="group hidden items-center gap-2.5 lg:flex"
+        <button
+          type="button"
+          onClick={() => router.push(ROUTES.home)}
           aria-label="VETNEB — Inicio"
+          className="group hidden cursor-pointer items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 lg:flex"
         >
           <span className="flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-bold text-primary-foreground shadow-[0_10px_26px_hsl(var(--vetneb-navy)/0.20)] ring-1 ring-vetneb-teal/30 transition-[background-color,box-shadow,border-color] group-hover:shadow-[0_12px_30px_hsl(var(--vetneb-navy)/0.24)]">
             <Microscope className="h-4 w-4" aria-hidden="true" />
@@ -61,36 +67,42 @@ export function Navbar() {
           <span className="hidden text-xs font-semibold text-muted-foreground lg:inline">
             Patología veterinaria
           </span>
-        </Link>
+        </button>
 
         <nav
           className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 lg:flex"
           aria-label="Navegación principal"
         >
           {navLinks.map((link) => (
-            <Link
+            <button
               key={link.href}
-              href={link.href}
-              className="rounded-md px-3.5 py-2 text-sm font-medium text-vetneb-ink/80 transition-colors hover:bg-accent/70 hover:text-vetneb-ink"
+              type="button"
+              onClick={() => router.push(link.href)}
+              className="rounded-md px-3.5 py-2 text-sm font-medium text-vetneb-ink/80 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
             >
               {link.label}
-            </Link>
+            </button>
           ))}
         </nav>
 
         <div className="flex items-center gap-2 sm:gap-3">
-          <Button asChild variant="outline" size="sm" className="public-cta-outline">
-            <Link href={ROUTES.login}>Iniciar sesión</Link>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="public-cta-outline"
+            onClick={() => router.push(ROUTES.login)}
+          >
+            Iniciar sesión
           </Button>
           <Button
-            asChild
+            type="button"
             size="sm"
             className="public-cta-primary hidden sm:flex"
+            onClick={() => router.push(ROUTES.contacto)}
           >
-            <Link href={ROUTES.contacto}>
-              Solicitar acceso
-              <ArrowRight className="h-4 w-4" aria-hidden="true" />
-            </Link>
+            Solicitar acceso
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
           </Button>
         </div>
       </div>

--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, EyeOff, ShieldCheck } from "lucide-react";
 
@@ -14,6 +13,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { loginClinic } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 
@@ -111,15 +111,16 @@ export function LoginContent() {
     >
       <div className="w-full max-w-md">
         <div className="mb-8 text-center">
-          <Link
+          <PublicRouteControl
             href={ROUTES.home}
+            variant="bare"
             className="inline-flex items-center justify-center"
             aria-label="PORTAL VETNEB — Inicio"
           >
             <span className="text-2xl font-bold text-vetneb-ink">
               PORTAL VETNEB
             </span>
-          </Link>
+          </PublicRouteControl>
           <p className="mt-2 text-xs font-semibold tracking-[0.08em] text-muted-foreground">
             Patología veterinaria
           </p>
@@ -152,14 +153,15 @@ export function LoginContent() {
               >
                 Clínicas
               </button>
-              <Link
+              <PublicRouteControl
                 href={ROUTES.particulares}
+                variant="bare"
                 className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
                 aria-pressed="false"
                 data-auth-particular-access-link="true"
               >
                 Particulares
-              </Link>
+              </PublicRouteControl>
             </div>
 
             <form
@@ -244,21 +246,26 @@ export function LoginContent() {
             <div className="mt-6 rounded-lg border border-vetneb-cyan/25 bg-vetneb-cyan/10 px-4 py-3 text-center">
               <p className="text-sm text-muted-foreground">
                 ¿Su clínica no tiene acceso?{" "}
-                <Link
+                <PublicRouteControl
                   href={ROUTES.contacto}
+                  variant="textLink"
                   className="font-medium text-primary hover:underline"
                 >
                   Solicite acceso
-                </Link>
+                </PublicRouteControl>
               </p>
             </div>
           </CardContent>
         </Card>
 
         <p className="mt-6 text-center text-xs text-muted-foreground">
-          <Link href={ROUTES.home} className="transition-colors hover:text-primary">
+          <PublicRouteControl
+            href={ROUTES.home}
+            variant="textLink"
+            className="transition-colors hover:text-primary"
+          >
             ← Volver al sitio público
-          </Link>
+          </PublicRouteControl>
         </p>
       </div>
     </div>

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
-import Link from "next/link";
 import {
   CalendarDays,
   Download,
@@ -36,6 +35,7 @@ import {
   PremiumPanel,
   VisualIcon,
 } from "@/components/public/VisualAccents";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 
 function formatDate(value: string | null | undefined) {
   if (!value) {
@@ -425,12 +425,13 @@ export function ParticularesContent() {
 
                   <p className="text-center text-sm text-muted-foreground">
                     ¿Tiene credenciales de clínica?{" "}
-                    <Link
+                    <PublicRouteControl
                       href={ROUTES.login}
+                      variant="textLink"
                       className="font-medium text-primary hover:underline"
                     >
                       Inicie sesión en el portal
-                    </Link>
+                    </PublicRouteControl>
                   </p>
                 </form>
               )}

--- a/frontend/src/components/public/PublicAction.tsx
+++ b/frontend/src/components/public/PublicAction.tsx
@@ -1,8 +1,10 @@
-import Link from "next/link";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import {
+  PublicExternalControl,
+  PublicRouteControl,
+} from "@/components/public/PublicRouteControl";
 
 export type PublicActionVariant =
   | "primaryLight"
@@ -18,9 +20,14 @@ type PublicActionProps = {
   className?: string;
   icon?: ReactNode;
   external?: boolean;
-} & Omit<ComponentPropsWithoutRef<typeof Link>, "href" | "children" | "className">;
+  replace?: boolean;
+  prefetch?: boolean;
+} & Omit<ComponentPropsWithoutRef<"button">, "type" | "children" | "className">;
 
-const actionClasses: Record<Exclude<PublicActionVariant, "textLink" | "contactCard">, string> = {
+const actionClasses: Record<
+  Exclude<PublicActionVariant, "textLink" | "contactCard">,
+  string
+> = {
   primaryLight:
     "w-full border-vetneb-line/90 bg-card/95 px-7 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto",
   primaryDark:
@@ -36,26 +43,39 @@ export function PublicAction({
   className,
   icon,
   external = false,
+  replace = false,
+  prefetch = true,
   ...props
 }: PublicActionProps) {
-  const rel = external ? "noopener noreferrer" : props.rel;
-  const target = external ? "_blank" : props.target;
-
   if (variant === "textLink") {
+    if (external) {
+      return (
+        <PublicExternalControl
+          href={href}
+          className={cn(
+            "inline-flex items-center gap-2 text-sm font-semibold text-vetneb-navy underline-offset-4 transition hover:text-vetneb-teal hover:underline",
+            className,
+          )}
+          {...props}
+        >
+          <span>{children}</span>
+          {icon}
+        </PublicExternalControl>
+      );
+    }
+
     return (
-      <Link
+      <PublicRouteControl
         href={href}
-        className={cn(
-          "inline-flex items-center gap-2 text-sm font-semibold text-vetneb-navy underline-offset-4 transition hover:text-vetneb-teal hover:underline",
-          className,
-        )}
-        rel={rel}
-        target={target}
+        variant="textLink"
+        replace={replace}
+        prefetch={prefetch}
+        className={className}
+        icon={icon}
         {...props}
       >
-        <span>{children}</span>
-        {icon}
-      </Link>
+        {children}
+      </PublicRouteControl>
     );
   }
 
@@ -68,34 +88,64 @@ export function PublicAction({
         )}
       >
         <span className="text-sm font-semibold text-vetneb-navy">{children}</span>
-        <Link
-          href={href}
-          rel={rel}
-          target={target}
-          className="inline-flex shrink-0 text-vetneb-teal transition group-hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
-          tabIndex={0}
-          {...props}
-        >
-          <span className="sr-only">
-            {typeof children === "string" ? children : "Ver"}
-          </span>
-          {icon ? <span aria-hidden="true">{icon}</span> : null}
-        </Link>
+        {external ? (
+          <PublicExternalControl
+            href={href}
+            className="inline-flex shrink-0 text-vetneb-teal transition group-hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            {...props}
+          >
+            <span className="sr-only">
+              {typeof children === "string" ? children : "Ver"}
+            </span>
+            {icon ? <span aria-hidden="true">{icon}</span> : null}
+          </PublicExternalControl>
+        ) : (
+          <PublicRouteControl
+            href={href}
+            variant="bare"
+            replace={replace}
+            prefetch={prefetch}
+            className="inline-flex shrink-0 text-vetneb-teal transition group-hover:translate-x-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            {...props}
+          >
+            <span className="sr-only">
+              {typeof children === "string" ? children : "Ver"}
+            </span>
+            {icon ? <span aria-hidden="true">{icon}</span> : null}
+          </PublicRouteControl>
+        )}
       </div>
     );
   }
 
-  return (
-    <Button
-      asChild
-      variant={variant === "primaryDark" ? "default" : "outline"}
-      size="lg"
-      className={cn(actionClasses[variant], className)}
-    >
-      <Link href={href} rel={rel} target={target} {...props}>
+  if (external) {
+    return (
+      <PublicExternalControl
+        href={href}
+        className={cn(
+          "inline-flex h-11 items-center justify-center gap-2 rounded-md border border-input bg-card/95 px-8 text-sm font-semibold ring-offset-background transition-[background-color,border-color,box-shadow,color] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55",
+          actionClasses[variant],
+          className,
+        )}
+        {...props}
+      >
         <span>{children}</span>
         {icon}
-      </Link>
-    </Button>
+      </PublicExternalControl>
+    );
+  }
+
+  return (
+    <PublicRouteControl
+      href={href}
+      variant={variant}
+      replace={replace}
+      prefetch={prefetch}
+      className={cn(actionClasses[variant], className)}
+      icon={icon}
+      {...props}
+    >
+      {children}
+    </PublicRouteControl>
   );
 }

--- a/frontend/src/components/public/PublicRouteControl.tsx
+++ b/frontend/src/components/public/PublicRouteControl.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type {
+  ComponentPropsWithoutRef,
+  FocusEvent,
+  MouseEvent,
+  ReactNode,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type PublicRouteControlVariant =
+  | "primaryLight"
+  | "primaryDark"
+  | "secondaryOutline"
+  | "textLink"
+  | "bare";
+
+type PublicRouteControlProps = {
+  href: string;
+  children: ReactNode;
+  variant?: PublicRouteControlVariant;
+  className?: string;
+  icon?: ReactNode;
+  replace?: boolean;
+  prefetch?: boolean;
+} & Omit<ComponentPropsWithoutRef<"button">, "type" | "children" | "className">;
+
+const styledClasses: Record<
+  Exclude<PublicRouteControlVariant, "textLink" | "bare">,
+  string
+> = {
+  primaryLight:
+    "w-full border-vetneb-line/90 bg-card/95 px-7 font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised hover:text-vetneb-navy sm:w-auto",
+  primaryDark:
+    "w-full clinical-primary-gradient clinical-primary-gradient-hover px-7 font-semibold text-primary-foreground shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] sm:w-auto",
+  secondaryOutline:
+    "w-full border border-white/60 bg-white/10 px-7 font-semibold text-white shadow-sm hover:bg-white/16 sm:w-auto",
+};
+
+export function PublicRouteControl({
+  href,
+  children,
+  variant = "primaryLight",
+  className,
+  icon,
+  replace = false,
+  prefetch = true,
+  disabled,
+  onClick,
+  onMouseEnter,
+  onFocus,
+  ...props
+}: PublicRouteControlProps) {
+  const router = useRouter();
+
+  const navigate = () => {
+    if (replace) {
+      router.replace(href);
+      return;
+    }
+
+    router.push(href);
+  };
+
+  const prefetchRoute = () => {
+    if (!prefetch || !href.startsWith("/")) {
+      return;
+    }
+
+    router.prefetch(href);
+  };
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+
+    if (event.defaultPrevented || disabled) {
+      return;
+    }
+
+    navigate();
+  };
+
+  const handleMouseEnter = (event: MouseEvent<HTMLButtonElement>) => {
+    onMouseEnter?.(event);
+
+    if (event.defaultPrevented || disabled) {
+      return;
+    }
+
+    prefetchRoute();
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLButtonElement>) => {
+    onFocus?.(event);
+
+    if (event.defaultPrevented || disabled) {
+      return;
+    }
+
+    prefetchRoute();
+  };
+
+  if (variant === "textLink") {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onFocus={handleFocus}
+        className={cn(
+          "inline-flex items-center gap-2 text-sm font-semibold text-vetneb-navy underline-offset-4 transition hover:text-vetneb-teal hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+          className,
+        )}
+        {...props}
+      >
+        <span>{children}</span>
+        {icon}
+      </button>
+    );
+  }
+
+  if (variant === "bare") {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onFocus={handleFocus}
+        className={cn(
+          "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      disabled={disabled}
+      variant={variant === "primaryDark" ? "default" : "outline"}
+      size="lg"
+      className={cn(styledClasses[variant], className)}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onFocus={handleFocus}
+      {...props}
+    >
+      {children}
+      {icon}
+    </Button>
+  );
+}
+
+type PublicExternalControlProps = {
+  href: string;
+  children: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  target?: "_blank" | "_self";
+} & Omit<ComponentPropsWithoutRef<"button">, "type" | "children" | "className">;
+
+export function PublicExternalControl({
+  href,
+  children,
+  className,
+  icon,
+  target = "_blank",
+  disabled,
+  onClick,
+  ...props
+}: PublicExternalControlProps) {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+
+    if (event.defaultPrevented || disabled) {
+      return;
+    }
+
+    if (target === "_self") {
+      window.location.assign(href);
+      return;
+    }
+
+    window.open(href, target, "noopener,noreferrer");
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={handleClick}
+      className={cn(
+        "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {icon}
+    </button>
+  );
+}

--- a/frontend/src/components/public/RenderPrimitives.tsx
+++ b/frontend/src/components/public/RenderPrimitives.tsx
@@ -1,8 +1,11 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import {
+  PublicExternalControl,
+  PublicRouteControl,
+} from "@/components/public/PublicRouteControl";
 
 type PublicHeroProps = {
   eyebrow?: ReactNode;
@@ -120,6 +123,9 @@ type PublicGradientButtonProps = {
   className?: string;
   href?: string;
   showArrow?: boolean;
+  replace?: boolean;
+  prefetch?: boolean;
+  external?: boolean;
   type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
   disabled?: boolean;
   onClick?: ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
@@ -133,6 +139,9 @@ export function PublicGradientButton({
   className,
   href,
   showArrow = false,
+  replace = false,
+  prefetch = true,
+  external = false,
   type = "button",
   disabled,
   onClick,
@@ -145,10 +154,38 @@ export function PublicGradientButton({
   );
 
   if (href) {
+    const useExternalControl =
+      external ||
+      href.startsWith("http://") ||
+      href.startsWith("https://") ||
+      href.startsWith("mailto:") ||
+      href.startsWith("tel:");
+
+    if (useExternalControl) {
+      return (
+        <PublicExternalControl
+          href={href}
+          disabled={disabled}
+          onClick={onClick}
+          className={cn(gradientButtonClassName, className)}
+        >
+          {content}
+        </PublicExternalControl>
+      );
+    }
+
     return (
-      <Link href={href} className={cn(gradientButtonClassName, className)}>
+      <PublicRouteControl
+        href={href}
+        variant="bare"
+        replace={replace}
+        prefetch={prefetch}
+        disabled={disabled}
+        onClick={onClick}
+        className={cn(gradientButtonClassName, className)}
+      >
         {content}
-      </Link>
+      </PublicRouteControl>
     );
   }
 

--- a/frontend/src/components/pwa/OfflineActions.tsx
+++ b/frontend/src/components/pwa/OfflineActions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { RotateCcw } from "lucide-react";
 
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
 
@@ -17,9 +17,13 @@ export function OfflineActions() {
         <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" />
         Reintentar conexión
       </Button>
-      <Button asChild variant="outline" className="w-full sm:w-auto">
-        <Link href={ROUTES.home}>Volver al inicio disponible</Link>
-      </Button>
+      <PublicRouteControl
+        href={ROUTES.home}
+        variant="primaryLight"
+        className="w-full sm:w-auto"
+      >
+        Volver al inicio disponible
+      </PublicRouteControl>
     </div>
   );
 }

--- a/test/frontend-admin-failed-login-alerts-card.test.ts
+++ b/test/frontend-admin-failed-login-alerts-card.test.ts
@@ -20,6 +20,7 @@ test("admin failed login alerts card is client-side and imports required depende
   assert.ok(source.includes('import { useEffect, useMemo, useState, useTransition } from "react";'));
   assert.ok(source.includes('import { Badge } from "@/components/ui/badge";'));
   assert.ok(source.includes('import { Button } from "@/components/ui/button";'));
+  assert.ok(source.includes('import { PublicExternalControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes("buildAdminFailedLoginAlertsCsvUrl"));
   assert.ok(source.includes("getAdminFailedLoginAlerts"));
   assert.ok(source.includes('import { formatDateTime } from "@/lib/utils";'));
@@ -110,7 +111,10 @@ test("admin failed login alerts card renders header and actions without technica
   assert.ok(source.includes('id="failed-login-alerts"'));
   assert.ok(source.includes("Intentos fallidos de login"));
   assert.ok(source.includes("Limpiar filtros"));
-  assert.ok(source.includes("<a href={csvUrl}>Exportar CSV</a>"));
+  assert.ok(source.includes("<PublicExternalControl"));
+  assert.ok(source.includes("href={csvUrl}"));
+  assert.ok(source.includes('target="_self"'));
+  assert.ok(source.includes("Exportar CSV"));
   assert.ok(source.includes('isPending ? "Actualizando..." : "Actualizar"'));
   assert.equal(source.includes(removedReadOnlyCopy), false);
   assert.equal(source.includes("passwords, tokens, hashes ni cookies."), false);

--- a/test/frontend-clinicas-page-content.test.ts
+++ b/test/frontend-clinicas-page-content.test.ts
@@ -16,7 +16,7 @@ test("clinicas page defines metadata and public layout wiring", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
@@ -43,7 +43,7 @@ test("clinicas page keeps hero CTAs visible on blue hero background", () => {
   assert.ok(source.includes("public-cta-primary"));
   assert.ok(source.includes("public-cta-on-hero"));
   assert.ok(source.includes("w-full sm:w-auto"));
-  assert.ok(source.includes('variant="outline"'));
+  assert.ok(source.includes('variant="secondaryOutline"'));
 });
 
 test("clinicas page lists operational feature cards", () => {
@@ -86,4 +86,3 @@ test("clinicas page keeps one continuous soft canvas below hero", () => {
   assert.equal(source.includes('className="bg-white py-16 md:py-20"'), false);
   assert.equal(source.includes('className="public-soft-canvas py-16 md:py-20"'), false);
 });
-

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -16,7 +16,7 @@ test("dashboard admin defines non-indexable metadata and admin dependencies", ()
   const source = read(ADMIN_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
   assert.ok(source.includes('title: "Administración — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -17,7 +17,7 @@ test("dashboard home defines non-indexable clinic metadata and imports live depe
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('title: "Dashboard Clínica — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));

--- a/test/frontend-dashboard-logistica.test.ts
+++ b/test/frontend-dashboard-logistica.test.ts
@@ -17,7 +17,7 @@ test("dashboard logistica defines non-indexable metadata and dependencies", () =
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('} from "lucide-react";'));
   assert.ok(source.includes('title: "Logística — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));

--- a/test/frontend-dashboard-shared-components.test.ts
+++ b/test/frontend-dashboard-shared-components.test.ts
@@ -16,10 +16,12 @@ function read(relativePath: string): string {
 test("dashboard topbar keeps route-registry logout action and UI dependencies", () => {
   const source = read(DASHBOARD_TOPBAR_PATH);
 
-  assert.ok(source.includes('import Link from "next/link";'));
-  assert.ok(source.includes('import { Button } from "@/components/ui/button";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
-  assert.ok(source.includes("<Link href={ROUTES.login}>Cerrar sesión</Link>"));
+  assert.ok(source.includes("<PublicRouteControl"));
+  assert.ok(source.includes("href={ROUTES.login}"));
+  assert.ok(source.includes("Cerrar sesión"));
+  assert.equal(source.includes('import Link from "next/link";'), false);
   assert.equal(source.includes('href="/login"'), false);
 });
 
@@ -41,7 +43,8 @@ test("dashboard topbar keeps protected dashboard header shell without mock sessi
 
   assert.ok(source.includes('<header'));
   assert.ok(source.includes("sticky top-0 z-40"));
-  assert.ok(source.includes('<Button asChild variant="outline" size="sm">'));
+  assert.ok(source.includes('variant="bare"'));
+  assert.ok(source.includes("border border-input bg-card/95"));
   assert.equal(source.includes("Usuario mock"), false);
   assert.equal(source.includes("Clínica Demo"), false);
   assert.equal(source.includes(">CL<"), false);

--- a/test/frontend-diagnostic-reports-landing-page.test.ts
+++ b/test/frontend-diagnostic-reports-landing-page.test.ts
@@ -26,7 +26,7 @@ test("veterinary diagnostic reports landing page defines public SEO metadata", (
   const source = read(DIAGNOSTIC_REPORTS_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes('import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";'));
   assert.ok(source.includes('import { VisualIcon } from "@/components/public/VisualAccents";'));

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -73,7 +73,9 @@ test("home page exposes mobile professionals block before services", () => {
   assert.ok(source.includes("Buscá profesionales vinculados a VETNEB para derivaciones,"));
   assert.ok(source.includes("interconsultas y coordinación clínica."));
   assert.ok(source.includes('className="public-cta-primary w-full sm:w-auto"'));
-  assert.ok(source.includes("<Link href={ROUTES.profesionales}>Buscar profesionales</Link>"));
+  assert.ok(source.includes("<PublicRouteControl"));
+  assert.ok(source.includes("href={ROUTES.profesionales}"));
+  assert.equal(source.includes("<Link"), false);
 });
 
 test("home page lists core laboratory services and services route CTA", () => {
@@ -115,7 +117,7 @@ test("home page exposes final conversion CTA without private route metadata", ()
   assert.ok(source.includes("public-cta-primary"));
   assert.ok(source.includes("public-cta-on-hero"));
   assert.ok(source.includes("public-cta-outline"));
-  assert.ok(source.includes('variant="outline"'));
+  assert.ok(source.includes('variant="primaryLight"'));
   assert.equal(source.includes("bg-primary py-16 text-white md:py-20"), false);
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes('"/api"'), false);

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -76,9 +76,10 @@ test("frontend login content keeps particular token entry on the dedicated publi
   assert.equal(source.includes("Ingresar con token"), false);
   assert.equal(source.includes("Ingrese el token recibido"), false);
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
-  assert.ok(source.includes("<Link"));
+  assert.ok(source.includes("<PublicRouteControl"));
   assert.ok(source.includes("href={ROUTES.particulares}"));
   assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("openParticularAccess"), false);
   assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
 });

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -92,9 +92,10 @@ test("login public page routes particular access away from the clinic login form
   assert.ok(source.includes('const requestedSurface = searchParams.get("tipo") ?? searchParams.get("surface");'));
   assert.ok(source.includes('if (requestedSurface === "particular")'));
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
-  assert.ok(source.includes("<Link"));
+  assert.ok(source.includes("<PublicRouteControl"));
   assert.ok(source.includes("href={ROUTES.particulares}"));
   assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("openParticularAccess"), false);
   assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
 });

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -39,7 +39,7 @@ test("login content keeps standalone login shell and form landmarks", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes('"use client";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { loginClinic } from "@/lib/api";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("min-h-screen public-page-canvas flex items-center justify-center p-4"));
@@ -79,6 +79,7 @@ test("login content exposes public navigation affordances without direct fetch",
 
   assert.ok(source.includes("href={ROUTES.home}"));
   assert.ok(source.includes("href={ROUTES.particulares}"));
+  assert.ok(source.includes("<PublicRouteControl"));
   assert.ok(source.includes('data-auth-particular-access-link="true"'));
   assert.ok(source.includes('aria-label="PORTAL VETNEB — Inicio"'));
   assert.ok(source.includes("¿Su clínica no tiene acceso?"));

--- a/test/frontend-login-password-visibility-contract.test.ts
+++ b/test/frontend-login-password-visibility-contract.test.ts
@@ -63,13 +63,14 @@ test("login redirects particular surface requests to the dedicated public route"
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
 });
 
-test("login particular access uses native Link navigation contract", () => {
+test("login particular access uses internal route control contract", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
-  assert.ok(source.includes("<Link"));
+  assert.ok(source.includes("<PublicRouteControl"));
   assert.ok(source.includes("href={ROUTES.particulares}"));
   assert.ok(source.includes('data-auth-particular-access-link="true"'));
   assert.ok(source.includes('aria-pressed="false"'));
+  assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("openParticularAccess"), false);
   assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
 });

--- a/test/frontend-native-link-preview-contract.test.ts
+++ b/test/frontend-native-link-preview-contract.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const FRONTEND_APP_ROOT = "frontend/src/app";
+const FRONTEND_COMPONENTS_ROOT = "frontend/src/components";
+const NAVBAR_PATH = "frontend/src/components/layout/Navbar.tsx";
+const HOME_PATH = "frontend/src/app/page.tsx";
+const PUBLIC_ACTION_PATH = "frontend/src/components/public/PublicAction.tsx";
+const OFFLINE_ACTIONS_PATH = "frontend/src/components/pwa/OfflineActions.tsx";
+const DASHBOARD_SIDEBAR_PATH =
+  "frontend/src/components/dashboard/DashboardSidebarFrame.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function collectTsLikeFiles(relativeRoot: string): string[] {
+  const absoluteRoot = resolve(process.cwd(), relativeRoot);
+  const files: string[] = [];
+
+  function walk(currentPath: string) {
+    for (const entry of readdirSync(currentPath)) {
+      const fullPath = `${currentPath}/${entry}`;
+      const info = statSync(fullPath);
+
+      if (info.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (entry.endsWith(".ts") || entry.endsWith(".tsx")) {
+        files.push(fullPath.replace(resolve(process.cwd(), "").replace(/\\/g, "/") + "/", ""));
+      }
+    }
+  }
+
+  walk(absoluteRoot.replace(/\\/g, "/"));
+
+  return files;
+}
+
+const appAndComponentFiles = [
+  ...collectTsLikeFiles(FRONTEND_APP_ROOT),
+  ...collectTsLikeFiles(FRONTEND_COMPONENTS_ROOT),
+];
+
+test("no internal visual navigation uses Button asChild + Link", () => {
+  for (const file of appAndComponentFiles) {
+    const source = read(file);
+
+    if (file.endsWith("frontend/src/components/ui/button.tsx")) {
+      continue;
+    }
+
+    assert.equal(
+      source.includes("Button asChild"),
+      false,
+      `${file} should not use Button asChild for navigation`,
+    );
+    assert.equal(source.includes("<Link"), false, `${file} should not render <Link>`);
+  }
+});
+
+test("navbar primary navigation avoids Link and uses route controls", () => {
+  const source = read(NAVBAR_PATH);
+
+  assert.equal(source.includes("<Link"), false);
+  assert.ok(source.includes('const navLinks = ['));
+  assert.ok(source.includes('aria-label="Navegación principal"'));
+  assert.ok(source.includes("router.push(link.href)"));
+});
+
+test("home hero CTAs avoid Link and use PublicRouteControl", () => {
+  const source = read(HOME_PATH);
+
+  assert.equal(source.includes("<Link"), false);
+  assert.ok(source.includes("<PublicRouteControl"));
+  assert.ok(source.includes("Acceder a informes y trazabilidad"));
+  assert.ok(source.includes("Consultar informes 24 hs"));
+  assert.ok(source.includes("href={ROUTES.login}"));
+  assert.ok(source.includes("href={ROUTES.particulares}"));
+});
+
+test("PublicAction internal href flow uses route controls instead of Link", () => {
+  const source = read(PUBLIC_ACTION_PATH);
+
+  assert.equal(source.includes("<Link"), false);
+  assert.ok(source.includes("PublicRouteControl"));
+  assert.ok(source.includes("PublicExternalControl"));
+});
+
+test("OfflineActions internal CTA avoids Link", () => {
+  const source = read(OFFLINE_ACTIONS_PATH);
+
+  assert.equal(source.includes("<Link"), false);
+  assert.ok(source.includes("<PublicRouteControl"));
+  assert.ok(source.includes("href={ROUTES.home}"));
+});
+
+test("DashboardSidebarFrame visual nav avoids Link", () => {
+  const source = read(DASHBOARD_SIDEBAR_PATH);
+
+  assert.equal(source.includes("<Link"), false);
+  assert.ok(source.includes("<PublicRouteControl"));
+  assert.ok(source.includes("href={item.href}"));
+  assert.ok(source.includes("href={child.href}"));
+});
+
+test("remaining anchors stay in explicit allowlist surfaces only", () => {
+  const expectedAnchorFiles = [
+    "frontend/src/app/page.tsx",
+    "frontend/src/components/layout/Footer.tsx",
+    "frontend/src/components/public/ContactoContent.tsx",
+    "frontend/src/components/public/ProfesionalesSearchContent.tsx",
+  ];
+
+  const actualAnchorFiles = appAndComponentFiles.filter((file) =>
+    /<a\b/.test(read(file)),
+  );
+
+  assert.deepEqual(actualAnchorFiles.sort(), expectedAnchorFiles.sort());
+
+  const home = read("frontend/src/app/page.tsx");
+  assert.ok(home.includes('href="https://wa.me/5493534138946"'));
+
+  const footer = read("frontend/src/components/layout/Footer.tsx");
+  assert.ok(footer.includes('href="https://wa.me/5493534138946"'));
+  assert.ok(footer.includes('href="mailto:lab.vetneb@gmail.com"'));
+
+  const contacto = read("frontend/src/components/public/ContactoContent.tsx");
+  assert.ok(contacto.includes("href={info.href}"));
+  assert.ok(contacto.includes('info.href.startsWith("http")'));
+
+  const profesionales = read(
+    "frontend/src/components/public/ProfesionalesSearchContent.tsx",
+  );
+  assert.ok(profesionales.includes("href={`mailto:${professional.email}`}"));
+  assert.ok(
+    profesionales.includes(
+      "href={`https://wa.me/549${professional.phone.replace(/\\D/g, \"\")}`}",
+    ),
+  );
+  assert.ok(profesionales.includes("href={professional.mapLink}"));
+  assert.ok(profesionales.includes('target="_blank"'));
+});
+
+test("navigation controls avoid anti-preview hacks", () => {
+  const guardedFiles = [
+    "frontend/src/components/public/PublicRouteControl.tsx",
+    "frontend/src/components/public/PublicAction.tsx",
+    "frontend/src/components/public/RenderPrimitives.tsx",
+    "frontend/src/components/layout/Navbar.tsx",
+    "frontend/src/components/layout/Footer.tsx",
+    "frontend/src/components/pwa/OfflineActions.tsx",
+    "frontend/src/components/dashboard/DashboardSidebarFrame.tsx",
+    "frontend/src/components/dashboard/DashboardTopbar.tsx",
+    "frontend/src/app/page.tsx",
+    "frontend/src/app/servicios/page.tsx",
+  ];
+
+  const forbiddenPatterns = [
+    "preventDefault",
+    "onPointerDown",
+    "onTouchStart",
+    "-webkit-touch-callout",
+    "user-select: none",
+  ];
+
+  for (const file of guardedFiles) {
+    const source = read(file);
+
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(
+        source.includes(pattern),
+        false,
+        `${file} should not contain ${pattern}`,
+      );
+    }
+  }
+});

--- a/test/frontend-pathology-laboratory-landing-page.test.ts
+++ b/test/frontend-pathology-laboratory-landing-page.test.ts
@@ -23,7 +23,7 @@ test("veterinary pathology laboratory landing page targets laboratory service in
   const source = read(PATHOLOGY_LAB_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes('import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));

--- a/test/frontend-public-button-contrast-contract.test.ts
+++ b/test/frontend-public-button-contrast-contract.test.ts
@@ -105,7 +105,10 @@ test("public pages use CTA contract classes and avoid low-contrast transparent h
   ];
 
   for (const source of sources) {
-    assert.ok(source.includes("import { Button } from \"@/components/ui/button\";"));
+    assert.ok(
+      source.includes("import { Button } from \"@/components/ui/button\";") ||
+        source.includes("PublicRouteControl"),
+    );
     assert.ok(source.includes("public-cta-"));
   }
 

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -30,7 +30,7 @@ test("public layout wraps pages with navbar main landmark and footer", () => {
 test("navbar uses centralized public routes for primary navigation", () => {
   const source = read(NAVBAR_PATH);
 
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { useRouter } from "next/navigation";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes('const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];'));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
@@ -93,23 +93,23 @@ test("navbar keeps expected public link order including precios", () => {
 test("navbar exposes home login and access CTAs with VETNEB brand", () => {
   const source = read(NAVBAR_PATH);
 
-  assert.ok(source.includes("href={ROUTES.home}"));
+  assert.ok(source.includes("router.push(ROUTES.home)"));
   assert.ok(source.includes('aria-label="VETNEB — Inicio"'));
   assert.ok(source.includes("rounded-md bg-primary px-3"));
   assert.ok(source.includes("font-bold text-primary-foreground"));
   assert.ok(source.includes("VETNEB"));
   assert.equal(source.includes(">VN<"), false);
   assert.equal(source.includes("Portal VETNEB"), false);
-  assert.ok(source.includes("href={ROUTES.login}"));
+  assert.ok(source.includes("router.push(ROUTES.login)"));
   assert.ok(source.includes("Iniciar sesión"));
-  assert.ok(source.includes("href={ROUTES.contacto}"));
+  assert.ok(source.includes("router.push(ROUTES.contacto)"));
   assert.ok(source.includes("Solicitar acceso"));
 });
 
 test("footer uses centralized public routes and contentinfo landmark", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { useRouter } from "next/navigation";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes('role="contentinfo"'));
   assert.ok(source.includes('const footerLinks = ['));
@@ -123,9 +123,9 @@ test("footer uses centralized public routes and contentinfo landmark", () => {
 test("footer exposes access links and legal copy without redundant brand block", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes("href={ROUTES.login}"));
+  assert.ok(source.includes("router.push(ROUTES.login)"));
   assert.ok(source.includes("Iniciar sesión"));
-  assert.ok(source.includes("href={ROUTES.contacto}"));
+  assert.ok(source.includes("router.push(ROUTES.contacto)"));
   assert.ok(source.includes("Solicitar acceso"));
   assert.ok(source.includes("Todos los derechos reservados"));
   assert.equal(source.includes("Laboratorio veterinario digital — Argentina"), false);

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -32,8 +32,7 @@ test("profesionales public page exposes search instead of conversion CTAs", () =
 test("servicios public page exposes conversion CTAs", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes('import Link from "next/link"'));
-  assert.ok(source.includes('import { Button } from "@/components/ui/button"'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
   assert.ok(source.includes("Coordinación diagnóstica para clínicas y profesionales"));
   assert.ok(source.includes("Solicitar coordinación diagnóstica"));

--- a/test/frontend-public-visual-primitives.test.ts
+++ b/test/frontend-public-visual-primitives.test.ts
@@ -27,10 +27,15 @@ test("public action primitive defines intentional action variants", () => {
 test("public action primitive avoids accidental default gradient on light CTAs", () => {
   const source = read(PUBLIC_ACTION_PATH);
 
-  assert.ok(source.includes('variant={variant === "primaryDark" ? "default" : "outline"}'));
+  assert.ok(source.includes('import {'));
+  assert.ok(source.includes("PublicRouteControl"));
+  assert.ok(source.includes("PublicExternalControl"));
+  assert.ok(source.includes("if (external) {"));
   assert.ok(source.includes("bg-card/95"));
   assert.ok(source.includes("text-vetneb-navy"));
   assert.ok(source.includes("clinical-primary-gradient"));
+  assert.equal(source.includes("<Link"), false);
+  assert.equal(source.includes("asChild"), false);
 });
 
 test("public hero primitive defines page-intent variants", () => {
@@ -62,6 +67,6 @@ test("public action contactCard variant renders non-interactive div container no
   assert.ok(source.includes("group flex items-center justify-between gap-4 rounded-lg"));
   // No absolute inset-0 overlay trick
   assert.equal(source.includes("absolute inset-0"), false);
-  // Explicit constrained Link CTA inside the contactCard branch
+  // Explicit constrained CTA control inside the contactCard branch
   assert.ok(source.includes("inline-flex shrink-0"));
 });

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -16,7 +16,7 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import Link from "next/link";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes('import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
@@ -70,7 +70,7 @@ test("servicios page exposes conversion CTAs and SEO copy", () => {
   assert.ok(source.includes("Diagnóstico integral para medicina veterinaria"));
   assert.ok(source.includes("Para tener en cuenta"));
   assert.ok(source.includes("Valores que guían el servicio"));
-  assert.ok(source.includes("veterinario confiable"));
+  assert.ok(source.includes("veterinaria confiable"));
 });
 
 test("servicios page remains public and avoids direct backend/API calls", () => {

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -365,7 +365,7 @@ test("dashboard topbar keeps sticky hierarchy and compact responsive shell", () 
       "title: string;",
       "subtitle?: string;",
       "{subtitle && (",
-      "<Button asChild variant=\"outline\" size=\"sm\">",
+      "<PublicRouteControl",
     ],
     "dashboard topbar hierarchy",
   );


### PR DESCRIPTION
## Summary
- replaces internal visual navigation controls with button-based routing to avoid native browser link previews
- adds PublicRouteControl and PublicExternalControl for route/external actions without rendering anchors
- migrates public CTAs, navbar/footer controls, dashboard nav/actions, login/offline actions, and visual primitives
- keeps only justified real anchors for external contact/protocol links where applicable
- adds native link preview regression contracts

## Validation
- pnpm test
  - tests 1788
  - pass 1787
  - fail 0
  - skipped 1
- pnpm build
- pnpm -C frontend build
- git diff --cached --check

## Scope
- frontend UI and tests only
- no backend changes
- no lockfile changes
- no GitHub Actions changes
- no Supabase/Render/env changes