### PR TITLE
fix(admin): hard delete particular tokens and disable autocomplete

### DIFF
--- a/PR-fix-admin-hard-delete-particular-tokens-autocomplete.md
+++ b/PR-fix-admin-hard-delete-particular-tokens-autocomplete.md
@@ -1,0 +1,78 @@
+# PR: fix(admin): hard delete particular tokens and disable autocomplete
+
+## Skills Claude utilizadas
+
+- `vetneb-security-production-invariants`
+  - Uso: validar privacidad, hard delete de tokens particulares, eliminación de sesiones asociadas por FK cascade, no exposición de `tokenHash`/`tokenLast4`, y ausencia de logs nuevos con token.
+
+- `vetneb-admin-dashboard-operational-actions`
+  - Uso: corregir comportamiento del dashboard admin, acción de eliminar token, actualización del listado y mensajes de UI.
+
+- `vetneb-protocolos-comunicacion`
+  - Uso: revisar contrato HTTP `DELETE`, compatibilidad legacy `PATCH /revoke`, CORS/OPTIONS y status codes.
+
+- `vetneb-bugs-errores-optimizacion-rutas`
+  - Uso: diagnosticar tokens inactivos persistentes, rutas admin particular tokens y autocomplete/autofill en formularios.
+
+- `vetneb-staff-senior-full-stack-engineer`
+  - Uso: implementar backend, frontend y tests con scope mínimo.
+
+## Diagnóstico
+
+- `revokeParticularToken(id)` hacía soft-delete con `isActive=false`, por lo que el token quedaba en servidor y seguía visible como inactivo.
+- El listado admin podía seguir mostrando tokens inactivos.
+- Los formularios de generación de tokens permitían sugerencias/autocomplete del navegador.
+
+## Cambios realizados
+
+- Se agregó `deleteParticularToken(id)` para borrar físicamente tokens particulares.
+- Se agregó endpoint `DELETE /api/admin/particular-tokens/:tokenId`.
+- `PATCH /api/admin/particular-tokens/:tokenId/revoke` queda como alias legacy, pero ahora ejecuta hard delete.
+- La respuesta de eliminación devuelve `deletedTokenId` y no devuelve detalle completo del token eliminado.
+- El frontend admin usa `deleteAdminParticularToken` y muestra terminología de eliminación.
+- La UI remueve el token eliminado del listado.
+- Se desactivó autocomplete en formularios sensibles de tokens particulares admin y clínica.
+- Se mantuvo el marker `app.options("/:tokenId", optionsHandler)` y se agregó `DELETE` a `access-control-allow-methods`.
+
+## Archivos modificados
+
+- `server/db-particular.ts`
+- `server/routes/admin-particular-tokens.fastify.ts`
+- `frontend/src/lib/api.ts`
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `test/admin-particular-tokens.fastify.test.ts`
+- `test/frontend-admin-particular-tokens.test.ts`
+
+## Validación
+
+```powershell
+node --experimental-strip-types --experimental-specifier-resolution=node --test test/security-critical-route-surface-registry.test.ts
+node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-particular-tokens.fastify.test.ts
+node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-particular-tokens.test.ts
+pnpm test
+pnpm build
+```
+
+Resultado local:
+
+```txt
+pnpm test: 1975 pass / 0 fail / 1 skipped
+pnpm build: OK
+```
+
+## Riesgos
+
+- Medio: cambia semántica de revocación a hard delete. Se conserva `PATCH /revoke` como alias legacy para compatibilidad.
+- Bajo: `particular_sessions` asociadas se eliminan por FK `ON DELETE CASCADE`.
+- Bajo: autocomplete depende del navegador; el portal ahora declara `autoComplete="off"` en formularios sensibles, pero historiales ya guardados por el navegador no pueden borrarse desde el servidor.
+
+## Evidencia de invariante
+
+- Token eliminado desaparece del servidor mediante hard delete.
+- El listado admin ya no muestra tokens eliminados.
+- Las sesiones particulares asociadas quedan invalidadas por cascade.
+- La respuesta de eliminación no devuelve `tokenHash` ni `tokenLast4`.
+- No se usa `Token inactivo` en la tarjeta admin.
+- Formularios sensibles de token tienen `autoComplete="off"`.
+- No se tocaron email, Gmail API, refresh token, dominio propio, variables reales de producción ni auth sessions/cookies.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@next/eslint-plugin-next": "15.5.18",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^25.9.1",

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -13,9 +13,9 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   createAdminParticularToken,
+  deleteAdminParticularToken,
   getAdminUsersRoles,
   getAdminParticularTokens,
