### PR TITLE
fix(frontend): show real map without native preview

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -55,6 +55,8 @@ const footerLinks = [
 
 const mapsLocationUrl =
   "https://www.google.com/maps?q=Blvd.%20Italia%20274%2C%20Villa%20Maria%2C%20Cordoba%2C%20Argentina";
+const mapsEmbedUrl =
+  "https://www.google.com/maps?output=embed&q=Blvd.%20Italia%20274%2C%20Villa%20Maria%2C%20Cordoba%2C%20Argentina";
 
 export function FooterFaq() {
   return (
@@ -199,45 +201,35 @@ export function Footer() {
             </ul>
           </div>
 
-          <div className="overflow-hidden rounded-xl border border-white/14 bg-[linear-gradient(165deg,rgba(255,255,255,0.16),rgba(255,255,255,0.08))] shadow-[0_14px_38px_rgba(0,0,0,0.22)]">
-            <div className="relative overflow-hidden p-4">
-              <div
+          <div className="overflow-hidden rounded-xl border border-white/14 bg-sidebar/96 shadow-[0_14px_38px_rgba(0,0,0,0.22)]">
+            <div className="relative h-52 overflow-hidden border-b border-white/18">
+              <iframe
+                title="Mapa de ubicación de Servicio Patológico VETNEB"
+                src={mapsEmbedUrl}
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
                 aria-hidden="true"
-                className="absolute inset-0 opacity-45 [background-image:radial-gradient(rgba(156,214,231,0.32)_1px,transparent_1px)] [background-size:16px_16px]"
+                tabIndex={-1}
+                className="h-full w-full border-0 pointer-events-none"
               />
-              <div
-                aria-hidden="true"
-                className="absolute -left-7 top-5 h-20 w-24 rounded-full border border-cyan-200/35"
-              />
-              <div
-                aria-hidden="true"
-                className="absolute bottom-[-1.2rem] right-[-2.2rem] h-24 w-36 rounded-full border border-sky-200/30"
-              />
-              <div className="relative rounded-lg border border-white/16 bg-sidebar/72 p-4 backdrop-blur-[1px]">
-                <div className="flex items-start gap-3">
-                  <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-200/22 text-cyan-100 ring-1 ring-cyan-100/30">
-                    <MapPin className="h-4 w-4" aria-hidden="true" />
-                  </span>
-                  <div>
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100/92">
-                      Ubicación
-                    </p>
-                    <p className="mt-1 text-sm font-semibold leading-tight text-white">
-                      Blvd. Italia 274, Villa María
-                    </p>
-                    <p className="mt-1 text-xs text-sidebar-foreground/86">
-                      Córdoba, Argentina
-                    </p>
-                  </div>
-                </div>
+              <div className="pointer-events-none absolute inset-x-3 top-3 rounded-md border border-white/24 bg-sidebar/86 px-3 py-2 text-white shadow-[0_10px_24px_rgba(0,0,0,0.35)] backdrop-blur-[2px]">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100/95">
+                  Ubicación
+                </p>
+                <p className="mt-0.5 text-sm font-semibold leading-tight">
+                  Blvd. Italia 274, Villa María
+                </p>
+                <p className="mt-0.5 text-xs text-sidebar-foreground/90">
+                  Córdoba, Argentina
+                </p>
               </div>
             </div>
-            <div className="border-t border-white/18 bg-sidebar/88 p-3">
+            <div className="bg-sidebar/92 p-3">
               <PublicExternalControl
                 href={mapsLocationUrl}
                 target="_blank"
                 aria-label="Ver ubicación del laboratorio en Google Maps"
-                className="inline-flex w-full items-center justify-center rounded-md border border-white/22 bg-white px-3 py-2 text-sm font-semibold text-vetneb-navy shadow-[0_6px_14px_rgba(255,255,255,0.22)] transition-colors hover:bg-vetneb-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar/80"
+                className="inline-flex w-full items-center justify-center rounded-md border border-white/22 bg-white px-3 py-2 text-sm font-semibold text-vetneb-navy shadow-[0_6px_14px_rgba(255,255,255,0.22)] transition-colors hover:bg-vetneb-surface-raised hover:text-vetneb-navy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar/80"
               >
                 Ver ubicación en Maps
               </PublicExternalControl>

--- a/test/frontend-footer-lab-info.test.ts
+++ b/test/frontend-footer-lab-info.test.ts
@@ -37,7 +37,7 @@ test("footer includes public FAQ content in the lower frontend area", () => {
   assert.ok(source.includes("tinciones especiales"));
 });
 
-test("footer unifies laboratory info navigation access and static map card", () => {
+test("footer unifies laboratory info navigation access and non-interactive real map card", () => {
   const source = read(FOOTER_PATH);
 
   assert.ok(source.includes("Servicio Patológico VETNEB"));
@@ -51,11 +51,23 @@ test("footer unifies laboratory info navigation access and static map card", () 
   assert.ok(source.includes("footerLinks.map((link) =>"));
   assert.ok(source.includes("lg:grid-cols-[1.35fr_0.75fr_0.75fr_1.15fr]"));
   assert.ok(source.includes("https://www.google.com/maps?q="));
+  assert.ok(source.includes("https://www.google.com/maps?output=embed&q="));
+  assert.ok(source.includes("mapsEmbedUrl"));
   assert.ok(source.includes("mapsLocationUrl"));
+  assert.ok(source.includes("<iframe"));
+  assert.ok(source.includes('title="Mapa de ubicación de Servicio Patológico VETNEB"'));
+  assert.ok(source.includes("src={mapsEmbedUrl}"));
+  assert.ok(source.includes('loading="lazy"'));
+  assert.ok(source.includes('referrerPolicy="no-referrer-when-downgrade"'));
+  assert.ok(source.includes('aria-hidden="true"'));
+  assert.ok(source.includes("tabIndex={-1}"));
+  assert.ok(source.includes("pointer-events-none"));
+  assert.ok(source.includes("Blvd. Italia 274, Villa María"));
+  assert.ok(source.includes("Córdoba, Argentina"));
   assert.ok(source.includes("Ver ubicación en Maps"));
   assert.ok(source.includes("Ver ubicación del laboratorio en Google Maps"));
-  assert.equal(source.includes("<iframe"), false);
-  assert.equal(source.includes("output=embed"), false);
+  assert.equal(/<a\b/.test(source), false);
+  assert.equal(/<Link\b/.test(source), false);
 });
 
 test("footer removes redundant brand block and keeps public routes safe", () => {

--- a/test/frontend-native-link-preview-contract.test.ts
+++ b/test/frontend-native-link-preview-contract.test.ts
@@ -64,7 +64,7 @@ const frontendSourceFiles = collectFiles(FRONTEND_SRC_ROOT, [
   ".css",
 ]);
 
-test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0, ANCHOR_HITS=0 and IFRAME_HITS=0", () => {
+test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0, ANCHOR_HITS=0 and IFRAME_HITS=1 (footer map only)", () => {
   const nextLinkImports = frontendSourceFiles.filter((file) =>
     /from\s+["']next\/link["']/.test(read(file)),
   );
@@ -89,8 +89,13 @@ test("frontend source keeps NEXT_LINK_IMPORTS=0, LINK_TAGS=0, ANCHOR_HITS=0 and 
   );
   assert.equal(
     iframes.length,
-    0,
-    `IFRAME_HITS should be 0, got ${iframes.length}: ${iframes.join(", ")}`,
+    1,
+    `IFRAME_HITS should be 1, got ${iframes.length}: ${iframes.join(", ")}`,
+  );
+  assert.deepEqual(
+    iframes,
+    [FOOTER_PATH],
+    `IFRAME_HITS can only come from ${FOOTER_PATH}, got: ${iframes.join(", ")}`,
   );
 });
 
@@ -160,14 +165,26 @@ test("PublicExternalControl covers WhatsApp, mailto and external map surfaces", 
   assert.ok(profesionales.includes('target="_blank"'));
 });
 
-test("frontend map surfaces avoid embedded Google Maps previews", () => {
+test("footer map surface uses a single non-interactive iframe and keeps external map control", () => {
   const footer = read(FOOTER_PATH);
 
-  assert.equal(footer.includes("<iframe"), false);
-  assert.equal(footer.includes("output=embed"), false);
-  assert.equal(footer.includes("mapsEmbedUrl"), false);
+  assert.ok(footer.includes("<iframe"));
+  assert.ok(footer.includes("mapsEmbedUrl"));
+  assert.ok(footer.includes("https://www.google.com/maps?output=embed&q="));
+  assert.ok(footer.includes('title="Mapa de ubicación de Servicio Patológico VETNEB"'));
+  assert.ok(footer.includes("src={mapsEmbedUrl}"));
+  assert.ok(footer.includes('loading="lazy"'));
+  assert.ok(footer.includes('referrerPolicy="no-referrer-when-downgrade"'));
+  assert.ok(footer.includes('aria-hidden="true"'));
+  assert.ok(footer.includes("tabIndex={-1}"));
+  assert.ok(footer.includes("pointer-events-none"));
   assert.ok(footer.includes("mapsLocationUrl"));
   assert.ok(footer.includes("<PublicExternalControl"));
+  assert.ok(footer.includes("href={mapsLocationUrl}"));
+  assert.ok(footer.includes('target="_blank"'));
+  assert.ok(footer.includes("Ver ubicación en Maps"));
+  assert.equal(/<a\b/.test(footer), false);
+  assert.equal(/<Link\b/.test(footer), false);
 });
 
 test("navigation controls avoid anti-preview hacks", () => {


### PR DESCRIPTION
## Summary
- restores a real Google Maps visual in the footer
- keeps the map iframe non-interactive to prevent native browser previews
- preserves the explicit PublicExternalControl CTA: Ver ubicación en Maps
- updates native link preview contracts for one justified non-interactive map iframe

## Validation
- NEXT_LINK_IMPORTS=0
- LINK_TAGS=0
- ANCHOR_HITS=0
- IFRAME_HITS=1
- iframe has pointer-events-none, aria-hidden=true, tabIndex=-1
- pnpm test
- pnpm build
- pnpm -C frontend build
- git diff --check

## Scope
- frontend footer map UI and tests only
- no backend changes
- no lockfile changes
- no GitHub Actions changes
- no Supabase/Render/env changes