### PR TITLE
security(frontend): harden security documentation and invariant coverage

### DIFF
--- a/docs/security/csp-reporting-rollout.md
+++ b/docs/security/csp-reporting-rollout.md
@@ -4,7 +4,7 @@
 
 This document is documentation-only. It does not add schema, routes,
 migrations, dependencies, middleware, layout changes or runtime behavior.
-It records the operative state of CSP reporting as of PRs #748–#752 and
+It records the operative state of CSP reporting as of PRs #748–#753 and
 the conditions required before any future promotion to enforcement.
 
 ## 2. Current state
@@ -98,6 +98,7 @@ to all inline scripts and styles — a separate PR.
 | Smoke contract | `test/frontend-csp-report-uri-contract.test.ts` (tests 13–15) |
 | Builder contract | `test/frontend-csp-policy-builder-contract.test.ts` |
 | Payload contract | `test/frontend-csp-report-endpoint-contract.test.ts` |
+| Production path invariants | `test/security-production-invariants.test.ts` |
 
 ## 8. Local validation
 

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -299,3 +299,17 @@ test("frontend CSP report route file is at the correct App Router path and expor
     cspPolicyFile,
   );
 });
+
+test("next.config.ts declara Content-Security-Policy-Report-Only y no el enforcing", () => {
+  // Production invariant: Report-Only must always be emitted.
+  // Enforcing Content-Security-Policy must remain absent until a dedicated PR
+  // with violation evidence is opened (see docs/security/csp-reporting-rollout.md).
+  const file = "frontend/next.config.ts";
+  const source = read(file);
+
+  assertContains(source, 'key: "Content-Security-Policy-Report-Only"', file);
+
+  // 'key: "Content-Security-Policy"' with a closing quote is NOT a substring of
+  // 'key: "Content-Security-Policy-Report-Only"', so this guard is unambiguous.
+  assertNotContains(source, 'key: "Content-Security-Policy"', file);
+});


### PR DESCRIPTION
## Summary
- update CSP reporting rollout documentation through #753
- add production invariant coverage for CSP Report-Only presence and enforcing CSP absence
- keep runtime behavior unchanged

## Contract
- CSP remains Content-Security-Policy-Report-Only
- no Content-Security-Policy enforcing header
- /api/security/csp-report remains present
- report-uri remains present
- report-to and Reporting-Endpoints remain gated by safe canonical origin
- no runtime global nonce activation
- no HSTS preload
- no production code changes
- no dependencies added
- no UI/copy/public route changes

## Validation
- pnpm security:public-surface
- pnpm test
- pnpm build
- pnpm -C frontend typecheck