### PR TITLE
fix(report): apply workflow authority to tokens

### DIFF
--- a/PR-fix-report-token-workflow-authority.md
+++ b/PR-fix-report-token-workflow-authority.md
@@ -1,0 +1,125 @@
+# PR: fix(report): apply workflow authority to tokens
+
+## Rama
+- `fix/report-token-workflow-authority`
+
+## Preguntas previas (resueltas antes del cierre)
+1. **¿Por qué los tokens mostraban “Sin seguimiento vinculado”?**
+- Porque la UI de tokens consultaba `study_tracking_cases` por `particularTokenId`, pero no existía garantía backend de crear/vincular ese tracking en todos los flujos de token + upload.
+
+2. **¿Se crea un `study_tracking_case` al generar token?**
+- Ahora sí se asegura en creación de token (admin y clínica) vía helper canónico `ensureStudyTrackingCaseForToken`.
+
+3. **Si no se crea, ¿existe endpoint/helper para ensure tracking by `particularTokenId`?**
+- Sí. Se implementó `server/lib/token-study-tracking.ts` con `ensureStudyTrackingCaseForToken(...)` y soporte por token/report.
+
+4. **¿El admin viewer lista por `study_tracking_cases` o por informes?**
+- Por `study_tracking_cases` (flujo canónico de seguimiento).
+
+5. **¿Tokens admin/clínica consultan tracking con el ID correcto?**
+- Sí, por `particularTokenId` del token listado.
+
+6. **¿El endpoint particular devuelve tracking real?**
+- Sí. `particular-study-tracking` obtiene el tracking del token autenticado y expone estado real del caso.
+
+7. **¿La subida de informe actualiza `currentStage` a `delivered`?**
+- Sí. En `POST /api/admin/reports/upload` se fuerza cierre en `delivered` (por token vinculado o por `reportId`).
+
+8. **¿`specialStainRequired` está asociado al caso/token correcto?**
+- Sí. Queda en el `study_tracking_case` canónico y se replica en vistas admin/clínica/particular vía lectura del mismo caso.
+
+9. **¿Clínica y particular son read-only?**
+- Sí para workflow mutation: la ruta clínica `POST /api/study-tracking` ahora responde `403` (`Solo administración puede crear seguimientos`), y particular solo tiene endpoints GET.
+
+10. **¿Hay riesgo de N requests excesivas?**
+- Riesgo residual moderado en admin list/detail de tokens por `ensure` en lectura (mitigado con `Promise.all` en listado). Se documenta abajo.
+
+## 1. Causa raíz de “Sin seguimiento vinculado”
+- Existía desacople entre token y tracking: la vista esperaba `study_tracking_cases` por token, pero los flujos backend no aseguraban consistentemente ese vínculo al crear token o al subir informe.
+
+## 2. Modelo correcto token → seguimiento
+- Fuente canónica: `study_tracking_cases`.
+- Clave de relación principal: `particularTokenId`.
+- Fallback de conciliación: `reportId`.
+- Helper central: `ensureStudyTrackingCaseForToken(...)`.
+
+## 3. Autoridad de modificación (solo admin)
+- Admin conserva mutación de workflow (`/api/admin/study-tracking` + cierre por upload admin).
+- Ruta clínica de creación de tracking (`POST /api/study-tracking`) bloqueada con `403`.
+
+## 4. Clínica read-only
+- Clínica consume tracking por lectura (`GET /api/study-tracking...`), sin creación de casos desde su endpoint de workflow.
+
+## 5. Particular read-only
+- Particular consulta tracking del token autenticado (`/api/particular/study-tracking/me`) sin capacidades de mutación.
+
+## 6. Tinción especial
+- `specialStainRequired` permanece en el caso canónico y se visualiza en admin/clínica/particular sin bifurcar estado de etapa.
+
+## 7. Upload de informe → Entrega
+- `server/routes/admin-reports.fastify.ts` ahora acepta `particularTokenId` en multipart.
+- Si hay token seleccionado:
+  - vincula token↔report,
+  - asegura/crea tracking,
+  - cierra en `currentStage = "delivered"`.
+- Si no hay token:
+  - busca tracking por `reportId` y lo cierra en `delivered`.
+
+## 8. Archivos modificados
+- `server/lib/token-study-tracking.ts` (nuevo)
+- `server/db-study-tracking.ts`
+- `server/routes/admin-reports.fastify.ts`
+- `server/routes/admin-particular-tokens.fastify.ts`
+- `server/routes/particular-tokens.fastify.ts`
+- `server/routes/study-tracking.fastify.ts`
+- `frontend/src/components/dashboard/UploadReportModal.tsx`
+- `test/admin-reports.fastify.test.ts`
+- `test/admin-particular-tokens.fastify.test.ts`
+- `test/particular-tokens.fastify.test.ts`
+- `test/study-tracking.fastify.test.ts`
+- `test/frontend-report-upload-modal.test.ts`
+- `test/frontend-report-actions.test.ts`
+- `test/clinic-management-route-policy.test.ts`
+- `test/security-mutation-permission-surface.test.ts`
+- `test/security-write-attribution-boundaries.test.ts`
+- `test/fastify-app.test.ts`
+- `test/report-write-surface-ownership.test.ts`
+
+## 9. Tests agregados/reforzados
+- `admin-reports.fastify.test.ts`:
+  - validación `particularTokenId` inválido,
+  - `particularTokenId` inexistente,
+  - mismatch de clínica,
+  - upload con token cierra tracking en `delivered`,
+  - upload sin token cierra tracking por `reportId` en `delivered`.
+- `study-tracking.fastify.test.ts`:
+  - POST clínica bloqueado (`403`) por autoridad admin-only.
+- Frontend tests del modal:
+  - validan envío de `particularTokenId` en multipart,
+  - eliminan expectativa de creación de tracking desde UI.
+- Actualización de tests de seguridad/contrato para nuevo comportamiento admin-only.
+
+## 10. Validaciones ejecutadas
+- `pnpm test` ✅
+- `pnpm validate:local` ✅
+- `pnpm --dir frontend lint` ✅ (1 warning preexistente por `eslint-disable` no usado en `frontend/src/app/api/security/csp-report/route.ts`)
+- `pnpm --dir frontend typecheck` ✅
+- `pnpm --dir frontend build` ✅
+
+## 11. Riesgos residuales
+- En admin tokens list/detail se ejecuta `ensure` en lectura para autocorregir vinculación; esto puede aumentar llamadas por item en listados grandes.
+- Se mantiene como tradeoff para consistencia inmediata del estado hasta introducir una estrategia de batch/prefetch específica.
+
+## 12. Checklist manual
+- [x] admin seguimiento de informes lista tokens/casos
+- [x] admin cambia etapa
+- [x] admin solicita tinción especial
+- [x] clínica ve alerta
+- [x] particular ve alerta
+- [x] admin sube informe
+- [x] clínica ve Entrega
+- [x] particular ve Entrega/informe disponible
+
+## 13. Notas de implementación
+- Se eliminó la creación de tracking desde frontend en upload modal.
+- El backend de upload quedó como punto de autoridad para cierre del workflow con informe.

--- a/frontend/src/components/dashboard/UploadReportModal.tsx
+++ b/frontend/src/components/dashboard/UploadReportModal.tsx
@@ -10,7 +10,6 @@ import { Input } from "@/components/ui/input";
 import { uploadAdminReport } from "@/lib/api";
 import { getAdminUsersRoles } from "@/lib/api";
 import {
-  createAdminStudyTrackingCase,
   getAdminParticularTokens,
   type AdminParticularTokenSummary,
 } from "@/lib/api";
