### PR TITLE
fix(auth): allow registered clinics to login via Next.js API proxy

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -82,6 +82,20 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 7,
   },
+  async rewrites() {
+    const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? "").trim().replace(/\/+$/, "");
+
+    if (!apiUrl) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiUrl}/api/:path*`,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -104,7 +104,7 @@ export function resolveApiBaseUrlForRuntime(input: {
     throw new Error(PUBLIC_API_CONFIGURATION_ERROR_MESSAGE);
   }
 
-  return normalizeApiBaseUrl(nextPublicApiUrl);
+  return "";
 }
 
 function warnApiFallback(functionName: string, error: unknown): void {

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -854,3 +854,124 @@ test("clinicAuthNativeRoutes persiste failed login sin secretos", async () => {
     await app.close();
   }
 });
+
+test(
+  "clinicAuthNativeRoutes clínica registrada con hash argon2 puede iniciar sesión",
+  async () => {
+    const { hashPassword, verifyPassword } = await import(
+      "../server/lib/auth-security.ts"
+    );
+
+    const storedHash = await hashPassword("clave-inicial-segura");
+    const sessionCalls: Array<{
+      clinicUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 4, 1, 0, 0, 0),
+      getClinicUserByUsername: async (username: string) => {
+        if (username === "clinica-registrada") {
+          return {
+            id: 99,
+            clinicId: 7,
+            username: "clinica-registrada",
+            passwordHash: storedHash,
+            authProId: null,
+            role: "clinic_owner",
+          };
+        }
+        return null;
+      },
+      verifyPassword,
+      generateSessionToken: () => "real-session-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createActiveSession: async (input: {
+        clinicUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        sessionCalls.push(input);
+      },
+      writeAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        payload: { username: "clinica-registrada", password: "clave-inicial-segura" },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      const body = JSON.parse(response.body);
+
+      assert.equal(body.success, true);
+      assert.equal(body.clinicUser.id, 99);
+      assert.equal(body.clinicUser.clinicId, 7);
+      assert.equal(body.clinicUser.username, "clinica-registrada");
+      assert.equal(body.clinicUser.role, "clinic_owner");
+      assert.equal(body.clinicUser.passwordHash, undefined);
+
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(sessionCalls[0].clinicUserId, 99);
+      assert.equal(sessionCalls[0].tokenHash, "hash:real-session-token");
+
+      const setCookie = getSetCookieHeader(response);
+
+      assert.ok(setCookie.includes(`${ENV.cookieName}=`));
+      assert.ok(setCookie.includes("HttpOnly"));
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuthNativeRoutes password incorrecto rechaza clínica registrada",
+  async () => {
+    const { hashPassword, verifyPassword } = await import(
+      "../server/lib/auth-security.ts"
+    );
+
+    const storedHash = await hashPassword("clave-correcta-123");
+
+    const app = await createTestApp({
+      getClinicUserByUsername: async (username: string) => {
+        if (username === "clinica-registrada") {
+          return {
+            id: 99,
+            clinicId: 7,
+            username: "clinica-registrada",
+            passwordHash: storedHash,
+            authProId: null,
+            role: "clinic_owner",
+          };
+        }
+        return null;
+      },
+      verifyPassword,
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        payload: { username: "clinica-registrada", password: "clave-incorrecta" },
+      });
+
+      assert.equal(response.statusCode, 401);
+
+      const body = JSON.parse(response.body);
+
+      assert.equal(body.success, false);
+      assert.ok(typeof body.error === "string" && body.error.length > 0);
+    } finally {
+      await app.close();
+    }
+  },
+);

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -96,3 +96,29 @@ test("frontend API client handles empty and JSON responses", () => {
   assert.ok(source.includes("return undefined as T;"));
   assert.ok(source.includes("return res.json() as Promise<T>;"));
 });
+
+const NEXT_CONFIG_PATH = "frontend/next.config.ts";
+
+test("resolveApiBaseUrlForRuntime retorna path relativo para que la cookie quede en el dominio del frontend", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes('return "";'),
+    "con NEXT_PUBLIC_API_URL configurado debe retornar string vacío y dejar que las rewrites proxyen la llamada",
+  );
+});
+
+test("next.config.ts declara rewrites que proxyan /api/** al backend cuando NEXT_PUBLIC_API_URL está configurado", () => {
+  const source = read(NEXT_CONFIG_PATH);
+
+  assert.ok(source.includes("async rewrites()"), "debe exportar rewrites()");
+  assert.ok(source.includes('source: "/api/:path*"'), "debe reescribir /api/**");
+  assert.ok(
+    source.includes("NEXT_PUBLIC_API_URL"),
+    "debe leer NEXT_PUBLIC_API_URL para la destination",
+  );
+  assert.ok(
+    source.includes('destination: `${apiUrl}/api/:path*`'),
+    "destination debe proxiar al backend",
+  );
+});


### PR DESCRIPTION
## Summary
- route frontend /api requests through Next.js rewrites to the backend
- keep clinic session cookies on the frontend domain
- add regression coverage for registered clinic login and API proxy behavior

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend typecheck

## Notes
- Fixes registered clinic login in split frontend/backend staging domains
- Does not touch CSP/security
- Does not change UI/copy/layout/Footer
- Does not add migrations
- Does not touch production secrets