### PR TITLE
feat(admin): replace token clinic id input with search selector

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   createAdminParticularToken,
+  getAdminUsersRoles,
   getAdminParticularTokens,
   revokeAdminParticularToken,
   type AdminParticularTokenCreatePayload,
@@ -36,6 +37,13 @@ type AdminParticularTokenFormState = {
   shippingDate: string;
 };
 
+type ClinicOption = {
+  id: number;
+  name: string;
+  usernames: string[];
+  locality: string | null;
+};
+
 const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
   clinicId: "",
   reportId: "",
@@ -53,10 +61,9 @@ const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
 };
 
 const REQUIRED_FIELD_LABELS: Array<{
-  key: keyof Omit<AdminParticularTokenFormState, "reportId">;
+  key: keyof Omit<AdminParticularTokenFormState, "clinicId" | "reportId">;
   label: string;
 }> = [
-  { key: "clinicId", label: "ID de clínica" },
   { key: "tutorLastName", label: "Apellido del tutor" },
   { key: "petName", label: "Nombre del paciente" },
   { key: "petAge", label: "Edad" },
@@ -86,6 +93,70 @@ const PET_SPECIES_OPTIONS = [
   { value: "Caprinos", label: "Caprinos" },
   { value: "Aves", label: "Aves" },
 ];
+
+function normalizeSearchText(value: string | number): string {
+  return String(value)
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
+function buildClinicSearchText(option: ClinicOption): string {
+  return normalizeSearchText(
+    [option.id, option.name, option.locality ?? "", ...option.usernames].join(
+      " ",
+    ),
+  );
+}
+
+function matchClinicOption(option: ClinicOption, query: string): boolean {
+  const normalizedQuery = normalizeSearchText(query);
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const searchable = buildClinicSearchText(option);
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+
+  return tokens.every((token) => searchable.includes(token));
+}
+
+function sortClinicOptions(a: ClinicOption, b: ClinicOption): number {
+  const nameComparison = a.name.localeCompare(b.name, "es", {
+    sensitivity: "base",
+  });
+
+  return nameComparison || a.id - b.id;
+}
+
+function dedupeClinicOptions(options: ClinicOption[]): ClinicOption[] {
+  const byId = new Map<number, ClinicOption>();
+
+  for (const option of options) {
+    const current = byId.get(option.id);
+
+    if (!current) {
+      byId.set(option.id, {
+        ...option,
+        usernames: [...option.usernames],
+      });
+      continue;
+    }
+
+    byId.set(option.id, {
+      ...current,
+      name: current.name || option.name,
+      locality: current.locality ?? option.locality,
+      usernames: Array.from(
+        new Set([...current.usernames, ...option.usernames]),
+      ).sort((a, b) => a.localeCompare(b, "es", { sensitivity: "base" })),
+    });
+  }
+
+  return Array.from(byId.values()).sort(sortClinicOptions);
+}
 
 function toIsoDate(value: string): string {
   return `${value}T00:00:00.000Z`;
@@ -127,11 +198,16 @@ function validateFormState(formState: AdminParticularTokenFormState): void {
 
 function buildPayload(
   formState: AdminParticularTokenFormState,
+  selectedClinic: ClinicOption | undefined,
 ): AdminParticularTokenCreatePayload {
   validateFormState(formState);
 
+  if (!selectedClinic) {
+    throw new Error("Seleccione una clínica registrada del listado.");
+  }
+
   return {
-    clinicId: parsePositiveInteger(formState.clinicId, "El ID de clínica"),
+    clinicId: selectedClinic.id,
     reportId: parseOptionalReportId(formState.reportId),
     tutorLastName: normalizeText(formState.tutorLastName),
     petName: normalizeText(formState.petName),
@@ -162,6 +238,10 @@ function formatTokenSource(token: AdminParticularTokenSummary): string {
 export function AdminParticularTokensCard() {
   const [formState, setFormState] =
     useState<AdminParticularTokenFormState>(INITIAL_FORM_STATE);
+  const [clinicSearch, setClinicSearch] = useState("");
+  const [clinicOptions, setClinicOptions] = useState<ClinicOption[]>([]);
+  const [isLoadingClinics, setIsLoadingClinics] = useState(false);
+  const [clinicLoadError, setClinicLoadError] = useState<string | null>(null);
   const [tokens, setTokens] = useState<AdminParticularTokenSummary[]>([]);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
   const [isLoadingTokens, setIsLoadingTokens] = useState(false);
@@ -169,6 +249,18 @@ export function AdminParticularTokensCard() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const selectedClinic = clinicOptions.find(
+    (option) => String(option.id) === formState.clinicId,
+  );
+  const hasClinicQuery = normalizeSearchText(clinicSearch).length > 0;
+  const filteredClinicOptions = hasClinicQuery
+    ? clinicOptions
+        .filter((option) => matchClinicOption(option, clinicSearch))
+        .slice(0, 20)
+    : selectedClinic
+      ? [selectedClinic]
+      : [];
 
   async function loadTokens() {
     setIsLoadingTokens(true);
@@ -191,6 +283,73 @@ export function AdminParticularTokensCard() {
     void loadTokens();
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadClinicOptions() {
+      setIsLoadingClinics(true);
+      setClinicLoadError(null);
+
+      try {
+        const limit = 100;
+        let offset = 0;
+        let total = Number.POSITIVE_INFINITY;
+        const options: ClinicOption[] = [];
+
+        while (offset < total) {
+          const snapshot = await getAdminUsersRoles({
+            userType: "clinic",
+            limit,
+            offset,
+          });
+
+          total = snapshot.total;
+
+          for (const user of snapshot.users) {
+            if (user.userType !== "clinic") {
+              continue;
+            }
+
+            options.push({
+              id: user.clinicId,
+              name: user.clinicName ?? `Clínica #${user.clinicId}`,
+              usernames: [user.username],
+              locality: user.clinicLocality ?? null,
+            });
+          }
+
+          offset += snapshot.users.length;
+
+          if (snapshot.users.length === 0) {
+            break;
+          }
+        }
+
+        if (!cancelled) {
+          setClinicOptions(dedupeClinicOptions(options));
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setClinicLoadError(
+            error instanceof Error
+              ? error.message
+              : "No se pudieron cargar las clínicas registradas.",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingClinics(false);
+        }
+      }
+    }
+
+    void loadClinicOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   function updateField(
     field: keyof AdminParticularTokenFormState,
     value: string,
@@ -202,6 +361,22 @@ export function AdminParticularTokensCard() {
 
   function resetForm() {
     setFormState(INITIAL_FORM_STATE);
+    setClinicSearch("");
+    setErrorMessage(null);
+  }
+
+  function selectClinic(option: ClinicOption) {
+    setFormState((current) => ({ ...current, clinicId: String(option.id) }));
+    setClinicSearch(option.name);
+    setErrorMessage(null);
+    setStatusMessage(null);
+  }
+
+  function handleClinicSearchChange(value: string) {
+    setClinicSearch(value);
+    setFormState((current) => ({ ...current, clinicId: "" }));
+    setErrorMessage(null);
+    setStatusMessage(null);
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -218,7 +393,7 @@ export function AdminParticularTokensCard() {
     let payload: AdminParticularTokenCreatePayload;
 
     try {
-      payload = buildPayload(formState);
+      payload = buildPayload(formState, selectedClinic);
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -289,21 +464,104 @@ export function AdminParticularTokensCard() {
       <CardContent className="space-y-6 pt-6">
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            <div>
-              <label htmlFor="admin-token-clinic-id" className="field-label">
-                ID de clínica
+            <div className="md:col-span-2">
+              <label htmlFor="admin-token-clinic-search" className="field-label">
+                Clínica
               </label>
               <Input
+                id="admin-token-clinic-search"
+                name="clinicSearch"
+                type="text"
+                placeholder="Buscar clínica por nombre, localidad, usuario o ID..."
+                autoComplete="off"
+                required
+                value={clinicSearch}
+                onChange={(event) => handleClinicSearchChange(event.target.value)}
+                disabled={isSubmitting}
+                aria-describedby="admin-token-clinic-help"
+              />
+              <input
                 id="admin-token-clinic-id"
                 name="clinicId"
-                type="number"
-                min="1"
-                inputMode="numeric"
-                required
+                type="hidden"
                 value={formState.clinicId}
-                onChange={(event) => updateField("clinicId", event.target.value)}
-                disabled={isSubmitting}
+                readOnly
               />
+              <p
+                id="admin-token-clinic-help"
+                className="mt-1 text-xs text-muted-foreground"
+              >
+                Seleccione una clínica del listado. La búsqueda admite texto
+                parcial, acentos, localidad, ID y usuarios asociados.
+              </p>
+
+              {clinicLoadError ? (
+                <p
+                  className="mt-2 clinical-alert-error px-3 py-2"
+                  role="alert"
+                >
+                  {clinicLoadError}
+                </p>
+              ) : null}
+
+              <div
+                className="mt-2 max-h-44 overflow-y-auto rounded-lg border border-vetneb-line/80 bg-card/92"
+                role="listbox"
+                aria-label="Clínicas registradas"
+              >
+                {isLoadingClinics ? (
+                  <p className="surface-empty m-2 py-3">
+                    Cargando clínicas registradas...
+                  </p>
+                ) : null}
+
+                {!isLoadingClinics &&
+                hasClinicQuery &&
+                filteredClinicOptions.length === 0 ? (
+                  <p className="surface-empty m-2 py-3">
+                    No hay clínicas registradas que coincidan con la búsqueda.
+                  </p>
+                ) : null}
+
+                {!isLoadingClinics
+                  ? filteredClinicOptions.map((option) => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className={`clinical-hover-row flex w-full items-center justify-between gap-2 border-b border-vetneb-line/35 px-3 py-2 text-left text-sm last:border-b-0 ${
+                          String(option.id) === formState.clinicId
+                            ? "bg-vetneb-teal/12 text-vetneb-navy shadow-[inset_0_0_0_1px_rgba(16,60,96,0.28)]"
+                            : "text-vetneb-ink/88"
+                        }`}
+                        onClick={() => selectClinic(option)}
+                        disabled={isSubmitting}
+                        role="option"
+                        aria-selected={String(option.id) === formState.clinicId}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate font-medium">
+                            {option.name}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            ID #{option.id} · Localidad:{" "}
+                            {option.locality ?? "No informada"}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            Usuarios:{" "}
+                            {option.usernames.length
+                              ? option.usernames.join(", ")
+                              : "Sin usuarios asociados"}
+                          </span>
+                        </span>
+                        {String(option.id) === formState.clinicId ? (
+                          <span className="clinical-pill shrink-0 px-2 py-0.5 text-xs tracking-normal">
+                            Seleccionada
+                          </span>
+                        ) : null}
+                      </button>
+                    ))
+                  : null}
+              </div>
             </div>
 
             <div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -276,6 +276,7 @@ export type AdminRoleUserSummary =
       role: ClinicUserRole;
       clinicId: number;
       clinicName: string | null;
+      clinicLocality?: string | null;
       createdAt: string;
       updatedAt: string;
     };

--- a/server/db-admin-users-roles.ts
+++ b/server/db-admin-users-roles.ts
@@ -3,6 +3,7 @@ import { and, asc, eq, ne } from "drizzle-orm";
 import { db } from "./db.ts";
 import {
   adminUsers,
+  clinicPublicProfiles,
   clinicUsers,
   clinics,
   type ClinicUserRole,
@@ -29,6 +30,7 @@ export type AdminRoleUserSummary =
       role: ClinicUserRole;
       clinicId: number;
       clinicName: string | null;
+      clinicLocality?: string | null;
       createdAt: string;
       updatedAt: string;
     };
@@ -76,6 +78,7 @@ type ClinicUserRoleRow = {
   role: ClinicUserRole;
   clinicId: number;
   clinicName: string | null;
+  clinicLocality: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -118,6 +121,7 @@ function serializeClinicUserRoleRow(
     role: row.role,
     clinicId: row.clinicId,
     clinicName: row.clinicName ?? null,
+    clinicLocality: row.clinicLocality ?? null,
     createdAt: toIsoDate(row.createdAt),
     updatedAt: toIsoDate(row.updatedAt),
   };
@@ -133,11 +137,16 @@ async function getClinicUserRoleRow(
       role: clinicUsers.role,
       clinicId: clinicUsers.clinicId,
       clinicName: clinics.name,
+      clinicLocality: clinicPublicProfiles.locality,
       createdAt: clinicUsers.createdAt,
       updatedAt: clinicUsers.updatedAt,
     })
     .from(clinicUsers)
     .leftJoin(clinics, eq(clinics.id, clinicUsers.clinicId))
+    .leftJoin(
+      clinicPublicProfiles,
+      eq(clinicPublicProfiles.clinicId, clinicUsers.clinicId),
+    )
     .where(eq(clinicUsers.id, clinicUserId))
     .limit(1);
 
@@ -175,11 +184,16 @@ export async function getAdminUsersRolesSnapshot(
             role: clinicUsers.role,
             clinicId: clinicUsers.clinicId,
             clinicName: clinics.name,
+            clinicLocality: clinicPublicProfiles.locality,
             createdAt: clinicUsers.createdAt,
             updatedAt: clinicUsers.updatedAt,
           })
           .from(clinicUsers)
           .leftJoin(clinics, eq(clinics.id, clinicUsers.clinicId))
+          .leftJoin(
+            clinicPublicProfiles,
+            eq(clinicPublicProfiles.clinicId, clinicUsers.clinicId),
+          )
           .orderBy(asc(clinicUsers.username))
       : Promise.resolve([]),
   ]);
@@ -202,6 +216,7 @@ export async function getAdminUsersRolesSnapshot(
         role: row.role,
         clinicId: row.clinicId,
         clinicName: row.clinicName ?? null,
+        clinicLocality: row.clinicLocality ?? null,
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
       }),

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -38,6 +38,7 @@ test("admin particular token generator uses admin helpers without technical copy
 
   assert.ok(card.includes('"use client";'));
   assert.ok(card.includes("createAdminParticularToken"));
+  assert.ok(card.includes("getAdminUsersRoles"));
   assert.ok(card.includes("getAdminParticularTokens"));
   assert.ok(card.includes("revokeAdminParticularToken"));
   assert.ok(card.includes("type AdminParticularTokenCreatePayload"));
@@ -52,13 +53,119 @@ test("admin particular token generator uses admin helpers without technical copy
   );
 });
 
-test("admin particular token generator requires clinic id and programmed fields", () => {
+test("admin particular token generator uses registered clinic selector instead of manual clinic id", () => {
   const source = read(ADMIN_CARD_PATH);
+  const types = read("frontend/src/types/index.ts");
 
   assert.ok(source.includes("clinicId: string;"));
-  assert.ok(source.includes('{ key: "clinicId", label: "ID de clínica" }'));
+  assert.equal(source.includes('{ key: "clinicId", label: "ID de clínica" }'), false);
+  assert.equal(source.includes('htmlFor="admin-token-clinic-id"'), false);
+  assert.equal(source.includes('name="clinicId"\n                type="number"'), false);
+  assert.ok(source.includes('htmlFor="admin-token-clinic-search"'));
+  assert.ok(source.includes("Clínica"));
+  assert.ok(
+    source.includes(
+      'placeholder="Buscar clínica por nombre, localidad, usuario o ID..."',
+    ),
+  );
   assert.ok(source.includes('id="admin-token-clinic-id"'));
-  assert.ok(source.includes("clinicId: parsePositiveInteger(formState.clinicId"));
+  assert.ok(source.includes('name="clinicId"'));
+  assert.ok(source.includes('type="hidden"'));
+  assert.ok(source.includes("const selectedClinic = clinicOptions.find("));
+  assert.ok(source.includes("payload = buildPayload(formState, selectedClinic);"));
+  assert.ok(source.includes("clinicId: selectedClinic.id"));
+  assert.ok(
+    source.includes('"Seleccione una clínica registrada del listado."'),
+  );
+  assert.ok(source.includes('role="listbox"'));
+  assert.ok(source.includes('role="option"'));
+  assert.ok(source.includes("aria-selected"));
+  assert.ok(types.includes("clinicLocality?: string | null;"));
+  assert.equal(source.includes("veterinario"), false);
+});
+
+test("admin particular token clinic selector loads deduped clinics by name user id and locality", () => {
+  const source = read(ADMIN_CARD_PATH);
+
+  assert.ok(source.includes('import {\n  createAdminParticularToken,\n  getAdminUsersRoles,'));
+  assert.ok(source.includes("getAdminUsersRoles({"));
+  assert.ok(source.includes('userType: "clinic",'));
+  assert.ok(source.includes("limit,"));
+  assert.ok(source.includes("offset,"));
+  assert.ok(source.includes("total = snapshot.total;"));
+  assert.ok(source.includes("offset += snapshot.users.length;"));
+  assert.ok(source.includes("function normalizeSearchText(value: string | number): string"));
+  assert.ok(source.includes('.normalize("NFD")'));
+  assert.ok(source.includes('.replace(/\\p{Diacritic}/gu, "")'));
+  assert.ok(source.includes("[option.id, option.name, option.locality ?? \"\", ...option.usernames].join("));
+  assert.ok(source.includes("function matchClinicOption(option: ClinicOption, query: string): boolean"));
+  assert.ok(source.includes("function dedupeClinicOptions(options: ClinicOption[]): ClinicOption[]"));
+  assert.ok(source.includes("const byId = new Map<number, ClinicOption>();"));
+  assert.ok(source.includes("locality: current.locality ?? option.locality"));
+  assert.ok(source.includes("user.clinicLocality ?? null"));
+  assert.ok(source.includes("Localidad:"));
+  assert.ok(source.includes("{option.locality ?? \"No informada\"}"));
+  assert.ok(source.includes("Usuarios:"));
+  assert.ok(source.includes("option.usernames.join(\", \")"));
+});
+
+type TestClinicOption = {
+  id: number;
+  name: string;
+  usernames: string[];
+  locality: string | null;
+};
+
+function testNormalize(value: string | number): string {
+  return String(value)
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
+function testBuildSearchText(option: TestClinicOption): string {
+  return testNormalize(
+    [option.id, option.name, option.locality ?? "", ...option.usernames].join(
+      " ",
+    ),
+  );
+}
+
+function testMatch(option: TestClinicOption, query: string): boolean {
+  const normalizedQuery = testNormalize(query);
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const searchable = testBuildSearchText(option);
+
+  return normalizedQuery
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((token) => searchable.includes(token));
+}
+
+test("admin particular token clinic selector matches by available locality contract", () => {
+  const clinic = {
+    id: 42,
+    name: "Clínica Ejemplo Sur",
+    usernames: ["usuario_ejemplo"],
+    locality: "Córdoba Capital",
+  };
+
+  assert.ok(testMatch(clinic, "Clinica Ejemplo"));
+  assert.ok(testMatch(clinic, "usuario_ejemplo"));
+  assert.ok(testMatch(clinic, "42"));
+  assert.ok(testMatch(clinic, "cordoba"));
+  assert.equal(testMatch(clinic, "rosario"), false);
+});
+
+test("admin particular token generator keeps programmed fields", () => {
+  const source = read(ADMIN_CARD_PATH);
+
+  assert.ok(source.includes('id="admin-token-clinic-id"'));
   assert.ok(source.includes("Complete el campo obligatorio"));
   assert.ok(source.includes("tutorLastName"));
   assert.ok(source.includes("petName"));
@@ -91,6 +198,9 @@ test("clinic token generator remains clinic-scoped and separate from admin gener
 
   assert.ok(clinic.includes("createClinicParticularToken"));
   assert.ok(clinic.includes("getClinicParticularTokens"));
+  assert.equal(clinic.includes("clinicId: string;"), false);
+  assert.equal(clinic.includes('name="clinicId"'), false);
+  assert.equal(clinic.includes("getAdminUsersRoles"), false);
   assert.equal(clinic.includes("createAdminParticularToken"), false);
   assert.equal(clinic.includes(removedClinicEndpoint), false);
 


### PR DESCRIPTION
## Summary
- Replace manual clinic ID entry in admin token generation with a clinic search/listbox selector.
- Search clinics by name, ID, associated users, and locality.
- Keep clinicId as an internal numeric payload field while preventing manual ID entry.
- Expose clinicLocality through admin users/roles data.
- Do not invent veterinarian/professional fields because they are not present in DB/API.

## Validation
- pnpm test
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local

## Notes
- Existing lint/build warning remains in frontend/src/app/api/security/csp-report/route.ts and is outside this PR.