### PR TITLE
test(auth): lock clinic registration email login contract

### DIFF
--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -216,3 +216,183 @@ test("toIsoDate acepta Date o string devuelto por raw SQL postgres-js", () => {
     "toIsoDate debe validar fechas inválidas",
   );
 });
+
+/* ============================================================================
+ * Contrato global: clínica registrada debe poder iniciar sesión por username
+ * o por contact_email. Tests source-only sobre server/db-admin-clinics.ts y
+ * server/db.ts. No tocan DB, no exponen secretos, no validan frontend.
+ * ========================================================================== */
+
+test("createAdminClinicWithUser persiste contact_email aplicando trim al input", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  const fnStart = source.indexOf(
+    "export async function createAdminClinicWithUser(",
+  );
+  assert.ok(fnStart >= 0, "createAdminClinicWithUser debe estar exportado");
+
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  const fnBody = source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+
+  assert.ok(
+    fnBody.includes("input.contactEmail.trim()"),
+    "createAdminClinicWithUser debe persistir contactEmail con .trim() en ambas ramas (legacy + drizzle)",
+  );
+
+  const trimOccurrences =
+    (fnBody.match(/input\.contactEmail\.trim\(\)/g) ?? []).length;
+  assert.ok(
+    trimOccurrences >= 2,
+    "se esperan al menos 2 usos de input.contactEmail.trim() (legacy raw SQL + drizzle insert), encontrados: " +
+      String(trimOccurrences),
+  );
+});
+
+test("createAdminClinicWithUser asocia el clinic_user creado al clinic recién insertado vía clinicId", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  const fnStart = source.indexOf(
+    "export async function createAdminClinicWithUser(",
+  );
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  const fnBody = source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+
+  assert.ok(
+    fnBody.includes("const clinic = insertedClinics[0]"),
+    "debe tomar la clínica recién insertada como referencia para el user",
+  );
+  assert.ok(
+    fnBody.includes(".insert(clinicUsers)"),
+    "debe insertar el clinic_user en la misma transacción",
+  );
+  assert.ok(
+    fnBody.includes("clinicId: clinic.clinicId"),
+    "el clinic_user debe asociarse al clinicId de la clínica recién creada",
+  );
+});
+
+test("createAdminClinicWithUser persiste username trim y role del input en clinic_user", () => {
+  const source = read("server/db-admin-clinics.ts");
+
+  const fnStart = source.indexOf(
+    "export async function createAdminClinicWithUser(",
+  );
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  const fnBody = source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+
+  assert.ok(
+    fnBody.includes("const username = input.username.trim()"),
+    "debe normalizar input.username con trim() antes de persistir",
+  );
+
+  const userInsertStart = fnBody.indexOf(".insert(clinicUsers)");
+  assert.ok(userInsertStart >= 0, "debe existir insert sobre clinicUsers");
+
+  const userInsertBlock = fnBody.slice(userInsertStart, userInsertStart + 600);
+  assert.ok(
+    userInsertBlock.includes("username,"),
+    "el insert de clinic_user debe persistir el username normalizado",
+  );
+  assert.ok(
+    userInsertBlock.includes("role: input.role"),
+    "el insert de clinic_user debe persistir el role recibido por input",
+  );
+  assert.ok(
+    userInsertBlock.includes("passwordHash: input.passwordHash"),
+    "el insert de clinic_user debe persistir el passwordHash (no hardcoded)",
+  );
+});
+
+test("getClinicUserByIdentifier en server/db.ts resuelve por username y por clinics.contact_email con lower(trim(...))", () => {
+  const source = read("server/db.ts");
+
+  const fnStart = source.indexOf(
+    "export async function getClinicUserByIdentifier(",
+  );
+  assert.ok(
+    fnStart >= 0,
+    "getClinicUserByIdentifier debe existir y estar exportado en server/db.ts",
+  );
+
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  const fnBody = source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+
+  assert.ok(
+    fnBody.includes("identifier.trim()") ||
+      fnBody.includes("normalizeLoginIdentifierForLookup"),
+    "getClinicUserByIdentifier debe normalizar el identifier con trim() (directo o por helper)",
+  );
+
+  assert.ok(
+    fnBody.includes("eq(clinicUsers.username,"),
+    "debe matchear por clinicUsers.username (rama username)",
+  );
+
+  assert.ok(
+    fnBody.includes("lower(trim(") &&
+      fnBody.includes("clinics.contactEmail"),
+    "debe matchear por lower(trim(clinics.contactEmail)) (rama email contacto de la clínica)",
+  );
+
+  assert.ok(
+    fnBody.includes(".limit(1)"),
+    "debe limitar a un solo registro",
+  );
+});
+
+test("getClinicUserByIdentifier usa join con clinics y NO referencia columna inexistente clinic_users.email", () => {
+  const source = read("server/db.ts");
+
+  const fnStart = source.indexOf(
+    "export async function getClinicUserByIdentifier(",
+  );
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  const fnBody = source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+
+  assert.ok(
+    fnBody.includes("leftJoin(clinics,") ||
+      fnBody.includes("innerJoin(clinics,"),
+    "debe hacer join sobre la tabla clinics para acceder a contact_email (la columna no vive en clinic_users)",
+  );
+
+  assert.ok(
+    fnBody.includes("clinicUsers.clinicId") &&
+      fnBody.includes("clinics.id"),
+    "el join debe ser por clinicUsers.clinicId = clinics.id",
+  );
+
+  assert.equal(
+    fnBody.includes("clinicUsers.email"),
+    false,
+    "NO debe referenciar clinicUsers.email: esa columna no existe en el schema",
+  );
+  assert.equal(
+    /\bclinic_users\.email\b/.test(fnBody),
+    false,
+    "NO debe referenciar clinic_users.email como columna: vive en clinics.contact_email",
+  );
+});
+
+test("getClinicUserByIdentifier devuelve la forma mínima esperada por el contrato de auth (id, clinicId, username, passwordHash, authProId, role)", () => {
+  const source = read("server/db.ts");
+
+  const fnStart = source.indexOf(
+    "export async function getClinicUserByIdentifier(",
+  );
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  const fnBody = source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+
+  for (const field of [
+    "id: clinicUsers.id",
+    "clinicId: clinicUsers.clinicId",
+    "username: clinicUsers.username",
+    "passwordHash: clinicUsers.passwordHash",
+    "authProId: clinicUsers.authProId",
+    "role: clinicUsers.role",
+  ]) {
+    assert.ok(
+      fnBody.includes(field),
+      "getClinicUserByIdentifier debe seleccionar el campo: " + field,
+    );
+  }
+});

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -1838,3 +1838,281 @@ test(
     }
   },
 );
