### PR TITLE
fix(auth): align staging session cookies across roles

### DIFF
--- a/PR-fix-staging-auth-connectivity-roles.md
+++ b/PR-fix-staging-auth-connectivity-roles.md
@@ -1,0 +1,95 @@
+# PR fix staging auth connectivity roles
+
+## 1. Rama
+- `fix/staging-auth-connectivity-roles`
+
+## 2. Causa raiz (hipotesis validada por codigo + smoke)
+- El frontend ya tenia `rewrite` de Next para proxyar `"/api/:path*"` al backend (`frontend/next.config.ts`), pero el cliente API en browser llamaba directo a `NEXT_PUBLIC_API_URL` absoluto.
+- Ese bypass del proxy provoca que `Set-Cookie` de login quede asociado al host del backend, no al host del frontend.
+- El middleware de Next que protege `"/dashboard/*"` se ejecuta en el host del frontend y solo puede leer cookies de ese host; por eso `/dashboard/admin` sin cookie frontend sigue en `404`.
+- Se aplico fix minimo para browser: usar base same-origin y dejar que el rewrite maneje `/api/*`.
+
+## 3. Diagnostico admin
+- `frontend/src/middleware.ts` mantiene contrato de seguridad: `/dashboard/admin` sin `admin_session_id` devuelve `404`.
+- `server/routes/auth.fastify.ts` (login unificado) y `server/routes/admin-auth.fastify.ts` emiten `admin_session_id` con `Path=/`, `HttpOnly`, `SameSite` y `Secure` en prod.
+- Si el login se hace cross-origin directo al backend, el cookie no queda en el host del frontend y el middleware no lo ve.
+
+## 4. Diagnostico clinica
+- `server/routes/auth.fastify.ts` emite `app_session_id` para clinica.
+- `frontend/src/middleware.ts` exige `app_session_id` en `/dashboard`.
+- El mismo problema de host de cookie aplica cuando browser llama directo a backend absoluto.
+
+## 5. Diagnostico particular
+- `server/routes/particular-auth.fastify.ts` emite `particular_session_id` y mantiene superficie separada.
+- `frontend/src/components/public/ParticularesContent.tsx` usa endpoints particulares con `credentials: include`.
+- Con fix same-origin en browser, tambien pasa por proxy de frontend y evita drift de host de cookie.
+
+## 6. Cookies esperadas por rol
+- Admin: `admin_session_id`
+- Clinica: `app_session_id`
+- Particular: `particular_session_id`
+- Atributos esperados: `Path=/`, `HttpOnly`, `SameSite=None` en production, `Secure` en HTTPS.
+
+## 7. CORS / credentials
+- Smoke staging (sin credenciales privadas) valido:
+  - Backend alive: OK
+  - Frontend alive: OK
+  - Preflight `OPTIONS /api/auth/login`: `204`, `Access-Control-Allow-Origin` exacto frontend staging, `Access-Control-Allow-Credentials=true`
+  - Bad origin en unsafe route: bloqueado con `403`
+- Verificacion manual adicional: respuestas `401` de login siguen exponiendo headers CORS correctos para origin permitido.
+
+## 8. Middleware
+- No se relajo seguridad:
+  - `/dashboard/admin` sin cookie admin sigue `404`
+  - `/dashboard` sin cookie clinica sigue redirect a `/login?next=...`
+  - matcher sigue restringido a `"/dashboard/:path*"`
+
+## 9. Implementaciones aplicadas
+- `frontend/src/lib/api.ts`
+  - Se agrego branch de runtime browser para usar base same-origin (`SAME_ORIGIN_API_BASE_URL`) y aprovechar el rewrite existente.
+  - En runtime server-side se mantiene `NEXT_PUBLIC_API_URL` normalizado para fetch absoluto cuando corresponde.
+- No se tocaron reglas de cookies backend, CORS, ni middleware de seguridad admin.
+
+## 10. Tests agregados/reforzados
+- `test/frontend-api-client-request.test.ts`
+  - Se agrego contrato explicito para branch browser same-origin.
+  - Se mantiene contrato de `NEXT_PUBLIC_API_URL` normalizado para runtime no-browser.
+  - Se valida que el rewrite `/api/:path*` siga declarado en `next.config.ts`.
+
+## 11. Validaciones ejecutadas
+- `pnpm test`: OK (2027 pass, 0 fail, 1 skipped)
+- `pnpm validate:local`: OK (`typecheck`, `typecheck:test`, `test`, `build`)
+- `pnpm --dir frontend lint`: OK con 1 warning preexistente (`unused eslint-disable` en `frontend/src/app/api/security/csp-report/route.ts:177`)
+- `pnpm --dir frontend typecheck`: OK
+- `pnpm --dir frontend build`: OK
+
+## 12. Riesgos residuales
+- No se pudo ejecutar login real por rol en staging dentro de este entorno porque faltan variables opcionales de smoke (`SMOKE_ADMIN_*`, `SMOKE_CLINIC_*`, `SMOKE_PARTICULAR_TOKEN`).
+- Aun hace falta validar manualmente en staging con credenciales reales que cada rol complete flujo E2E post-deploy.
+
+## 13. Checklist manual staging
+- [ ] login admin
+- [ ] verificar `admin_session_id`
+- [ ] abrir `/dashboard/admin`
+- [ ] login clinica
+- [ ] verificar `app_session_id`
+- [ ] abrir `/dashboard`
+- [ ] token particular
+- [ ] verificar `particular_session_id`
+- [ ] abrir caso particular
+
+## 14. Respuestas a preguntas obligatorias
+1. Frontend staging llama al backend correcto (`NEXT_PUBLIC_API_URL` en `.env.example` apunta a backend staging) y ahora en browser lo hace via same-origin + rewrite.
+2. Si, fetch de auth usa `credentials: include` por defecto en `apiFetch`.
+3. Si, backend CORS permite origen exacto cuando coincide con allowlist.
+4. Si, backend responde `Access-Control-Allow-Credentials: true` para origen permitido.
+5. Si, admin login emite `Set-Cookie` de `admin_session_id` por contrato de rutas.
+6. Si, clinica login emite `Set-Cookie` de `app_session_id` por contrato de rutas.
+7. Si, particular login emite `Set-Cookie` de `particular_session_id` por contrato de rutas.
+8. Si, cookies usan `Path=/`.
+9. Si, cookies son `Secure` en `NODE_ENV=production`.
+10. Si, `SameSite` es `none` en production y `lax` fuera de production.
+11. `Domain` se omite (host-only), y por eso era clave usar proxy same-origin para que middleware frontend pueda ver cookie.
+12. `TRUST_PROXY` esta gobernado por ENV y usado en Fastify app (`trustProxy: ENV.trustProxy`).
+13. Si, middleware frontend busca `admin_session_id` para admin y `app_session_id` para dashboard clinica; backend setea esos nombres.
+14. No se observaron evidencias de SW/PWA cacheando auth en este analisis; el problema principal fue el bypass del proxy same-origin en browser.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -48,6 +48,7 @@ import type {
 } from "@/types";
 
 const LOCAL_DEVELOPMENT_API_BASE_URL = "http://localhost:3000";
