### PR TITLE
fix(auth): prevent unified login runtime 500

### DIFF
--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -16,6 +16,7 @@ import {
   createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
+  type RateLimitEntry,
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
 import {
@@ -998,14 +999,54 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    const rateLimitKey = request.ip || "unknown";
     const currentTime = now();
-    const failureEntry = await getOrCreateRateLimitEntry(
-      loginRateLimitStore,
-      rateLimitKey,
-      loginRateLimitWindowMs,
-      currentTime,
-    );
+    const identifier = normalizeLoginIdentifier(request.body?.identifier);
+    const username = normalizeLoginIdentifier(request.body?.username);
+    const loginIdentifier = identifier || username;
+    const isUnifiedPayload =
+      !!request.body &&
+      typeof request.body === "object" &&
+      Object.prototype.hasOwnProperty.call(request.body, "identifier");
+    const password =
+      typeof request.body?.password === "string" ? request.body.password : "";
+
+    if (!loginIdentifier || !password) {
+      return reply.code(400).send({
+        success: false,
+        error: isUnifiedPayload
+          ? "Identificador y contraseña requeridos"
+          : "Usuario y contrasena son obligatorios",
+      });
+    }
+
+    const rateLimitKey = request.ip || "unknown";
+    const failureEntry: RateLimitEntry = {
+      count: 0,
+      resetAt: currentTime + loginRateLimitWindowMs,
+    };
+    let canUseRateLimitStore = true;
+
+    try {
+      const existingEntry = await getOrCreateRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        loginRateLimitWindowMs,
+        currentTime,
+      );
+
+      failureEntry.count = existingEntry.count;
+      failureEntry.resetAt = existingEntry.resetAt;
+    } catch (error) {
+      canUseRateLimitStore = false;
+      request.log.error(
+        {
+          err: error,
+          code: "AUTH_LOGIN_RATE_LIMIT_GET_FAILED",
+          route: "/api/auth/login",
+        },
+        "No se pudo leer el rate limit de login unificado",
+      );
+    }
 
     const recordFailedLoginAttempt = async (input: {
       username?: string | null;
@@ -1024,6 +1065,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         request.log.warn(
           {
             err: error,
+            code: "AUTH_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
             surface: "clinic",
             reason: input.reason,
           },
@@ -1032,7 +1074,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       }
     };
 
-    if (failureEntry.count >= loginRateLimitMaxAttempts) {
+    if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
@@ -1041,12 +1083,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
 
-      const attemptedIdentifier =
-        normalizeLoginIdentifier(request.body?.identifier) ||
-        normalizeLoginIdentifier(request.body?.username);
-
       await recordFailedLoginAttempt({
-        username: attemptedIdentifier,
+        username: loginIdentifier,
         reason: "rate_limited",
       });
 
@@ -1060,28 +1098,46 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       username?: string | null;
       reason: LoginFailedAttemptReason;
     }) => {
-      const updatedEntry = await incrementRateLimitEntry(
-        loginRateLimitStore,
-        rateLimitKey,
-        failureEntry,
-        currentTime,
-      );
+      if (canUseRateLimitStore) {
+        try {
+          const updatedEntry = await incrementRateLimitEntry(
+            loginRateLimitStore,
+            rateLimitKey,
+            failureEntry,
+            currentTime,
+          );
 
-      failureEntry.count = updatedEntry.count;
-      failureEntry.resetAt = updatedEntry.resetAt;
+          failureEntry.count = updatedEntry.count;
+          failureEntry.resetAt = updatedEntry.resetAt;
 
-      setLoginRateLimitHeaders(reply, {
-        max: loginRateLimitMaxAttempts,
-        windowMs: loginRateLimitWindowMs,
-        failedCount: failureEntry.count,
-        resetAt: failureEntry.resetAt,
-        now: currentTime,
-      });
+          setLoginRateLimitHeaders(reply, {
+            max: loginRateLimitMaxAttempts,
+            windowMs: loginRateLimitWindowMs,
+            failedCount: failureEntry.count,
+            resetAt: failureEntry.resetAt,
+            now: currentTime,
+          });
+        } catch (error) {
+          canUseRateLimitStore = false;
+          request.log.error(
+            {
+              err: error,
+              code: "AUTH_LOGIN_RATE_LIMIT_INCREMENT_FAILED",
+              route: "/api/auth/login",
+            },
+            "No se pudo actualizar el rate limit de login unificado",
+          );
+        }
+      }
 
       await recordFailedLoginAttempt(input);
     };
 
     const markSuccess = () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
@@ -1090,30 +1146,6 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
     };
