### PR TITLE
feat(auth): add unified RBAC login routing

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { loginClinic } from "@/lib/api";
+import { loginUnified } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 
 const SAFE_LOGIN_REDIRECT_ORIGIN = "https://portal.vetneb.local";
@@ -88,8 +88,18 @@ export function LoginContent() {
     setIsSubmitting(true);
 
     try {
-      await loginClinic({ username, password });
-      router.replace(getSafeNextPath(searchParams.get("next")));
+      const response = await loginUnified({
+        identifier: username,
+        password,
+      });
+
+      const safeNextPath = getSafeNextPath(searchParams.get("next"));
+      const destination =
+        response.role === "clinic" && response.redirectTo === ROUTES.dashboard
+          ? safeNextPath
+          : response.redirectTo;
+
+      router.replace(destination);
       router.refresh();
     } catch (error) {
       setErrorMessage(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,8 @@ import type {
   AuditEntry,
   AuthUser,
   LoginCredentials,
+  UnifiedLoginCredentials,
+  UnifiedLoginResponse,
   ParticularAuthResponse,
   ParticularLoginCredentials,
   DashboardStats,
@@ -216,6 +218,15 @@ export async function loginClinic(
   credentials: LoginCredentials,
 ): Promise<AuthUser> {
   return apiFetch<AuthUser>("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify(credentials),
+  });
+}
+
+export async function loginUnified(
+  credentials: UnifiedLoginCredentials,
+): Promise<UnifiedLoginResponse> {
+  return apiFetch<UnifiedLoginResponse>("/api/auth/login", {
     method: "POST",
     body: JSON.stringify(credentials),
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -172,6 +172,19 @@ export type LoginCredentials = {
   password: string;
 };
 
+export type UnifiedLoginCredentials = {
+  identifier: string;
+  password: string;
+};
+
+export type UnifiedLoginRole = "admin" | "clinic" | "particular";
+
+export type UnifiedLoginResponse = {
+  success: true;
+  role: UnifiedLoginRole;
+  redirectTo: string;
+};
+
 export type ParticularLoginCredentials = {
   token: string;
 };

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -53,6 +53,19 @@ type SessionClinicUserRecord = {
   role: unknown;
 };
 
+type AdminUserRecord = {
+  id: number;
+  username: string;
+  passwordHash: string;
+};
+
+type ParticularTokenAuthRecord = {
+  id: number;
+  clinicId: number;
+  reportId: number | null;
+  isActive: boolean;
+};
+
 type ActiveSessionRecord = {
   clinicUserId: number;
   expiresAt: Date | null;
@@ -81,6 +94,16 @@ type AuditWriteInput = {
   };
 };
 
+type AdminAuditWriteInput = {
+  event: string;
+  targetAdminUserId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    adminUserId?: number | null;
+  };
+};
+
 type LoginFailedAttemptReason =
   | "missing_credentials"
   | "invalid_credentials"
@@ -94,6 +117,39 @@ type RecordLoginFailedAttemptInput = {
   userAgent?: string | null;
   createdAt: Date;
 };
+
+type UnifiedLoginRole = "admin" | "clinic" | "particular";
+
+type AuthenticatedAdminCandidate = {
+  role: "admin";
+  redirectTo: string;
+  setCookie: string;
+};
+
+type AuthenticatedClinicCandidate = {
+  role: "clinic";
+  redirectTo: string;
+  setCookie: string;
+  clinicUser: {
+    id: number;
+    clinicId: number;
+    username: string;
+    authProId: string | null;
+    role: ReturnType<typeof normalizeClinicUserRole>;
+  };
+  permissions: ReturnType<typeof getClinicPermissions>;
+};
+
+type AuthenticatedParticularCandidate = {
+  role: "particular";
+  redirectTo: string;
+  setCookie: string;
+};
+
+type UnifiedAuthenticatedCandidate =
+  | AuthenticatedAdminCandidate
+  | AuthenticatedClinicCandidate
+  | AuthenticatedParticularCandidate;
 
 export type AuthNativeRoutesOptions = {
   createActiveSession?: (input: {
@@ -126,6 +182,28 @@ export type AuthNativeRoutesOptions = {
     password: string,
     passwordHash: string,
   ) => Promise<VerifyPasswordResult>;
+  createAdminSession?: (input: {
+    adminUserId: number;
+    tokenHash: string;
+    expiresAt: Date;
+  }) => Promise<unknown>;
+  getAdminUserByUsername?: (
+    username: string,
+  ) => Promise<AdminUserRecord | null>;
+  writeAdminAuditLog?: (
+    req: unknown,
+    input: AdminAuditWriteInput,
+  ) => Promise<void>;
+  createParticularSession?: (input: {
+    particularTokenId: number;
+    tokenHash: string;
+    lastAccess: Date;
+    expiresAt: Date;
+  }) => Promise<unknown>;
+  getParticularTokenByTokenHash?: (
+    tokenHash: string,
+  ) => Promise<ParticularTokenAuthRecord | null>;
+  updateParticularTokenLastLogin?: (tokenId: number) => Promise<void>;
   writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
   recordLoginFailedAttempt?: (
     input: RecordLoginFailedAttemptInput,
@@ -157,6 +235,12 @@ type NativeAuthDeps = Required<
     | "hashPassword"
     | "hashSessionToken"
     | "verifyPassword"
+    | "createAdminSession"
+    | "getAdminUserByUsername"
+    | "writeAdminAuditLog"
+    | "createParticularSession"
+    | "getParticularTokenByTokenHash"
+    | "updateParticularTokenLastLogin"
     | "writeAuditLog"
     | "recordLoginFailedAttempt"
   >
@@ -171,6 +255,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
+      const dbParticular = await import("../db-particular.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const audit = await import("../lib/audit.ts");
 
@@ -186,6 +271,17 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
         hashPassword: authSecurity.hashPassword,
         hashSessionToken: authSecurity.hashSessionToken,
         verifyPassword: authSecurity.verifyPassword,
+        createAdminSession: db.createAdminSession,
+        getAdminUserByUsername: db.getAdminUserByUsername,
+        writeAdminAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AdminAuditWriteInput,
+        ) => Promise<void>,
+        createParticularSession: dbParticular.createParticularSession,
+        getParticularTokenByTokenHash:
+          dbParticular.getParticularTokenByTokenHash,
+        updateParticularTokenLastLogin:
+          dbParticular.updateParticularTokenLastLogin,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
           input: AuditWriteInput,
@@ -409,6 +505,22 @@ function buildSessionCookie(token: string) {
   });
 }
 
+function buildAdminSessionCookie(token: string) {
+  return serializeCookie({
+    name: ENV.adminCookieName,
+    value: token,
+    maxAgeSeconds: ENV.sessionTtlHours * 60 * 60,
+  });
+}
+
+function buildParticularSessionCookie(token: string) {
+  return serializeCookie({
+    name: ENV.particularCookieName,
+    value: token,
+    maxAgeSeconds: ENV.sessionTtlHours * 60 * 60,
+  });
+}
+
 function buildClearSessionCookie() {
   return serializeCookie({
     name: ENV.cookieName,
@@ -459,6 +571,212 @@ function createAuditRequestLike(
     ip: request.ip,
     headers: request.headers,
     auth,
+  };
+}
+
+function createAdminAuditRequestLike(
+  request: FastifyRequest,
+  admin: Pick<AdminUserRecord, "id" | "username">,
+) {
+  return {
+    method: request.method,
+    originalUrl: request.url,
+    ip: request.ip,
+    headers: request.headers,
+    adminAuth: {
+      id: admin.id,
+      username: admin.username,
+    },
+  };
+}
+
+function normalizeLoginIdentifier(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveRoleRedirect(role: UnifiedLoginRole) {
+  if (role === "admin") {
+    return "/dashboard/admin";
+  }
+
+  if (role === "particular") {
+    return "/particulares";
+  }
+
+  return "/dashboard";
+}
+
+async function authenticateAdminCandidate(
+  request: FastifyRequest,
+  deps: NativeAuthDeps,
+  input: {
+    identifier: string;
+    password: string;
+    currentTime: number;
+  },
+): Promise<AuthenticatedAdminCandidate | null> {
+  const admin = await deps.getAdminUserByUsername(input.identifier);
+
+  if (!admin) {
+    return null;
+  }
+
+  const valid = await deps.verifyPassword(input.password, admin.passwordHash);
+
+  if (!valid.valid) {
+    return null;
+  }
+
+  const token = deps.generateSessionToken();
+  const tokenHash = deps.hashSessionToken(token);
+  const expiresAt = new Date(
+    input.currentTime + ENV.sessionTtlHours * 60 * 60 * 1000,
+  );
+
+  await deps.createAdminSession({
+    adminUserId: admin.id,
+    tokenHash,
+    expiresAt,
+  });
+
+  await deps.writeAdminAuditLog(createAdminAuditRequestLike(request, admin), {
+    event: AUDIT_EVENTS.ADMIN_LOGIN_SUCCEEDED,
+    targetAdminUserId: admin.id,
+    metadata: {
+      username: admin.username,
+      sessionExpiresAt: expiresAt,
+    },
+    actor: {
+      type: "admin_user",
+      adminUserId: admin.id,
+    },
+  });
+
+  return {
+    role: "admin",
+    redirectTo: resolveRoleRedirect("admin"),
+    setCookie: buildAdminSessionCookie(token),
+  };
+}
+
+async function authenticateClinicCandidate(
+  request: FastifyRequest,
+  deps: NativeAuthDeps,
+  input: {
+    identifier: string;
+    password: string;
+    currentTime: number;
+  },
+): Promise<AuthenticatedClinicCandidate | null> {
+  const clinicUser = await deps.getClinicUserByUsername(input.identifier);
+
+  if (!clinicUser) {
+    return null;
+  }
+
+  const passwordCheck = await deps.verifyPassword(
+    input.password,
+    clinicUser.passwordHash,
+  );
+
+  if (!passwordCheck.valid) {
+    return null;
+  }
+
+  const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
+
+  if (passwordCheck.needsRehash) {
+    const newHash = await deps.hashPassword(input.password);
+
+    await deps.upsertClinicUser({
+      clinicId: clinicUser.clinicId,
+      username: clinicUser.username,
+      passwordHash: newHash,
+      authProId: clinicUser.authProId ?? null,
+      role,
+    });
+  }
+
+  const token = deps.generateSessionToken();
+  const tokenHash = deps.hashSessionToken(token);
+  const expiresAt = new Date(
+    input.currentTime + ENV.sessionTtlHours * 60 * 60 * 1000,
+  );
+
+  await deps.createActiveSession({
+    clinicUserId: clinicUser.id,
+    tokenHash,
+    expiresAt,
+  });
+
+  await deps.writeAuditLog(createAuditRequestLike(request), {
+    event: AUDIT_EVENTS.CLINIC_LOGIN_SUCCEEDED,
+    clinicId: clinicUser.clinicId,
+    targetClinicUserId: clinicUser.id,
+    metadata: {
+      username: clinicUser.username,
+      role,
+      sessionExpiresAt: expiresAt,
+    },
+    actor: {
+      type: "clinic_user",
+      clinicUserId: clinicUser.id,
+    },
+  });
+
+  return {
+    role: "clinic",
+    redirectTo: resolveRoleRedirect("clinic"),
+    setCookie: buildSessionCookie(token),
+    clinicUser: {
+      id: clinicUser.id,
+      clinicId: clinicUser.clinicId,
+      username: clinicUser.username,
+      authProId: clinicUser.authProId ?? null,
+      role,
+    },
+    permissions: getClinicPermissions(role),
+  };
+}
+
+async function authenticateParticularCandidate(
+  deps: NativeAuthDeps,
+  input: {
+    identifier: string;
+    password: string;
+    currentTime: number;
+  },
+): Promise<AuthenticatedParticularCandidate | null> {
+  if (input.identifier !== input.password) {
+    return null;
+  }
+
+  const tokenHash = deps.hashSessionToken(input.identifier);
+  const particularToken = await deps.getParticularTokenByTokenHash(tokenHash);
+
+  if (!particularToken || !particularToken.isActive) {
+    return null;
+  }
+
+  const sessionToken = deps.generateSessionToken();
+  const sessionTokenHash = deps.hashSessionToken(sessionToken);
+  const expiresAt = new Date(
+    input.currentTime + ENV.sessionTtlHours * 60 * 60 * 1000,
+  );
+
+  await deps.createParticularSession({
+    particularTokenId: particularToken.id,
+    tokenHash: sessionTokenHash,
+    lastAccess: new Date(input.currentTime),
+    expiresAt,
+  });
+
+  await deps.updateParticularTokenLastLogin(particularToken.id);
+
+  return {
+    role: "particular",
+    redirectTo: resolveRoleRedirect("particular"),
+    setCookie: buildParticularSessionCookie(sessionToken),
   };
 }
 
@@ -571,6 +889,30 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     hashSessionToken:
       options.hashSessionToken ?? defaultDeps!.hashSessionToken,
     verifyPassword: options.verifyPassword ?? defaultDeps!.verifyPassword,
+    createAdminSession:
+      options.createAdminSession ??
+      defaultDeps?.createAdminSession ??
+      (async () => undefined),
+    getAdminUserByUsername:
+      options.getAdminUserByUsername ??
+      defaultDeps?.getAdminUserByUsername ??
+      (async () => null),
+    writeAdminAuditLog:
+      options.writeAdminAuditLog ??
+      defaultDeps?.writeAdminAuditLog ??
+      (async () => undefined),
+    createParticularSession:
+      options.createParticularSession ??
+      defaultDeps?.createParticularSession ??
+      (async () => undefined),
+    getParticularTokenByTokenHash:
+      options.getParticularTokenByTokenHash ??
+      defaultDeps?.getParticularTokenByTokenHash ??
+      (async () => null),
+    updateParticularTokenLastLogin:
+      options.updateParticularTokenLastLogin ??
+      defaultDeps?.updateParticularTokenLastLogin ??
+      (async () => undefined),
     writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
     recordLoginFailedAttempt:
       options.recordLoginFailedAttempt ??
@@ -647,6 +989,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
 
   app.post<{
     Body: {
+      identifier?: unknown;
       username?: unknown;
       password?: unknown;
     };
@@ -698,13 +1041,12 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
 
-      const attemptedUsername =
-        typeof request.body?.username === "string"
-          ? request.body.username.trim()
-          : "";
+      const attemptedIdentifier =
+        normalizeLoginIdentifier(request.body?.identifier) ||
+        normalizeLoginIdentifier(request.body?.username);
 
       await recordFailedLoginAttempt({
-        username: attemptedUsername,
+        username: attemptedIdentifier,
         reason: "rate_limited",
       });
 
@@ -749,47 +1091,91 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       });
     };
 
-    const username =
-      typeof request.body?.username === "string"
-        ? request.body.username.trim()
-        : "";
+    const identifier = normalizeLoginIdentifier(request.body?.identifier);
+    const username = normalizeLoginIdentifier(request.body?.username);
+    const loginIdentifier = identifier || username;
+    const isUnifiedPayload =
+      !!request.body &&
+      typeof request.body === "object" &&
+      Object.prototype.hasOwnProperty.call(request.body, "identifier");
     const password =
       typeof request.body?.password === "string" ? request.body.password : "";
 
-    if (!username || !password) {
+    if (!loginIdentifier || !password) {
       await markFailure({
-        username,
+        username: loginIdentifier,
         reason: "missing_credentials",
       });
 
       return reply.code(400).send({
         success: false,
-        error: "Usuario y contrasena son obligatorios",
+        error: isUnifiedPayload
+          ? "Identificador y contraseña requeridos"
+          : "Usuario y contrasena son obligatorios",
       });
     }
 
-    const clinicUser = await deps.getClinicUserByUsername(username);
+    if (isUnifiedPayload) {
+      const candidateResolvers: Array<
+        () => Promise<UnifiedAuthenticatedCandidate | null>
+      > = [
+        () =>
+          authenticateAdminCandidate(request, deps, {
+            identifier: loginIdentifier,
+            password,
+            currentTime,
+          }),
+        () =>
+          authenticateClinicCandidate(request, deps, {
+            identifier: loginIdentifier,
+            password,
+            currentTime,
+          }),
+        () =>
+          authenticateParticularCandidate(deps, {
+            identifier: loginIdentifier,
+            password,
+            currentTime,
+          }),
+      ];
 
-    if (!clinicUser) {
+      for (const resolveCandidate of candidateResolvers) {
+        const candidate = await resolveCandidate();
+
+        if (!candidate) {
+          continue;
+        }
+
+        reply.header("set-cookie", candidate.setCookie);
+        markSuccess();
+
+        return reply.code(200).send({
+          success: true,
+          role: candidate.role,
+          redirectTo: candidate.redirectTo,
+        });
+      }
+
       await markFailure({
-        username,
+        username: loginIdentifier,
         reason: "invalid_credentials",
       });
 
       return reply.code(401).send({
         success: false,
-        error: "Usuario o contraseña inválidos",
+        error: "Credenciales inválidas",
       });
     }
 
-    const passwordCheck = await deps.verifyPassword(
+    const clinicCandidate = await authenticateClinicCandidate(request, deps, {
+      identifier: loginIdentifier,
       password,
-      clinicUser.passwordHash,
-    );
+      currentTime,
+    });
 
-    if (!passwordCheck.valid) {
+    if (!clinicCandidate) {
       await markFailure({
-        username,
+        username: loginIdentifier,
         reason: "invalid_credentials",
       });
 
@@ -799,60 +1185,13 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const role = normalizeClinicUserRole(clinicUser.role, "clinic_staff");
-
-    if (passwordCheck.needsRehash) {
-      const newHash = await deps.hashPassword(password);
-
-      await deps.upsertClinicUser({
-        clinicId: clinicUser.clinicId,
-        username: clinicUser.username,
-        passwordHash: newHash,
-        authProId: clinicUser.authProId ?? null,
-        role,
-      });
-    }
-
-    const token = deps.generateSessionToken();
-    const tokenHash = deps.hashSessionToken(token);
-    const expiresAt = new Date(
-      currentTime + ENV.sessionTtlHours * 60 * 60 * 1000,
-    );
-
-    await deps.createActiveSession({
-      clinicUserId: clinicUser.id,
-      tokenHash,
-      expiresAt,
-    });
-
-    await deps.writeAuditLog(createAuditRequestLike(request), {
-      event: AUDIT_EVENTS.CLINIC_LOGIN_SUCCEEDED,
-      clinicId: clinicUser.clinicId,
-      targetClinicUserId: clinicUser.id,
-      metadata: {
-        username: clinicUser.username,
-        role,
-        sessionExpiresAt: expiresAt,
-      },
-      actor: {
-        type: "clinic_user",
-        clinicUserId: clinicUser.id,
-      },
-    });
-
-    reply.header("set-cookie", buildSessionCookie(token));
+    reply.header("set-cookie", clinicCandidate.setCookie);
     markSuccess();
 
     return reply.code(200).send({
       success: true,
-      clinicUser: {
-        id: clinicUser.id,
-        clinicId: clinicUser.clinicId,
-        username: clinicUser.username,
-        authProId: clinicUser.authProId ?? null,
-        role,
-      },
-      permissions: getClinicPermissions(role),
+      clinicUser: clinicCandidate.clinicUser,
+      permissions: clinicCandidate.permissions,
     });
   });
 

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -44,6 +44,12 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       valid: false,
       needsRehash: false,
     }),
+    createAdminSession: async () => {},
+    getAdminUserByUsername: async () => null,
+    writeAdminAuditLog: async () => {},
+    createParticularSession: async () => {},
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularTokenLastLogin: async () => {},
     writeAuditLog: async () => {},
     recordLoginFailedAttempt: async () => {},
     ...overrides,
@@ -223,6 +229,367 @@ test(
       assert.equal(auditCalls[0].event, AUDIT_EVENTS.CLINIC_LOGIN_SUCCEEDED);
       assert.equal(auditCalls[0].clinicId, 3);
       assert.equal(auditCalls[0].targetClinicUserId, 7);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuthNativeRoutes login unificado autentica admin y crea cookie admin",
+  async () => {
+    const adminSessionCalls: Array<{
+      adminUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async (username: string) => {
+        assert.equal(username, "admin@vetneb");
+
+        return {
+          id: 101,
+          username: "admin@vetneb",
+          passwordHash: "admin-hash",
+        };
+      },
+      getClinicUserByUsername: async () => {
+        throw new Error("no debe evaluar clinic cuando admin autenticó");
+      },
+      verifyPassword: async (password: string, passwordHash: string) => {
+        assert.equal(password, "secret");
+        assert.equal(passwordHash, "admin-hash");
+
+        return {
+          valid: true,
+          needsRehash: false,
+        };
+      },
+      generateSessionToken: () => "admin-token-123",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createAdminSession: async (input: {
+        adminUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        adminSessionCalls.push(input);
+      },
+      writeAdminAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: " admin@vetneb ",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "admin",
+        redirectTo: "/dashboard/admin",
+      });
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.adminCookieName}=admin-token-123`));
+      assert.equal(setCookie.includes(`${ENV.cookieName}=`), false);
+      assert.equal(setCookie.includes(`${ENV.particularCookieName}=`), false);
+
+      assert.equal(adminSessionCalls.length, 1);
+      assert.equal(adminSessionCalls[0].adminUserId, 101);
+      assert.equal(adminSessionCalls[0].tokenHash, "hash:admin-token-123");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuthNativeRoutes login unificado autentica clínica y crea cookie app_session_id",
+  async () => {
+    const clinicSessionCalls: Array<{
+      clinicUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async () => null,
+      getClinicUserByUsername: async (username: string) => {
+        assert.equal(username, "clinica@vetneb");
+
+        return {
+          id: 77,
+          clinicId: 9,
+          username: "clinica@vetneb",
+          passwordHash: "clinic-hash",
+          authProId: null,
+          role: "clinic_staff",
+        };
+      },
+      verifyPassword: async (password: string, passwordHash: string) => {
+        assert.equal(password, "secret");
+        assert.equal(passwordHash, "clinic-hash");
+
+        return {
+          valid: true,
+          needsRehash: false,
+        };
+      },
+      generateSessionToken: () => "clinic-token-123",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createActiveSession: async (input: {
+        clinicUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        clinicSessionCalls.push(input);
+      },
+      writeAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "clinica@vetneb",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "clinic",
+        redirectTo: "/dashboard",
+      });
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.cookieName}=clinic-token-123`));
+      assert.equal(setCookie.includes(`${ENV.adminCookieName}=`), false);
+      assert.equal(setCookie.includes(`${ENV.particularCookieName}=`), false);
+
+      assert.equal(clinicSessionCalls.length, 1);
+      assert.equal(clinicSessionCalls[0].clinicUserId, 77);
+      assert.equal(clinicSessionCalls[0].tokenHash, "hash:clinic-token-123");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuthNativeRoutes login unificado autentica particular y crea cookie particular_session_id",
+  async () => {
+    const particularSessionCalls: Array<{
+      particularTokenId: number;
+      tokenHash: string;
+      lastAccess: Date;
+      expiresAt: Date;
+    }> = [];
+    const lastLoginCalls: number[] = [];
+
+    const app = await createTestApp({
+      now: () => Date.UTC(2026, 4, 9, 0, 0, 0),
+      getAdminUserByUsername: async () => null,
+      getClinicUserByUsername: async () => null,
+      getParticularTokenByTokenHash: async (tokenHash: string) => {
+        assert.equal(tokenHash, "hash:PARTICULAR-TOKEN-1");
+
+        return {
+          id: 501,
+          clinicId: 7,
+          reportId: 301,
+          isActive: true,
+        };
+      },
+      generateSessionToken: () => "particular-session-123",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createParticularSession: async (input: {
+        particularTokenId: number;
+        tokenHash: string;
+        lastAccess: Date;
+        expiresAt: Date;
+      }) => {
+        particularSessionCalls.push(input);
+      },
+      updateParticularTokenLastLogin: async (tokenId: number) => {
+        lastLoginCalls.push(tokenId);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "PARTICULAR-TOKEN-1",
+          password: "PARTICULAR-TOKEN-1",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "particular",
+        redirectTo: "/particulares",
+      });
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(
+        setCookie.includes(`${ENV.particularCookieName}=particular-session-123`),
+      );
+      assert.equal(setCookie.includes(`${ENV.cookieName}=`), false);
+      assert.equal(setCookie.includes(`${ENV.adminCookieName}=`), false);
+
+      assert.equal(particularSessionCalls.length, 1);
+      assert.equal(particularSessionCalls[0].particularTokenId, 501);
+      assert.equal(
+        particularSessionCalls[0].tokenHash,
+        "hash:particular-session-123",
+      );
+      assert.deepEqual(lastLoginCalls, [501]);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test("clinicAuthNativeRoutes login unificado responde error genérico para credenciales inválidas", async () => {
+  const app = await createTestApp({
+    getAdminUserByUsername: async () => null,
+    getClinicUserByUsername: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        identifier: "desconocido",
+        password: "incorrecta",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Credenciales inválidas",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes login unificado valida payload inválido sin stacktrace", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        identifier: " ",
+        password: "",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Identificador y contraseña requeridos",
+    });
+    assert.equal(response.body.toLowerCase().includes("error interno"), false);
+    assert.equal(response.body.toLowerCase().includes("stack"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test(
+  "clinicAuthNativeRoutes login unificado prioriza admin ante colisión de identifier",
+  async () => {
+    let clinicLookupCalls = 0;
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async (username: string) => {
+        if (username === "shared-user") {
+          return {
+            id: 1,
+            username: "shared-user",
+            passwordHash: "shared-hash",
+          };
+        }
+
+        return null;
+      },
+      getClinicUserByUsername: async () => {
+        clinicLookupCalls += 1;
+
+        return {
+          id: 7,
+          clinicId: 3,
+          username: "shared-user",
+          passwordHash: "shared-hash",
+          authProId: null,
+          role: "clinic_owner",
+        };
+      },
+      verifyPassword: async (password: string, passwordHash: string) => ({
+        valid: password === "secret" && passwordHash === "shared-hash",
+        needsRehash: false,
+      }),
+      generateSessionToken: () => "admin-priority-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createAdminSession: async () => {},
+      writeAdminAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "shared-user",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "admin",
+        redirectTo: "/dashboard/admin",
+      });
+      assert.equal(clinicLookupCalls, 0);
     } finally {
       await app.close();
     }

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -17,10 +17,13 @@ test("frontend login content calls clinic login and redirects to dashboard", () 
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes('"use client"'));
-  assert.ok(source.includes('import { loginClinic } from "@/lib/api"'));
+  assert.ok(source.includes('import { loginUnified } from "@/lib/api"'));
   assert.ok(source.includes('import { useRouter, useSearchParams } from "next/navigation"'));
-  assert.ok(source.includes("await loginClinic({ username, password })"));
-  assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
+  assert.ok(source.includes("const response = await loginUnified({"));
+  assert.ok(source.includes("identifier: username,"));
+  assert.ok(source.includes("const destination ="));
+  assert.ok(source.includes("response.redirectTo"));
+  assert.ok(source.includes("router.replace(destination)"));
   assert.ok(source.includes("router.refresh()"));
 });
 

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -19,10 +19,12 @@ test("login public page submits clinic credentials through the API client", () =
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import { FormEvent, useEffect, useState } from "react";'));
   assert.ok(source.includes('import { useRouter, useSearchParams } from "next/navigation";'));
-  assert.ok(source.includes('import { loginClinic } from "@/lib/api";'));
+  assert.ok(source.includes('import { loginUnified } from "@/lib/api";'));
   assert.ok(source.includes("async function handleSubmit"));
   assert.ok(source.includes("event.preventDefault();"));
-  assert.ok(source.includes("await loginClinic({ username, password });"));
+  assert.ok(source.includes("const response = await loginUnified({"));
+  assert.ok(source.includes("identifier: username,"));
+  assert.ok(source.includes("password,"));
   assert.ok(source.includes('aria-label="Formulario de inicio de sesión"'));
   assert.ok(source.includes("onSubmit={handleSubmit}"));
 });
@@ -43,7 +45,9 @@ test("login public page redirects safely after successful authentication", () =>
   assert.ok(source.includes("return ROUTES.dashboard;"));
   assert.equal(source.includes("return nextPath;"), false);
   assert.equal(source.includes("return candidate;"), false);
-  assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
+  assert.ok(source.includes("const destination ="));
+  assert.ok(source.includes("response.redirectTo"));
+  assert.ok(source.includes("router.replace(destination);"));
   assert.ok(source.includes("router.refresh();"));
 });
 
@@ -73,13 +77,13 @@ test("login public page handles loading and error states", () => {
   assert.ok(source.includes("aria-pressed={isPasswordVisible}"));
 });
 
-test("API client exposes clinic login contract against backend auth endpoint", () => {
+test("API client exposes unified login contract against backend auth endpoint", () => {
   const source = read(API_CLIENT_PATH);
 
-  assert.ok(source.includes("export async function loginClinic("));
-  assert.ok(source.includes("credentials: LoginCredentials,"));
-  assert.ok(source.includes("Promise<AuthUser>"));
-  assert.ok(source.includes('return apiFetch<AuthUser>("/api/auth/login", {'));
+  assert.ok(source.includes("export async function loginUnified("));
+  assert.ok(source.includes("credentials: UnifiedLoginCredentials,"));
+  assert.ok(source.includes("Promise<UnifiedLoginResponse>"));
+  assert.ok(source.includes('return apiFetch<UnifiedLoginResponse>("/api/auth/login", {'));
   assert.ok(source.includes('method: "POST",'));
   assert.ok(source.includes("body: JSON.stringify(credentials),"));
 });

--- a/test/frontend-login-next-redirect-boundary.test.ts
+++ b/test/frontend-login-next-redirect-boundary.test.ts
@@ -32,7 +32,9 @@ test("login next redirect helper keeps strict dashboard boundary checks", () => 
   assert.equal(source.includes("safePath === ROUTES.dashboardAdmin"), false);
   assert.equal(source.includes("safePath.startsWith(`${ROUTES.dashboardAdmin}/`)"), false);
   assert.equal(source.includes('if (!nextPath?.startsWith("/dashboard"))'), false);
-  assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
+  assert.ok(source.includes("const destination ="));
+  assert.ok(source.includes("response.redirectTo"));
+  assert.ok(source.includes("router.replace(destination);"));
   assert.ok(source.includes('requestedSurface === "particular"'));
   assert.ok(source.includes("router.replace(ROUTES.particulares);"));
 });

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -40,7 +40,7 @@ test("login content keeps standalone login shell and form landmarks", () => {
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
-  assert.ok(source.includes('import { loginClinic } from "@/lib/api";'));
+  assert.ok(source.includes('import { loginUnified } from "@/lib/api";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("min-h-screen public-page-canvas flex items-center justify-center p-4"));
   assert.equal(source.includes("bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800"), false);
@@ -71,7 +71,9 @@ test("login content keeps safe dashboard redirect and error handling", () => {
   assert.equal(source.includes("safePath === ROUTES.dashboardAdmin"), false);
   assert.equal(source.includes("safePath.startsWith(`${ROUTES.dashboardAdmin}/`)"), false);
   assert.ok(source.includes("return ROUTES.dashboard;"));
-  assert.ok(source.includes('router.replace(getSafeNextPath(searchParams.get("next")))'));
+  assert.ok(source.includes("const destination ="));
+  assert.ok(source.includes("response.redirectTo"));
+  assert.ok(source.includes("router.replace(destination);"));
   assert.ok(source.includes("router.refresh();"));
   assert.ok(source.includes("setErrorMessage("));
   assert.ok(source.includes('role="alert"'));

--- a/test/security-audit-logging-phase-boundaries.test.ts
+++ b/test/security-audit-logging-phase-boundaries.test.ts
@@ -165,13 +165,22 @@ test("auth login audit happens after session persistence and before success resp
     clinicAuth,
     [
       "if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {",
+      "const clinicCandidate = await authenticateClinicCandidate(request, deps, {",
+      "return reply.code(200).send({",
+    ],
+    "clinic auth login audit phase",
+  );
+
+  assertContainsInOrder(
+    clinicAuth,
+    [
+      "async function authenticateClinicCandidate(",
       "const token = deps.generateSessionToken();",
       "await deps.createActiveSession({",
       "await deps.writeAuditLog(createAuditRequestLike(request), {",
       "event: AUDIT_EVENTS.CLINIC_LOGIN_SUCCEEDED",
-      "return reply.code(200).send({",
     ],
-    "clinic auth login audit phase",
+    "clinic auth candidate audit phase",
   );
 
   assertContainsInOrder(

--- a/test/security-session-cookie-boundaries.test.ts
+++ b/test/security-session-cookie-boundaries.test.ts
@@ -142,12 +142,35 @@ test("session cookie serializers keep security attributes stable", () => {
 });
 
 test("clinic admin and particular route surfaces read only their own cookie", () => {
-  assertCookieBoundary(
-    CLINIC_SESSION_FILES,
-    "cookies[ENV.cookieName]",
-    "name: ENV.cookieName",
-    ["cookies[ENV.adminCookieName]", "cookies[ENV.particularCookieName]", "name: ENV.adminCookieName", "name: ENV.particularCookieName"],
-  );
+  for (const file of CLINIC_SESSION_FILES) {
+    const source = readSource(file);
+
+    assertContains(source, "cookies[ENV.cookieName]", `${file} cookie read`);
+    assertContains(source, "name: ENV.cookieName", `${file} cookie write or clear`);
+    assertNotContains(
+      source,
+      "cookies[ENV.adminCookieName]",
+      `${file} cross-cookie read boundary`,
+    );
+    assertNotContains(
+      source,
+      "cookies[ENV.particularCookieName]",
+      `${file} cross-cookie read boundary`,
+    );
+
+    if (file !== "server/routes/auth.fastify.ts") {
+      assertNotContains(
+        source,
+        "name: ENV.adminCookieName",
+        `${file} cross-cookie write boundary`,
+      );
+      assertNotContains(
+        source,
+        "name: ENV.particularCookieName",
+        `${file} cross-cookie write boundary`,
+      );
+    }
+  }
 
   assertCookieBoundary(
     ADMIN_SESSION_FILES,


### PR DESCRIPTION
## Summary
- add unified login flow for admin, clinic/client, and particular users
- resolve role server-side from real credentials
- return role-based redirect targets
- connect the login screen to the unified auth flow
- preserve existing legacy auth endpoints

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend typecheck

## Notes
- Admin receives admin_session_id and redirects to /dashboard/admin
- Clinic/client receives app_session_id and redirects to /dashboard
- Particular receives particular_session_id and redirects to /particulares
- Does not touch CSP/security headers, HSTS, nonce, or CSP enforcement
- Does not add migrations
- Does not touch production secrets
- Does not remove legacy login endpoints