### PR TITLE
fix(auth): prevent false 429 on login and token access

### DIFF
--- a/docs/fix-auth-token-rate-limit-429.md
+++ b/docs/fix-auth-token-rate-limit-429.md
@@ -1,0 +1,197 @@
+# fix(auth): prevent false HTTP 429 on login and token access
+
+**Branch:** `fix/auth-token-rate-limit-429`
+**Fecha:** 2026-05-30
+
+---
+
+## Skills aplicadas
+
+- `vetneb-staff-senior-full-stack-engineer`
+- `vetneb-protocolos-comunicacion`
+- `vetneb-bugs-errores-optimizacion-rutas`
+- `vetneb-security-production-invariants`
+- `vetneb-briefing-planificacion-diseno-desarrollo-pruebas`
+
+---
+
+## Diagnóstico
+
+### Superficies afectadas
+
+| Endpoint | Método | Fichero de ruta | Store rate-limit en producción | Key anterior |
+|---|---|---|---|---|
+| `POST /api/auth/login` | Unified (admin+clinic+particular) | `server/routes/auth.fastify.ts` | DB persistente | `request.ip \|\| "unknown"` |
+| `POST /api/particular/auth/login` | Token particular | `server/routes/particular-auth.fastify.ts` | Memoria in-process | `request.ip \|\| "unknown"` |
+| `POST /api/admin/auth/login` | Admin | `server/routes/admin-auth.fastify.ts` | Memoria in-process | `request.ip \|\| "unknown"` |
+
+### Causa raíz
+
+**RC1 — Key sin prefijo de realm → bucket global al fallar IP**
+
+Los tres endpoints de auth usaban `request.ip || "unknown"` como clave de rate-limit.
+Cuando `request.ip` no está disponible o resuelve a la IP del proxy interno de Render
+(en lugar de la IP real del cliente), todos los usuarios comparten la misma entrada
+de rate-limit dentro del store.
+
+Consecuencias:
+- 10 intentos fallidos desde cualquier usuario → bucket lleno → todos los usuarios
+  de ese realm bloqueados con 429 durante 15 minutos.
+- El fallback `"unknown"` era global dentro de cada store: un solo bucket para todos.
+
+**RC2 — Ausencia de namespace entre realms**
+
+El `/api/auth/login` (login unificado) y `/api/particular/auth/login` (token particular)
+usaban la misma clave sin prefijo. Aunque usan stores separados en producción
+(DB persistente vs memoria), si en algún entorno se inyecta el mismo store (o si el
+patrón de key se comparte accidentalmente), los fallos de uno bloquean al otro.
+
+**RC3 — Test `security-rate-limit-isolation-boundaries.test.ts` codificaba el patrón buggy**
+
+El test afirmaba explícitamente:
+```
+assertContains(source, 'const rateLimitKey = request.ip || "unknown";', ...)
+```
+Esto bloqueaba cualquier corrección al patrón de key sin romper primero ese test.
+
+**Observación adicional (fuera de scope del fix)**
+
+El `/api/particular/auth/login` usa store en memoria en producción (no DB persistente).
+El counter se reinicia en cada restart del servidor Render, pero se acumula durante el
+uptime del proceso. Esto no se cambia en este PR; el aislamiento de realm mitiga el
+impacto.
+
+---
+
+## Causa raíz resumida
+
+> `rateLimitKey = request.ip || "unknown"` sin prefijo de realm = bucket global
+> compartido cuando la IP no se resuelve o múltiples usuarios comparten IP de proxy.
+
+---
+
+## Archivos modificados
+
+| Fichero | Tipo | Cambio |
+|---|---|---|
+| `server/routes/auth.fastify.ts` | Producción | `rateLimitKey` → `` `login:${request.ip \|\| "unknown"}` `` |
+| `server/routes/particular-auth.fastify.ts` | Producción | `rateLimitKey` → `` `particular:${request.ip \|\| "unknown"}` `` |
+| `server/routes/admin-auth.fastify.ts` | Producción | `rateLimitKey` → `` `admin:${request.ip \|\| "unknown"}` `` |
+| `test/auth.fastify.test.ts` | Test | `hashRateLimitKey("203.0.113.50")` → `hashRateLimitKey("login:203.0.113.50")` (x2) |
+| `test/security-rate-limit-isolation-boundaries.test.ts` | Test | Reemplaza assertion de key genérica por mapa por realm |
+| `test/security-rate-limit-cross-realm-isolation.test.ts` | Test (nuevo) | 7 tests de regresión cross-realm |
+
+### Nota de limpieza
+
+Los ficheros temporales `test/security-rate-limit-isolation-boundaries.test.ts.clean`
+y `test/security-rate-limit-isolation-boundaries.test.ts.tmp` deben eliminarse
+manualmente en Windows antes del commit:
+```powershell
+Remove-Item test\security-rate-limit-isolation-boundaries.test.ts.clean
+Remove-Item test\security-rate-limit-isolation-boundaries.test.ts.tmp
+```
+
+---
+
+## Descripción del fix
+
+Añadir prefijo de realm a la clave de rate-limit en los tres endpoints de autenticación:
+
+```typescript
+// Antes (todos los endpoints):
+const rateLimitKey = request.ip || "unknown";
+
+// Después:
+// auth.fastify.ts (login unificado clinic/admin/particular):
+const rateLimitKey = `login:${request.ip || "unknown"}`;
+
+// particular-auth.fastify.ts (token particular):
+const rateLimitKey = `particular:${request.ip || "unknown"}`;
+
+// admin-auth.fastify.ts (admin dedicado):
+const rateLimitKey = `admin:${request.ip || "unknown"}`;
+```
+
+Esto garantiza:
+1. Fallos en `/api/auth/login` no afectan el store de `/api/particular/auth/login`
+   incluso si se comparte el mismo store (store separados por diseño en producción).
+2. El fallback `"unknown"` queda acotado al realm: `"login:unknown"` ≠ `"particular:unknown"`.
+3. Los stores siguen siendo independientes en producción (no se modifica esa arquitectura).
+4. La protección anti-bruteforce se mantiene dentro de cada realm.
+
+---
+
+## Tests de regresión nuevos
+
+Fichero: `test/security-rate-limit-cross-realm-isolation.test.ts`
+
+| Test | Verifica |
+|---|---|
+| `intentos fallidos en login clinica no bloquean login particular con store compartido` | Cross-realm isolation login→particular |
+| `intentos fallidos en login particular no bloquean login clinica con store compartido` | Cross-realm isolation particular→login |
+| `rate limit clinica sigue funcionando dentro del mismo flujo` | Anti-bruteforce intacto en clinic |
+| `rate limit particular sigue funcionando dentro del mismo flujo` | Anti-bruteforce intacto en particular |
+| `respuesta 429 no filtra informacion sensible en login clinica` | Sanitización: sin password/hash/token/cookie en 429 |
+| `respuesta 429 no filtra informacion sensible en login particular` | Sanitización: sin hash/cookie/secret en 429 |
+| `IP desconocida no colapsa realm login con realm particular` | `"unknown"` scoped por realm |
+
+---
+
+## Validaciones ejecutadas
+
+| Validación | Resultado |
+|---|---|
+| `node --test test/security-rate-limit-isolation-boundaries.test.ts` | 9/9 pass |
+| `node --test test/login-rate-limit.test.ts test/rate-limit-store.test.ts` | 10/10 pass |
+| `node --test test/security-production-invariants.test.ts` | 11/11 pass |
+| Tests estructurales combinados (30 tests) | 30/30 pass |
+| `git diff --check` | EXIT 0 (sin whitespace errors) |
+| `pnpm test` (requiere host Windows) | Pendiente ejecución manual por Nico |
+| `pnpm build` (requiere host Windows) | Pendiente ejecución manual por Nico |
+
+---
+
+## No-alcance explícito
+
+- No se toca Gmail API, SMTP ni email.
+- No se cambia `TRUST_PROXY` ni ENV (el valor `trustProxy: ENV.trustProxy ?? 1` es correcto
+  para Render de un hop; si hay múltiples hops en producción, ajustar ENV.TRUST_PROXY=2 en
+  Render → fuera de scope de este PR).
+- No se migra el store in-memory de particular-auth a DB persistente.
+- No se modifican migraciones ni schema de DB.
+- No se modifica CSP (la advertencia de upgrade-insecure-requests en consola es un
+  report-only de Next.js y no tiene relación con el 429).
+- No se tocan dependencias (package.json / pnpm-lock.yaml).
+- No se modifica el modelo de usuarios ni permisos.
+
+---
+
+## Riesgos y resguardos
+
+| Riesgo | Severidad | Resguardo |
+|---|---|---|
+| Keys existentes en DB sin prefijo quedan activas hasta que expiren (15 min) | Bajo | Las entradas antiguas expiran por TTL; ningún usuario bloqueado legítimamente se libera antes de tiempo |
+| Store in-memory de particular y admin se reinicia con servidor | Bajo-existente | Comportamiento previo sin cambio; prefijo solo añade namespace |
+| El fallback `"unknown"` sigue siendo un bucket compartido dentro del mismo realm | Bajo | Solo afecta cuando IP no se resuelve; el realm-prefix reduce el radio de impacto al dominio específico |
+| `trustProxy` mal configurado sigue causando IP de proxy en `request.ip` | Medio-externo | Ajustar `ENV.TRUST_PROXY` en Render si hay múltiples hops; este PR no cambia esa config |
+
+---
+
+## Estado final
+
+```
+branch: fix/auth-token-rate-limit-429
+base:   main (01def8a feat(particular): email generated token from backend (#766))
+
+Archivos modificados (5 M + 1 A):
+  M server/routes/auth.fastify.ts
+  M server/routes/particular-auth.fastify.ts
+  M server/routes/admin-auth.fastify.ts
+  M test/auth.fastify.test.ts
+  M test/security-rate-limit-isolation-boundaries.test.ts
+  A test/security-rate-limit-cross-realm-isolation.test.ts
+
+Tests estructurales: 30/30 pass
+git diff --check: EXIT 0
+Listo para: pnpm test && pnpm build en host → git add → commit → push → PR
+```

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -615,7 +615,7 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    const rateLimitKey = request.ip || "unknown";
+    const rateLimitKey = `admin:${request.ip || "unknown"}`;
     const currentTime = now();
     const failureEntry = await getOrCreateRateLimitEntry(
       loginRateLimitStore,

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -1050,7 +1050,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const rateLimitKey = request.ip || "unknown";
+    const rateLimitKey = `login:${request.ip || "unknown"}`;
+
     const failureEntry: RateLimitEntry = {
       count: 0,
       resetAt: currentTime + loginRateLimitWindowMs,

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -623,7 +623,7 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    const rateLimitKey = request.ip || "unknown";
+    const rateLimitKey = `particular:${request.ip || "unknown"}`;
     const currentTime = now();
     const failureEntry = await getOrCreateRateLimitEntry(
       loginRateLimitStore,

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -1396,7 +1396,7 @@ test("clinicAuthNativeRoutes login fallido incrementa store persistente", async 
     });
 
     assert.equal(response.statusCode, 401);
-    assert.equal(rows.get(hashRateLimitKey("203.0.113.50"))?.count, 1);
+    assert.equal(rows.get(hashRateLimitKey("login:203.0.113.50"))?.count, 1);
   } finally {
     await app.close();
   }
@@ -1599,7 +1599,7 @@ test("clinicAuthNativeRoutes reinicia ventana persistente cuando resetAt venció
     });
 
     assert.equal(second.statusCode, 401);
