### PR TITLE
feat(clinic): align particular token form with admin contract

### DIFF
--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -440,10 +440,12 @@ export function ClinicParticularTokensCard() {
             <textarea
               id="clinic-token-details-lesion"
               name="detailsLesion"
-              className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              className="field-textarea"
               required
               value={formState.detailsLesion}
-              onChange={(event) => updateField("detailsLesion", event.target.value)}
+              onChange={(event) =>
+                updateField("detailsLesion", event.target.value)
+              }
               disabled={isSubmitting}
             />
           </div>

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const ADMIN_TOKENS_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
 const CLINIC_DASHBOARD_SIDEBAR_PATH =
   "frontend/src/components/dashboard/ClinicDashboardSidebar.tsx";
 const CLINIC_TOKENS_CARD_PATH =
@@ -15,6 +17,27 @@ function read(relativePath: string): string {
     /\r\n/g,
     "\n",
   );
+}
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `Missing start marker: ${start}`);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `Missing end marker: ${end}`);
+
+  return source.slice(startIndex, endIndex);
+}
+
+function assertOrdered(source: string, markers: string[]): void {
+  let previousIndex = -1;
+
+  for (const marker of markers) {
+    const index = source.indexOf(marker);
+    assert.notEqual(index, -1, `Missing marker: ${marker}`);
+    assert.ok(index > previousIndex, `${marker} must keep expected order`);
+    previousIndex = index;
+  }
 }
 
 test("clinic dashboard exists as a clinic-only dashboard and keeps admin out", () => {
@@ -78,6 +101,135 @@ test("clinic token generation requires all programmed data fields", () => {
   assert.ok(source.includes("Complete el campo obligatorio"));
   assert.ok(source.includes("required"));
   assert.ok(source.includes("reportId: parseOptionalReportId(formState.reportId)"));
+});
+
+test("clinic token generator stays session scoped without clinic id controls", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+  const api = read(API_PATH);
+  const payloadType = sectionBetween(
+    api,
+    "export type ClinicParticularTokenCreatePayload = {",
+    "};",
+  );
+  const formState = sectionBetween(
+    source,
+    "type ClinicParticularTokenFormState = {",
+    "};",
+  );
+  const payloadBuilder = sectionBetween(
+    source,
+    "function buildPayload(",
+    "function formatTokenSource",
+  );
+
+  assert.equal(source.includes("ID de clínica"), false);
+  assert.equal(source.includes('name="clinicId"'), false);
+  assert.equal(source.includes("clinicId: string;"), false);
+  assert.equal(source.includes("getAdminUsersRoles"), false);
+  assert.equal(source.includes("selectedClinic"), false);
+  assert.equal(formState.includes("clinicId"), false);
+  assert.equal(payloadType.includes("clinicId"), false);
+  assert.equal(payloadBuilder.includes("clinicId"), false);
+  assert.ok(source.includes("payload = buildPayload(formState);"));
+  assert.ok(
+    source.includes("const response = await createClinicParticularToken(payload);"),
+  );
+  assert.ok(api.includes('"/api/particular-tokens"'));
+});
+
+test("clinic token form keeps admin field labels and required contract", () => {
+  const clinic = read(CLINIC_TOKENS_CARD_PATH);
+  const admin = read(ADMIN_TOKENS_CARD_PATH);
+  const clinicRequiredFields = sectionBetween(
+    clinic,
+    "const REQUIRED_FIELD_LABELS:",
+    "];",
+  );
+  const adminRequiredFields = sectionBetween(
+    admin,
+    "const REQUIRED_FIELD_LABELS:",
+    "];",
+  );
+
+  for (const label of [
+    "Apellido del tutor",
+    "Nombre del paciente",
+    "Edad",
+    "Raza",
+    "Sexo",
+    "Especie",
+    "Ubicación de la muestra",
+    "Evolución",
+    "Fecha de extracción",
+    "Fecha de envío",
+    "Detalle de lesión",
+  ]) {
+    assert.ok(clinic.includes(label), `clinic form must include ${label}`);
+    assert.ok(admin.includes(label), `admin form must include ${label}`);
+  }
+
+  for (const field of [
+    "tutorLastName",
+    "petName",
+    "petAge",
+    "petBreed",
+    "petSex",
+    "petSpecies",
+    "sampleLocation",
+    "sampleEvolution",
+    "detailsLesion",
+    "extractionDate",
+    "shippingDate",
+  ]) {
+    assert.ok(clinicRequiredFields.includes(`{ key: "${field}"`));
+    assert.ok(adminRequiredFields.includes(`{ key: "${field}"`));
+  }
+
+  assert.equal(clinicRequiredFields.includes('{ key: "reportId"'), false);
+  assert.equal(adminRequiredFields.includes('{ key: "reportId"'), false);
+  assert.ok(clinic.includes('className="field-textarea"'));
+  assert.ok(admin.includes('className="field-textarea"'));
+});
+
+test("clinic report link remains optional and distinct from clinic identity", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+  const reportField = sectionBetween(
+    source,
+    'id="clinic-token-report-id"',
+    "</div>",
+  );
+
+  assert.ok(source.includes("ID informe vinculado"));
+  assert.ok(
+    source.includes("El ID de informe debe ser un número entero positivo."),
+  );
+  assert.ok(reportField.includes('name="reportId"'));
+  assert.ok(reportField.includes('placeholder="Opcional"'));
+  assert.equal(reportField.includes("required"), false);
+  assert.equal(reportField.includes("clinicId"), false);
+  assert.equal(source.includes("ID de clínica"), false);
+});
+
+test("clinic token generation keeps generated token block list refresh and reset", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+  const submitSuccess = sectionBetween(
+    source,
+    "const response = await createClinicParticularToken(payload);",
+    "} catch (error) {",
+  );
+
+  assert.ok(source.includes("Token generado"));
+  assert.ok(source.includes('aria-label="Token particular generado"'));
+  assert.ok(source.includes("El token completo solo se muestra una vez."));
+  assert.ok(source.includes("Últimos tokens de la clínica"));
+  assert.ok(source.includes('onClick={() => void loadTokens()}'));
+  assert.ok(source.includes("setFormState(INITIAL_FORM_STATE);"));
+  assertOrdered(submitSuccess, [
+    "setGeneratedToken(response.token);",
+    "setStatusMessage(response.message);",
+    "resetForm();",
+    "await loadTokens();",
+  ]);
 });
 
 test("frontend api exposes clinic-scoped particular token helpers", () => {


### PR DESCRIPTION
## Summary
- Align clinic particular-token generation form with the admin token form contract.
- Confirm clinic token generation does not render or send clinicId manually.
- Add frontend contract coverage for clinic token generation behavior.

## Validation
- pnpm test
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local