### PR TITLE
security(frontend): add reporting-endpoints and unify csp source of truth

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,58 +1,79 @@
 import type { NextConfig } from "next";
 
-const isProduction = process.env.NODE_ENV === "production";
+import {
+  buildCspReportingEndpointConfig,
+  buildReportOnlyCsp,
+  CSP_REPORT_URI_PATH,
+} from "./src/lib/security/csp-policy";
 
-const cspReportOnlyDirectives = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "frame-ancestors 'none'",
-  "form-action 'self'",
-  "img-src 'self' data: blob: https:",
-  "font-src 'self' data:",
-  "style-src 'self' 'unsafe-inline'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-  "connect-src 'self' https:",
-  "frame-src https://www.google.com https://maps.google.com",
-  "manifest-src 'self'",
-  "worker-src 'self' blob:",
-  "upgrade-insecure-requests",
-  "report-uri /api/security/csp-report",
-];
+const isProductionBuild = process.env.NODE_ENV === "production";
 
-const contentSecurityPolicyReportOnly = cspReportOnlyDirectives.join("; ");
+type SecurityHeader = {
+  key: string;
+  value: string;
+};
 
-const securityHeaders = [
-  {
-    key: "X-Content-Type-Options",
-    value: "nosniff",
-  },
-  {
-    key: "X-Frame-Options",
-    value: "DENY",
-  },
-  {
-    key: "Referrer-Policy",
-    value: "strict-origin-when-cross-origin",
-  },
-  {
-    key: "Permissions-Policy",
-    value:
-      "camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=()",
-  },
-  ...(isProduction
-    ? [
-        {
-          key: "Strict-Transport-Security",
-          value: "max-age=63072000; includeSubDomains",
-        },
-      ]
-    : []),
-  {
-    key: "Content-Security-Policy-Report-Only",
-    value: contentSecurityPolicyReportOnly,
-  },
-];
+export type BuildSecurityHeadersOptions = {
+  isProduction?: boolean;
+  siteUrl?: string | null;
+};
+
+export function buildSecurityHeaders(
+  options: BuildSecurityHeadersOptions = {},
+): SecurityHeader[] {
+  const isProduction = options.isProduction ?? isProductionBuild;
+  const siteUrl =
+    options.siteUrl === undefined
+      ? process.env.NEXT_PUBLIC_SITE_URL
+      : options.siteUrl;
+  const reportingConfig = buildCspReportingEndpointConfig(siteUrl);
+  const contentSecurityPolicyReportOnly = buildReportOnlyCsp({
+    reportUri: CSP_REPORT_URI_PATH,
+    reportTo: reportingConfig?.reportToGroup,
+  });
+
+  return [
+    {
+      key: "X-Content-Type-Options",
+      value: "nosniff",
+    },
+    {
+      key: "X-Frame-Options",
+      value: "DENY",
+    },
+    {
+      key: "Referrer-Policy",
+      value: "strict-origin-when-cross-origin",
+    },
+    {
+      key: "Permissions-Policy",
+      value:
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=()",
+    },
+    ...(isProduction
+      ? [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
+          },
+        ]
+      : []),
+    ...(reportingConfig
+      ? [
+          {
+            key: "Reporting-Endpoints",
+            value: reportingConfig.reportingEndpointsHeaderValue,
+          },
+        ]
+      : []),
+    {
+      key: "Content-Security-Policy-Report-Only",
+      value: contentSecurityPolicyReportOnly,
+    },
+  ];
+}
+
+const securityHeaders = buildSecurityHeaders();
 
 const nextConfig: NextConfig = {
   compress: true,

--- a/frontend/src/lib/security/csp-policy.ts
+++ b/frontend/src/lib/security/csp-policy.ts
@@ -4,14 +4,14 @@
 //
 // INVARIANTS (do not break without explicit PR):
 // - Without options, returned policy MUST stay byte-equivalent (directive set
-//   and order) to the static Content-Security-Policy-Report-Only in
-//   frontend/next.config.ts at the time of the previous PR (#746/#747).
-// - Adding `reportUri` appends `report-uri <uri>` as the LAST directive,
-//   preserving the rest of the order. Tests lock this.
+//   and order) to the baseline Content-Security-Policy-Report-Only from
+//   previous PRs (#746/#747).
+// - Adding only `reportUri` appends `report-uri <uri>` as the LAST directive,
+//   preserving the rest of the order. If `reportTo` is present, it follows
+//   `report-uri` and MUST match a Reporting-Endpoints header.
 // - This module MUST NOT emit Content-Security-Policy (enforcing).
-// - This module MUST NOT emit `report-to`. That directive will be introduced
-//   in a follow-up PR together with a `Reporting-Endpoints` header and a
-//   confirmed absolute canonical origin.
+// - This module MUST NOT emit `report-to` unless a caller provides a reporting
+//   group after validating a confirmed absolute canonical origin.
 // - `'unsafe-inline'` and `'unsafe-eval'` are kept temporarily (see #747).
 
 export type BuildReportOnlyCspOptions = {
@@ -26,10 +26,17 @@ export type BuildReportOnlyCspOptions = {
    * for validity; this helper does not validate URLs.
    */
   reportUri?: string;
+
+  /**
+   * If provided, `report-to <group>` is appended after `report-uri`.
+   * Callers must only provide this after a canonical https reporting origin
+   * has been validated and a matching Reporting-Endpoints header is emitted.
+   */
+  reportTo?: string;
 };
 
 function buildDirectives(options: BuildReportOnlyCspOptions): readonly string[] {
-  const { nonce, reportUri } = options;
+  const { nonce, reportUri, reportTo } = options;
 
   const scriptSrc: string[] = ["'self'", "'unsafe-inline'", "'unsafe-eval'"];
   const styleSrc: string[] = ["'self'", "'unsafe-inline'"];
@@ -60,6 +67,10 @@ function buildDirectives(options: BuildReportOnlyCspOptions): readonly string[] 
     directives.push(`report-uri ${reportUri}`);
   }
 
+  if (reportTo) {
+    directives.push(`report-to ${reportTo}`);
+  }
+
   return directives;
 }
 
@@ -80,3 +91,62 @@ export function buildReportOnlyCspDirectives(
  * Kept here so callers (next.config.ts, tests) share a single source of truth.
  */
 export const CSP_REPORT_URI_PATH = "/api/security/csp-report";
+
+export const CSP_REPORT_TO_GROUP = "csp-endpoint";
+
+export type CspReportingEndpointConfig = {
+  origin: string;
+  endpointUrl: string;
+  reportToGroup: typeof CSP_REPORT_TO_GROUP;
+  reportingEndpointsHeaderValue: string;
+};
+
+const LOCAL_REPORTING_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "[::1]",
+]);
+
+export function resolveCanonicalReportingOrigin(
+  rawOrigin: string | null | undefined,
+): string | null {
+  const value = rawOrigin?.trim();
+  if (!value) return null;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:") return null;
+  if (!url.hostname) return null;
+  if (url.username || url.password) return null;
+  if (url.pathname !== "/" && url.pathname !== "") return null;
+  if (url.search || url.hash) return null;
+
+  const hostname = url.hostname.toLowerCase();
+  if (LOCAL_REPORTING_HOSTS.has(hostname)) return null;
+  if (hostname.startsWith("127.")) return null;
+
+  return url.origin;
+}
+
+export function buildCspReportingEndpointConfig(
+  rawOrigin: string | null | undefined,
+): CspReportingEndpointConfig | null {
+  const origin = resolveCanonicalReportingOrigin(rawOrigin);
+  if (!origin) return null;
+
+  const endpointUrl = `${origin}${CSP_REPORT_URI_PATH}`;
+
+  return {
+    origin,
+    endpointUrl,
+    reportToGroup: CSP_REPORT_TO_GROUP,
+    reportingEndpointsHeaderValue: `${CSP_REPORT_TO_GROUP}="${endpointUrl}"`,
+  };
+}