-  revokeAdminParticularToken,
   type AdminParticularTokenCreatePayload,
   type AdminParticularTokenSummary,
 } from "@/lib/api";
@@ -510,13 +510,13 @@ export function AdminParticularTokensCard() {
     }
   }
 
-  async function handleRevokeToken(token: AdminParticularTokenSummary) {
+  async function handleDeleteToken(token: AdminParticularTokenSummary) {
     if (revokingTokenId !== null) {
       return;
     }
 
     const confirmed = window.confirm(
-      `¿Revocar el token ****${token.tokenLast4} de ${token.petName}? Esta acción inhabilita su uso para acceso particular.`,
+      `¿Eliminar permanentemente el token ****${token.tokenLast4} de ${token.petName}? Esta acción no se puede deshacer y eliminará el token del servidor.`,
     );
 
     if (!confirmed) {
@@ -528,14 +528,14 @@ export function AdminParticularTokensCard() {
     setRevokingTokenId(token.id);
 
     try {
-      const response = await revokeAdminParticularToken(token.id);
+      const response = await deleteAdminParticularToken(token.id);
       setStatusMessage(response.message);
-      await loadTokens();
+      setTokens((current) => current.filter((t) => t.id !== token.id));
     } catch (error) {
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : "No se pudo revocar el token particular.",
+          : "No se pudo eliminar el token particular.",
       );
     } finally {
       setRevokingTokenId(null);
@@ -548,7 +548,7 @@ export function AdminParticularTokensCard() {
         <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6 pt-6">
-        <form className="space-y-4" onSubmit={handleSubmit}>
+        <form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
             <div className="md:col-span-2">
               <label htmlFor="admin-token-clinic-search" className="field-label">
@@ -661,6 +661,7 @@ export function AdminParticularTokensCard() {
                 min="1"
                 inputMode="numeric"
                 placeholder="Opcional"
+                autoComplete="off"
                 value={formState.reportId}
                 onChange={(event) => updateField("reportId", event.target.value)}
                 disabled={isSubmitting}
@@ -676,6 +677,7 @@ export function AdminParticularTokensCard() {
                 name="particularEmail"
                 type="email"
                 placeholder="email@ejemplo.com"
+                autoComplete="off"
                 required
                 value={formState.particularEmail}
                 onChange={(event) =>
@@ -701,6 +703,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-tutor-last-name"
                 name="tutorLastName"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.tutorLastName}
                 onChange={(event) =>
@@ -718,6 +721,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-pet-name"
                 name="petName"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.petName}
                 onChange={(event) => updateField("petName", event.target.value)}
@@ -733,6 +737,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-pet-age"
                 name="petAge"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.petAge}
                 onChange={(event) => updateField("petAge", event.target.value)}
@@ -748,6 +753,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-pet-breed"
                 name="petBreed"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.petBreed}
                 onChange={(event) => updateField("petBreed", event.target.value)}
@@ -807,6 +813,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-sample-location"
                 name="sampleLocation"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.sampleLocation}
                 onChange={(event) =>
@@ -824,6 +831,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-sample-evolution"
                 name="sampleEvolution"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.sampleEvolution}
                 onChange={(event) =>
@@ -841,6 +849,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-extraction-date"
                 name="extractionDate"
                 type="date"
+                autoComplete="off"
                 required
                 value={formState.extractionDate}
                 onChange={(event) =>
@@ -858,6 +867,7 @@ export function AdminParticularTokensCard() {
                 id="admin-token-shipping-date"
                 name="shippingDate"
                 type="date"
+                autoComplete="off"
                 required
                 value={formState.shippingDate}
                 onChange={(event) =>
@@ -876,6 +886,7 @@ export function AdminParticularTokensCard() {
               id="admin-token-details-lesion"
               name="detailsLesion"
               className="field-textarea"
+              autoComplete="off"
               required
               value={formState.detailsLesion}
               onChange={(event) =>
@@ -1088,14 +1099,10 @@ export function AdminParticularTokensCard() {
                       type="button"
                       variant="destructive"
                       size="sm"
-                      disabled={!token.isActive || revokingTokenId === token.id}
-                      onClick={() => void handleRevokeToken(token)}
+                      disabled={revokingTokenId === token.id}
+                      onClick={() => void handleDeleteToken(token)}
                     >
-                      {revokingTokenId === token.id
-                        ? "Revocando..."
-                        : token.isActive
-                          ? "Revocar token"
-                          : "Token inactivo"}
+                      {revokingTokenId === token.id ? "Eliminando..." : "Eliminar token"}
                     </Button>
                   </div>
                 </div>

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -326,7 +326,7 @@ export function ClinicParticularTokensCard() {
         <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6 pt-6">
-        <form className="space-y-4" onSubmit={handleSubmit}>
+        <form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
             <div>
               <label htmlFor="clinic-token-report-id" className="field-label">
@@ -336,6 +336,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-report-id"
                 name="reportId"
                 type="number"
+                autoComplete="off"
                 min="1"
                 inputMode="numeric"
                 placeholder="Opcional"
@@ -353,6 +354,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-particular-email"
                 name="particularEmail"
                 type="email"
+                autoComplete="off"
                 placeholder="email@ejemplo.com"
                 required
                 value={formState.particularEmail}
@@ -379,6 +381,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-tutor-last-name"
                 name="tutorLastName"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.tutorLastName}
                 onChange={(event) =>
@@ -396,6 +399,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-pet-name"
                 name="petName"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.petName}
                 onChange={(event) => updateField("petName", event.target.value)}
@@ -411,6 +415,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-pet-age"
                 name="petAge"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.petAge}
                 onChange={(event) => updateField("petAge", event.target.value)}
@@ -426,6 +431,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-pet-breed"
                 name="petBreed"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.petBreed}
                 onChange={(event) => updateField("petBreed", event.target.value)}
@@ -485,6 +491,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-sample-location"
                 name="sampleLocation"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.sampleLocation}
                 onChange={(event) =>
@@ -502,6 +509,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-sample-evolution"
                 name="sampleEvolution"
                 type="text"
+                autoComplete="off"
                 required
                 value={formState.sampleEvolution}
                 onChange={(event) =>
@@ -519,6 +527,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-extraction-date"
                 name="extractionDate"
                 type="date"
+                autoComplete="off"
                 required
                 value={formState.extractionDate}
                 onChange={(event) =>
@@ -536,6 +545,7 @@ export function ClinicParticularTokensCard() {
                 id="clinic-token-shipping-date"
                 name="shippingDate"
                 type="date"
+                autoComplete="off"
                 required
                 value={formState.shippingDate}
                 onChange={(event) =>
@@ -554,6 +564,7 @@ export function ClinicParticularTokensCard() {
               id="clinic-token-details-lesion"
               name="detailsLesion"
               className="field-textarea"
+              autoComplete="off"
               required
               value={formState.detailsLesion}
               onChange={(event) =>
@@ -774,6 +785,3 @@ export function ClinicParticularTokensCard() {
           )}
         </div>
       </CardContent>
-    </Card>
-  );
-}

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -785,3 +785,6 @@ export function ClinicParticularTokensCard() {
           )}
         </div>
       </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -548,8 +548,24 @@ export async function revokeAdminParticularToken(
   );
 }
 
+export type AdminParticularTokenDeleteResponse = {
+  success: true;
+  message: string;
+  deletedTokenId: number;
+};
 
-
+export async function deleteAdminParticularToken(
+  tokenId: number,
+  options?: RequestInit,
+): Promise<AdminParticularTokenDeleteResponse> {
+  return apiFetch<AdminParticularTokenDeleteResponse>(
+    `/api/admin/particular-tokens/${tokenId}`,
+    {
+      ...options,
+      method: "DELETE",
+    },
+  );
+}
 
 export type ClinicParticularTokenSummary = AdminParticularTokenSummary;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
+      '@next/eslint-plugin-next':
+        specifier: 15.5.18
+        version: 15.5.18
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0

--- a/server/db-particular.ts
+++ b/server/db-particular.ts
@@ -99,6 +99,15 @@ export async function revokeParticularToken(id: number) {
   return result[0];
 }
 
+export async function deleteParticularToken(id: number) {
+  const result = await db
+    .delete(particularTokens)
+    .where(eq(particularTokens.id, id))
+    .returning({ id: particularTokens.id });
+
+  return result[0] ?? null;
+}
+
 export async function updateParticularTokenLastLogin(id: number) {
   await db
     .update(particularTokens)

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -101,6 +101,9 @@ export type AdminParticularTokensNativeRoutesOptions = {
   revokeParticularToken?: (
     id: number,
   ) => Promise<ParticularToken | null | undefined>;
+  deleteParticularToken?: (
+    id: number,
+  ) => Promise<{ id: number } | null>;
   sendParticularTokenEmail?: (input: {
     to: string;
     token: string;
@@ -133,6 +136,7 @@ type NativeAdminParticularTokensDeps = Required<
     | "listParticularTokens"
     | "updateParticularTokenReport"
     | "revokeParticularToken"
+    | "deleteParticularToken"
     | "sendParticularTokenEmail"
   >
 >;
@@ -161,6 +165,7 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
         listParticularTokens: dbParticular.listParticularTokens,
         updateParticularTokenReport: dbParticular.updateParticularTokenReport,
         revokeParticularToken: dbParticular.revokeParticularToken,
+        deleteParticularToken: dbParticular.deleteParticularToken,
         sendParticularTokenEmail: email.sendParticularTokenEmail,
       };
     })();
@@ -473,6 +478,7 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     !!options.listParticularTokens &&
     !!options.updateParticularTokenReport &&
     !!options.revokeParticularToken &&
+    !!options.deleteParticularToken &&
     !!options.sendParticularTokenEmail;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
@@ -504,6 +510,8 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       defaultDeps!.updateParticularTokenReport,
     revokeParticularToken:
       options.revokeParticularToken ?? defaultDeps!.revokeParticularToken,
+    deleteParticularToken:
+      options.deleteParticularToken ?? defaultDeps!.deleteParticularToken,
     sendParticularTokenEmail:
       options.sendParticularTokenEmail ??
       defaultDeps!.sendParticularTokenEmail,
@@ -554,7 +562,7 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     }
 
     applyCorsHeaders(request, reply, allowedOrigins);
-    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
+    reply.header("access-control-allow-methods", "GET,POST,PATCH,DELETE,OPTIONS");
 
     const requestedHeaders =
       typeof request.headers["access-control-request-headers"] === "string"
@@ -864,6 +872,55 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     });
   });
 
+  app.delete<{
+    Params: {
+      tokenId: string;
+    };
+  }>("/:tokenId", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const tokenId = parseEntityId(request.params.tokenId);
+
+    if (typeof tokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de token inválido",
+      });
+    }
+
+    const existing = await deps.getParticularTokenById(tokenId);
+
+    if (!existing) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    }
+
+    const deleted = await deps.deleteParticularToken(tokenId);
+
+    if (!deleted) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      message: "Token particular eliminado correctamente",
+      deletedTokenId: tokenId,
+    });
+  });
+
   app.patch<{
     Params: {
       tokenId: string;
@@ -897,13 +954,9 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const revoked = await deps.revokeParticularToken(tokenId);
-    const report =
-      revoked && typeof revoked.reportId === "number"
-        ? await deps.getReportById(revoked.reportId)
-        : null;
+    const deleted = await deps.deleteParticularToken(tokenId);
 
-    if (!revoked) {
+    if (!deleted) {
       return reply.code(404).send({
         success: false,
         error: "Token particular no encontrado",
@@ -912,10 +965,8 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
 
     return reply.code(200).send({
       success: true,
-      message: existing.isActive
-        ? "Token particular revocado correctamente"
-        : "Token particular ya estaba inactivo",
-      particularToken: serializeParticularTokenDetail(revoked, report),
+      message: "Token particular eliminado correctamente",
+      deletedTokenId: tokenId,
     });
   });
 };

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -102,6 +102,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       createParticularTokenFixture({
         isActive: false,
       }),
+    deleteParticularToken: async (id: number) => ({ id }),
     sendParticularTokenEmail: async () => ({
       sent: true,
       messageId: "particular-email-1",
@@ -578,20 +579,17 @@ test(
 );
 
 test(
-  "adminParticularTokensNativeRoutes revoca PATCH /:tokenId/revoke con mensaje y token sanitizado",
+  "adminParticularTokensNativeRoutes PATCH /:tokenId/revoke ahora hard-deletea y responde deletedTokenId",
   async () => {
     const activeToken = createParticularTokenFixture({ isActive: true });
-    const revokedToken = createParticularTokenFixture({ isActive: false });
-    const report = createReportFixture();
-    const revokeCalls: number[] = [];
+    const deleteCalls: number[] = [];
 
     const app = await createTestApp({
       getParticularTokenById: async () => activeToken,
-      revokeParticularToken: async (tokenId: number) => {
-        revokeCalls.push(tokenId);
-        return revokedToken;
+      deleteParticularToken: async (tokenId: number) => {
+        deleteCalls.push(tokenId);
+        return { id: tokenId };
       },
-      getReportById: async () => report,
     });
 
     try {
@@ -605,13 +603,13 @@ test(
       });
 
       assert.equal(response.statusCode, 200);
-      assert.deepEqual(revokeCalls, [7]);
+      assert.deepEqual(deleteCalls, [7]);
       const body = JSON.parse(response.body);
       assert.equal(body.success, true);
-      assert.equal(body.message, "Token particular revocado correctamente");
-      assert.equal(body.particularToken.id, 7);
-      assert.equal(body.particularToken.isActive, false);
-      assert.equal(body.particularToken.tokenHash, undefined);
+      assert.equal(body.message, "Token particular eliminado correctamente");
+      assert.equal(body.deletedTokenId, 7);
+      assert.equal(body.particularToken, undefined);
+      assert.equal(body.tokenHash, undefined);
     } finally {
       await app.close();
     }
@@ -619,14 +617,81 @@ test(
 );
 
 test(
-  "adminParticularTokensNativeRoutes bloquea revoke con origin no permitido",
+  "adminParticularTokensNativeRoutes DELETE /:tokenId elimina físicamente y responde deletedTokenId",
+  async () => {
+    const activeToken = createParticularTokenFixture({ isActive: true });
+    const deleteCalls: number[] = [];
+
+    const app = await createTestApp({
+      getParticularTokenById: async () => activeToken,
+      deleteParticularToken: async (tokenId: number) => {
+        deleteCalls.push(tokenId);
+        return { id: tokenId };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/admin/particular-tokens/7",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(deleteCalls, [7]);
+      const body = JSON.parse(response.body);
+      assert.equal(body.success, true);
+      assert.equal(body.message, "Token particular eliminado correctamente");
+      assert.equal(body.deletedTokenId, 7);
+      assert.equal(body.particularToken, undefined);
+      assert.equal(body.tokenHash, undefined);
+      assert.equal(body.tokenLast4, undefined);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes DELETE /:tokenId devuelve 404 si token no existe",
+  async () => {
+    const app = await createTestApp({
+      getParticularTokenById: async () => undefined,
+    });
+
+    try {
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/admin/particular-tokens/999",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 404);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes DELETE /:tokenId bloquea origin no permitido",
   async () => {
     const app = await createTestApp();
 
     try {
       const response = await app.inject({
-        method: "PATCH",
-        url: "/api/admin/particular-tokens/7/revoke",
+        method: "DELETE",
+        url: "/api/admin/particular-tokens/7",
         headers: {
           origin: "https://evil.example",
           cookie: `${ENV.adminCookieName}=admin-session-token`,
@@ -638,6 +703,33 @@ test(
         success: false,
         error: "Origen no permitido",
       });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes GET / no devuelve tokenHash en listado",
+  async () => {
+    const token = createParticularTokenFixture();
+    const app = await createTestApp({
+      listParticularTokens: async () => [token],
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.particularTokens[0].tokenHash, undefined);
+      assert.ok(body.particularTokens[0].tokenLast4);
     } finally {
       await app.close();
     }

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -50,7 +50,7 @@ test("admin particular token generator uses admin helpers without technical copy
   assert.ok(card.includes("createAdminParticularToken"));
   assert.ok(card.includes("getAdminUsersRoles"));
   assert.ok(card.includes("getAdminParticularTokens"));
-  assert.ok(card.includes("revokeAdminParticularToken"));
+  assert.ok(card.includes("deleteAdminParticularToken"));
   assert.ok(card.includes("type AdminParticularTokenCreatePayload"));
   assert.ok(card.includes("type AdminParticularTokenSummary"));
   assert.equal(card.includes(removedScopedCopy), false);
@@ -58,8 +58,12 @@ test("admin particular token generator uses admin helpers without technical copy
   assert.ok(api.includes("export async function createAdminParticularToken("));
   assert.ok(api.includes('"/api/admin/particular-tokens"'));
   assert.ok(api.includes("export async function revokeAdminParticularToken("));
+  assert.ok(api.includes("export async function deleteAdminParticularToken("));
   assert.ok(
     api.includes("`/api/admin/particular-tokens/${tokenId}/revoke`,"),
+  );
+  assert.ok(
+    api.includes("`/api/admin/particular-tokens/${tokenId}`"),
   );
 });
 
@@ -97,7 +101,7 @@ test("admin particular token generator uses registered clinic selector instead o
 test("admin particular token clinic selector loads deduped clinics by name user id and locality", () => {
   const source = read(ADMIN_CARD_PATH);
 
-  assert.ok(source.includes('import {\n  createAdminParticularToken,\n  getAdminUsersRoles,'));
+  assert.ok(source.includes('import {\n  createAdminParticularToken,\n  deleteAdminParticularToken,\n  getAdminUsersRoles,'));
   assert.ok(source.includes("getAdminUsersRoles({"));
   assert.ok(source.includes('userType: "clinic",'));
   assert.ok(source.includes("limit,"));
@@ -353,4 +357,72 @@ test("admin and clinic token forms keep normalized sex and species options", () 
       previousIndex = index;
     }
   }
+});
+
+test("admin particular token form has autoComplete off on form element and all sensitive inputs", () => {
+  const source = read(ADMIN_CARD_PATH);
+
+  assert.ok(source.includes('autoComplete="off"'), "form or inputs must have autoComplete off");
+  assert.ok(source.includes('<form') && source.includes('autoComplete="off"'), "form container must disable autocomplete");
+  assert.equal(source.includes('autoComplete="on"'), false, "no autoComplete=on allowed");
+
+  const sensitiveInputIds = [
+    "admin-token-particular-email",
+    "admin-token-tutor-last-name",
+    "admin-token-pet-name",
+    "admin-token-pet-age",
+    "admin-token-pet-breed",
+    "admin-token-sample-location",
+    "admin-token-sample-evolution",
+    "admin-token-extraction-date",
+    "admin-token-shipping-date",
+    "admin-token-report-id",
+  ];
+
+  for (const id of sensitiveInputIds) {
+    const idx = source.indexOf(`id="${id}"`);
+    assert.ok(idx !== -1, `input ${id} must exist`);
+    const block = source.slice(idx, idx + 400);
+    assert.ok(block.includes('autoComplete="off"'), `input ${id} must have autoComplete="off"`);
+  }
+});
+
+test("clinic particular token form has autoComplete off on form element and all sensitive inputs", () => {
+  const source = read(CLINIC_CARD_PATH);
+
+  assert.ok(source.includes('autoComplete="off"'), "clinic form must have autoComplete off");
+  assert.equal(source.includes('autoComplete="on"'), false, "no autoComplete=on in clinic form");
+
+  const sensitiveInputIds = [
+    "clinic-token-particular-email",
+    "clinic-token-tutor-last-name",
+    "clinic-token-pet-name",
+    "clinic-token-pet-age",
+    "clinic-token-pet-breed",
+    "clinic-token-sample-location",
+    "clinic-token-sample-evolution",
+    "clinic-token-extraction-date",
+    "clinic-token-shipping-date",
+    "clinic-token-report-id",
+  ];
+
+  for (const id of sensitiveInputIds) {
+    const idx = source.indexOf(`id="${id}"`);
+    assert.ok(idx !== -1, `clinic input ${id} must exist`);
+    const block = source.slice(idx, idx + 400);
+    assert.ok(block.includes('autoComplete="off"'), `clinic input ${id} must have autoComplete="off"`);
+  }
+});
+
+test("admin token card delete handler uses deleteAdminParticularToken not revokeAdminParticularToken", () => {
+  const card = read(ADMIN_CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes("deleteAdminParticularToken"), "card must import deleteAdminParticularToken");
+  assert.equal(card.includes("revokeAdminParticularToken"), false, "card must not reference revokeAdminParticularToken");
+  assert.ok(card.includes("handleDeleteToken"), "card must have handleDeleteToken function");
+  assert.ok(card.includes("Eliminar token"), "card must show delete terminology");
+  assert.equal(card.includes("Token inactivo"), false, "card must not show Token inactivo state");
+  assert.ok(api.includes("export type AdminParticularTokenDeleteResponse"), "api must export AdminParticularTokenDeleteResponse type");
+  assert.ok(api.includes('method: "DELETE"'), "deleteAdminParticularToken must use DELETE method");
 });


### PR DESCRIPTION
# PR: fix(admin): hard delete particular tokens and disable autocomplete

## Skills Claude utilizadas

- `vetneb-security-production-invariants`
  - Uso: validar privacidad, hard delete de tokens particulares, eliminación de sesiones asociadas por FK cascade, no exposición de `tokenHash`/`tokenLast4`, y ausencia de logs nuevos con token.

- `vetneb-admin-dashboard-operational-actions`
  - Uso: corregir comportamiento del dashboard admin, acción de eliminar token, actualización del listado y mensajes de UI.

- `vetneb-protocolos-comunicacion`
  - Uso: revisar contrato HTTP `DELETE`, compatibilidad legacy `PATCH /revoke`, CORS/OPTIONS y status codes.

- `vetneb-bugs-errores-optimizacion-rutas`
  - Uso: diagnosticar tokens inactivos persistentes, rutas admin particular tokens y autocomplete/autofill en formularios.

- `vetneb-staff-senior-full-stack-engineer`
  - Uso: implementar backend, frontend y tests con scope mínimo.

## Diagnóstico

- `revokeParticularToken(id)` hacía soft-delete con `isActive=false`, por lo que el token quedaba en servidor y seguía visible como inactivo.
- El listado admin podía seguir mostrando tokens inactivos.
- Los formularios de generación de tokens permitían sugerencias/autocomplete del navegador.

## Cambios realizados

- Se agregó `deleteParticularToken(id)` para borrar físicamente tokens particulares.
- Se agregó endpoint `DELETE /api/admin/particular-tokens/:tokenId`.
- `PATCH /api/admin/particular-tokens/:tokenId/revoke` queda como alias legacy, pero ahora ejecuta hard delete.
- La respuesta de eliminación devuelve `deletedTokenId` y no devuelve detalle completo del token eliminado.
- El frontend admin usa `deleteAdminParticularToken` y muestra terminología de eliminación.
- La UI remueve el token eliminado del listado.
- Se desactivó autocomplete en formularios sensibles de tokens particulares admin y clínica.
- Se mantuvo el marker `app.options("/:tokenId", optionsHandler)` y se agregó `DELETE` a `access-control-allow-methods`.

## Archivos modificados

- `server/db-particular.ts`
- `server/routes/admin-particular-tokens.fastify.ts`
- `frontend/src/lib/api.ts`
- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
- `test/admin-particular-tokens.fastify.test.ts`
- `test/frontend-admin-particular-tokens.test.ts`

## Validación

```powershell
node --experimental-strip-types --experimental-specifier-resolution=node --test test/security-critical-route-surface-registry.test.ts
node --experimental-strip-types --experimental-specifier-resolution=node --test test/admin-particular-tokens.fastify.test.ts
node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-particular-tokens.test.ts
pnpm test
pnpm build
```

Resultado local:

```txt
pnpm test: 1975 pass / 0 fail / 1 skipped
pnpm build: OK
```

## Riesgos

- Medio: cambia semántica de revocación a hard delete. Se conserva `PATCH /revoke` como alias legacy para compatibilidad.
- Bajo: `particular_sessions` asociadas se eliminan por FK `ON DELETE CASCADE`.
- Bajo: autocomplete depende del navegador; el portal ahora declara `autoComplete="off"` en formularios sensibles, pero historiales ya guardados por el navegador no pueden borrarse desde el servidor.

## Evidencia de invariante

- Token eliminado desaparece del servidor mediante hard delete.
- El listado admin ya no muestra tokens eliminados.
- Las sesiones particulares asociadas quedan invalidadas por cascade.
- La respuesta de eliminación no devuelve `tokenHash` ni `tokenLast4`.
- No se usa `Token inactivo` en la tarjeta admin.
- Formularios sensibles de token tienen `autoComplete="off"`.
- No se tocaron email, Gmail API, refresh token, dominio propio, variables reales de producción ni auth sessions/cookies.
