### PR TITLE
fix(admin): allow token workflow stage edits

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -17,6 +17,8 @@ import {
   getAdminUsersRoles,
   getAdminParticularTokens,
   getAdminStudyTrackingCases,
+  updateAdminStudyTrackingCase,
+  type AdminStudyTrackingStage,
   type AdminStudyTrackingCaseSummary,
   type AdminParticularTokenCreatePayload,
   type AdminParticularTokenSummary,
@@ -261,6 +263,17 @@ const TRACKING_STAGE_LABELS: Record<AdminStudyTrackingCaseSummary["currentStage"
   delivered: "Informe disponible / Publicado",
 };
 
+const TRACKING_STAGE_OPTIONS: Array<{
+  value: AdminStudyTrackingStage;
+  label: string;
+}> = [
+  { value: "reception", label: "Recepción de muestra" },
+  { value: "processing", label: "Procesamiento" },
+  { value: "evaluation", label: "Evaluación" },
+  { value: "report_development", label: "Desarrollo de informe" },
+  { value: "delivered", label: "Informe disponible / Publicado" },
+];
+
 function getTrackingStageLabel(
   stage: AdminStudyTrackingCaseSummary["currentStage"],
 ): string {
@@ -292,6 +305,9 @@ export function AdminParticularTokensCard() {
   const [copyErrorMessage, setCopyErrorMessage] = useState<string | null>(null);
   const [isLoadingTokens, setIsLoadingTokens] = useState(false);
   const [revokingTokenId, setRevokingTokenId] = useState<number | null>(null);
+  const [updatingTrackingCaseIds, setUpdatingTrackingCaseIds] = useState<
+    Record<number, boolean>
+  >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -602,6 +618,41 @@ export function AdminParticularTokensCard() {
       );
     } finally {
       setRevokingTokenId(null);
+    }
+  }
+
+  async function handleTrackingStageChange(
+    tokenId: number,
+    trackingCase: AdminStudyTrackingCaseSummary,
+    nextStage: AdminStudyTrackingStage,
+  ) {
+    if (trackingCase.currentStage === nextStage) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setUpdatingTrackingCaseIds((current) => ({
+      ...current,
+      [trackingCase.id]: true,
+    }));
+
+    try {
+      const response = await updateAdminStudyTrackingCase(trackingCase.id, {
+        currentStage: nextStage,
+      });
+
+      setTrackingCasesByTokenId((current) => ({
+        ...current,
+        [tokenId]: response.trackingCase,
+      }));
+    } catch {
+      setErrorMessage("No se pudo cambiar la etapa del seguimiento.");
+    } finally {
+      setUpdatingTrackingCaseIds((current) => {
+        const next = { ...current };
+        delete next[trackingCase.id];
+        return next;
+      });
     }
   }
 
@@ -1079,6 +1130,9 @@ export function AdminParticularTokensCard() {
             <div className="space-y-2">
               {tokens.map((token) => {
                 const trackingCase = trackingCasesByTokenId[token.id];
+                const isUpdatingTrackingCase = trackingCase
+                  ? Boolean(updatingTrackingCaseIds[trackingCase.id])
+                  : false;
 
                 return (
                   <div
@@ -1174,6 +1228,31 @@ export function AdminParticularTokensCard() {
                           <p className="mt-1 text-xs text-vetneb-ink">
                             Etapa: {getTrackingStageLabel(trackingCase.currentStage)}
                           </p>
+                          <label
+                            htmlFor={`admin-tracking-stage-${trackingCase.id}`}
+                            className="mt-2 block text-xs font-semibold text-vetneb-navy"
+                          >
+                            Cambiar etapa del seguimiento
+                          </label>
+                          <select
+                            id={`admin-tracking-stage-${trackingCase.id}`}
+                            className="field-select mt-1 text-xs"
+                            value={trackingCase.currentStage}
+                            onChange={(event) =>
+                              void handleTrackingStageChange(
+                                token.id,
+                                trackingCase,
+                                event.target.value as AdminStudyTrackingStage,
+                              )
+                            }
+                            disabled={isUpdatingTrackingCase}
+                          >
+                            {TRACKING_STAGE_OPTIONS.map((stageOption) => (
+                              <option key={stageOption.value} value={stageOption.value}>
+                                {stageOption.label}
+                              </option>
+                            ))}
+                          </select>
                           <p className="mt-1 text-xs text-muted-foreground">
                             {trackingCase.specialStainRequired
                               ? "Alerta: Solicitud de tinción especial"

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 const PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
 const CARD_PATH =
   "frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx";
+const ADMIN_PARTICULAR_TOKENS_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
 const SIDEBAR_PATH =
   "frontend/src/components/dashboard/AdminDashboardSidebar.tsx";
 const API_PATH = "frontend/src/lib/api.ts";
@@ -85,4 +87,31 @@ test("tarjeta y cliente API soportan paginación y mutaciones manuales", () => {
   assert.ok(api.includes("`/api/admin/study-tracking${qs ? `?${qs}` : \"\"}`"));
   assert.ok(api.includes("`/api/admin/study-tracking/${trackingCaseId}`"));
   assert.ok(api.includes('credentials: options.credentials ?? "include",'));
+});
+
+test("admin tokens card permite cambiar etapa de seguimiento desde la card", () => {
+  const card = read(ADMIN_PARTICULAR_TOKENS_CARD_PATH);
+
+  assert.ok(card.includes("updateAdminStudyTrackingCase"));
+  assert.ok(card.includes("Cambiar etapa del seguimiento"));
+  assert.ok(card.includes('id={`admin-tracking-stage-${trackingCase.id}`}'));
+  assert.ok(card.includes("value={trackingCase.currentStage}"));
+  assert.ok(card.includes("updateAdminStudyTrackingCase(trackingCase.id, {"));
+  assert.ok(card.includes("currentStage: nextStage"));
+  assert.ok(card.includes("No se pudo cambiar la etapa del seguimiento."));
+  assert.ok(card.includes("[tokenId]: response.trackingCase"));
+});
+
+test("admin tokens card reutiliza las cinco etapas de seguimiento", () => {
+  const card = read(ADMIN_PARTICULAR_TOKENS_CARD_PATH);
+
+  for (const stage of [
+    "Recepción de muestra",
+    "Procesamiento",
+    "Evaluación",
+    "Desarrollo de informe",
+    "Informe disponible / Publicado",
+  ]) {
+    assert.ok(card.includes(stage), `debe incluir la etapa ${stage}`);
+  }
 });


### PR DESCRIPTION
## Resumen
- Permite al admin cambiar manualmente la etapa de seguimiento desde cada token administrado.
- Usa updateAdminStudyTrackingCase sin recargar la página.
- Actualiza trackingCasesByTokenId localmente con response.trackingCase.
- Mantiene clínica y particular en modo observación.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Scope
- frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
- test/frontend-admin-report-workflow.test.ts