### PR TITLE
feat(notifications): make notification center global across roles

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -109,6 +109,7 @@ export default async function InformesPage({
       <DashboardTopbar
         title="Informes"
         subtitle="Consulta de informes médicos veterinarios"
+        notifications="clinic"
       />
       <main className="dashboard-main">
         <Card className="dashboard-surface">

--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -91,6 +91,7 @@ export default async function MetricasPage() {
       <DashboardTopbar
         title="Métricas de logística"
         subtitle="Cumplimiento, SLA y reportes operativos"
+        notifications="clinic"
       />
       <main className="dashboard-main">
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -106,6 +106,7 @@ export default async function LogisticaPage() {
       <DashboardTopbar
         title="Logística"
         subtitle="Visitas de campo y planes de ruta"
+        notifications="clinic"
       />
       <main className="dashboard-main">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -49,6 +49,7 @@ export default async function RutasPage() {
       <DashboardTopbar
         title="Planes de ruta"
         subtitle="Planificación y gestión de rutas de entrega"
+        notifications="clinic"
       />
       <main className="dashboard-main">
         <div className="grid grid-cols-2 gap-3 md:grid-cols-4">

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -50,6 +50,7 @@ export default async function VisitasPage() {
       <DashboardTopbar
         title="Visitas de campo"
         subtitle="Seguimiento de visitas programadas y en curso"
+        notifications="clinic"
       />
       <main className="dashboard-main">
         <div className="grid grid-cols-2 gap-3 md:grid-cols-4">

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -76,7 +76,11 @@ export default async function DashboardPage() {
 
   return (
     <>
-      <DashboardTopbar title="Dashboard Clínica" subtitle="Resumen operativo clínica" />
+      <DashboardTopbar
+        title="Dashboard Clínica"
+        subtitle="Resumen operativo clínica"
+        notifications="clinic"
+      />
       <main className="dashboard-main">
         <section className="surface-note-info" aria-labelledby="dashboard-operational-priority">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">

--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -4,19 +4,28 @@ import { Bell } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-  getAdminStudyTrackingNotifications,
-  markAdminStudyTrackingNotificationRead,
+  getDashboardNotifications,
+  markAllDashboardNotificationsRead,
+  markDashboardNotificationRead,
   type AdminStudyTrackingNotificationSummary,
+  type DashboardNotificationSurface,
 } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 
 const NOTIFICATIONS_LIMIT = 20;
 const POLLING_INTERVAL_MS = 30_000;
 
-export function DashboardNotificationsBell() {
+type DashboardNotificationsBellProps = {
+  surface: DashboardNotificationSurface;
+};
+
+export function DashboardNotificationsBell({
+  surface,
+}: DashboardNotificationsBellProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isPollingEnabled, setIsPollingEnabled] = useState(false);
+  const [isMarkingAllAsRead, setIsMarkingAllAsRead] = useState(false);
   const [notifications, setNotifications] = useState<
     AdminStudyTrackingNotificationSummary[]
   >([]);
@@ -39,7 +48,7 @@ export function DashboardNotificationsBell() {
     setErrorMessage(null);
 
     try {
-      const response = await getAdminStudyTrackingNotifications({
+      const response = await getDashboardNotifications(surface, {
         limit: NOTIFICATIONS_LIMIT,
         offset: 0,
       });
@@ -50,7 +59,7 @@ export function DashboardNotificationsBell() {
       isFetchingRef.current = false;
       setIsLoading(false);
     }
-  }, []);
+  }, [surface]);
 
   useEffect(() => {
     if (!isPollingEnabled) {
@@ -88,7 +97,11 @@ export function DashboardNotificationsBell() {
   async function handleMarkAsRead(
     notification: AdminStudyTrackingNotificationSummary,
   ) {
-    if (notification.isRead || updatingNotificationId !== null) {
+    if (
+      notification.isRead ||
+      updatingNotificationId !== null ||
+      isMarkingAllAsRead
+    ) {
       return;
     }
 
@@ -96,7 +109,8 @@ export function DashboardNotificationsBell() {
     setErrorMessage(null);
 
     try {
-      const response = await markAdminStudyTrackingNotificationRead(
+      const response = await markDashboardNotificationRead(
+        surface,
         notification.id,
       );
       setNotifications((current) =>
@@ -110,6 +124,35 @@ export function DashboardNotificationsBell() {
       setErrorMessage("No se pudieron cargar las notificaciones.");
     } finally {
       setUpdatingNotificationId(null);
+    }
+  }
+
+  async function handleMarkAllAsRead() {
+    if (isMarkingAllAsRead || updatingNotificationId !== null) {
+      return;
+    }
+
+    setIsMarkingAllAsRead(true);
+    setErrorMessage(null);
+
+    try {
+      await markAllDashboardNotificationsRead(surface);
+      const readAt = new Date().toISOString();
+      setNotifications((current) =>
+        current.map((notification) =>
+          notification.isRead
+            ? notification
+            : {
+                ...notification,
+                isRead: true,
+                readAt,
+              },
+        ),
+      );
+    } catch {
+      setErrorMessage("No se pudieron cargar las notificaciones.");
+    } finally {
+      setIsMarkingAllAsRead(false);
     }
   }
 
@@ -130,7 +173,7 @@ export function DashboardNotificationsBell() {
       </button>
 
       {isOpen ? (
-        <div className="absolute right-0 z-50 mt-2 w-[20rem] rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl">
+        <div className="absolute right-0 z-50 mt-2 w-[min(20rem,calc(100vw-1rem))] rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl">
           <div className="mb-2 flex items-center justify-between gap-2">
             <p className="text-sm font-semibold text-vetneb-ink">Notificaciones</p>
             <div className="flex items-center gap-2">
@@ -153,6 +196,22 @@ export function DashboardNotificationsBell() {
                 disabled={isLoading}
               >
                 {isLoading ? "Actualizando..." : "Actualizar"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void handleMarkAllAsRead()}
+                disabled={
+                  isLoading ||
+                  isMarkingAllAsRead ||
+                  updatingNotificationId !== null ||
+                  unreadCount === 0
+                }
+              >
+                {isMarkingAllAsRead
+                  ? "Marcando..."
+                  : "Marcar todas como leídas"}
               </Button>
             </div>
           </div>

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -5,7 +5,7 @@ import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 interface DashboardTopbarProps {
   title: string;
   subtitle?: string;
-  notifications?: "admin" | false;
+  notifications?: "admin" | "clinic" | "particular" | false;
 }
 
 export function DashboardTopbar({
@@ -42,7 +42,7 @@ export function DashboardTopbar({
       </div>
 
       <div className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3">
-        {notifications === "admin" ? <DashboardNotificationsBell /> : null}
+        {notifications ? <DashboardNotificationsBell surface={notifications} /> : null}
         <PublicRouteControl
           href={ROUTES.login}
           variant="bare"

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -39,6 +39,7 @@ import {
   VisualIcon,
 } from "@/components/public/VisualAccents";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";
 
 function formatDate(value: string | null | undefined) {
   if (!value) {
@@ -309,22 +310,25 @@ export function ParticularesContent() {
         <PremiumPanel className="overflow-hidden">
           <Card className="border-0 bg-transparent shadow-none">
             <CardHeader className="clinical-muted-band border-b">
-              <div className="flex items-start gap-3">
-                <VisualIcon
-                  icon={session ? UserRound : KeyRound}
-                  tone={session ? "emerald" : "blue"}
-                  className="h-11 w-11 rounded-xl"
-                />
-                <div>
-                  <CardTitle className="text-xl text-vetneb-ink">
-                    {session ? "Sesión particular activa" : "Ingresar con token"}
-                  </CardTitle>
-                  <CardDescription className="mt-1 leading-relaxed">
-                    {session
-                      ? "Datos visibles del caso autenticado con seguimiento trazable del proceso diagnóstico."
-                      : "Pegue el token recibido para consultar el estado del estudio y acceder al informe cuando esté disponible."}
-                  </CardDescription>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-start gap-3">
+                  <VisualIcon
+                    icon={session ? UserRound : KeyRound}
+                    tone={session ? "emerald" : "blue"}
+                    className="h-11 w-11 rounded-xl"
+                  />
+                  <div>
+                    <CardTitle className="text-xl text-vetneb-ink">
+                      {session ? "Sesión particular activa" : "Ingresar con token"}
+                    </CardTitle>
+                    <CardDescription className="mt-1 leading-relaxed">
+                      {session
+                        ? "Datos visibles del caso autenticado con seguimiento trazable del proceso diagnóstico."
+                        : "Pegue el token recibido para consultar el estado del estudio y acceder al informe cuando esté disponible."}
+                    </CardDescription>
+                  </div>
                 </div>
+                {session ? <DashboardNotificationsBell surface="particular" /> : null}
               </div>
             </CardHeader>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -928,14 +928,33 @@ export type AdminStudyTrackingNotificationsReadAllResponse = {
   updatedCount: number;
 };
 
-export async function getAdminStudyTrackingNotifications(
-  params: {
-    unreadOnly?: boolean;
-    limit?: number;
-    offset?: number;
-  } = {},
-  options?: RequestInit,
-): Promise<AdminStudyTrackingNotificationsSnapshot> {
+export type DashboardNotificationSurface =
+  | "admin"
+  | "clinic"
+  | "particular";
+
+type DashboardNotificationsQuery = {
+  unreadOnly?: boolean;
+  limit?: number;
+  offset?: number;
+};
+
+function buildDashboardNotificationsPath(surface: DashboardNotificationSurface) {
+  switch (surface) {
+    case "admin":
+      return "/api/admin/study-tracking/notifications";
+    case "clinic":
+      return "/api/study-tracking/notifications";
+    case "particular":
+      return "/api/particular/study-tracking/notifications";
+    default:
+      return "/api/admin/study-tracking/notifications";
+  }
+}
+
+function buildDashboardNotificationsQuery(
+  params: DashboardNotificationsQuery = {},
+) {
   const query = new URLSearchParams();
 
   if (typeof params.unreadOnly === "boolean") {
@@ -950,37 +969,116 @@ export async function getAdminStudyTrackingNotifications(
     query.set("offset", String(params.offset));
   }
 
-  const qs = query.toString();
+  return query.toString();
+}
+
+export async function getDashboardNotifications(
+  surface: DashboardNotificationSurface,
+  params: {
+    unreadOnly?: boolean;
+    limit?: number;
+    offset?: number;
+  } = {},
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsSnapshot> {
+  const qs = buildDashboardNotificationsQuery(params);
+  const basePath = buildDashboardNotificationsPath(surface);
 
   return apiFetch<AdminStudyTrackingNotificationsSnapshot>(
-    `/api/admin/study-tracking/notifications${qs ? `?${qs}` : ""}`,
+    `${basePath}${qs ? `?${qs}` : ""}`,
     options,
   );
+}
+
+export async function markDashboardNotificationRead(
+  surface: DashboardNotificationSurface,
+  notificationId: number,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationReadResponse> {
+  const basePath = buildDashboardNotificationsPath(surface);
+
+  return apiFetch<AdminStudyTrackingNotificationReadResponse>(
+    `${basePath}/${notificationId}/read`,
+    {
+      ...options,
+      method: "PATCH",
+    },
+  );
+}
+
+export async function markAllDashboardNotificationsRead(
+  surface: DashboardNotificationSurface,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsReadAllResponse> {
+  const basePath = buildDashboardNotificationsPath(surface);
+
+  return apiFetch<AdminStudyTrackingNotificationsReadAllResponse>(
+    `${basePath}/read-all`,
+    {
+      ...options,
+      method: "PATCH",
+    },
+  );
+}
+
+export async function getAdminStudyTrackingNotifications(
+  params: DashboardNotificationsQuery = {},
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsSnapshot> {
+  return getDashboardNotifications("admin", params, options);
 }
 
 export async function markAdminStudyTrackingNotificationRead(
   notificationId: number,
   options?: RequestInit,
 ): Promise<AdminStudyTrackingNotificationReadResponse> {
-  return apiFetch<AdminStudyTrackingNotificationReadResponse>(
-    `/api/admin/study-tracking/notifications/${notificationId}/read`,
-    {
-      ...options,
-      method: "PATCH",
-    },
-  );
+  return markDashboardNotificationRead("admin", notificationId, options);
 }
 
 export async function markAllAdminStudyTrackingNotificationsRead(
   options?: RequestInit,
 ): Promise<AdminStudyTrackingNotificationsReadAllResponse> {
-  return apiFetch<AdminStudyTrackingNotificationsReadAllResponse>(
-    "/api/admin/study-tracking/notifications/read-all",
-    {
-      ...options,
-      method: "PATCH",
-    },
-  );
+  return markAllDashboardNotificationsRead("admin", options);
+}
+
+export async function getClinicStudyTrackingNotifications(
+  params: DashboardNotificationsQuery = {},
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsSnapshot> {
+  return getDashboardNotifications("clinic", params, options);
+}
+
+export async function markClinicStudyTrackingNotificationRead(
+  notificationId: number,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationReadResponse> {
+  return markDashboardNotificationRead("clinic", notificationId, options);
+}
+
+export async function markAllClinicStudyTrackingNotificationsRead(
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsReadAllResponse> {
+  return markAllDashboardNotificationsRead("clinic", options);
+}
+
+export async function getParticularStudyTrackingNotifications(
+  params: DashboardNotificationsQuery = {},
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsSnapshot> {
+  return getDashboardNotifications("particular", params, options);
+}
+
+export async function markParticularStudyTrackingNotificationRead(
+  notificationId: number,
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationReadResponse> {
+  return markDashboardNotificationRead("particular", notificationId, options);
+}
+
+export async function markAllParticularStudyTrackingNotificationsRead(
+  options?: RequestInit,
+): Promise<AdminStudyTrackingNotificationsReadAllResponse> {
+  return markAllDashboardNotificationsRead("particular", options);
 }
 
 export type ClinicStudyTrackingCaseSummary = AdminStudyTrackingCaseSummary;

--- a/server/db-study-tracking.ts
+++ b/server/db-study-tracking.ts
@@ -7,6 +7,33 @@ import {
   type NewStudyTrackingNotification,
 } from "../drizzle/schema.ts";
 
+type NotificationScope = {
+  clinicId?: number;
+  particularTokenId?: number;
+};
+
+function buildStudyTrackingNotificationScopeFilters(scope: NotificationScope) {
+  const scopeFilters = [];
+
+  if (typeof scope.clinicId === "number") {
+    scopeFilters.push(eq(studyTrackingNotifications.clinicId, scope.clinicId));
+  }
+
+  if (typeof scope.particularTokenId === "number") {
+    scopeFilters.push(
+      eq(studyTrackingNotifications.particularTokenId, scope.particularTokenId),
+    );
+  }
+
+  if (scopeFilters.length === 0) {
+    throw new Error(
+      "markStudyTrackingNotificationReadScoped requires clinicId or particularTokenId",
+    );
+  }
+
+  return scopeFilters;
+}
+
 export async function createStudyTrackingCase(
   input: Omit<NewStudyTrackingCase, "id" | "createdAt" | "updatedAt">,
 ) {
@@ -223,6 +250,44 @@ export async function markAllStudyTrackingNotificationsRead(params?: {
       readAt: new Date(),
     })
     .where(and(...filters))
+    .returning({ id: studyTrackingNotifications.id });
+
+  return {
+    updatedCount: updated.length,
+  };
+}
+
+export async function markStudyTrackingNotificationReadScoped(params: {
+  id: number;
+  clinicId?: number;
+  particularTokenId?: number;
+}) {
+  const scopeFilters = buildStudyTrackingNotificationScopeFilters(params);
+  const now = new Date();
+  const result = await db
+    .update(studyTrackingNotifications)
+    .set({
+      isRead: true,
+      readAt: now,
+    })
+    .where(and(eq(studyTrackingNotifications.id, params.id), ...scopeFilters))
+    .returning();
+
+  return result[0];
+}
+
+export async function markAllStudyTrackingNotificationsReadScoped(params: {
+  clinicId?: number;
+  particularTokenId?: number;
+}) {
+  const scopeFilters = buildStudyTrackingNotificationScopeFilters(params);
+  const updated = await db
+    .update(studyTrackingNotifications)
+    .set({
+      isRead: true,
+      readAt: new Date(),
+    })
+    .where(and(eq(studyTrackingNotifications.isRead, false), ...scopeFilters))
     .returning({ id: studyTrackingNotifications.id });
 
   return {

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -6,7 +6,12 @@ import type {
 } from "fastify";
 import multer from "multer";
 
-import type { ParticularToken, Report, StudyTrackingCase } from "../../drizzle/schema.ts";
+import type {
+  ParticularToken,
+  Report,
+  StudyTrackingCase,
+  StudyTrackingNotification,
+} from "../../drizzle/schema.ts";
 import type { Multer } from "multer";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
@@ -118,6 +123,17 @@ export type AdminReportsNativeRoutesOptions = {
     id: number,
     input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
   ) => Promise<StudyTrackingCase | null | undefined>;
+  createStudyTrackingNotification?: (input: {
+    studyTrackingCaseId: number;
+    clinicId: number;
+    reportId: number | null;
+    particularTokenId: number | null;
+    type: string;
+    title: string;
+    message: string;
+    isRead: boolean;
+    readAt: Date | null;
+  }) => Promise<StudyTrackingNotification>;
   createSignedReportUrl?: (storagePath: string) => Promise<string>;
   createSignedReportDownloadUrl?: (
     storagePath: string,
@@ -172,6 +188,7 @@ type NativeAdminReportsDeps = Required<
     | "getStudyTrackingCaseByReportId"
     | "createStudyTrackingCase"
     | "updateStudyTrackingCase"
+    | "createStudyTrackingNotification"
     | "createSignedReportUrl"
     | "createSignedReportDownloadUrl"
     | "writeAuditLog"
@@ -207,6 +224,8 @@ async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
           dbStudyTracking.getStudyTrackingCaseByReportId,
         createStudyTrackingCase: dbStudyTracking.createStudyTrackingCase,
         updateStudyTrackingCase: dbStudyTracking.updateStudyTrackingCase,
+        createStudyTrackingNotification:
+          dbStudyTracking.createStudyTrackingNotification,
         createSignedReportUrl: storage.createSignedReportUrl,
         createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
         writeAuditLog: audit.writeAuditLog as (
@@ -236,6 +255,7 @@ function hasAllInjectedDeps(options: AdminReportsNativeRoutesOptions) {
     !!options.getStudyTrackingCaseByReportId &&
     !!options.createStudyTrackingCase &&
     !!options.updateStudyTrackingCase &&
+    !!options.createStudyTrackingNotification &&
     !!options.createSignedReportUrl &&
     !!options.createSignedReportDownloadUrl &&
     !!options.writeAuditLog
@@ -277,6 +297,9 @@ async function resolveDeps(
       options.createStudyTrackingCase ?? defaultDeps!.createStudyTrackingCase,
     updateStudyTrackingCase:
       options.updateStudyTrackingCase ?? defaultDeps!.updateStudyTrackingCase,
+    createStudyTrackingNotification:
+      options.createStudyTrackingNotification ??
+      defaultDeps!.createStudyTrackingNotification,
     createSignedReportUrl:
       options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
     createSignedReportDownloadUrl:
@@ -640,6 +663,64 @@ async function ensureTrackingForLinkedToken(
   );
 }
 
+function shouldCreateReportDeliveredNotification(input: {
+  previousTrackingCase: StudyTrackingCase | null;
+  trackingCase: StudyTrackingCase | null;
+}) {
+  const { previousTrackingCase, trackingCase } = input;
+
+  if (!trackingCase || trackingCase.currentStage !== "delivered") {
+    return false;
+  }
+
+  if (!previousTrackingCase) {
+    return true;
+  }
+
+  return previousTrackingCase.currentStage !== "delivered";
+}
+
+async function createReportDeliveredNotificationSafely(
+  deps: NativeAdminReportsDeps,
+  input: {
+    previousTrackingCase: StudyTrackingCase | null;
+    trackingCase: StudyTrackingCase | null;
+    clinicId: number;
+    reportId: number;
+  },
+) {
+  if (!shouldCreateReportDeliveredNotification(input) || !input.trackingCase) {
+    return;
+  }
+
+  try {
+    await deps.createStudyTrackingNotification({
+      studyTrackingCaseId: input.trackingCase.id,
+      clinicId: input.clinicId,
+      reportId: input.reportId,
+      particularTokenId: input.trackingCase.particularTokenId,
+      type: "report_delivered",
+      title: "Informe disponible",
+      message: "El informe del estudio ya está disponible.",
+      isRead: false,
+      readAt: null,
+    });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "unknown_error";
+
+    console.warn(
+      "[admin-reports] report_delivered notification failed",
+      JSON.stringify({
+        reportId: input.reportId,
+        clinicId: input.clinicId,
+        trackingCaseId: input.trackingCase.id,
+        error: errorMessage,
+      }),
+    );
+  }
+}
+
 async function serializeReport(report: Report, deps: NativeAdminReportsDeps) {
   const [previewUrl, downloadUrl] = await Promise.all([
     deps.createSignedReportUrl(report.storagePath),
@@ -835,9 +916,15 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
 
     const nowDate = new Date(now());
     let trackingCase: StudyTrackingCase | null = null;
+    let previousTrackingCase: StudyTrackingCase | null = null;
     let linkedTokenId: number | null = null;
 
     if (selectedParticularToken) {
+      previousTrackingCase =
+        (await deps.getParticularStudyTrackingCase(selectedParticularToken.id)) ??
+        (await deps.getStudyTrackingCaseByReportId(report.id)) ??
+        null;
+
       const updatedToken = await deps.updateParticularTokenReport(
         selectedParticularToken.id,
         report.id,
@@ -855,6 +942,9 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
         nowDate,
       });
     } else {
+      previousTrackingCase =
+        (await deps.getStudyTrackingCaseByReportId(report.id)) ?? null;
+
       trackingCase = await ensureDeliveredTrackingByReportId(
         deps,
         report.id,
@@ -862,6 +952,13 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
       );
       linkedTokenId = trackingCase?.particularTokenId ?? null;
     }
+
+    await createReportDeliveredNotificationSafely(deps, {
+      previousTrackingCase,
+      trackingCase,
+      clinicId: report.clinicId,
+      reportId: report.id,
+    });
 
     await deps.writeAuditLog(createAuditRequestLike(request, admin), {
       event: AUDIT_EVENTS.REPORT_UPLOADED,

--- a/server/routes/particular-study-tracking.fastify.ts
+++ b/server/routes/particular-study-tracking.fastify.ts
@@ -12,6 +12,7 @@ import type {
 import { ENV } from "../lib/env.ts";
 import {
   parseBooleanQuery,
+  parseEntityId,
   parseOffset,
   parsePositiveInt,
   serializeStudyTrackingCase,
@@ -66,10 +67,20 @@ export type ParticularStudyTrackingNativeRoutesOptions = {
     limit: number;
     offset: number;
   }) => Promise<StudyTrackingNotification[]>;
+  markStudyTrackingNotificationReadScoped?: (params: {
+    id: number;
+    clinicId?: number;
+    particularTokenId?: number;
+  }) => Promise<StudyTrackingNotification | null | undefined>;
+  markAllStudyTrackingNotificationsReadScoped?: (params: {
+    clinicId?: number;
+    particularTokenId?: number;
+  }) => Promise<{ updatedCount: number }>;
   now?: () => number;
 };
 
 const REQUEST_TIMER_KEY = "__particularStudyTrackingRequestTimer";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type ParticularStudyTrackingFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -85,6 +96,8 @@ type NativeParticularStudyTrackingDeps = Required<
     | "hashSessionToken"
     | "getParticularStudyTrackingCase"
     | "listStudyTrackingNotifications"
+    | "markStudyTrackingNotificationReadScoped"
+    | "markAllStudyTrackingNotificationsReadScoped"
   >
 >;
 
@@ -111,6 +124,10 @@ async function loadDefaultDeps(): Promise<NativeParticularStudyTrackingDeps> {
           dbStudyTracking.getParticularStudyTrackingCase,
         listStudyTrackingNotifications:
           dbStudyTracking.listStudyTrackingNotifications,
+        markStudyTrackingNotificationReadScoped:
+          dbStudyTracking.markStudyTrackingNotificationReadScoped,
+        markAllStudyTrackingNotificationsReadScoped:
+          dbStudyTracking.markAllStudyTrackingNotificationsReadScoped,
       };
     })();
   }
@@ -128,7 +145,9 @@ function hasAllInjectedDeps(
     !!options.updateParticularSessionLastAccess &&
     !!options.hashSessionToken &&
     !!options.getParticularStudyTrackingCase &&
-    !!options.listStudyTrackingNotifications
+    !!options.listStudyTrackingNotifications &&
+    !!options.markStudyTrackingNotificationReadScoped &&
+    !!options.markAllStudyTrackingNotificationsReadScoped
   );
 }
 
@@ -158,6 +177,12 @@ async function resolveDeps(
     listStudyTrackingNotifications:
       options.listStudyTrackingNotifications ??
       defaultDeps!.listStudyTrackingNotifications,
+    markStudyTrackingNotificationReadScoped:
+      options.markStudyTrackingNotificationReadScoped ??
+      defaultDeps!.markStudyTrackingNotificationReadScoped,
+    markAllStudyTrackingNotificationsReadScoped:
+      options.markAllStudyTrackingNotificationsReadScoped ??
+      defaultDeps!.markAllStudyTrackingNotificationsReadScoped,
   };
 }
 
@@ -234,6 +259,28 @@ function getRequestOrigin(request: FastifyRequest): string | null {
   }
 
   return null;
+}
+
+function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+) {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin || !allowedOrigins.has(requestOrigin)) {
+    reply.code(403).send({
+      success: false,
+      error: "Origen no permitido",
+    });
+    return false;
+  }
+
+  return true;
 }
 
 function applyCorsHeaders(
@@ -451,7 +498,7 @@ export const particularStudyTrackingNativeRoutes: FastifyPluginAsync<
     }
 
     applyCorsHeaders(request, reply, allowedOrigins);
-    reply.header("access-control-allow-methods", "GET,OPTIONS");
+    reply.header("access-control-allow-methods", "GET,PATCH,OPTIONS");
 
     const requestedHeaders =
       typeof request.headers["access-control-request-headers"] === "string"
@@ -464,6 +511,8 @@ export const particularStudyTrackingNativeRoutes: FastifyPluginAsync<
 
   app.options("/me", optionsHandler);
   app.options("/notifications", optionsHandler);
+  app.options("/notifications/:notificationId/read", optionsHandler);
+  app.options("/notifications/read-all", optionsHandler);
 
   app.get("/me", async (request, reply) => {
     const deps = await resolveDeps(options);
@@ -535,6 +584,81 @@ export const particularStudyTrackingNativeRoutes: FastifyPluginAsync<
         limit,
         offset,
       },
+    });
+  });
+
+  app.patch<{
+    Params: {
+      notificationId: string;
+    };
+  }>("/notifications/:notificationId/read", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const deps = await resolveDeps(options);
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const notificationId = parseEntityId(request.params.notificationId);
+
+    if (typeof notificationId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de notificación inválido",
+      });
+    }
+
+    const notification = await deps.markStudyTrackingNotificationReadScoped({
+      id: notificationId,
+      particularTokenId: particular.tokenId,
+    });
+
+    if (!notification) {
+      return reply.code(404).send({
+        success: false,
+        error: "Notificación no encontrada",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      notification: serializeStudyTrackingNotification(notification),
+    });
+  });
+
+  app.patch("/notifications/read-all", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const deps = await resolveDeps(options);
+    const particular = await authenticateParticularUser(
+      request,
+      reply,
+      deps,
+      now,
+    );
+
+    if (!particular) {
+      return reply;
+    }
+
+    const result = await deps.markAllStudyTrackingNotificationsReadScoped({
+      particularTokenId: particular.tokenId,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      updatedCount: result.updatedCount,
     });
   });
 };

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -157,6 +157,15 @@ export type StudyTrackingNativeRoutesOptions = {
     limit: number;
     offset: number;
   }) => Promise<StudyTrackingNotification[]>;
+  markStudyTrackingNotificationReadScoped?: (params: {
+    id: number;
+    clinicId?: number;
+    particularTokenId?: number;
+  }) => Promise<StudyTrackingNotification | null | undefined>;
+  markAllStudyTrackingNotificationsReadScoped?: (params: {
+    clinicId?: number;
+    particularTokenId?: number;
+  }) => Promise<{ updatedCount: number }>;
   sendSpecialStainRequiredEmail?: (input: {
     to: Array<string | null | undefined>;
     clinicName: string;
@@ -199,6 +208,8 @@ type NativeStudyTrackingDeps = Required<
     | "listStudyTrackingCases"
     | "createStudyTrackingNotification"
     | "listStudyTrackingNotifications"
+    | "markStudyTrackingNotificationReadScoped"
+    | "markAllStudyTrackingNotificationsReadScoped"
     | "sendSpecialStainRequiredEmail"
     | "writeAuditLog"
   >
@@ -235,6 +246,10 @@ async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
           dbStudyTracking.createStudyTrackingNotification,
         listStudyTrackingNotifications:
           dbStudyTracking.listStudyTrackingNotifications,
+        markStudyTrackingNotificationReadScoped:
+          dbStudyTracking.markStudyTrackingNotificationReadScoped,
+        markAllStudyTrackingNotificationsReadScoped:
+          dbStudyTracking.markAllStudyTrackingNotificationsReadScoped,
         sendSpecialStainRequiredEmail: email.sendSpecialStainRequiredEmail,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
@@ -355,11 +370,7 @@ function enforceTrustedOrigin(
 
   const requestOrigin = getRequestOrigin(request);
 
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
+  if (requestOrigin && allowedOrigins.has(requestOrigin)) {
     return true;
   }
 
@@ -619,6 +630,8 @@ export const studyTrackingNativeRoutes: FastifyPluginAsync<
     !!options.listStudyTrackingCases &&
     !!options.createStudyTrackingNotification &&
     !!options.listStudyTrackingNotifications &&
+    !!options.markStudyTrackingNotificationReadScoped &&
+    !!options.markAllStudyTrackingNotificationsReadScoped &&
     !!options.sendSpecialStainRequiredEmail &&
     !!options.writeAuditLog;
 
@@ -657,6 +670,12 @@ export const studyTrackingNativeRoutes: FastifyPluginAsync<
     listStudyTrackingNotifications:
       options.listStudyTrackingNotifications ??
       defaultDeps!.listStudyTrackingNotifications,
+    markStudyTrackingNotificationReadScoped:
+      options.markStudyTrackingNotificationReadScoped ??
+      defaultDeps!.markStudyTrackingNotificationReadScoped,
+    markAllStudyTrackingNotificationsReadScoped:
+      options.markAllStudyTrackingNotificationsReadScoped ??
+      defaultDeps!.markAllStudyTrackingNotificationsReadScoped,
     sendSpecialStainRequiredEmail:
       options.sendSpecialStainRequiredEmail ??
       defaultDeps!.sendSpecialStainRequiredEmail,
@@ -709,7 +728,7 @@ export const studyTrackingNativeRoutes: FastifyPluginAsync<
     }
 
     applyCorsHeaders(request, reply, allowedOrigins);
-    reply.header("access-control-allow-methods", "GET,POST,OPTIONS");
+    reply.header("access-control-allow-methods", "GET,POST,PATCH,OPTIONS");
 
     const requestedHeaders =
       typeof request.headers["access-control-request-headers"] === "string"
@@ -722,6 +741,8 @@ export const studyTrackingNativeRoutes: FastifyPluginAsync<
 
   app.options("/", optionsHandler);
   app.options("/notifications", optionsHandler);
+  app.options("/notifications/:notificationId/read", optionsHandler);
+  app.options("/notifications/read-all", optionsHandler);
   app.options("/:trackingCaseId", optionsHandler);
 
   app.get<{
@@ -758,6 +779,69 @@ export const studyTrackingNativeRoutes: FastifyPluginAsync<
         limit,
         offset,
       },
+    });
+  });
+
+  app.patch<{
+    Params: {
+      notificationId: string;
+    };
+  }>("/notifications/:notificationId/read", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const notificationId = parseEntityId(request.params.notificationId);
+
+    if (typeof notificationId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de notificación inválido",
+      });
+    }
+
+    const notification = await deps.markStudyTrackingNotificationReadScoped({
+      id: notificationId,
+      clinicId: auth.clinicId,
+    });
+
+    if (!notification) {
+      return reply.code(404).send({
+        success: false,
+        error: "Notificación no encontrada",
+      });
+    }
+
+    return reply.code(200).send({
+      success: true,
+      notification: serializeStudyTrackingNotification(notification),
+    });
+  });
+
+  app.patch("/notifications/read-all", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const result = await deps.markAllStudyTrackingNotificationsReadScoped({
+      clinicId: auth.clinicId,
+    });
+
+    return reply.code(200).send({
+      success: true,
+      updatedCount: result.updatedCount,
     });
   });
 

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -88,6 +88,23 @@ function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createNotificationFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 41,
+    studyTrackingCaseId: 11,
+    clinicId: 3,
+    reportId: 88,
+    particularTokenId: 7,
+    type: "report_delivered",
+    title: "Informe disponible",
+    message: "El informe del estudio ya está disponible.",
+    isRead: false,
+    readAt: null,
+    createdAt: new Date("2026-04-22T12:01:00.000Z"),
+    ...overrides,
+  };
+}
+
 function createAuthStubs(overrides: Record<string, unknown> = {}) {
   return {
     deleteAdminSession: async () => {},
@@ -125,6 +142,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
       );
     },
     updateStudyTrackingCase: async () => null,
+    createStudyTrackingNotification: async () => createNotificationFixture(),
     createSignedReportUrl: async (storagePath: string) =>
       `signed-preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
@@ -623,6 +641,7 @@ test("adminReportsNativeRoutes vincula token y cierra tracking en delivered al s
   const updateTokenCalls: Array<Record<string, unknown>> = [];
   const createTrackingCalls: Array<Record<string, unknown>> = [];
   const updateTrackingCalls: Array<Record<string, unknown>> = [];
+  const notificationCalls: Array<Record<string, unknown>> = [];
   const auditCalls: Array<Record<string, unknown>> = [];
 
   const app = await createTestApp({
@@ -653,6 +672,10 @@ test("adminReportsNativeRoutes vincula token y cierra tracking en delivered al s
         ...input,
       });
     },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture(input);
+    },
     writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
       auditCalls.push(input);
     },
@@ -678,6 +701,19 @@ test("adminReportsNativeRoutes vincula token y cierra tracking en delivered al s
     assert.equal(createTrackingCalls[0].currentStage, "delivered");
     assert.equal(createTrackingCalls[0].specialStainRequired, false);
     assert.equal(updateTrackingCalls.length, 0);
+    assert.equal(notificationCalls.length, 1);
+    assert.equal(notificationCalls[0].type, "report_delivered");
+    assert.equal(notificationCalls[0].title, "Informe disponible");
+    assert.equal(
+      notificationCalls[0].message,
+      "El informe del estudio ya está disponible.",
+    );
+    assert.equal(notificationCalls[0].clinicId, 3);
+    assert.equal(notificationCalls[0].reportId, 88);
+    assert.equal(notificationCalls[0].particularTokenId, 7);
+    assert.equal(notificationCalls[0].studyTrackingCaseId, 11);
+    assert.equal(notificationCalls[0].isRead, false);
+    assert.equal(notificationCalls[0].readAt, null);
     assert.equal(auditCalls.length, 1);
     assert.equal(
       (auditCalls[0].metadata as Record<string, unknown>).particularTokenId,
@@ -714,6 +750,7 @@ test("adminReportsNativeRoutes cierra tracking por reportId en delivered cuando 
     deliveredAt: null,
   });
   const updateTrackingCalls: Array<Record<string, unknown>> = [];
+  const notificationCalls: Array<Record<string, unknown>> = [];
   const auditCalls: Array<Record<string, unknown>> = [];
 
   const app = await createTestApp({
@@ -726,6 +763,10 @@ test("adminReportsNativeRoutes cierra tracking por reportId en delivered cuando 
         id,
         ...input,
       });
+    },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture(input);
     },
     writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
       auditCalls.push(input);
@@ -755,6 +796,12 @@ test("adminReportsNativeRoutes cierra tracking por reportId en delivered cuando 
         },
       },
     ]);
+    assert.equal(notificationCalls.length, 1);
+    assert.equal(notificationCalls[0].type, "report_delivered");
+    assert.equal(notificationCalls[0].clinicId, 3);
+    assert.equal(notificationCalls[0].reportId, 88);
+    assert.equal(notificationCalls[0].particularTokenId, null);
+    assert.equal(notificationCalls[0].studyTrackingCaseId, 22);
     assert.equal(auditCalls.length, 1);
     assert.equal(
       (auditCalls[0].metadata as Record<string, unknown>).trackingCaseId,
@@ -764,6 +811,107 @@ test("adminReportsNativeRoutes cierra tracking por reportId en delivered cuando 
       (auditCalls[0].metadata as Record<string, unknown>).trackingStage,
       "delivered",
     );
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes no duplica report_delivered cuando el tracking ya estaba delivered", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    patientName: "Luna",
+  });
+  const trackingCase = createTrackingCaseFixture({
+    id: 22,
+    reportId: 88,
+    particularTokenId: null,
+    currentStage: "delivered",
+    deliveredAt: new Date("2026-04-22T12:00:00.000Z"),
+  });
+  const updateTrackingCalls: Array<Record<string, unknown>> = [];
+  const notificationCalls: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    getStudyTrackingCaseByReportId: async () => trackingCase,
+    updateStudyTrackingCase: async (id: number, input: Record<string, unknown>) => {
+      updateTrackingCalls.push({ id, input });
+      return createTrackingCaseFixture({ id, ...input });
+    },
+    createStudyTrackingNotification: async (input: Record<string, unknown>) => {
+      notificationCalls.push(input);
+      return createNotificationFixture(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(updateTrackingCalls.length, 0);
+    assert.equal(notificationCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes no aborta upload si falla report_delivered notification", async () => {
+  const multipart = buildMultipartReportPayload({
+    clinicId: "3",
+    patientName: "Luna",
+  });
+  const nowDate = new Date("2026-04-22T12:00:00.000Z");
+  const trackingCase = createTrackingCaseFixture({
+    id: 22,
+    reportId: 88,
+    particularTokenId: null,
+    currentStage: "evaluation",
+    deliveredAt: null,
+  });
+  const auditCalls: Array<Record<string, unknown>> = [];
+
+  const app = await createTestApp({
+    now: () => nowDate.getTime(),
+    getStudyTrackingCaseByReportId: async () => trackingCase,
+    updateStudyTrackingCase: async (id: number, input: Record<string, unknown>) =>
+      createTrackingCaseFixture({
+        ...trackingCase,
+        id,
+        ...input,
+      }),
+    createStudyTrackingNotification: async () => {
+      throw new Error("notification_failure");
+    },
+    writeAuditLog: async (_req: unknown, input: Record<string, unknown>) => {
+      auditCalls.push(input);
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/reports/upload",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": `multipart/form-data; boundary=${multipart.boundary}`,
+      },
+      payload: multipart.payload,
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(auditCalls.length, 1);
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.report.id, 88);
   } finally {
     await app.close();
   }

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -226,6 +226,7 @@ function buildAdminReportsRouteStubs() {
     getStudyTrackingCaseByReportId: async () => null,
     createStudyTrackingCase: async () => ({} as any),
     updateStudyTrackingCase: async () => null,
+    createStudyTrackingNotification: async () => ({} as any),
     createSignedReportUrl: async (storagePath: string) =>
       `signed-preview:${storagePath}`,
     createSignedReportDownloadUrl: async (
@@ -507,6 +508,10 @@ function buildStudyTrackingRouteStubs() {
     listStudyTrackingCases: async () => [],
     createStudyTrackingNotification: async () => ({} as any),
     listStudyTrackingNotifications: async () => [],
+    markStudyTrackingNotificationReadScoped: async () => null,
+    markAllStudyTrackingNotificationsReadScoped: async () => ({
+      updatedCount: 0,
+    }),
     writeAuditLog: async () => {},
     sendSpecialStainRequiredEmail: async () => ({ sent: true }),
   };
@@ -573,6 +578,10 @@ function buildParticularStudyTrackingRouteStubs() {
     hashSessionToken: (token: string) => `hash:${token}`,
     getParticularStudyTrackingCase: async () => null,
     listStudyTrackingNotifications: async () => [],
+    markStudyTrackingNotificationReadScoped: async () => null,
+    markAllStudyTrackingNotificationsReadScoped: async () => ({
+      updatedCount: 0,
+    }),
   };
 }
 

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -71,11 +71,13 @@ test("dashboard topbar soporta notifications='admin' y monta la campana", () => 
       'import { DashboardNotificationsBell } from "./DashboardNotificationsBell";',
     ),
   );
-  assert.ok(topbar.includes('notifications?: "admin" | false;'));
+  assert.ok(
+    topbar.includes('notifications?: "admin" | "clinic" | "particular" | false;'),
+  );
   assert.ok(topbar.includes("notifications = false,"));
   assert.ok(
     topbar.includes(
-      '{notifications === "admin" ? <DashboardNotificationsBell /> : null}',
+      "{notifications ? <DashboardNotificationsBell surface={notifications} /> : null}",
     ),
   );
   assert.ok(page.includes('notifications="admin"'));
@@ -97,24 +99,36 @@ test("campana de notificaciones admin existe con UX in-app y polling", () => {
   assert.ok(bell.includes("window.clearInterval(intervalId);"));
 });
 
-test("campana usa API de notificaciones admin para listar y marcar leídas", () => {
+test("campana usa API de notificaciones por surface para listar y marcar leídas", () => {
   const bell = read(BELL_PATH);
 
-  assert.ok(bell.includes("getAdminStudyTrackingNotifications("));
-  assert.ok(bell.includes("markAdminStudyTrackingNotificationRead("));
+  assert.ok(bell.includes("surface: DashboardNotificationSurface;"));
+  assert.ok(bell.includes("getDashboardNotifications(surface, {"));
+  assert.ok(bell.includes("markDashboardNotificationRead("));
+  assert.ok(bell.includes("markAllDashboardNotificationsRead(surface)"));
   assert.ok(bell.includes("setNotifications(response.notifications);"));
   assert.ok(bell.includes("response.notification"));
+  assert.ok(bell.includes("Marcar todas como leídas"));
 });
 
-test("api frontend expone funciones de notificaciones admin", () => {
+test("api frontend expone funciones de notificaciones por surface y compat admin", () => {
   const api = read(API_PATH);
 
   assert.ok(api.includes("export type AdminStudyTrackingNotificationSummary = {"));
+  assert.ok(api.includes("export type DashboardNotificationSurface ="));
+  assert.ok(api.includes('case "admin":'));
+  assert.ok(api.includes('case "clinic":'));
+  assert.ok(api.includes('case "particular":'));
+  assert.ok(api.includes("export async function getDashboardNotifications("));
+  assert.ok(api.includes("export async function markDashboardNotificationRead("));
+  assert.ok(api.includes("export async function markAllDashboardNotificationsRead("));
   assert.ok(api.includes("export async function getAdminStudyTrackingNotifications("));
-  assert.ok(api.includes("unreadOnly?: boolean;"));
-  assert.ok(api.includes("`/api/admin/study-tracking/notifications${qs ? `?${qs}` : \"\"}`"));
+  assert.ok(api.includes("export async function getClinicStudyTrackingNotifications("));
+  assert.ok(api.includes("export async function getParticularStudyTrackingNotifications("));
   assert.ok(api.includes("export async function markAdminStudyTrackingNotificationRead("));
-  assert.ok(api.includes("`/api/admin/study-tracking/notifications/${notificationId}/read`"));
+  assert.ok(api.includes("export async function markClinicStudyTrackingNotificationRead("));
+  assert.ok(api.includes("export async function markParticularStudyTrackingNotificationRead("));
   assert.ok(api.includes("export async function markAllAdminStudyTrackingNotificationsRead("));
-  assert.ok(api.includes('"/api/admin/study-tracking/notifications/read-all"'));
+  assert.ok(api.includes("export async function markAllClinicStudyTrackingNotificationsRead("));
+  assert.ok(api.includes("export async function markAllParticularStudyTrackingNotificationsRead("));
 });

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -60,6 +60,7 @@ test("dashboard home renders clinic operational summary, stats, reports, and fie
 
   assert.ok(source.includes('title="Dashboard Clínica"'));
   assert.ok(source.includes('subtitle="Resumen operativo clínica"'));
+  assert.ok(source.includes('notifications="clinic"'));
   assert.ok(source.includes("Estado operativo clínica"));
   assert.ok(source.includes("Priorice informes pendientes y visitas activas"));
   assert.ok(source.includes("statsLoadError ?"));

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -73,6 +73,7 @@ test("dashboard informes renders clinic reports surface without technical source
 
   assert.ok(source.includes('title="Informes"'));
   assert.ok(source.includes('subtitle="Consulta de informes médicos veterinarios"'));
+  assert.ok(source.includes('notifications="clinic"'));
   assert.equal(source.includes("<UploadReportModal />"), false);
   assert.equal(source.includes("/api/admin"), false);
   assert.equal(source.includes(removedSourceCopy), false);

--- a/test/frontend-dashboard-logistica-metricas.test.ts
+++ b/test/frontend-dashboard-logistica-metricas.test.ts
@@ -67,6 +67,7 @@ test("dashboard logistica metricas renders summary cards without technical sourc
 
   assert.ok(source.includes('title="Métricas de logística"'));
   assert.ok(source.includes('subtitle="Cumplimiento, SLA y reportes operativos"'));
+  assert.ok(source.includes('notifications="clinic"'));
   assert.ok(source.includes("Cumplimiento promedio"));
   assert.ok(source.includes("Paradas completadas"));
   assert.ok(source.includes("Duración promedio"));

--- a/test/frontend-dashboard-logistica-rutas.test.ts
+++ b/test/frontend-dashboard-logistica-rutas.test.ts
@@ -44,6 +44,7 @@ test("dashboard logistica rutas renders topbar without technical source copy", (
 
   assert.ok(source.includes('title="Planes de ruta"'));
   assert.ok(source.includes('subtitle="Planificación y gestión de rutas de entrega"'));
+  assert.ok(source.includes('notifications="clinic"'));
   assert.equal(source.includes(removedSourcePrefix), false);
   assert.equal(source.includes(removedRoutePlansEndpoint), false);
 });

--- a/test/frontend-dashboard-logistica-visitas.test.ts
+++ b/test/frontend-dashboard-logistica-visitas.test.ts
@@ -43,6 +43,7 @@ test("dashboard logistica visitas renders topbar without technical source copy",
 
   assert.ok(source.includes('title="Visitas de campo"'));
   assert.ok(source.includes('subtitle="Seguimiento de visitas programadas y en curso"'));
+  assert.ok(source.includes('notifications="clinic"'));
   assert.equal(source.includes(removedSourcePrefix), false);
   assert.equal(source.includes(removedFieldVisitsEndpoint), false);
 });

--- a/test/frontend-dashboard-logistica.test.ts
+++ b/test/frontend-dashboard-logistica.test.ts
@@ -51,6 +51,7 @@ test("dashboard logistica reads field visits and route plans through API helpers
 test("dashboard logistica computes active visits and active route plans explicitly", () => {
   const source = read(LOGISTICA_PAGE_PATH);
 
+  assert.ok(source.includes('notifications="clinic"'));
   assert.ok(source.includes("const activeVisits = fieldVisits.filter("));
   assert.ok(source.includes('v.status === "in_progress" || v.status === "scheduled"'));
   assert.ok(source.includes("const activePlans = routePlans.filter("));

--- a/test/frontend-dashboard-shared-components.test.ts
+++ b/test/frontend-dashboard-shared-components.test.ts
@@ -31,7 +31,9 @@ test("dashboard topbar keeps typed title and optional subtitle props", () => {
   assert.ok(source.includes("interface DashboardTopbarProps"));
   assert.ok(source.includes("title: string;"));
   assert.ok(source.includes("subtitle?: string;"));
-  assert.ok(source.includes('notifications?: "admin" | false;'));
+  assert.ok(
+    source.includes('notifications?: "admin" | "clinic" | "particular" | false;'),
+  );
   assert.ok(source.includes("notifications = false,"));
   assert.ok(source.includes("export function DashboardTopbar({"));
   assert.ok(source.includes("<h1"));
@@ -40,7 +42,7 @@ test("dashboard topbar keeps typed title and optional subtitle props", () => {
   assert.ok(source.includes("{subtitle}"));
 });
 
-test("dashboard topbar renders notifications bell only in admin mode", () => {
+test("dashboard topbar renders notifications bell for configured dashboard surface", () => {
   const source = read(DASHBOARD_TOPBAR_PATH);
 
   assert.ok(
@@ -50,7 +52,7 @@ test("dashboard topbar renders notifications bell only in admin mode", () => {
   );
   assert.ok(
     source.includes(
-      '{notifications === "admin" ? <DashboardNotificationsBell /> : null}',
+      "{notifications ? <DashboardNotificationsBell surface={notifications} /> : null}",
     ),
   );
 });

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -57,3 +57,14 @@ test("particulares content muestra estado y alerta desde study-tracking en sesi�
   assert.ok(source.includes("Alerta: Solicitud de tinción especial."));
   assert.ok(source.includes("trackingCase"));
 });
+
+test("particulares content integra campana token-scoped en sesión activa", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";',
+    ),
+  );
+  assert.ok(source.includes('<DashboardNotificationsBell surface="particular" />'));
+});

--- a/test/particular-study-tracking.fastify.test.ts
+++ b/test/particular-study-tracking.fastify.test.ts
@@ -89,6 +89,14 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     ...createParticularAuthStubs(),
     getParticularStudyTrackingCase: async () => createTrackingCaseFixture(),
     listStudyTrackingNotifications: async () => [createNotificationFixture()],
+    markStudyTrackingNotificationReadScoped: async () =>
+      createNotificationFixture({
+        isRead: true,
+        readAt: new Date("2026-04-23T12:00:00.000Z"),
+      }),
+    markAllStudyTrackingNotificationsReadScoped: async () => ({
+      updatedCount: 1,
+    }),
     now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
     ...overrides,
   });
@@ -194,6 +202,153 @@ test("particularStudyTrackingNativeRoutes expone GET /notifications con filtro p
     assert.equal(body.notifications[0].type, "stage_changed");
     assert.equal(body.pagination.limit, 5);
     assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes expone PATCH /notifications/:notificationId/read scoped por token", async () => {
+  const markCalls: Array<Record<string, unknown>> = [];
+  const readAt = new Date("2026-04-23T12:00:00.000Z");
+  const app = await createTestApp({
+    markStudyTrackingNotificationReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markCalls.push(params);
+      return createNotificationFixture({
+        id: params.id,
+        isRead: true,
+        readAt,
+      });
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/notifications/21/read",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(markCalls, [{ id: 21, particularTokenId: 7 }]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.notification.id, 21);
+    assert.equal(body.notification.isRead, true);
+    assert.equal(body.notification.readAt, readAt.toISOString());
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes responde 404 genérico en PATCH /notifications/:notificationId/read cross-token", async () => {
+  const markCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    markStudyTrackingNotificationReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markCalls.push(params);
+      return null;
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/notifications/999/read",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(markCalls, [{ id: 999, particularTokenId: 7 }]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Notificación no encontrada",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes expone PATCH /notifications/read-all scoped por token", async () => {
+  const markAllCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    markAllStudyTrackingNotificationsReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markAllCalls.push(params);
+      return { updatedCount: 3 };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/notifications/read-all",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(markAllCalls, [{ particularTokenId: 7 }]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      updatedCount: 3,
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin origin confiable", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/notifications/read-all",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin sesión particular", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/notifications/read-all",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Particular no autenticado",
+    });
   } finally {
     await app.close();
   }

--- a/test/report-write-surface-ownership.test.ts
+++ b/test/report-write-surface-ownership.test.ts
@@ -139,6 +139,7 @@ async function createAdminReportUploadApp(overrides: Record<string, unknown> = {
     getStudyTrackingCaseByReportId: async () => null,
     createStudyTrackingCase: async () => ({} as any),
     updateStudyTrackingCase: async () => null,
+    createStudyTrackingNotification: async () => ({} as any),
     createSignedReportUrl: async (storagePath: string) =>
       `signed-preview:${storagePath}`,
     createSignedReportDownloadUrl: async (

--- a/test/security-mutation-permission-surface.test.ts
+++ b/test/security-mutation-permission-surface.test.ts
@@ -7,7 +7,8 @@ type SensitiveMutationRoute = {
   file: string;
   method: "post" | "patch" | "delete";
   path: string;
-  permissionGuard: string;
+  authGuard: string;
+  permissionGuard?: string;
   protectedCalls: readonly string[];
 };
 
@@ -16,6 +17,7 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/reports-status.fastify.ts",
     method: "patch",
     path: "/:reportId/status",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireReportStatusWritePermission",
     protectedCalls: ["deps.updateReportStatus", "deps.writeAuditLog"],
   },
@@ -23,6 +25,7 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/report-access-tokens.fastify.ts",
     method: "post",
     path: "/",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireReportAccessTokenManagementPermission",
     protectedCalls: ["deps.createReportAccessToken", "deps.writeAuditLog"],
   },
@@ -30,6 +33,7 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/report-access-tokens.fastify.ts",
     method: "patch",
     path: "/:tokenId/revoke",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireReportAccessTokenManagementPermission",
     protectedCalls: ["deps.revokeReportAccessToken", "deps.writeAuditLog"],
   },
@@ -37,6 +41,7 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/particular-tokens.fastify.ts",
     method: "post",
     path: "/",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireParticularTokenManagementPermission",
     protectedCalls: ["deps.createParticularToken"],
   },
@@ -44,13 +49,29 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/particular-tokens.fastify.ts",
     method: "patch",
     path: "/:tokenId/report",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireParticularTokenManagementPermission",
     protectedCalls: ["deps.updateParticularTokenReport"],
   },
   {
     file: "server/routes/study-tracking.fastify.ts",
+    method: "patch",
+    path: "/notifications/:notificationId/read",
+    authGuard: "authenticateClinicUser",
+    protectedCalls: ["deps.markStudyTrackingNotificationReadScoped"],
+  },
+  {
+    file: "server/routes/study-tracking.fastify.ts",
+    method: "patch",
+    path: "/notifications/read-all",
+    authGuard: "authenticateClinicUser",
+    protectedCalls: ["deps.markAllStudyTrackingNotificationsReadScoped"],
+  },
+  {
+    file: "server/routes/study-tracking.fastify.ts",
     method: "post",
     path: "/",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireStudyTrackingManagementPermission",
     protectedCalls: [
       "deps.createStudyTrackingCase",
@@ -60,9 +81,24 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     ],
   },
   {
+    file: "server/routes/particular-study-tracking.fastify.ts",
+    method: "patch",
+    path: "/notifications/:notificationId/read",
+    authGuard: "authenticateParticularUser",
+    protectedCalls: ["deps.markStudyTrackingNotificationReadScoped"],
+  },
+  {
+    file: "server/routes/particular-study-tracking.fastify.ts",
+    method: "patch",
+    path: "/notifications/read-all",
+    authGuard: "authenticateParticularUser",
+    protectedCalls: ["deps.markAllStudyTrackingNotificationsReadScoped"],
+  },
+  {
     file: "server/routes/clinic-public-profile.fastify.ts",
     method: "patch",
     path: "/",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireClinicManagementPermission",
     protectedCalls: [
       "deps.patchClinicPublicProfile",
@@ -73,6 +109,7 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/clinic-public-profile.fastify.ts",
     method: "post",
     path: "/avatar",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireClinicManagementPermission",
     protectedCalls: [
       "runAvatarUpload",
@@ -86,6 +123,7 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     file: "server/routes/clinic-public-profile.fastify.ts",
     method: "delete",
     path: "/avatar",
+    authGuard: "authenticateClinicUser",
     permissionGuard: "requireClinicManagementPermission",
     protectedCalls: [
       "deps.removeClinicPublicAvatar",
@@ -208,13 +246,19 @@ test("rutas mutantes sensibles validan origin, sesión y permiso antes de operar
     const block = extractRouteBlock(route);
 
     assertContains(block, "enforceTrustedOrigin", context);
-    assertContains(block, "authenticateClinicUser", context);
-    assertContains(block, route.permissionGuard, context);
+    assertContains(block, route.authGuard, context);
+
+    if (route.permissionGuard) {
+      assertContains(block, route.permissionGuard, context);
+    }
 
     for (const protectedCall of route.protectedCalls) {
       assertBefore(block, "enforceTrustedOrigin", protectedCall, context);
-      assertBefore(block, "authenticateClinicUser", protectedCall, context);
-      assertBefore(block, route.permissionGuard, protectedCall, context);
+      assertBefore(block, route.authGuard, protectedCall, context);
+
+      if (route.permissionGuard) {
+        assertBefore(block, route.permissionGuard, protectedCall, context);
+      }
     }
   }
 });
@@ -223,7 +267,7 @@ test("permission helpers devuelven 403 estable antes de mutaciones sensibles", (
   const helpersByFile = new Map<string, string[]>();
 
   for (const route of SENSITIVE_MUTATION_ROUTES) {
-    if (route.permissionGuard === "auth.canUploadReports") {
+    if (!route.permissionGuard || route.permissionGuard === "auth.canUploadReports") {
       continue;
     }
 

--- a/test/study-tracking-suite-completeness.test.ts
+++ b/test/study-tracking-suite-completeness.test.ts
@@ -137,7 +137,7 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
   {
     slug: "particular-study-tracking-read-surface",
     purpose:
-      "Particular study tracking remains a read-only token-scoped surface for tracking detail and notifications using the particular session cookie.",
+      "Particular study tracking keeps token-scoped reads and notification read acknowledgements using the particular session cookie without exposing write operations outside its own scope.",
     testFiles: [
       {
         path: "test/particular-study-tracking.fastify.test.ts",
@@ -145,6 +145,8 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
           "particularStudyTrackingNativeRoutes",
           "getParticularStudyTrackingCase",
           "listStudyTrackingNotifications",
+          "markStudyTrackingNotificationReadScoped",
+          "markAllStudyTrackingNotificationsReadScoped",
           "ENV.particularCookieName",
           "particularTokenId: 7",
         ],
@@ -160,8 +162,12 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
           "app.get(\"/me\"",
           "app.get<{",
           "\"/notifications\"",
+          "\"/notifications/:notificationId/read\"",
+          "\"/notifications/read-all\"",
           "getParticularStudyTrackingCase",
           "listStudyTrackingNotifications",
+          "markStudyTrackingNotificationReadScoped",
+          "markAllStudyTrackingNotificationsReadScoped",
           "particularTokenId: particular.tokenId",
           "serializeStudyTrackingCase",
           "serializeStudyTrackingNotification",
@@ -406,18 +412,21 @@ test("study tracking suite remains connected to runtime anchors", () => {
   }
 });
 
-test("study tracking suite keeps particular surface read-only", () => {
+test("study tracking suite keeps particular surface token-scoped sin create/delete", () => {
   const source = readSource("server/routes/particular-study-tracking.fastify.ts");
 
   assert.equal(source.includes("app.post("), false);
-  assert.equal(source.includes("app.patch("), false);
   assert.equal(source.includes("app.delete("), false);
 
   for (const requiredMarker of [
     "app.get(\"/me\"",
     "\"/notifications\"",
+    "\"/notifications/:notificationId/read\"",
+    "\"/notifications/read-all\"",
     "getParticularStudyTrackingCase",
     "listStudyTrackingNotifications",
+    "markStudyTrackingNotificationReadScoped",
+    "markAllStudyTrackingNotificationsReadScoped",
   ]) {
     assertContains(source, requiredMarker, "particular study tracking read surface");
   }

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -142,6 +142,14 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     listStudyTrackingCases: async () => [createTrackingCaseFixture()],
     createStudyTrackingNotification: async () => createNotificationFixture(),
     listStudyTrackingNotifications: async () => [createNotificationFixture()],
+    markStudyTrackingNotificationReadScoped: async () =>
+      createNotificationFixture({
+        isRead: true,
+        readAt: new Date("2026-04-21T12:00:00.000Z"),
+      }),
+    markAllStudyTrackingNotificationsReadScoped: async () => ({
+      updatedCount: 1,
+    }),
     sendSpecialStainRequiredEmail: async () => ({ sent: true }),
     writeAuditLog: async () => {},
     now: () => new Date("2026-04-24T00:00:00.000Z").getTime(),
@@ -221,6 +229,153 @@ test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async 
     assert.equal(body.notifications[0].type, "stage_changed");
     assert.equal(body.pagination.limit, 5);
     assert.equal(body.pagination.offset, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes expone PATCH /notifications/:notificationId/read clinic-scoped", async () => {
+  const markCalls: Array<Record<string, unknown>> = [];
+  const readAt = new Date("2026-04-21T12:00:00.000Z");
+  const app = await createTestApp({
+    markStudyTrackingNotificationReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markCalls.push(params);
+      return createNotificationFixture({
+        id: params.id,
+        isRead: true,
+        readAt,
+      });
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/study-tracking/notifications/21/read",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(markCalls, [{ id: 21, clinicId: 3 }]);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.success, true);
+    assert.equal(body.notification.id, 21);
+    assert.equal(body.notification.isRead, true);
+    assert.equal(body.notification.readAt, readAt.toISOString());
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes responde 404 genérico en PATCH /notifications/:notificationId/read cross-clinic", async () => {
+  const markCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    markStudyTrackingNotificationReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markCalls.push(params);
+      return null;
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/study-tracking/notifications/999/read",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(markCalls, [{ id: 999, clinicId: 3 }]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Notificación no encontrada",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes expone PATCH /notifications/read-all clinic-scoped", async () => {
+  const markAllCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    markAllStudyTrackingNotificationsReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markAllCalls.push(params);
+      return { updatedCount: 4 };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/study-tracking/notifications/read-all",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(markAllCalls, [{ clinicId: 3 }]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      updatedCount: 4,
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin origin confiable", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/study-tracking/notifications/read-all",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin sesión", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/study-tracking/notifications/read-all",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autenticado",
+    });
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Resumen
- Convierte la campana de notificaciones en un centro global reutilizable por surface: admin, clínica y particular.
- Mantiene aislamiento por rol: admin global, clínica por clinicId, particular por particularTokenId.
- Agrega PATCH read/read-all para notificaciones de clínica y particular con ownership scoped.
- Agrega evento report_delivered cuando un informe pasa efectivamente a entregado.
- Evita duplicados de report_delivered si el tracking ya estaba delivered.
- Mantiene compatibilidad con endpoints admin existentes.
- Integra campana en dashboards clínica/logística y en la superficie particular.

## Seguridad
- No hay fuga cross-clinic.
- No hay fuga cross-token.
- PATCH de lectura requiere autenticación y trusted origin.
- No se expone token completo en notificaciones.
- Las mutaciones scoped filtran en DB y devuelven 404 genérico si no hay ownership.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Resultado
- pnpm test OK: 2062 pass, 0 fail, 1 skipped
- pnpm build OK
- dist/index.js generado correctamente

## Eventos de notificación
- token_created
- stage_changed
- special_stain_required
- special_stain_resolved
- report_delivered