### PR TITLE
fix(ops): align staging smoke with logout and token report states

### DIFF
--- a/scripts/dev/smoke-staging.ps1
+++ b/scripts/dev/smoke-staging.ps1
@@ -558,6 +558,7 @@ if ($hasAdminCreds) {
     -Retries $Retries `
     -ExpectedStatusCodes @(200) `
     -RequestHeaders @{ Origin = $FrontendUrl } `
+    -BodyObject @{} `
     -WebSession $adminSession
 
   Add-CheckResult -Name "Admin logout (/api/admin/auth/logout)" -Status ($(if ($adminLogout.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($adminLogout.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $adminLogout.Error }))
@@ -616,7 +617,7 @@ if ($hasClinicCreds) {
   $clinicParticularTokens = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular-tokens?limit=10&offset=0" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
   Add-CheckResult -Name "Clinic particular tokens list (/api/particular-tokens?limit=10&offset=0)" -Status ($(if ($clinicParticularTokens.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicParticularTokens.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicParticularTokens.Error }))
 
-  $clinicLogout = Invoke-SmokeRequest -Method "POST" -Url "$BackendUrl/api/auth/logout" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $clinicSession
+  $clinicLogout = Invoke-SmokeRequest -Method "POST" -Url "$BackendUrl/api/auth/logout" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -BodyObject @{} -WebSession $clinicSession
   Add-CheckResult -Name "Clinic logout (/api/auth/logout)" -Status ($(if ($clinicLogout.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($clinicLogout.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $clinicLogout.Error }))
 } else {
   Mark-CredentialCheckSkipSet -CheckNames @(
@@ -651,9 +652,11 @@ if ($hasParticularToken) {
   $particularMe = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/me" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
   Add-CheckResult -Name "Particular me (/api/particular/auth/me)" -Status ($(if ($particularMe.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($particularMe.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $particularMe.Error }))
 
-  $particularPreviewUrl = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/report/preview-url" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  $particularPreviewUrl = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/report/preview-url" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200, 409) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
   if (-not $particularPreviewUrl.Success) {
-    Add-CheckResult -Name "Particular report preview (/api/particular/auth/report/preview-url)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200. " + $particularPreviewUrl.Error)
+    Add-CheckResult -Name "Particular report preview (/api/particular/auth/report/preview-url)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200 o 409. " + $particularPreviewUrl.Error)
+  } elseif ($particularPreviewUrl.StatusCode -eq 409) {
+    Add-CheckResult -Name "Particular report preview (/api/particular/auth/report/preview-url)" -Status "OK" -Required $true -Detail "HTTP 409 sin informe vinculado"
   } else {
     $previewPresent = $false
     if ($null -ne $particularPreviewUrl.Json -and $null -ne $particularPreviewUrl.Json.previewUrl) {
@@ -662,9 +665,11 @@ if ($hasParticularToken) {
     Add-CheckResult -Name "Particular report preview (/api/particular/auth/report/preview-url)" -Status "OK" -Required $true -Detail ("HTTP 200 signedUrl=" + ($(if ($previewPresent) { "present" } else { "missing" })))
   }
 
-  $particularDownloadUrl = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/report/download-url" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  $particularDownloadUrl = Invoke-SmokeRequest -Method "GET" -Url "$BackendUrl/api/particular/auth/report/download-url" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200, 409) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
   if (-not $particularDownloadUrl.Success) {
-    Add-CheckResult -Name "Particular report download (/api/particular/auth/report/download-url)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200. " + $particularDownloadUrl.Error)
+    Add-CheckResult -Name "Particular report download (/api/particular/auth/report/download-url)" -Status "FAIL" -Required $true -Detail ("Esperado HTTP 200 o 409. " + $particularDownloadUrl.Error)
+  } elseif ($particularDownloadUrl.StatusCode -eq 409) {
+    Add-CheckResult -Name "Particular report download (/api/particular/auth/report/download-url)" -Status "OK" -Required $true -Detail "HTTP 409 sin informe vinculado"
   } else {
     $downloadPresent = $false
     if ($null -ne $particularDownloadUrl.Json -and $null -ne $particularDownloadUrl.Json.downloadUrl) {
@@ -673,7 +678,7 @@ if ($hasParticularToken) {
     Add-CheckResult -Name "Particular report download (/api/particular/auth/report/download-url)" -Status "OK" -Required $true -Detail ("HTTP 200 signedUrl=" + ($(if ($downloadPresent) { "present" } else { "missing" })))
   }
 
-  $particularLogout = Invoke-SmokeRequest -Method "POST" -Url "$BackendUrl/api/particular/auth/logout" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -WebSession $particularSession
+  $particularLogout = Invoke-SmokeRequest -Method "POST" -Url "$BackendUrl/api/particular/auth/logout" -TimeoutSec $TimeoutSec -Retries $Retries -ExpectedStatusCodes @(200) -RequestHeaders @{ Origin = $FrontendUrl } -BodyObject @{} -WebSession $particularSession
   Add-CheckResult -Name "Particular logout (/api/particular/auth/logout)" -Status ($(if ($particularLogout.Success) { "OK" } else { "FAIL" })) -Required $true -Detail ($(if ($particularLogout.Success) { "HTTP 200" } else { "Esperado HTTP 200. " + $particularLogout.Error }))
 } else {
   Mark-CredentialCheckSkipSet -CheckNames @(

--- a/test/smoke-staging-script-contract.test.ts
+++ b/test/smoke-staging-script-contract.test.ts
@@ -55,6 +55,46 @@ test("staging smoke script contains authenticated endpoints", () => {
   }
 });
 
+test("staging smoke script forces json body for logout endpoints", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assert.match(
+    source,
+    /\$adminLogout[\s\S]*?\/api\/admin\/auth\/logout[\s\S]*?-BodyObject @\{\}/,
+    "admin logout must include -BodyObject @{}",
+  );
+  assert.match(
+    source,
+    /\$clinicLogout[\s\S]*?\/api\/auth\/logout[\s\S]*?-BodyObject @\{\}/,
+    "clinic logout must include -BodyObject @{}",
+  );
+  assert.match(
+    source,
+    /\$particularLogout[\s\S]*?\/api\/particular\/auth\/logout[\s\S]*?-BodyObject @\{\}/,
+    "particular logout must include -BodyObject @{}",
+  );
+});
+
+test("staging smoke script accepts 409 for particular report urls", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assert.match(
+    source,
+    /\$particularPreviewUrl[\s\S]*?\/api\/particular\/auth\/report\/preview-url[\s\S]*?-ExpectedStatusCodes @\(200, 409\)/,
+    "particular preview url must accept HTTP 200 and 409",
+  );
+  assert.match(
+    source,
+    /\$particularDownloadUrl[\s\S]*?\/api\/particular\/auth\/report\/download-url[\s\S]*?-ExpectedStatusCodes @\(200, 409\)/,
+    "particular download url must accept HTTP 200 and 409",
+  );
+  assertContains(
+    source,
+    "HTTP 409 sin informe vinculado",
+    "particular report url checks must document unlinked report token state",
+  );
+});
+
 test("staging smoke script validates bad origin rejection", () => {
   const source = readSource(SCRIPT_PATH);
 


### PR DESCRIPTION
## Resumen
- Ajusta smoke-staging para enviar body JSON vacío en logout admin, clínica y particular.
- Alinea preview/download particular para aceptar HTTP 409 cuando el token no tiene informe vinculado.
- Mantiene 401/403/404/500 como fallas reales.
- Agrega cobertura de contrato sobre el script de smoke.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Resultado
- 2045 tests pass
- 0 fail
- 1 skipped
- build OK

## Decisión técnica
- HTTP 409 en preview/download particular es estado válido cuando el token existe, autentica correctamente, pero aún no tiene informe vinculado.