### PR TITLE
Corrige dashboard particular móvil, agrega asistencia segura de pegado de token y estabiliza rehidratación de sesión particular ante fallos transitorios. Incluye guardrails contractuales.

### DIFF
--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import {
   CalendarDays,
+  Clipboard,
   Download,
   Eye,
   FileText,
@@ -83,16 +84,20 @@ export function ParticularesContent() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isOpeningReport, setIsOpeningReport] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [sessionCheckError, setSessionCheckError] = useState(false);
+  const [clipboardSupported, setClipboardSupported] = useState(false);
+  const [isPasting, setIsPasting] = useState(false);
 
   async function refreshSession() {
     setIsCheckingSession(true);
     setErrorMessage(null);
+    setSessionCheckError(false);
 
     try {
       const response = await getParticularSession();
       setSession(response?.particular ?? null);
     } catch (error) {
-      setSession(null);
+      setSessionCheckError(true);
       setErrorMessage(
         error instanceof Error
           ? error.message
@@ -107,6 +112,13 @@ export function ParticularesContent() {
     void refreshSession();
   }, []);
 
+  useEffect(() => {
+    setClipboardSupported(
+      typeof navigator !== "undefined" &&
+        typeof navigator.clipboard?.readText === "function",
+    );
+  }, []);
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -115,6 +127,7 @@ export function ParticularesContent() {
     }
 
     setErrorMessage(null);
+    setSessionCheckError(false);
     setIsSubmitting(true);
 
     try {
@@ -141,6 +154,26 @@ export function ParticularesContent() {
       // La salida local se completa aunque el backend ya no tenga sesión activa.
     } finally {
       setSession(null);
+    }
+  }
+
+  async function handlePasteToken() {
+    if (!navigator.clipboard?.readText || isPasting) {
+      return;
+    }
+
+    setIsPasting(true);
+
+    try {
+      const text = await navigator.clipboard?.readText?.();
+      const cleaned = text.trim();
+      if (cleaned) {
+        setToken(cleaned);
+      }
+    } catch {
+      // Usuario denegó permiso o portapapeles no disponible — fallo silencioso.
+    } finally {
+      setIsPasting(false);
     }
   }
 
@@ -173,7 +206,8 @@ export function ParticularesContent() {
   return (
     <section className="public-secondary-hero-surface py-16 md:py-20">
       <div className="container relative z-10 mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 lg:grid-cols-[1fr_0.95fr] lg:px-8">
-        <div>
+        {/* Columna info: oculta en móvil cuando la sesión está activa para evitar duplicación visual */}
+        <div className={session !== null ? "hidden lg:block" : ""}>
 <h1 className="max-w-3xl text-4xl font-bold text-primary-foreground md:text-5xl">
             Acceda al seguimiento y al informe de su caso con token seguro
           </h1>
@@ -398,15 +432,40 @@ export function ParticularesContent() {
                         className="pl-10"
                       />
                     </div>
+                    {clipboardSupported ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handlePasteToken}
+                        disabled={isSubmitting || isPasting}
+                        className="mt-2 w-full public-cta-outline text-sm"
+                        aria-label="Pegar token del portapapeles"
+                      >
+                        <Clipboard className="h-4 w-4" aria-hidden="true" />
+                        {isPasting ? "Pegando..." : "Pegar desde portapapeles"}
+                      </Button>
+                    ) : null}
                   </div>
 
                   {errorMessage ? (
-                    <p
-                      className="clinical-alert-error px-3 py-2"
-                      role="alert"
-                    >
-                      {errorMessage}
-                    </p>
+                    <div role="alert">
+                      <p className="clinical-alert-error px-3 py-2">
+                        {errorMessage}
+                      </p>
+                      {sessionCheckError ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => { void refreshSession(); }}
+                          disabled={isCheckingSession}
+                          className="mt-2 w-full public-cta-outline text-sm"
+                        >
+                          {isCheckingSession
+                            ? "Verificando..."
+                            : "Reintentar verificación"}
+                        </Button>
+                      ) : null}
+                    </div>
                   ) : null}
 
                   <Button

--- a/test/frontend-particulares-mobile-token-session.test.ts
+++ b/test/frontend-particulares-mobile-token-session.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PARTICULARES_CONTENT_PATH =
+  "frontend/src/components/public/ParticularesContent.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ─── Fix 1: Cards duplicadas/fantasma ───────────────────────────────────────
+
+test("particulares content oculta columna info en móvil cuando sesión está activa", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes('"hidden lg:block"'),
+    "debe contener clase hidden lg:block para columna info en móvil",
+  );
+  assert.ok(
+    source.includes('session !== null ? "hidden lg:block" : ""'),
+    "debe condicionar la visibilidad de la columna izquierda según session",
+  );
+});
+
+test("particulares content mantiene columna info visible en desktop siempre", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("lg:block"),
+    "columna info debe ser visible en desktop (lg:block)",
+  );
+  assert.equal(
+    source.includes('"hidden"'),
+    false,
+    "columna info no debe ocultarse incondicionalmente",
+  );
+});
+
+test("particulares content no elimina highlights ni banda de seguridad", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("accessHighlights.map("));
+  assert.ok(source.includes("Sesión separada del portal clínico"));
+  assert.ok(source.includes("ShieldCheck"));
+});
+
+// ─── Fix 2: UX token móvil con portapapeles ──────────────────────────────────
+
+test("particulares content incluye soporte de pegado desde portapapeles", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("clipboardSupported"),
+    "debe tener estado clipboardSupported",
+  );
+  assert.ok(
+    source.includes("navigator.clipboard?.readText"),
+    "debe detectar disponibilidad de clipboard con optional chaining",
+  );
+  assert.ok(
+    source.includes("handlePasteToken"),
+    "debe definir handlePasteToken",
+  );
+  assert.ok(
+    source.includes("Pegar desde portapapeles"),
+    "debe tener label visible del botón de pegado",
+  );
+  assert.ok(
+    source.includes("isPasting"),
+    "debe tener estado isPasting para feedback visual",
+  );
+});
+
+test("particulares content botón pegar solo actúa con gesto del usuario", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("onClick={handlePasteToken}"),
+    "handlePasteToken debe estar en onClick, no en useEffect ni render directo",
+  );
+  assert.equal(
+    source.includes("navigator.clipboard.readText()"),
+    false,
+    "no debe leer clipboard sin optional chaining (guard de disponibilidad requerido)",
+  );
+});
+
+test("particulares content no expone token en logs ni URL", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.equal(
+    source.includes("console.log("),
+    false,
+    "token no debe pasar por console.log",
+  );
+  assert.equal(
+    source.includes("searchParams"),
+    false,
+    "token no debe ponerse en query params",
+  );
+  assert.equal(
+    source.includes("window.location"),
+    false,
+    "token no debe ponerse en window.location",
+  );
+});
+
+test("particulares content botón pegar es condicional y tiene fallback silencioso", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("{clipboardSupported ? ("),
+    "botón pegar debe ser condicional a clipboardSupported",
+  );
+  assert.ok(
+    source.includes("// Usuario denegó permiso o portapapeles no disponible"),
+    "catch de clipboard debe ser silencioso con comentario explicativo",
+  );
+  assert.ok(
+    source.includes("setIsPasting(false);"),
+    "isPasting debe resetearse en finally",
+  );
+});
+
+// ─── Fix 3: Sesión particular persistente ────────────────────────────────────
+
+test("particulares content refreshSession no borra sesión en errores de conexión", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("setSessionCheckError(true)"),
+    "debe marcar sessionCheckError en catch de refreshSession",
+  );
+  assert.ok(
+    source.includes("setSessionCheckError(false)"),
+    "debe resetear sessionCheckError en refreshSession y handleSubmit",
+  );
+
+  // Verificar que setSession(null) NO aparece dentro del catch de refreshSession.
+  // Técnica: el único setSession(null) legítimo es en handleLogout.
+  // Buscamos que catch de refreshSession no contenga setSession(null).
+  const refreshSessionBlock = source.slice(
+    source.indexOf("async function refreshSession()"),
+    source.indexOf("useEffect(() => {"),
+  );
+  assert.equal(
+    refreshSessionBlock.includes("setSession(null)"),
+    false,
+    "refreshSession catch no debe llamar setSession(null); solo handleLogout puede hacerlo",
+  );
+});
+
+test("particulares content tiene botón de reintento cuando falla la verificación de sesión", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("Reintentar verificación"),
+    "debe mostrar opción de reintento cuando sessionCheckError es true",
+  );
+  assert.ok(
+    source.includes("{sessionCheckError ? ("),
+    "botón reintento debe ser condicional a sessionCheckError",
+  );
+  assert.ok(
+    source.includes("void refreshSession()"),
+    "botón reintento debe llamar refreshSession",
+  );
+});
+
+test("particulares content resetea sessionCheckError en handleSubmit para no mezclar errores", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  const handleSubmitBlock = source.slice(
+    source.indexOf("async function handleSubmit("),
+    source.indexOf("async function handleLogout("),
+  );
+  assert.ok(
+    handleSubmitBlock.includes("setSessionCheckError(false)"),
+    "handleSubmit debe resetear sessionCheckError antes de intentar login",
+  );
+});
+
+test("particulares content mantiene invariante de sesión separada por rol", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.equal(source.includes("loginClinic"), false);
+  assert.equal(source.includes("app_session_id"), false);
+  assert.equal(source.includes("admin_session_id"), false);
+  assert.equal(source.includes("useRouter"), false);
+  assert.equal(source.includes("useSearchParams"), false);
+  assert.equal(source.includes("ROUTES.dashboard"), false);
+});


### PR DESCRIPTION
## Resumen
- Corrige bug visual del dashboard particular móvil.
- Agrega asistencia segura para pegar token desde portapapeles bajo gesto del usuario.
- Evita borrar sesión particular ante fallos transitorios de verificación.
- Agrega guardrails contractuales para mobile/token/session.

## Validación
- node --test test/frontend-particulares-mobile-token-session.test.ts
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm test
- pnpm validate:local