### PR TITLE
fix(auth): remove role tabs from login screen

### DIFF
--- a/frontend/e2e/login-hydration.spec.ts
+++ b/frontend/e2e/login-hydration.spec.ts
@@ -34,17 +34,20 @@ function collectHydrationFailures(page: Page) {
 
 async function expectInitialLoginState(page: Page) {
   const form = page.getByRole("form", { name: loginFormName });
-  const username = page.getByLabel("Usuario", { exact: true });
+  const heading = page.getByRole("heading", { name: "Iniciar sesión" });
+  const username = page.getByLabel("Usuario o email", { exact: true });
   const password = page.getByLabel("Contraseña", { exact: true });
   const submit = form.getByRole("button", { name: "Iniciar sesión" });
   const clinicTab = page.getByRole("button", { name: "Clínicas" });
+  const particularesTab = page.getByRole("link", { name: "Particulares" });
   const passwordToggle = form.locator(
     '[data-auth-credential-visibility-toggle="true"]',
   );
 
+  await expect(heading).toBeVisible();
   await expect(form).toBeVisible();
-  await expect(clinicTab).toBeEnabled();
-  await expect(clinicTab).toHaveAttribute("aria-pressed", "true");
+  await expect(clinicTab).toHaveCount(0);
+  await expect(particularesTab).toHaveCount(0);
   await expect(username).toHaveValue("");
   await expect(username).toBeEnabled();
   await expect(password).toHaveValue("");

--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -136,34 +136,10 @@ export function LoginContent() {
             </div>
             <CardTitle className="text-xl">Iniciar sesión</CardTitle>
             <CardDescription>
-              Acceda como clínica o ingrese con token particular
+              Acceda al portal privado con sus credenciales.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div
-              className="mb-5 grid grid-cols-2 rounded-lg border border-vetneb-line/90 bg-vetneb-surface-muted/75 p-1"
-              aria-label="Tipo de acceso"
-            >
-              <button
-                type="button"
-                className="rounded-md border border-vetneb-teal/30 bg-card px-3 py-2 text-sm font-medium text-vetneb-ink shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
-                disabled={isSubmitting}
-                aria-pressed="true"
-                data-auth-clinic-access-tab="true"
-              >
-                Clínicas
-              </button>
-              <PublicRouteControl
-                href={ROUTES.particulares}
-                variant="bare"
-                className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
-                aria-pressed="false"
-                data-auth-particular-access-link="true"
-              >
-                Particulares
-              </PublicRouteControl>
-            </div>
-
             <form
               className="space-y-4"
               aria-label="Formulario de inicio de sesión"
@@ -171,13 +147,13 @@ export function LoginContent() {
             >
               <div>
                 <label htmlFor="username" className="field-label">
-                  Usuario
+                  Usuario o email
                 </label>
                 <Input
                   id="username"
                   name="username"
                   type="text"
-                  placeholder="nombre_usuario"
+                  placeholder="nombre_usuario o email@dominio.com"
                   autoComplete="username"
                   autoFocus
                   required

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -69,19 +69,30 @@ test("frontend login page wraps client search params usage in suspense", () => {
   assert.ok(source.includes("<LoginContent />"));
   assert.ok(source.includes("</Suspense>"));
 });
-test("frontend login content keeps particular token entry on the dedicated public surface", () => {
+test("frontend login content keeps particular token access on the dedicated public surface", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.equal(source.includes("Token de acceso"), false);
   assert.equal(source.includes("Ingresar con token"), false);
   assert.equal(source.includes("Ingrese el token recibido"), false);
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
-  assert.ok(source.includes("<PublicRouteControl"));
-  assert.ok(source.includes("href={ROUTES.particulares}"));
-  assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.ok(source.includes('if (requestedSurface === "particular")'));
   assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("openParticularAccess"), false);
   assert.equal(source.includes("router.push(ROUTES.particulares);"), false);
+});
+
+test("frontend login content removes role tabs and keeps a single login surface", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes("Iniciar sesión"));
+  assert.ok(source.includes("Acceda al portal privado con sus credenciales."));
+  assert.ok(source.includes("Usuario o email"));
+  assert.equal(source.includes('data-auth-clinic-access-tab="true"'), false);
+  assert.equal(source.includes('data-auth-particular-access-link="true"'), false);
+  assert.equal(source.includes("aria-label=\"Tipo de acceso\""), false);
+  assert.equal(source.includes("Clínicas"), false);
+  assert.equal(source.includes("Particulares"), false);
 });
 test("frontend login content allows toggling clinic password visibility", () => {
   const source = read(LOGIN_CONTENT_PATH);
@@ -96,5 +107,5 @@ test("frontend login content allows toggling clinic password visibility", () => 
   assert.ok(source.includes('aria-pressed={isPasswordVisible}'));
   assert.ok(source.includes('aria-controls="password"'));
   assert.ok(source.includes('data-auth-credential-visibility-toggle="true"'));
-  assert.ok(source.includes('data-auth-clinic-access-tab="true"'));
+  assert.ok(source.includes('className="public-cta-primary w-full"'));
 });

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -61,7 +61,7 @@ test("login public page handles loading and error states", () => {
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("disabled={isSubmitting}"));
   assert.ok(source.includes('isSubmitting ? "Iniciando sesión..." : "Iniciar sesión"'));
-  assert.ok(source.includes('data-auth-clinic-access-tab="true"'));
+  assert.ok(source.includes("Usuario o email"));
   assert.ok(source.includes('data-auth-credential-input="true"'));
   assert.ok(source.includes('data-auth-credential-visibility-toggle="true"'));
   assert.ok(source.includes('aria-controls="password"'));
@@ -92,9 +92,11 @@ test("login public page routes particular access away from the clinic login form
   assert.ok(source.includes('const requestedSurface = searchParams.get("tipo") ?? searchParams.get("surface");'));
   assert.ok(source.includes('if (requestedSurface === "particular")'));
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
-  assert.ok(source.includes("<PublicRouteControl"));
-  assert.ok(source.includes("href={ROUTES.particulares}"));
-  assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.ok(source.includes("Acceda al portal privado con sus credenciales."));
+  assert.equal(source.includes("Clínicas"), false);
+  assert.equal(source.includes("Particulares"), false);
+  assert.equal(source.includes('data-auth-particular-access-link="true"'), false);
+  assert.equal(source.includes('data-auth-clinic-access-tab="true"'), false);
   assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("openParticularAccess"), false);
   assert.equal(source.includes("router.push(ROUTES.particulares);"), false);

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -49,9 +49,12 @@ test("login content keeps standalone login shell and form landmarks", () => {
   assert.equal(source.includes(">VN<"), false);
   assert.equal(source.includes("Laboratorio veterinario digital"), false);
   assert.ok(source.includes("Iniciar sesión"));
+  assert.ok(source.includes("Acceda al portal privado con sus credenciales."));
   assert.ok(source.includes('aria-label="Formulario de inicio de sesión"'));
-  assert.ok(source.includes("Usuario"));
+  assert.ok(source.includes("Usuario o email"));
   assert.ok(source.includes("Contraseña"));
+  assert.equal(source.includes("Clínicas"), false);
+  assert.equal(source.includes("Particulares"), false);
 });
 
 test("login content keeps safe dashboard redirect and error handling", () => {
@@ -78,9 +81,10 @@ test("login content exposes public navigation affordances without direct fetch",
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes("href={ROUTES.home}"));
-  assert.ok(source.includes("href={ROUTES.particulares}"));
+  assert.ok(source.includes('if (requestedSurface === "particular")'));
+  assert.ok(source.includes("router.replace(ROUTES.particulares);"));
   assert.ok(source.includes("<PublicRouteControl"));
-  assert.ok(source.includes('data-auth-particular-access-link="true"'));
+  assert.equal(source.includes('data-auth-particular-access-link="true"'), false);
   assert.ok(source.includes('aria-label="PORTAL VETNEB — Inicio"'));
   assert.ok(source.includes("¿Su clínica no tiene acceso?"));
   assert.ok(source.includes("href={ROUTES.contacto}"));

--- a/test/frontend-login-password-visibility-contract.test.ts
+++ b/test/frontend-login-password-visibility-contract.test.ts
@@ -63,13 +63,17 @@ test("login redirects particular surface requests to the dedicated public route"
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
 });
 
-test("login particular access uses internal route control contract", () => {
+test("login removes explicit role tabs from the clinic form surface", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
-  assert.ok(source.includes("<PublicRouteControl"));
-  assert.ok(source.includes("href={ROUTES.particulares}"));
-  assert.ok(source.includes('data-auth-particular-access-link="true"'));
-  assert.ok(source.includes('aria-pressed="false"'));
+  assert.ok(source.includes('aria-label="Formulario de inicio de sesión"'));
+  assert.ok(source.includes("Usuario o email"));
+  assert.ok(source.includes("Contraseña"));
+  assert.equal(source.includes("Clínicas"), false);
+  assert.equal(source.includes("Particulares"), false);
+  assert.equal(source.includes('data-auth-particular-access-link="true"'), false);
+  assert.equal(source.includes('data-auth-clinic-access-tab="true"'), false);
+  assert.equal(source.includes('aria-label="Tipo de acceso"'), false);
   assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("openParticularAccess"), false);
   assert.equal(source.includes("router.push(ROUTES.particulares);"), false);

--- a/test/frontend-public-button-contrast-contract.test.ts
+++ b/test/frontend-public-button-contrast-contract.test.ts
@@ -141,10 +141,11 @@ test("login and particulares submit CTAs keep loading semantics and contract cla
 
   assert.ok(login.includes("public-cta-primary w-full"));
   assert.ok(login.includes("aria-busy={isSubmitting}"));
-  assert.ok(login.includes('aria-pressed="true"'));
-  assert.ok(login.includes('aria-pressed="false"'));
-  assert.ok(login.includes("href={ROUTES.particulares}"));
-  assert.ok(login.includes('data-auth-particular-access-link="true"'));
+  assert.ok(login.includes("aria-pressed={isPasswordVisible}"));
+  assert.equal(login.includes("Clínicas"), false);
+  assert.equal(login.includes("Particulares"), false);
+  assert.equal(login.includes('data-auth-particular-access-link="true"'), false);
+  assert.equal(login.includes('data-auth-clinic-access-tab="true"'), false);
   assert.equal(login.includes("router.push(ROUTES.particulares);"), false);
 
   assert.ok(particulares.includes("public-cta-primary w-full"));


### PR DESCRIPTION
## Summary
- remove Clinics/Particulares tabs from the login screen
- keep a single login form
- update login UI contract coverage

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend typecheck

## Notes
- Does not touch CSP/security
- Does not add migrations
- Does not touch production secrets
- Does not change dashboards
- Preserves the current login submit flow