### PR TITLE
feat(particular): add token communication safeguard

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -24,6 +24,7 @@ import { formatDate } from "@/lib/utils";
 type AdminParticularTokenFormState = {
   clinicId: string;
   reportId: string;
+  particularEmail: string;
   tutorLastName: string;
   petName: string;
   petAge: string;
@@ -44,9 +45,15 @@ type ClinicOption = {
   locality: string | null;
 };
 
+type GeneratedTokenDetails = {
+  petName: string;
+  tutorLastName: string;
+};
+
 const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
   clinicId: "",
   reportId: "",
+  particularEmail: "",
   tutorLastName: "",
   petName: "",
   petAge: "",
@@ -61,7 +68,10 @@ const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
 };
 
 const REQUIRED_FIELD_LABELS: Array<{
-  key: keyof Omit<AdminParticularTokenFormState, "clinicId" | "reportId">;
+  key: keyof Omit<
+    AdminParticularTokenFormState,
+    "clinicId" | "reportId" | "particularEmail"
+  >;
   label: string;
 }> = [
   { key: "tutorLastName", label: "Apellido del tutor" },
@@ -166,6 +176,10 @@ function normalizeText(value: string): string {
   return value.trim();
 }
 
+function buildManualTokenMessage(token: string, details: GeneratedTokenDetails): string {
+  return `Hola. VETNEB informa que ya podés consultar el seguimiento/informe de ${details.petName}. Token de acceso: ${token}. Conservá este token; es personal y permite acceder a la consulta particular.`;
+}
+
 function parsePositiveInteger(value: string, label: string): number {
   const parsedValue = Number(value.trim());
 
@@ -244,6 +258,16 @@ export function AdminParticularTokensCard() {
   const [clinicLoadError, setClinicLoadError] = useState<string | null>(null);
   const [tokens, setTokens] = useState<AdminParticularTokenSummary[]>([]);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [generatedTokenRecipientEmail, setGeneratedTokenRecipientEmail] =
+    useState<string | null>(null);
+  const [generatedTokenDetails, setGeneratedTokenDetails] =
+    useState<GeneratedTokenDetails | null>(null);
+  const [isGeneratedTokenConfirmed, setIsGeneratedTokenConfirmed] =
+    useState(false);
+  const [copyStatusMessage, setCopyStatusMessage] = useState<string | null>(
+    null,
+  );
+  const [copyErrorMessage, setCopyErrorMessage] = useState<string | null>(null);
   const [isLoadingTokens, setIsLoadingTokens] = useState(false);
   const [revokingTokenId, setRevokingTokenId] = useState<number | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -359,6 +383,50 @@ export function AdminParticularTokensCard() {
     setStatusMessage(null);
   }
 
+  function clearGeneratedTokenState() {
+    setGeneratedToken(null);
+    setGeneratedTokenRecipientEmail(null);
+    setGeneratedTokenDetails(null);
+    setIsGeneratedTokenConfirmed(false);
+    setCopyStatusMessage(null);
+    setCopyErrorMessage(null);
+  }
+
+  async function handleCopyManualMessage() {
+    if (!generatedToken || !generatedTokenDetails) {
+      return;
+    }
+
+    setCopyStatusMessage(null);
+    setCopyErrorMessage(null);
+
+    if (!navigator.clipboard?.writeText) {
+      setCopyErrorMessage(
+        "No se pudo acceder al portapapeles. Copiá el token manualmente antes de cerrar este bloque.",
+      );
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(
+        buildManualTokenMessage(generatedToken, generatedTokenDetails),
+      );
+      setCopyStatusMessage("Mensaje copiado al portapapeles.");
+    } catch {
+      setCopyErrorMessage(
+        "No se pudo copiar el mensaje. Copiá el token manualmente antes de cerrar este bloque.",
+      );
+    }
+  }
+
+  function handleCloseGeneratedToken() {
+    if (!isGeneratedTokenConfirmed) {
+      return;
+    }
+
+    clearGeneratedTokenState();
+  }
+
   function resetForm() {
     setFormState(INITIAL_FORM_STATE);
     setClinicSearch("");
@@ -388,7 +456,13 @@ export function AdminParticularTokensCard() {
 
     setErrorMessage(null);
     setStatusMessage(null);
-    setGeneratedToken(null);
+
+    if (generatedToken) {
+      setErrorMessage(
+        "Cerrá el token visible luego de confirmar la comunicación antes de generar otro.",
+      );
+      return;
+    }
 
     let payload: AdminParticularTokenCreatePayload;
 
@@ -403,12 +477,23 @@ export function AdminParticularTokensCard() {
       return;
     }
 
+    const generatedRecipientEmail = formState.particularEmail.trim();
+    const nextGeneratedTokenDetails: GeneratedTokenDetails = {
+      petName: payload.petName,
+      tutorLastName: payload.tutorLastName,
+    };
+
     setIsSubmitting(true);
 
     try {
       const response = await createAdminParticularToken(payload);
 
       setGeneratedToken(response.token);
+      setGeneratedTokenRecipientEmail(generatedRecipientEmail || null);
+      setGeneratedTokenDetails(nextGeneratedTokenDetails);
+      setIsGeneratedTokenConfirmed(false);
+      setCopyStatusMessage(null);
+      setCopyErrorMessage(null);
       setStatusMessage(response.message);
       resetForm();
       await loadTokens();
@@ -438,7 +523,6 @@ export function AdminParticularTokensCard() {
 
     setErrorMessage(null);
     setStatusMessage(null);
-    setGeneratedToken(null);
     setRevokingTokenId(token.id);
 
     try {
@@ -579,6 +663,31 @@ export function AdminParticularTokensCard() {
                 onChange={(event) => updateField("reportId", event.target.value)}
                 disabled={isSubmitting}
               />
+            </div>
+
+            <div>
+              <label htmlFor="admin-token-particular-email" className="field-label">
+                Email del particular
+              </label>
+              <Input
+                id="admin-token-particular-email"
+                name="particularEmail"
+                type="email"
+                placeholder="email@ejemplo.com"
+                value={formState.particularEmail}
+                onChange={(event) =>
+                  updateField("particularEmail", event.target.value)
+                }
+                disabled={isSubmitting}
+                aria-describedby="admin-token-particular-email-help"
+              />
+              <p
+                id="admin-token-particular-email-help"
+                className="mt-1 text-xs text-muted-foreground"
+              >
+                Opcional. Se usa solo para preparar la comunicación manual del
+                token; no se envía automáticamente.
+              </p>
             </div>
 
             <div>
@@ -789,7 +898,7 @@ export function AdminParticularTokensCard() {
           ) : null}
 
           {generatedToken ? (
-            <div className="clinical-muted-band rounded-lg p-4">
+            <div className="clinical-muted-band space-y-3 rounded-lg p-4">
               <p className="text-sm font-semibold text-vetneb-navy">
                 Token generado
               </p>
@@ -802,10 +911,68 @@ export function AdminParticularTokensCard() {
               <p className="mt-2 text-xs text-muted-foreground">
                 Copiar ahora. El token completo solo se muestra una vez.
               </p>
+              <div className="clinical-alert-error px-3 py-2">
+                <p className="text-sm font-semibold">
+                  IMPORTANTE: el token completo solo se muestra una vez.
+                </p>
+                <p className="mt-1 text-sm">
+                  Antes de cerrar este bloque, verificá que el email del
+                  particular sea correcto y que el token haya sido copiado o
+                  comunicado por el canal acordado.
+                </p>
+              </div>
+              <p className="text-sm text-vetneb-ink">
+                {generatedTokenRecipientEmail
+                  ? `Email indicado: ${generatedTokenRecipientEmail}`
+                  : "No se indicó email del particular. Copiá el token por el canal acordado antes de cerrar este bloque."}
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleCopyManualMessage()}
+                >
+                  Copiar mensaje para enviar
+                </Button>
+              </div>
+              {copyStatusMessage ? (
+                <p className="clinical-alert-success px-3 py-2 text-sm">
+                  {copyStatusMessage}
+                </p>
+              ) : null}
+              {copyErrorMessage ? (
+                <p className="clinical-alert-error px-3 py-2 text-sm" role="alert">
+                  {copyErrorMessage}
+                </p>
+              ) : null}
+              <label className="flex items-start gap-2 text-sm text-vetneb-ink">
+                <input
+                  type="checkbox"
+                  className="mt-1"
+                  checked={isGeneratedTokenConfirmed}
+                  onChange={(event) =>
+                    setIsGeneratedTokenConfirmed(event.target.checked)
+                  }
+                />
+                <span>
+                  Confirmo que copié o comuniqué el token al destinatario
+                  correcto.
+                </span>
+              </label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleCloseGeneratedToken}
+                disabled={!isGeneratedTokenConfirmed}
+              >
+                Cerrar token visible
+              </Button>
             </div>
           ) : null}
 
-          <Button type="submit" disabled={isSubmitting}>
+          <Button type="submit" disabled={isSubmitting || generatedToken !== null}>
             {isSubmitting ? "Generando token..." : "Generar token particular"}
           </Button>
         </form>

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -16,6 +16,7 @@ import { formatDate } from "@/lib/utils";
 
 type ClinicParticularTokenFormState = {
   reportId: string;
+  particularEmail: string;
   tutorLastName: string;
   petName: string;
   petAge: string;
@@ -29,8 +30,14 @@ type ClinicParticularTokenFormState = {
   shippingDate: string;
 };
 
+type GeneratedTokenDetails = {
+  petName: string;
+  tutorLastName: string;
+};
+
 const INITIAL_FORM_STATE: ClinicParticularTokenFormState = {
   reportId: "",
+  particularEmail: "",
   tutorLastName: "",
   petName: "",
   petAge: "",
@@ -45,7 +52,10 @@ const INITIAL_FORM_STATE: ClinicParticularTokenFormState = {
 };
 
 const REQUIRED_FIELD_LABELS: Array<{
-  key: keyof Omit<ClinicParticularTokenFormState, "reportId">;
+  key: keyof Omit<
+    ClinicParticularTokenFormState,
+    "reportId" | "particularEmail"
+  >;
   label: string;
 }> = [
   { key: "tutorLastName", label: "Apellido del tutor" },
@@ -84,6 +94,10 @@ function toIsoDate(value: string): string {
 
 function normalizeText(value: string): string {
   return value.trim();
+}
+
+function buildManualTokenMessage(token: string, details: GeneratedTokenDetails): string {
+  return `Hola. VETNEB informa que ya podés consultar el seguimiento/informe de ${details.petName}. Token de acceso: ${token}. Conservá este token; es personal y permite acceder a la consulta particular.`;
 }
 
 function parseOptionalReportId(value: string): number | null {
@@ -150,6 +164,16 @@ export function ClinicParticularTokensCard() {
     useState<ClinicParticularTokenFormState>(INITIAL_FORM_STATE);
   const [tokens, setTokens] = useState<ClinicParticularTokenSummary[]>([]);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [generatedTokenRecipientEmail, setGeneratedTokenRecipientEmail] =
+    useState<string | null>(null);
+  const [generatedTokenDetails, setGeneratedTokenDetails] =
+    useState<GeneratedTokenDetails | null>(null);
+  const [isGeneratedTokenConfirmed, setIsGeneratedTokenConfirmed] =
+    useState(false);
+  const [copyStatusMessage, setCopyStatusMessage] = useState<string | null>(
+    null,
+  );
+  const [copyErrorMessage, setCopyErrorMessage] = useState<string | null>(null);
   const [isLoadingTokens, setIsLoadingTokens] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -185,6 +209,50 @@ export function ClinicParticularTokensCard() {
     setStatusMessage(null);
   }
 
+  function clearGeneratedTokenState() {
+    setGeneratedToken(null);
+    setGeneratedTokenRecipientEmail(null);
+    setGeneratedTokenDetails(null);
+    setIsGeneratedTokenConfirmed(false);
+    setCopyStatusMessage(null);
+    setCopyErrorMessage(null);
+  }
+
+  async function handleCopyManualMessage() {
+    if (!generatedToken || !generatedTokenDetails) {
+      return;
+    }
+
+    setCopyStatusMessage(null);
+    setCopyErrorMessage(null);
+
+    if (!navigator.clipboard?.writeText) {
+      setCopyErrorMessage(
+        "No se pudo acceder al portapapeles. Copiá el token manualmente antes de cerrar este bloque.",
+      );
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(
+        buildManualTokenMessage(generatedToken, generatedTokenDetails),
+      );
+      setCopyStatusMessage("Mensaje copiado al portapapeles.");
+    } catch {
+      setCopyErrorMessage(
+        "No se pudo copiar el mensaje. Copiá el token manualmente antes de cerrar este bloque.",
+      );
+    }
+  }
+
+  function handleCloseGeneratedToken() {
+    if (!isGeneratedTokenConfirmed) {
+      return;
+    }
+
+    clearGeneratedTokenState();
+  }
+
   function resetForm() {
     setFormState(INITIAL_FORM_STATE);
   }
@@ -198,7 +266,13 @@ export function ClinicParticularTokensCard() {
 
     setErrorMessage(null);
     setStatusMessage(null);
-    setGeneratedToken(null);
+
+    if (generatedToken) {
+      setErrorMessage(
+        "Cerrá el token visible luego de confirmar la comunicación antes de generar otro.",
+      );
+      return;
+    }
 
     let payload: ClinicParticularTokenCreatePayload;
 
@@ -213,12 +287,23 @@ export function ClinicParticularTokensCard() {
       return;
     }
 
+    const generatedRecipientEmail = formState.particularEmail.trim();
+    const nextGeneratedTokenDetails: GeneratedTokenDetails = {
+      petName: payload.petName,
+      tutorLastName: payload.tutorLastName,
+    };
+
     setIsSubmitting(true);
 
     try {
       const response = await createClinicParticularToken(payload);
 
       setGeneratedToken(response.token);
+      setGeneratedTokenRecipientEmail(generatedRecipientEmail || null);
+      setGeneratedTokenDetails(nextGeneratedTokenDetails);
+      setIsGeneratedTokenConfirmed(false);
+      setCopyStatusMessage(null);
+      setCopyErrorMessage(null);
       setStatusMessage(response.message);
       resetForm();
       await loadTokens();
@@ -256,6 +341,31 @@ export function ClinicParticularTokensCard() {
                 onChange={(event) => updateField("reportId", event.target.value)}
                 disabled={isSubmitting}
               />
+            </div>
+
+            <div>
+              <label htmlFor="clinic-token-particular-email" className="field-label">
+                Email del particular
+              </label>
+              <Input
+                id="clinic-token-particular-email"
+                name="particularEmail"
+                type="email"
+                placeholder="email@ejemplo.com"
+                value={formState.particularEmail}
+                onChange={(event) =>
+                  updateField("particularEmail", event.target.value)
+                }
+                disabled={isSubmitting}
+                aria-describedby="clinic-token-particular-email-help"
+              />
+              <p
+                id="clinic-token-particular-email-help"
+                className="mt-1 text-xs text-muted-foreground"
+              >
+                Opcional. Se usa solo para preparar la comunicación manual del
+                token; no se envía automáticamente.
+              </p>
             </div>
 
             <div>
@@ -466,7 +576,7 @@ export function ClinicParticularTokensCard() {
           ) : null}
 
           {generatedToken ? (
-            <div className="clinical-muted-band rounded-lg p-4">
+            <div className="clinical-muted-band space-y-3 rounded-lg p-4">
               <p className="text-sm font-semibold text-vetneb-navy">
                 Token generado
               </p>
@@ -479,10 +589,68 @@ export function ClinicParticularTokensCard() {
               <p className="mt-2 text-xs text-muted-foreground">
                 Copiar ahora. El token completo solo se muestra una vez.
               </p>
+              <div className="clinical-alert-error px-3 py-2">
+                <p className="text-sm font-semibold">
+                  IMPORTANTE: el token completo solo se muestra una vez.
+                </p>
+                <p className="mt-1 text-sm">
+                  Antes de cerrar este bloque, verificá que el email del
+                  particular sea correcto y que el token haya sido copiado o
+                  comunicado por el canal acordado.
+                </p>
+              </div>
+              <p className="text-sm text-vetneb-ink">
+                {generatedTokenRecipientEmail
+                  ? `Email indicado: ${generatedTokenRecipientEmail}`
+                  : "No se indicó email del particular. Copiá el token por el canal acordado antes de cerrar este bloque."}
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleCopyManualMessage()}
+                >
+                  Copiar mensaje para enviar
+                </Button>
+              </div>
+              {copyStatusMessage ? (
+                <p className="clinical-alert-success px-3 py-2 text-sm">
+                  {copyStatusMessage}
+                </p>
+              ) : null}
+              {copyErrorMessage ? (
+                <p className="clinical-alert-error px-3 py-2 text-sm" role="alert">
+                  {copyErrorMessage}
+                </p>
+              ) : null}
+              <label className="flex items-start gap-2 text-sm text-vetneb-ink">
+                <input
+                  type="checkbox"
+                  className="mt-1"
+                  checked={isGeneratedTokenConfirmed}
+                  onChange={(event) =>
+                    setIsGeneratedTokenConfirmed(event.target.checked)
+                  }
+                />
+                <span>
+                  Confirmo que copié o comuniqué el token al destinatario
+                  correcto.
+                </span>
+              </label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleCloseGeneratedToken}
+                disabled={!isGeneratedTokenConfirmed}
+              >
+                Cerrar token visible
+              </Button>
             </div>
           ) : null}
 
-          <Button type="submit" disabled={isSubmitting}>
+          <Button type="submit" disabled={isSubmitting || generatedToken !== null}>
             {isSubmitting ? "Generando token..." : "Generar token particular"}
           </Button>
         </form>

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -30,6 +30,16 @@ function read(relativePath: string): string {
   );
 }
 
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `Missing start marker: ${start}`);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `Missing end marker: ${end}`);
+
+  return source.slice(startIndex, endIndex);
+}
+
 test("admin particular token generator uses admin helpers without technical copy", () => {
   const card = read(ADMIN_CARD_PATH);
   const api = read(API_PATH);
@@ -178,6 +188,93 @@ test("admin particular token generator keeps programmed fields", () => {
   assert.ok(source.includes("detailsLesion"));
   assert.ok(source.includes("extractionDate"));
   assert.ok(source.includes("shippingDate"));
+});
+
+test("admin particular token form keeps recipient email frontend only", () => {
+  const source = read(ADMIN_CARD_PATH);
+  const api = read(API_PATH);
+  const payloadType = sectionBetween(
+    api,
+    "export type AdminParticularTokenCreatePayload = {",
+    "};",
+  );
+  const payloadBuilder = sectionBetween(
+    source,
+    "function buildPayload(",
+    "function formatTokenSource",
+  );
+  const submitSuccess = sectionBetween(
+    source,
+    "const response = await createAdminParticularToken(payload);",
+    "} catch (error) {",
+  );
+
+  assert.ok(source.includes("particularEmail: string;"));
+  assert.ok(source.includes('name="particularEmail"'));
+  assert.ok(source.includes('type="email"'));
+  assert.ok(source.includes('placeholder="email@ejemplo.com"'));
+  assert.ok(source.includes("Email del particular"));
+  assert.ok(
+    source.includes(
+      "Opcional. Se usa solo para preparar la comunicación manual del",
+    ),
+  );
+  assert.ok(source.includes("token; no se envía automáticamente."));
+  assert.ok(source.includes("const generatedRecipientEmail = formState.particularEmail.trim();"));
+  assert.ok(
+    source.includes("const response = await createAdminParticularToken(payload);"),
+  );
+  assert.ok(
+    submitSuccess.includes(
+      "setGeneratedTokenRecipientEmail(generatedRecipientEmail || null);",
+    ),
+  );
+  assert.ok(submitSuccess.includes("setGeneratedTokenDetails(nextGeneratedTokenDetails);"));
+  assert.equal(payloadType.includes("particularEmail"), false);
+  assert.equal(payloadType.includes("recipientEmail"), false);
+  assert.equal(payloadBuilder.includes("particularEmail"), false);
+  assert.equal(payloadBuilder.includes("recipientEmail"), false);
+  assert.equal(payloadBuilder.includes("email:"), false);
+});
+
+test("admin generated token block requires manual communication confirmation", () => {
+  const source = read(ADMIN_CARD_PATH);
+  const clearGeneratedToken = sectionBetween(
+    source,
+    "function clearGeneratedTokenState()",
+    "async function handleCopyManualMessage()",
+  );
+
+  assert.ok(source.includes("IMPORTANTE: el token completo solo se muestra una vez."));
+  assert.ok(
+    source.includes(
+      "Antes de cerrar este bloque, verificá que el email del",
+    ),
+  );
+  assert.ok(source.includes("particular sea correcto y que el token haya sido copiado o"));
+  assert.ok(source.includes("Email indicado:"));
+  assert.ok(source.includes("No se indicó email del particular."));
+  assert.ok(source.includes("Copiar mensaje para enviar"));
+  assert.ok(source.includes("navigator.clipboard?.writeText"));
+  assert.ok(source.includes("buildManualTokenMessage(generatedToken, generatedTokenDetails)"));
+  assert.ok(
+    source.includes(
+      "Hola. VETNEB informa que ya podés consultar el seguimiento/informe de",
+    ),
+  );
+  assert.ok(source.includes('type="checkbox"'));
+  assert.ok(
+    source.includes(
+      "Confirmo que copié o comuniqué el token al destinatario",
+    ),
+  );
+  assert.ok(source.includes("Cerrar token visible"));
+  assert.ok(source.includes("disabled={!isGeneratedTokenConfirmed}"));
+  assert.ok(clearGeneratedToken.includes("setGeneratedToken(null);"));
+  assert.ok(clearGeneratedToken.includes("setGeneratedTokenRecipientEmail(null);"));
+  assert.ok(clearGeneratedToken.includes("setIsGeneratedTokenConfirmed(false);"));
+  assert.ok(clearGeneratedToken.includes("setCopyStatusMessage(null);"));
+  assert.ok(source.includes("disabled={isSubmitting || generatedToken !== null}"));
 });
 
 test("admin dashboard mounts token generator and exposes admin navigation anchor", () => {

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -210,6 +210,53 @@ test("clinic report link remains optional and distinct from clinic identity", ()
   assert.equal(source.includes("ID de clínica"), false);
 });
 
+test("clinic particular token form keeps recipient email frontend only", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+  const api = read(API_PATH);
+  const payloadType = sectionBetween(
+    api,
+    "export type ClinicParticularTokenCreatePayload = {",
+    "};",
+  );
+  const payloadBuilder = sectionBetween(
+    source,
+    "function buildPayload(",
+    "function formatTokenSource",
+  );
+  const submitSuccess = sectionBetween(
+    source,
+    "const response = await createClinicParticularToken(payload);",
+    "} catch (error) {",
+  );
+
+  assert.ok(source.includes("particularEmail: string;"));
+  assert.ok(source.includes('name="particularEmail"'));
+  assert.ok(source.includes('type="email"'));
+  assert.ok(source.includes('placeholder="email@ejemplo.com"'));
+  assert.ok(source.includes("Email del particular"));
+  assert.ok(
+    source.includes(
+      "Opcional. Se usa solo para preparar la comunicación manual del",
+    ),
+  );
+  assert.ok(source.includes("token; no se envía automáticamente."));
+  assert.ok(source.includes("const generatedRecipientEmail = formState.particularEmail.trim();"));
+  assert.ok(
+    source.includes("const response = await createClinicParticularToken(payload);"),
+  );
+  assert.ok(
+    submitSuccess.includes(
+      "setGeneratedTokenRecipientEmail(generatedRecipientEmail || null);",
+    ),
+  );
+  assert.ok(submitSuccess.includes("setGeneratedTokenDetails(nextGeneratedTokenDetails);"));
+  assert.equal(payloadType.includes("particularEmail"), false);
+  assert.equal(payloadType.includes("recipientEmail"), false);
+  assert.equal(payloadBuilder.includes("particularEmail"), false);
+  assert.equal(payloadBuilder.includes("recipientEmail"), false);
+  assert.equal(payloadBuilder.includes("email:"), false);
+});
+
 test("clinic token generation keeps generated token block list refresh and reset", () => {
   const source = read(CLINIC_TOKENS_CARD_PATH);
   const submitSuccess = sectionBetween(
@@ -221,6 +268,13 @@ test("clinic token generation keeps generated token block list refresh and reset
   assert.ok(source.includes("Token generado"));
   assert.ok(source.includes('aria-label="Token particular generado"'));
   assert.ok(source.includes("El token completo solo se muestra una vez."));
+  assert.ok(source.includes("IMPORTANTE: el token completo solo se muestra una vez."));
+  assert.ok(source.includes("Email indicado:"));
+  assert.ok(source.includes("No se indicó email del particular."));
+  assert.ok(source.includes("Copiar mensaje para enviar"));
+  assert.ok(source.includes('type="checkbox"'));
+  assert.ok(source.includes("Cerrar token visible"));
+  assert.ok(source.includes("disabled={!isGeneratedTokenConfirmed}"));
   assert.ok(source.includes("Últimos tokens de la clínica"));
   assert.ok(source.includes('onClick={() => void loadTokens()}'));
   assert.ok(source.includes("setFormState(INITIAL_FORM_STATE);"));
@@ -230,6 +284,33 @@ test("clinic token generation keeps generated token block list refresh and reset
     "resetForm();",
     "await loadTokens();",
   ]);
+});
+
+test("clinic generated token block clears only through confirmation close", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+  const clearGeneratedToken = sectionBetween(
+    source,
+    "function clearGeneratedTokenState()",
+    "async function handleCopyManualMessage()",
+  );
+
+  assert.ok(source.includes("navigator.clipboard?.writeText"));
+  assert.ok(source.includes("buildManualTokenMessage(generatedToken, generatedTokenDetails)"));
+  assert.ok(
+    source.includes(
+      "Hola. VETNEB informa que ya podés consultar el seguimiento/informe de",
+    ),
+  );
+  assert.ok(
+    source.includes(
+      "Confirmo que copié o comuniqué el token al destinatario",
+    ),
+  );
+  assert.ok(clearGeneratedToken.includes("setGeneratedToken(null);"));
+  assert.ok(clearGeneratedToken.includes("setGeneratedTokenRecipientEmail(null);"));
+  assert.ok(clearGeneratedToken.includes("setIsGeneratedTokenConfirmed(false);"));
+  assert.ok(clearGeneratedToken.includes("setCopyStatusMessage(null);"));
+  assert.ok(source.includes("disabled={isSubmitting || generatedToken !== null}"));
 });
 
 test("frontend api exposes clinic-scoped particular token helpers", () => {


### PR DESCRIPTION
## Summary
- Add frontend-only particular email field to admin and clinic token generation forms.
- Add one-time-token communication warnings before hiding the generated token.
- Add manual copy-message workflow for communicating the token outside the portal.
- Confirm the particular email is not sent to backend and is not persisted.

## Validation
- pnpm test
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local

## Notes
- No backend, SMTP/Gmail, migrations, CSP/security, env, package or lockfile changes in this PR.