### PR TITLE
security(frontend): audit inline csp enforcement blockers

### DIFF
--- a/docs/security/csp-reporting-rollout.md
+++ b/docs/security/csp-reporting-rollout.md
@@ -4,7 +4,7 @@
 
 This document is documentation-only. It does not add schema, routes,
 migrations, dependencies, middleware, layout changes or runtime behavior.
-It records the operative state of CSP reporting as of PRs #748–#753 and
+It records the operative state of CSP reporting as of PRs #748–#756 and
 the conditions required before any future promotion to enforcement.
 
 ## 2. Current state
@@ -168,3 +168,45 @@ failures). No user-facing impact.
 - Configuring CSP violation alert thresholds or rate limits on the report endpoint.
 - Defining report retention policy.
 - Any migration, schema, dependency, UI, or auth change.
+
+## 12. Inline/eval blocker audit
+
+Before opening a `Content-Security-Policy` enforcement PR, run the inline blocker audit
+to confirm the frontend source is free of patterns that require `'unsafe-inline'` or
+`'unsafe-eval'`.
+
+### How to run
+
+```powershell
+node --experimental-strip-types --experimental-specifier-resolution=node `
+     --test test/frontend-csp-inline-blockers-contract.test.ts
+```
+
+Or as part of the full test suite:
+
+```powershell
+pnpm test
+```
+
+### What is audited
+
+| Pattern | CSP impact | Current status |
+|---|---|---|
+| `eval()` | Requires `'unsafe-eval'` in `script-src` | **0 occurrences** ✓ |
+| `new Function()` | Requires `'unsafe-eval'` in `script-src` | **0 occurrences** ✓ |
+| Inline event handler strings (`onclick="..."`) | Requires `'unsafe-inline'` | **0 occurrences** ✓ |
+| Bare `<script>` (no `type="application/ld+json"`) | Requires `'unsafe-inline'` or nonce | **0 occurrences** ✓ (all 7 `<script>` tags are JSON-LD) |
+| `dangerouslySetInnerHTML` without JSON-LD guard | Requires `'unsafe-inline'` or nonce | **0 violations** ✓ (7 uses, all JSON-LD guarded) |
+
+### Interpreting results
+
+A **PASS** means the frontend source is free of the audited blockers.
+
+A **FAIL** means the failing pattern must be resolved before enforcement:
+- `eval()` / `new Function()` → refactor to avoid dynamic code evaluation.
+- Inline event handler string → migrate to React synthetic event prop.
+- Bare `<script>` → add `type="application/ld+json"` or move to `next/script` with strategy.
+- `dangerouslySetInnerHTML` without JSON-LD guard → refactor or add a nonce PR first.
+
+Note: `'unsafe-inline'` and `'unsafe-eval'` remain in the current Report-Only CSP (see `#747`).
+Removing them requires resolving the above patterns AND a nonce strategy PR. See Section 9.

