### PR TITLE
fix(frontend): remove remaining native previews and preserve CTA contrast

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,7 +4,10 @@ import { ClipboardCheck, FlaskConical, Microscope, Network } from "lucide-react"
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
-import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import {
+  PublicExternalControl,
+  PublicRouteControl,
+} from "@/components/public/PublicRouteControl";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { createPageMetadata } from "@/lib/seo";
@@ -123,7 +126,7 @@ export default function HomePage() {
                 <PublicRouteControl
                   href={ROUTES.particulares}
                   variant="secondaryOutline"
-                  className="public-cta-on-hero w-full sm:w-auto"
+                  className="public-cta-on-hero w-full text-vetneb-navy hover:text-vetneb-navy active:text-vetneb-navy focus-visible:text-vetneb-navy sm:w-auto"
                 >
                   Consultar informes 24 hs
                 </PublicRouteControl>
@@ -137,14 +140,13 @@ export default function HomePage() {
                   Horario de atención Lunes a viernes de 8 a 17hs
                 </p>
                 <p className="mt-1 text-xs">
-                  <a
+                  <PublicExternalControl
                     href="https://wa.me/5493534138946"
                     target="_blank"
-                    rel="noopener noreferrer"
                     className="font-semibold underline decoration-vetneb-navy/55 underline-offset-4 transition hover:text-vetneb-teal"
                   >
                     Whatsapp: 3534138946
-                  </a>
+                  </PublicExternalControl>
                 </p>
               </div>
             </div>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -10,6 +10,7 @@ import {
   Phone,
 } from "lucide-react";
 
+import { PublicExternalControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 
 const faqItems = [
@@ -117,26 +118,26 @@ export function Footer() {
                   <Phone className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" aria-hidden="true" />
                   <span>
                     WhatsApp:{" "}
-                    <a
+                    <PublicExternalControl
                       href="https://wa.me/5493534138946"
                       target="_blank"
-                      rel="noopener noreferrer"
                       className="underline underline-offset-2 hover:text-vetneb-teal"
                     >
                       3534138946
-                    </a>
+                    </PublicExternalControl>
                   </span>
                 </li>
                 <li className="flex items-start gap-2">
                   <Mail className="mt-0.5 h-4 w-4 shrink-0 text-primary-foreground/70" aria-hidden="true" />
                   <span>
                     Mail:{" "}
-                    <a
+                    <PublicExternalControl
                       href="mailto:lab.vetneb@gmail.com"
+                      target="_self"
                       className="underline underline-offset-2 hover:text-vetneb-teal"
                     >
                       lab.vetneb@gmail.com
-                    </a>
+                    </PublicExternalControl>
                   </span>
                 </li>
               </ul>

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicExternalControl } from "@/components/public/PublicRouteControl";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -363,13 +364,13 @@ export function ContactoContent() {
                         </CardHeader>
                         <CardContent>
                           {info.href ? (
-                            <a
+                            <PublicExternalControl
                               href={info.href}
-                              {...(info.href.startsWith("http") ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                              target={info.href.startsWith("http") ? "_blank" : "_self"}
                               className="text-vetneb-ink font-medium underline underline-offset-2 hover:text-primary"
                             >
                               {info.value}
-                            </a>
+                            </PublicExternalControl>
                           ) : (
                             <p className="text-vetneb-ink font-medium">{info.value}</p>
                           )}

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PublicExternalControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { Button } from "@/components/ui/button";
@@ -321,12 +322,13 @@ export function ProfesionalesSearchContent() {
                                       Email
                                     </dt>
                                     <dd className="mt-1">
-                                      <a
+                                      <PublicExternalControl
                                         href={`mailto:${professional.email}`}
+                                        target="_self"
                                         className="underline underline-offset-2 hover:text-primary"
                                       >
                                         {professional.email}
-                                      </a>
+                                      </PublicExternalControl>
                                     </dd>
                                   </div>
                                 ) : null}
@@ -337,12 +339,13 @@ export function ProfesionalesSearchContent() {
                                       Teléfono
                                     </dt>
                                     <dd className="mt-1">
-                                      <a
+                                      <PublicExternalControl
                                         href={`https://wa.me/549${professional.phone.replace(/\D/g, "")}`}
+                                        target="_blank"
                                         className="underline underline-offset-2 hover:text-primary"
                                       >
                                         {professional.phone}
-                                      </a>
+                                      </PublicExternalControl>
                                     </dd>
                                   </div>
                                 ) : null}
@@ -353,14 +356,13 @@ export function ProfesionalesSearchContent() {
                                       Mapa
                                     </dt>
                                     <dd className="mt-1">
-                                      <a
+                                      <PublicExternalControl
                                         href={professional.mapLink}
                                         target="_blank"
-                                        rel="noopener noreferrer"
                                         className="underline underline-offset-2 hover:text-primary"
                                       >
                                         Ver ubicación en mapa
-                                      </a>
+                                      </PublicExternalControl>
                                     </dd>
                                   </div>
                                 ) : null}

--- a/frontend/src/components/public/PublicAction.tsx
+++ b/frontend/src/components/public/PublicAction.tsx
@@ -33,7 +33,7 @@ const actionClasses: Record<
   primaryDark:
     "w-full clinical-primary-gradient clinical-primary-gradient-hover px-7 font-semibold text-primary-foreground shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] sm:w-auto",
   secondaryOutline:
-    "w-full border border-white/60 bg-white/10 px-7 font-semibold text-white shadow-sm hover:bg-white/16 sm:w-auto",
+    "w-full border border-white/60 bg-white/10 px-7 font-semibold text-vetneb-navy shadow-sm hover:bg-white/16 hover:text-vetneb-navy active:text-vetneb-navy focus-visible:text-vetneb-navy sm:w-auto",
 };
 
 export function PublicAction({

--- a/frontend/src/components/public/PublicRouteControl.tsx
+++ b/frontend/src/components/public/PublicRouteControl.tsx
@@ -37,7 +37,7 @@ const styledClasses: Record<
   primaryDark:
     "w-full clinical-primary-gradient clinical-primary-gradient-hover px-7 font-semibold text-primary-foreground shadow-[0_14px_35px_hsl(var(--vetneb-navy)/0.22)] sm:w-auto",
   secondaryOutline:
-    "w-full border border-white/60 bg-white/10 px-7 font-semibold text-white shadow-sm hover:bg-white/16 sm:w-auto",
+    "w-full border border-white/60 bg-white/10 px-7 font-semibold text-vetneb-navy shadow-sm hover:bg-white/16 hover:text-vetneb-navy active:text-vetneb-navy focus-visible:text-vetneb-navy sm:w-auto",
 };
 
 export function PublicRouteControl({

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -47,10 +47,16 @@ test("home page exposes accessible hero and primary CTAs", () => {
   assert.equal(source.includes("premium-card p-6"), false);
   assert.ok(source.includes("Horario de atención Lunes a viernes de 8 a 17hs"));
   assert.ok(source.includes("Whatsapp: 3534138946"));
+  assert.ok(source.includes("<PublicExternalControl"));
   assert.ok(source.includes('href="https://wa.me/5493534138946"'));
   assert.ok(source.includes('target="_blank"'));
-  assert.ok(source.includes('rel="noopener noreferrer"'));
+  assert.equal(/<a\b/.test(source), false);
   assert.ok(source.includes('href={ROUTES.login}'));
+  assert.ok(
+    source.includes(
+      'className="public-cta-on-hero w-full text-vetneb-navy hover:text-vetneb-navy active:text-vetneb-navy focus-visible:text-vetneb-navy sm:w-auto"',
+    ),
+  );
 });
 
 test("home page exposes mobile professionals block before services", () => {

--- a/test/frontend-native-link-preview-contract.test.ts
+++ b/test/frontend-native-link-preview-contract.test.ts
@@ -3,11 +3,19 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
+const FRONTEND_SRC_ROOT = "frontend/src";
 const FRONTEND_APP_ROOT = "frontend/src/app";
 const FRONTEND_COMPONENTS_ROOT = "frontend/src/components";
 const NAVBAR_PATH = "frontend/src/components/layout/Navbar.tsx";
 const HOME_PATH = "frontend/src/app/page.tsx";
+const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
+const CONTACTO_PATH = "frontend/src/components/public/ContactoContent.tsx";
+const PROFESIONALES_PATH =
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx";
 const PUBLIC_ACTION_PATH = "frontend/src/components/public/PublicAction.tsx";
+const PUBLIC_ROUTE_CONTROL_PATH =
+  "frontend/src/components/public/PublicRouteControl.tsx";
+const RENDER_PRIMITIVES_PATH = "frontend/src/components/public/RenderPrimitives.tsx";
 const OFFLINE_ACTIONS_PATH = "frontend/src/components/pwa/OfflineActions.tsx";
 const DASHBOARD_SIDEBAR_PATH =
   "frontend/src/components/dashboard/DashboardSidebarFrame.tsx";
@@ -19,9 +27,10 @@ function read(relativePath: string): string {
   );
 }
 
-function collectTsLikeFiles(relativeRoot: string): string[] {
+function collectFiles(relativeRoot: string, extensions: string[]): string[] {
   const absoluteRoot = resolve(process.cwd(), relativeRoot);
   const files: string[] = [];
+  const rootPrefix = resolve(process.cwd(), "").replace(/\\/g, "/") + "/";
 
   function walk(currentPath: string) {
     for (const entry of readdirSync(currentPath)) {
@@ -33,8 +42,8 @@ function collectTsLikeFiles(relativeRoot: string): string[] {
         continue;
       }
 
-      if (entry.endsWith(".ts") || entry.endsWith(".tsx")) {
-        files.push(fullPath.replace(resolve(process.cwd(), "").replace(/\\/g, "/") + "/", ""));
+      if (extensions.some((extension) => entry.endsWith(extension))) {
+        files.push(fullPath.replace(rootPrefix, ""));
       }
     }
   }
@@ -45,9 +54,39 @@ function collectTsLikeFiles(relativeRoot: string): string[] {
 }
 
 const appAndComponentFiles = [
-  ...collectTsLikeFiles(FRONTEND_APP_ROOT),
-  ...collectTsLikeFiles(FRONTEND_COMPONENTS_ROOT),
+  ...collectFiles(FRONTEND_APP_ROOT, [".ts", ".tsx"]),
+  ...collectFiles(FRONTEND_COMPONENTS_ROOT, [".ts", ".tsx"]),
 ];
+
+const frontendSourceFiles = collectFiles(FRONTEND_SRC_ROOT, [
+  ".ts",
+  ".tsx",
+  ".css",
+]);
+
+test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0 and ANCHOR_HITS=0", () => {
+  const nextLinkImports = frontendSourceFiles.filter((file) =>
+    /from\s+["']next\/link["']/.test(read(file)),
+  );
+  const linkTags = frontendSourceFiles.filter((file) => /<Link\b/.test(read(file)));
+  const anchors = frontendSourceFiles.filter((file) => /<a\b/.test(read(file)));
+
+  assert.equal(
+    nextLinkImports.length,
+    0,
+    `NEXT_LINK_IMPORTS should be 0, got ${nextLinkImports.length}: ${nextLinkImports.join(", ")}`,
+  );
+  assert.equal(
+    linkTags.length,
+    0,
+    `LINK_TAGS should be 0, got ${linkTags.length}: ${linkTags.join(", ")}`,
+  );
+  assert.equal(
+    anchors.length,
+    0,
+    `ANCHOR_HITS should be 0, got ${anchors.length}: ${anchors.join(", ")}`,
+  );
+});
 
 test("no internal visual navigation uses Button asChild + Link", () => {
   for (const file of appAndComponentFiles) {
@@ -66,16 +105,7 @@ test("no internal visual navigation uses Button asChild + Link", () => {
   }
 });
 
-test("navbar primary navigation avoids Link and uses route controls", () => {
-  const source = read(NAVBAR_PATH);
-
-  assert.equal(source.includes("<Link"), false);
-  assert.ok(source.includes('const navLinks = ['));
-  assert.ok(source.includes('aria-label="Navegación principal"'));
-  assert.ok(source.includes("router.push(link.href)"));
-});
-
-test("home hero CTAs avoid Link and use PublicRouteControl", () => {
+test("home hero CTAs use PublicRouteControl with explicit visible text class", () => {
   const source = read(HOME_PATH);
 
   assert.equal(source.includes("<Link"), false);
@@ -84,61 +114,34 @@ test("home hero CTAs avoid Link and use PublicRouteControl", () => {
   assert.ok(source.includes("Consultar informes 24 hs"));
   assert.ok(source.includes("href={ROUTES.login}"));
   assert.ok(source.includes("href={ROUTES.particulares}"));
-});
-
-test("PublicAction internal href flow uses route controls instead of Link", () => {
-  const source = read(PUBLIC_ACTION_PATH);
-
-  assert.equal(source.includes("<Link"), false);
-  assert.ok(source.includes("PublicRouteControl"));
-  assert.ok(source.includes("PublicExternalControl"));
-});
-
-test("OfflineActions internal CTA avoids Link", () => {
-  const source = read(OFFLINE_ACTIONS_PATH);
-
-  assert.equal(source.includes("<Link"), false);
-  assert.ok(source.includes("<PublicRouteControl"));
-  assert.ok(source.includes("href={ROUTES.home}"));
-});
-
-test("DashboardSidebarFrame visual nav avoids Link", () => {
-  const source = read(DASHBOARD_SIDEBAR_PATH);
-
-  assert.equal(source.includes("<Link"), false);
-  assert.ok(source.includes("<PublicRouteControl"));
-  assert.ok(source.includes("href={item.href}"));
-  assert.ok(source.includes("href={child.href}"));
-});
-
-test("remaining anchors stay in explicit allowlist surfaces only", () => {
-  const expectedAnchorFiles = [
-    "frontend/src/app/page.tsx",
-    "frontend/src/components/layout/Footer.tsx",
-    "frontend/src/components/public/ContactoContent.tsx",
-    "frontend/src/components/public/ProfesionalesSearchContent.tsx",
-  ];
-
-  const actualAnchorFiles = appAndComponentFiles.filter((file) =>
-    /<a\b/.test(read(file)),
+  assert.ok(
+    source.includes(
+      'className="public-cta-on-hero w-full text-vetneb-navy hover:text-vetneb-navy active:text-vetneb-navy focus-visible:text-vetneb-navy sm:w-auto"',
+    ),
   );
+});
 
-  assert.deepEqual(actualAnchorFiles.sort(), expectedAnchorFiles.sort());
+test("PublicExternalControl covers WhatsApp, mailto and external map surfaces", () => {
+  const home = read(HOME_PATH);
+  const footer = read(FOOTER_PATH);
+  const contacto = read(CONTACTO_PATH);
+  const profesionales = read(PROFESIONALES_PATH);
 
-  const home = read("frontend/src/app/page.tsx");
+  assert.ok(home.includes("<PublicExternalControl"));
   assert.ok(home.includes('href="https://wa.me/5493534138946"'));
+  assert.ok(home.includes('target="_blank"'));
 
-  const footer = read("frontend/src/components/layout/Footer.tsx");
+  assert.ok(footer.includes("<PublicExternalControl"));
   assert.ok(footer.includes('href="https://wa.me/5493534138946"'));
   assert.ok(footer.includes('href="mailto:lab.vetneb@gmail.com"'));
 
-  const contacto = read("frontend/src/components/public/ContactoContent.tsx");
+  assert.ok(contacto.includes("<PublicExternalControl"));
   assert.ok(contacto.includes("href={info.href}"));
-  assert.ok(contacto.includes('info.href.startsWith("http")'));
-
-  const profesionales = read(
-    "frontend/src/components/public/ProfesionalesSearchContent.tsx",
+  assert.ok(
+    contacto.includes('target={info.href.startsWith("http") ? "_blank" : "_self"}'),
   );
+
+  assert.ok(profesionales.includes("<PublicExternalControl"));
   assert.ok(profesionales.includes("href={`mailto:${professional.email}`}"));
   assert.ok(
     profesionales.includes(
@@ -151,16 +154,14 @@ test("remaining anchors stay in explicit allowlist surfaces only", () => {
 
 test("navigation controls avoid anti-preview hacks", () => {
   const guardedFiles = [
-    "frontend/src/components/public/PublicRouteControl.tsx",
-    "frontend/src/components/public/PublicAction.tsx",
-    "frontend/src/components/public/RenderPrimitives.tsx",
-    "frontend/src/components/layout/Navbar.tsx",
-    "frontend/src/components/layout/Footer.tsx",
-    "frontend/src/components/pwa/OfflineActions.tsx",
-    "frontend/src/components/dashboard/DashboardSidebarFrame.tsx",
-    "frontend/src/components/dashboard/DashboardTopbar.tsx",
-    "frontend/src/app/page.tsx",
-    "frontend/src/app/servicios/page.tsx",
+    PUBLIC_ROUTE_CONTROL_PATH,
+    PUBLIC_ACTION_PATH,
+    RENDER_PRIMITIVES_PATH,
+    NAVBAR_PATH,
+    FOOTER_PATH,
+    HOME_PATH,
+    OFFLINE_ACTIONS_PATH,
+    DASHBOARD_SIDEBAR_PATH,
   ];
 
   const forbiddenPatterns = [

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -82,8 +82,9 @@ test("profesionales search content renders professional result cards", () => {
   assert.ok(source.includes("professional.publicAddress"));
   assert.ok(source.includes("professional.mapLink"));
   assert.ok(source.includes("Ver ubicación en mapa"));
+  assert.ok(source.includes("<PublicExternalControl"));
   assert.ok(source.includes('target="_blank"'));
-  assert.ok(source.includes('rel="noopener noreferrer"'));
+  assert.equal(/<a\b/.test(source), false);
   assert.ok(source.includes("mailto:${professional.email}"));
   assert.ok(source.includes("https://wa.me/549"));
 });

--- a/test/frontend-public-button-contrast-contract.test.ts
+++ b/test/frontend-public-button-contrast-contract.test.ts
@@ -14,6 +14,8 @@ const PARTICULARES_CONTENT_PATH =
 const CONTACTO_CONTENT_PATH = "frontend/src/components/public/ContactoContent.tsx";
 const LOGIN_CONTENT_PATH = "frontend/src/components/public/LoginContent.tsx";
 const NAVBAR_PATH = "frontend/src/components/layout/Navbar.tsx";
+const PUBLIC_ROUTE_CONTROL_PATH =
+  "frontend/src/components/public/PublicRouteControl.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -113,9 +115,23 @@ test("public pages use CTA contract classes and avoid low-contrast transparent h
   }
 
   assert.ok(home.includes("public-cta-on-hero"));
+  assert.ok(
+    home.includes(
+      'className="public-cta-on-hero w-full text-vetneb-navy hover:text-vetneb-navy active:text-vetneb-navy focus-visible:text-vetneb-navy sm:w-auto"',
+    ),
+  );
   assert.ok(clinicas.includes("public-cta-on-hero"));
   assert.equal(home.includes("bg-white/10 text-white"), false);
   assert.equal(clinicas.includes("bg-white/10 font-semibold text-white"), false);
+});
+
+test("secondaryOutline CTA variant keeps explicit readable text in all interaction states", () => {
+  const source = read(PUBLIC_ROUTE_CONTROL_PATH);
+
+  assert.ok(source.includes('text-vetneb-navy'));
+  assert.ok(source.includes("hover:text-vetneb-navy"));
+  assert.ok(source.includes("active:text-vetneb-navy"));
+  assert.ok(source.includes("focus-visible:text-vetneb-navy"));
 });
 
 test("login and particulares submit CTAs keep loading semantics and contract class", () => {

--- a/test/frontend-public-page-semantics.test.ts
+++ b/test/frontend-public-page-semantics.test.ts
@@ -98,8 +98,9 @@ test("profesionales content keeps semantic search/result structure and map safet
   assert.ok(source.includes("searchPublicProfessionals("));
   assert.ok(source.includes("router.push(`${ROUTES.profesionales}${params.size ? `?${params}` : \"\"}`)"));
   assert.ok(source.includes("Ver ubicación en mapa"));
+  assert.ok(source.includes("<PublicExternalControl"));
   assert.ok(source.includes('target="_blank"'));
-  assert.ok(source.includes('rel="noopener noreferrer"'));
+  assert.equal(/<a\b/.test(source), false);
   assert.equal(source.includes('from "gsap"'), false);
 });
 


### PR DESCRIPTION
## Summary
- replaces remaining external/contact anchors with PublicExternalControl
- brings frontend link surface to zero anchors for preview-sensitive UI
- preserves CTA text contrast for the home hero secondary action
- hardens native link preview and CTA contrast contracts

## Validation
- NEXT_LINK_IMPORTS=0
- LINK_TAGS=0
- ANCHOR_HITS=0
- ASCHILD_HITS=3
- pnpm test
- pnpm build
- pnpm -C frontend build
- git diff --check

## Scope
- frontend UI and tests only
- no backend changes
- no lockfile changes
- no GitHub Actions changes
- no Supabase/Render/env changes