### PR TITLE
fix(auth): isolate login rate limits by identifier

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,6 +58,8 @@ export const BACKEND_OPERATION_ERROR_MESSAGE =
   "El backend no pudo completar la operación. Reintentá y, si persiste, revisá estado del sistema y logs de backend.";
 export const ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE =
   "Sesión admin no autenticada o inválida. Iniciá sesión nuevamente.";
+export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE =
+  "Demasiados intentos de inicio de sesión. Intente más tarde.";
 
 function isLocalOrLanHostname(hostname: string): boolean {
   const normalizedHost = hostname.trim().toLowerCase();
@@ -154,6 +156,46 @@ function warnApiFallback(functionName: string, error: unknown): void {
   }
 }
 
+function readRetryAfterSeconds(headers: Headers): number | null {
+  const retryAfterValue =
+    headers.get("Retry-After") ?? headers.get("RateLimit-Reset");
+
+  if (!retryAfterValue) {
+    return null;
+  }
+
+  const retryAfterSeconds = Number.parseInt(retryAfterValue, 10);
+
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+    return null;
+  }
+
+  return retryAfterSeconds;
+}
+
+function buildRateLimitErrorMessage(
+  backendMessage: string | null,
+  headers: Headers,
+): string {
+  const baseMessage = backendMessage ?? LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE;
+  const retryAfterSeconds = readRetryAfterSeconds(headers);
+
+  if (!retryAfterSeconds) {
+    return baseMessage;
+  }
+
+  if (retryAfterSeconds >= 60) {
+    const retryAfterMinutes = Math.ceil(retryAfterSeconds / 60);
+    const unit = retryAfterMinutes === 1 ? "minuto" : "minutos";
+
+    return `${baseMessage} Reintente en ${retryAfterMinutes} ${unit}.`;
+  }
+
+  const unit = retryAfterSeconds === 1 ? "segundo" : "segundos";
+
+  return `${baseMessage} Reintente en ${retryAfterSeconds} ${unit}.`;
+}
+
 async function apiFetch<T>(
   path: string,
   options: RequestInit = {},
@@ -205,6 +247,10 @@ async function apiFetch<T>(
         : typeof body.message === "string" && body.message.trim()
           ? body.message
           : null;
+
+    if (res.status === 429) {
+      throw new Error(buildRateLimitErrorMessage(backendMessage, res.headers));
+    }
 
     if (backendMessage) {
       throw new Error(backendMessage);

--- a/server/lib/login-rate-limit.ts
+++ b/server/lib/login-rate-limit.ts
@@ -2,3 +2,41 @@
 export const LOGIN_RATE_LIMIT_MAX_ATTEMPTS = 10;
 export const LOGIN_RATE_LIMIT_ERROR_MESSAGE =
   "Demasiados intentos de inicio de sesión. Intente más tarde.";
+
+const LOGIN_RATE_LIMIT_KEY_VERSION = "v2";
+const LOGIN_RATE_LIMIT_IDENTIFIER_MAX_LENGTH = 256;
+
+export type LoginRateLimitSurface =
+  | "admin"
+  | "clinic"
+  | "particular"
+  | "unified";
+
+export function normalizeLoginRateLimitIdentifier(identifier: string): string {
+  return (
+    identifier
+      .trim()
+      .toLowerCase()
+      .slice(0, LOGIN_RATE_LIMIT_IDENTIFIER_MAX_LENGTH) || "unknown"
+  );
+}
+
+export function buildLoginRateLimitKey(input: {
+  surface: LoginRateLimitSurface;
+  identifier: string;
+  ipAddress?: string | null;
+}): string {
+  const normalizedIdentifier = normalizeLoginRateLimitIdentifier(
+    input.identifier,
+  );
+  const normalizedIpAddress = input.ipAddress?.trim() || "unknown";
+
+  return [
+    "login",
+    LOGIN_RATE_LIMIT_KEY_VERSION,
+    input.surface,
+    normalizedIdentifier,
+    "ip",
+    normalizedIpAddress,
+  ].join(":");
+}

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -7,6 +7,7 @@ import type {
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -412,7 +413,7 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
   reply.header(
     "access-control-expose-headers",
-    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
   );
 }
 
@@ -572,8 +573,15 @@ function setLoginRateLimitHeaders(
   );
   reply.header(
     "RateLimit-Reset",
-    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
+    String(getLoginRateLimitResetSeconds(input)),
   );
+}
+
+function getLoginRateLimitResetSeconds(input: {
+  resetAt: number;
+  now: number;
+}) {
+  return Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0);
 }
 
 function getUserAgent(request: FastifyRequest) {
@@ -1050,7 +1058,11 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const rateLimitKey = `login:${request.ip || "unknown"}`;
+    const rateLimitKey = buildLoginRateLimitKey({
+      surface: isUnifiedPayload ? "unified" : "clinic",
+      identifier: loginIdentifier,
+      ipAddress: request.ip || null,
+    });
 
     const failureEntry: RateLimitEntry = {
       count: 0,
@@ -1114,6 +1126,15 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         resetAt: failureEntry.resetAt,
         now: currentTime,
       });
+      reply.header(
+        "Retry-After",
+        String(
+          getLoginRateLimitResetSeconds({
+            resetAt: failureEntry.resetAt,
+            now: currentTime,
+          }),
+        ),
+      );
 
       await recordFailedLoginAttempt({
         username: loginIdentifier,

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -12,6 +12,7 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { ENV } = await import("../server/lib/env.ts");
 const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
 const {
+  buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
 } = await import("../server/lib/login-rate-limit.ts");
 const {
@@ -1402,7 +1403,18 @@ test("clinicAuthNativeRoutes login fallido incrementa store persistente", async 
     });
 
     assert.equal(response.statusCode, 401);
-    assert.equal(rows.get(hashRateLimitKey("login:203.0.113.50"))?.count, 1);
+    assert.equal(
+      rows.get(
+        hashRateLimitKey(
+          buildLoginRateLimitKey({
+            surface: "clinic",
+            identifier: "vetneb",
+            ipAddress: "203.0.113.50",
+          }),
+        ),
+      )?.count,
+      1,
+    );
   } finally {
     await app.close();
   }
@@ -1469,6 +1481,64 @@ test("clinicAuthNativeRoutes bloquea login al superar límite persistente", asyn
     });
     assert.equal(third.headers["ratelimit-limit"], "2");
     assert.equal(third.headers["ratelimit-remaining"], "0");
+    assert.equal(third.headers["retry-after"], "60");
+  } finally {
+    await app.close();
+  }
+});
+
+test("clinicAuthNativeRoutes no agrupa identificadores distintos bajo la misma IP", async () => {
+  const currentTime = Date.UTC(2026, 4, 8, 0, 0, 0);
+  const { store } = createPersistentRateLimitStoreHarness({
+    now: () => currentTime,
+  });
+  const seenIdentifiers: string[] = [];
+
+  const app = await createTestApp({
+    now: () => currentTime,
+    loginRateLimitStore: store,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 1,
+    getAdminUserByIdentifier: async () => null,
+    getClinicUserByIdentifier: async (identifier: string) => {
+      seenIdentifiers.push(identifier);
+      return null;
+    },
+    getParticularTokenByTokenHash: async () => null,
+  });
+
+  try {
+    const first = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.51",
+      payload: {
+        identifier: "clinica-a@example.test",
+        password: "bad-1",
+      },
+    });
+    const second = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+      remoteAddress: "203.0.113.51",
+      payload: {
+        identifier: "clinica-b@example.test",
+        password: "bad-2",
+      },
+    });
+
+    assert.equal(first.statusCode, 401);
+    assert.equal(second.statusCode, 401);
+    assert.deepEqual(seenIdentifiers, [
+      "clinica-a@example.test",
+      "clinica-b@example.test",
+    ]);
   } finally {
     await app.close();
   }
