### PR TITLE
feat(auth): support email identifier in unified login

### DIFF
--- a/drizzle/migrations/0029_admin_users_email_identifier.sql
+++ b/drizzle/migrations/0029_admin_users_email_identifier.sql
@@ -1,0 +1,9 @@
+-- 0029_admin_users_email_identifier.sql
+-- Habilita login admin por email real sin romper username legacy.
+
+ALTER TABLE "admin_users"
+  ADD COLUMN IF NOT EXISTS "email" varchar(255);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "admin_users_email_lower_uidx"
+  ON "admin_users" (lower("email"))
+  WHERE "email" IS NOT NULL;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
                         "when":  1777122000000,
                         "tag":  "0028_ensure_report_workflow_columns",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  29,
+                        "version":  "7",
+                        "when":  1777125600000,
+                        "tag":  "0029_admin_users_email_identifier",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -221,6 +221,7 @@ export const clinicUsers = pgTable(
 export const adminUsers = pgTable("admin_users", {
   id: serial("id").primaryKey(),
   username: varchar("username", { length: 100 }).notNull().unique(),
+  email: varchar("email", { length: 255 }),
   passwordHash: varchar("password_hash", { length: 255 }).notNull(),
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),

--- a/server/db.ts
+++ b/server/db.ts
@@ -66,6 +66,55 @@ export async function getClinicUserByUsername(username: string) {
   return result[0];
 }
 
+function normalizeLoginIdentifierForLookup(identifier: string) {
+  const trimmedIdentifier = identifier.trim();
+  const normalizedEmail = trimmedIdentifier.toLowerCase();
+  const canMatchEmail = normalizedEmail.includes("@");
+
+  return {
+    trimmedIdentifier,
+    normalizedEmail,
+    canMatchEmail,
+  };
+}
+
+export async function getClinicUserByIdentifier(identifier: string) {
+  const { trimmedIdentifier, normalizedEmail, canMatchEmail } =
+    normalizeLoginIdentifierForLookup(identifier);
+
+  if (!trimmedIdentifier) {
+    return undefined;
+  }
+
+  const whereClauses = [eq(clinicUsers.username, trimmedIdentifier)];
+
+  if (canMatchEmail) {
+    whereClauses.push(
+      sql`lower(trim(${clinics.contactEmail})) = ${normalizedEmail}`,
+    );
+  }
+
+  const result = await db
+    .select({
+      id: clinicUsers.id,
+      clinicId: clinicUsers.clinicId,
+      username: clinicUsers.username,
+      passwordHash: clinicUsers.passwordHash,
+      authProId: clinicUsers.authProId,
+      role: clinicUsers.role,
+    })
+    .from(clinicUsers)
+    .leftJoin(clinics, eq(clinicUsers.clinicId, clinics.id))
+    .where(or(...whereClauses)!)
+    .orderBy(
+      sql`CASE WHEN ${clinicUsers.username} = ${trimmedIdentifier} THEN 0 ELSE 1 END`,
+      clinicUsers.id,
+    )
+    .limit(1);
+
+  return result[0];
+}
+
 export async function upsertClinicUser(user: {
   clinicId: number;
   username: string;
@@ -118,6 +167,35 @@ export async function getAdminUserByUsername(username: string) {
     .select()
     .from(adminUsers)
     .where(eq(adminUsers.username, username.trim()))
+    .limit(1);
+
+  return result[0];
+}
+
+export async function getAdminUserByIdentifier(identifier: string) {
+  const { trimmedIdentifier, normalizedEmail, canMatchEmail } =
+    normalizeLoginIdentifierForLookup(identifier);
+
+  if (!trimmedIdentifier) {
+    return undefined;
+  }
+
+  const whereClauses = [eq(adminUsers.username, trimmedIdentifier)];
+
+  if (canMatchEmail) {
+    whereClauses.push(
+      sql`lower(trim(${adminUsers.email})) = ${normalizedEmail}`,
+    );
+  }
+
+  const result = await db
+    .select()
+    .from(adminUsers)
+    .where(or(...whereClauses)!)
+    .orderBy(
+      sql`CASE WHEN ${adminUsers.username} = ${trimmedIdentifier} THEN 0 ELSE 1 END`,
+      adminUsers.id,
+    )
     .limit(1);
 
   return result[0];

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -57,6 +57,7 @@ type SessionClinicUserRecord = {
 type AdminUserRecord = {
   id: number;
   username: string;
+  email?: string | null;
   passwordHash: string;
 };
 
@@ -168,6 +169,9 @@ export type AuthNativeRoutesOptions = {
   getClinicUserByUsername?: (
     username: string,
   ) => Promise<ClinicUserRecord | null>;
+  getClinicUserByIdentifier?: (
+    identifier: string,
+  ) => Promise<ClinicUserRecord | null>;
   updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
   upsertClinicUser?: (input: {
     clinicId: number;
@@ -190,6 +194,9 @@ export type AuthNativeRoutesOptions = {
   }) => Promise<unknown>;
   getAdminUserByUsername?: (
     username: string,
+  ) => Promise<AdminUserRecord | null>;
+  getAdminUserByIdentifier?: (
+    identifier: string,
   ) => Promise<AdminUserRecord | null>;
   writeAdminAuditLog?: (
     req: unknown,
@@ -230,6 +237,7 @@ type NativeAuthDeps = Required<
     | "getActiveSessionByToken"
     | "getClinicUserById"
     | "getClinicUserByUsername"
+    | "getClinicUserByIdentifier"
     | "updateSessionLastAccess"
     | "upsertClinicUser"
     | "generateSessionToken"
@@ -238,6 +246,7 @@ type NativeAuthDeps = Required<
     | "verifyPassword"
     | "createAdminSession"
     | "getAdminUserByUsername"
+    | "getAdminUserByIdentifier"
     | "writeAdminAuditLog"
     | "createParticularSession"
     | "getParticularTokenByTokenHash"
@@ -266,6 +275,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
         getActiveSessionByToken: db.getActiveSessionByToken,
         getClinicUserById: db.getClinicUserById,
         getClinicUserByUsername: db.getClinicUserByUsername,
+        getClinicUserByIdentifier: db.getClinicUserByIdentifier,
         updateSessionLastAccess: db.updateSessionLastAccess,
         upsertClinicUser: db.upsertClinicUser,
         generateSessionToken: authSecurity.generateSessionToken,
@@ -274,6 +284,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
         verifyPassword: authSecurity.verifyPassword,
         createAdminSession: db.createAdminSession,
         getAdminUserByUsername: db.getAdminUserByUsername,
+        getAdminUserByIdentifier: db.getAdminUserByIdentifier,
         writeAdminAuditLog: audit.writeAuditLog as (
           req: unknown,
           input: AdminAuditWriteInput,
@@ -616,7 +627,7 @@ async function authenticateAdminCandidate(
     currentTime: number;
   },
 ): Promise<AuthenticatedAdminCandidate | null> {
-  const admin = await deps.getAdminUserByUsername(input.identifier);
+  const admin = await deps.getAdminUserByIdentifier(input.identifier);
 
   if (!admin) {
     return null;
@@ -669,7 +680,7 @@ async function authenticateClinicCandidate(
     currentTime: number;
   },
 ): Promise<AuthenticatedClinicCandidate | null> {
-  const clinicUser = await deps.getClinicUserByUsername(input.identifier);
+  const clinicUser = await deps.getClinicUserByIdentifier(input.identifier);
 
   if (!clinicUser) {
     return null;
@@ -880,6 +891,11 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       options.getClinicUserById ?? defaultDeps!.getClinicUserById,
     getClinicUserByUsername:
       options.getClinicUserByUsername ?? defaultDeps!.getClinicUserByUsername,
+    getClinicUserByIdentifier:
+      options.getClinicUserByIdentifier ??
+      defaultDeps?.getClinicUserByIdentifier ??
+      options.getClinicUserByUsername ??
+      defaultDeps!.getClinicUserByUsername,
     updateSessionLastAccess:
       options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
     upsertClinicUser:
@@ -895,6 +911,12 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       defaultDeps?.createAdminSession ??
       (async () => undefined),
     getAdminUserByUsername:
+      options.getAdminUserByUsername ??
+      defaultDeps?.getAdminUserByUsername ??
+      (async () => null),
+    getAdminUserByIdentifier:
+      options.getAdminUserByIdentifier ??
+      defaultDeps?.getAdminUserByIdentifier ??
       options.getAdminUserByUsername ??
       defaultDeps?.getAdminUserByUsername ??
       (async () => null),

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -268,6 +268,10 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
       const dbParticular = await import("../db-particular.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const audit = await import("../lib/audit.ts");
+      const getClinicUserByIdentifier = async (identifier: string) =>
+        (await db.getClinicUserByIdentifier(identifier)) ?? null;
+      const getAdminUserByIdentifier = async (identifier: string) =>
+        (await db.getAdminUserByIdentifier(identifier)) ?? null;
 
       return {
         createActiveSession: db.createActiveSession,
@@ -275,7 +279,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
         getActiveSessionByToken: db.getActiveSessionByToken,
         getClinicUserById: db.getClinicUserById,
         getClinicUserByUsername: db.getClinicUserByUsername,
-        getClinicUserByIdentifier: db.getClinicUserByIdentifier,
+        getClinicUserByIdentifier,
         updateSessionLastAccess: db.updateSessionLastAccess,
         upsertClinicUser: db.upsertClinicUser,
         generateSessionToken: authSecurity.generateSessionToken,
@@ -284,7 +288,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
         verifyPassword: authSecurity.verifyPassword,
         createAdminSession: db.createAdminSession,
         getAdminUserByUsername: db.getAdminUserByUsername,
-        getAdminUserByIdentifier: db.getAdminUserByIdentifier,
+        getAdminUserByIdentifier,
         writeAdminAuditLog: audit.writeAuditLog as (
           req: unknown,
           input: AdminAuditWriteInput,
@@ -309,7 +313,12 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
     })();
   }
 
-  return defaultDepsPromise;
+  const depsPromise = defaultDepsPromise;
+  if (!depsPromise) {
+    throw new Error("No se pudieron inicializar dependencias de autenticación");
+  }
+
+  return depsPromise;
 }
 
 function getAllowedOrigins(): string[] {

--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -172,7 +172,7 @@ test("migración 0026 existe y añade contact_email y contact_phone con ADD COLU
   );
 });
 
-test("journal de migraciones conserva 0026 y deja 0028 como última entrada", () => {
+test("journal de migraciones conserva 0026 y deja 0029 como última entrada", () => {
   const raw = read("drizzle/migrations/meta/_journal.json");
   const journal = JSON.parse(raw) as {
     entries: Array<{ idx: number; tag: string }>;
@@ -190,10 +190,10 @@ test("journal de migraciones conserva 0026 y deja 0028 como última entrada", ()
   );
   assert.equal(
     last?.tag,
-    "0028_ensure_report_workflow_columns",
-    "la última entrada del journal debe ser 0028_ensure_report_workflow_columns",
+    "0029_admin_users_email_identifier",
+    "la última entrada del journal debe ser 0029_admin_users_email_identifier",
   );
-  assert.equal(last?.idx, 28, "idx de la última migración debe ser 28");
+  assert.equal(last?.idx, 29, "idx de la última migración debe ser 29");
 });
 
 test("toIsoDate acepta Date o string devuelto por raw SQL postgres-js", () => {

--- a/test/admin-email-login-migration.test.ts
+++ b/test/admin-email-login-migration.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const migrationPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "0029_admin_users_email_identifier.sql",
+);
+const journalPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "meta",
+  "_journal.json",
+);
+const schemaPath = resolve(process.cwd(), "drizzle", "schema.ts");
+
+function readText(path: string): string {
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+}
+
+test("admin email login migration exists with email column and unique index", () => {
+  assert.ok(
+    existsSync(migrationPath),
+    "missing 0029_admin_users_email_identifier.sql",
+  );
+
+  const source = readText(migrationPath);
+  assert.match(source, /ALTER TABLE "admin_users"/);
+  assert.match(source, /ADD COLUMN IF NOT EXISTS "email" varchar\(255\)/);
+  assert.match(source, /CREATE UNIQUE INDEX IF NOT EXISTS "admin_users_email_lower_uidx"/);
+  assert.match(source, /ON "admin_users" \(lower\("email"\)\)/);
+  assert.match(source, /WHERE "email" IS NOT NULL/);
+});
+
+test("admin email login migration is registered in drizzle journal", () => {
+  const journal = JSON.parse(readText(journalPath)) as {
+    entries?: Array<{ tag?: string }>;
+  };
+
+  assert.ok(Array.isArray(journal.entries), "_journal.json must define entries");
+  assert.ok(
+    journal.entries?.some(
+      (entry) => entry.tag === "0029_admin_users_email_identifier",
+    ),
+    "drizzle journal must register 0029_admin_users_email_identifier",
+  );
+});
+
+test("drizzle schema keeps admin_users email column contract", () => {
+  const schemaSource = readText(schemaPath);
+  assert.match(schemaSource, /pgTable\("admin_users"/);
+  assert.match(schemaSource, /email:\s+varchar\("email",\s*\{\s*length:\s*255\s*\}\)/);
+});

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -392,6 +392,91 @@ test(
 );
 
 test(
+  "clinicAuthNativeRoutes login unificado autentica admin por email registrado",
+  async () => {
+    const adminSessionCalls: Array<{
+      adminUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+    let adminUsernameLookupCalls = 0;
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async () => {
+        adminUsernameLookupCalls += 1;
+        return null;
+      },
+      getAdminUserByIdentifier: async (identifier: string) => {
+        assert.equal(identifier, "Admin.Fixture@VetNEB.test");
+
+        return {
+          id: 205,
+          username: "VETNEB",
+          email: "admin.fixture@vetneb.test",
+          passwordHash: "admin-hash",
+        };
+      },
+      getClinicUserByIdentifier: async () => {
+        throw new Error("no debe evaluar clinic cuando admin autenticó");
+      },
+      verifyPassword: async (password: string, passwordHash: string) => {
+        assert.equal(password, "secret");
+        assert.equal(passwordHash, "admin-hash");
+
+        return {
+          valid: true,
+          needsRehash: false,
+        };
+      },
+      generateSessionToken: () => "admin-email-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createAdminSession: async (input: {
+        adminUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        adminSessionCalls.push(input);
+      },
+      writeAdminAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "  Admin.Fixture@VetNEB.test  ",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "admin",
+        redirectTo: "/dashboard/admin",
+      });
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.adminCookieName}=admin-email-token`));
+      assert.equal(setCookie.includes(`${ENV.cookieName}=`), false);
+      assert.equal(setCookie.includes(`${ENV.particularCookieName}=`), false);
+
+      assert.equal(adminSessionCalls.length, 1);
+      assert.equal(adminSessionCalls[0].adminUserId, 205);
+      assert.equal(adminSessionCalls[0].tokenHash, "hash:admin-email-token");
+      assert.equal(adminUsernameLookupCalls, 0);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "clinicAuthNativeRoutes login unificado autentica clínica y crea cookie app_session_id",
   async () => {
     const clinicSessionCalls: Array<{
@@ -464,6 +549,91 @@ test(
       assert.equal(clinicSessionCalls.length, 1);
       assert.equal(clinicSessionCalls[0].clinicUserId, 77);
       assert.equal(clinicSessionCalls[0].tokenHash, "hash:clinic-token-123");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuthNativeRoutes login unificado autentica clínica por email asociado",
+  async () => {
+    const clinicSessionCalls: Array<{
+      clinicUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+    let clinicUsernameLookupCalls = 0;
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByIdentifier: async () => null,
+      getClinicUserByUsername: async () => {
+        clinicUsernameLookupCalls += 1;
+        return null;
+      },
+      getClinicUserByIdentifier: async (identifier: string) => {
+        assert.equal(identifier, "Clinica@VetNEB.com");
+
+        return {
+          id: 78,
+          clinicId: 11,
+          username: "clinica-owner",
+          passwordHash: "clinic-hash",
+          authProId: null,
+          role: "clinic_owner",
+        };
+      },
+      verifyPassword: async (password: string, passwordHash: string) => {
+        assert.equal(password, "secret");
+        assert.equal(passwordHash, "clinic-hash");
+
+        return {
+          valid: true,
+          needsRehash: false,
+        };
+      },
+      generateSessionToken: () => "clinic-email-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createActiveSession: async (input: {
+        clinicUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        clinicSessionCalls.push(input);
+      },
+      writeAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "  Clinica@VetNEB.com  ",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "clinic",
+        redirectTo: "/dashboard",
+      });
+
+      const setCookie = getSetCookieHeader(response);
+      assert.ok(setCookie.includes(`${ENV.cookieName}=clinic-email-token`));
+      assert.equal(setCookie.includes(`${ENV.adminCookieName}=`), false);
+      assert.equal(setCookie.includes(`${ENV.particularCookieName}=`), false);
+
+      assert.equal(clinicSessionCalls.length, 1);
+      assert.equal(clinicSessionCalls[0].clinicUserId, 78);
+      assert.equal(clinicSessionCalls[0].tokenHash, "hash:clinic-email-token");
+      assert.equal(clinicUsernameLookupCalls, 0);
     } finally {
       await app.close();
     }
@@ -838,6 +1008,73 @@ test(
         },
         payload: {
           identifier: "shared-user",
+          password: "secret",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        role: "admin",
+        redirectTo: "/dashboard/admin",
+      });
+      assert.equal(clinicLookupCalls, 0);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "clinicAuthNativeRoutes login unificado prioriza admin ante colisión email/username entre roles",
+  async () => {
+    let clinicLookupCalls = 0;
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByIdentifier: async (identifier: string) => {
+        if (identifier === "shared@vetneb.com") {
+          return {
+            id: 10,
+            username: "VETNEB",
+            email: "shared@vetneb.com",
+            passwordHash: "shared-hash",
+          };
+        }
+
+        return null;
+      },
+      getClinicUserByIdentifier: async () => {
+        clinicLookupCalls += 1;
+
+        return {
+          id: 7,
+          clinicId: 3,
+          username: "shared@vetneb.com",
+          passwordHash: "shared-hash",
+          authProId: null,
+          role: "clinic_owner",
+        };
+      },
+      verifyPassword: async (password: string, passwordHash: string) => ({
+        valid: password === "secret" && passwordHash === "shared-hash",
+        needsRehash: false,
+      }),
+      generateSessionToken: () => "admin-priority-email-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createAdminSession: async () => {},
+      writeAdminAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        payload: {
+          identifier: "shared@vetneb.com",
           password: "secret",
         },
       });

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -60,6 +60,8 @@ test("frontend login content handles controlled credentials loading and errors",
   assert.ok(source.includes('const [password, setPassword] = useState("")'));
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
   assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes("error instanceof Error"));
+  assert.ok(source.includes("? error.message"));
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("disabled={isSubmitting}"));
 });

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -62,6 +62,8 @@ test("login public page handles loading and error states", () => {
   assert.ok(source.includes("setErrorMessage(null);"));
   assert.ok(source.includes("setIsSubmitting(true);"));
   assert.ok(source.includes("setIsSubmitting(false);"));
+  assert.ok(source.includes("error instanceof Error"));
+  assert.ok(source.includes("? error.message"));
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("disabled={isSubmitting}"));
   assert.ok(source.includes('isSubmitting ? "Iniciando sesión..." : "Iniciar sesión"'));


### PR DESCRIPTION
## Summary
- support email as an identifier in unified RBAC login
- keep username login working
- add admin_users.email via migration
- resolve clinic login by username or clinic contact email
- preserve token-based particular login

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend typecheck

## Notes
- Requires applying migration 0029 before testing admin email login in staging/production
- Does not touch CSP/security headers, HSTS, nonce, or CSP enforcement
- Does not touch production secrets
- Does not remove legacy auth endpoints
- Maintains generic invalid credentials responses