### PR TITLE
feat(report): unify workflow tracking across roles

### DIFF
--- a/PR-feat-report-workflow-unified-token-tracking.md
+++ b/PR-feat-report-workflow-unified-token-tracking.md
@@ -1,0 +1,117 @@
+# PR: feat/report-workflow-unified-token-tracking
+
+## 1. Rama
+- `feat/report-workflow-unified-token-tracking`
+
+## 2. Objetivo
+- Unificar el seguimiento del informe/estudio para que la etapa actual y la alerta de tinción especial sean consistentes y visibles en admin, clínica y particular (sesión por token), sin romper seguridad ni aislamiento por rol.
+
+## 3. Diagnóstico de fuente de verdad del workflow
+- La fuente de verdad funcional para seguimiento ya existía en `study_tracking_cases` y en los endpoints:
+  - Admin: `/api/admin/study-tracking`
+  - Clínica: `/api/study-tracking`
+  - Particular: `/api/particular/study-tracking/me`
+- Se detectó superficie paralela en admin con `/api/admin/report-workflow` (flujo legacy/alterno) que divergía en naming y contrato de estados.
+- No faltaron columnas para `currentStage` ni `specialStainRequired`.
+
+## 4. Diagnóstico admin
+- El visor de "Seguimiento de informes" consumía `report-workflow` en vez de `study-tracking`.
+- La acción de etapa/tinción existía, pero sobre contrato distinto al utilizado por clínica/particular.
+- Riesgo: desalineación semántica de estados mostrados respecto al resto de roles.
+
+## 5. Diagnóstico clínica
+- La tarjeta de últimos tokens no incorporaba la etapa real de seguimiento por token.
+- No mostraba de forma consistente la alerta de tinción especial proveniente del tracking.
+- Contrato clínico ya disponible para consulta scoped por clínica, faltaba consumirlo en UI.
+
+## 6. Diagnóstico particular
+- La sesión activa cargaba datos de autenticación/reportes, pero no mostraba de forma explícita la etapa actual del tracking.
+- En caso sin informe vinculado quedaba mensaje genérico, sin reflejar el estado real del estudio.
+- El endpoint particular de tracking ya existía, faltaba integrarlo en frontend.
+
+## 7. Estados soportados
+- Flujo unificado mostrado en frontend:
+  1. `reception` → Recepción de muestra
+  2. `processing` → Procesamiento
+  3. `evaluation` → Evaluación
+  4. `report_development` → Desarrollo de informe
+  5. `delivered` → Informe disponible / Publicado
+- La solicitud de tinción especial permanece como alerta separada (`specialStainRequired`), no como estado terminal.
+
+## 8. Alerta de tinción especial
+- Se mantiene lógica de alerta independiente y visible en los tres roles.
+- Se presenta como "Solicitud de tinción especial" cuando `specialStainRequired = true`.
+- Queda ubicada lógicamente entre evaluación y desarrollo de informe al no reemplazar la etapa actual ni el progreso.
+
+## 9. Implementaciones aplicadas
+- API frontend (`frontend/src/lib/api.ts`):
+  - Nuevo helper `getParticularStudyTrackingCase()` con manejo de errores recuperables.
+  - Nuevos contratos/helpers admin para `study-tracking`:
+    - `AdminStudyTrackingSnapshot`
+    - `AdminStudyTrackingUpdatePayload`
+    - `AdminStudyTrackingUpdateResponse`
+    - `getAdminStudyTrackingCases()`
+    - `updateAdminStudyTrackingCase()`
+  - Nuevos contratos/helpers clínica:
+    - `ClinicStudyTrackingCaseSummary`
+    - `ClinicStudyTrackingSnapshot`
+    - `getClinicStudyTrackingCases()`
+- Admin UI (`frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx`):
+  - Migra de `/api/admin/report-workflow` a `/api/admin/study-tracking`.
+  - Conserva acciones de cambio de etapa y solicitar/resolver tinción especial con patch unificado.
+  - Ajusta labels de etapa y copy para contrato unificado.
+- Admin tokens (`frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`):
+  - Carga tracking por `particularTokenId` para cada token visible.
+  - Muestra bloque "Seguimiento" con etapa + alerta de tinción especial.
+- Clínica tokens (`frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`):
+  - Integra consulta `study-tracking` por token y renderiza etapa + alerta.
+- Particular (`frontend/src/components/public/ParticularesContent.tsx`):
+  - Carga tracking en sesión activa (login, check de sesión, cleanup en logout).
+  - Muestra "Seguimiento del estudio" con etapa actual y alerta.
+  - En casos sin informe vinculado muestra estado real cuando hay tracking.
+
+## 10. Implementaciones descartadas por requerir DB/migration
+- No se requirieron migrations ni cambios de schema para cumplir el objetivo.
+- No se implementó alteración de tablas porque `currentStage` y `specialStainRequired` ya estaban disponibles en la fuente de verdad.
+
+## 11. Archivos modificados
+- `frontend/src/lib/api.ts`
+- `frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx`
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `test/frontend-admin-report-workflow.test.ts`
+- `test/frontend-admin-particular-tokens.test.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `test/frontend-particulares-content.test.ts`
+
+## 12. Tests agregados/reforzados
+- `test/frontend-admin-report-workflow.test.ts`:
+  - Ajuste de labels/contratos al flujo unificado de `study-tracking`.
+- `test/frontend-admin-particular-tokens.test.ts`:
+  - Cobertura de consumo de seguimiento por token y alerta.
+- `test/frontend-dashboard-clinic-tokens.test.ts`:
+  - Cobertura de visualización de etapa/alerta desde tracking clínico.
+- `test/frontend-particulares-content.test.ts`:
+  - Cobertura de estado y alerta en sesión particular activa.
+
+## 13. Validaciones ejecutadas
+- `pnpm test` ✅
+- `pnpm validate:local` ✅
+- `pnpm --dir frontend lint` ✅ (1 warning preexistente en `frontend/src/app/api/security/csp-report/route.ts`: unused eslint-disable)
+- `pnpm --dir frontend typecheck` ✅
+- `pnpm --dir frontend build` ✅
+
+## 14. Riesgos residuales
+- En tarjetas de tokens (admin/clínica) se hacen consultas de tracking por token listado (`N` requests para `N` tokens). Funcionalmente correcto; puede optimizarse luego con endpoint bulk si hiciera falta.
+- Persiste endpoint legacy `/api/admin/report-workflow` en backend; ya no es la fuente consumida por esta UI, pero conviene planificar deprecación controlada para evitar regresiones futuras.
+- Warning de lint no relacionado sigue vigente en ruta CSP.
+
+## 15. Checklist manual
+- [ ] Admin seguimiento de informes
+- [ ] Admin últimos tokens
+- [ ] Clínica últimos tokens
+- [ ] Particular sesión activa
+- [ ] Caso con alerta de tinción especial
+- [ ] Caso sin informe vinculado
+- [ ] Caso con informe publicado

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -16,6 +16,8 @@ import {
   deleteAdminParticularToken,
   getAdminUsersRoles,
   getAdminParticularTokens,
+  getAdminStudyTrackingCases,
+  type AdminStudyTrackingCaseSummary,
   type AdminParticularTokenCreatePayload,
   type AdminParticularTokenSummary,
 } from "@/lib/api";
@@ -251,6 +253,20 @@ function formatTokenSource(token: AdminParticularTokenSummary): string {
   return "Sistema";
 }
 
+const TRACKING_STAGE_LABELS: Record<AdminStudyTrackingCaseSummary["currentStage"], string> = {
+  reception: "Recepción de muestra",
+  processing: "Procesamiento",
+  evaluation: "Evaluación",
+  report_development: "Desarrollo de informe",
+  delivered: "Informe disponible / Publicado",
+};
+
+function getTrackingStageLabel(
+  stage: AdminStudyTrackingCaseSummary["currentStage"],
+): string {
+  return TRACKING_STAGE_LABELS[stage] ?? stage;
+}
+
 export function AdminParticularTokensCard() {
   const [formState, setFormState] =
     useState<AdminParticularTokenFormState>(INITIAL_FORM_STATE);
@@ -259,6 +275,10 @@ export function AdminParticularTokensCard() {
   const [isLoadingClinics, setIsLoadingClinics] = useState(false);
   const [clinicLoadError, setClinicLoadError] = useState<string | null>(null);
   const [tokens, setTokens] = useState<AdminParticularTokenSummary[]>([]);
+  const [trackingCasesByTokenId, setTrackingCasesByTokenId] = useState<
+    Record<number, AdminStudyTrackingCaseSummary>
+  >({});
+  const [trackingLoadError, setTrackingLoadError] = useState<string | null>(null);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
   const [generatedTokenRecipientEmail, setGeneratedTokenRecipientEmail] =
     useState<string | null>(null);
@@ -290,16 +310,54 @@ export function AdminParticularTokensCard() {
 
   async function loadTokens() {
     setIsLoadingTokens(true);
+    setTrackingLoadError(null);
 
     try {
       const snapshot = await getAdminParticularTokens({ limit: 10, offset: 0 });
       setTokens(snapshot.particularTokens);
+
+      if (snapshot.particularTokens.length === 0) {
+        setTrackingCasesByTokenId({});
+        return;
+      }
+
+      try {
+        const trackingEntries = await Promise.all(
+          snapshot.particularTokens.map(async (token) => {
+            const trackingSnapshot = await getAdminStudyTrackingCases({
+              particularTokenId: token.id,
+              limit: 1,
+              offset: 0,
+            });
+
+            return [token.id, trackingSnapshot.trackingCases[0] ?? null] as const;
+          }),
+        );
+
+        const nextTrackingByTokenId: Record<number, AdminStudyTrackingCaseSummary> = {};
+
+        for (const [tokenId, trackingCase] of trackingEntries) {
+          if (trackingCase) {
+            nextTrackingByTokenId[tokenId] = trackingCase;
+          }
+        }
+
+        setTrackingCasesByTokenId(nextTrackingByTokenId);
+      } catch (error) {
+        setTrackingCasesByTokenId({});
+        setTrackingLoadError(
+          error instanceof Error
+            ? error.message
+            : "No se pudo cargar el seguimiento de los tokens listados.",
+        );
+      }
     } catch (error) {
       setErrorMessage(
         error instanceof Error
           ? error.message
           : "No se pudieron cargar los tokens particulares.",
       );
+      setTrackingCasesByTokenId({});
     } finally {
       setIsLoadingTokens(false);
     }
@@ -531,6 +589,11 @@ export function AdminParticularTokensCard() {
       const response = await deleteAdminParticularToken(token.id);
       setStatusMessage(response.message);
       setTokens((current) => current.filter((t) => t.id !== token.id));
+      setTrackingCasesByTokenId((current) => {
+        const next = { ...current };
+        delete next[token.id];
+        return next;
+      });
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -1006,13 +1069,22 @@ export function AdminParticularTokensCard() {
             </Button>
           </div>
 
+          {trackingLoadError ? (
+            <p className="clinical-alert-warning px-3 py-2 text-sm" role="alert">
+              {trackingLoadError}
+            </p>
+          ) : null}
+
           {tokens.length ? (
             <div className="space-y-2">
-              {tokens.map((token) => (
-                <div
-                  key={token.id}
-                  className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
-                >
+              {tokens.map((token) => {
+                const trackingCase = trackingCasesByTokenId[token.id];
+
+                return (
+                  <div
+                    key={token.id}
+                    className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
+                  >
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="space-y-1">
                       <p className="text-sm font-semibold text-vetneb-ink">
@@ -1038,7 +1110,7 @@ export function AdminParticularTokensCard() {
                     </div>
                   </div>
 
-                  <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-5">
+                  <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-6">
                     <div className="clinical-muted-band rounded-lg px-3 py-2">
                       <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                         Paciente
@@ -1092,6 +1164,28 @@ export function AdminParticularTokensCard() {
                         Origen: {formatTokenSource(token)}
                       </p>
                     </div>
+
+                    <div className="clinical-muted-band rounded-lg px-3 py-2">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                        Seguimiento
+                      </p>
+                      {trackingCase ? (
+                        <>
+                          <p className="mt-1 text-xs text-vetneb-ink">
+                            Etapa: {getTrackingStageLabel(trackingCase.currentStage)}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {trackingCase.specialStainRequired
+                              ? "Alerta: Solicitud de tinción especial"
+                              : "Sin alerta de tinción especial"}
+                          </p>
+                        </>
+                      ) : (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Sin seguimiento vinculado.
+                        </p>
+                      )}
+                    </div>
                   </div>
 
                   <div className="mt-3 flex justify-end">
@@ -1105,8 +1199,9 @@ export function AdminParticularTokensCard() {
                       {revokingTokenId === token.id ? "Eliminando..." : "Eliminar token"}
                     </Button>
                   </div>
-                </div>
-              ))}
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <p className="surface-empty">

--- a/frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx
+++ b/frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx
@@ -20,32 +20,31 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  getAdminReportWorkflow,
-  updateAdminReportSpecialStain,
-  updateAdminReportWorkflowStage,
-  type AdminReportWorkflowItem,
-  type AdminReportWorkflowStage,
+  getAdminStudyTrackingCases,
+  updateAdminStudyTrackingCase,
+  type AdminStudyTrackingCaseSummary,
+  type AdminStudyTrackingStage,
 } from "@/lib/api";
 
 const PAGE_LIMIT = 20;
 
 const WORKFLOW_STAGES: Array<{
-  value: AdminReportWorkflowStage;
+  value: AdminStudyTrackingStage;
   label: string;
 }> = [
-  { value: "sample_received", label: "Recepción de muestra" },
+  { value: "reception", label: "Recepción de muestra" },
   { value: "processing", label: "Procesamiento" },
   { value: "evaluation", label: "Evaluación" },
   { value: "report_development", label: "Desarrollo de informe" },
-  { value: "delivered", label: "Entrega" },
+  { value: "delivered", label: "Informe disponible / Publicado" },
 ];
 
-function getStageLabel(stage: AdminReportWorkflowStage) {
+function getStageLabel(stage: AdminStudyTrackingStage) {
   return WORKFLOW_STAGES.find((option) => option.value === stage)?.label ?? stage;
 }
 
 function getStageVariant(
-  stage: AdminReportWorkflowStage,
+  stage: AdminStudyTrackingStage,
 ): "default" | "secondary" | "outline" {
   if (stage === "delivered") return "default";
   if (stage === "report_development" || stage === "evaluation") {
@@ -73,11 +72,11 @@ function formatReportDate(value: string | null) {
 }
 
 export function AdminReportWorkflowViewerCard() {
-  const [reports, setReports] = useState<AdminReportWorkflowItem[]>([]);
+  const [trackingCases, setTrackingCases] = useState<AdminStudyTrackingCaseSummary[]>([]);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [busyReportId, setBusyReportId] = useState<number | null>(null);
+  const [busyTrackingCaseId, setBusyTrackingCaseId] = useState<number | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const loadWorkflow = useCallback(async (nextOffset: number) => {
@@ -85,19 +84,19 @@ export function AdminReportWorkflowViewerCard() {
     setErrorMessage(null);
 
     try {
-      const snapshot = await getAdminReportWorkflow({
-        limit: PAGE_LIMIT,
+      const snapshot = await getAdminStudyTrackingCases({
+        limit: PAGE_LIMIT + 1,
         offset: nextOffset,
       });
-      setReports(snapshot.reports);
-      setHasMore(snapshot.pagination.hasMore);
+      setTrackingCases(snapshot.trackingCases.slice(0, PAGE_LIMIT));
+      setHasMore(snapshot.trackingCases.length > PAGE_LIMIT);
     } catch (error) {
-      setReports([]);
+      setTrackingCases([]);
       setHasMore(false);
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : "No se pudo cargar el seguimiento de informes.",
+          : "No se pudo cargar el seguimiento de estudios.",
       );
     } finally {
       setIsLoading(false);
@@ -109,45 +108,50 @@ export function AdminReportWorkflowViewerCard() {
   }, [loadWorkflow, offset]);
 
   async function handleStageChange(
-    report: AdminReportWorkflowItem,
-    stage: AdminReportWorkflowStage,
+    trackingCase: AdminStudyTrackingCaseSummary,
+    stage: AdminStudyTrackingStage,
   ) {
-    if (stage === report.workflowStage || busyReportId !== null) {
+    if (stage === trackingCase.currentStage || busyTrackingCaseId !== null) {
       return;
     }
 
-    setBusyReportId(report.id);
+    setBusyTrackingCaseId(trackingCase.id);
     setErrorMessage(null);
 
     try {
-      const response = await updateAdminReportWorkflowStage(report.id, stage);
-      setReports((current) =>
-        current.map((item) => (item.id === report.id ? response.report : item)),
+      const response = await updateAdminStudyTrackingCase(trackingCase.id, {
+        currentStage: stage,
+      });
+      setTrackingCases((current) =>
+        current.map((item) =>
+          item.id === trackingCase.id ? response.trackingCase : item,
+        ),
       );
     } catch (error) {
       setErrorMessage(
         error instanceof Error ? error.message : "No se pudo cambiar la etapa.",
       );
     } finally {
-      setBusyReportId(null);
+      setBusyTrackingCaseId(null);
     }
   }
 
-  async function handleSpecialStainChange(report: AdminReportWorkflowItem) {
-    if (busyReportId !== null) {
+  async function handleSpecialStainChange(trackingCase: AdminStudyTrackingCaseSummary) {
+    if (busyTrackingCaseId !== null) {
       return;
     }
 
-    setBusyReportId(report.id);
+    setBusyTrackingCaseId(trackingCase.id);
     setErrorMessage(null);
 
     try {
-      const response = await updateAdminReportSpecialStain(
-        report.id,
-        !report.specialStainRequested,
-      );
-      setReports((current) =>
-        current.map((item) => (item.id === report.id ? response.report : item)),
+      const response = await updateAdminStudyTrackingCase(trackingCase.id, {
+        specialStainRequired: !trackingCase.specialStainRequired,
+      });
+      setTrackingCases((current) =>
+        current.map((item) =>
+          item.id === trackingCase.id ? response.trackingCase : item,
+        ),
       );
     } catch (error) {
       setErrorMessage(
@@ -156,7 +160,7 @@ export function AdminReportWorkflowViewerCard() {
           : "No se pudo actualizar la tinción especial.",
       );
     } finally {
-      setBusyReportId(null);
+      setBusyTrackingCaseId(null);
     }
   }
 
@@ -166,7 +170,7 @@ export function AdminReportWorkflowViewerCard() {
         <div>
           <CardTitle className="text-base">Seguimiento de informes</CardTitle>
           <CardDescription>
-            Etapas globales del informe y solicitudes manuales de tinción especial
+            Fuente única de etapas y alertas clínicas para admin, clínica y particular
           </CardDescription>
         </div>
         <Button
@@ -189,9 +193,8 @@ export function AdminReportWorkflowViewerCard() {
           <TableHeader>
             <TableRow>
               <TableHead>Clínica</TableHead>
-              <TableHead>Paciente / informe</TableHead>
-              <TableHead>Tipo de estudio</TableHead>
-              <TableHead>Fecha de carga / recepción</TableHead>
+              <TableHead>Reporte / token</TableHead>
+              <TableHead>Fechas clave</TableHead>
               <TableHead>Etapa actual</TableHead>
               <TableHead>Alerta tinción especial</TableHead>
               <TableHead>Acciones</TableHead>
@@ -200,63 +203,70 @@ export function AdminReportWorkflowViewerCard() {
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={7} className="clinical-table-state">
-                  Cargando informes...
+                <TableCell colSpan={6} className="clinical-table-state">
+                  Cargando seguimientos...
                 </TableCell>
               </TableRow>
-            ) : reports.length === 0 ? (
+            ) : trackingCases.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} className="clinical-table-state">
-                  No hay informes disponibles para seguimiento.
+                <TableCell colSpan={6} className="clinical-table-state">
+                  No hay seguimientos disponibles.
                 </TableCell>
               </TableRow>
             ) : (
-              reports.map((report) => {
-                const busy = busyReportId === report.id;
+              trackingCases.map((trackingCase) => {
+                const busy = busyTrackingCaseId === trackingCase.id;
 
                 return (
-                  <TableRow key={report.id}>
+                  <TableRow key={trackingCase.id}>
                     <TableCell className="text-sm text-vetneb-ink">
-                      {report.clinicName ?? `Clínica #${report.clinicId}`}
+                      Clínica #{trackingCase.clinicId}
                     </TableCell>
                     <TableCell className="text-sm">
                       <p className="font-medium text-vetneb-ink">