--- a/test/frontend-csp-inline-blockers-contract.test.ts
+++ b/test/frontend-csp-inline-blockers-contract.test.ts
@@ -1,0 +1,175 @@
+// test/frontend-csp-inline-blockers-contract.test.ts
+// VETNEB #756 — Pre-enforcement CSP audit: inline/eval blocker contract.
+//
+// This test is NOT an enforcement gate — CSP remains Report-Only.
+// It is a reproducible audit that documents the current baseline and will
+// catch regressions before a future enforcement PR.
+//
+// Audit scope: frontend/src/**/*.ts and *.tsx (runtime source only).
+// Excluded: test/, docs/, node_modules, .next/.
+//
+// Baseline (as of #756):
+//   eval()                   → 0 occurrences ✓
+//   new Function()           → 0 occurrences ✓
+//   inline event handlers    → 0 occurrences ✓
+//   bare <script> (non-LD)   → 0 occurrences ✓ (all 7 are type="application/ld+json")
+//   dangerouslySetInnerHTML  → 7 uses, ALL JSON-LD guarded ✓
+//
+// If any test fails, the failing pattern is a BLOCKER for CSP enforcement:
+// it would require 'unsafe-inline'/'unsafe-eval', a nonce, or elimination
+// before Content-Security-Policy (enforcing) can be activated.
+//
+// Run standalone:
+//   node --experimental-strip-types --experimental-specifier-resolution=node \
+//        --test test/frontend-csp-inline-blockers-contract.test.ts
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+
+const FRONTEND_SRC = resolve(process.cwd(), "frontend/src");
+const TS_EXTENSIONS = new Set([".ts", ".tsx"]);
+
+function walkDir(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkDir(full));
+    } else if (entry.isFile() && TS_EXTENSIONS.has(extname(entry.name))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+type Violation = { file: string; line: number; snippet: string };
+
+function scanLines(files: string[], pattern: RegExp): Violation[] {
+  const violations: Violation[] = [];
+  for (const file of files) {
+    const content = readFileSync(file, "utf8");
+    content.split("\n").forEach((line, idx) => {
+      if (pattern.test(line)) {
+        violations.push({
+          file: relative(process.cwd(), file),
+          line: idx + 1,
+          snippet: line.trim().slice(0, 120),
+        });
+      }
+    });
+  }
+  return violations;
+}
+
+const runtimeFiles = walkDir(FRONTEND_SRC);
+
+// ── 1. eval() ──────────────────────────────────────────────────────────────
+
+test("no eval() calls in frontend/src runtime source", () => {
+  // eval() requires 'unsafe-eval' in script-src — a hard blocker for enforcement.
+  const found = scanLines(runtimeFiles, /\beval\s*\(/);
+  assert.deepEqual(
+    found,
+    [],
+    `eval() found — BLOCKER for CSP enforcement (requires 'unsafe-eval'):\n${JSON.stringify(found, null, 2)}`,
+  );
+});
+
+// ── 2. new Function() ──────────────────────────────────────────────────────
+
+test("no new Function() calls in frontend/src runtime source", () => {
+  // new Function() is treated as eval() under CSP — requires 'unsafe-eval'.
+  const found = scanLines(runtimeFiles, /\bnew\s+Function\s*\(/);
+  assert.deepEqual(
+    found,
+    [],
+    `new Function() found — BLOCKER for CSP enforcement (requires 'unsafe-eval'):\n${JSON.stringify(found, null, 2)}`,
+  );
+});
+
+// ── 3. Inline event handler string attributes ───────────────────────────────
+
+test("no inline event handler attributes in frontend/src (onerror=, onclick=, onload= as string literals)", () => {
+  // Raw string event handler attributes (onclick="...", onerror="...") inject
+  // executable code that requires 'unsafe-inline'. These are distinct from
+  // React synthetic event props (onClick={...}) which are NOT inline handlers.
+  const found = scanLines(
+    runtimeFiles,
+    /\b(?:onerror|onclick|onload|onfocus|onblur|onsubmit|onmouseover)\s*=\s*["']/,
+  );
+  assert.deepEqual(
+    found,
+    [],
+    `Inline event handler string attribute found — BLOCKER for CSP enforcement (requires 'unsafe-inline'):\n${JSON.stringify(found, null, 2)}`,
+  );
+});
+
+// ── 4. Bare executable <script> tags ───────────────────────────────────────
+
+test("all <script> JSX elements in frontend/src declare type=\"application/ld+json\" (no bare executable scripts)", () => {
+  // A <script> tag without type="application/ld+json" is an inline executable script.
+  // Under CSP enforcement it requires 'unsafe-inline' or a per-request nonce.
+  // All current <script> tags are JSON-LD structured data (safe, serialized via
+  // JSON.stringify). This test guards that no bare executable script is introduced.
+  const violations: Violation[] = [];
+  for (const file of runtimeFiles) {
+    if (!file.endsWith(".tsx")) continue;
+    const content = readFileSync(file, "utf8");
+    const lines = content.split("\n");
+    lines.forEach((line, idx) => {
+      if (/<script\b/.test(line)) {
+        // Inspect up to 4 lines starting at the <script tag for the type attribute.
+        const window = lines.slice(idx, idx + 4).join(" ");
+        if (!/type\s*=\s*["']application\/ld\+json["']/.test(window)) {
+          violations.push({
+            file: relative(process.cwd(), file),
+            line: idx + 1,
+            snippet: line.trim().slice(0, 120),
+          });
+        }
+      }
+    });
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `Bare executable <script> (no type="application/ld+json") found — BLOCKER for CSP enforcement without a nonce:\n${JSON.stringify(violations, null, 2)}`,
+  );
+});
+
+// ── 5. dangerouslySetInnerHTML guard (complements security:public-surface) ──
+
+test("all dangerouslySetInnerHTML uses in frontend/src are JSON-LD guarded (application/ld+json + JSON.stringify)", () => {
+  // dangerouslySetInnerHTML injects raw HTML — under enforcing CSP it would require
+  // 'unsafe-inline' or a nonce on the parent script/style context.
+  // All current uses are JSON-LD structured data blocks serialized via JSON.stringify.
+  // security:public-surface applies the same guard at the script level.
+  const violations: Violation[] = [];
+  for (const file of runtimeFiles) {
+    const content = readFileSync(file, "utf8");
+    let searchFrom = 0;
+    let pos: number;
+    while ((pos = content.indexOf("dangerouslySetInnerHTML", searchFrom)) !== -1) {
+      const lineNum = content.slice(0, pos).split("\n").length;
+      const snippet = content.slice(Math.max(0, pos - 150), pos + 250);
+      const isJsonLd =
+        /application\/ld\+json/.test(snippet) &&
+        /JSON\.stringify\s*\(/.test(snippet);
+      if (!isJsonLd) {
+        violations.push({
+          file: relative(process.cwd(), file),
+          line: lineNum,
+          snippet: snippet.replace(/\s+/g, " ").trim().slice(0, 120),
+        });
+      }
+      searchFrom = pos + 1;
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `dangerouslySetInnerHTML without JSON-LD guard found — BLOCKER for CSP enforcement (requires nonce or elimination):\n${JSON.stringify(violations, null, 2)}`,
+  );
+});


### PR DESCRIPTION
## Summary
- add a reproducible audit for CSP inline/eval enforcement blockers
- verify eval, new Function, inline event handlers, executable script tags, and unguarded dangerouslySetInnerHTML patterns
- document the inline/eval blocker baseline for future CSP enforcement work

## Contract
- CSP remains Content-Security-Policy-Report-Only
- no Content-Security-Policy enforcing header
- unsafe-inline and unsafe-eval remain unchanged
- no runtime global nonce activation
- no HSTS preload
- no runtime/header changes
- no dependencies added
- no UI/copy/public route changes

## Validation
- pnpm security:public-surface
- pnpm test
- pnpm build
- pnpm -C frontend typecheck