### PR TITLE
fix(auth): persist sessions across tab closes

### DIFF
--- a/PR-fix-auth-persist-sessions-tab-close.md
+++ b/PR-fix-auth-persist-sessions-tab-close.md
@@ -1,0 +1,71 @@
+# PR: fix(auth): persist sessions across tab closes
+
+## Skills Claude utilizadas
+
+- `vetneb-security-production-invariants`
+  - Uso: validar cookies HttpOnly, Max-Age positivo, logout explícito, separación de dominios admin/clinic/particular y no regresión de auth.
+
+- `vetneb-protocolos-comunicacion`
+  - Uso: revisar contratos HTTP `Set-Cookie`, `Max-Age`, `Expires`, `SameSite`, `Secure`, CORS y persistencia cliente-servidor.
+
+- `vetneb-staff-senior-full-stack-engineer`
+  - Uso: implementar tests mínimos de contrato y mantener compatibilidad con Fastify, frontend y suite existente.
+
+- `vetneb-bugs-errores-optimizacion-rutas`
+  - Uso: auditar si había pérdida de sesión por rutas, middleware, redirects, recarga, cookies o estado frontend.
+
+## Diagnóstico
+
+El backend ya generaba cookies persistentes para los tres roles mediante `Max-Age = ENV.sessionTtlHours * 60 * 60`.
+
+Roles auditados:
+
+- Administrador: `admin_session_id`
+- Clínica: `app_session_id`
+- Particular: `particular_session_id`
+
+También se verificó que el logout de cada rol limpia únicamente su cookie correspondiente con `Max-Age=0` y `Expires=Thu, 01 Jan 1970 00:00:00 GMT`.
+
+No se encontró uso de `sessionStorage`, `localStorage`, `beforeunload`, `unload` ni `visibilitychange` como mecanismo de cierre de sesión al cerrar pestaña.
+
+## Cambios realizados
+
+- Se agregaron contratos de persistencia para cookies de login por rol.
+- Se reforzaron tests runtime existentes para exigir `Max-Age` positivo en login.
+- Se reforzó el guardrail de seguridad de cookies de sesión.
+- Se agregó un test dedicado para evitar regresiones de cookies sin `Max-Age`, logout por cierre de pestaña y estado frontend como fuente de verdad de sesión.
+
+## Archivos modificados
+
+- `test/auth.fastify.test.ts`
+- `test/admin-auth.fastify.test.ts`
+- `test/particular-auth.fastify.test.ts`
+- `test/security-session-cookie-boundaries.test.ts`
+- `test/auth-cookie-persistence-contract.test.ts`
+
+## Validación
+
+```powershell
+pnpm test
+pnpm build
+```
+
+Resultado local:
+
+```txt
+pnpm test: 1965 pass / 0 fail / 1 skipped
+pnpm build: OK
+```
+
+## Riesgos
+
+- Bajo: no se cambia lógica productiva de auth; se agregan contratos para proteger comportamiento existente.
+- Bajo: el TTL sigue dependiendo de `SESSION_TTL_HOURS`.
+- Medio si se interpreta "solo logout" como sesión infinita: este PR no elimina expiración TTL por seguridad. Mantiene persistencia al cerrar pestaña mientras el TTL esté vigente.
+
+## Evidencia de invariante
+
+- Las cookies de login de admin, clínica y particular son persistentes porque incluyen `Max-Age` positivo.
+- Cerrar pestaña o navegador no ejecuta logout.
+- Logout explícito sigue limpiando solo la cookie del rol correspondiente.
+- No se tocaron email, Gmail API, dominio propio, variables reales de producción ni permisos RBAC.

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -121,6 +121,8 @@ test(
       assert.ok(setCookie.includes(`${ENV.adminCookieName}=admin-token-123`));
       assert.ok(setCookie.includes("Path=/"));
       assert.ok(setCookie.includes("HttpOnly"));
+      assert.ok(setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`));
+      assert.equal(setCookie.includes("Max-Age=0"), false);
 
       assert.deepEqual(JSON.parse(response.body), {
         success: true,

--- a/test/auth-cookie-persistence-contract.test.ts
+++ b/test/auth-cookie-persistence-contract.test.ts
@@ -1,0 +1,288 @@
+/**
+ * auth-cookie-persistence-contract.test.ts
+ *
+ * Guarantees that:
+ *  1. Login cookies for all three roles carry a positive Max-Age (persistent cookies).
+ *  2. Logout builders clear with Max-Age=0 only.
+ *  3. No frontend code uses sessionStorage/localStorage as auth source of truth.
+ *  4. No frontend code triggers logout on beforeunload / unload / visibilitychange.
+ *
+ * These are source-level contract tests — they fail fast if the invariant is broken
+ * before any runtime test executes.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+}
+
+function collectTsFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const full = `${dir}/${entry}`;
+    const stat = statSync(full);
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") continue;
+      results.push(...collectTsFiles(full));
+    } else if (entry.endsWith(".ts") || entry.endsWith(".tsx")) {
+      results.push(full);
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Cookie builders use positive Max-Age on login
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: clinic login builder encodes positive Max-Age", () => {
+  const source = readSource("server/routes/auth.fastify.ts");
+
+  assert.ok(
+    source.includes("maxAgeSeconds: ENV.sessionTtlHours * 60 * 60"),
+    "buildSessionCookie must pass maxAgeSeconds = sessionTtlHours * 3600",
+  );
+  assert.ok(
+    source.includes("function buildSessionCookie"),
+    "buildSessionCookie must be defined",
+  );
+  assert.ok(
+    source.includes("function buildAdminSessionCookie"),
+    "buildAdminSessionCookie must be defined (unified auth sets admin cookie)",
+  );
+  assert.ok(
+    source.includes("function buildParticularSessionCookie"),
+    "buildParticularSessionCookie must be defined (unified auth sets particular cookie)",
+  );
+});
+
+test("cookie persistence contract: admin login builder encodes positive Max-Age", () => {
+  const source = readSource("server/routes/admin-auth.fastify.ts");
+
+  assert.ok(
+    source.includes("maxAgeSeconds: ENV.sessionTtlHours * 60 * 60"),
+    "buildAdminSessionCookie must pass maxAgeSeconds = sessionTtlHours * 3600",
+  );
+  assert.ok(
+    source.includes("function buildAdminSessionCookie"),
+    "buildAdminSessionCookie must be defined",
+  );
+});
+
+test("cookie persistence contract: particular login builder encodes positive Max-Age", () => {
+  const source = readSource("server/routes/particular-auth.fastify.ts");
+
+  assert.ok(
+    source.includes("maxAgeSeconds: ENV.sessionTtlHours * 60 * 60"),
+    "buildParticularSessionCookie must pass maxAgeSeconds = sessionTtlHours * 3600",
+  );
+  assert.ok(
+    source.includes("function buildParticularSessionCookie"),
+    "buildParticularSessionCookie must be defined",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2. Logout builders clear with Max-Age=0 and epoch Expires
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: logout builders clear with Max-Age=0 and epoch Expires", () => {
+  for (const [label, file, clearFn] of [
+    ["clinic", "server/routes/auth.fastify.ts", "buildClearSessionCookie"],
+    ["admin", "server/routes/admin-auth.fastify.ts", "buildClearAdminSessionCookie"],
+    ["particular", "server/routes/particular-auth.fastify.ts", "buildClearParticularSessionCookie"],
+  ] as const) {
+    const source = readSource(file);
+
+    assert.ok(
+      source.includes(`function ${clearFn}`),
+      `${label}: ${clearFn} must be defined`,
+    );
+    assert.ok(
+      source.includes("maxAgeSeconds: 0"),
+      `${label}: ${clearFn} must pass maxAgeSeconds: 0`,
+    );
+    assert.ok(
+      source.includes('expires: "Thu, 01 Jan 1970 00:00:00 GMT"'),
+      `${label}: ${clearFn} must include epoch Expires`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Login cookie serializer emits Max-Age directive
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: serializeCookie emits Max-Age directive", () => {
+  for (const [label, file] of [
+    ["clinic", "server/routes/auth.fastify.ts"],
+    ["admin", "server/routes/admin-auth.fastify.ts"],
+    ["particular", "server/routes/particular-auth.fastify.ts"],
+  ] as const) {
+    const source = readSource(file);
+
+    assert.ok(
+      source.includes("Max-Age=${input.maxAgeSeconds}"),
+      `${label}: serializeCookie must emit Max-Age directive`,
+    );
+    assert.ok(
+      source.includes('typeof input.maxAgeSeconds === "number"'),
+      `${label}: serializeCookie must guard maxAgeSeconds type before emitting`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. No frontend code uses sessionStorage / localStorage as auth source
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: frontend has no sessionStorage or localStorage auth source", () => {
+  const frontendSrcDir = resolve(REPO_ROOT, "frontend/src");
+  const files = collectTsFiles(frontendSrcDir);
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const relPath = file.replace(REPO_ROOT + "/", "");
+
+    assert.equal(
+      source.includes("sessionStorage"),
+      false,
+      `${relPath} must not use sessionStorage`,
+    );
+    assert.equal(
+      source.includes("localStorage"),
+      false,
+      `${relPath} must not use localStorage`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. No frontend code triggers logout on tab close events
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: frontend has no beforeunload/unload/visibilitychange logout", () => {
+  const frontendSrcDir = resolve(REPO_ROOT, "frontend/src");
+  const files = collectTsFiles(frontendSrcDir);
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const relPath = file.replace(REPO_ROOT + "/", "");
+
+    assert.equal(
+      source.includes("beforeunload"),
+      false,
+      `${relPath} must not register beforeunload`,
+    );
+    assert.equal(
+      source.includes('"unload"'),
+      false,
+      `${relPath} must not register unload event listener`,
+    );
+    assert.equal(
+      source.includes("'unload'"),
+      false,
+      `${relPath} must not register unload event listener`,
+    );
+    assert.equal(
+      source.includes("visibilitychange"),
+      false,
+      `${relPath} must not register visibilitychange`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Session validation is cookie-based (not memory-based) on page load
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: AuthContext calls backend on mount to hydrate session", () => {
+  const source = readSource("frontend/src/context/AuthContext.tsx");
+
+  assert.ok(
+    source.includes("getClinicSession"),
+    "AuthContext must call getClinicSession to validate session from cookie",
+  );
+  assert.ok(
+    source.includes("useEffect"),
+    "AuthContext must use useEffect to trigger hydration on mount",
+  );
+  assert.ok(
+    source.includes("refreshSession"),
+    "AuthContext must expose refreshSession for rehydration",
+  );
+  assert.equal(
+    source.includes("sessionStorage"),
+    false,
+    "AuthContext must not use sessionStorage",
+  );
+  assert.equal(
+    source.includes("localStorage"),
+    false,
+    "AuthContext must not use localStorage",
+  );
+});
+
+test("cookie persistence contract: ParticularesContent calls backend on mount to hydrate session", () => {
+  const source = readSource("frontend/src/components/public/ParticularesContent.tsx");
+
+  assert.ok(
+    source.includes("getParticularSession"),
+    "ParticularesContent must call getParticularSession to validate session from cookie",
+  );
+  assert.ok(
+    source.includes("useEffect"),
+    "ParticularesContent must use useEffect to trigger hydration on mount",
+  );
+  assert.equal(
+    source.includes("sessionStorage"),
+    false,
+    "ParticularesContent must not use sessionStorage",
+  );
+  assert.equal(
+    source.includes("localStorage"),
+    false,
+    "ParticularesContent must not use localStorage",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 7. Middleware protects /dashboard/* using cookies (not memory state)
+// ---------------------------------------------------------------------------
+
+test("cookie persistence contract: Next.js middleware guards dashboard using cookie presence", () => {
+  const source = readSource("frontend/src/middleware.ts");
+
+  assert.ok(
+    source.includes("request.cookies.get"),
+    "middleware must read cookies from request to protect dashboard",
+  );
+  assert.ok(
+    source.includes("app_session_id"),
+    "middleware must check app_session_id for clinic dashboard",
+  );
+  assert.ok(
+    source.includes("admin_session_id"),
+    "middleware must check admin_session_id for admin dashboard",
+  );
+  assert.equal(
+    source.includes("sessionStorage"),
+    false,
+    "middleware must not check sessionStorage",
+  );
+  assert.equal(
+    source.includes("localStorage"),
+    false,
+    "middleware must not check localStorage",
+  );
+});

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -204,6 +204,8 @@ test(
       assert.ok(setCookie.includes(`${ENV.cookieName}=token-123`));
       assert.ok(setCookie.includes("Path=/"));
       assert.ok(setCookie.includes("HttpOnly"));
+      assert.ok(setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`));
+      assert.equal(setCookie.includes("Max-Age=0"), false);
 
       assert.deepEqual(JSON.parse(response.body), {
         success: true,
@@ -301,6 +303,8 @@ test(
 
       const setCookie = getSetCookieHeader(response);
       assert.ok(setCookie.includes(`${ENV.adminCookieName}=admin-token-123`));
+      assert.ok(setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`));
+      assert.equal(setCookie.includes("Max-Age=0"), false);
       assert.equal(setCookie.includes(`${ENV.cookieName}=`), false);
       assert.equal(setCookie.includes(`${ENV.particularCookieName}=`), false);
 
@@ -704,6 +708,8 @@ test(
       assert.ok(
         setCookie.includes(`${ENV.particularCookieName}=particular-session-123`),
       );
+      assert.ok(setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`));
+      assert.equal(setCookie.includes("Max-Age=0"), false);
       assert.equal(setCookie.includes(`${ENV.cookieName}=`), false);
       assert.equal(setCookie.includes(`${ENV.adminCookieName}=`), false);
 

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -165,6 +165,8 @@ test(
       );
       assert.ok(setCookie.includes("Path=/"));
       assert.ok(setCookie.includes("HttpOnly"));
+      assert.ok(setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`));
+      assert.equal(setCookie.includes("Max-Age=0"), false);
 
       assert.equal(sessionCalls.length, 1);
       assert.equal(sessionCalls[0].particularTokenId, particularToken.id);

--- a/test/security-session-cookie-boundaries.test.ts
+++ b/test/security-session-cookie-boundaries.test.ts
@@ -288,17 +288,23 @@ test("runtime middleware and fastify tests remain explicit for cookie contracts"
   assertContains(clinicAuthTests, "setCookie.includes(`${ENV.cookieName}=token-123`)", "clinic login set cookie");
   assertContains(clinicAuthTests, 'setCookie.includes("Path=/")', "clinic login cookie path");
   assertContains(clinicAuthTests, 'setCookie.includes("HttpOnly")', "clinic login cookie httpOnly");
+  assertContains(clinicAuthTests, "setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`)", "clinic login cookie persistent max age");
+  assertContains(clinicAuthTests, 'setCookie.includes("Max-Age=0"), false', "clinic login cookie not session cookie");
   assertContains(clinicAuthTests, 'setCookie.includes("Max-Age=0")', "clinic logout max age");
 
   assertContains(adminAuthTests, "setCookie.includes(`${ENV.adminCookieName}=admin-token-123`)", "admin login set cookie");
   assertContains(adminAuthTests, 'setCookie.includes("Path=/")', "admin login cookie path");
   assertContains(adminAuthTests, 'setCookie.includes("HttpOnly")', "admin login cookie httpOnly");
+  assertContains(adminAuthTests, "setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`)", "admin login cookie persistent max age");
+  assertContains(adminAuthTests, 'setCookie.includes("Max-Age=0"), false', "admin login cookie not session cookie");
   assertContains(adminAuthTests, 'setCookie.includes("Max-Age=0")', "admin logout max age");
 
   assertContains(particularAuthTests, "setCookie.includes(", "particular login set cookie");
   assertContains(particularAuthTests, "ENV.particularCookieName", "particular login uses env cookie");
   assertContains(particularAuthTests, 'setCookie.includes("Path=/")', "particular login cookie path");
   assertContains(particularAuthTests, 'setCookie.includes("HttpOnly")', "particular login cookie httpOnly");
+  assertContains(particularAuthTests, "setCookie.includes(`Max-Age=${ENV.sessionTtlHours * 60 * 60}`)", "particular login cookie persistent max age");
+  assertContains(particularAuthTests, 'setCookie.includes("Max-Age=0"), false', "particular login cookie not session cookie");
   assertContains(particularAuthTests, 'setCookie.includes("Max-Age=0")', "particular logout max age");
 });
 