@@ -1605,7 +1675,18 @@ test("clinicAuthNativeRoutes reinicia ventana persistente cuando resetAt venció
     });
 
     assert.equal(second.statusCode, 401);
-    assert.equal(rows.get(hashRateLimitKey("login:203.0.113.53"))?.count, 1);
+    assert.equal(
+      rows.get(
+        hashRateLimitKey(
+          buildLoginRateLimitKey({
+            surface: "clinic",
+            identifier: "vetneb",
+            ipAddress: "203.0.113.53",
+          }),
+        ),
+      )?.count,
+      1,
+    );
   } finally {
     await secondApp.close();
   }

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -72,11 +72,22 @@ test("frontend API client surfaces backend errors safely", () => {
   assert.ok(source.includes("error?: unknown;"));
   assert.ok(source.includes("message?: unknown;"));
   assert.ok(source.includes("const backendMessage ="));
+  assert.ok(source.includes("if (res.status === 429) {"));
+  assert.ok(source.includes("buildRateLimitErrorMessage(backendMessage, res.headers)"));
   assert.ok(source.includes("if (backendMessage) {"));
   assert.ok(source.includes("throw new Error(backendMessage);"));
   assert.ok(source.includes("if (res.status >= 500) {"));
   assert.ok(source.includes("throw new Error(BACKEND_OPERATION_ERROR_MESSAGE);"));
   assert.ok(source.includes("throw new Error(`HTTP ${res.status}`);"));
+});
+
+test("frontend API client formats 429 login rate-limit guidance from headers", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE ="));
+  assert.ok(source.includes('headers.get("Retry-After") ?? headers.get("RateLimit-Reset")'));
+  assert.ok(source.includes("function buildRateLimitErrorMessage("));
+  assert.ok(source.includes("Reintente en"));
 });
 
 test("frontend API client maps fetch network and CORS errors to operational admin guidance", () => {

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -79,6 +79,15 @@ test("login public page handles loading and error states", () => {
   assert.ok(source.includes("aria-pressed={isPasswordVisible}"));
 });
 
+test("login public page prevents mobile double submit while request is pending", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes("if (isSubmitting)"));
+  assert.ok(source.includes("return;"));
+  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes("aria-busy={isSubmitting}"));
+});
+
 test("API client exposes unified login contract against backend auth endpoint", () => {
   const source = read(API_CLIENT_PATH);
 

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -1,9 +1,11 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
+  normalizeLoginRateLimitIdentifier,
 } from "../server/lib/login-rate-limit.ts";
 
 test("constantes de login rate limit son estables", () => {
@@ -12,5 +14,18 @@ test("constantes de login rate limit son estables", () => {
   assert.equal(
     LOGIN_RATE_LIMIT_ERROR_MESSAGE,
     "Demasiados intentos de inicio de sesión. Intente más tarde.",
+  );
+});
+
+test("login rate limit key incluye version, superficie, identificador normalizado e IP", () => {
+  assert.equal(normalizeLoginRateLimitIdentifier("  User@VETNEB.test "), "user@vetneb.test");
+  assert.equal(normalizeLoginRateLimitIdentifier("A".repeat(300)).length, 256);
+  assert.equal(
+    buildLoginRateLimitKey({
+      surface: "unified",
+      identifier: "  User@VETNEB.test ",
+      ipAddress: "203.0.113.50",
+    }),
+    "login:v2:unified:user@vetneb.test:ip:203.0.113.50",
   );
 });

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -29,6 +29,7 @@ const RATE_LIMIT_ISOLATION_BOUNDARIES = {
     "429 does not set session cookies",
     "429 returns before DB storage signing or audit work",
     "request logs mark 429 as RATE_LIMITED",
+    "login key includes surface identifier and IP",
   ],
 } as const;
 
@@ -110,6 +111,7 @@ test("rate limit isolation matrix documents the protected contract", () => {
       "429 does not set session cookies",
       "429 returns before DB storage signing or audit work",
       "request logs mark 429 as RATE_LIMITED",
+      "login key includes surface identifier and IP",
     ],
   });
 });