@@ -88,28 +87,6 @@ function buildParticularTokenLabel(token: AdminParticularTokenSummary) {
     : "sin informe vinculado";
 
   return `Token ****${token.tokenLast4} · ${token.petName} · ${token.tutorLastName} · ${linkedLabel}`;
-}
-
-function getTrackingReceptionAt(uploadDate: string) {
-  if (uploadDate) {
-    return `${uploadDate}T00:00:00.000Z`;
-  }
-
-  return new Date().toISOString();
-}
-
-function formatTrackingDateLabel(value: string) {
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return "calculada automáticamente";
-  }
-
-  return new Intl.DateTimeFormat("es-AR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  }).format(date);
 }
 
 export function UploadReportModal() {
@@ -409,28 +386,13 @@ export function UploadReportModal() {
       formData.append("uploadDate", uploadDate);
     }
 
+    if (selectedParticularToken) {
+      formData.append("particularTokenId", String(selectedParticularToken.id));
+    }
+
     try {
       const response = await uploadAdminReport(formData);
-
-      if (selectedParticularToken) {
-        const trackingResponse = await createAdminStudyTrackingCase({
-          clinicId: Number(clinicId),
-          reportId: response.report.id,
-          particularTokenId: selectedParticularToken.id,
-          receptionAt: getTrackingReceptionAt(uploadDate),
-          currentStage: "reception",
-        });
-
-        const estimatedDelivery = formatTrackingDateLabel(
-          trackingResponse.trackingCase.estimatedDeliveryAt,
-        );
-
-        setSuccessMessage(
-          `${response.message}. Seguimiento particular creado con entrega estimada ${estimatedDelivery}.`,
-        );
-      } else {
-        setSuccessMessage(response.message);
-      }
+      setSuccessMessage(response.message);
 
       resetForm();
       router.refresh();

--- a/server/db-study-tracking.ts
+++ b/server/db-study-tracking.ts
@@ -62,6 +62,16 @@ export async function getParticularStudyTrackingCase(particularTokenId: number) 
   return result[0];
 }
 
+export async function getStudyTrackingCaseByReportId(reportId: number) {
+  const result = await db
+    .select()
+    .from(studyTrackingCases)
+    .where(eq(studyTrackingCases.reportId, reportId))
+    .limit(1);
+
+  return result[0];
+}
+
 export async function listStudyTrackingCases(params?: {
   clinicId?: number;
   reportId?: number;

--- a/server/lib/token-study-tracking.ts
+++ b/server/lib/token-study-tracking.ts
@@ -1,0 +1,174 @@
+import type { ParticularToken, StudyTrackingCase } from "../../drizzle/schema.ts";
+import {
+  applyEstimatedDeliveryRules,
+  applyStageTimestampDefaults,
+} from "./study-tracking.ts";
+
+type TokenTrackingRecord = Pick<
+  ParticularToken,
+  | "id"
+  | "clinicId"
+  | "reportId"
+  | "shippingDate"
+  | "extractionDate"
+  | "detailsLesion"
+  | "createdByAdminId"
+  | "createdByClinicUserId"
+>;
+
+type EnsureTokenTrackingInput = {
+  token: TokenTrackingRecord;
+  createdByAdminId?: number | null;
+  createdByClinicUserId?: number | null;
+  now?: Date;
+};
+
+type EnsureTokenTrackingDeps = {
+  getParticularStudyTrackingCase: (
+    particularTokenId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getStudyTrackingCaseByReportId: (
+    reportId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  createStudyTrackingCase: (
+    input: Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">,
+  ) => Promise<StudyTrackingCase>;
+  updateStudyTrackingCase: (
+    id: number,
+    input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+};
+
+function toSafeDate(value: Date | null | undefined): Date | null {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return null;
+  }
+
+  return value;
+}
+
+function getTokenReceptionAt(token: TokenTrackingRecord, now: Date): Date {
+  return (
+    toSafeDate(token.shippingDate) ??
+    toSafeDate(token.extractionDate) ??
+    now
+  );
+}
+
+function hasAnyPatchValue(
+  patch: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
+): boolean {
+  return Object.keys(patch).length > 0;
+}
+
+export async function ensureStudyTrackingCaseForToken(
+  deps: EnsureTokenTrackingDeps,
+  input: EnsureTokenTrackingInput,
+): Promise<StudyTrackingCase> {
+  const now = input.now ?? new Date();
+  const token = input.token;
+  const tokenReportId =
+    typeof token.reportId === "number" ? token.reportId : null;
+
+  const caseByToken =
+    (await deps.getParticularStudyTrackingCase(token.id)) ?? null;
+  const caseByReport =
+    tokenReportId === null
+      ? null
+      : ((await deps.getStudyTrackingCaseByReportId(tokenReportId)) ?? null);
+
+  if (caseByToken) {
+    const patch: Partial<
+      Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">
+    > = {};
+
+    if (
+      tokenReportId !== null &&
+      caseByToken.reportId !== tokenReportId &&
+      (!caseByReport || caseByReport.id === caseByToken.id)
+    ) {
+      patch.reportId = tokenReportId;
+    }
+
+    if (tokenReportId !== null && caseByToken.currentStage !== "delivered") {
+      const stageDefaults = applyStageTimestampDefaults(caseByToken, {
+        currentStage: "delivered",
+      });
+      patch.currentStage = "delivered";
+      patch.deliveredAt = stageDefaults.deliveredAt ?? now;
+    }
+
+    if (!hasAnyPatchValue(patch)) {
+      return caseByToken;
+    }
+
+    return (await deps.updateStudyTrackingCase(caseByToken.id, patch)) ?? caseByToken;
+  }
+
+  if (caseByReport && caseByReport.particularTokenId === token.id) {
+    if (caseByReport.currentStage === "delivered") {
+      return caseByReport;
+    }
+
+    const stageDefaults = applyStageTimestampDefaults(caseByReport, {
+      currentStage: "delivered",
+    });
+    return (
+      (await deps.updateStudyTrackingCase(caseByReport.id, {
+        currentStage: "delivered",
+        deliveredAt: stageDefaults.deliveredAt ?? now,
+      })) ?? caseByReport
+    );
+  }
+
+  if (caseByReport && caseByReport.particularTokenId === null) {
+    const patch: Partial<
+      Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">
+    > = {
+      particularTokenId: token.id,
+    };
+
+    if (caseByReport.currentStage !== "delivered") {
+      const stageDefaults = applyStageTimestampDefaults(caseByReport, {
+        currentStage: "delivered",
+      });
+      patch.currentStage = "delivered";
+      patch.deliveredAt = stageDefaults.deliveredAt ?? now;
+    }
+
+    return (await deps.updateStudyTrackingCase(caseByReport.id, patch)) ?? caseByReport;
+  }
+
+  const receptionAt = getTokenReceptionAt(token, now);
+  const delivery = applyEstimatedDeliveryRules({ receptionAt });
+  const createdByAdminId =
+    input.createdByAdminId ?? token.createdByAdminId ?? null;
+  const createdByClinicUserId =
+    input.createdByClinicUserId ?? token.createdByClinicUserId ?? null;
+  const isDelivered = tokenReportId !== null;
+
+  return deps.createStudyTrackingCase({
+    clinicId: token.clinicId,
+    reportId: tokenReportId,
+    particularTokenId: token.id,
+    createdByAdminId,
+    createdByClinicUserId,
+    receptionAt,
+    estimatedDeliveryAt: delivery.estimatedDeliveryAt,
+    estimatedDeliveryAutoCalculatedAt: delivery.estimatedDeliveryAutoCalculatedAt,
+    estimatedDeliveryWasManuallyAdjusted:
+      delivery.estimatedDeliveryWasManuallyAdjusted,
+    currentStage: isDelivered ? "delivered" : "reception",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: isDelivered ? now : null,
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+    paymentUrl: null,
+    adminContactEmail: null,
+    adminContactPhone: null,
+    notes: token.detailsLesion ?? null,
+  });
+}
+

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -4,7 +4,7 @@ import type {
   FastifyRequest,
 } from "fastify";
 
-import type { ParticularToken, Report } from "../../drizzle/schema.ts";
+import type { ParticularToken, Report, StudyTrackingCase } from "../../drizzle/schema.ts";
 import { ENV } from "../lib/env.ts";
 import {
   adminCreateParticularTokenSchema,
@@ -26,6 +26,7 @@ import {
 } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import { getSafeEmailTransportErrorMetadata } from "../lib/email.ts";
+import { ensureStudyTrackingCaseForToken } from "../lib/token-study-tracking.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -110,6 +111,19 @@ export type AdminParticularTokensNativeRoutesOptions = {
     tutorLastName: string;
     petName: string;
   }) => Promise<ParticularTokenEmailResult>;
+  getParticularStudyTrackingCase?: (
+    particularTokenId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getStudyTrackingCaseByReportId?: (
+    reportId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  createStudyTrackingCase?: (
+    input: Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">,
+  ) => Promise<StudyTrackingCase>;
+  updateStudyTrackingCase?: (
+    id: number,
+    input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
+  ) => Promise<StudyTrackingCase | null | undefined>;
   now?: () => number;
 };
 
@@ -138,6 +152,10 @@ type NativeAdminParticularTokensDeps = Required<
     | "revokeParticularToken"
     | "deleteParticularToken"
     | "sendParticularTokenEmail"
+    | "getParticularStudyTrackingCase"
+    | "getStudyTrackingCaseByReportId"
+    | "createStudyTrackingCase"
+    | "updateStudyTrackingCase"
   >
 >;
 
@@ -149,6 +167,7 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const dbParticular = await import("../db-particular.ts");
+      const dbStudyTracking = await import("../db-study-tracking.ts");
       const email = await import("../lib/email.ts");
 
       return {
@@ -167,6 +186,12 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
         revokeParticularToken: dbParticular.revokeParticularToken,
         deleteParticularToken: dbParticular.deleteParticularToken,
         sendParticularTokenEmail: email.sendParticularTokenEmail,
+        getParticularStudyTrackingCase:
+          dbStudyTracking.getParticularStudyTrackingCase,
+        getStudyTrackingCaseByReportId:
+          dbStudyTracking.getStudyTrackingCaseByReportId,
+        createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
+        updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
       };
     })();
   }
@@ -479,7 +504,11 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     !!options.updateParticularTokenReport &&
     !!options.revokeParticularToken &&
     !!options.deleteParticularToken &&
-    !!options.sendParticularTokenEmail;
+    !!options.sendParticularTokenEmail &&
+    !!options.getParticularStudyTrackingCase &&
+    !!options.getStudyTrackingCaseByReportId &&
+    !!options.createStudyTrackingCase &&
+    !!options.updateStudyTrackingCase;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -515,10 +544,48 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     sendParticularTokenEmail:
       options.sendParticularTokenEmail ??
       defaultDeps!.sendParticularTokenEmail,
+    getParticularStudyTrackingCase:
+      options.getParticularStudyTrackingCase ??
+      defaultDeps!.getParticularStudyTrackingCase,
+    getStudyTrackingCaseByReportId:
+      options.getStudyTrackingCaseByReportId ??
+      defaultDeps!.getStudyTrackingCaseByReportId,
+    createStudyTrackingCase:
+      options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
+    updateStudyTrackingCase:
+      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
   };
 
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
+
+  async function ensureTrackingForToken(
+    token: ParticularToken,
+    createdByAdminId: number | null,
+  ) {
+    try {
+      await ensureStudyTrackingCaseForToken(
+        {
+          getParticularStudyTrackingCase: deps.getParticularStudyTrackingCase,
+          getStudyTrackingCaseByReportId: deps.getStudyTrackingCaseByReportId,
+          createStudyTrackingCase: deps.createStudyTrackingCase,
+          updateStudyTrackingCase: deps.updateStudyTrackingCase,
+        },
+        {
+          token,
+          createdByAdminId,
+          createdByClinicUserId: token.createdByClinicUserId ?? null,
+          now: new Date(now()),
+        },
+      );
+    } catch (error) {
+      console.error("[TRACKING] ensure-by-token failed", {
+        tokenId: token.id,
+        clinicId: token.clinicId,
+        errorName: getSafeErrorName(error),
+      });
+    }
+  }
 
   app.addHook("onRequest", async (request, reply) => {
     (request as AdminParticularTokensFastifyRequest)[REQUEST_TIMER_KEY] =
@@ -702,6 +769,8 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       });
     }
 
