### PR TITLE
feat(admin): add token workflow notification bell

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -656,6 +656,36 @@ export function AdminParticularTokensCard() {
     }
   }
 
+  async function handleSpecialStainChange(
+    tokenId: number,
+    trackingCase: AdminStudyTrackingCaseSummary,
+  ) {
+    setErrorMessage(null);
+    setUpdatingTrackingCaseIds((current) => ({
+      ...current,
+      [trackingCase.id]: true,
+    }));
+
+    try {
+      const response = await updateAdminStudyTrackingCase(trackingCase.id, {
+        specialStainRequired: !trackingCase.specialStainRequired,
+      });
+
+      setTrackingCasesByTokenId((current) => ({
+        ...current,
+        [tokenId]: response.trackingCase,
+      }));
+    } catch {
+      setErrorMessage("No se pudo actualizar la alerta de tinción especial.");
+    } finally {
+      setUpdatingTrackingCaseIds((current) => {
+        const next = { ...current };
+        delete next[trackingCase.id];
+        return next;
+      });
+    }
+  }
+
   return (
     <Card className="dashboard-surface">
       <CardHeader className="border-b border-vetneb-line/70">
@@ -1258,6 +1288,20 @@ export function AdminParticularTokensCard() {
                               ? "Alerta: Solicitud de tinción especial"
                               : "Sin alerta de tinción especial"}
                           </p>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="mt-2 w-full"
+                            onClick={() =>
+                              void handleSpecialStainChange(token.id, trackingCase)
+                            }
+                            disabled={isUpdatingTrackingCase}
+                          >
+                            {trackingCase.specialStainRequired
+                              ? "Resolver tinción especial"
+                              : "Solicitar tinción especial"}
+                          </Button>
                         </>
                       ) : (
                         <p className="mt-1 text-xs text-muted-foreground">

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -26,7 +26,6 @@ import { AdminPricingEditorCard } from "./AdminPricingEditorCard";
 import { AdminSchemaHealthStatusCard } from "./AdminSchemaHealthStatusCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
-import { AdminReportWorkflowViewerCard } from "@/components/dashboard/AdminReportWorkflowViewerCard";
 import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
@@ -391,6 +390,7 @@ export default async function AdminPage({
       <DashboardTopbar
         title="Administración"
         subtitle="Auditoría, reportes y estado operacional"
+        notifications="admin"
       />
       <main className="dashboard-main">
         <section
@@ -414,9 +414,6 @@ export default async function AdminPage({
               <UploadReportModal />
             </div>
           </div>
-        </section>
-        <section id="admin-report-workflow">
-          <AdminReportWorkflowViewerCard />
         </section>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <Card className="dashboard-surface h-full">

--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -29,11 +29,6 @@ const adminNavItems: DashboardNavItem[] = [
     icon: ClipboardPlus,
   },
   {
-    label: "Seguimiento de informes",
-    href: `${ROUTES.dashboardAdmin}#admin-report-workflow`,
-    icon: ScrollText,
-  },
-  {
     label: "Estado",
     href: `${ROUTES.dashboardAdmin}#admin-health`,
     icon: Activity,

--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  getAdminStudyTrackingNotifications,
+  markAdminStudyTrackingNotificationRead,
+  type AdminStudyTrackingNotificationSummary,
+} from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+
+const NOTIFICATIONS_LIMIT = 20;
+const POLLING_INTERVAL_MS = 30_000;
+
+export function DashboardNotificationsBell() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPollingEnabled, setIsPollingEnabled] = useState(false);
+  const [notifications, setNotifications] = useState<
+    AdminStudyTrackingNotificationSummary[]
+  >([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [updatingNotificationId, setUpdatingNotificationId] = useState<
+    number | null
+  >(null);
+  const isFetchingRef = useRef(false);
+
+  const unreadCount = notifications.filter((notification) => !notification.isRead)
+    .length;
+
+  const loadNotifications = useCallback(async () => {
+    if (isFetchingRef.current) {
+      return;
+    }
+
+    isFetchingRef.current = true;
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await getAdminStudyTrackingNotifications({
+        limit: NOTIFICATIONS_LIMIT,
+        offset: 0,
+      });
+      setNotifications(response.notifications);
+    } catch {
+      setErrorMessage("No se pudieron cargar las notificaciones.");
+    } finally {
+      isFetchingRef.current = false;
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isPollingEnabled) {
+      return;
+    }
+
+    void loadNotifications();
+
+    const intervalId = window.setInterval(() => {
+      void loadNotifications();
+    }, POLLING_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [isPollingEnabled, loadNotifications]);
+
+  function handleToggleOpen() {
+    setIsOpen((current) => {
+      const next = !current;
+
+      if (next) {
+        void loadNotifications();
+      }
+
+      return next;
+    });
+  }
+
+  function handleEnableNotifications() {
+    setIsPollingEnabled(true);
+    void loadNotifications();
+  }
+
+  async function handleMarkAsRead(
+    notification: AdminStudyTrackingNotificationSummary,
+  ) {
+    if (notification.isRead || updatingNotificationId !== null) {
+      return;
+    }
+
+    setUpdatingNotificationId(notification.id);
+    setErrorMessage(null);
+
+    try {
+      const response = await markAdminStudyTrackingNotificationRead(
+        notification.id,
+      );
+      setNotifications((current) =>
+        current.map((currentNotification) =>
+          currentNotification.id === notification.id
+            ? response.notification
+            : currentNotification,
+        ),
+      );
+    } catch {
+      setErrorMessage("No se pudieron cargar las notificaciones.");
+    } finally {
+      setUpdatingNotificationId(null);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="Notificaciones"
+        className="relative inline-flex h-9 w-9 items-center justify-center rounded-md border border-input bg-card/95 text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground"
+        onClick={handleToggleOpen}
+      >
+        <Bell className="h-4 w-4" aria-hidden="true" />
+        {unreadCount > 0 ? (
+          <span className="absolute -right-1 -top-1 inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-vetneb-teal px-1 text-[0.62rem] font-semibold leading-none text-vetneb-navy">
+            {unreadCount}
+          </span>
+        ) : null}
+      </button>
+
+      {isOpen ? (
+        <div className="absolute right-0 z-50 mt-2 w-[20rem] rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-vetneb-ink">Notificaciones</p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleEnableNotifications}
+                disabled={isPollingEnabled}
+              >
+                {isPollingEnabled
+                  ? "Notificaciones activadas"
+                  : "Activar notificaciones"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void loadNotifications()}
+                disabled={isLoading}
+              >
+                {isLoading ? "Actualizando..." : "Actualizar"}
+              </Button>
+            </div>
+          </div>
+
+          {errorMessage ? (
+            <p className="clinical-alert-warning px-3 py-2 text-xs" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {!errorMessage && !isLoading && notifications.length === 0 ? (
+            <p className="surface-empty py-3 text-sm">No hay notificaciones.</p>
+          ) : null}
+
+          <ul className="max-h-72 space-y-2 overflow-y-auto pr-1">
+            {notifications.map((notification) => (
+              <li key={notification.id}>
+                <button
+                  type="button"
+                  className="w-full rounded-md border border-vetneb-line/70 bg-vetneb-surface-raised/78 px-3 py-2 text-left transition-colors hover:border-vetneb-teal/45"
+                  onClick={() => void handleMarkAsRead(notification)}
+                  disabled={
+                    notification.isRead ||
+                    updatingNotificationId === notification.id
+                  }
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="text-xs font-semibold text-vetneb-ink">
+                      {notification.title}
+                    </p>
+                    <span className="text-[0.66rem] text-muted-foreground">
+                      {notification.isRead ? "Leída" : "No leída"}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {notification.message}
+                  </p>
+                  <p className="mt-1 text-[0.66rem] text-muted-foreground">
+                    {formatDateTime(notification.createdAt)}
+                  </p>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -1,12 +1,18 @@
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
+import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 
 interface DashboardTopbarProps {
   title: string;
   subtitle?: string;
+  notifications?: "admin" | false;
 }
 
-export function DashboardTopbar({ title, subtitle }: DashboardTopbarProps) {
+export function DashboardTopbar({
+  title,
+  subtitle,
+  notifications = false,
+}: DashboardTopbarProps) {
   return (
     <header
       className="sticky top-0 z-40 flex min-h-[4.5rem] items-center justify-between border-b border-vetneb-line/80 bg-card/90 px-4 py-2.5 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/78 sm:px-6"
@@ -36,6 +42,7 @@ export function DashboardTopbar({ title, subtitle }: DashboardTopbarProps) {
       </div>
 
       <div className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3">
+        {notifications === "admin" ? <DashboardNotificationsBell /> : null}
         <PublicRouteControl
           href={ROUTES.login}
           variant="bare"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -848,6 +848,95 @@ export async function updateAdminStudyTrackingCase(
   );
 }
 
+export type AdminStudyTrackingNotificationSummary = {
+  id: number;
+  studyTrackingCaseId: number;
+  clinicId: number;
+  reportId: number | null;
+  particularTokenId: number | null;
+  type: string;
+  title: string;
+  message: string;
+  isRead: boolean;
+  readAt: string | null;
+  createdAt: string;
+};
+
+export type AdminStudyTrackingNotificationsSnapshot = {
+  success: true;
+  count: number;
+  notifications: AdminStudyTrackingNotificationSummary[];
+  pagination: {
+    limit: number;
+    offset: number;
+  };
+};
+
+export type AdminStudyTrackingNotificationReadResponse = {
+  success: true;
+  notification: AdminStudyTrackingNotificationSummary;
+};
+
+export type AdminStudyTrackingNotificationsReadAllResponse = {
+  success: true;
+  updatedCount: number;
+};
+
+export async function getAdminStudyTrackingNotifications(
+  params: {
+    unreadOnly?: boolean;
+    limit?: number;
+    offset?: number;
+  } = {},
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsSnapshot> {
+  const query = new URLSearchParams();
+
+  if (typeof params.unreadOnly === "boolean") {
+    query.set("unreadOnly", String(params.unreadOnly));
+  }
+
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+
+  const qs = query.toString();
+
+  return apiFetch<AdminStudyTrackingNotificationsSnapshot>(
+    `/api/admin/study-tracking/notifications${qs ? `?${qs}` : ""}`,
+    options,
+  );
+}
+
+export async function markAdminStudyTrackingNotificationRead(
+  notificationId: number,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationReadResponse> {
+  return apiFetch<AdminStudyTrackingNotificationReadResponse>(
+    `/api/admin/study-tracking/notifications/${notificationId}/read`,
+    {
+      ...options,
+      method: "PATCH",
+    },
+  );
+}
+
+export async function markAllAdminStudyTrackingNotificationsRead(
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsReadAllResponse> {
+  return apiFetch<AdminStudyTrackingNotificationsReadAllResponse>(
+    "/api/admin/study-tracking/notifications/read-all",
+    {
+      ...options,
+      method: "PATCH",
+    },
+  );
+}
+
 export type ClinicStudyTrackingCaseSummary = AdminStudyTrackingCaseSummary;
 
 export type ClinicStudyTrackingSnapshot = {

--- a/server/db-study-tracking.ts
+++ b/server/db-study-tracking.ts
@@ -192,3 +192,40 @@ export async function listStudyTrackingNotifications(params?: {
     .limit(limit)
     .offset(offset);
 }
+
+export async function markStudyTrackingNotificationRead(id: number) {
+  const now = new Date();
+  const result = await db
+    .update(studyTrackingNotifications)
+    .set({
+      isRead: true,
+      readAt: now,
+    })
+    .where(eq(studyTrackingNotifications.id, id))
+    .returning();
+
+  return result[0];
+}
+
+export async function markAllStudyTrackingNotificationsRead(params?: {
+  clinicId?: number;
+}) {
+  const filters = [eq(studyTrackingNotifications.isRead, false)];
+
+  if (typeof params?.clinicId === "number") {
+    filters.push(eq(studyTrackingNotifications.clinicId, params.clinicId));
+  }
+
+  const updated = await db
+    .update(studyTrackingNotifications)
+    .set({
+      isRead: true,
+      readAt: new Date(),
+    })
+    .where(and(...filters))
+    .returning({ id: studyTrackingNotifications.id });
+
+  return {
+    updatedCount: updated.length,
+  };
+}

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -4,7 +4,12 @@ import type {
   FastifyRequest,
 } from "fastify";
 
-import type { ParticularToken, Report, StudyTrackingCase } from "../../drizzle/schema.ts";
+import type {
+  ParticularToken,
+  Report,
+  StudyTrackingCase,
+  StudyTrackingNotification,
+} from "../../drizzle/schema.ts";
 import { ENV } from "../lib/env.ts";
 import {
   adminCreateParticularTokenSchema,
@@ -124,6 +129,17 @@ export type AdminParticularTokensNativeRoutesOptions = {
     id: number,
     input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
   ) => Promise<StudyTrackingCase | null | undefined>;
+  createStudyTrackingNotification?: (input: {
+    studyTrackingCaseId: number;
+    clinicId: number;
+    reportId: number | null;
+    particularTokenId: number | null;
+    type: string;
+    title: string;
+    message: string;
+    isRead: boolean;
+    readAt: Date | null;
+  }) => Promise<StudyTrackingNotification>;
   now?: () => number;
 };
 
@@ -156,6 +172,7 @@ type NativeAdminParticularTokensDeps = Required<
     | "getStudyTrackingCaseByReportId"
     | "createStudyTrackingCase"
     | "updateStudyTrackingCase"
+    | "createStudyTrackingNotification"
   >
 >;
 
@@ -192,6 +209,8 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
           dbStudyTracking.getStudyTrackingCaseByReportId,
         createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
         updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
+        createStudyTrackingNotification:
+          dbStudyTracking.createStudyTrackingNotification,
       };
     })();
   }
@@ -508,7 +527,8 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
     !!options.getParticularStudyTrackingCase &&
     !!options.getStudyTrackingCaseByReportId &&
     !!options.createStudyTrackingCase &&
-    !!options.updateStudyTrackingCase;
+    !!options.updateStudyTrackingCase &&
+    !!options.createStudyTrackingNotification;
 
   const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -554,6 +574,9 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
     updateStudyTrackingCase:
       options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
+    createStudyTrackingNotification:
+      options.createStudyTrackingNotification ??
+      defaultDeps!.createStudyTrackingNotification,
   };
 
   const now = options.now ?? (() => Date.now());
@@ -562,9 +585,9 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
   async function ensureTrackingForToken(
     token: ParticularToken,
     createdByAdminId: number | null,
-  ) {
+  ): Promise<StudyTrackingCase | null> {
     try {
-      await ensureStudyTrackingCaseForToken(
+      return await ensureStudyTrackingCaseForToken(
         {
           getParticularStudyTrackingCase: deps.getParticularStudyTrackingCase,
           getStudyTrackingCaseByReportId: deps.getStudyTrackingCaseByReportId,
@@ -584,6 +607,7 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
         clinicId: token.clinicId,
         errorName: getSafeErrorName(error),
       });
+      return null;
     }
   }
 
@@ -769,7 +793,30 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    await ensureTrackingForToken(particularToken, admin.id);
+    const trackingCase = await ensureTrackingForToken(particularToken, admin.id);
+
+    if (trackingCase) {
+      try {
+        await deps.createStudyTrackingNotification({
+          studyTrackingCaseId: trackingCase.id,
+          clinicId: particularToken.clinicId,
+          reportId:
+            particularToken.reportId ?? trackingCase.reportId ?? null,
+          particularTokenId: particularToken.id,
+          type: "token_created",
+          title: "Token particular generado",
+          message: `Se generó un token particular para ${particularToken.petName}.`,
+          isRead: false,
+          readAt: null,
+        });
+      } catch (error) {
+        console.error("[TRACKING] notification token_created failed", {
+          tokenId: particularToken.id,
+          trackingCaseId: trackingCase.id,
+          errorName: getSafeErrorName(error),
+        });
+      }
+    }
 
     return reply.code(201).send({
       success: true,

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -165,6 +165,12 @@ export type AdminStudyTrackingNativeRoutesOptions = {
     limit: number;
     offset: number;
   }) => Promise<StudyTrackingNotification[]>;
+  markStudyTrackingNotificationRead?: (
+    id: number,
+  ) => Promise<StudyTrackingNotification | null | undefined>;
+  markAllStudyTrackingNotificationsRead?: (params?: {
+    clinicId?: number;
+  }) => Promise<{ updatedCount: number }>;
   sendSpecialStainRequiredEmail?: (input: {
     to: Array<string | null | undefined>;
     clinicName: string;
@@ -208,6 +214,8 @@ type NativeAdminStudyTrackingDeps = Required<
     | "listStudyTrackingCases"
     | "createStudyTrackingNotification"
     | "listStudyTrackingNotifications"
+    | "markStudyTrackingNotificationRead"
+    | "markAllStudyTrackingNotificationsRead"
     | "sendSpecialStainRequiredEmail"
     | "writeAuditLog"
   >
@@ -245,6 +253,10 @@ async function loadDefaultDeps(): Promise<NativeAdminStudyTrackingDeps> {
           dbStudyTracking.createStudyTrackingNotification,
         listStudyTrackingNotifications:
           dbStudyTracking.listStudyTrackingNotifications,
+        markStudyTrackingNotificationRead:
+          dbStudyTracking.markStudyTrackingNotificationRead,
+        markAllStudyTrackingNotificationsRead:
+          dbStudyTracking.markAllStudyTrackingNotificationsRead,
         sendSpecialStainRequiredEmail: email.sendSpecialStainRequiredEmail,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
@@ -602,6 +614,8 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
     !!options.listStudyTrackingCases &&
     !!options.createStudyTrackingNotification &&
     !!options.listStudyTrackingNotifications &&
+    !!options.markStudyTrackingNotificationRead &&
+    !!options.markAllStudyTrackingNotificationsRead &&
     !!options.sendSpecialStainRequiredEmail &&
     !!options.writeAuditLog;
 
@@ -643,6 +657,12 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
     listStudyTrackingNotifications:
       options.listStudyTrackingNotifications ??
       defaultDeps!.listStudyTrackingNotifications,
+    markStudyTrackingNotificationRead:
+      options.markStudyTrackingNotificationRead ??
+      defaultDeps!.markStudyTrackingNotificationRead,
+    markAllStudyTrackingNotificationsRead:
+      options.markAllStudyTrackingNotificationsRead ??
+      defaultDeps!.markAllStudyTrackingNotificationsRead,
     sendSpecialStainRequiredEmail:
       options.sendSpecialStainRequiredEmail ??
       defaultDeps!.sendSpecialStainRequiredEmail,
@@ -708,6 +728,8 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
 
   app.options("/", optionsHandler);
   app.options("/notifications", optionsHandler);
+  app.options("/notifications/:notificationId/read", optionsHandler);
+  app.options("/notifications/read-all", optionsHandler);
   app.options("/:trackingCaseId", optionsHandler);
 
   app.get<{
@@ -718,9 +740,14 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       offset?: unknown;
     };
   }>("/notifications", async (request, reply) => {
-    const admin = await authenticateAdminUser(request, reply, deps, now);
+    const authenticatedAdmin = await authenticateAdminUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
 
-    if (!admin) {
+    if (!authenticatedAdmin) {
       return reply;
     }
 
@@ -746,6 +773,78 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
         limit,
         offset,
       },
+    });
+  });
+
+  app.patch<{
+    Params: {
+      notificationId: string;
+    };
+  }>("/notifications/:notificationId/read", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const authenticatedAdmin = await authenticateAdminUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!authenticatedAdmin) {
+      return reply;
+    }
+
+    const notificationId = parseEntityId(request.params.notificationId);
+
+    if (typeof notificationId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de notificación inválido",
+      });
+    }
+
+    const notification = await deps.markStudyTrackingNotificationRead(
+      notificationId,
+    );
+
+    if (!notification) {
+      return reply.code(404).send({
+        success: false,
+        error: "Notificación no encontrada",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      notification: serializeStudyTrackingNotification(notification),
+    });
+  });
+
+  app.patch<{
+    Querystring: {
+      clinicId?: unknown;
+    };
+  }>("/notifications/read-all", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const clinicId = parseEntityId(request.query.clinicId);
+    const result = await deps.markAllStudyTrackingNotificationsRead({
+      clinicId,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      updatedCount: result.updatedCount,
     });
   });
 
@@ -1139,6 +1238,7 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       typeof parsed.data.currentStage !== "undefined" &&
       parsed.data.currentStage !== current.currentStage;
     let updateNotification: StudyTrackingNotification | null = null;
+    let specialStainResolvedNotification: StudyTrackingNotification | null = null;
     let stageChangeNotification: StudyTrackingNotification | null = null;
 
     const updated = await deps.updateStudyTrackingCase(trackingCaseId, {
@@ -1229,6 +1329,21 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       await notifySpecialStainByEmail(finalCase, deps);
     }
 
+    if (current.specialStainRequired && !updated.specialStainRequired) {
+      specialStainResolvedNotification =
+        await deps.createStudyTrackingNotification({
+          studyTrackingCaseId: updated.id,
+          clinicId: updated.clinicId,
+          reportId: updated.reportId ?? null,
+          particularTokenId: updated.particularTokenId ?? null,
+          type: "special_stain_resolved",
+          title: "Tinción especial resuelta",
+          message: "La solicitud de tinción especial fue resuelta.",
+          isRead: false,
+          readAt: null,
+        });
+    }
+
     if (stageChanged) {
       stageChangeNotification = await deps.createStudyTrackingNotification({
         studyTrackingCaseId: finalCase.id,
@@ -1287,6 +1402,23 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
           title: stageChangeNotification.title,
           fromStage: current.currentStage,
           toStage: finalCase.currentStage,
+          createdVia: "admin",
+        },
+      });
+    }
+
+    if (specialStainResolvedNotification) {
+      await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+        event: AUDIT_EVENTS.STUDY_TRACKING_NOTIFICATION_CREATED,
+        clinicId: specialStainResolvedNotification.clinicId,
+        reportId: specialStainResolvedNotification.reportId ?? null,
+        metadata: {
+          trackingCaseId: specialStainResolvedNotification.studyTrackingCaseId,
+          notificationId: specialStainResolvedNotification.id,
+          particularTokenId:
+            specialStainResolvedNotification.particularTokenId ?? null,
+          type: specialStainResolvedNotification.type,
+          title: specialStainResolvedNotification.title,
           createdVia: "admin",
         },
       });

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -140,6 +140,19 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     getStudyTrackingCaseByReportId: async () => null,
     createStudyTrackingCase: async () => createTrackingCaseFixture(),
     updateStudyTrackingCase: async () => createTrackingCaseFixture(),
+    createStudyTrackingNotification: async () => ({
+      id: 29,
+      studyTrackingCaseId: 11,
+      clinicId: 3,
+      reportId: 55,
+      particularTokenId: 7,
+      type: "token_created",
+      title: "Token particular generado",
+      message: "Se generó un token particular para Luna.",
+      isRead: false,
+      readAt: null,
+      createdAt: new Date("2026-04-20T13:00:00.000Z"),
+    }),
     ...overrides,
   });
 
@@ -157,6 +170,7 @@ test(
     });
     const createCalls: Array<Record<string, unknown>> = [];
     const emailCalls: Array<Record<string, unknown>> = [];
+    const notificationCalls: Array<Record<string, unknown>> = [];
 
     const app = await createTestApp({
       generateSessionToken: () => rawToken,
@@ -175,6 +189,22 @@ test(
       sendParticularTokenEmail: async (input: Record<string, unknown>) => {
         emailCalls.push(input);
         return { sent: true, messageId: "particular-email-1" };
+      },
+      createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+        notificationCalls.push(input);
+        return {
+          id: 29,
+          studyTrackingCaseId: 11,
+          clinicId: 3,
+          reportId: 55,
+          particularTokenId: 7,
+          type: "token_created",
+          title: "Token particular generado",
+          message: "Se generó un token particular para Luna.",
+          isRead: false,
+          readAt: null,
+          createdAt: new Date("2026-04-20T13:00:00.000Z"),
+        };
       },
     });
 
@@ -226,6 +256,18 @@ test(
           petName: "Luna",
         },
       ]);
+      assert.equal(notificationCalls.length, 1);
+      assert.equal(notificationCalls[0].studyTrackingCaseId, 11);
+      assert.equal(notificationCalls[0].clinicId, 3);
+      assert.equal(notificationCalls[0].reportId, 55);
+      assert.equal(notificationCalls[0].particularTokenId, 7);
+      assert.equal(notificationCalls[0].type, "token_created");
+      assert.equal(notificationCalls[0].title, "Token particular generado");
+      assert.equal(
+        notificationCalls[0].message,
+        "Se generó un token particular para Luna.",
+      );
+      assert.equal(String(notificationCalls[0].message).includes(rawToken), false);
 
       assert.deepEqual(JSON.parse(response.body), {
         success: true,
@@ -312,6 +354,73 @@ test(
       });
       assert.equal(createCalls.length, 0);
       assert.equal(emailCalls.length, 0);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminParticularTokensNativeRoutes mantiene creación si ensureTrackingForToken falla",
+  async () => {
+    const createdToken = createParticularTokenFixture();
+    const notificationCalls: Array<Record<string, unknown>> = [];
+
+    const app = await createTestApp({
+      createParticularToken: async () => createdToken,
+      getParticularStudyTrackingCase: async () => {
+        throw new Error("db timeout");
+      },
+      createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+        notificationCalls.push(input);
+        return {
+          id: 33,
+          studyTrackingCaseId: 11,
+          clinicId: 3,
+          reportId: 55,
+          particularTokenId: 7,
+          type: "token_created",
+          title: "Token particular generado",
+          message: "Se generó un token particular para Luna.",
+          isRead: false,
+          readAt: null,
+          createdAt: new Date("2026-04-20T13:00:00.000Z"),
+        };
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/particular-tokens",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+          "content-type": "application/json",
+        },
+        payload: {
+          clinicId: 3,
+          reportId: 55,
+          recipientEmail: "tutor@example.com",
+          tutorLastName: "Gomez",
+          petName: "Luna",
+          petAge: "8 años",
+          petBreed: "Caniche",
+          petSex: "Hembra",
+          petSpecies: "Canina",
+          sampleLocation: "Pabellón auricular",
+          sampleEvolution: "15 días",
+          detailsLesion: "Lesión nodular pequeña",
+          extractionDate: "2026-04-20T00:00:00.000Z",
+          shippingDate: "2026-04-21T00:00:00.000Z",
+        },
+      });
+
+      assert.equal(response.statusCode, 201);
+      assert.equal(notificationCalls.length, 0);
+      const body = JSON.parse(response.body);
+      assert.equal(body.success, true);
+      assert.ok(body.token);
     } finally {
       await app.close();
     }

--- a/test/admin-study-tracking.fastify.test.ts
+++ b/test/admin-study-tracking.fastify.test.ts
@@ -135,6 +135,11 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     listStudyTrackingCases: async () => [createTrackingCaseFixture()],
     createStudyTrackingNotification: async () => createNotificationFixture(),
     listStudyTrackingNotifications: async () => [createNotificationFixture()],
+    markStudyTrackingNotificationRead: async () => createNotificationFixture({
+      isRead: true,
+      readAt: new Date("2026-04-21T12:00:00.000Z"),
+    }),
+    markAllStudyTrackingNotificationsRead: async () => ({ updatedCount: 1 }),
     sendSpecialStainRequiredEmail: async () => ({ sent: true }),
     writeAuditLog: async () => {},
     now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
@@ -180,6 +185,75 @@ test("adminStudyTrackingNativeRoutes expone GET /notifications con filtros admin
     assert.equal(body.notifications[0].clinicId, 3);
     assert.equal(body.pagination.limit, 5);
     assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes expone PATCH /notifications/:notificationId/read y marca leída", async () => {
+  const markCalls: number[] = [];
+  const readAt = new Date("2026-04-21T12:00:00.000Z");
+  const app = await createTestApp({
+    markStudyTrackingNotificationRead: async (notificationId: number) => {
+      markCalls.push(notificationId);
+      return createNotificationFixture({
+        id: notificationId,
+        isRead: true,
+        readAt,
+      });
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/notifications/21/read",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(markCalls, [21]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.notification.id, 21);
+    assert.equal(body.notification.isRead, true);
+    assert.equal(body.notification.readAt, readAt.toISOString());
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes expone PATCH /notifications/read-all y marca todas", async () => {
+  const markAllCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    markAllStudyTrackingNotificationsRead: async (
+      params?: Record<string, unknown>,
+    ) => {
+      markAllCalls.push(params ?? {});
+      return { updatedCount: 4 };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/notifications/read-all?clinicId=3",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(markAllCalls, [{ clinicId: 3 }]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      updatedCount: 4,
+    });
   } finally {
     await app.close();
   }
@@ -624,4 +698,54 @@ test("adminStudyTrackingNativeRoutes actualiza PATCH /:trackingCaseId y notifica
   }
 });
 
+test("adminStudyTrackingNativeRoutes notifica special_stain_resolved cuando la alerta pasa a false", async () => {
+  const notificationCalls: Array<Record<string, unknown>> = [];
+  const current = createTrackingCaseFixture({
+    currentStage: "evaluation",
+    specialStainRequired: true,
+    specialStainNotifiedAt: new Date("2026-04-20T13:30:00.000Z"),
+  });
+  const updated = createTrackingCaseFixture({
+    currentStage: "evaluation",
+    specialStainRequired: false,
+    specialStainNotifiedAt: new Date("2026-04-20T13:30:00.000Z"),
+  });
 
+  const app = await createTestApp({
+    getClinicScopedStudyTrackingCase: async () => current,
+    updateStudyTrackingCase: async () => updated,
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture({ id: 61, ...input });
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/11",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        specialStainRequired: false,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(notificationCalls.length, 1);
+    assert.equal(notificationCalls[0].type, "special_stain_resolved");
+    assert.equal(notificationCalls[0].title, "Tinción especial resuelta");
+    assert.equal(
+      notificationCalls[0].message,
+      "La solicitud de tinción especial fue resuelta.",
+    );
+    assert.equal(notificationCalls[0].isRead, false);
+    assert.equal(notificationCalls[0].readAt, null);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -436,5 +436,10 @@ test("admin token card consume seguimiento por token desde study-tracking", () =
   assert.ok(card.includes("Seguimiento"));
   assert.ok(card.includes("getTrackingStageLabel("));
   assert.ok(card.includes("Alerta: Solicitud de tinción especial"));
+  assert.ok(card.includes("Solicitar tinción especial"));
+  assert.ok(card.includes("Resolver tinción especial"));
+  assert.ok(card.includes("handleSpecialStainChange("));
+  assert.ok(card.includes("specialStainRequired: !trackingCase.specialStainRequired"));
+  assert.ok(card.includes("No se pudo actualizar la alerta de tinción especial."));
   assert.ok(api.includes("export async function getAdminStudyTrackingCases("));
 });

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -4,12 +4,13 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
-const CARD_PATH =
-  "frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx";
-const ADMIN_PARTICULAR_TOKENS_CARD_PATH =
-  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
+const TOPBAR_PATH = "frontend/src/components/dashboard/DashboardTopbar.tsx";
 const SIDEBAR_PATH =
   "frontend/src/components/dashboard/AdminDashboardSidebar.tsx";
+const ADMIN_PARTICULAR_TOKENS_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
+const BELL_PATH =
+  "frontend/src/components/dashboard/DashboardNotificationsBell.tsx";
 const API_PATH = "frontend/src/lib/api.ts";
 
 function read(relativePath: string): string {
@@ -19,99 +20,101 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard Admin integra la tarjeta de seguimiento sin retirar la carga PDF", () => {
+test("dashboard admin elimina la sección de seguimiento redundante sin tocar la carga de informes", () => {
   const page = read(PAGE_PATH);
 
-  assert.ok(
+  assert.equal(
     page.includes(
       'import { AdminReportWorkflowViewerCard } from "@/components/dashboard/AdminReportWorkflowViewerCard";',
     ),
+    false,
   );
-  assert.ok(page.includes('id="admin-report-workflow"'));
-  assert.ok(page.includes("<AdminReportWorkflowViewerCard />"));
-  assert.ok(page.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
+  assert.equal(page.includes('id="admin-report-workflow"'), false);
+  assert.equal(page.includes("<AdminReportWorkflowViewerCard />"), false);
+  assert.ok(
+    page.includes(
+      'import { UploadReportModal } from "@/components/dashboard/UploadReportModal";',
+    ),
+  );
   assert.ok(page.includes("<UploadReportModal />"));
 });
 
-test("sidebar Admin enlaza al seguimiento de informes renderizado", () => {
+test("sidebar admin no muestra seguimiento de informes y conserva anclas operativas", () => {
   const sidebar = read(SIDEBAR_PATH);
-  const page = read(PAGE_PATH);
 
-  assert.ok(sidebar.includes('label: "Seguimiento de informes"'));
-  assert.ok(
-    sidebar.includes('href: `${ROUTES.dashboardAdmin}#admin-report-workflow`'),
-  );
-  assert.ok(page.includes('id="admin-report-workflow"'));
-  assert.ok(page.includes("<AdminReportWorkflowViewerCard />"));
+  assert.equal(sidebar.includes('label: "Seguimiento de informes"'), false);
+  assert.equal(sidebar.includes("#admin-report-workflow"), false);
+  assert.ok(sidebar.includes('label: "Tokens particulares"'));
+  assert.ok(sidebar.includes('label: "Auditoría"'));
 });
 
-test("tarjeta presenta cinco etapas globales y tinción especial como alerta aparte", () => {
-  const card = read(CARD_PATH);
-  const stagesStart = card.indexOf("const WORKFLOW_STAGES");
-  const stagesEnd = card.indexOf("];", stagesStart);
-  const stages = card.slice(stagesStart, stagesEnd);
-
-  for (const stage of [
-    "Recepción de muestra",
-    "Procesamiento",
-    "Evaluación",
-    "Desarrollo de informe",
-    "Informe disponible / Publicado",
-  ]) {
-    assert.ok(stages.includes(stage), `debe mostrar ${stage}`);
-  }
-
-  assert.equal(stages.includes("tinción"), false);
-  assert.ok(card.includes("Seguimiento de informes"));
-  assert.ok(card.includes("Alerta tinción especial"));
-  assert.ok(card.includes("Solicitar"));
-  assert.ok(card.includes("Resolver"));
-  assert.ok(card.includes("Reporte / token"));
-  assert.equal(card.includes("citologia"), false);
-  assert.equal(card.includes("histopatologia"), false);
-  assert.equal(card.includes("hemoparasitos"), false);
-});
-
-test("tarjeta y cliente API soportan paginación y mutaciones manuales", () => {
-  const card = read(CARD_PATH);
-  const api = read(API_PATH);
-
-  assert.ok(card.includes("const PAGE_LIMIT = 20;"));
-  assert.ok(card.includes("limit: PAGE_LIMIT"));
-  assert.ok(card.includes("Anterior"));
-  assert.ok(card.includes("Siguiente"));
-  assert.ok(card.includes("handleStageChange"));
-  assert.ok(card.includes("handleSpecialStainChange"));
-  assert.ok(api.includes("export async function getAdminStudyTrackingCases("));
-  assert.ok(api.includes("export async function updateAdminStudyTrackingCase("));
-  assert.ok(api.includes("`/api/admin/study-tracking${qs ? `?${qs}` : \"\"}`"));
-  assert.ok(api.includes("`/api/admin/study-tracking/${trackingCaseId}`"));
-  assert.ok(api.includes('credentials: options.credentials ?? "include",'));
-});
-
-test("admin tokens card permite cambiar etapa de seguimiento desde la card", () => {
+test("admin tokens card permite solicitar y resolver tinción especial por tracking case", () => {
   const card = read(ADMIN_PARTICULAR_TOKENS_CARD_PATH);
 
-  assert.ok(card.includes("updateAdminStudyTrackingCase"));
-  assert.ok(card.includes("Cambiar etapa del seguimiento"));
-  assert.ok(card.includes('id={`admin-tracking-stage-${trackingCase.id}`}'));
-  assert.ok(card.includes("value={trackingCase.currentStage}"));
+  assert.ok(card.includes("handleSpecialStainChange("));
   assert.ok(card.includes("updateAdminStudyTrackingCase(trackingCase.id, {"));
-  assert.ok(card.includes("currentStage: nextStage"));
-  assert.ok(card.includes("No se pudo cambiar la etapa del seguimiento."));
+  assert.ok(card.includes("specialStainRequired: !trackingCase.specialStainRequired"));
+  assert.ok(card.includes("Solicitar tinción especial"));
+  assert.ok(card.includes("Resolver tinción especial"));
+  assert.ok(card.includes("Alerta: Solicitud de tinción especial"));
+  assert.ok(card.includes("Sin alerta de tinción especial"));
+  assert.ok(card.includes("No se pudo actualizar la alerta de tinción especial."));
   assert.ok(card.includes("[tokenId]: response.trackingCase"));
 });
 
-test("admin tokens card reutiliza las cinco etapas de seguimiento", () => {
-  const card = read(ADMIN_PARTICULAR_TOKENS_CARD_PATH);
+test("dashboard topbar soporta notifications='admin' y monta la campana", () => {
+  const topbar = read(TOPBAR_PATH);
+  const page = read(PAGE_PATH);
 
-  for (const stage of [
-    "Recepción de muestra",
-    "Procesamiento",
-    "Evaluación",
-    "Desarrollo de informe",
-    "Informe disponible / Publicado",
-  ]) {
-    assert.ok(card.includes(stage), `debe incluir la etapa ${stage}`);
-  }
+  assert.ok(
+    topbar.includes(
+      'import { DashboardNotificationsBell } from "./DashboardNotificationsBell";',
+    ),
+  );
+  assert.ok(topbar.includes('notifications?: "admin" | false;'));
+  assert.ok(topbar.includes("notifications = false,"));
+  assert.ok(
+    topbar.includes(
+      '{notifications === "admin" ? <DashboardNotificationsBell /> : null}',
+    ),
+  );
+  assert.ok(page.includes('notifications="admin"'));
+});
+
+test("campana de notificaciones admin existe con UX in-app y polling", () => {
+  const bell = read(BELL_PATH);
+
+  assert.ok(bell.includes('"use client";'));
+  assert.ok(bell.includes('import { Bell } from "lucide-react";'));
+  assert.ok(bell.includes("aria-label=\"Notificaciones\""));
+  assert.ok(bell.includes("Notificaciones"));
+  assert.ok(bell.includes("Activar notificaciones"));
+  assert.ok(bell.includes("Actualizar"));
+  assert.ok(bell.includes("No hay notificaciones."));
+  assert.ok(bell.includes("No se pudieron cargar las notificaciones."));
+  assert.ok(bell.includes("POLLING_INTERVAL_MS = 30_000"));
+  assert.ok(bell.includes("window.setInterval(() => {"));
+  assert.ok(bell.includes("window.clearInterval(intervalId);"));
+});
+
+test("campana usa API de notificaciones admin para listar y marcar leídas", () => {
+  const bell = read(BELL_PATH);
+
+  assert.ok(bell.includes("getAdminStudyTrackingNotifications("));
+  assert.ok(bell.includes("markAdminStudyTrackingNotificationRead("));
+  assert.ok(bell.includes("setNotifications(response.notifications);"));
+  assert.ok(bell.includes("response.notification"));
+});
+
+test("api frontend expone funciones de notificaciones admin", () => {
+  const api = read(API_PATH);
+
+  assert.ok(api.includes("export type AdminStudyTrackingNotificationSummary = {"));
+  assert.ok(api.includes("export async function getAdminStudyTrackingNotifications("));
+  assert.ok(api.includes("unreadOnly?: boolean;"));
+  assert.ok(api.includes("`/api/admin/study-tracking/notifications${qs ? `?${qs}` : \"\"}`"));
+  assert.ok(api.includes("export async function markAdminStudyTrackingNotificationRead("));
+  assert.ok(api.includes("`/api/admin/study-tracking/notifications/${notificationId}/read`"));
+  assert.ok(api.includes("export async function markAllAdminStudyTrackingNotificationsRead("));
+  assert.ok(api.includes('"/api/admin/study-tracking/notifications/read-all"'));
 });

--- a/test/frontend-dashboard-shared-components.test.ts
+++ b/test/frontend-dashboard-shared-components.test.ts
@@ -31,11 +31,28 @@ test("dashboard topbar keeps typed title and optional subtitle props", () => {
   assert.ok(source.includes("interface DashboardTopbarProps"));
   assert.ok(source.includes("title: string;"));
   assert.ok(source.includes("subtitle?: string;"));
-  assert.ok(source.includes("export function DashboardTopbar({ title, subtitle }: DashboardTopbarProps)"));
+  assert.ok(source.includes('notifications?: "admin" | false;'));
+  assert.ok(source.includes("notifications = false,"));
+  assert.ok(source.includes("export function DashboardTopbar({"));
   assert.ok(source.includes("<h1"));
   assert.ok(source.includes("{title}"));
   assert.ok(source.includes("{subtitle && ("));
   assert.ok(source.includes("{subtitle}"));
+});
+
+test("dashboard topbar renders notifications bell only in admin mode", () => {
+  const source = read(DASHBOARD_TOPBAR_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { DashboardNotificationsBell } from "./DashboardNotificationsBell";',
+    ),
+  );
+  assert.ok(
+    source.includes(
+      '{notifications === "admin" ? <DashboardNotificationsBell /> : null}',
+    ),
+  );
 });
 
 test("dashboard topbar keeps protected dashboard header shell without mock session chip", () => {


### PR DESCRIPTION
## Resumen
- Elimina la sección redundante Seguimiento de informes del dashboard admin.
- Mantiene Últimos tokens administrados como superficie principal de workflow.
- Permite solicitar/resolver tinción especial desde cada token administrado.
- Agrega campana in-app admin con polling activable y actualización manual.
- Agrega API frontend para listar y marcar notificaciones como leídas.
- Agrega backend para marcar notificaciones como leídas individual y masivo.
- Genera notificaciones para token_created, stage_changed, special_stain_required y special_stain_resolved.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Resultado
- 2043 tests pass
- 0 fail
- 1 skipped
- build OK

## Decisiones técnicas
- Campana in-app sin browser push notifications.
- Polling seguro cada 30 segundos solo al activar notificaciones.
- El token completo no se guarda en notificaciones, logs ni auditoría.
- markAll queda expuesto en API frontend/backend para uso posterior.