### PR TITLE
security(frontend): consolidate csp reporting readiness contracts

### DIFF
--- a/docs/security/csp-reporting-rollout.md
+++ b/docs/security/csp-reporting-rollout.md
@@ -4,7 +4,7 @@
 
 This document is documentation-only. It does not add schema, routes,
 migrations, dependencies, middleware, layout changes or runtime behavior.
-It records the operative state of CSP reporting as of PRs #748–#750 and
+It records the operative state of CSP reporting as of PRs #748–#752 and
 the conditions required before any future promotion to enforcement.
 
 ## 2. Current state
@@ -97,6 +97,7 @@ to all inline scripts and styles — a separate PR.
 | CSP report endpoint | `frontend/src/app/api/security/csp-report/route.ts` |
 | Smoke contract | `test/frontend-csp-report-uri-contract.test.ts` (tests 13–15) |
 | Builder contract | `test/frontend-csp-policy-builder-contract.test.ts` |
+| Payload contract | `test/frontend-csp-report-endpoint-contract.test.ts` |
 
 ## 8. Local validation
 

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -274,3 +274,28 @@ test("logs de request sanitizan tokens y accesos públicos antes de escribir con
     assertContains(source, "buildRequestLogLine({", file);
   }
 });
+
+test("frontend CSP report route file is at the correct App Router path and exports required handlers", () => {
+  // Production invariant: if frontend/src/app/api/security/csp-report/route.ts is
+  // moved or renamed, the production URL /api/security/csp-report silently changes.
+  // Browsers sending CSP reports would get 404s without any test failure in the
+  // endpoint contract tests (which import by absolute path, not by URL).
+  const ROUTE_FILE = "frontend/src/app/api/security/csp-report/route.ts";
+  const routeSource = read(ROUTE_FILE);
+
+  assert.ok(routeSource.length > 0, `${ROUTE_FILE} must exist and be non-empty`);
+  assertContains(routeSource, "export async function POST(", ROUTE_FILE);
+  assertContains(routeSource, "{ status: 204 }", ROUTE_FILE);
+  assertContains(routeSource, "{ status: 405, headers:", ROUTE_FILE);
+
+  // Verify the CSP_REPORT_URI_PATH constant in csp-policy.ts still matches
+  // the App Router file path segment. A drift here means the header points
+  // browsers to an endpoint that no longer exists at the declared URL.
+  const cspPolicyFile = "frontend/src/lib/security/csp-policy.ts";
+  const cspPolicySource = read(cspPolicyFile);
+  assertContains(
+    cspPolicySource,
+    'CSP_REPORT_URI_PATH = "/api/security/csp-report"',
+    cspPolicyFile,
+  );
+});


### PR DESCRIPTION
## Summary
- update CSP reporting rollout documentation through #752
- add a production invariant for the App Router CSP report endpoint path
- keep runtime behavior unchanged

## Contract
- CSP remains Content-Security-Policy-Report-Only
- no Content-Security-Policy enforcing header
- /api/security/csp-report remains present
- report-uri remains present
- report-to and Reporting-Endpoints remain gated by safe canonical origin
- no runtime global nonce activation
- no HSTS preload
- no production code changes
- no dependencies added
- no UI/copy/public route changes

## Validation
- pnpm security:public-surface
- pnpm test
- pnpm build
- pnpm -C frontend typecheck