+    await ensureTrackingForToken(particularToken, admin.id);
+
     return reply.code(201).send({
       success: true,
       message: "Token particular creado correctamente",
@@ -732,6 +801,10 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       limit,
       offset,
     });
+
+    await Promise.all(
+      tokens.map((token) => ensureTrackingForToken(token, admin.id)),
+    );
 
     return reply.code(200).send({
       success: true,
@@ -775,6 +848,8 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
         error: "Token particular no encontrado",
       });
     }
+
+    await ensureTrackingForToken(token, admin.id);
 
     const report =
       typeof token.reportId === "number"
@@ -854,6 +929,10 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       tokenId,
       parsed.data.reportId,
     );
+
+    if (updated) {
+      await ensureTrackingForToken(updated, admin.id);
+    }
 
     const report =
       updated && typeof updated.reportId === "number"

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -6,7 +6,7 @@ import type {
 } from "fastify";
 import multer from "multer";
 
-import type { Report } from "../../drizzle/schema.ts";
+import type { ParticularToken, Report, StudyTrackingCase } from "../../drizzle/schema.ts";
 import type { Multer } from "multer";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
@@ -25,6 +25,7 @@ import {
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
+import { ensureStudyTrackingCaseForToken } from "../lib/token-study-tracking.ts";
 
 type AdminUserRecord = {
   id: number;
@@ -97,6 +98,26 @@ export type AdminReportsNativeRoutesOptions = {
   getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
   uploadReport?: (input: ReportUploadInput) => Promise<string>;
   upsertReport?: (input: UpsertReportInput) => Promise<Report>;
+  getParticularTokenById?: (
+    tokenId: number,
+  ) => Promise<ParticularToken | null | undefined>;
+  updateParticularTokenReport?: (
+    id: number,
+    reportId: number | null,
+  ) => Promise<ParticularToken | null | undefined>;
+  getParticularStudyTrackingCase?: (
+    particularTokenId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getStudyTrackingCaseByReportId?: (
+    reportId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  createStudyTrackingCase?: (
+    input: Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">,
+  ) => Promise<StudyTrackingCase>;
+  updateStudyTrackingCase?: (
+    id: number,
+    input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
+  ) => Promise<StudyTrackingCase | null | undefined>;
   createSignedReportUrl?: (storagePath: string) => Promise<string>;
   createSignedReportDownloadUrl?: (
     storagePath: string,
@@ -145,6 +166,12 @@ type NativeAdminReportsDeps = Required<
     | "getClinicById"
     | "uploadReport"
     | "upsertReport"
+    | "getParticularTokenById"
+    | "updateParticularTokenReport"
+    | "getParticularStudyTrackingCase"
+    | "getStudyTrackingCaseByReportId"
+    | "createStudyTrackingCase"
+    | "updateStudyTrackingCase"
     | "createSignedReportUrl"
     | "createSignedReportDownloadUrl"
     | "writeAuditLog"
@@ -160,6 +187,8 @@ async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
       const authSecurity = await import("../lib/auth-security.ts");
       const storage = await import("../lib/supabase.ts");
       const audit = await import("../lib/audit.ts");
+      const dbParticular = await import("../db-particular.ts");
+      const dbStudyTracking = await import("../db-study-tracking.ts");
 
       return {
         deleteAdminSession: db.deleteAdminSession,
@@ -170,6 +199,14 @@ async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
         getClinicById: db.getClinicById,
         uploadReport: storage.uploadReport,
         upsertReport: db.upsertReport,
+        getParticularTokenById: dbParticular.getParticularTokenById,
+        updateParticularTokenReport: dbParticular.updateParticularTokenReport,
+        getParticularStudyTrackingCase:
+          dbStudyTracking.getParticularStudyTrackingCase,
+        getStudyTrackingCaseByReportId:
+          dbStudyTracking.getStudyTrackingCaseByReportId,
+        createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
+        updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
         createSignedReportUrl: storage.createSignedReportUrl,
         createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
         writeAuditLog: audit.writeAuditLog as (
@@ -193,6 +230,12 @@ function hasAllInjectedDeps(options: AdminReportsNativeRoutesOptions) {
     !!options.getClinicById &&
     !!options.uploadReport &&
     !!options.upsertReport &&
+    !!options.getParticularTokenById &&
+    !!options.updateParticularTokenReport &&
+    !!options.getParticularStudyTrackingCase &&
+    !!options.getStudyTrackingCaseByReportId &&
+    !!options.createStudyTrackingCase &&
+    !!options.updateStudyTrackingCase &&
     !!options.createSignedReportUrl &&
     !!options.createSignedReportDownloadUrl &&
     !!options.writeAuditLog
@@ -219,6 +262,21 @@ async function resolveDeps(
     getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
     uploadReport: options.uploadReport ?? defaultDeps!.uploadReport,
     upsertReport: options.upsertReport ?? defaultDeps!.upsertReport,
+    getParticularTokenById:
+      options.getParticularTokenById ?? defaultDeps!.getParticularTokenById,
+    updateParticularTokenReport:
+      options.updateParticularTokenReport ??
+      defaultDeps!.updateParticularTokenReport,
+    getParticularStudyTrackingCase:
+      options.getParticularStudyTrackingCase ??
+      defaultDeps!.getParticularStudyTrackingCase,
+    getStudyTrackingCaseByReportId:
+      options.getStudyTrackingCaseByReportId ??
+      defaultDeps!.getStudyTrackingCaseByReportId,
+    createStudyTrackingCase:
+      options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
+    updateStudyTrackingCase:
+      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
     createSignedReportUrl:
       options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
     createSignedReportDownloadUrl:
@@ -537,6 +595,51 @@ function createAuditRequestLike(
   };
 }
 
+async function ensureDeliveredTrackingByReportId(
+  deps: NativeAdminReportsDeps,
+  reportId: number,
+  nowDate: Date,
+) {
+  const trackingCase =
+    (await deps.getStudyTrackingCaseByReportId(reportId)) ?? null;
+
+  if (!trackingCase || trackingCase.currentStage === "delivered") {
+    return trackingCase;
+  }
+
+  return (
+    (await deps.updateStudyTrackingCase(trackingCase.id, {
+      reportId,
+      currentStage: "delivered",
+      deliveredAt: trackingCase.deliveredAt ?? nowDate,
+    })) ?? trackingCase
+  );
+}
+
+async function ensureTrackingForLinkedToken(
+  deps: NativeAdminReportsDeps,
+  token: ParticularToken,
+  input: {
+    adminUserId: number;
+    nowDate: Date;
+  },
+) {
+  return ensureStudyTrackingCaseForToken(
+    {
+      getParticularStudyTrackingCase: deps.getParticularStudyTrackingCase,
+      getStudyTrackingCaseByReportId: deps.getStudyTrackingCaseByReportId,
+      createStudyTrackingCase: deps.createStudyTrackingCase,
+      updateStudyTrackingCase: deps.updateStudyTrackingCase,
+    },
+    {
+      token,
+      createdByAdminId: input.adminUserId,
+      createdByClinicUserId: token.createdByClinicUserId ?? null,
+      now: input.nowDate,
+    },
+  );
+}
+
 async function serializeReport(report: Report, deps: NativeAdminReportsDeps) {
   const [previewUrl, downloadUrl] = await Promise.all([
     deps.createSignedReportUrl(report.storagePath),
@@ -648,11 +751,26 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
 
     const body = getMultipartBody(request);
     const clinicId = parseReportId(body.clinicId);
+    const rawParticularTokenId =
+      typeof body.particularTokenId === "string" ||
+      typeof body.particularTokenId === "number"
+        ? String(body.particularTokenId).trim()
+        : "";
+    const particularTokenId = rawParticularTokenId
+      ? parseReportId(rawParticularTokenId)
+      : undefined;
 
     if (typeof clinicId !== "number") {
       return reply.code(400).send({
         success: false,
         error: "clinicId es obligatorio",
+      });
+    }
+
+    if (rawParticularTokenId && typeof particularTokenId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "particularTokenId inválido",
       });
     }
 
@@ -669,6 +787,28 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
       return reply.code(400).send({
         success: false,
         error: "No se proporciono ningun archivo",
+      });
+    }
+
+    const selectedParticularToken =
+      typeof particularTokenId === "number"
+        ? await deps.getParticularTokenById(particularTokenId)
+        : null;
+
+    if (typeof particularTokenId === "number" && !selectedParticularToken) {
+      return reply.code(404).send({
+        success: false,
+        error: "Token particular no encontrado",
+      });
+    }
+
+    if (
+      selectedParticularToken &&
+      selectedParticularToken.clinicId !== clinicId
+    ) {
+      return reply.code(400).send({
+        success: false,
+        error: "El token particular no pertenece a la clínica indicada",
       });
     }
 
@@ -693,6 +833,36 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
       createdByAdminUserId: admin.id,
     });
 
+    const nowDate = new Date(now());
+    let trackingCase: StudyTrackingCase | null = null;
+    let linkedTokenId: number | null = null;
+
+    if (selectedParticularToken) {
+      const updatedToken = await deps.updateParticularTokenReport(
+        selectedParticularToken.id,
+        report.id,
+      );
+      const tokenForTracking = {
+        ...selectedParticularToken,
+        reportId: report.id,
+        updatedAt: nowDate,
+      } as ParticularToken;
+      const linkedToken = updatedToken ?? tokenForTracking;
+
+      linkedTokenId = linkedToken.id;
+      trackingCase = await ensureTrackingForLinkedToken(deps, linkedToken, {
+        adminUserId: admin.id,
+        nowDate,
+      });
+    } else {
+      trackingCase = await ensureDeliveredTrackingByReportId(
+        deps,
+        report.id,
+        nowDate,
+      );
+      linkedTokenId = trackingCase?.particularTokenId ?? null;
+    }
+
     await deps.writeAuditLog(createAuditRequestLike(request, admin), {
       event: AUDIT_EVENTS.REPORT_UPLOADED,
       clinicId: report.clinicId,
@@ -705,6 +875,9 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
         studyType: studyType ?? null,
         uploadDate: uploadDate ?? null,
         uploadedVia: "admin",
+        particularTokenId: linkedTokenId,
+        trackingCaseId: trackingCase?.id ?? null,
+        trackingStage: trackingCase?.currentStage ?? null,
       },
     });
 

--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -4,7 +4,7 @@ import type {
   FastifyRequest,
 } from "fastify";
 
-import type { ParticularToken, Report } from "../../drizzle/schema.ts";
+import type { ParticularToken, Report, StudyTrackingCase } from "../../drizzle/schema.ts";
 import { ENV } from "../lib/env.ts";
 import {
   buildValidationError,
@@ -30,6 +30,7 @@ import {
 } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import { getSafeEmailTransportErrorMetadata } from "../lib/email.ts";
+import { ensureStudyTrackingCaseForToken } from "../lib/token-study-tracking.ts";
 
 type ClinicUserRecord = {
   id: number;
@@ -116,6 +117,19 @@ export type ParticularTokensNativeRoutesOptions = {
     tutorLastName: string;
     petName: string;
   }) => Promise<ParticularTokenEmailResult>;
+  getParticularStudyTrackingCase?: (
+    particularTokenId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  getStudyTrackingCaseByReportId?: (
+    reportId: number,
+  ) => Promise<StudyTrackingCase | null | undefined>;
+  createStudyTrackingCase?: (
+    input: Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">,
+  ) => Promise<StudyTrackingCase>;
+  updateStudyTrackingCase?: (
+    id: number,
+    input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
+  ) => Promise<StudyTrackingCase | null | undefined>;
   now?: () => number;
 };
 
@@ -142,6 +156,10 @@ type NativeParticularTokensDeps = Required<
     | "updateParticularTokenReport"
     | "revokeParticularToken"
     | "sendParticularTokenEmail"
+    | "getParticularStudyTrackingCase"
+    | "getStudyTrackingCaseByReportId"
+    | "createStudyTrackingCase"
+    | "updateStudyTrackingCase"
   >
 >;
 
@@ -153,6 +171,7 @@ async function loadDefaultDeps(): Promise<NativeParticularTokensDeps> {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const dbParticular = await import("../db-particular.ts");
+      const dbStudyTracking = await import("../db-study-tracking.ts");
       const email = await import("../lib/email.ts");
 
       return {
@@ -170,6 +189,12 @@ async function loadDefaultDeps(): Promise<NativeParticularTokensDeps> {
         updateParticularTokenReport: dbParticular.updateParticularTokenReport,
         revokeParticularToken: dbParticular.revokeParticularToken,
         sendParticularTokenEmail: email.sendParticularTokenEmail,
+        getParticularStudyTrackingCase:
+          dbStudyTracking.getParticularStudyTrackingCase,
+        getStudyTrackingCaseByReportId:
+          dbStudyTracking.getStudyTrackingCaseByReportId,
+        createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
+        updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
       };
     })();
   }
@@ -504,7 +529,11 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
     !!options.listParticularTokens &&
     !!options.updateParticularTokenReport &&
     !!options.revokeParticularToken &&
-    !!options.sendParticularTokenEmail;
+    !!options.sendParticularTokenEmail &&
+    !!options.getParticularStudyTrackingCase &&
+    !!options.getStudyTrackingCaseByReportId &&
+    !!options.createStudyTrackingCase &&
+    !!options.updateStudyTrackingCase;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -537,10 +566,48 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
     sendParticularTokenEmail:
       options.sendParticularTokenEmail ??
       defaultDeps!.sendParticularTokenEmail,
+    getParticularStudyTrackingCase:
+      options.getParticularStudyTrackingCase ??
+      defaultDeps!.getParticularStudyTrackingCase,
+    getStudyTrackingCaseByReportId:
+      options.getStudyTrackingCaseByReportId ??
+      defaultDeps!.getStudyTrackingCaseByReportId,
+    createStudyTrackingCase:
+      options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
+    updateStudyTrackingCase:
+      options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
   };
 
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
+
+  async function ensureTrackingForToken(
+    token: ParticularToken,
+    clinicUserId: number | null,
+  ) {
+    try {
+      await ensureStudyTrackingCaseForToken(
+        {
+          getParticularStudyTrackingCase: deps.getParticularStudyTrackingCase,
+          getStudyTrackingCaseByReportId: deps.getStudyTrackingCaseByReportId,
+          createStudyTrackingCase: deps.createStudyTrackingCase,
+          updateStudyTrackingCase: deps.updateStudyTrackingCase,
+        },
+        {
+          token,
+          createdByAdminId: token.createdByAdminId ?? null,
+          createdByClinicUserId: clinicUserId,
+          now: new Date(now()),
+        },
+      );
+    } catch (error) {
+      console.error("[TRACKING] ensure-by-token failed", {
+        tokenId: token.id,
+        clinicId: token.clinicId,
+        errorName: getSafeErrorName(error),
+      });
+    }
+  }
 
   app.addHook("onRequest", async (request, reply) => {
     (request as ParticularTokensFastifyRequest)[REQUEST_TIMER_KEY] =
@@ -716,6 +783,8 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
           "No se pudo enviar el email del token particular. El token fue desactivado; reintentá la generación más tarde.",
       });
     }
+
+    await ensureTrackingForToken(particularToken, auth.id);
 
     return reply.code(201).send({
       success: true,

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -532,13 +532,9 @@ function requireStudyTrackingManagementPermission(
   auth: AuthenticatedClinicUser,
   reply: FastifyReply,
 ) {
-  if (auth.canManageClinicUsers) {
-    return true;
-  }
-
   reply.code(403).send({
     success: false,
-    error: "No autorizado para administrar recursos de la clinica",
+    error: "Solo administración puede crear seguimientos",
   });
 
   return false;

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -67,6 +67,35 @@ function createParticularTokenFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    clinicId: 3,
+    reportId: 55,
+    particularTokenId: 7,
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryWasManuallyAdjusted: false,
+    currentStage: "reception",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+    paymentUrl: null,
+    adminContactEmail: null,
+    adminContactPhone: null,
+    notes: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T12:30:00.000Z"),
+    ...overrides,
+  };
+}
+
 function createAuthStubs(overrides: Record<string, unknown> = {}) {
   return {
     deleteAdminSession: async () => {},
@@ -107,6 +136,10 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       sent: true,
       messageId: "particular-email-1",
     }),
+    getParticularStudyTrackingCase: async () => createTrackingCaseFixture(),
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => createTrackingCaseFixture(),
+    updateStudyTrackingCase: async () => createTrackingCaseFixture(),
     ...overrides,
   });
 

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -31,6 +31,63 @@ function createReportFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createParticularTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    clinicId: 3,
+    reportId: null,
+    tokenHash: "hash:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    tokenLast4: "aaaa",
+    tutorLastName: "Gomez",
+    petName: "Luna",
+    petAge: "8 años",
+    petBreed: "Caniche",
+    petSex: "Hembra",
+    petSpecies: "Canina",
+    sampleLocation: "Pabellón auricular",
+    sampleEvolution: "15 días",
+    detailsLesion: "Lesión nodular pequeña",
+    extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+    shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+    isActive: true,
+    lastLoginAt: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T12:30:00.000Z"),
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    ...overrides,
+  };
+}
+
+function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    clinicId: 3,
+    reportId: 88,
+    particularTokenId: 7,
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryWasManuallyAdjusted: false,
+    currentStage: "delivered",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: new Date("2026-04-22T12:00:00.000Z"),
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+    paymentUrl: null,
+    adminContactEmail: null,
+    adminContactPhone: null,
+    notes: "Lesión nodular pequeña",
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 function createAuthStubs(overrides: Record<string, unknown> = {}) {
   return {
     deleteAdminSession: async () => {},
@@ -58,6 +115,16 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     getClinicById: async () => ({ id: 3 }),
     uploadReport: async () => "reports/3/luna-report.pdf",
     upsertReport: async () => createReportFixture(),
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => {
+      throw new Error(
+        "createStudyTrackingCase no debe ejecutarse sin particularTokenId",
+      );
+    },
+    updateStudyTrackingCase: async () => null,
     createSignedReportUrl: async (storagePath: string) =>
       `signed-preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
@@ -240,6 +307,9 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
               studyType: "histopatologia",
               uploadDate: "2026-04-22T09:00:00.000Z",
               uploadedVia: "admin",
+              particularTokenId: null,
+              trackingCaseId: null,
+              trackingStage: null,
             },
           },
         },
@@ -413,6 +483,287 @@ test("adminReportsNativeRoutes devuelve 404 cuando clinicId no existe", async ()
       error: "Clinica no encontrada",
     });
     assert.equal(uploadCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes valida particularTokenId antes de storage", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    particularTokenId: "invalid",
+  });
+  let uploadCalls = 0;
+
+  const app = await createTestApp({
+    uploadReport: async () => {
+      uploadCalls += 1;
+      return "reports/3/luna-report.pdf";
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "particularTokenId inválido",
+    });
+    assert.equal(uploadCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes devuelve 404 cuando particularTokenId no existe", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    particularTokenId: "7",
+  });
+  let uploadCalls = 0;
+
+  const app = await createTestApp({
+    getParticularTokenById: async () => null,
+    uploadReport: async () => {
+      uploadCalls += 1;
+      return "reports/3/luna-report.pdf";
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Token particular no encontrado",
+    });
+    assert.equal(uploadCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes bloquea upload si particularTokenId pertenece a otra clínica", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    particularTokenId: "7",
+  });
+  let uploadCalls = 0;
+
+  const app = await createTestApp({
+    getParticularTokenById: async () =>
+      createParticularTokenFixture({
+        clinicId: 999,
+      }),
+    uploadReport: async () => {
+      uploadCalls += 1;
+      return "reports/3/luna-report.pdf";
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "El token particular no pertenece a la clínica indicada",
+    });
+    assert.equal(uploadCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes vincula token y cierra tracking en delivered al subir informe", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    particularTokenId: "7",
+    patientName: " Luna ",
+    studyType: " histopatologia ",
+    uploadDate: "2026-04-22T09:00:00.000Z",
+  });
+  const nowDate = new Date("2026-04-22T12:00:00.000Z");
+  const selectedToken = createParticularTokenFixture({
+    reportId: null,
+  });
+  const linkedToken = createParticularTokenFixture({
+    reportId: 88,
+    updatedAt: nowDate,
+  });
+  const updateTokenCalls: Array<Record<string, unknown>> = [];
+  const createTrackingCalls: Array<Record<string, unknown>> = [];
+  const updateTrackingCalls: Array<Record<string, unknown>> = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    now: () => nowDate.getTime(),
+    getParticularTokenById: async () => selectedToken,
+    updateParticularTokenReport: async (id: number, reportId: number | null) => {
+      updateTokenCalls.push({ id, reportId });
+      return linkedToken;
+    },
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async (input: Record<string, unknown>) => {
+      createTrackingCalls.push(input);
+      return createTrackingCaseFixture({
+        reportId: 88,
+        particularTokenId: 7,
+        currentStage: "delivered",
+        deliveredAt: nowDate,
+      });
+    },
+    updateStudyTrackingCase: async (
+      id: number,
+      input: Record<string, unknown>,
+    ) => {
+      updateTrackingCalls.push({ id, input });
+      return createTrackingCaseFixture({
+        id,
+        ...input,
+      });
+    },
+    writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+      auditCalls.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(updateTokenCalls, [{ id: 7, reportId: 88 }]);
+    assert.equal(createTrackingCalls.length, 1);
+    assert.equal(createTrackingCalls[0].reportId, 88);
+    assert.equal(createTrackingCalls[0].particularTokenId, 7);
+    assert.equal(createTrackingCalls[0].currentStage, "delivered");
+    assert.equal(createTrackingCalls[0].specialStainRequired, false);
+    assert.equal(updateTrackingCalls.length, 0);
+    assert.equal(auditCalls.length, 1);
+    assert.equal(
+      (auditCalls[0].metadata as Record<string, unknown>).particularTokenId,
+      7,
+    );
+    assert.equal(
+      (auditCalls[0].metadata as Record<string, unknown>).trackingCaseId,
+      11,
+    );
+    assert.equal(
+      (auditCalls[0].metadata as Record<string, unknown>).trackingStage,
+      "delivered",
+    );
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.report.id, 88);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes cierra tracking por reportId en delivered cuando no hay token", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    patientName: "Luna",
+  });
+  const nowDate = new Date("2026-04-22T12:00:00.000Z");
+  const trackingCase = createTrackingCaseFixture({
+    id: 22,
+    reportId: 88,
+    particularTokenId: null,
+    currentStage: "evaluation",
+    deliveredAt: null,
+  });
+  const updateTrackingCalls: Array<Record<string, unknown>> = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    now: () => nowDate.getTime(),
+    getStudyTrackingCaseByReportId: async () => trackingCase,
+    updateStudyTrackingCase: async (id: number, input: Record<string, unknown>) => {
+      updateTrackingCalls.push({ id, input });
+      return createTrackingCaseFixture({
+        ...trackingCase,
+        id,
+        ...input,
+      });
+    },
+    writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+      auditCalls.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(updateTrackingCalls, [
+      {
+        id: 22,
+        input: {
+          reportId: 88,
+          currentStage: "delivered",
+          deliveredAt: nowDate,
+        },
+      },
+    ]);
+    assert.equal(auditCalls.length, 1);
+    assert.equal(
+      (auditCalls[0].metadata as Record<string, unknown>).trackingCaseId,
+      22,
+    );
+    assert.equal(
+      (auditCalls[0].metadata as Record<string, unknown>).trackingStage,
+      "delivered",
+    );
   } finally {
     await app.close();
   }

--- a/test/clinic-management-route-policy.test.ts
+++ b/test/clinic-management-route-policy.test.ts
@@ -81,11 +81,7 @@ test("study-tracking exige management permission nativa al crear casos", () => {
   );
   assert.match(
     source,
-    /if \(auth\.canManageClinicUsers\) \{\s*return true;/s,
-  );
-  assert.match(
-    source,
-    /error: "No autorizado para administrar recursos de la clinica"/,
+    /error: "Solo administración puede crear seguimientos"/,
   );
 
   assert.match(
@@ -93,4 +89,3 @@ test("study-tracking exige management permission nativa al crear casos", () => {
     /app\.post<[\s\S]*?>\(\s*"\/"[\s\S]*?enforceTrustedOrigin\(request, reply, allowedOrigins\)[\s\S]*?requireStudyTrackingManagementPermission\(auth, reply\)/s,
   );
 });
-

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -192,6 +192,10 @@ function buildAdminParticularTokensRouteStubs() {
       sent: true as const,
       messageId: "particular-email-1",
     }),
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
   };
 }
 function buildAdminReportsRouteStubs() {
@@ -216,12 +220,19 @@ function buildAdminReportsRouteStubs() {
       updatedAt: new Date("2026-04-22T09:30:00.000Z"),
       storagePath: "reports/admin-test.pdf",
     } as any),
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
     createSignedReportUrl: async (storagePath: string) =>
       `signed-preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
       storagePath: string,
       fileName?: string,
     ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    writeAuditLog: async () => {},
   };
 }
 
@@ -473,6 +484,10 @@ function buildParticularTokensRouteStubs() {
       sent: true as const,
       messageId: "particular-email-1",
     }),
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
   };
 }
 function buildStudyTrackingRouteStubs() {

--- a/test/frontend-report-actions.test.ts
+++ b/test/frontend-report-actions.test.ts
@@ -24,7 +24,7 @@ test("upload report modal is client-side and imports upload dependencies", () =>
   assert.ok(source.includes('import { uploadAdminReport } from "@/lib/api";'));
   assert.ok(source.includes('import { getAdminUsersRoles } from "@/lib/api";'));
   assert.ok(source.includes("getAdminParticularTokens"));
-  assert.ok(source.includes("createAdminStudyTrackingCase"));
+  assert.equal(source.includes("createAdminStudyTrackingCase"), false);
 });
 
 test("upload report modal keeps study type options", () => {
@@ -80,16 +80,24 @@ test("upload report modal validates PDF file and submits FormData safely", () =>
   assert.ok(source.includes('formData.append("patientName", patientName.trim());'));
   assert.ok(source.includes('formData.append("studyType", studyType);'));
   assert.ok(source.includes('formData.append("uploadDate", uploadDate);'));
+  assert.ok(source.includes("if (selectedParticularToken) {"));
+  assert.ok(
+    source.includes(
+      'formData.append("particularTokenId", String(selectedParticularToken.id));',
+    ),
+  );
 });
 
 test("upload report modal calls upload API refreshes dashboard and handles errors", () => {
   const source = read(UPLOAD_REPORT_MODAL_PATH);
 
   assert.ok(source.includes("const response = await uploadAdminReport(formData);"));
-  assert.ok(source.includes("const trackingResponse = await createAdminStudyTrackingCase({"));
-  assert.ok(source.includes("response.report.id"));
-  assert.ok(source.includes("trackingResponse.trackingCase.estimatedDeliveryAt"));
-  assert.ok(source.includes("Seguimiento particular creado con entrega estimada"));
+  assert.equal(source.includes("createAdminStudyTrackingCase"), false);
+  assert.equal(source.includes("trackingResponse"), false);
+  assert.equal(
+    source.includes("Seguimiento particular creado con entrega estimada"),
+    false,
+  );
   assert.ok(source.includes("setSuccessMessage(response.message);"));
   assert.ok(source.includes("resetForm();"));
   assert.ok(source.includes("router.refresh();"));
@@ -632,12 +640,13 @@ test("upload modal: no invalid token ID sent when no particular token is selecte
   );
   assert.ok(
     source.includes("if (selectedParticularToken) {"),
-    "tracking case creation must be gated on selectedParticularToken",
+    "particularTokenId append must be gated on selectedParticularToken",
   );
-  assert.equal(
-    source.includes('formData.append("particularTokenId"'),
-    false,
-    "particularTokenId must NOT be appended to formData directly — only used for tracking",
+  assert.ok(
+    source.includes(
+      'formData.append("particularTokenId", String(selectedParticularToken.id));',
+    ),
+    "particularTokenId must be appended only when a valid token is selected",
   );
 });
 
@@ -665,12 +674,15 @@ test("upload modal: missing particular tokens do not block submit button", () =>
 });
 
 // 13. Valid token ID is sent when a particular token is selected
-test("upload modal: valid token ID is passed to tracking case when selected", () => {
+test("upload modal: valid token ID is appended to upload payload when selected", () => {
   const source = read(UPLOAD_REPORT_MODAL_PATH);
   assert.ok(
-    source.includes("particularTokenId: selectedParticularToken.id,"),
-    "when a token is selected, its ID must be passed to createAdminStudyTrackingCase",
+    source.includes(
+      'formData.append("particularTokenId", String(selectedParticularToken.id));',
+    ),
+    "when a token is selected, its ID must be sent in multipart upload",
   );
+  assert.equal(source.includes("createAdminStudyTrackingCase"), false);
   assert.ok(
     source.includes("const selectedParticularToken = particularTokens.find("),
     "selectedParticularToken must be derived from particularTokenId state",

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -23,7 +23,11 @@ test("frontend upload report modal remains available as admin-only implementatio
   assert.ok(source.includes("uploadAdminReport"));
   assert.ok(source.includes("getAdminUsersRoles"));
   assert.ok(source.includes("getAdminParticularTokens"));
-  assert.ok(source.includes("createAdminStudyTrackingCase"));
+  assert.ok(
+    source.includes(
+      'formData.append("particularTokenId", String(selectedParticularToken.id));',
+    ),
+  );
   assert.ok(source.includes("uploadAdminReport"));
 });
 

--- a/test/particular-tokens.fastify.test.ts
+++ b/test/particular-tokens.fastify.test.ts
@@ -59,6 +59,35 @@ function createParticularTokenFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    clinicId: 3,
+    reportId: 55,
+    particularTokenId: 7,
+    createdByAdminId: null,
+    createdByClinicUserId: 9,
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryWasManuallyAdjusted: false,
+    currentStage: "reception",
+    processingAt: null,
+    evaluationAt: null,
+    reportDevelopmentAt: null,
+    deliveredAt: null,
+    specialStainRequired: false,
+    specialStainNotifiedAt: null,
+    paymentUrl: null,
+    adminContactEmail: null,
+    adminContactPhone: null,
+    notes: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T12:30:00.000Z"),
+    ...overrides,
+  };
+}
+
 function createAuthStubs(overrides: Record<string, unknown> = {}) {
   return {
     deleteActiveSession: async () => {},
@@ -100,6 +129,10 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       sent: true,
       messageId: "particular-email-1",
     }),
+    getParticularStudyTrackingCase: async () => createTrackingCaseFixture(),
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => createTrackingCaseFixture(),
+    updateStudyTrackingCase: async () => createTrackingCaseFixture(),
     ...overrides,
   });
 

--- a/test/report-write-surface-ownership.test.ts
+++ b/test/report-write-surface-ownership.test.ts
@@ -133,6 +133,12 @@ async function createAdminReportUploadApp(overrides: Record<string, unknown> = {
     getClinicById: async () => ({ id: 3 }),
     uploadReport: async () => "reports/3/luna-report.pdf",
     upsertReport: async () => createReportFixture(),
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
     createSignedReportUrl: async (storagePath: string) =>
       `signed-preview:${storagePath}`,
     createSignedReportDownloadUrl: async (

--- a/test/security-mutation-permission-surface.test.ts
+++ b/test/security-mutation-permission-surface.test.ts
@@ -252,7 +252,20 @@ test("permission helpers devuelven 403 estable antes de mutaciones sensibles", (
 
       assertContains(helperSource, "reply.code(403).send", `${file} ${helper}`);
       assertContains(helperSource, "return false;", `${file} ${helper}`);
-      assertContains(helperSource, "return true;", `${file} ${helper}`);
+
+      const isClinicStudyTrackingHelper =
+        file === "server/routes/study-tracking.fastify.ts" &&
+        helper === "requireStudyTrackingManagementPermission";
+
+      if (isClinicStudyTrackingHelper) {
+        assertContains(
+          helperSource,
+          'error: "Solo administración puede crear seguimientos"',
+          `${file} ${helper}`,
+        );
+      } else {
+        assertContains(helperSource, "return true;", `${file} ${helper}`);
+      }
     }
   }
 });

--- a/test/security-write-attribution-boundaries.test.ts
+++ b/test/security-write-attribution-boundaries.test.ts
@@ -189,8 +189,12 @@ test("runtime attribution tests remain explicit for critical writes", () => {
   assertContains(reportsStatusTests, "changedByClinicUserId: 9", "clinic report status runtime attribution");
   assertContains(reportsStatusTests, "changedByAdminUserId: null", "clinic report status runtime attribution");
 
-  assertContains(studyTrackingTests, "assert.equal(createCalls[0].createdByAdminId, null)", "clinic study tracking runtime attribution");
-  assertContains(studyTrackingTests, "assert.equal(createCalls[0].createdByClinicUserId, 9)", "clinic study tracking runtime attribution");
+  assertContains(studyTrackingTests, "assert.equal(response.statusCode, 403)", "clinic study tracking runtime authorization");
+  assertContains(
+    studyTrackingTests,
+    'error: "Solo administración puede crear seguimientos"',
+    "clinic study tracking runtime authorization",
+  );
 
   assertContains(adminStudyTrackingTests, "assert.equal(createCalls[0].createdByAdminId, 1)", "admin study tracking runtime attribution");
   assertContains(adminStudyTrackingTests, "assert.equal(createCalls[0].createdByClinicUserId, null)", "admin study tracking runtime attribution");

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -226,22 +226,16 @@ test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async 
   }
 });
 
-test("studyTrackingNativeRoutes crea POST / con vínculos y notificación especial", async () => {
+test("studyTrackingNativeRoutes bloquea POST / porque el workflow es admin-only", async () => {
   const createCalls: Array<Record<string, unknown>> = [];
   const updateTokenCalls: Array<Record<string, unknown>> = [];
   const notificationCalls: Array<Record<string, unknown>> = [];
   const emailCalls: Array<Record<string, unknown>> = [];
-  const notifiedAt = new Date("2026-04-20T13:30:00.000Z");
-  const created = createTrackingCaseFixture({ specialStainRequired: true });
-  const updated = createTrackingCaseFixture({
-    specialStainRequired: true,
-    specialStainNotifiedAt: notifiedAt,
-  });
 
   const app = await createTestApp({
     createStudyTrackingCase: async (input: Record<string, unknown>) => {
       createCalls.push(input);
-      return created;
+      return createTrackingCaseFixture({ specialStainRequired: true });
     },
     updateParticularTokenReport: async (
       particularTokenId: number,
@@ -254,19 +248,10 @@ test("studyTrackingNativeRoutes crea POST / con vínculos y notificación especi
       notificationCalls.push(input);
       return createNotificationFixture();
     },
-    updateStudyTrackingCase: async (
-      trackingCaseId: number,
-      input: Record<string, unknown>,
-    ) => {
-      assert.equal(trackingCaseId, 11);
-      assert.deepEqual(input, { specialStainNotifiedAt: notifiedAt });
-      return updated;
-    },
     sendSpecialStainRequiredEmail: async (input: Record<string, unknown>) => {
       emailCalls.push(input);
       return { sent: true };
     },
-    createDate: () => notifiedAt,
   });
 
   try {
@@ -291,34 +276,21 @@ test("studyTrackingNativeRoutes crea POST / con vínculos y notificación especi
       },
     });
 
-    assert.equal(response.statusCode, 201);
+    assert.equal(response.statusCode, 403);
     assert.equal(
       response.headers["access-control-allow-origin"],
       "http://localhost:3000",
     );
-    assert.equal(createCalls.length, 1);
-    assert.equal(createCalls[0].clinicId, 3);
-    assert.equal(createCalls[0].reportId, 55);
-    assert.equal(createCalls[0].particularTokenId, 7);
-    assert.equal(createCalls[0].createdByAdminId, null);
-    assert.equal(createCalls[0].createdByClinicUserId, 9);
-    assert.equal(createCalls[0].specialStainRequired, true);
-    assert.equal(createCalls[0].estimatedDeliveryWasManuallyAdjusted, false);
-    assert.ok(createCalls[0].estimatedDeliveryAt instanceof Date);
-    assert.deepEqual(updateTokenCalls, [{ particularTokenId: 7, reportId: 55 }]);
-    assert.equal(notificationCalls.length, 1);
-    assert.equal(notificationCalls[0].studyTrackingCaseId, 11);
-    assert.equal(notificationCalls[0].clinicId, 3);
-    assert.equal(notificationCalls[0].type, "special_stain_required");
-    assert.equal(emailCalls.length, 1);
-    assert.deepEqual(emailCalls[0].to, ["clinic@example.com", "admin@example.com"]);
+    assert.equal(createCalls.length, 0);
+    assert.equal(updateTokenCalls.length, 0);
+    assert.equal(notificationCalls.length, 0);
+    assert.equal(emailCalls.length, 0);
 
     const body = JSON.parse(response.body);
-    assert.equal(body.success, true);
-    assert.equal(body.message, "Seguimiento creado correctamente");
-    assert.equal(body.trackingCase.id, 11);
-    assert.equal(body.trackingCase.clinicId, 3);
-    assert.equal(body.trackingCase.specialStainNotifiedAt, notifiedAt.toISOString());
+    assert.deepEqual(body, {
+      success: false,
+      error: "Solo administración puede crear seguimientos",
+    });
   } finally {
     await app.close();
   }


### PR DESCRIPTION
# PR: fix(report): apply workflow authority to tokens

## Rama
- `fix/report-token-workflow-authority`

## Preguntas previas (resueltas antes del cierre)
1. **¿Por qué los tokens mostraban “Sin seguimiento vinculado”?**
- Porque la UI de tokens consultaba `study_tracking_cases` por `particularTokenId`, pero no existía garantía backend de crear/vincular ese tracking en todos los flujos de token + upload.

2. **¿Se crea un `study_tracking_case` al generar token?**
- Ahora sí se asegura en creación de token (admin y clínica) vía helper canónico `ensureStudyTrackingCaseForToken`.

3. **Si no se crea, ¿existe endpoint/helper para ensure tracking by `particularTokenId`?**
- Sí. Se implementó `server/lib/token-study-tracking.ts` con `ensureStudyTrackingCaseForToken(...)` y soporte por token/report.

4. **¿El admin viewer lista por `study_tracking_cases` o por informes?**
- Por `study_tracking_cases` (flujo canónico de seguimiento).

5. **¿Tokens admin/clínica consultan tracking con el ID correcto?**
- Sí, por `particularTokenId` del token listado.

6. **¿El endpoint particular devuelve tracking real?**
- Sí. `particular-study-tracking` obtiene el tracking del token autenticado y expone estado real del caso.

7. **¿La subida de informe actualiza `currentStage` a `delivered`?**
- Sí. En `POST /api/admin/reports/upload` se fuerza cierre en `delivered` (por token vinculado o por `reportId`).

8. **¿`specialStainRequired` está asociado al caso/token correcto?**
- Sí. Queda en el `study_tracking_case` canónico y se replica en vistas admin/clínica/particular vía lectura del mismo caso.

9. **¿Clínica y particular son read-only?**
- Sí para workflow mutation: la ruta clínica `POST /api/study-tracking` ahora responde `403` (`Solo administración puede crear seguimientos`), y particular solo tiene endpoints GET.

10. **¿Hay riesgo de N requests excesivas?**
- Riesgo residual moderado en admin list/detail de tokens por `ensure` en lectura (mitigado con `Promise.all` en listado). Se documenta abajo.

## 1. Causa raíz de “Sin seguimiento vinculado”
- Existía desacople entre token y tracking: la vista esperaba `study_tracking_cases` por token, pero los flujos backend no aseguraban consistentemente ese vínculo al crear token o al subir informe.

## 2. Modelo correcto token → seguimiento
- Fuente canónica: `study_tracking_cases`.
- Clave de relación principal: `particularTokenId`.
- Fallback de conciliación: `reportId`.
- Helper central: `ensureStudyTrackingCaseForToken(...)`.

## 3. Autoridad de modificación (solo admin)
- Admin conserva mutación de workflow (`/api/admin/study-tracking` + cierre por upload admin).
- Ruta clínica de creación de tracking (`POST /api/study-tracking`) bloqueada con `403`.

## 4. Clínica read-only
- Clínica consume tracking por lectura (`GET /api/study-tracking...`), sin creación de casos desde su endpoint de workflow.

## 5. Particular read-only
- Particular consulta tracking del token autenticado (`/api/particular/study-tracking/me`) sin capacidades de mutación.

## 6. Tinción especial
- `specialStainRequired` permanece en el caso canónico y se visualiza en admin/clínica/particular sin bifurcar estado de etapa.

## 7. Upload de informe → Entrega
- `server/routes/admin-reports.fastify.ts` ahora acepta `particularTokenId` en multipart.
- Si hay token seleccionado:
  - vincula token↔report,
  - asegura/crea tracking,
  - cierra en `currentStage = "delivered"`.
- Si no hay token:
  - busca tracking por `reportId` y lo cierra en `delivered`.

## 8. Archivos modificados
- `server/lib/token-study-tracking.ts` (nuevo)
- `server/db-study-tracking.ts`
- `server/routes/admin-reports.fastify.ts`
- `server/routes/admin-particular-tokens.fastify.ts`
- `server/routes/particular-tokens.fastify.ts`
- `server/routes/study-tracking.fastify.ts`
- `frontend/src/components/dashboard/UploadReportModal.tsx`
- `test/admin-reports.fastify.test.ts`
- `test/admin-particular-tokens.fastify.test.ts`
- `test/particular-tokens.fastify.test.ts`
- `test/study-tracking.fastify.test.ts`
- `test/frontend-report-upload-modal.test.ts`
- `test/frontend-report-actions.test.ts`
- `test/clinic-management-route-policy.test.ts`
- `test/security-mutation-permission-surface.test.ts`
- `test/security-write-attribution-boundaries.test.ts`
- `test/fastify-app.test.ts`
- `test/report-write-surface-ownership.test.ts`

## 9. Tests agregados/reforzados
- `admin-reports.fastify.test.ts`:
  - validación `particularTokenId` inválido,
  - `particularTokenId` inexistente,
  - mismatch de clínica,
  - upload con token cierra tracking en `delivered`,
  - upload sin token cierra tracking por `reportId` en `delivered`.
- `study-tracking.fastify.test.ts`:
  - POST clínica bloqueado (`403`) por autoridad admin-only.
- Frontend tests del modal:
  - validan envío de `particularTokenId` en multipart,
  - eliminan expectativa de creación de tracking desde UI.
- Actualización de tests de seguridad/contrato para nuevo comportamiento admin-only.

## 10. Validaciones ejecutadas
- `pnpm test` ✅
- `pnpm validate:local` ✅
- `pnpm --dir frontend lint` ✅ (1 warning preexistente por `eslint-disable` no usado en `frontend/src/app/api/security/csp-report/route.ts`)
- `pnpm --dir frontend typecheck` ✅
- `pnpm --dir frontend build` ✅

## 11. Riesgos residuales
- En admin tokens list/detail se ejecuta `ensure` en lectura para autocorregir vinculación; esto puede aumentar llamadas por item en listados grandes.
- Se mantiene como tradeoff para consistencia inmediata del estado hasta introducir una estrategia de batch/prefetch específica.

## 12. Checklist manual
- [x] admin seguimiento de informes lista tokens/casos
- [x] admin cambia etapa
- [x] admin solicita tinción especial
- [x] clínica ve alerta
- [x] particular ve alerta
- [x] admin sube informe
- [x] clínica ve Entrega
- [x] particular ve Entrega/informe disponible

## 13. Notas de implementación
- Se eliminó la creación de tracking desde frontend en upload modal.
- El backend de upload quedó como punto de autoridad para cierre del workflow con informe.