+const SAME_ORIGIN_API_BASE_URL = "";
 
 export const PUBLIC_API_CONFIGURATION_ERROR_MESSAGE =
   "El servicio público no está configurado para recibir solicitudes. Contacte a VETNEB por los canales oficiales.";
@@ -79,12 +80,15 @@ function normalizeApiBaseUrl(value: string): string {
 export function resolveApiBaseUrlForRuntime(input: {
   nodeEnv?: string;
   nextPublicApiUrl?: string;
+  isBrowserRuntime?: boolean;
 } = {}): string {
   const nodeEnv = input.nodeEnv ?? process.env.NODE_ENV ?? "development";
   const nextPublicApiUrl = (
     input.nextPublicApiUrl ?? process.env.NEXT_PUBLIC_API_URL ?? ""
   ).trim();
   const isDevelopment = nodeEnv === "development";
+  const isBrowserRuntime =
+    input.isBrowserRuntime ?? typeof window !== "undefined";
 
   if (!nextPublicApiUrl) {
     if (isDevelopment) {
@@ -104,6 +108,12 @@ export function resolveApiBaseUrlForRuntime(input: {
 
   if (!isDevelopment && isLocalOrLanHostname(parsedUrl.hostname)) {
     throw new Error(PUBLIC_API_CONFIGURATION_ERROR_MESSAGE);
+  }
+
+  // In browser runtime we intentionally keep API calls same-origin so Next rewrites
+  // can proxy `/api/*` and session cookies stay bound to the frontend host.
+  if (isBrowserRuntime) {
+    return SAME_ORIGIN_API_BASE_URL;
   }
 
   return normalizeApiBaseUrl(nextPublicApiUrl);

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -16,6 +16,7 @@ test("frontend API client resolves backend base URL with explicit public safegua
   const source = read(API_CLIENT_PATH);
 
   assert.ok(source.includes("const LOCAL_DEVELOPMENT_API_BASE_URL = \"http://localhost:3000\";"));
+  assert.ok(source.includes('const SAME_ORIGIN_API_BASE_URL = "";'));
   assert.ok(source.includes("export const PUBLIC_API_CONFIGURATION_ERROR_MESSAGE ="));
   assert.ok(source.includes("El servicio público no está configurado para recibir solicitudes."));
   assert.ok(source.includes("export function resolveApiBaseUrlForRuntime("));
@@ -112,13 +113,24 @@ test("resolveApiBaseUrlForRuntime retorna NEXT_PUBLIC_API_URL normalizado cuando
   );
 });
 
-test("resolveApiBaseUrlForRuntime no retorna string vacío en producción con NEXT_PUBLIC_API_URL válido", () => {
+test("resolveApiBaseUrlForRuntime usa same-origin en browser para que rewrites preserven cookies de sesión", () => {
   const source = read(API_CLIENT_PATH);
 
-  assert.equal(
-    source.includes('return "";'),
-    false,
-    "no debe dejar base vacía cuando NEXT_PUBLIC_API_URL es válido",
+  assert.ok(
+    source.includes("const isBrowserRuntime ="),
+    "debe detectar runtime browser/server",
+  );
+  assert.ok(
+    source.includes('input.isBrowserRuntime ?? typeof window !== "undefined"'),
+    "debe permitir branch explícito de browser en tests y runtime",
+  );
+  assert.ok(
+    source.includes("if (isBrowserRuntime) {"),
+    "en browser debe usar base same-origin",
+  );
+  assert.ok(
+    source.includes("return SAME_ORIGIN_API_BASE_URL;"),
+    "en browser la base debe resolver al proxy same-origin",
   );
 });
 


### PR DESCRIPTION
# PR fix staging auth connectivity roles

## 1. Rama
- `fix/staging-auth-connectivity-roles`

## 2. Causa raiz (hipotesis validada por codigo + smoke)
- El frontend ya tenia `rewrite` de Next para proxyar `"/api/:path*"` al backend (`frontend/next.config.ts`), pero el cliente API en browser llamaba directo a `NEXT_PUBLIC_API_URL` absoluto.
- Ese bypass del proxy provoca que `Set-Cookie` de login quede asociado al host del backend, no al host del frontend.
- El middleware de Next que protege `"/dashboard/*"` se ejecuta en el host del frontend y solo puede leer cookies de ese host; por eso `/dashboard/admin` sin cookie frontend sigue en `404`.
- Se aplico fix minimo para browser: usar base same-origin y dejar que el rewrite maneje `/api/*`.

## 3. Diagnostico admin
- `frontend/src/middleware.ts` mantiene contrato de seguridad: `/dashboard/admin` sin `admin_session_id` devuelve `404`.
- `server/routes/auth.fastify.ts` (login unificado) y `server/routes/admin-auth.fastify.ts` emiten `admin_session_id` con `Path=/`, `HttpOnly`, `SameSite` y `Secure` en prod.
- Si el login se hace cross-origin directo al backend, el cookie no queda en el host del frontend y el middleware no lo ve.

## 4. Diagnostico clinica
- `server/routes/auth.fastify.ts` emite `app_session_id` para clinica.
- `frontend/src/middleware.ts` exige `app_session_id` en `/dashboard`.
- El mismo problema de host de cookie aplica cuando browser llama directo a backend absoluto.

## 5. Diagnostico particular
- `server/routes/particular-auth.fastify.ts` emite `particular_session_id` y mantiene superficie separada.
- `frontend/src/components/public/ParticularesContent.tsx` usa endpoints particulares con `credentials: include`.
- Con fix same-origin en browser, tambien pasa por proxy de frontend y evita drift de host de cookie.

## 6. Cookies esperadas por rol
- Admin: `admin_session_id`
- Clinica: `app_session_id`
- Particular: `particular_session_id`
- Atributos esperados: `Path=/`, `HttpOnly`, `SameSite=None` en production, `Secure` en HTTPS.

## 7. CORS / credentials
- Smoke staging (sin credenciales privadas) valido:
  - Backend alive: OK
  - Frontend alive: OK
  - Preflight `OPTIONS /api/auth/login`: `204`, `Access-Control-Allow-Origin` exacto frontend staging, `Access-Control-Allow-Credentials=true`
  - Bad origin en unsafe route: bloqueado con `403`
- Verificacion manual adicional: respuestas `401` de login siguen exponiendo headers CORS correctos para origin permitido.

## 8. Middleware
- No se relajo seguridad:
  - `/dashboard/admin` sin cookie admin sigue `404`
  - `/dashboard` sin cookie clinica sigue redirect a `/login?next=...`
  - matcher sigue restringido a `"/dashboard/:path*"`

## 9. Implementaciones aplicadas
- `frontend/src/lib/api.ts`
  - Se agrego branch de runtime browser para usar base same-origin (`SAME_ORIGIN_API_BASE_URL`) y aprovechar el rewrite existente.
  - En runtime server-side se mantiene `NEXT_PUBLIC_API_URL` normalizado para fetch absoluto cuando corresponde.
- No se tocaron reglas de cookies backend, CORS, ni middleware de seguridad admin.

## 10. Tests agregados/reforzados
- `test/frontend-api-client-request.test.ts`
  - Se agrego contrato explicito para branch browser same-origin.
  - Se mantiene contrato de `NEXT_PUBLIC_API_URL` normalizado para runtime no-browser.
  - Se valida que el rewrite `/api/:path*` siga declarado en `next.config.ts`.

## 11. Validaciones ejecutadas
- `pnpm test`: OK (2027 pass, 0 fail, 1 skipped)
- `pnpm validate:local`: OK (`typecheck`, `typecheck:test`, `test`, `build`)
- `pnpm --dir frontend lint`: OK con 1 warning preexistente (`unused eslint-disable` en `frontend/src/app/api/security/csp-report/route.ts:177`)
- `pnpm --dir frontend typecheck`: OK
- `pnpm --dir frontend build`: OK

## 12. Riesgos residuales
- No se pudo ejecutar login real por rol en staging dentro de este entorno porque faltan variables opcionales de smoke (`SMOKE_ADMIN_*`, `SMOKE_CLINIC_*`, `SMOKE_PARTICULAR_TOKEN`).
- Aun hace falta validar manualmente en staging con credenciales reales que cada rol complete flujo E2E post-deploy.

## 13. Checklist manual staging
- [ ] login admin
- [ ] verificar `admin_session_id`
- [ ] abrir `/dashboard/admin`
- [ ] login clinica
- [ ] verificar `app_session_id`
- [ ] abrir `/dashboard`
- [ ] token particular
- [ ] verificar `particular_session_id`
- [ ] abrir caso particular

## 14. Respuestas a preguntas obligatorias
1. Frontend staging llama al backend correcto (`NEXT_PUBLIC_API_URL` en `.env.example` apunta a backend staging) y ahora en browser lo hace via same-origin + rewrite.
2. Si, fetch de auth usa `credentials: include` por defecto en `apiFetch`.
3. Si, backend CORS permite origen exacto cuando coincide con allowlist.
4. Si, backend responde `Access-Control-Allow-Credentials: true` para origen permitido.
5. Si, admin login emite `Set-Cookie` de `admin_session_id` por contrato de rutas.
6. Si, clinica login emite `Set-Cookie` de `app_session_id` por contrato de rutas.
7. Si, particular login emite `Set-Cookie` de `particular_session_id` por contrato de rutas.
8. Si, cookies usan `Path=/`.
9. Si, cookies son `Secure` en `NODE_ENV=production`.
10. Si, `SameSite` es `none` en production y `lax` fuera de production.
11. `Domain` se omite (host-only), y por eso era clave usar proxy same-origin para que middleware frontend pueda ver cookie.
12. `TRUST_PROXY` esta gobernado por ENV y usado en Fastify app (`trustProxy: ENV.trustProxy`).
13. Si, middleware frontend busca `admin_session_id` para admin y `app_session_id` para dashboard clinica; backend setea esos nombres.
14. No se observaron evidencias de SW/PWA cacheando auth en este analisis; el problema principal fue el bypass del proxy same-origin en browser.