### PR DESCRIPTION
# PR: fix(auth): persist sessions across tab closes

## Skills Claude utilizadas

- `vetneb-security-production-invariants`
  - Uso: validar cookies HttpOnly, Max-Age positivo, logout explícito, separación de dominios admin/clinic/particular y no regresión de auth.

- `vetneb-protocolos-comunicacion`
  - Uso: revisar contratos HTTP `Set-Cookie`, `Max-Age`, `Expires`, `SameSite`, `Secure`, CORS y persistencia cliente-servidor.

- `vetneb-staff-senior-full-stack-engineer`
  - Uso: implementar tests mínimos de contrato y mantener compatibilidad con Fastify, frontend y suite existente.

- `vetneb-bugs-errores-optimizacion-rutas`
  - Uso: auditar si había pérdida de sesión por rutas, middleware, redirects, recarga, cookies o estado frontend.

## Diagnóstico

El backend ya generaba cookies persistentes para los tres roles mediante `Max-Age = ENV.sessionTtlHours * 60 * 60`.

Roles auditados:

- Administrador: `admin_session_id`
- Clínica: `app_session_id`
- Particular: `particular_session_id`

También se verificó que el logout de cada rol limpia únicamente su cookie correspondiente con `Max-Age=0` y `Expires=Thu, 01 Jan 1970 00:00:00 GMT`.

