### PR TITLE
fix(email): stabilize contact delivery and log safe transport failures

### DIFF
--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -29,6 +29,10 @@ type SafeEmailTransportErrorInput = {
   command: string;
   responseCode?: number;
   hostname: string;
+  providerError?: string;
+  providerStatus?: string;
+  providerReason?: string;
+  providerMessage?: string;
 };
 
 const GMAIL_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -40,6 +44,10 @@ class SafeEmailTransportError extends Error {
   command: string;
   responseCode?: number;
   hostname: string;
+  providerError?: string;
+  providerStatus?: string;
+  providerReason?: string;
+  providerMessage?: string;
 
   constructor(message: string, input: SafeEmailTransportErrorInput) {
     super(message);
@@ -51,7 +59,50 @@ class SafeEmailTransportError extends Error {
     if (typeof input.responseCode === "number") {
       this.responseCode = input.responseCode;
     }
+
+    if (typeof input.providerError === "string") {
+      this.providerError = input.providerError;
+    }
+
+    if (typeof input.providerStatus === "string") {
+      this.providerStatus = input.providerStatus;
+    }
+
+    if (typeof input.providerReason === "string") {
+      this.providerReason = input.providerReason;
+    }
+
+    if (typeof input.providerMessage === "string") {
+      this.providerMessage = input.providerMessage;
+    }
   }
+}
+
+const MAX_SAFE_LOG_STRING_LENGTH = 200;
+
+const SENSITIVE_REDACTION_PATTERNS: Array<[RegExp, string]> = [
+  [/ya29\.[A-Za-z0-9_\-]{4,}/g, "[REDACTED:access_token]"],
+  [/1\/\/[A-Za-z0-9_\-]{4,}/g, "[REDACTED:refresh_token]"],
+  [/Bearer\s+\S+/gi, "Bearer [REDACTED]"],
+  [/"refresh_token"\s*:\s*"[^"]*"/g, '"refresh_token":"[REDACTED]"'],
+  [/"access_token"\s*:\s*"[^"]*"/g, '"access_token":"[REDACTED]"'],
+  [/"client_secret"\s*:\s*"[^"]*"/g, '"client_secret":"[REDACTED]"'],
+  [/\btoken=[^\s&"]+/gi, "token=[REDACTED]"],
+  [/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, "[REDACTED:email]"],
+];
+
+function sanitizeLogString(value: string): string {
+  let result = value;
+
+  for (const [pattern, replacement] of SENSITIVE_REDACTION_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+
+  if (result.length > MAX_SAFE_LOG_STRING_LENGTH) {
+    result = `${result.slice(0, MAX_SAFE_LOG_STRING_LENGTH)}...[truncated]`;
+  }
+
+  return result;
 }
 
 function isLikelyEmail(value: string): boolean {
@@ -166,6 +217,10 @@ function buildGmailApiError(
     command: string;
     url: string;
     responseCode?: number;
+    providerError?: string;
+    providerStatus?: string;
+    providerReason?: string;
+    providerMessage?: string;
   },
 ) {
   return new SafeEmailTransportError(message, {
@@ -173,6 +228,10 @@ function buildGmailApiError(
     command: input.command,
     responseCode: input.responseCode,
     hostname: new URL(input.url).hostname,
+    providerError: input.providerError,
+    providerStatus: input.providerStatus,
+    providerReason: input.providerReason,
+    providerMessage: input.providerMessage,
   });
 }
 
@@ -231,11 +290,15 @@ async function getGmailApiAccessToken() {
   );
 
   if (!response.ok) {
+    const errorBody = await readJsonObject(response);
+
     throw buildGmailApiError("Gmail API token request failed", {
       code: "GMAIL_API_TOKEN_FAILED",
       command: "TOKEN",
       url: GMAIL_OAUTH_TOKEN_URL,
       responseCode: response.status,
+      providerError: typeof errorBody.error === "string" ? errorBody.error : undefined,
+      providerReason: typeof errorBody.error_description === "string" ? errorBody.error_description : undefined,
     });
   }
 
@@ -287,11 +350,25 @@ async function sendGmailApiMessage(
   );
 
   if (!response.ok) {
+    const errorBody = await readJsonObject(response);
+    const providerErrorObj =
+      errorBody.error !== null &&
+      typeof errorBody.error === "object" &&
+      !Array.isArray(errorBody.error)
+        ? (errorBody.error as Record<string, unknown>)
+        : null;
+
     throw buildGmailApiError("Gmail API send request failed", {
       code: "GMAIL_API_SEND_FAILED",
       command: "SEND",
       url: GMAIL_MESSAGES_SEND_URL,
       responseCode: response.status,
+      providerError: providerErrorObj && typeof providerErrorObj.status === "string"
+        ? providerErrorObj.status
+        : undefined,
+      providerMessage: providerErrorObj && typeof providerErrorObj.message === "string"
+        ? providerErrorObj.message
+        : undefined,
     });
   }
 
@@ -446,6 +523,95 @@ function resolveContactRecipients(): string[] {
   return [];
 }
 
+export function getSafeEmailTransportErrorMetadata(
+  error: unknown,
+): Record<string, unknown> {
+  if (error instanceof SafeEmailTransportError) {
+    const metadata: Record<string, unknown> = {
+      errorName: error.name,
+      code: error.code,
+      command: error.command,
+      hostname: error.hostname,
+    };
+
+    if (typeof error.responseCode === "number") {
+      metadata.responseCode = error.responseCode;
+    }
+
+    if (typeof error.providerError === "string") {
+      metadata.providerError = sanitizeLogString(error.providerError);
+    }
+
+    if (typeof error.providerStatus === "string") {
+      metadata.providerStatus = sanitizeLogString(error.providerStatus);
+    }
+
+    if (typeof error.providerReason === "string") {
+      metadata.providerReason = sanitizeLogString(error.providerReason);
+    }
+
+    if (typeof error.providerMessage === "string") {
+      metadata.providerMessage = sanitizeLogString(error.providerMessage);
+    }
+
+    return metadata;
+  }
+
+
+  const metadata: Record<string, unknown> = {
+    errorName:
+      error instanceof Error && error.name.trim()
+        ? error.name
+        : "unknown_error",
+  };
+
+  if (!error || typeof error !== "object") {
+    return metadata;
+  }
+
+  const record = error as Record<string, unknown>;
+
+  const code =
+    typeof record.code === "string" && record.code.trim()
+      ? record.code.trim()
+      : undefined;
+  const command =
+    typeof record.command === "string" && record.command.trim()
+      ? record.command.trim()
+      : undefined;
+  const responseCode =
+    typeof record.responseCode === "number" &&
+    Number.isFinite(record.responseCode)
+      ? record.responseCode
+      : undefined;
+  const syscall =
+    typeof record.syscall === "string" && record.syscall.trim()
+      ? record.syscall.trim()
+      : undefined;
+  const hostname =
+    typeof record.hostname === "string" && record.hostname.trim()
+      ? sanitizeLogString(record.hostname.trim())
+      : undefined;
+  const port =
+    typeof record.port === "number" && Number.isFinite(record.port)
+      ? record.port
+      : undefined;
+  const address =
+    typeof record.address === "string" && record.address.trim()
+      ? sanitizeLogString(record.address.trim())
+      : undefined;
+
+  if (code !== undefined) metadata.code = code;
+  if (command !== undefined) metadata.command = command;
+  if (responseCode !== undefined) metadata.responseCode = responseCode;
+  if (syscall !== undefined) metadata.errorSyscall = syscall;
+  if (hostname !== undefined) metadata.hostname = hostname;
+  if (port !== undefined) metadata.errorPort = port;
+  if (address !== undefined) metadata.errorAddress = address;
+
+  return metadata;
+}
+
 export async function sendContactMessageEmail(input: {
   name: string;
   email: string;
@@ -459,8 +625,8 @@ export async function sendContactMessageEmail(input: {
 
   if (recipients.length === 0) {
     console.info("[EMAIL] contact_message skipped: smtp disabled", {
-      email: input.email,
-      clinicName: input.clinicName,
+      hasReplyTo: Boolean(input.email),
+      hasClinicName: Boolean(input.clinicName),
     });
 
     return { sent: false, reason: "smtp_disabled" as const };
@@ -475,16 +641,17 @@ export async function sendContactMessageEmail(input: {
 
   if (!delivery) {
     console.info("[EMAIL] contact_message skipped: smtp disabled", {
-      email: input.email,
-      clinicName: input.clinicName,
+      hasReplyTo: Boolean(input.email),
+      hasClinicName: Boolean(input.clinicName),
     });
 
     return { sent: false, reason: "smtp_disabled" as const };
   }
 
   console.info("[EMAIL] contact_message sent", {
-    email: input.email,
-    clinicName: input.clinicName,
+    hasReplyTo: Boolean(input.email),
+    hasClinicName: Boolean(input.clinicName),
+    recipientCount: recipients.length,
     messageId: delivery.messageId,
     transport: delivery.transport,
   });

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -25,6 +25,7 @@ import {
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import { getSafeEmailTransportErrorMetadata } from "../lib/email.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -682,7 +683,7 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
 
       console.error("[EMAIL] particular_token failed", {
         tokenId: particularToken.id,
-        errorName: getSafeErrorName(error),
+        ...getSafeEmailTransportErrorMetadata(error),
       });
 
       return reply.code(502).send({

--- a/server/routes/contact.fastify.ts
+++ b/server/routes/contact.fastify.ts
@@ -1,3 +1,4 @@
+import { getSafeEmailTransportErrorMetadata } from "../lib/email.ts";
 import type {
   FastifyPluginAsync,
   FastifyReply,
@@ -357,12 +358,9 @@ export const contactNativeRoutes: FastifyPluginAsync<
         message: parsed.data.message,
       });
     } catch (error) {
-      const diagnostics = extractSafeContactEmailErrorDiagnostics(error);
-
       console.error("[EMAIL] contact_message failed", {
-        email: parsed.data.email,
-        clinicName: normalizedClinicName,
-        ...diagnostics,
+        hasClinicName: Boolean(normalizedClinicName),
+        ...getSafeEmailTransportErrorMetadata(error),
       });
 
       return reply.code(502).send({

--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -29,6 +29,7 @@ import {
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import { getSafeEmailTransportErrorMetadata } from "../lib/email.ts";
 
 type ClinicUserRecord = {
   id: number;
@@ -705,7 +706,7 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
 
       console.error("[EMAIL] particular_token failed", {
         tokenId: particularToken.id,
-        errorName: getSafeErrorName(error),
+        ...getSafeEmailTransportErrorMetadata(error),
       });
 
       return reply.code(502).send({

--- a/test/contact-route.test.ts
+++ b/test/contact-route.test.ts
@@ -281,15 +281,16 @@ test("contact endpoint returns controlled smtp error and logs only safe diagnost
   assert.equal(errorCalls[0]?.[0], "[EMAIL] contact_message failed");
 
   const payload = errorCalls[0]?.[1] as Record<string, unknown>;
-  assert.equal(payload.email, "maria@example.com");
-  assert.equal(payload.clinicName, "Clinica Sur");
+  assert.equal("email" in payload, false, "contact email must not appear in error log");
+  assert.equal(payload.hasClinicName, true);
+  assert.equal("clinicName" in payload, false);
   assert.equal(payload.errorName, "Error");
-  assert.equal(payload.errorCode, "ESOCKET");
-  assert.equal(payload.errorCommand, "CONN");
+  assert.equal(payload.code, "ESOCKET");
+  assert.equal(payload.command, "CONN");
   assert.equal(payload.errorSyscall, "connect");
-  assert.equal(payload.errorHostname, "smtp.gmail.com");
+  assert.equal(payload.hostname, "smtp.gmail.com");
   assert.equal(payload.errorPort, 587);
-  assert.equal(payload.errorResponseCode, 421);
+  assert.equal(payload.responseCode, 421);
   assert.equal(payload.errorAddress, "74.125.140.108");
 
   for (const forbiddenKey of [
@@ -304,6 +305,7 @@ test("contact endpoint returns controlled smtp error and logs only safe diagnost
   }
 
   const serializedPayload = JSON.stringify(payload);
+  assert.equal(serializedPayload.includes("maria@example.com"), false, "contact email must not appear serialized");
   assert.equal(serializedPayload.includes(sensitivePass), false);
   assert.equal(serializedPayload.includes(sensitiveUser), false);
   assert.equal(serializedPayload.includes(sensitiveAccessToken), false);

--- a/test/email-safe-metadata.test.ts
+++ b/test/email-safe-metadata.test.ts
@@ -1,0 +1,400 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { getSafeEmailTransportErrorMetadata, sendContactMessageEmail } = await import(
+  "../server/lib/email.ts"
+);
+
+type EmailEnvSnapshot = {
+  isProduction: boolean;
+  contactTo: string[];
+  gmailApi: {
+    enabled: boolean;
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    from: string;
+  };
+};
+
+function snapshotEnv(): EmailEnvSnapshot {
+  return {
+    isProduction: ENV.isProduction,
+    contactTo: ENV.contactTo,
+    gmailApi: {
+      enabled: ENV.gmailApi.enabled,
+      clientId: ENV.gmailApi.clientId,
+      clientSecret: ENV.gmailApi.clientSecret,
+      refreshToken: ENV.gmailApi.refreshToken,
+      from: ENV.gmailApi.from,
+    },
+  };
+}
+
+function restoreEnv(snapshot: EmailEnvSnapshot) {
+  (ENV as any).isProduction = snapshot.isProduction;
+  (ENV as any).contactTo = snapshot.contactTo;
+  (ENV.gmailApi as any).enabled = snapshot.gmailApi.enabled;
+  (ENV.gmailApi as any).clientId = snapshot.gmailApi.clientId;
+  (ENV.gmailApi as any).clientSecret = snapshot.gmailApi.clientSecret;
+  (ENV.gmailApi as any).refreshToken = snapshot.gmailApi.refreshToken;
+  (ENV.gmailApi as any).from = snapshot.gmailApi.from;
+}
+
+function enableGmailApi() {
+  (ENV.gmailApi as any).enabled = true;
+  (ENV.gmailApi as any).clientId = "test-client-id";
+  (ENV.gmailApi as any).clientSecret = "test-client-secret";
+  (ENV.gmailApi as any).refreshToken = "test-refresh-token";
+  (ENV.gmailApi as any).from = "lab.vetneb@gmail.com";
+  (ENV as any).isProduction = true;
+  (ENV as any).contactTo = ["ops@vetneb.com"];
+}
+
+// ── Generic error path ────────────────────────────────────────────────────────
+
+test("getSafeEmailTransportErrorMetadata: errorName para Error genérico", () => {
+  const error = new Error("algo salió mal");
+  const metadata = getSafeEmailTransportErrorMetadata(error);
+  assert.equal(metadata.errorName, "Error");
+});
+
+test("getSafeEmailTransportErrorMetadata: unknown_error para non-Error", () => {
+  assert.equal(getSafeEmailTransportErrorMetadata("falla").errorName, "unknown_error");
+  assert.equal(getSafeEmailTransportErrorMetadata(null).errorName, "unknown_error");
+  assert.equal(getSafeEmailTransportErrorMetadata(42).errorName, "unknown_error");
+});
+
+test("getSafeEmailTransportErrorMetadata: extrae campos SMTP del error", () => {
+  const smtpError = Object.assign(new Error("SMTP conn failed"), {
+    code: "ESOCKET",
+    command: "CONN",
+    syscall: "connect",
+    hostname: "smtp.gmail.com",
+    port: 587,
+    responseCode: 421,
+    address: "74.125.140.108",
+  });
+
+  const metadata = getSafeEmailTransportErrorMetadata(smtpError);
+
+  assert.equal(metadata.errorName, "Error");
+  assert.equal(metadata.code, "ESOCKET");
+  assert.equal(metadata.command, "CONN");
+  assert.equal(metadata.errorSyscall, "connect");
+  assert.equal(metadata.hostname, "smtp.gmail.com");
+  assert.equal(metadata.errorPort, 587);
+  assert.equal(metadata.responseCode, 421);
+  assert.equal(metadata.errorAddress, "74.125.140.108");
+  assert.equal("providerError" in metadata, false);
+  assert.equal("providerMessage" in metadata, false);
+});
+
+test("getSafeEmailTransportErrorMetadata: no expone campos sensibles de error SMTP", () => {
+  const smtpError = Object.assign(new Error("SMTP auth failed"), {
+    code: "EAUTH",
+    command: "AUTH",
+    hostname: "smtp.gmail.com",
+    pass: "super-secret-password",
+    auth: { user: "user@example.com", pass: "secret" },
+  });
+
+  const metadata = getSafeEmailTransportErrorMetadata(smtpError);
+  const serialized = JSON.stringify(metadata);
+
+  assert.equal("pass" in metadata, false);
+  assert.equal("auth" in metadata, false);
+  assert.equal(serialized.includes("super-secret-password"), false);
+  assert.equal(serialized.includes("secret"), false);
+});
+
+// ── SafeEmailTransportError path (vía Gmail API) ──────────────────────────────
+
+test("getSafeEmailTransportErrorMetadata: captura code/command/hostname/responseCode de EmailTransportError (token failure)", async () => {
+  const originalEnv = snapshotEnv();
+  const originalFetch = globalThis.fetch;
+
+  enableGmailApi();
+
+  (globalThis as any).fetch = async (url: string) => {
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(
+        JSON.stringify({ error: "invalid_grant", error_description: "Token has been expired or revoked." }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error("unexpected fetch");
+  };
+
+  try {
+    const caught = await sendContactMessageEmail({
+      name: "Test User",
+      email: "test@example.com",
+      clinicName: null,
+      message: "Mensaje de prueba para metadata.",
+    }).catch((e: unknown) => e);
+
+    assert.ok(caught instanceof Error, "debe lanzar un Error");
+
+    const metadata = getSafeEmailTransportErrorMetadata(caught);
+
+    assert.equal(metadata.errorName, "EmailTransportError");
+    assert.equal(metadata.code, "GMAIL_API_TOKEN_FAILED");
+    assert.equal(metadata.command, "TOKEN");
+    assert.equal(metadata.hostname, "oauth2.googleapis.com");
+    assert.equal(metadata.responseCode, 401);
+    assert.equal(metadata.providerError, "invalid_grant");
+    assert.equal(
+      metadata.providerReason,
+      "Token has been expired or revoked.",
+    );
+    assert.equal("providerMessage" in metadata, false);
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+    restoreEnv(originalEnv);
+  }
+});
+
+test("getSafeEmailTransportErrorMetadata: captura providerError/providerMessage de fallo Gmail send", async () => {
+  const originalEnv = snapshotEnv();
+  const originalFetch = globalThis.fetch;
+
+  enableGmailApi();
+
+  (globalThis as any).fetch = async (url: string) => {
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(
+        JSON.stringify({ access_token: "ya29.test-access-token" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    if (url.includes("gmail.googleapis.com")) {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: 403,
+            status: "PERMISSION_DENIED",
+            message: "Request had insufficient authentication scopes.",
+          },
+        }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error("unexpected fetch");
+  };
+
+  try {
+    const caught = await sendContactMessageEmail({
+      name: "Test User",
+      email: "test@example.com",
+      clinicName: null,
+      message: "Mensaje de prueba para metadata de send.",
+    }).catch((e: unknown) => e);
+
+    assert.ok(caught instanceof Error, "debe lanzar un Error");
+
+    const metadata = getSafeEmailTransportErrorMetadata(caught);
+
+    assert.equal(metadata.errorName, "EmailTransportError");
+    assert.equal(metadata.code, "GMAIL_API_SEND_FAILED");
+    assert.equal(metadata.command, "SEND");
+    assert.equal(metadata.hostname, "gmail.googleapis.com");
+    assert.equal(metadata.responseCode, 403);
+    assert.equal(metadata.providerError, "PERMISSION_DENIED");
+    assert.equal(
+      metadata.providerMessage,
+      "Request had insufficient authentication scopes.",
+    );
+    assert.equal("providerReason" in metadata, false);
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+    restoreEnv(originalEnv);
+  }
+});
+
+// ── Sanitizer ────────────────────────────────────────────────────────────────
+
+test("getSafeEmailTransportErrorMetadata: redacta access token ya29 en providerReason", async () => {
+  const originalEnv = snapshotEnv();
+  const originalFetch = globalThis.fetch;
+
+  enableGmailApi();
+
+  (globalThis as any).fetch = async (url: string) => {
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Token ya29.AQEBsJ_SENSITIVE_TOKEN has expired. Contact user@domain.com.",
+        }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error("unexpected fetch");
+  };
+
+  try {
+    const caught = await sendContactMessageEmail({
+      name: "Sanitizer Test",
+      email: "sanitizer@example.com",
+      clinicName: null,
+      message: "Mensaje de prueba sanitizer.",
+    }).catch((e: unknown) => e);
+
+    assert.ok(caught instanceof Error);
+
+    const metadata = getSafeEmailTransportErrorMetadata(caught);
+    const reason = metadata.providerReason as string;
+
+    assert.ok(typeof reason === "string");
+    assert.equal(reason.includes("ya29."), false, "access token debe estar redactado");
+    assert.equal(reason.includes("AQEBsJ_SENSITIVE_TOKEN"), false);
+    assert.equal(reason.includes("[REDACTED:access_token]"), true);
+    assert.equal(reason.includes("@domain.com"), false, "email debe estar redactado");
+    assert.equal(reason.includes("[REDACTED:email]"), true);
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+    restoreEnv(originalEnv);
+  }
+});
+
+test("getSafeEmailTransportErrorMetadata: redacta refresh token 1// en providerReason", async () => {
+  const originalEnv = snapshotEnv();
+  const originalFetch = globalThis.fetch;
+
+  enableGmailApi();
+
+  (globalThis as any).fetch = async (url: string) => {
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Invalid refresh token 1//AEzb9SENSITIVE_REFRESH_HERE provided.",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error("unexpected fetch");
+  };
+
+  try {
+    const caught = await sendContactMessageEmail({
+      name: "Refresh Test",
+      email: "refresh@example.com",
+      clinicName: null,
+      message: "Mensaje de prueba refresh token.",
+    }).catch((e: unknown) => e);
+
+    assert.ok(caught instanceof Error);
+
+    const metadata = getSafeEmailTransportErrorMetadata(caught);
+    const reason = metadata.providerReason as string;
+
+    assert.ok(typeof reason === "string");
+    assert.equal(reason.includes("1//AEzb9"), false, "refresh token debe estar redactado");
+    assert.equal(reason.includes("[REDACTED:refresh_token]"), true);
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+    restoreEnv(originalEnv);
+  }
+});
+
+test("getSafeEmailTransportErrorMetadata: trunca providerReason cuando supera el límite", async () => {
+  const originalEnv = snapshotEnv();
+  const originalFetch = globalThis.fetch;
+
+  enableGmailApi();
+
+  const longDescription = "A".repeat(300);
+
+  (globalThis as any).fetch = async (url: string) => {
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(
+        JSON.stringify({ error: "invalid_grant", error_description: longDescription }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error("unexpected fetch");
+  };
+
+  try {
+    const caught = await sendContactMessageEmail({
+      name: "Truncate Test",
+      email: "truncate@example.com",
+      clinicName: null,
+      message: "Mensaje de prueba truncado.",
+    }).catch((e: unknown) => e);
+
+    assert.ok(caught instanceof Error);
+
+    const metadata = getSafeEmailTransportErrorMetadata(caught);
+    const reason = metadata.providerReason as string;
+
+    assert.ok(typeof reason === "string");
+    assert.ok(reason.length <= 215, `providerReason debe estar truncado; longitud: ${reason.length}`);
+    assert.ok(reason.includes("...[truncated]"), "debe incluir marcador de truncado");
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+    restoreEnv(originalEnv);
+  }
+});
+
+test("getSafeEmailTransportErrorMetadata: no expone secretos de token ni creds en metadata", async () => {
+  const originalEnv = snapshotEnv();
+  const originalFetch = globalThis.fetch;
+
+  enableGmailApi();
+
+  (globalThis as any).fetch = async (url: string) => {
+    if (url.includes("oauth2.googleapis.com")) {
+      return new Response(
+        JSON.stringify({ access_token: "ya29.secret-access-token" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    if (url.includes("gmail.googleapis.com")) {
+      return new Response(
+        JSON.stringify({ error: { status: "UNAUTHENTICATED", message: "Invalid credentials." } }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error("unexpected fetch");
+  };
+
+  try {
+    const caught = await sendContactMessageEmail({
+      name: "Secrets Test",
+      email: "secrets@example.com",
+      clinicName: null,
+      message: "Mensaje de prueba secretos.",
+    }).catch((e: unknown) => e);
+
+    assert.ok(caught instanceof Error);
+
+    const metadata = getSafeEmailTransportErrorMetadata(caught);
+    const serialized = JSON.stringify(metadata);
+
+    assert.equal(serialized.includes("test-client-secret"), false, "client_secret no debe aparecer");
+    assert.equal(serialized.includes("test-refresh-token"), false, "refresh_token no debe aparecer");
+    assert.equal(serialized.includes("ya29.secret-access-token"), false, "access_token no debe aparecer");
+    assert.equal(serialized.includes("secrets@example.com"), false, "email no debe aparecer");
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+    restoreEnv(originalEnv);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds sanitized Gmail API/email transport failure metadata for operational diagnosis.
- Applies safe email failure logging to contact and particular-token flows.
- Removes contact email/clinicName PII from email transport logs.
- Adds coverage for safe metadata redaction and contact failure diagnostics.

## Validation
- pnpm test: 1951 tests, 1950 pass, 0 fail, 1 skipped
- pnpm build

## Notes
- No SMTP behavior change.
- No CSP change.
- No auth/login change.
- No secrets, cookies, raw tokens, envs, or user message bodies are logged.