### PR TITLE
fix(frontend): replace embedded map with static external control

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -53,8 +53,8 @@ const footerLinks = [
   { label: "Contacto", href: ROUTES.contacto },
 ];
 
-const mapsEmbedUrl =
-  "https://www.google.com/maps?q=Blvd.%20Italia%20274%2C%20Villa%20Maria%2C%20Cordoba%2C%20Argentina&output=embed";
+const mapsLocationUrl =
+  "https://www.google.com/maps?q=Blvd.%20Italia%20274%2C%20Villa%20Maria%2C%20Cordoba%2C%20Argentina";
 
 export function FooterFaq() {
   return (
@@ -200,14 +200,38 @@ export function Footer() {
           </div>
 
           <div className="overflow-hidden rounded-lg border border-white/12 bg-white/10 shadow-[0_12px_36px_rgba(0,0,0,0.18)]">
-            <iframe
-              title="Ubicación de Servicio Patológico VETNEB en Google Maps"
-              src={mapsEmbedUrl}
-              className="h-40 w-full"
-              loading="lazy"
-              allowFullScreen
-              referrerPolicy="no-referrer-when-downgrade"
-            />
+            <div className="relative h-40 overflow-hidden bg-gradient-to-br from-cyan-100 via-sky-100 to-slate-200">
+              <div
+                aria-hidden="true"
+                className="absolute inset-0 opacity-70 [background-image:linear-gradient(to_right,rgba(15,45,62,0.10)_1px,transparent_1px),linear-gradient(to_bottom,rgba(15,45,62,0.10)_1px,transparent_1px)] [background-size:24px_24px]"
+              />
+              <div
+                aria-hidden="true"
+                className="absolute -left-4 top-6 h-12 w-44 rounded-full border border-sky-300/75 bg-sky-200/55"
+              />
+              <div
+                aria-hidden="true"
+                className="absolute right-[-2.5rem] top-14 h-16 w-52 rounded-full border border-cyan-300/75 bg-cyan-200/50"
+              />
+              <div className="absolute inset-x-0 bottom-0 bg-white/86 p-3 backdrop-blur-[1px]">
+                <p className="text-xs font-semibold text-vetneb-navy">
+                  Blvd. Italia 274, Villa María
+                </p>
+                <p className="text-[11px] text-vetneb-navy/80">
+                  Córdoba, Argentina
+                </p>
+              </div>
+            </div>
+            <div className="border-t border-white/18 bg-sidebar/88 p-3">
+              <PublicExternalControl
+                href={mapsLocationUrl}
+                target="_blank"
+                aria-label="Ver ubicación del laboratorio en Google Maps"
+                className="inline-flex w-full items-center justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-vetneb-navy shadow-sm transition-colors hover:bg-vetneb-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+              >
+                Ver ubicación en Maps
+              </PublicExternalControl>
+            </div>
           </div>
         </div>
       </section>

--- a/test/frontend-footer-lab-info.test.ts
+++ b/test/frontend-footer-lab-info.test.ts
@@ -37,7 +37,7 @@ test("footer includes public FAQ content in the lower frontend area", () => {
   assert.ok(source.includes("tinciones especiales"));
 });
 
-test("footer unifies laboratory info navigation access and reduced map", () => {
+test("footer unifies laboratory info navigation access and static map card", () => {
   const source = read(FOOTER_PATH);
 
   assert.ok(source.includes("Servicio Patológico VETNEB"));
@@ -51,9 +51,11 @@ test("footer unifies laboratory info navigation access and reduced map", () => {
   assert.ok(source.includes("footerLinks.map((link) =>"));
   assert.ok(source.includes("lg:grid-cols-[1.35fr_0.75fr_0.75fr_1.15fr]"));
   assert.ok(source.includes("https://www.google.com/maps?q="));
-  assert.ok(source.includes("output=embed"));
-  assert.ok(source.includes('className="h-40 w-full"'));
-  assert.ok(source.includes("Ubicación de Servicio Patológico VETNEB en Google Maps"));
+  assert.ok(source.includes("mapsLocationUrl"));
+  assert.ok(source.includes("Ver ubicación en Maps"));
+  assert.ok(source.includes("Ver ubicación del laboratorio en Google Maps"));
+  assert.equal(source.includes("<iframe"), false);
+  assert.equal(source.includes("output=embed"), false);
 });
 
 test("footer removes redundant brand block and keeps public routes safe", () => {

--- a/test/frontend-native-link-preview-contract.test.ts
+++ b/test/frontend-native-link-preview-contract.test.ts
@@ -64,12 +64,13 @@ const frontendSourceFiles = collectFiles(FRONTEND_SRC_ROOT, [
   ".css",
 ]);
 
-test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0 and ANCHOR_HITS=0", () => {
+test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0, ANCHOR_HITS=0 and IFRAME_HITS=0", () => {
   const nextLinkImports = frontendSourceFiles.filter((file) =>
     /from\s+["']next\/link["']/.test(read(file)),
   );
   const linkTags = frontendSourceFiles.filter((file) => /<Link\b/.test(read(file)));
   const anchors = frontendSourceFiles.filter((file) => /<a\b/.test(read(file)));
+  const iframes = frontendSourceFiles.filter((file) => /<iframe\b/.test(read(file)));
 
   assert.equal(
     nextLinkImports.length,
@@ -85,6 +86,11 @@ test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0 and ANCHOR_HITS=0",
     anchors.length,
     0,
     `ANCHOR_HITS should be 0, got ${anchors.length}: ${anchors.join(", ")}`,
+  );
+  assert.equal(
+    iframes.length,
+    0,
+    `IFRAME_HITS should be 0, got ${iframes.length}: ${iframes.join(", ")}`,
   );
 });
 
@@ -134,6 +140,8 @@ test("PublicExternalControl covers WhatsApp, mailto and external map surfaces", 
   assert.ok(footer.includes("<PublicExternalControl"));
   assert.ok(footer.includes('href="https://wa.me/5493534138946"'));
   assert.ok(footer.includes('href="mailto:lab.vetneb@gmail.com"'));
+  assert.ok(footer.includes("href={mapsLocationUrl}"));
+  assert.ok(footer.includes("Ver ubicación en Maps"));
 
   assert.ok(contacto.includes("<PublicExternalControl"));
   assert.ok(contacto.includes("href={info.href}"));
@@ -150,6 +158,16 @@ test("PublicExternalControl covers WhatsApp, mailto and external map surfaces", 
   );
   assert.ok(profesionales.includes("href={professional.mapLink}"));
   assert.ok(profesionales.includes('target="_blank"'));
+});
+
+test("frontend map surfaces avoid embedded Google Maps previews", () => {
+  const footer = read(FOOTER_PATH);
+
+  assert.equal(footer.includes("<iframe"), false);
+  assert.equal(footer.includes("output=embed"), false);
+  assert.equal(footer.includes("mapsEmbedUrl"), false);
+  assert.ok(footer.includes("mapsLocationUrl"));
+  assert.ok(footer.includes("<PublicExternalControl"));
 });
 
 test("navigation controls avoid anti-preview hacks", () => {


### PR DESCRIPTION
## Summary
- replaces embedded Google Maps iframe with a static non-interactive location card
- keeps explicit Maps navigation through PublicExternalControl
- prevents native browser previews originating from iframe-internal Google Maps links
- hardens native link preview contracts for anchors and iframes

## Validation
- NEXT_LINK_IMPORTS=0
- LINK_TAGS=0
- ANCHOR_HITS=0
- IFRAME_HITS=0
- pnpm test
- pnpm build
- pnpm -C frontend build
- git diff --check

## Scope
- frontend footer map UI and tests only
- no backend changes
- no lockfile changes
- no GitHub Actions changes
- no Supabase/Render/env changes