No se encontró uso de `sessionStorage`, `localStorage`, `beforeunload`, `unload` ni `visibilitychange` como mecanismo de cierre de sesión al cerrar pestaña.

## Cambios realizados

- Se agregaron contratos de persistencia para cookies de login por rol.
- Se reforzaron tests runtime existentes para exigir `Max-Age` positivo en login.
- Se reforzó el guardrail de seguridad de cookies de sesión.
- Se agregó un test dedicado para evitar regresiones de cookies sin `Max-Age`, logout por cierre de pestaña y estado frontend como fuente de verdad de sesión.

## Archivos modificados

- `test/auth.fastify.test.ts`
- `test/admin-auth.fastify.test.ts`
- `test/particular-auth.fastify.test.ts`
- `test/security-session-cookie-boundaries.test.ts`
- `test/auth-cookie-persistence-contract.test.ts`

## Validación

```powershell
pnpm test
pnpm build
```

Resultado local:

```txt
pnpm test: 1965 pass / 0 fail / 1 skipped
pnpm build: OK
```

## Riesgos

- Bajo: no se cambia lógica productiva de auth; se agregan contratos para proteger comportamiento existente.
- Bajo: el TTL sigue dependiendo de `SESSION_TTL_HOURS`.
- Medio si se interpreta "solo logout" como sesión infinita: este PR no elimina expiración TTL por seguridad. Mantiene persistencia al cerrar pestaña mientras el TTL esté vigente.

## Evidencia de invariante

- Las cookies de login de admin, clínica y particular son persistentes porque incluyen `Max-Age` positivo.
- Cerrar pestaña o navegador no ejecuta logout.
- Logout explícito sigue limpiando solo la cookie del rol correspondiente.
- No se tocaron email, Gmail API, dominio propio, variables reales de producción ni permisos RBAC.