--- a/test/frontend-csp-policy-builder-contract.test.ts
+++ b/test/frontend-csp-policy-builder-contract.test.ts
@@ -5,9 +5,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  buildCspReportingEndpointConfig,
   buildReportOnlyCsp,
   buildReportOnlyCspDirectives,
+  CSP_REPORT_TO_GROUP,
   CSP_REPORT_URI_PATH,
+  resolveCanonicalReportingOrigin,
 } from "../frontend/src/lib/security/csp-policy.ts";
 
 const EXPECTED_BASE_DIRECTIVES: readonly string[] = [
@@ -101,19 +104,26 @@ test("buildReportOnlyCsp({ nonce, reportUri }) supports both at once", () => {
   assert.ok(csp.endsWith(`report-uri ${CSP_REPORT_URI_PATH}`));
 });
 
-test("buildReportOnlyCsp() NEVER emits report-to (this PR uses only report-uri)", () => {
+test("buildReportOnlyCsp() emits report-to only when a reporting group is provided", () => {
   for (const opts of [
     {},
     { nonce: "x" },
     { reportUri: CSP_REPORT_URI_PATH },
-    { nonce: "x", reportUri: CSP_REPORT_URI_PATH },
   ]) {
     const csp = buildReportOnlyCsp(opts);
     assert.ok(
       !/\breport-to\b/.test(csp),
-      `report-to must not appear (opts=${JSON.stringify(opts)})`,
+      `report-to must require an explicit group (opts=${JSON.stringify(opts)})`,
     );
   }
+
+  const csp = buildReportOnlyCsp({
+    reportUri: CSP_REPORT_URI_PATH,
+    reportTo: CSP_REPORT_TO_GROUP,
+  });
+
+  assert.ok(csp.includes(`report-uri ${CSP_REPORT_URI_PATH}`));
+  assert.ok(csp.endsWith(`report-to ${CSP_REPORT_TO_GROUP}`));
 });
 
 test("buildReportOnlyCsp() never claims an enforcing CSP", () => {
@@ -121,10 +131,77 @@ test("buildReportOnlyCsp() never claims an enforcing CSP", () => {
   assert.ok(!csp.toLowerCase().includes("content-security-policy:"));
 });
 
-test("directive count: 14 base + 0/1 reporting", () => {
+test("directive count: 14 base + optional report-uri/report-to directives", () => {
   assert.equal(buildReportOnlyCspDirectives().length, 14);
   assert.equal(
     buildReportOnlyCspDirectives({ reportUri: CSP_REPORT_URI_PATH }).length,
     15,
   );
+  assert.equal(
+    buildReportOnlyCspDirectives({
+      reportUri: CSP_REPORT_URI_PATH,
+      reportTo: CSP_REPORT_TO_GROUP,
+    }).length,
+    16,
+  );
+});
+
+test("resolveCanonicalReportingOrigin normalizes a strict https root origin", () => {
+  assert.equal(
+    resolveCanonicalReportingOrigin(" https://Portal.Example.com/ "),
+    "https://portal.example.com",
+  );
+  assert.equal(
+    resolveCanonicalReportingOrigin("https://portal.example.com:443/"),
+    "https://portal.example.com",
+  );
+  assert.equal(
+    resolveCanonicalReportingOrigin("https://portal.example.com:8443/"),
+    "https://portal.example.com:8443",
+  );
+});
+
+test("resolveCanonicalReportingOrigin rejects unsafe or non-canonical origins", () => {
+  const unsafeOrigins = [
+    undefined,
+    null,
+    "",
+    "not a url",
+    "http://portal.example.com",
+    "https://portal.example.com/path",
+    "https://portal.example.com/?q=1",
+    "https://portal.example.com/#hash",
+    "https://user@portal.example.com",
+    "https://user:pass@portal.example.com",
+    "https://localhost",
+    "https://127.0.0.1",
+    "https://127.1.2.3",
+    "https://0.0.0.0",
+    "https://[::1]",
+  ];
+
+  for (const origin of unsafeOrigins) {
+    assert.equal(
+      resolveCanonicalReportingOrigin(origin),
+      null,
+      `expected unsafe origin to be rejected: ${String(origin)}`,
+    );
+  }
+});
+
+test("buildCspReportingEndpointConfig builds Reporting-Endpoints from the canonical origin", () => {
+  const config = buildCspReportingEndpointConfig("https://Portal.Example.com/");
+
+  assert.deepEqual(config, {
+    origin: "https://portal.example.com",
+    endpointUrl: `https://portal.example.com${CSP_REPORT_URI_PATH}`,
+    reportToGroup: CSP_REPORT_TO_GROUP,
+    reportingEndpointsHeaderValue: `${CSP_REPORT_TO_GROUP}="https://portal.example.com${CSP_REPORT_URI_PATH}"`,
+  });
+});
+
+test("buildCspReportingEndpointConfig returns null when no trusted canonical origin exists", () => {
+  assert.equal(buildCspReportingEndpointConfig(undefined), null);
+  assert.equal(buildCspReportingEndpointConfig("http://portal.example.com"), null);
+  assert.equal(buildCspReportingEndpointConfig("https://localhost"), null);
 });

--- a/test/frontend-csp-report-only-contract.test.ts
+++ b/test/frontend-csp-report-only-contract.test.ts
@@ -3,6 +3,13 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import {
+  buildCspReportingEndpointConfig,
+  buildReportOnlyCsp,
+  CSP_REPORT_TO_GROUP,
+  CSP_REPORT_URI_PATH,
+} from "../frontend/src/lib/security/csp-policy.ts";
+
 const repoRoot = process.cwd();
 const nextConfigPath = join(repoRoot, "frontend", "next.config.ts");
 const footerPath = join(
@@ -21,55 +28,7 @@ function readIfExists(path: string): string {
 const nextConfigSrc = readIfExists(nextConfigPath);
 const footerSrc = readIfExists(footerPath);
 
-function extractCspReportOnlyValue(source: string): string | null {
-  const headerMatch = source.match(
-    /key:\s*["']Content-Security-Policy-Report-Only["']\s*,\s*value:\s*([^,}]+?)(?=\s*[,}])/s,
-  );
-
-  if (!headerMatch) {
-    return null;
-  }
-
-  const expression = headerMatch[1].trim();
-
-  if (
-    (expression.startsWith('"') && expression.endsWith('"')) ||
-    (expression.startsWith("'") && expression.endsWith("'")) ||
-    (expression.startsWith("`") && expression.endsWith("`"))
-  ) {
-    return expression.slice(1, -1);
-  }
-
-  const directivesMatch = source.match(
-    /const\s+cspReportOnlyDirectives\s*=\s*\[([\s\S]+?)\];/,
-  );
-
-  if (!directivesMatch) {
-    return null;
-  }
-
-  const directives = directivesMatch[1]
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith("//"))
-    .map((line) => line.replace(/,\s*$/, "").trim())
-    .map((line) => {
-      if (
-        (line.startsWith('"') && line.endsWith('"')) ||
-        (line.startsWith("'") && line.endsWith("'")) ||
-        (line.startsWith("`") && line.endsWith("`"))
-      ) {
-        return line.slice(1, -1);
-      }
-
-      return null;
-    })
-    .filter((line): line is string => line !== null);
-
-  return directives.length > 0 ? directives.join("; ") : null;
-}
-
-const cspValue = extractCspReportOnlyValue(nextConfigSrc);
+const cspValue = buildReportOnlyCsp({ reportUri: CSP_REPORT_URI_PATH });
 
 test("CSP Report-Only: declares Content-Security-Policy-Report-Only", () => {
   assert.ok(nextConfigSrc.length > 0, "frontend/next.config.ts must be readable");
@@ -166,34 +125,44 @@ test("CSP Report-Only: frame-src permits the public Google Maps iframe", () => {
   );
 });
 
-test("CSP Report-Only: references the same-origin CSP report endpoint without report-to", () => {
+test("CSP Report-Only: references the same-origin CSP report endpoint by default", () => {
   assert.match(
-    nextConfigSrc,
+    cspValue ?? "",
     /\breport-uri\s+\/api\/security\/csp-report\b/,
     "report-uri must point to the same-origin CSP report endpoint",
   );
   assert.doesNotMatch(
-    nextConfigSrc,
+    cspValue ?? "",
     /\breport-to\b/,
-    "report-to must not be added until Reporting-Endpoints is introduced safely",
+    "report-to must not be added without a trusted canonical origin",
+  );
+  assert.equal(buildCspReportingEndpointConfig(undefined), null);
+});
+
+test("CSP Report-Only: adds report-to only with a matching Reporting-Endpoints header", () => {
+  const reportingConfig = buildCspReportingEndpointConfig("https://Portal.Example.com/");
+  assert.ok(reportingConfig, "expected a reporting config for a trusted origin");
+
+  const csp = buildReportOnlyCsp({
+    reportUri: CSP_REPORT_URI_PATH,
+    reportTo: reportingConfig.reportToGroup,
+  });
+
+  assert.match(csp, new RegExp(`\\breport-uri\\s+${CSP_REPORT_URI_PATH}\\b`));
+  assert.match(csp, new RegExp(`\\breport-to\\s+${CSP_REPORT_TO_GROUP}\\b`));
+  assert.equal(
+    reportingConfig.reportingEndpointsHeaderValue,
+    `${CSP_REPORT_TO_GROUP}="https://portal.example.com${CSP_REPORT_URI_PATH}"`,
   );
 });
 
 test("CSP Report-Only: header remains the last securityHeaders entry", () => {
-  const securityHeadersMatch = nextConfigSrc.match(
-    /const\s+securityHeaders\s*=\s*\[([\s\S]*?)\n\s*\];/,
-  );
+  const cspHeaderIndex = nextConfigSrc.indexOf('key: "Content-Security-Policy-Report-Only"');
+  const reportingHeaderIndex = nextConfigSrc.indexOf('key: "Reporting-Endpoints"');
 
-  assert.ok(securityHeadersMatch, "securityHeaders array must be present");
-
-  const keys = [...securityHeadersMatch[1].matchAll(/key:\s*["']([^"']+)["']/g)].map(
-    (match) => match[1],
-  );
-
-  assert.ok(keys.length >= 5, `securityHeaders appears incomplete: ${keys.length} keys found`);
-  assert.equal(
-    keys[keys.length - 1],
-    "Content-Security-Policy-Report-Only",
+  assert.ok(cspHeaderIndex > 0, "Content-Security-Policy-Report-Only header must be present");
+  assert.ok(
+    reportingHeaderIndex === -1 || cspHeaderIndex > reportingHeaderIndex,
     "Content-Security-Policy-Report-Only must be the last security header",
   );
 });

--- a/test/frontend-csp-report-uri-contract.test.ts
+++ b/test/frontend-csp-report-uri-contract.test.ts
@@ -1,7 +1,7 @@
 // test/frontend-csp-report-uri-contract.test.ts
-// VETNEB #748 - Asserts that the CSP Report-Only emitted from next.config.ts
-// now references the same-origin /api/security/csp-report endpoint and that
-// Reporting-Endpoints / report-to are NOT yet present (tracked for #749).
+// VETNEB #749 - Asserts that the CSP Report-Only emitted from next.config.ts
+// uses the shared CSP builder and only enables Reporting-Endpoints / report-to
+// when a strict canonical frontend origin is configured.
 //
 // This test reads next.config.ts as source. It does not boot Next.
 
@@ -11,15 +11,41 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
+import {
+  buildCspReportingEndpointConfig,
+  buildReportOnlyCsp,
+  CSP_REPORT_TO_GROUP,
+  CSP_REPORT_URI_PATH,
+} from "../frontend/src/lib/security/csp-policy.ts";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const NEXT_CONFIG_PATH = resolve(__dirname, "../frontend/next.config.ts");
 const NEXT_CONFIG_SOURCE = readFileSync(NEXT_CONFIG_PATH, "utf8");
+const BASELINE_CSP = buildReportOnlyCsp({ reportUri: CSP_REPORT_URI_PATH });
+
+test("next.config.ts consumes buildReportOnlyCsp() as the CSP source of truth", () => {
+  assert.match(
+    NEXT_CONFIG_SOURCE,
+    /buildReportOnlyCsp\(\s*\{/,
+    "expected next.config.ts to build CSP through buildReportOnlyCsp()",
+  );
+  assert.doesNotMatch(
+    NEXT_CONFIG_SOURCE,
+    /const\s+cspReportOnlyDirectives\s*=/,
+    "next.config.ts must not duplicate the long CSP directive list",
+  );
+  assert.match(
+    NEXT_CONFIG_SOURCE,
+    /reportUri:\s*CSP_REPORT_URI_PATH/,
+    "next.config.ts must pass the canonical report-uri path to buildReportOnlyCsp()",
+  );
+});
 
 test("next.config.ts CSP Report-Only references /api/security/csp-report", () => {
   assert.match(
-    NEXT_CONFIG_SOURCE,
-    /report-uri\s+\/api\/security\/csp-report/,
+    BASELINE_CSP,
+    new RegExp(`report-uri\\s+${CSP_REPORT_URI_PATH.replaceAll("/", "\\/")}`),
     "expected report-uri /api/security/csp-report inside CSP Report-Only directives",
   );
 });
@@ -34,27 +60,85 @@ test("next.config.ts does NOT introduce Content-Security-Policy enforcing", () =
   );
 });
 
-test("next.config.ts does NOT yet add report-to or Reporting-Endpoints (tracked for #749)", () => {
-  assert.ok(
-    !/\breport-to\b/.test(NEXT_CONFIG_SOURCE),
-    "report-to must not appear in this PR",
+test("next.config.ts wires report-to and Reporting-Endpoints to the trusted origin guard", () => {
+  assert.match(
+    NEXT_CONFIG_SOURCE,
+    /options\.siteUrl\s*===\s*undefined[\s\S]*?process\.env\.NEXT_PUBLIC_SITE_URL[\s\S]*?buildCspReportingEndpointConfig\(siteUrl\)/,
+    "next.config.ts must validate NEXT_PUBLIC_SITE_URL before reporting endpoint headers",
   );
-  assert.ok(
-    !/Reporting-Endpoints/i.test(NEXT_CONFIG_SOURCE),
-    "Reporting-Endpoints header must not appear in this PR",
+  assert.match(
+    NEXT_CONFIG_SOURCE,
+    /reportTo:\s*reportingConfig\?\.reportToGroup/,
+    "report-to must be driven by the validated reporting config",
+  );
+  assert.match(
+    NEXT_CONFIG_SOURCE,
+    /key:\s*"Reporting-Endpoints"[\s\S]*?value:\s*reportingConfig\.reportingEndpointsHeaderValue/,
+    "Reporting-Endpoints must use the validated endpoint header value",
+  );
+});
+
+test("CSP builder omits report-to when no trusted canonical origin exists", () => {
+  assert.doesNotMatch(
+    BASELINE_CSP,
+    /\breport-to\b/,
+    "report-to must not appear without a trusted canonical origin",
+  );
+  assert.equal(buildCspReportingEndpointConfig(undefined), null);
+});
+
+test("CSP reporting config emits report-to and Reporting-Endpoints for a trusted canonical origin", () => {
+  const reportingConfig = buildCspReportingEndpointConfig("https://Portal.Example.com/");
+  assert.ok(reportingConfig, "expected a reporting config for a trusted origin");
+  const csp = buildReportOnlyCsp({
+    reportUri: CSP_REPORT_URI_PATH,
+    reportTo: reportingConfig.reportToGroup,
+  });
+
+  assert.match(csp, new RegExp(`\\breport-uri\\s+${CSP_REPORT_URI_PATH}\\b`));
+  assert.match(csp, new RegExp(`\\breport-to\\s+${CSP_REPORT_TO_GROUP}\\b`));
+  assert.equal(
+    reportingConfig.reportingEndpointsHeaderValue,
+    `${CSP_REPORT_TO_GROUP}="https://portal.example.com${CSP_REPORT_URI_PATH}"`,
+  );
+});
+
+test("CSP reporting config rejects unsafe canonical origin inputs for reporting", () => {
+  const unsafeOrigins = [
+    "http://portal.example.com",
+    "https://portal.example.com/path",
+    "https://portal.example.com/?q=1",
+    "https://portal.example.com/#hash",
+    "https://user:pass@portal.example.com",
+    "https://localhost",
+    "https://127.0.0.1",
+    "https://0.0.0.0",
+  ];
+
+  for (const siteUrl of unsafeOrigins) {
+    assert.equal(
+      buildCspReportingEndpointConfig(siteUrl),
+      null,
+      `Reporting-Endpoints config leaked for ${siteUrl}`,
+    );
+  }
+});
+
+test("next.config.ts does not emit legacy Report-To header", () => {
+  assert.doesNotMatch(
+    NEXT_CONFIG_SOURCE,
+    /key:\s*["']Report-To["']/,
+    "legacy Report-To header must not be introduced",
   );
 });
 
 test("next.config.ts preserves Google Maps frame-src", () => {
-  assert.match(
-    NEXT_CONFIG_SOURCE,
-    /frame-src\s+https:\/\/www\.google\.com\s+https:\/\/maps\.google\.com/,
-  );
+  assert.match(BASELINE_CSP, /frame-src\s+https:\/\/www\.google\.com\s+https:\/\/maps\.google\.com/);
 });
 
 test("next.config.ts preserves worker-src and manifest-src", () => {
-  assert.match(NEXT_CONFIG_SOURCE, /worker-src\s+'self'\s+blob:/);
-  assert.match(NEXT_CONFIG_SOURCE, /manifest-src\s+'self'/);
+  assert.match(BASELINE_CSP, /worker-src\s+'self'\s+blob:/);
+  assert.match(BASELINE_CSP, /manifest-src\s+'self'/);
 });
 
 test("next.config.ts keeps #745 headers intact", () => {

--- a/test/frontend-next-config-security-headers.test.ts
+++ b/test/frontend-next-config-security-headers.test.ts
@@ -107,28 +107,20 @@ test("next.config.ts applies securityHeaders to all routes via catch-all source"
 
 test("next.config.ts securityHeaders block has no duplicate keys", () => {
   const source = read(CONFIG_PATH);
+  const securityHeaderKeys = [
+    "X-Content-Type-Options",
+    "X-Frame-Options",
+    "Referrer-Policy",
+    "Permissions-Policy",
+    "Strict-Transport-Security",
+    "Reporting-Endpoints",
+    "Content-Security-Policy-Report-Only",
+  ];
 
-  // Extract only the securityHeaders const block
-  const blockMatch = source.match(
-    /const securityHeaders\s*=\s*\[([\s\S]*?)\];/,
-  );
-  assert.ok(blockMatch, "securityHeaders const block must exist");
-
-  const block = blockMatch[1];
-  const keys = [...block.matchAll(/key:\s*"([^"]+)"/g)].map((m) => m[1]);
-
-  const seen = new Set<string>();
-  const duplicates: string[] = [];
-  for (const key of keys) {
-    if (seen.has(key)) duplicates.push(key);
-    seen.add(key);
+  for (const key of securityHeaderKeys) {
+    const matches = source.match(new RegExp(`key:\\s*"${key}"`, "g")) ?? [];
+    assert.ok(matches.length <= 1, `Duplicate key in securityHeaders: ${key}`);
   }
-
-  assert.deepEqual(
-    duplicates,
-    [],
-    `Duplicate keys in securityHeaders: ${duplicates.join(", ")}`,
-  );
 });
 
 test("next.config.ts poweredByHeader is disabled", () => {


### PR DESCRIPTION
## Summary
- unify CSP Report-Only generation through buildReportOnlyCsp()
- add Reporting-Endpoints/report-to only when NEXT_PUBLIC_SITE_URL resolves to a safe canonical HTTPS origin
- keep report-uri /api/security/csp-report as fallback/source-compatible reporting path

## Contract
- CSP remains Content-Security-Policy-Report-Only
- no Content-Security-Policy enforcing header
- no runtime global nonce activation
- no HSTS preload
- no UI/copy/public route changes
- no dependencies added

## Validation
- pnpm security:public-surface
- pnpm test
- pnpm build
- pnpm -C frontend typecheck