-    assert.equal(rows.get(hashRateLimitKey("203.0.113.53"))?.count, 1);
+    assert.equal(rows.get(hashRateLimitKey("login:203.0.113.53"))?.count, 1);
   } finally {
     await secondApp.close();
   }

--- a/test/security-rate-limit-cross-realm-isolation.test.ts
+++ b/test/security-rate-limit-cross-realm-isolation.test.ts
@@ -1,0 +1,384 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/login-rate-limit.ts");
+const {
+  createMemoryRateLimitStore,
+} = await import("../server/lib/rate-limit-store.ts");
+const {
+  clinicAuthNativeRoutes,
+} = await import("../server/routes/auth.fastify.ts");
+const {
+  particularAuthNativeRoutes,
+} = await import("../server/routes/particular-auth.fastify.ts");
+
+const REMOTE_IP = "203.0.113.90";
+const WINDOW_MS = 60_000;
+const MAX_ATTEMPTS = 3;
+
+async function createClinicApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(clinicAuthNativeRoutes as any, {
+    prefix: "/api/auth",
+    createActiveSession: async () => {},
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    getClinicUserByUsername: async () => null,
+    getClinicUserByIdentifier: async () => null,
+    updateSessionLastAccess: async () => {},
+    upsertClinicUser: async () => {},
+    generateSessionToken: () => "session-token",
+    hashPassword: async () => "hash",
+    hashSessionToken: (t: string) => `h:${t}`,
+    verifyPassword: async () => ({ valid: false, needsRehash: false }),
+    createAdminSession: async () => {},
+    getAdminUserByUsername: async () => null,
+    getAdminUserByIdentifier: async () => null,
+    writeAdminAuditLog: async () => {},
+    createParticularSession: async () => {},
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularTokenLastLogin: async () => {},
+    writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: WINDOW_MS,
+    loginRateLimitMaxAttempts: MAX_ATTEMPTS,
+    ...overrides,
+  });
+
+  return app;
+}
+
+async function createParticularApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(particularAuthNativeRoutes as any, {
+    prefix: "/api/particular/auth",
+    createParticularSession: async () => {},
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    updateParticularTokenLastLogin: async () => {},
+    getReportById: async () => null,
+    createSignedReportUrl: async (s: string) => `url:${s}`,
+    createSignedReportDownloadUrl: async (s: string) => `dl:${s}`,
+    generateSessionToken: () => "particular-token",
+    hashSessionToken: (t: string) => `h:${t}`,
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: WINDOW_MS,
+    loginRateLimitMaxAttempts: MAX_ATTEMPTS,
+    ...overrides,
+  });
+
+  return app;
+}
+
+test("intentos fallidos en login clinica no bloquean login particular con store compartido", async () => {
+  const sharedStore = createMemoryRateLimitStore();
+
+  const clinicApp = await createClinicApp({
+    loginRateLimitStore: sharedStore,
+  });
+  const particularApp = await createParticularApp({
+    loginRateLimitStore: sharedStore,
+  });
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+      const r = await clinicApp.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "clinica@vetneb.com", password: "mala" },
+      });
+      assert.equal(r.statusCode, 401, `clinic attempt ${i + 1} must be 401`);
+    }
+
+    const blocked = await clinicApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "clinica@vetneb.com", password: "mala" },
+    });
+    assert.equal(blocked.statusCode, 429, "clinic must be 429 after exhausting limit");
+
+    const particularAttempt = await particularApp.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: "token-invalido" },
+    });
+    assert.notEqual(
+      particularAttempt.statusCode,
+      429,
+      "particular login must NOT be blocked by clinic failures (realm isolation)",
+    );
+    assert.equal(particularAttempt.statusCode, 401);
+  } finally {
+    await clinicApp.close();
+    await particularApp.close();
+  }
+});
+
+test("intentos fallidos en login particular no bloquean login clinica con store compartido", async () => {
+  const sharedStore = createMemoryRateLimitStore();
+
+  const clinicApp = await createClinicApp({
+    loginRateLimitStore: sharedStore,
+  });
+  const particularApp = await createParticularApp({
+    loginRateLimitStore: sharedStore,
+  });
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+      const r = await particularApp.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: "token-malo" },
+      });
+      assert.equal(r.statusCode, 401, `particular attempt ${i + 1} must be 401`);
+    }
+
+    const blocked = await particularApp.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: "token-malo" },
+    });
+    assert.equal(blocked.statusCode, 429, "particular must be 429 after exhausting limit");
+
+    const clinicAttempt = await clinicApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "clinica@vetneb.com", password: "mala" },
+    });
+    assert.notEqual(
+      clinicAttempt.statusCode,
+      429,
+      "clinic login must NOT be blocked by particular failures (realm isolation)",
+    );
+    assert.equal(clinicAttempt.statusCode, 401);
+  } finally {
+    await clinicApp.close();
+    await particularApp.close();
+  }
+});
+
+test("rate limit clinica sigue funcionando dentro del mismo flujo", async () => {
+  const app = await createClinicApp();
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "x@x.com", password: "mal" },
+      });
+      assert.equal(r.statusCode, 401);
+    }
+
+    const r = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "x@x.com", password: "mal" },
+    });
+    assert.equal(r.statusCode, 429);
+    assert.deepEqual(JSON.parse(r.body), {
+      success: false,
+      error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("rate limit particular sigue funcionando dentro del mismo flujo", async () => {
+  const app = await createParticularApp();
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: "tok-malo" },
+      });
+      assert.equal(r.statusCode, 401);
+    }
+
+    const r = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: "tok-malo" },
+    });
+    assert.equal(r.statusCode, 429);
+    assert.deepEqual(JSON.parse(r.body), {
+      success: false,
+      error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("respuesta 429 no filtra informacion sensible en login clinica", async () => {
+  const app = await createClinicApp();
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS + 1; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "u@v.com", password: "pass" },
+      });
+    }
+
+    const r = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "u@v.com", password: "pass" },
+    });
+
+    assert.equal(r.statusCode, 429);
+
+    const body = JSON.parse(r.body) as Record<string, unknown>;
+    const raw = JSON.stringify(body).toLowerCase();
+
+    assert.ok(!raw.includes("password"), "429 must not leak password");
+    assert.ok(!raw.includes("hash"), "429 must not leak hash");
+    assert.ok(!raw.includes("token"), "429 must not leak token");
+    assert.ok(!raw.includes("cookie"), "429 must not leak cookie");
+    assert.ok(!raw.includes("secret"), "429 must not leak secret");
+
+    const setCookie = r.headers["set-cookie"];
+    assert.ok(
+      !setCookie,
+      "429 must not set session cookie",
+    );
+
+    assert.ok(r.headers["ratelimit-limit"], "429 must include RateLimit-Limit");
+    assert.ok(r.headers["ratelimit-remaining"] !== undefined, "429 must include RateLimit-Remaining");
+    assert.equal(r.headers["ratelimit-remaining"], "0");
+  } finally {
+    await app.close();
+  }
+});
+
+test("respuesta 429 no filtra informacion sensible en login particular", async () => {
+  const app = await createParticularApp();
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS + 1; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: "tok" },
+      });
+    }
+
+    const r = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: "tok" },
+    });
+
+    assert.equal(r.statusCode, 429);
+
+    const body = JSON.parse(r.body) as Record<string, unknown>;
+    const raw = JSON.stringify(body).toLowerCase();
+
+    assert.ok(!raw.includes("hash"), "429 must not leak hash");
+    assert.ok(!raw.includes("cookie"), "429 must not leak cookie");
+    assert.ok(!raw.includes("secret"), "429 must not leak secret");
+
+    const setCookie = r.headers["set-cookie"];
+    assert.ok(
+      !setCookie,
+      "429 must not set particular session cookie",
+    );
+
+    assert.ok(r.headers["ratelimit-limit"], "429 must include RateLimit-Limit");
+    assert.equal(r.headers["ratelimit-remaining"], "0");
+  } finally {
+    await app.close();
+  }
+});
+
+test("IP desconocida no colapsa realm login con realm particular", async () => {
+  const sharedStore = createMemoryRateLimitStore();
+
+  const clinicApp = await createClinicApp({ loginRateLimitStore: sharedStore });
+  const particularApp = await createParticularApp({ loginRateLimitStore: sharedStore });
+
+  try {
+    for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+      await clinicApp.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        payload: { username: "u@v.com", password: "mal" },
+      });
+    }
+
+    const clinicBlocked = await clinicApp.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      payload: { username: "u@v.com", password: "mal" },
+    });
+    assert.equal(clinicBlocked.statusCode, 429, "clinic:unknown must be rate-limited");
+
+    const particularAttempt = await particularApp.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      payload: { token: "tok-invalido" },
+    });
+    assert.notEqual(
+      particularAttempt.statusCode,
+      429,
+      "particular:unknown must NOT be blocked by clinic:unknown exhaustion",
+    );
+    assert.equal(particularAttempt.statusCode, 401);
+  } finally {
+    await clinicApp.close();
+    await particularApp.close();
+  }
+});

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -253,9 +253,17 @@ test("auth login rate limits keep separate in-memory stores per auth domain", ()
       "options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS",
       `${file} login max attempts`,
     );
+    const realmKeyByFile = {
+      "server/routes/auth.fastify.ts":
+        'const rateLimitKey = `login:${request.ip || "unknown"}`;',
+      "server/routes/admin-auth.fastify.ts":
+        'const rateLimitKey = `admin:${request.ip || "unknown"}`;',
+      "server/routes/particular-auth.fastify.ts":
+        'const rateLimitKey = `particular:${request.ip || "unknown"}`;',
+    };
     assertContains(
       source,
-      "const rateLimitKey = request.ip || \"unknown\";",
+      realmKeyByFile[file],
       `${file} login key`,
     );
     assertContains(


### PR DESCRIPTION
## Summary
- Isolate auth rate-limit keys by realm
- Prevent login and particular-token flows from sharing false 429 buckets
- Preserve anti-bruteforce protection within each flow
- Add cross-realm regression coverage

## Validation
- pnpm test: 1940 passed, 0 failed, 1 skipped
- pnpm build: OK
- git diff --check: OK