### PR TITLE
feat(particular): email generated token from backend

### DIFF
--- a/docs/entrega-particular-email-generated-token.md
+++ b/docs/entrega-particular-email-generated-token.md
@@ -1,0 +1,43 @@
+# Entrega: email automatico de token particular
+
+## Resumen
+
+Se agrego `recipientEmail` al contrato de generacion de tokens particulares para admin y clinica. El backend valida el email, genera el token como antes, guarda solo hash y ultimos 4 caracteres, envia el token por email usando el transporte SMTP/Gmail existente y conserva el token visible una sola vez en la respuesta exitosa.
+
+Si el envio automatico no esta disponible o falla, el backend desactiva el token creado y responde con error controlado sin devolver el token raw.
+
+## Archivos modificados
+
+- `server/lib/particular-token.ts`
+- `server/lib/email.ts`
+- `server/routes/admin-particular-tokens.fastify.ts`
+- `server/routes/particular-tokens.fastify.ts`
+- `frontend/src/lib/api.ts`
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `test/admin-particular-token-schema.test.ts`
+- `test/admin-particular-tokens.fastify.test.ts`
+- `test/particular-token.test.ts`
+- `test/particular-token-edge.test.ts`
+- `test/particular-tokens.fastify.test.ts`
+- `test/email-success.test.ts`
+- `test/frontend-admin-particular-tokens.test.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `test/fastify-app.test.ts`
+
+## Validaciones ejecutadas
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-particular-tokens.fastify.test.ts test/particular-tokens.fastify.test.ts test/particular-token.test.ts test/particular-token-edge.test.ts test/admin-particular-token-schema.test.ts test/email-success.test.ts test/frontend-admin-particular-tokens.test.ts test/frontend-dashboard-clinic-tokens.test.ts`
+- `pnpm test` - 1934 tests, 0 fallos
+- `pnpm build`
+
+## Decision sobre persistencia de recipientEmail
+
+`recipientEmail` no se persiste en base de datos. No existe un campo explicito para ese dato en `particular_tokens`, y este PR lo usa solo como destinatario operativo del envio automatico. Los tests de rutas verifican que `recipientEmail` no se entregue al helper de persistencia `createParticularToken`.
+
+## Riesgos y resguardos
+
+- El email contiene el token raw porque es el canal de entrega solicitado. El token no se guarda en claro y no se registra al particular como usuario.
+- Los logs del envio no imprimen el token raw. Las pruebas cubren que el template incluye el token en el cuerpo del email y que no aparece en logs de envio.
+- Si el envio falla o SMTP/Gmail no esta configurado, la respuesta no es success: el token creado se desactiva y el backend no devuelve el token raw.
+- No se tocaron migraciones, `.env`, login/auth, CSP/security, package.json ni lockfile.

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -70,10 +70,11 @@ const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
 const REQUIRED_FIELD_LABELS: Array<{
   key: keyof Omit<
     AdminParticularTokenFormState,
-    "clinicId" | "reportId" | "particularEmail"
+    "clinicId" | "reportId"
   >;
   label: string;
 }> = [
+  { key: "particularEmail", label: "Email del particular" },
   { key: "tutorLastName", label: "Apellido del tutor" },
   { key: "petName", label: "Nombre del paciente" },
   { key: "petAge", label: "Edad" },
@@ -223,6 +224,7 @@ function buildPayload(
   return {
     clinicId: selectedClinic.id,
     reportId: parseOptionalReportId(formState.reportId),
+    recipientEmail: normalizeText(formState.particularEmail),
     tutorLastName: normalizeText(formState.tutorLastName),
     petName: normalizeText(formState.petName),
     petAge: normalizeText(formState.petAge),
@@ -674,6 +676,7 @@ export function AdminParticularTokensCard() {
                 name="particularEmail"
                 type="email"
                 placeholder="email@ejemplo.com"
+                required
                 value={formState.particularEmail}
                 onChange={(event) =>
                   updateField("particularEmail", event.target.value)
@@ -685,8 +688,8 @@ export function AdminParticularTokensCard() {
                 id="admin-token-particular-email-help"
                 className="mt-1 text-xs text-muted-foreground"
               >
-                Opcional. Se usa solo para preparar la comunicación manual del
-                token; no se envía automáticamente.
+                Obligatorio. El backend enviará el token a este email usando la
+                configuración de correo de VETNEB.
               </p>
             </div>
 
@@ -916,15 +919,14 @@ export function AdminParticularTokensCard() {
                   IMPORTANTE: el token completo solo se muestra una vez.
                 </p>
                 <p className="mt-1 text-sm">
-                  Antes de cerrar este bloque, verificá que el email del
-                  particular sea correcto y que el token haya sido copiado o
-                  comunicado por el canal acordado.
+                  Antes de cerrar este bloque, verificá que el token haya sido
+                  copiado si necesitás respaldo operativo.
                 </p>
               </div>
               <p className="text-sm text-vetneb-ink">
                 {generatedTokenRecipientEmail
-                  ? `Email indicado: ${generatedTokenRecipientEmail}`
-                  : "No se indicó email del particular. Copiá el token por el canal acordado antes de cerrar este bloque."}
+                  ? `Email enviado a: ${generatedTokenRecipientEmail}`
+                  : "El backend informó envío correcto del email."}
               </p>
               <div className="flex flex-wrap items-center gap-2">
                 <Button
@@ -956,8 +958,8 @@ export function AdminParticularTokensCard() {
                   }
                 />
                 <span>
-                  Confirmo que copié o comuniqué el token al destinatario
-                  correcto.
+                  Confirmo que registré el token visible o que no necesito copia
+                  adicional.
                 </span>
               </label>
               <Button

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -54,10 +54,11 @@ const INITIAL_FORM_STATE: ClinicParticularTokenFormState = {
 const REQUIRED_FIELD_LABELS: Array<{
   key: keyof Omit<
     ClinicParticularTokenFormState,
-    "reportId" | "particularEmail"
+    "reportId"
   >;
   label: string;
 }> = [
+  { key: "particularEmail", label: "Email del particular" },
   { key: "tutorLastName", label: "Apellido del tutor" },
   { key: "petName", label: "Nombre del paciente" },
   { key: "petAge", label: "Edad" },
@@ -133,6 +134,7 @@ function buildPayload(
 
   return {
     reportId: parseOptionalReportId(formState.reportId),
+    recipientEmail: normalizeText(formState.particularEmail),
     tutorLastName: normalizeText(formState.tutorLastName),
     petName: normalizeText(formState.petName),
     petAge: normalizeText(formState.petAge),
@@ -352,6 +354,7 @@ export function ClinicParticularTokensCard() {
                 name="particularEmail"
                 type="email"
                 placeholder="email@ejemplo.com"
+                required
                 value={formState.particularEmail}
                 onChange={(event) =>
                   updateField("particularEmail", event.target.value)
@@ -363,8 +366,8 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-particular-email-help"
                 className="mt-1 text-xs text-muted-foreground"
               >
-                Opcional. Se usa solo para preparar la comunicación manual del
-                token; no se envía automáticamente.
+                Obligatorio. El backend enviará el token a este email usando la
+                configuración de correo de VETNEB.
               </p>
             </div>
 
@@ -594,15 +597,14 @@ export function ClinicParticularTokensCard() {
                   IMPORTANTE: el token completo solo se muestra una vez.
                 </p>
                 <p className="mt-1 text-sm">
-                  Antes de cerrar este bloque, verificá que el email del
-                  particular sea correcto y que el token haya sido copiado o
-                  comunicado por el canal acordado.
+                  Antes de cerrar este bloque, verificá que el token haya sido
+                  copiado si necesitás respaldo operativo.
                 </p>
               </div>
               <p className="text-sm text-vetneb-ink">
                 {generatedTokenRecipientEmail
-                  ? `Email indicado: ${generatedTokenRecipientEmail}`
-                  : "No se indicó email del particular. Copiá el token por el canal acordado antes de cerrar este bloque."}
+                  ? `Email enviado a: ${generatedTokenRecipientEmail}`
+                  : "El backend informó envío correcto del email."}
               </p>
               <div className="flex flex-wrap items-center gap-2">
                 <Button
@@ -634,8 +636,8 @@ export function ClinicParticularTokensCard() {
                   }
                 />
                 <span>
-                  Confirmo que copié o comuniqué el token al destinatario
-                  correcto.
+                  Confirmo que registré el token visible o que no necesito copia
+                  adicional.
                 </span>
               </label>
               <Button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -449,6 +449,7 @@ export type AdminParticularTokenReportLinkResponse = {
 export type AdminParticularTokenCreatePayload = {
   clinicId: number;
   reportId?: number | null;
+  recipientEmail: string;
   tutorLastName: string;
   petName: string;
   petAge: string;
@@ -564,6 +565,7 @@ export type ClinicParticularTokensSnapshot = {
 
 export type ClinicParticularTokenCreatePayload = {
   reportId?: number | null;
+  recipientEmail: string;
   tutorLastName: string;
   petName: string;
   petAge: string;

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -408,6 +408,26 @@ function buildContactMessageText(input: {
   ].join("\n");
 }
 
+function buildParticularTokenText(input: {
+  token: string;
+  tutorLastName: string;
+  petName: string;
+}) {
+  return [
+    "Hola,",
+    "",
+    `VETNEB generó un token de acceso particular para consultar el seguimiento o informe de ${input.petName}.`,
+    "",
+    `Tutor/a: ${input.tutorLastName}`,
+    `Paciente: ${input.petName}`,
+    `Token de acceso: ${input.token}`,
+    "",
+    "Ingresá al portal VETNEB para usarlo. Conservá este token y no lo compartas.",
+    "",
+    "Equipo VETNEB",
+  ].join("\n");
+}
+
 function resolveContactRecipients(): string[] {
   const explicitRecipients = normalizeRecipients(ENV.contactTo);
 
@@ -465,6 +485,49 @@ export async function sendContactMessageEmail(input: {
   console.info("[EMAIL] contact_message sent", {
     email: input.email,
     clinicName: input.clinicName,
+    messageId: delivery.messageId,
+    transport: delivery.transport,
+  });
+
+  return {
+    sent: true,
+    messageId: delivery.messageId,
+  };
+}
+
+export async function sendParticularTokenEmail(input: {
+  to: string;
+  token: string;
+  tutorLastName: string;
+  petName: string;
+}): Promise<
+  | { sent: false; reason: "no_recipients" | "smtp_disabled" }
+  | { sent: true; messageId: string }
+> {
+  const recipients = normalizeRecipients([input.to]);
+
+  if (recipients.length === 0) {
+    console.info("[EMAIL] particular_token skipped: no recipients");
+
+    return { sent: false, reason: "no_recipients" as const };
+  }
+
+  const delivery = await sendConfiguredEmailMessage({
+    to: recipients,
+    subject: "[VETNEB] Token de acceso particular",
+    text: buildParticularTokenText(input),
+  });
+
+  if (!delivery) {
+    console.info("[EMAIL] particular_token skipped: smtp disabled", {
+      recipients,
+    });
+
+    return { sent: false, reason: "smtp_disabled" as const };
+  }
+
+  console.info("[EMAIL] particular_token sent", {
+    recipients,
     messageId: delivery.messageId,
     transport: delivery.transport,
   });

--- a/server/lib/particular-token.ts
+++ b/server/lib/particular-token.ts
@@ -24,6 +24,11 @@ const reportIdSchema = z.union([
 ]);
 
 export const particularTokenBaseSchema = z.object({
+  recipientEmail: z
+    .string()
+    .trim()
+    .email("Email del particular inválido")
+    .max(255, "Email del particular no puede superar 255 caracteres"),
   tutorLastName: requiredText(255, "Tutor: apellido"),
   petName: requiredText(255, "Mascota: nombre"),
   petAge: requiredText(100, "Mascota: edad"),

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -41,6 +41,10 @@ type ClinicRecord = {
   id: number;
 };
 
+type ParticularTokenEmailResult =
+  | { sent: true; messageId: string }
+  | { sent: false; reason: "no_recipients" | "smtp_disabled" };
+
 type AuthenticatedAdminUser = {
   id: number;
   username: string;
@@ -96,6 +100,12 @@ export type AdminParticularTokensNativeRoutesOptions = {
   revokeParticularToken?: (
     id: number,
   ) => Promise<ParticularToken | null | undefined>;
+  sendParticularTokenEmail?: (input: {
+    to: string;
+    token: string;
+    tutorLastName: string;
+    petName: string;
+  }) => Promise<ParticularTokenEmailResult>;
   now?: () => number;
 };
 
@@ -122,6 +132,7 @@ type NativeAdminParticularTokensDeps = Required<
     | "listParticularTokens"
     | "updateParticularTokenReport"
     | "revokeParticularToken"
+    | "sendParticularTokenEmail"
   >
 >;
 
@@ -133,6 +144,7 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const dbParticular = await import("../db-particular.ts");
+      const email = await import("../lib/email.ts");
 
       return {
         deleteAdminSession: db.deleteAdminSession,
@@ -148,6 +160,7 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
         listParticularTokens: dbParticular.listParticularTokens,
         updateParticularTokenReport: dbParticular.updateParticularTokenReport,
         revokeParticularToken: dbParticular.revokeParticularToken,
+        sendParticularTokenEmail: email.sendParticularTokenEmail,
       };
     })();
   }
@@ -359,6 +372,26 @@ function buildClearAdminSessionCookie() {
   });
 }
 
+function getSafeErrorName(error: unknown) {
+  return error instanceof Error && error.name.trim()
+    ? error.name
+    : "unknown_error";
+}
+
+async function revokeParticularTokenAfterEmailFailure(
+  deps: NativeAdminParticularTokensDeps,
+  tokenId: number,
+) {
+  try {
+    await deps.revokeParticularToken(tokenId);
+  } catch (error) {
+    console.error("[EMAIL] particular_token cleanup failed", {
+      tokenId,
+      errorName: getSafeErrorName(error),
+    });
+  }
+}
+
 
 async function authenticateAdminUser(
   request: FastifyRequest,
@@ -438,7 +471,8 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     !!options.getParticularTokenById &&
     !!options.listParticularTokens &&
     !!options.updateParticularTokenReport &&
-    !!options.revokeParticularToken;
+    !!options.revokeParticularToken &&
+    !!options.sendParticularTokenEmail;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -469,6 +503,9 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       defaultDeps!.updateParticularTokenReport,
     revokeParticularToken:
       options.revokeParticularToken ?? defaultDeps!.revokeParticularToken,
+    sendParticularTokenEmail:
+      options.sendParticularTokenEmail ??
+      defaultDeps!.sendParticularTokenEmail,
   };
 
   const now = options.now ?? (() => Date.now());
@@ -547,6 +584,7 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       detailsLesion?: unknown;
       extractionDate?: unknown;
       shippingDate?: unknown;
+      recipientEmail?: unknown;
     };
   }>("/", async (request, reply) => {
     if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
@@ -620,6 +658,40 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       isActive: true,
       lastLoginAt: null,
     });
+
+    try {
+      const emailResult = await deps.sendParticularTokenEmail({
+        to: parsed.data.recipientEmail,
+        token: rawToken,
+        tutorLastName: parsed.data.tutorLastName,
+        petName: parsed.data.petName,
+      });
+
+      if (!emailResult.sent) {
+        await revokeParticularTokenAfterEmailFailure(deps, particularToken.id);
+
+        return reply.code(503).send({
+          success: false,
+          reason: emailResult.reason,
+          error:
+            "No se pudo enviar el email del token particular. El token fue desactivado; reintentá la generación cuando el servicio de email esté disponible.",
+        });
+      }
+    } catch (error) {
+      await revokeParticularTokenAfterEmailFailure(deps, particularToken.id);
+
+      console.error("[EMAIL] particular_token failed", {
+        tokenId: particularToken.id,
+        errorName: getSafeErrorName(error),
+      });
+
+      return reply.code(502).send({
+        success: false,
+        reason: "email_delivery_failed",
+        error:
+          "No se pudo enviar el email del token particular. El token fue desactivado; reintentá la generación más tarde.",
+      });
+    }
 
     return reply.code(201).send({
       success: true,

--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -44,6 +44,10 @@ type ActiveSessionRecord = {
   lastAccess?: Date | null;
 };
 
+type ParticularTokenEmailResult =
+  | { sent: true; messageId: string }
+  | { sent: false; reason: "no_recipients" | "smtp_disabled" };
+
 type AuthenticatedClinicUser = {
   id: number;
   clinicId: number;
@@ -102,6 +106,15 @@ export type ParticularTokensNativeRoutesOptions = {
     id: number,
     reportId: number | null,
   ) => Promise<ParticularToken | null | undefined>;
+  revokeParticularToken?: (
+    id: number,
+  ) => Promise<ParticularToken | null | undefined>;
+  sendParticularTokenEmail?: (input: {
+    to: string;
+    token: string;
+    tutorLastName: string;
+    petName: string;
+  }) => Promise<ParticularTokenEmailResult>;
   now?: () => number;
 };
 
@@ -126,6 +139,8 @@ type NativeParticularTokensDeps = Required<
     | "getClinicScopedParticularToken"
     | "listParticularTokens"
     | "updateParticularTokenReport"
+    | "revokeParticularToken"
+    | "sendParticularTokenEmail"
   >
 >;
 
@@ -137,6 +152,7 @@ async function loadDefaultDeps(): Promise<NativeParticularTokensDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const dbParticular = await import("../db-particular.ts");
+      const email = await import("../lib/email.ts");
 
       return {
         deleteActiveSession: db.deleteActiveSession,
@@ -151,6 +167,8 @@ async function loadDefaultDeps(): Promise<NativeParticularTokensDeps> {
           dbParticular.getClinicScopedParticularToken,
         listParticularTokens: dbParticular.listParticularTokens,
         updateParticularTokenReport: dbParticular.updateParticularTokenReport,
+        revokeParticularToken: dbParticular.revokeParticularToken,
+        sendParticularTokenEmail: email.sendParticularTokenEmail,
       };
     })();
   }
@@ -362,6 +380,26 @@ function buildClearSessionCookie() {
   });
 }
 
+function getSafeErrorName(error: unknown) {
+  return error instanceof Error && error.name.trim()
+    ? error.name
+    : "unknown_error";
+}
+
+async function revokeParticularTokenAfterEmailFailure(
+  deps: NativeParticularTokensDeps,
+  tokenId: number,
+) {
+  try {
+    await deps.revokeParticularToken(tokenId);
+  } catch (error) {
+    console.error("[EMAIL] particular_token cleanup failed", {
+      tokenId,
+      errorName: getSafeErrorName(error),
+    });
+  }
+}
+
 async function authenticateClinicUser(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -463,7 +501,9 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
     !!options.createParticularToken &&
     !!options.getClinicScopedParticularToken &&
     !!options.listParticularTokens &&
-    !!options.updateParticularTokenReport;
+    !!options.updateParticularTokenReport &&
+    !!options.revokeParticularToken &&
+    !!options.sendParticularTokenEmail;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -491,6 +531,11 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
     updateParticularTokenReport:
       options.updateParticularTokenReport ??
       defaultDeps!.updateParticularTokenReport,
+    revokeParticularToken:
+      options.revokeParticularToken ?? defaultDeps!.revokeParticularToken,
+    sendParticularTokenEmail:
+      options.sendParticularTokenEmail ??
+      defaultDeps!.sendParticularTokenEmail,
   };
 
   const now = options.now ?? (() => Date.now());
@@ -567,6 +612,7 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
       detailsLesion?: unknown;
       extractionDate?: unknown;
       shippingDate?: unknown;
+      recipientEmail?: unknown;
     };
   }>("/", async (request, reply) => {
     if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
@@ -635,6 +681,40 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
       isActive: true,
       lastLoginAt: null,
     });
+
+    try {
+      const emailResult = await deps.sendParticularTokenEmail({
+        to: parsed.data.recipientEmail,
+        token: rawToken,
+        tutorLastName: parsed.data.tutorLastName,
+        petName: parsed.data.petName,
+      });
+
+      if (!emailResult.sent) {
+        await revokeParticularTokenAfterEmailFailure(deps, particularToken.id);
+
+        return reply.code(503).send({
+          success: false,
+          reason: emailResult.reason,
+          error:
+            "No se pudo enviar el email del token particular. El token fue desactivado; reintentá la generación cuando el servicio de email esté disponible.",
+        });
+      }
+    } catch (error) {
+      await revokeParticularTokenAfterEmailFailure(deps, particularToken.id);
+
+      console.error("[EMAIL] particular_token failed", {
+        tokenId: particularToken.id,
+        errorName: getSafeErrorName(error),
+      });
+
+      return reply.code(502).send({
+        success: false,
+        reason: "email_delivery_failed",
+        error:
+          "No se pudo enviar el email del token particular. El token fue desactivado; reintentá la generación más tarde.",
+      });
+    }
 
     return reply.code(201).send({
       success: true,

--- a/test/admin-particular-token-schema.test.ts
+++ b/test/admin-particular-token-schema.test.ts
@@ -7,6 +7,7 @@ import {
 test("adminCreateParticularTokenSchema requiere clinicId válido y normaliza campos base", () => {
   const parsed = adminCreateParticularTokenSchema.safeParse({
     clinicId: "5",
+    recipientEmail: " tutor@example.com ",
     tutorLastName: " Gomez ",
     petName: " Luna ",
     petAge: " 8 años ",
@@ -28,6 +29,7 @@ test("adminCreateParticularTokenSchema requiere clinicId válido y normaliza cam
   assert.equal(parsed.success, true);
 
   assert.equal(parsed.data.clinicId, 5);
+  assert.equal(parsed.data.recipientEmail, "tutor@example.com");
   assert.equal(parsed.data.detailsLesion, undefined);
   assert.equal(parsed.data.reportId, null);
   assert.equal(parsed.data.tutorLastName, "Gomez");
@@ -40,6 +42,7 @@ test("adminCreateParticularTokenSchema requiere clinicId válido y normaliza cam
 
 test("adminCreateParticularTokenSchema rechaza clinicId ausente", () => {
   const parsed = adminCreateParticularTokenSchema.safeParse({
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",
@@ -59,6 +62,7 @@ test("adminCreateParticularTokenSchema rechaza clinicId ausente", () => {
 test("adminCreateParticularTokenSchema rechaza clinicId no positivo", () => {
   const parsed = adminCreateParticularTokenSchema.safeParse({
     clinicId: "0",
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",
@@ -78,6 +82,7 @@ test("adminCreateParticularTokenSchema rechaza clinicId no positivo", () => {
 test("adminCreateParticularTokenSchema conserva detailsLesion cuando viene con texto", () => {
   const parsed = adminCreateParticularTokenSchema.safeParse({
     clinicId: "8",
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -102,6 +102,10 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       createParticularTokenFixture({
         isActive: false,
       }),
+    sendParticularTokenEmail: async () => ({
+      sent: true,
+      messageId: "particular-email-1",
+    }),
     ...overrides,
   });
 
@@ -118,6 +122,7 @@ test(
       tokenHash: `hash:${rawToken}`,
     });
     const createCalls: Array<Record<string, unknown>> = [];
+    const emailCalls: Array<Record<string, unknown>> = [];
 
     const app = await createTestApp({
       generateSessionToken: () => rawToken,
@@ -133,6 +138,10 @@ test(
         createCalls.push(input);
         return createdToken;
       },
+      sendParticularTokenEmail: async (input: Record<string, unknown>) => {
+        emailCalls.push(input);
+        return { sent: true, messageId: "particular-email-1" };
+      },
     });
 
     try {
@@ -147,6 +156,7 @@ test(
         payload: {
           clinicId: 3,
           reportId: 55,
+          recipientEmail: "tutor@example.com",
           tutorLastName: "Gomez",
           petName: "Luna",
           petAge: "8 años",
@@ -173,6 +183,15 @@ test(
       assert.equal(createCalls[0].createdByClinicUserId, null);
       assert.equal(createCalls[0].tokenHash, `hash:${rawToken}`);
       assert.equal(createCalls[0].tokenLast4, "aaaa");
+      assert.equal(createCalls[0].recipientEmail, undefined);
+      assert.deepEqual(emailCalls, [
+        {
+          to: "tutor@example.com",
+          token: rawToken,
+          tutorLastName: "Gomez",
+          petName: "Luna",
+        },
+      ]);
 
       assert.deepEqual(JSON.parse(response.body), {
         success: true,
@@ -203,6 +222,124 @@ test(
           hasLinkedReport: true,
         },
       });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes valida recipientEmail antes de crear token",
+  async () => {
+    const createCalls: Array<Record<string, unknown>> = [];
+    const emailCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      createParticularToken: async (input: Record<string, unknown>) => {
+        createCalls.push(input);
+        return createParticularTokenFixture();
+      },
+      sendParticularTokenEmail: async (input: Record<string, unknown>) => {
+        emailCalls.push(input);
+        return { sent: true, messageId: "particular-email-1" };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/particular-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          recipientEmail: "no-es-email",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Email del particular inválido",
+      });
+      assert.equal(createCalls.length, 0);
+      assert.equal(emailCalls.length, 0);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes desactiva token si falla el envío de email",
+  async () => {
+    const createdToken = createParticularTokenFixture();
+    const createCalls: Array<Record<string, unknown>> = [];
+    const revokeCalls: number[] = [];
+
+    const app = await createTestApp({
+      createParticularToken: async (input: Record<string, unknown>) => {
+        createCalls.push(input);
+        return createdToken;
+      },
+      revokeParticularToken: async (tokenId: number) => {
+        revokeCalls.push(tokenId);
+        return createParticularTokenFixture({ id: tokenId, isActive: false });
+      },
+      sendParticularTokenEmail: async () => ({
+        sent: false,
+        reason: "smtp_disabled",
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/particular-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          recipientEmail: "tutor@example.com",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      const body = JSON.parse(response.body);
+      assert.equal(response.statusCode, 503);
+      assert.equal(body.success, false);
+      assert.equal(body.reason, "smtp_disabled");
+      assert.equal(body.token, undefined);
+      assert.equal(createCalls.length, 1);
+      assert.equal(createCalls[0].recipientEmail, undefined);
+      assert.deepEqual(revokeCalls, [7]);
     } finally {
       await app.close();
     }

--- a/test/email-success.test.ts
+++ b/test/email-success.test.ts
@@ -9,7 +9,97 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { ENV } = await import("../server/lib/env.ts");
-const { sendSpecialStainRequiredEmail } = await import("../server/lib/email.ts");
+const {
+  sendParticularTokenEmail,
+  sendSpecialStainRequiredEmail,
+} = await import("../server/lib/email.ts");
+
+test("sendParticularTokenEmail envia token particular con payload minimo", async () => {
+  const originalInfo = console.info;
+  const infoCalls: unknown[][] = [];
+  console.info = (...args: unknown[]) => {
+    infoCalls.push(args);
+  };
+
+  const originalSmtp = {
+    enabled: ENV.smtp.enabled,
+    host: ENV.smtp.host,
+    port: ENV.smtp.port,
+    secure: ENV.smtp.secure,
+    user: ENV.smtp.user,
+    pass: ENV.smtp.pass,
+    from: ENV.smtp.from,
+  };
+  const originalGmailApi = {
+    enabled: ENV.gmailApi.enabled,
+    clientId: ENV.gmailApi.clientId,
+    clientSecret: ENV.gmailApi.clientSecret,
+    refreshToken: ENV.gmailApi.refreshToken,
+    from: ENV.gmailApi.from,
+  };
+  const originalCreateTransport = nodemailer.createTransport;
+  const sendMailCalls: Array<Record<string, unknown>> = [];
+
+  (ENV.smtp as any).enabled = true;
+  (ENV.smtp as any).host = "smtp-particular.example.com";
+  (ENV.smtp as any).port = 587;
+  (ENV.smtp as any).secure = false;
+  (ENV.smtp as any).user = "smtp-user";
+  (ENV.smtp as any).pass = "smtp-pass";
+  (ENV.smtp as any).from = "noreply@vetneb.com";
+  (ENV.gmailApi as any).enabled = false;
+  (ENV.gmailApi as any).clientId = "";
+  (ENV.gmailApi as any).clientSecret = "";
+  (ENV.gmailApi as any).refreshToken = "";
+  (ENV.gmailApi as any).from = "";
+
+  (nodemailer as any).createTransport = () => ({
+    sendMail: async (payload: Record<string, unknown>) => {
+      sendMailCalls.push(payload);
+      return { messageId: "particular-message-123" };
+    },
+  });
+
+  try {
+    const result = await sendParticularTokenEmail({
+      to: " TUTOR@Example.com ",
+      token: "token-visible-una-sola-vez",
+      tutorLastName: "Gomez",
+      petName: "Luna",
+    });
+
+    assert.deepEqual(result, {
+      sent: true,
+      messageId: "particular-message-123",
+    });
+  } finally {
+    console.info = originalInfo;
+    (nodemailer as any).createTransport = originalCreateTransport;
+    (ENV.smtp as any).enabled = originalSmtp.enabled;
+    (ENV.smtp as any).host = originalSmtp.host;
+    (ENV.smtp as any).port = originalSmtp.port;
+    (ENV.smtp as any).secure = originalSmtp.secure;
+    (ENV.smtp as any).user = originalSmtp.user;
+    (ENV.smtp as any).pass = originalSmtp.pass;
+    (ENV.smtp as any).from = originalSmtp.from;
+    (ENV.gmailApi as any).enabled = originalGmailApi.enabled;
+    (ENV.gmailApi as any).clientId = originalGmailApi.clientId;
+    (ENV.gmailApi as any).clientSecret = originalGmailApi.clientSecret;
+    (ENV.gmailApi as any).refreshToken = originalGmailApi.refreshToken;
+    (ENV.gmailApi as any).from = originalGmailApi.from;
+  }
+
+  assert.equal(sendMailCalls.length, 1);
+  const payload = sendMailCalls[0];
+  assert.equal(payload.from, "noreply@vetneb.com");
+  assert.equal(payload.to, "tutor@example.com");
+  assert.equal(payload.subject, "[VETNEB] Token de acceso particular");
+  assert.equal(typeof payload.text, "string");
+  assert.equal(String(payload.text).includes("token-visible-una-sola-vez"), true);
+  assert.equal(String(payload.text).includes("Tutor/a: Gomez"), true);
+  assert.equal(String(payload.text).includes("Paciente: Luna"), true);
+  assert.equal(JSON.stringify(infoCalls).includes("token-visible-una-sola-vez"), false);
+});
 
 test("sendSpecialStainRequiredEmail envia correo con payload esperado cuando SMTP esta habilitado", async () => {
   const originalInfo = console.info;

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -187,6 +187,11 @@ function buildAdminParticularTokensRouteStubs() {
     getParticularTokenById: async () => null,
     listParticularTokens: async () => [],
     updateParticularTokenReport: async () => null,
+    revokeParticularToken: async () => null,
+    sendParticularTokenEmail: async () => ({
+      sent: true as const,
+      messageId: "particular-email-1",
+    }),
   };
 }
 function buildAdminReportsRouteStubs() {
@@ -463,6 +468,11 @@ function buildParticularTokensRouteStubs() {
     getClinicScopedParticularToken: async () => null,
     listParticularTokens: async () => [],
     updateParticularTokenReport: async () => null,
+    revokeParticularToken: async () => null,
+    sendParticularTokenEmail: async () => ({
+      sent: true as const,
+      messageId: "particular-email-1",
+    }),
   };
 }
 function buildStudyTrackingRouteStubs() {

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -190,7 +190,7 @@ test("admin particular token generator keeps programmed fields", () => {
   assert.ok(source.includes("shippingDate"));
 });
 
-test("admin particular token form keeps recipient email frontend only", () => {
+test("admin particular token form sends recipient email through backend contract", () => {
   const source = read(ADMIN_CARD_PATH);
   const api = read(API_PATH);
   const payloadType = sectionBetween(
@@ -213,13 +213,15 @@ test("admin particular token form keeps recipient email frontend only", () => {
   assert.ok(source.includes('name="particularEmail"'));
   assert.ok(source.includes('type="email"'));
   assert.ok(source.includes('placeholder="email@ejemplo.com"'));
+  assert.ok(source.includes("recipientEmail: normalizeText(formState.particularEmail),"));
+  assert.ok(source.includes('required'));
   assert.ok(source.includes("Email del particular"));
   assert.ok(
     source.includes(
-      "Opcional. Se usa solo para preparar la comunicación manual del",
+      "Obligatorio. El backend enviará el token a este email usando la",
     ),
   );
-  assert.ok(source.includes("token; no se envía automáticamente."));
+  assert.ok(source.includes("configuración de correo de VETNEB."));
   assert.ok(source.includes("const generatedRecipientEmail = formState.particularEmail.trim();"));
   assert.ok(
     source.includes("const response = await createAdminParticularToken(payload);"),
@@ -231,9 +233,9 @@ test("admin particular token form keeps recipient email frontend only", () => {
   );
   assert.ok(submitSuccess.includes("setGeneratedTokenDetails(nextGeneratedTokenDetails);"));
   assert.equal(payloadType.includes("particularEmail"), false);
-  assert.equal(payloadType.includes("recipientEmail"), false);
-  assert.equal(payloadBuilder.includes("particularEmail"), false);
-  assert.equal(payloadBuilder.includes("recipientEmail"), false);
+  assert.ok(payloadType.includes("recipientEmail: string;"));
+  assert.ok(payloadBuilder.includes("formState.particularEmail"));
+  assert.ok(payloadBuilder.includes("recipientEmail: normalizeText(formState.particularEmail),"));
   assert.equal(payloadBuilder.includes("email:"), false);
 });
 
@@ -248,12 +250,12 @@ test("admin generated token block requires manual communication confirmation", (
   assert.ok(source.includes("IMPORTANTE: el token completo solo se muestra una vez."));
   assert.ok(
     source.includes(
-      "Antes de cerrar este bloque, verificá que el email del",
+      "Antes de cerrar este bloque, verificá que el token haya sido",
     ),
   );
-  assert.ok(source.includes("particular sea correcto y que el token haya sido copiado o"));
-  assert.ok(source.includes("Email indicado:"));
-  assert.ok(source.includes("No se indicó email del particular."));
+  assert.ok(source.includes("copiado si necesitás respaldo operativo."));
+  assert.ok(source.includes("Email enviado a:"));
+  assert.ok(source.includes("El backend informó envío correcto del email."));
   assert.ok(source.includes("Copiar mensaje para enviar"));
   assert.ok(source.includes("navigator.clipboard?.writeText"));
   assert.ok(source.includes("buildManualTokenMessage(generatedToken, generatedTokenDetails)"));
@@ -265,7 +267,7 @@ test("admin generated token block requires manual communication confirmation", (
   assert.ok(source.includes('type="checkbox"'));
   assert.ok(
     source.includes(
-      "Confirmo que copié o comuniqué el token al destinatario",
+      "Confirmo que registré el token visible o que no necesito copia",
     ),
   );
   assert.ok(source.includes("Cerrar token visible"));

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -210,7 +210,7 @@ test("clinic report link remains optional and distinct from clinic identity", ()
   assert.equal(source.includes("ID de clínica"), false);
 });
 
-test("clinic particular token form keeps recipient email frontend only", () => {
+test("clinic particular token form sends recipient email through backend contract", () => {
   const source = read(CLINIC_TOKENS_CARD_PATH);
   const api = read(API_PATH);
   const payloadType = sectionBetween(
@@ -233,13 +233,15 @@ test("clinic particular token form keeps recipient email frontend only", () => {
   assert.ok(source.includes('name="particularEmail"'));
   assert.ok(source.includes('type="email"'));
   assert.ok(source.includes('placeholder="email@ejemplo.com"'));
+  assert.ok(source.includes("recipientEmail: normalizeText(formState.particularEmail),"));
+  assert.ok(source.includes('required'));
   assert.ok(source.includes("Email del particular"));
   assert.ok(
     source.includes(
-      "Opcional. Se usa solo para preparar la comunicación manual del",
+      "Obligatorio. El backend enviará el token a este email usando la",
     ),
   );
-  assert.ok(source.includes("token; no se envía automáticamente."));
+  assert.ok(source.includes("configuración de correo de VETNEB."));
   assert.ok(source.includes("const generatedRecipientEmail = formState.particularEmail.trim();"));
   assert.ok(
     source.includes("const response = await createClinicParticularToken(payload);"),
@@ -251,9 +253,9 @@ test("clinic particular token form keeps recipient email frontend only", () => {
   );
   assert.ok(submitSuccess.includes("setGeneratedTokenDetails(nextGeneratedTokenDetails);"));
   assert.equal(payloadType.includes("particularEmail"), false);
-  assert.equal(payloadType.includes("recipientEmail"), false);
-  assert.equal(payloadBuilder.includes("particularEmail"), false);
-  assert.equal(payloadBuilder.includes("recipientEmail"), false);
+  assert.ok(payloadType.includes("recipientEmail: string;"));
+  assert.ok(payloadBuilder.includes("formState.particularEmail"));
+  assert.ok(payloadBuilder.includes("recipientEmail: normalizeText(formState.particularEmail),"));
   assert.equal(payloadBuilder.includes("email:"), false);
 });
 
@@ -269,8 +271,8 @@ test("clinic token generation keeps generated token block list refresh and reset
   assert.ok(source.includes('aria-label="Token particular generado"'));
   assert.ok(source.includes("El token completo solo se muestra una vez."));
   assert.ok(source.includes("IMPORTANTE: el token completo solo se muestra una vez."));
-  assert.ok(source.includes("Email indicado:"));
-  assert.ok(source.includes("No se indicó email del particular."));
+  assert.ok(source.includes("Email enviado a:"));
+  assert.ok(source.includes("El backend informó envío correcto del email."));
   assert.ok(source.includes("Copiar mensaje para enviar"));
   assert.ok(source.includes('type="checkbox"'));
   assert.ok(source.includes("Cerrar token visible"));
@@ -303,7 +305,7 @@ test("clinic generated token block clears only through confirmation close", () =
   );
   assert.ok(
     source.includes(
-      "Confirmo que copié o comuniqué el token al destinatario",
+      "Confirmo que registré el token visible o que no necesito copia",
     ),
   );
   assert.ok(clearGeneratedToken.includes("setGeneratedToken(null);"));

--- a/test/particular-token-edge.test.ts
+++ b/test/particular-token-edge.test.ts
@@ -10,6 +10,7 @@ import {
 
 test("clinicCreateParticularTokenSchema acepta reportId positivo y detailsLesion al limite", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({
+    recipientEmail: "tutor@example.com",
     tutorLastName: " Gomez ",
     petName: " Luna ",
     petAge: " 8 años ",
@@ -36,6 +37,7 @@ test("clinicCreateParticularTokenSchema acepta reportId positivo y detailsLesion
 
 test("clinicCreateParticularTokenSchema rechaza detailsLesion fuera de limite", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",
@@ -64,6 +66,7 @@ test("clinicCreateParticularTokenSchema rechaza detailsLesion fuera de limite", 
 
 test("clinicCreateParticularTokenSchema rechaza fechas invalidas", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",
@@ -95,6 +98,7 @@ test("clinicCreateParticularTokenSchema rechaza fechas invalidas", () => {
 test("adminCreateParticularTokenSchema acepta reportId positivo y rechaza clinicId no numerico", () => {
   const valid = adminCreateParticularTokenSchema.safeParse({
     clinicId: "8",
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",
@@ -110,6 +114,7 @@ test("adminCreateParticularTokenSchema acepta reportId positivo y rechaza clinic
 
   const invalidClinic = adminCreateParticularTokenSchema.safeParse({
     clinicId: "abc",
+    recipientEmail: "tutor@example.com",
     tutorLastName: "Gomez",
     petName: "Luna",
     petAge: "8 años",

--- a/test/particular-token.test.ts
+++ b/test/particular-token.test.ts
@@ -13,6 +13,7 @@ import {
 
 test("clinicCreateParticularTokenSchema normaliza detailsLesion vacío y reportId null", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({
+    recipientEmail: " tutor@example.com ",
     tutorLastName: " Gomez ",
     petName: " Luna ",
     petAge: " 8 años ",
@@ -34,6 +35,7 @@ test("clinicCreateParticularTokenSchema normaliza detailsLesion vacío y reportI
   assert.equal(parsed.success, true);
 
   assert.equal(parsed.data.detailsLesion, undefined);
+  assert.equal(parsed.data.recipientEmail, "tutor@example.com");
   assert.equal(parsed.data.reportId, null);
   assert.equal(parsed.data.tutorLastName, "Gomez");
   assert.equal(parsed.data.petName, "Luna");
@@ -72,6 +74,7 @@ test("helpers numéricos de particular-token respetan fallback y límites", () =
 
 test("buildValidationError devuelve el primer mensaje del schema", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({
+    recipientEmail: "tutor@example.com",
     tutorLastName: "",
     petName: "",
     petAge: "",

--- a/test/particular-tokens.fastify.test.ts
+++ b/test/particular-tokens.fastify.test.ts
@@ -92,6 +92,14 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     getClinicScopedParticularToken: async () => createParticularTokenFixture(),
     listParticularTokens: async () => [createParticularTokenFixture()],
     updateParticularTokenReport: async () => createParticularTokenFixture(),
+    revokeParticularToken: async () =>
+      createParticularTokenFixture({
+        isActive: false,
+      }),
+    sendParticularTokenEmail: async () => ({
+      sent: true,
+      messageId: "particular-email-1",
+    }),
     ...overrides,
   });
 
@@ -107,6 +115,7 @@ test(
       tokenHash: `hash:${rawToken}`,
     });
     const createCalls: Array<Record<string, unknown>> = [];
+    const emailCalls: Array<Record<string, unknown>> = [];
 
     const app = await createTestApp({
       generateSessionToken: () => rawToken,
@@ -117,6 +126,10 @@ test(
       createParticularToken: async (input: Record<string, unknown>) => {
         createCalls.push(input);
         return createdToken;
+      },
+      sendParticularTokenEmail: async (input: Record<string, unknown>) => {
+        emailCalls.push(input);
+        return { sent: true, messageId: "particular-email-1" };
       },
     });
 
@@ -131,6 +144,7 @@ test(
         },
         payload: {
           reportId: 55,
+          recipientEmail: "tutor@example.com",
           tutorLastName: "Gomez",
           petName: "Luna",
           petAge: "8 años",
@@ -157,6 +171,15 @@ test(
       assert.equal(createCalls[0].createdByClinicUserId, 9);
       assert.equal(createCalls[0].tokenHash, `hash:${rawToken}`);
       assert.equal(createCalls[0].tokenLast4, "aaaa");
+      assert.equal(createCalls[0].recipientEmail, undefined);
+      assert.deepEqual(emailCalls, [
+        {
+          to: "tutor@example.com",
+          token: rawToken,
+          tutorLastName: "Gomez",
+          petName: "Luna",
+        },
+      ]);
 
       assert.deepEqual(JSON.parse(response.body), {
         success: true,
@@ -187,6 +210,115 @@ test(
           hasLinkedReport: true,
         },
       });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularTokensNativeRoutes valida recipientEmail antes de crear token",
+  async () => {
+    const createCalls: Array<Record<string, unknown>> = [];
+    const emailCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      createParticularToken: async (input: Record<string, unknown>) => {
+        createCalls.push(input);
+        return createParticularTokenFixture();
+      },
+      sendParticularTokenEmail: async (input: Record<string, unknown>) => {
+        emailCalls.push(input);
+        return { sent: true, messageId: "particular-email-1" };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          recipientEmail: "no-es-email",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Email del particular inválido",
+      });
+      assert.equal(createCalls.length, 0);
+      assert.equal(emailCalls.length, 0);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularTokensNativeRoutes desactiva token si el servicio de email falla",
+  async () => {
+    const createdToken = createParticularTokenFixture();
+    const revokeCalls: number[] = [];
+
+    const app = await createTestApp({
+      createParticularToken: async () => createdToken,
+      revokeParticularToken: async (tokenId: number) => {
+        revokeCalls.push(tokenId);
+        return createParticularTokenFixture({ id: tokenId, isActive: false });
+      },
+      sendParticularTokenEmail: async () => {
+        throw new Error("smtp unavailable");
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          recipientEmail: "tutor@example.com",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      const body = JSON.parse(response.body);
+      assert.equal(response.statusCode, 502);
+      assert.equal(body.success, false);
+      assert.equal(body.reason, "email_delivery_failed");
+      assert.equal(body.token, undefined);
+      assert.deepEqual(revokeCalls, [7]);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Summary
- Require recipientEmail when generating particular tokens
- Send generated particular token email from backend using configured SMTP/Gmail transport
- Keep recipientEmail non-persistent for this PR
- Preserve one-time raw token visibility
- Deactivate generated token and return controlled error if email delivery fails

## Validation
- pnpm test: 1934 tests, 0 failures
- pnpm build: OK