-
-    const identifier = normalizeLoginIdentifier(request.body?.identifier);
-    const username = normalizeLoginIdentifier(request.body?.username);
-    const loginIdentifier = identifier || username;
-    const isUnifiedPayload =
-      !!request.body &&
-      typeof request.body === "object" &&
-      Object.prototype.hasOwnProperty.call(request.body, "identifier");
-    const password =
-      typeof request.body?.password === "string" ? request.body.password : "";
-
-    if (!loginIdentifier || !password) {
-      await markFailure({
-        username: loginIdentifier,
-        reason: "missing_credentials",
-      });
-
-      return reply.code(400).send({
-        success: false,
-        error: isUnifiedPayload
-          ? "Identificador y contraseña requeridos"
-          : "Usuario y contrasena son obligatorios",
-      });
-    }
 
     if (isUnifiedPayload) {
       const candidateResolvers: Array<

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -314,6 +314,84 @@ test(
 );
 
 test(
+  "clinicAuthNativeRoutes login unificado autentica admin VETNEB y mantiene cookie admin exclusiva",
+  async () => {
+    const adminSessionCalls: Array<{
+      adminUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async (username: string) => {
+        assert.equal(username, "VETNEB");
+
+        return {
+          id: 109,
+          username: "VETNEB",
+          passwordHash: "admin-hash",
+        };
+      },
+      getClinicUserByUsername: async () => {
+        throw new Error("no debe evaluar clinic cuando admin autenticó");
+      },
+      verifyPassword: async (password: string, passwordHash: string) => {
+        assert.equal(password, "secret");
+        assert.equal(passwordHash, "admin-hash");
+
+        return {
+          valid: true,
+          needsRehash: false,
+        };
+      },
+      generateSessionToken: () => "admin-vetneb-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createAdminSession: async (input: {
+        adminUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        adminSessionCalls.push(input);
+      },
+      writeAdminAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "VETNEB",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "admin",
+        redirectTo: "/dashboard/admin",
+      });
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.adminCookieName}=admin-vetneb-token`));
+      assert.equal(setCookie.includes(`${ENV.cookieName}=`), false);
+      assert.equal(setCookie.includes(`${ENV.particularCookieName}=`), false);
+
+      assert.equal(adminSessionCalls.length, 1);
+      assert.equal(adminSessionCalls[0].adminUserId, 109);
+      assert.equal(adminSessionCalls[0].tokenHash, "hash:admin-vetneb-token");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "clinicAuthNativeRoutes login unificado autentica clínica y crea cookie app_session_id",
   async () => {
     const clinicSessionCalls: Array<{
@@ -525,6 +603,187 @@ test("clinicAuthNativeRoutes login unificado valida payload inválido sin stackt
     });
     assert.equal(response.body.toLowerCase().includes("error interno"), false);
     assert.equal(response.body.toLowerCase().includes("stack"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes login unificado valida payload inválido antes de rate-limit y auditoría", async () => {
+  const rateLimitCalls = {
+    get: 0,
+    set: 0,
+    increment: 0,
+  };
+  const failedAttempts: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    loginRateLimitStore: {
+      get: async () => {
+        rateLimitCalls.get += 1;
+        throw new Error("rate limit get failed");
+      },
+      set: async () => {
+        rateLimitCalls.set += 1;
+        throw new Error("rate limit set failed");
+      },
+      increment: async () => {
+        rateLimitCalls.increment += 1;
+        throw new Error("rate limit increment failed");
+      },
+    },
+    recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+      failedAttempts.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        identifier: " ",
+        password: "",
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Identificador y contraseña requeridos",
+    });
+    assert.deepEqual(rateLimitCalls, {
+      get: 0,
+      set: 0,
+      increment: 0,
+    });
+    assert.equal(failedAttempts.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes login unificado mantiene 401 cuando falla lectura de rate-limit store", async () => {
+  const app = await createTestApp({
+    loginRateLimitStore: {
+      get: async () => {
+        throw new Error("rate limit get failed");
+      },
+      set: async () => {
+        throw new Error("rate limit set failed");
+      },
+      increment: async () => {
+        throw new Error("rate limit increment failed");
+      },
+    },
+    getAdminUserByUsername: async () => null,
+    getClinicUserByUsername: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        identifier: "desconocido",
+        password: "incorrecta",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Credenciales inválidas",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes login unificado mantiene 401 cuando falla incremento de rate-limit store", async () => {
+  const app = await createTestApp({
+    loginRateLimitStore: {
+      get: async () => ({
+        count: 0,
+        resetAt: Date.now() + 60_000,
+      }),
+      set: async () => {},
+      increment: async () => {
+        throw new Error("rate limit increment failed");
+      },
+    },
+    getAdminUserByUsername: async () => null,
+    getClinicUserByUsername: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        identifier: "desconocido",
+        password: "incorrecta",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Credenciales inválidas",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes login unificado fallido mantiene 401 aunque falle registro auxiliar", async () => {
+  const app = await createTestApp({
+    getAdminUserByUsername: async () => null,
+    getClinicUserByUsername: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    recordLoginFailedAttempt: async () => {
+      throw new Error("auxiliar login failed");
+    },
+    writeAuditLog: async () => {
+      throw new Error("no debe invocarse auditoría de éxito en login fallido");
+    },
+    writeAdminAuditLog: async () => {
+      throw new Error("no debe invocarse auditoría de éxito en login fallido");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      payload: {
+        identifier: "desconocido",
+        password: "incorrecta",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Credenciales inválidas",
+    });
+    assert.equal(
+      response.body.toLowerCase().includes("error interno del servidor"),
+      false,
+    );
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary
- prevent /api/auth/login from returning 500 before payload validation
- validate login payload before touching persistent rate-limit dependencies
- keep invalid payload and invalid credentials responses controlled
- preserve legacy admin login and role cookie boundaries

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend typecheck

## Notes
- Real staging probe confirmed legacy admin works while unified login returns 500
- Does not touch CSP/security headers, HSTS, nonce, or CSP enforcement
- Does not add migrations
- Does not touch production secrets
- Does not change UI