@@ -254,18 +256,23 @@ test("auth login rate limits keep separate in-memory stores per auth domain", ()
       `${file} login max attempts`,
     );
     const realmKeyByFile = {
-      "server/routes/auth.fastify.ts":
-        'const rateLimitKey = `login:${request.ip || "unknown"}`;',
-      "server/routes/admin-auth.fastify.ts":
+      "server/routes/auth.fastify.ts": [
+        "buildLoginRateLimitKey({",
+        'surface: isUnifiedPayload ? "unified" : "clinic",',
+        "identifier: loginIdentifier,",
+        "ipAddress: request.ip || null,",
+      ],
+      "server/routes/admin-auth.fastify.ts": [
         'const rateLimitKey = `admin:${request.ip || "unknown"}`;',
-      "server/routes/particular-auth.fastify.ts":
+      ],
+      "server/routes/particular-auth.fastify.ts": [
         'const rateLimitKey = `particular:${request.ip || "unknown"}`;',
-    };
-    assertContains(
-      source,
-      realmKeyByFile[file],
-      `${file} login key`,
-    );
+      ],
+    } satisfies Record<(typeof file), readonly string[]>;
+
+    for (const marker of realmKeyByFile[file]) {
+      assertContains(source, marker, `${file} login key`);
+    }
     assertContains(
       source,
       "error: LOGIN_RATE_LIMIT_ERROR_MESSAGE",


### PR DESCRIPTION
## Resumen
- Cambia el rate limit de login unificado de una clave global por IP a una clave versionada por superficie, identificador e IP.
- Evita que usuarios distintos queden bloqueados por colapso de IP en staging/proxy.
- Mantiene seguridad sin desactivar rate limit.
- Agrega Retry-After y mantiene RateLimit-*.
- Mejora UX frontend para 429, evitando mostrar solo HTTP 429.
- Agrega cobertura para aislamiento por identificador, Retry-After, UX 429 y doble submit móvil.

## Diagnóstico
El login unificado estaba rate-limited por login:<request.ip>. En staging, Render/proxy podía agrupar usuarios distintos bajo la misma IP efectiva y bloquear desktop/móvil con HTTP 429.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Resultado
- pnpm test OK: 2050/2050
- pnpm build OK
- dist/index.js generado correctamente

## Issue
Closes #788