-                        {report.patientName ?? "Sin paciente informado"}
+                        Reporte:{" "}
+                        {typeof trackingCase.reportId === "number"
+                          ? `#${trackingCase.reportId}`
+                          : "Sin vínculo"}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        {report.fileName ?? `Informe #${report.id}`}
+                        Token particular:{" "}
+                        {typeof trackingCase.particularTokenId === "number"
+                          ? `#${trackingCase.particularTokenId}`
+                          : "Sin vínculo"}
                       </p>
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
-                      {report.studyType ?? "-"}
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {formatReportDate(report.uploadDate ?? report.createdAt)}
+                      <p>Recepción: {formatReportDate(trackingCase.receptionAt)}</p>
+                      <p>Actualizado: {formatReportDate(trackingCase.updatedAt)}</p>
                     </TableCell>
                     <TableCell>
-                      <Badge variant={getStageVariant(report.workflowStage)}>
-                        {getStageLabel(report.workflowStage)}
+                      <Badge variant={getStageVariant(trackingCase.currentStage)}>
+                        {getStageLabel(trackingCase.currentStage)}
                       </Badge>
                     </TableCell>
                     <TableCell>
-                      {report.specialStainRequested ? (
-                        <Badge variant="secondary">Solicitada</Badge>
+                      {trackingCase.specialStainRequired ? (
+                        <Badge variant="secondary">Solicitud de tinción especial</Badge>
                       ) : (
                         <Badge variant="outline">Sin alerta</Badge>
                       )}
                     </TableCell>
                     <TableCell>
                       <div className="flex min-w-[270px] items-center gap-2">
-                        <label className="sr-only" htmlFor={`workflow-stage-${report.id}`}>
+                        <label
+                          className="sr-only"
+                          htmlFor={`workflow-stage-${trackingCase.id}`}
+                        >
                           Cambiar etapa
                         </label>
                         <select
-                          id={`workflow-stage-${report.id}`}
-                          value={report.workflowStage}
+                          id={`workflow-stage-${trackingCase.id}`}
+                          value={trackingCase.currentStage}
                           onChange={(event) =>
                             void handleStageChange(
-                              report,
-                              event.target.value as AdminReportWorkflowStage,
+                              trackingCase,
+                              event.target.value as AdminStudyTrackingStage,
                             )
                           }
                           disabled={busy}
@@ -273,9 +283,9 @@ export function AdminReportWorkflowViewerCard() {
                           variant="outline"
                           size="sm"
                           disabled={busy}
-                          onClick={() => void handleSpecialStainChange(report)}
+                          onClick={() => void handleSpecialStainChange(trackingCase)}
                         >
-                          {report.specialStainRequested ? "Resolver" : "Solicitar"}
+                          {trackingCase.specialStainRequired ? "Resolver" : "Solicitar"}
                         </Button>
                       </div>
                     </TableCell>
@@ -287,7 +297,7 @@ export function AdminReportWorkflowViewerCard() {
         </Table>
         <div className="flex items-center justify-between px-6 pb-5 text-sm text-muted-foreground">
           <span>
-            Mostrando hasta {PAGE_LIMIT} informes
+            Mostrando hasta {PAGE_LIMIT} seguimientos
             {offset > 0 ? ` desde el registro ${offset + 1}` : ""}
           </span>
           <div className="flex gap-2">

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -8,7 +8,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
   createClinicParticularToken,
+  getClinicStudyTrackingCases,
   getClinicParticularTokens,
+  type ClinicStudyTrackingCaseSummary,
   type ClinicParticularTokenCreatePayload,
   type ClinicParticularTokenSummary,
 } from "@/lib/api";
@@ -161,10 +163,28 @@ function formatTokenSource(token: ClinicParticularTokenSummary): string {
   return "Sistema";
 }
 
+const TRACKING_STAGE_LABELS: Record<ClinicStudyTrackingCaseSummary["currentStage"], string> = {
+  reception: "Recepción de muestra",
+  processing: "Procesamiento",
+  evaluation: "Evaluación",
+  report_development: "Desarrollo de informe",
+  delivered: "Informe disponible / Publicado",
+};
+
+function getTrackingStageLabel(
+  stage: ClinicStudyTrackingCaseSummary["currentStage"],
+): string {
+  return TRACKING_STAGE_LABELS[stage] ?? stage;
+}
+
 export function ClinicParticularTokensCard() {
   const [formState, setFormState] =
     useState<ClinicParticularTokenFormState>(INITIAL_FORM_STATE);
   const [tokens, setTokens] = useState<ClinicParticularTokenSummary[]>([]);
+  const [trackingCasesByTokenId, setTrackingCasesByTokenId] = useState<
+    Record<number, ClinicStudyTrackingCaseSummary>
+  >({});
+  const [trackingLoadError, setTrackingLoadError] = useState<string | null>(null);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
   const [generatedTokenRecipientEmail, setGeneratedTokenRecipientEmail] =
     useState<string | null>(null);
@@ -183,16 +203,54 @@ export function ClinicParticularTokensCard() {
 
   async function loadTokens() {
     setIsLoadingTokens(true);
+    setTrackingLoadError(null);
 
     try {
       const snapshot = await getClinicParticularTokens({ limit: 10, offset: 0 });
       setTokens(snapshot.particularTokens);
+
+      if (snapshot.particularTokens.length === 0) {
+        setTrackingCasesByTokenId({});
+        return;
+      }
+
+      try {
+        const trackingEntries = await Promise.all(
+          snapshot.particularTokens.map(async (token) => {
+            const trackingSnapshot = await getClinicStudyTrackingCases({
+              particularTokenId: token.id,
+              limit: 1,
+              offset: 0,
+            });
+
+            return [token.id, trackingSnapshot.trackingCases[0] ?? null] as const;
+          }),
+        );
+
+        const nextTrackingByTokenId: Record<number, ClinicStudyTrackingCaseSummary> = {};
+
+        for (const [tokenId, trackingCase] of trackingEntries) {
+          if (trackingCase) {
+            nextTrackingByTokenId[tokenId] = trackingCase;
+          }
+        }
+
+        setTrackingCasesByTokenId(nextTrackingByTokenId);
+      } catch (error) {
+        setTrackingCasesByTokenId({});
+        setTrackingLoadError(
+          error instanceof Error
+            ? error.message
+            : "No se pudo cargar el seguimiento de los tokens listados.",
+        );
+      }
     } catch (error) {
       setErrorMessage(
         error instanceof Error
           ? error.message
           : "No se pudieron cargar los tokens particulares.",
       );
+      setTrackingCasesByTokenId({});
     } finally {
       setIsLoadingTokens(false);
     }
@@ -684,13 +742,22 @@ export function ClinicParticularTokensCard() {
             </Button>
           </div>
 
+          {trackingLoadError ? (
+            <p className="clinical-alert-warning px-3 py-2 text-sm" role="alert">
+              {trackingLoadError}
+            </p>
+          ) : null}
+
           {tokens.length ? (
             <div className="space-y-2">
-              {tokens.map((token) => (
-                <div
-                  key={token.id}
-                  className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
-                >
+              {tokens.map((token) => {
+                const trackingCase = trackingCasesByTokenId[token.id];
+
+                return (
+                  <div
+                    key={token.id}
+                    className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
+                  >
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="space-y-1">
                       <p className="text-sm font-semibold text-vetneb-ink">
@@ -716,7 +783,7 @@ export function ClinicParticularTokensCard() {
                     </div>
                   </div>
 
-                  <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-5">
+                  <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-6">
                     <div className="clinical-muted-band rounded-lg px-3 py-2">
                       <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                         Paciente
@@ -772,9 +839,32 @@ export function ClinicParticularTokensCard() {
                         Origen: {formatTokenSource(token)}
                       </p>
                     </div>
+
+                    <div className="clinical-muted-band rounded-lg px-3 py-2">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                        Seguimiento
+                      </p>
+                      {trackingCase ? (
+                        <>
+                          <p className="mt-1 text-xs text-vetneb-ink">
+                            Etapa: {getTrackingStageLabel(trackingCase.currentStage)}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {trackingCase.specialStainRequired
+                              ? "Alerta: Solicitud de tinción especial"
+                              : "Sin alerta de tinción especial"}
+                          </p>
+                        </>
+                      ) : (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Sin seguimiento vinculado.
+                        </p>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <p className="surface-empty">

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -17,9 +17,11 @@ import {
 import {
   getParticularReportDownloadUrl,
   getParticularReportPreviewUrl,
+  getParticularStudyTrackingCase,
   getParticularSession,
   loginParticular,
   logoutParticular,
+  type AdminStudyTrackingCaseSummary,
 } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 import type { ParticularSession } from "@/types";
@@ -56,6 +58,20 @@ function formatDate(value: string | null | undefined) {
   }).format(date);
 }
 
+const TRACKING_STAGE_LABELS: Record<AdminStudyTrackingCaseSummary["currentStage"], string> = {
+  reception: "Recepción de muestra",
+  processing: "Procesamiento",
+  evaluation: "Evaluación",
+  report_development: "Desarrollo de informe",
+  delivered: "Informe disponible / Publicado",
+};
+
+function getTrackingStageLabel(
+  stage: AdminStudyTrackingCaseSummary["currentStage"],
+) {
+  return TRACKING_STAGE_LABELS[stage] ?? stage;
+}
+
 const accessHighlights = [
   {
     title: "Token",
@@ -83,6 +99,8 @@ export function ParticularesContent() {
   const [isCheckingSession, setIsCheckingSession] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isOpeningReport, setIsOpeningReport] = useState(false);
+  const [trackingCase, setTrackingCase] = useState<AdminStudyTrackingCaseSummary | null>(null);
+  const [trackingLoadError, setTrackingLoadError] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [sessionCheckError, setSessionCheckError] = useState(false);
   const [clipboardSupported, setClipboardSupported] = useState(false);
@@ -92,12 +110,31 @@ export function ParticularesContent() {
     setIsCheckingSession(true);
     setErrorMessage(null);
     setSessionCheckError(false);
+    setTrackingLoadError(null);
 
     try {
       const response = await getParticularSession();
       setSession(response?.particular ?? null);
+      const nextSession = response?.particular ?? null;
+
+      if (nextSession) {
+        try {
+          const trackingSnapshot = await getParticularStudyTrackingCase();
+          setTrackingCase(trackingSnapshot);
+        } catch (error) {
+          setTrackingCase(null);
+          setTrackingLoadError(
+            error instanceof Error
+              ? error.message
+              : "No se pudo cargar el seguimiento del estudio.",
+          );
+        }
+      } else {
+        setTrackingCase(null);
+      }
     } catch (error) {
       setSessionCheckError(true);
+      setTrackingCase(null);
       setErrorMessage(
         error instanceof Error
           ? error.message
@@ -133,8 +170,21 @@ export function ParticularesContent() {
     try {
       const response = await loginParticular({ token });
       setSession(response.particular);
+      setTrackingLoadError(null);
+      try {
+        const trackingSnapshot = await getParticularStudyTrackingCase();
+        setTrackingCase(trackingSnapshot);
+      } catch (error) {
+        setTrackingCase(null);
+        setTrackingLoadError(
+          error instanceof Error
+            ? error.message
+            : "No se pudo cargar el seguimiento del estudio.",
+        );
+      }
       setToken("");
     } catch (error) {
+      setTrackingCase(null);
       setErrorMessage(
         error instanceof Error
           ? error.message
@@ -147,6 +197,7 @@ export function ParticularesContent() {
 
   async function handleLogout() {
     setErrorMessage(null);
+    setTrackingLoadError(null);
 
     try {
       await logoutParticular();
@@ -154,6 +205,7 @@ export function ParticularesContent() {
       // La salida local se completa aunque el backend ya no tenga sesión activa.
     } finally {
       setSession(null);
+      setTrackingCase(null);
     }
   }
 
@@ -336,6 +388,34 @@ export function ParticularesContent() {
                     </dl>
                   </div>
 
+                  <div className="clinical-muted-band rounded-lg p-4 shadow-sm">
+                    <h3 className="font-semibold text-vetneb-navy">
+                      Seguimiento del estudio
+                    </h3>
+                    {trackingCase ? (
+                      <div className="mt-2 space-y-2">
+                        <p className="text-sm text-vetneb-ink">
+                          Estado del estudio:{" "}
+                          <span className="font-semibold">
+                            {getTrackingStageLabel(trackingCase.currentStage)}
+                          </span>
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Actualizado: {formatDate(trackingCase.updatedAt)}
+                        </p>
+                        {trackingCase.specialStainRequired ? (
+                          <div className="clinical-alert-warning p-3 text-sm">
+                            Alerta: Solicitud de tinción especial.
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        No hay seguimiento operativo vinculado para esta sesión.
+                      </p>
+                    )}
+                  </div>
+
                   {session.report ? (
                     <div className="clinical-muted-band rounded-lg p-4 shadow-sm">
                       <div className="flex items-start gap-3">
@@ -379,11 +459,20 @@ export function ParticularesContent() {
                     </div>
                   ) : (
                     <div className="clinical-alert-warning p-4">
-                      El caso todavía no tiene un informe vinculado. El estudio
-                      continúa en evaluación profesional y se habilitará cuando
-                      finalice la validación diagnóstica.
+                      {trackingCase
+                        ? `El caso todavía no tiene un informe vinculado. Estado del estudio: ${getTrackingStageLabel(trackingCase.currentStage)}.`
+                        : "El caso todavía no tiene un informe vinculado. El estudio continúa en evaluación profesional y se habilitará cuando finalice la validación diagnóstica."}
                     </div>
                   )}
+
+                  {trackingLoadError ? (
+                    <p
+                      className="clinical-alert-warning px-3 py-2 text-sm"
+                      role="alert"
+                    >
+                      {trackingLoadError}
+                    </p>
+                  ) : null}
 
                   {errorMessage ? (
                     <p

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -305,6 +305,33 @@ export async function getParticularReportDownloadUrl(): Promise<string> {
   return response.downloadUrl;
 }
 
+const PARTICULAR_STUDY_TRACKING_RECOVERABLE_ERRORS = new Set([
+  "Particular no autenticado",
+  "Sesión particular inválida",
+  "Sesión particular expirada",
+  "Token particular inválido o inactivo",
+  "Seguimiento no encontrado para el token particular autenticado",
+]);
+
+export async function getParticularStudyTrackingCase(): Promise<AdminStudyTrackingCaseSummary | null> {
+  try {
+    const response = await apiFetch<{
+      success: true;
+      trackingCase: AdminStudyTrackingCaseSummary;
+    }>("/api/particular/study-tracking/me");
+    return response.trackingCase;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      PARTICULAR_STUDY_TRACKING_RECOVERABLE_ERRORS.has(error.message)
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 type ReportReadOptions = {
   throwOnError?: boolean;
 };
@@ -736,6 +763,135 @@ export async function createAdminStudyTrackingCase(
       method: "POST",
       body: JSON.stringify(payload),
     },
+  );
+}
+
+export type AdminStudyTrackingSnapshot = {
+  success: true;
+  count: number;
+  trackingCases: AdminStudyTrackingCaseSummary[];
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+};
+
+export type AdminStudyTrackingUpdatePayload = {
+  reportId?: number | null;
+  particularTokenId?: number | null;
+  currentStage?: AdminStudyTrackingStage;
+  specialStainRequired?: boolean;
+  paymentUrl?: string | null;
+  adminContactEmail?: string | null;
+  adminContactPhone?: string | null;
+  notes?: string | null;
+};
+
+export type AdminStudyTrackingUpdateResponse = {
+  success: true;
+  message: string;
+  trackingCase: AdminStudyTrackingCaseSummary;
+};
+
+export async function getAdminStudyTrackingCases(
+  params: {
+    clinicId?: number;
+    reportId?: number;
+    particularTokenId?: number;
+    limit?: number;
+    offset?: number;
+  } = {},
+  options?: RequestInit,
+): Promise<AdminStudyTrackingSnapshot> {
+  const query = new URLSearchParams();
+
+  if (typeof params.clinicId === "number") {
+    query.set("clinicId", String(params.clinicId));
+  }
+
+  if (typeof params.reportId === "number") {
+    query.set("reportId", String(params.reportId));
+  }
+
+  if (typeof params.particularTokenId === "number") {
+    query.set("particularTokenId", String(params.particularTokenId));
+  }
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<AdminStudyTrackingSnapshot>(
+    `/api/admin/study-tracking${qs ? `?${qs}` : ""}`,
+    options,
+  );
+}
+
+export async function updateAdminStudyTrackingCase(
+  trackingCaseId: number,
+  payload: AdminStudyTrackingUpdatePayload,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingUpdateResponse> {
+  return apiFetch<AdminStudyTrackingUpdateResponse>(
+    `/api/admin/study-tracking/${trackingCaseId}`,
+    {
+      ...options,
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export type ClinicStudyTrackingCaseSummary = AdminStudyTrackingCaseSummary;
+
+export type ClinicStudyTrackingSnapshot = {
+  success: true;
+  count: number;
+  trackingCases: ClinicStudyTrackingCaseSummary[];
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+};
+
+export async function getClinicStudyTrackingCases(
+  params: {
+    reportId?: number;
+    particularTokenId?: number;
+    limit?: number;
+    offset?: number;
+  } = {},
+  options?: RequestInit,
+): Promise<ClinicStudyTrackingSnapshot> {
+  const query = new URLSearchParams();
+
+  if (typeof params.reportId === "number") {
+    query.set("reportId", String(params.reportId));
+  }
+
+  if (typeof params.particularTokenId === "number") {
+    query.set("particularTokenId", String(params.particularTokenId));
+  }
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<ClinicStudyTrackingSnapshot>(
+    `/api/study-tracking${qs ? `?${qs}` : ""}`,
+    options,
   );
 }
 

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -426,3 +426,15 @@ test("admin token card delete handler uses deleteAdminParticularToken not revoke
   assert.ok(api.includes("export type AdminParticularTokenDeleteResponse"), "api must export AdminParticularTokenDeleteResponse type");
   assert.ok(api.includes('method: "DELETE"'), "deleteAdminParticularToken must use DELETE method");
 });
+
+test("admin token card consume seguimiento por token desde study-tracking", () => {
+  const card = read(ADMIN_CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes("getAdminStudyTrackingCases"));
+  assert.ok(card.includes("trackingCasesByTokenId"));
+  assert.ok(card.includes("Seguimiento"));
+  assert.ok(card.includes("getTrackingStageLabel("));
+  assert.ok(card.includes("Alerta: Solicitud de tinción especial"));
+  assert.ok(api.includes("export async function getAdminStudyTrackingCases("));
+});

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -54,7 +54,7 @@ test("tarjeta presenta cinco etapas globales y tinción especial como alerta apa
     "Procesamiento",
     "Evaluación",
     "Desarrollo de informe",
-    "Entrega",
+    "Informe disponible / Publicado",
   ]) {
     assert.ok(stages.includes(stage), `debe mostrar ${stage}`);
   }
@@ -64,7 +64,7 @@ test("tarjeta presenta cinco etapas globales y tinción especial como alerta apa
   assert.ok(card.includes("Alerta tinción especial"));
   assert.ok(card.includes("Solicitar"));
   assert.ok(card.includes("Resolver"));
-  assert.ok(card.includes("Tipo de estudio"));
+  assert.ok(card.includes("Reporte / token"));
   assert.equal(card.includes("citologia"), false);
   assert.equal(card.includes("histopatologia"), false);
   assert.equal(card.includes("hemoparasitos"), false);
@@ -80,10 +80,9 @@ test("tarjeta y cliente API soportan paginación y mutaciones manuales", () => {
   assert.ok(card.includes("Siguiente"));
   assert.ok(card.includes("handleStageChange"));
   assert.ok(card.includes("handleSpecialStainChange"));
-  assert.ok(api.includes("export async function getAdminReportWorkflow("));
-  assert.ok(api.includes("export async function updateAdminReportWorkflowStage("));
-  assert.ok(api.includes("export async function updateAdminReportSpecialStain("));
-  assert.ok(api.includes("`/api/admin/report-workflow/${reportId}/stage`"));
-  assert.ok(api.includes("`/api/admin/report-workflow/${reportId}/special-stain`"));
+  assert.ok(api.includes("export async function getAdminStudyTrackingCases("));
+  assert.ok(api.includes("export async function updateAdminStudyTrackingCase("));
+  assert.ok(api.includes("`/api/admin/study-tracking${qs ? `?${qs}` : \"\"}`"));
+  assert.ok(api.includes("`/api/admin/study-tracking/${trackingCaseId}`"));
   assert.ok(api.includes('credentials: options.credentials ?? "include",'));
 });

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -327,3 +327,15 @@ test("frontend api exposes clinic-scoped particular token helpers", () => {
   assert.ok(source.includes("`/api/particular-tokens${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("`/api/particular-tokens/${tokenId}/report`"));
 });
+
+test("clinic token card muestra seguimiento y alerta de tinción especial desde study-tracking", () => {
+  const card = read(CLINIC_TOKENS_CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes("getClinicStudyTrackingCases"));
+  assert.ok(card.includes("trackingCasesByTokenId"));
+  assert.ok(card.includes("Seguimiento"));
+  assert.ok(card.includes("getTrackingStageLabel("));
+  assert.ok(card.includes("Alerta: Solicitud de tinción especial"));
+  assert.ok(api.includes("export async function getClinicStudyTrackingCases("));
+});

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -47,3 +47,13 @@ test("particulares content keeps neutral logout control and removes resumen labe
   assert.equal(source.includes("className=\"public-cta-secondary\""), false);
   assert.equal(source.includes("Resumen de caso"), false);
 });
+
+test("particulares content muestra estado y alerta desde study-tracking en sesión activa", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("getParticularStudyTrackingCase"));
+  assert.ok(source.includes("Seguimiento del estudio"));
+  assert.ok(source.includes("Estado del estudio:"));
+  assert.ok(source.includes("Alerta: Solicitud de tinción especial."));
+  assert.ok(source.includes("trackingCase"));
+});


### PR DESCRIPTION
# PR: feat/report-workflow-unified-token-tracking

## 1. Rama
- `feat/report-workflow-unified-token-tracking`

## 2. Objetivo
- Unificar el seguimiento del informe/estudio para que la etapa actual y la alerta de tinción especial sean consistentes y visibles en admin, clínica y particular (sesión por token), sin romper seguridad ni aislamiento por rol.

## 3. Diagnóstico de fuente de verdad del workflow
- La fuente de verdad funcional para seguimiento ya existía en `study_tracking_cases` y en los endpoints:
  - Admin: `/api/admin/study-tracking`
  - Clínica: `/api/study-tracking`
  - Particular: `/api/particular/study-tracking/me`
- Se detectó superficie paralela en admin con `/api/admin/report-workflow` (flujo legacy/alterno) que divergía en naming y contrato de estados.
- No faltaron columnas para `currentStage` ni `specialStainRequired`.

## 4. Diagnóstico admin
- El visor de "Seguimiento de informes" consumía `report-workflow` en vez de `study-tracking`.
- La acción de etapa/tinción existía, pero sobre contrato distinto al utilizado por clínica/particular.
- Riesgo: desalineación semántica de estados mostrados respecto al resto de roles.

## 5. Diagnóstico clínica
- La tarjeta de últimos tokens no incorporaba la etapa real de seguimiento por token.
- No mostraba de forma consistente la alerta de tinción especial proveniente del tracking.
- Contrato clínico ya disponible para consulta scoped por clínica, faltaba consumirlo en UI.

## 6. Diagnóstico particular
- La sesión activa cargaba datos de autenticación/reportes, pero no mostraba de forma explícita la etapa actual del tracking.
- En caso sin informe vinculado quedaba mensaje genérico, sin reflejar el estado real del estudio.
- El endpoint particular de tracking ya existía, faltaba integrarlo en frontend.

## 7. Estados soportados
- Flujo unificado mostrado en frontend:
  1. `reception` → Recepción de muestra
  2. `processing` → Procesamiento
  3. `evaluation` → Evaluación
  4. `report_development` → Desarrollo de informe
  5. `delivered` → Informe disponible / Publicado
- La solicitud de tinción especial permanece como alerta separada (`specialStainRequired`), no como estado terminal.

## 8. Alerta de tinción especial
- Se mantiene lógica de alerta independiente y visible en los tres roles.
- Se presenta como "Solicitud de tinción especial" cuando `specialStainRequired = true`.
- Queda ubicada lógicamente entre evaluación y desarrollo de informe al no reemplazar la etapa actual ni el progreso.

## 9. Implementaciones aplicadas
- API frontend (`frontend/src/lib/api.ts`):
  - Nuevo helper `getParticularStudyTrackingCase()` con manejo de errores recuperables.
  - Nuevos contratos/helpers admin para `study-tracking`:
    - `AdminStudyTrackingSnapshot`
    - `AdminStudyTrackingUpdatePayload`
    - `AdminStudyTrackingUpdateResponse`
    - `getAdminStudyTrackingCases()`
    - `updateAdminStudyTrackingCase()`
  - Nuevos contratos/helpers clínica:
    - `ClinicStudyTrackingCaseSummary`
    - `ClinicStudyTrackingSnapshot`
    - `getClinicStudyTrackingCases()`
- Admin UI (`frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx`):
  - Migra de `/api/admin/report-workflow` a `/api/admin/study-tracking`.
  - Conserva acciones de cambio de etapa y solicitar/resolver tinción especial con patch unificado.
  - Ajusta labels de etapa y copy para contrato unificado.
- Admin tokens (`frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`):
  - Carga tracking por `particularTokenId` para cada token visible.
  - Muestra bloque "Seguimiento" con etapa + alerta de tinción especial.
- Clínica tokens (`frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`):
  - Integra consulta `study-tracking` por token y renderiza etapa + alerta.
- Particular (`frontend/src/components/public/ParticularesContent.tsx`):
  - Carga tracking en sesión activa (login, check de sesión, cleanup en logout).
  - Muestra "Seguimiento del estudio" con etapa actual y alerta.
  - En casos sin informe vinculado muestra estado real cuando hay tracking.

## 10. Implementaciones descartadas por requerir DB/migration
- No se requirieron migrations ni cambios de schema para cumplir el objetivo.
- No se implementó alteración de tablas porque `currentStage` y `specialStainRequired` ya estaban disponibles en la fuente de verdad.

## 11. Archivos modificados
- `frontend/src/lib/api.ts`
- `frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx`
- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
- `frontend/src/components/public/ParticularesContent.tsx`
- `test/frontend-admin-report-workflow.test.ts`
- `test/frontend-admin-particular-tokens.test.ts`
- `test/frontend-dashboard-clinic-tokens.test.ts`
- `test/frontend-particulares-content.test.ts`

## 12. Tests agregados/reforzados
- `test/frontend-admin-report-workflow.test.ts`:
  - Ajuste de labels/contratos al flujo unificado de `study-tracking`.
- `test/frontend-admin-particular-tokens.test.ts`:
  - Cobertura de consumo de seguimiento por token y alerta.
- `test/frontend-dashboard-clinic-tokens.test.ts`:
  - Cobertura de visualización de etapa/alerta desde tracking clínico.
- `test/frontend-particulares-content.test.ts`:
  - Cobertura de estado y alerta en sesión particular activa.

## 13. Validaciones ejecutadas
- `pnpm test` ✅
- `pnpm validate:local` ✅
- `pnpm --dir frontend lint` ✅ (1 warning preexistente en `frontend/src/app/api/security/csp-report/route.ts`: unused eslint-disable)
- `pnpm --dir frontend typecheck` ✅
- `pnpm --dir frontend build` ✅

## 14. Riesgos residuales
- En tarjetas de tokens (admin/clínica) se hacen consultas de tracking por token listado (`N` requests para `N` tokens). Funcionalmente correcto; puede optimizarse luego con endpoint bulk si hiciera falta.
- Persiste endpoint legacy `/api/admin/report-workflow` en backend; ya no es la fuente consumida por esta UI, pero conviene planificar deprecación controlada para evitar regresiones futuras.
- Warning de lint no relacionado sigue vigente en ruta CSP.

## 15. Checklist manual
- [ ] Admin seguimiento de informes
- [ ] Admin últimos tokens
- [ ] Clínica últimos tokens
- [ ] Particular sesión activa
- [ ] Caso con alerta de tinción especial
- [ ] Caso sin informe vinculado
- [ ] Caso con informe publicado