+
+/* ============================================================================
+ * Contrato global del login unificado para clínica recién registrada.
+ *
+ * Garantiza que una clínica creada vía createAdminClinicWithUser puede iniciar
+ * sesión por ambas vías:
+ *   (a) username (el usuario propio del clinic_user)
+ *   (b) contact email de la clínica
+ *
+ * Verifica además:
+ *   - role=clinic, redirectTo=/dashboard
+ *   - Cookie app_session_id presente
+ *   - Cookies admin_session_id / particular_session_id ausentes
+ *   - Body no expone passwordHash, token ni cookies
+ *   - El handler usa getClinicUserByIdentifier explícito (no solo fallback
+ *     getClinicUserByUsername)
+ * ========================================================================== */
+
+test(
+  "login unificado: clínica registrada puede iniciar sesión por username (contrato global, app_session_id exclusiva)",
+  async () => {
+    const identifierLookups: string[] = [];
+    let usernameFallbackCalls = 0;
+    const sessionCalls: Array<{
+      clinicUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async () => null,
+      getAdminUserByIdentifier: async () => null,
+      getClinicUserByUsername: async () => {
+        usernameFallbackCalls += 1;
+        return null;
+      },
+      getClinicUserByIdentifier: async (identifier: string) => {
+        identifierLookups.push(identifier);
+
+        if (identifier === "clinica-registrada") {
+          return {
+            id: 4242,
+            clinicId: 808,
+            username: "clinica-registrada",
+            passwordHash: "stored-hash",
+            authProId: null,
+            role: "clinic_owner",
+          };
+        }
+        return null;
+      },
+      verifyPassword: async () => ({ valid: true, needsRehash: false }),
+      generateSessionToken: () => "username-login-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createActiveSession: async (input: {
+        clinicUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        sessionCalls.push(input);
+      },
+      writeAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        payload: {
+          identifier: "clinica-registrada",
+          password: "clave-secreta",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      const body = JSON.parse(response.body);
+
+      assert.equal(body.success, true);
+      assert.equal(body.role, "clinic");
+      assert.equal(body.redirectTo, "/dashboard");
+
+      // El handler debe haber usado el lookup unificado explícito,
+      // no haber caído al fallback de username puro.
+      assert.equal(identifierLookups.length, 1);
+      assert.equal(identifierLookups[0], "clinica-registrada");
+      assert.equal(
+        usernameFallbackCalls,
+        0,
+        "getClinicUserByUsername no debe llamarse cuando getClinicUserByIdentifier responde",
+      );
+
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(sessionCalls[0].clinicUserId, 4242);
+      assert.equal(sessionCalls[0].tokenHash, "hash:username-login-token");
+
+      const setCookie = getSetCookieHeader(response);
+
+      // Cookie de clínica presente
+      assert.ok(
+        setCookie.includes(`${ENV.cookieName}=username-login-token`),
+        "debe emitir cookie app_session_id (ENV.cookieName) con el token de sesión clínica",
+      );
+      assert.ok(setCookie.includes("HttpOnly"));
+
+      // Cookies de otras superficies ausentes
+      assert.equal(
+        setCookie.includes(`${ENV.adminCookieName}=`),
+        false,
+        "no debe emitir cookie admin_session_id en login de clínica",
+      );
+      assert.equal(
+        setCookie.includes(`${ENV.particularCookieName}=`),
+        false,
+        "no debe emitir cookie particular_session_id en login de clínica",
+      );
+
+      // Body no debe filtrar secretos
+      const rawBody = response.body.toLowerCase();
+      assert.equal(
+        rawBody.includes("passwordhash"),
+        false,
+        "el body no debe exponer passwordHash",
+      );
+      assert.equal(
+        rawBody.includes("password_hash"),
+        false,
+        "el body no debe exponer password_hash",
+      );
+      assert.equal(
+        rawBody.includes("stored-hash"),
+        false,
+        "el body no debe filtrar el hash almacenado",
+      );
+      assert.equal(
+        rawBody.includes("clave-secreta"),
+        false,
+        "el body no debe reflejar el password en claro",
+      );
+      assert.equal(
+        rawBody.includes("username-login-token"),
+        false,
+        "el body no debe exponer el session token (solo la cookie httpOnly debe transportarlo)",
+      );
+      assert.equal(
+        rawBody.includes("cookie"),
+        false,
+        "el body no debe mencionar cookies",
+      );
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "login unificado: clínica registrada puede iniciar sesión por contact_email asociado (contrato global, app_session_id exclusiva)",
+  async () => {
+    const identifierLookups: string[] = [];
+    let usernameFallbackCalls = 0;
+    const sessionCalls: Array<{
+      clinicUserId: number;
+      tokenHash: string;
+      expiresAt: Date;
+    }> = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      getAdminUserByUsername: async () => null,
+      getAdminUserByIdentifier: async () => null,
+      getClinicUserByUsername: async () => {
+        usernameFallbackCalls += 1;
+        return null;
+      },
+      getClinicUserByIdentifier: async (identifier: string) => {
+        // El handler/route debe pasar el identifier tal cual lo recibió
+        // (la normalización lower/trim ocurre dentro de getClinicUserByIdentifier
+        // en server/db.ts, no en la ruta).
+        identifierLookups.push(identifier);
+
+        if (identifier.trim().toLowerCase() === "contacto@clinica-registrada.com") {
+          return {
+            id: 4242,
+            clinicId: 808,
+            username: "clinica-registrada",
+            passwordHash: "stored-hash",
+            authProId: null,
+            role: "clinic_owner",
+          };
+        }
+        return null;
+      },
+      verifyPassword: async () => ({ valid: true, needsRehash: false }),
+      generateSessionToken: () => "email-login-token",
+      hashSessionToken: (token: string) => `hash:${token}`,
+      createActiveSession: async (input: {
+        clinicUserId: number;
+        tokenHash: string;
+        expiresAt: Date;
+      }) => {
+        sessionCalls.push(input);
+      },
+      writeAuditLog: async () => {},
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        payload: {
+          // Espacios + mayúsculas para verificar que el contrato tolera
+          // identificadores email "sucios" entregados por el frontend.
+          identifier: "  Contacto@Clinica-Registrada.com  ",
+          password: "clave-secreta",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      const body = JSON.parse(response.body);
+
+      assert.equal(body.success, true);
+      assert.equal(body.role, "clinic");
+      assert.equal(body.redirectTo, "/dashboard");
+
+      assert.equal(
+        identifierLookups.length,
+        1,
+        "getClinicUserByIdentifier debe ser invocado exactamente una vez",
+      );
+      assert.equal(
+        usernameFallbackCalls,
+        0,
+        "getClinicUserByUsername no debe usarse como fallback cuando getClinicUserByIdentifier está disponible y responde",
+      );
+
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(sessionCalls[0].clinicUserId, 4242);
+      assert.equal(sessionCalls[0].tokenHash, "hash:email-login-token");
+
+      const setCookie = getSetCookieHeader(response);
+
+      assert.ok(
+        setCookie.includes(`${ENV.cookieName}=email-login-token`),
+        "debe emitir cookie app_session_id (ENV.cookieName) con el token de sesión clínica",
+      );
+      assert.ok(setCookie.includes("HttpOnly"));
+
+      assert.equal(
+        setCookie.includes(`${ENV.adminCookieName}=`),
+        false,
+        "no debe emitir cookie admin_session_id en login de clínica por email",
+      );
+      assert.equal(
+        setCookie.includes(`${ENV.particularCookieName}=`),
+        false,
+        "no debe emitir cookie particular_session_id en login de clínica por email",
+      );
+
+      const rawBody = response.body.toLowerCase();
+      assert.equal(rawBody.includes("passwordhash"), false);
+      assert.equal(rawBody.includes("password_hash"), false);
+      assert.equal(rawBody.includes("stored-hash"), false);
+      assert.equal(rawBody.includes("clave-secreta"), false);
+      assert.equal(
+        rawBody.includes("email-login-token"),
+        false,
+        "el body no debe exponer el session token de login por email",
+      );
+      assert.equal(rawBody.includes("cookie"), false);
+    } finally {
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- Lock clinic registration/login contract for username and contact email.
- Add regression coverage for unified clinic login returning role=clinic and redirectTo=/dashboard.
- Assert app_session_id is used and admin/particular cookies are absent.

## Validation
- pnpm test
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local