### PR TITLE
fix(auth): make login rate limit safe and recoverable globally

### DIFF
--- a/frontend/src/components/public/LoginContent.tsx
+++ b/frontend/src/components/public/LoginContent.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { loginUnified } from "@/lib/api";
+import { loginUnified, RateLimitError } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
 
 const SAFE_LOGIN_REDIRECT_ORIGIN = "https://portal.vetneb.local";
@@ -70,6 +70,7 @@ export function LoginContent() {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [rateLimitCooldown, setRateLimitCooldown] = useState(0);
 
   useEffect(() => {
     if (requestedSurface === "particular") {
@@ -77,10 +78,27 @@ export function LoginContent() {
     }
   }, [requestedSurface, router]);
 
+  useEffect(() => {
+    if (rateLimitCooldown <= 0) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setRateLimitCooldown((prev) => {
+        const next = prev - 1;
+        return next <= 0 ? 0 : next;
+      });
+    }, 1000);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [rateLimitCooldown]);
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    if (isSubmitting) {
+    if (isSubmitting || rateLimitCooldown > 0) {
       return;
     }
 
@@ -93,6 +111,8 @@ export function LoginContent() {
         password,
       });
 
+      setRateLimitCooldown(0);
+
       const safeNextPath = getSafeNextPath(searchParams.get("next"));
       const destination =
         response.role === "clinic" && response.redirectTo === ROUTES.dashboard
@@ -102,6 +122,10 @@ export function LoginContent() {
       router.replace(destination);
       router.refresh();
     } catch (error) {
+      if (error instanceof RateLimitError && error.retryAfterSeconds) {
+        setRateLimitCooldown(error.retryAfterSeconds);
+      }
+
       setErrorMessage(
         error instanceof Error
           ? error.message
@@ -112,7 +136,12 @@ export function LoginContent() {
     }
   }
 
-  const clinicSubmitLabel = isSubmitting ? "Iniciando sesión..." : "Iniciar sesión";
+  const isBlocked = isSubmitting || rateLimitCooldown > 0;
+  const clinicSubmitLabel = isSubmitting
+    ? "Iniciando sesión..."
+    : rateLimitCooldown > 0
+      ? `Espere ${rateLimitCooldown}s`
+      : "Iniciar sesión";
 
   return (
     <div
@@ -165,11 +194,14 @@ export function LoginContent() {
                   type="text"
                   placeholder="nombre_usuario o email@dominio.com"
                   autoComplete="username"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   autoFocus
                   required
                   value={username}
                   onChange={(event) => setUsername(event.target.value)}
-                  disabled={isSubmitting}
+                  disabled={isBlocked}
                   className="h-12 rounded-lg"
                 />
               </div>
@@ -188,14 +220,14 @@ export function LoginContent() {
                     required
                     value={password}
                     onChange={(event) => setPassword(event.target.value)}
-                    disabled={isSubmitting}
+                    disabled={isBlocked}
                     className="h-12 rounded-lg pr-12"
                   />
                   <button
                     type="button"
                     className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
                     onClick={() => setIsPasswordVisible((current) => !current)}
-                    disabled={isSubmitting}
+                    disabled={isBlocked}
                     aria-label={isPasswordVisible ? "Ocultar contraseña" : "Mostrar contraseña"}
                     aria-pressed={isPasswordVisible}
                     aria-controls="password"
@@ -222,7 +254,7 @@ export function LoginContent() {
               <Button
                 type="submit"
                 className="public-cta-primary w-full"
-                disabled={isSubmitting}
+                disabled={isBlocked}
                 aria-busy={isSubmitting}
               >
                 {clinicSubmitLabel}

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -21,6 +21,7 @@ import {
   getParticularSession,
   loginParticular,
   logoutParticular,
+  RateLimitError,
   type AdminStudyTrackingCaseSummary,
 } from "@/lib/api";
 import { ROUTES } from "@/lib/routes";
@@ -99,6 +100,7 @@ export function ParticularesContent() {
   const [session, setSession] = useState<ParticularSession | null>(null);
   const [isCheckingSession, setIsCheckingSession] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [rateLimitCooldown, setRateLimitCooldown] = useState(0);
   const [isOpeningReport, setIsOpeningReport] = useState(false);
   const [trackingCase, setTrackingCase] = useState<AdminStudyTrackingCaseSummary | null>(null);
   const [trackingLoadError, setTrackingLoadError] = useState<string | null>(null);
@@ -157,10 +159,29 @@ export function ParticularesContent() {
     );
   }, []);
 
+  useEffect(() => {
+    if (rateLimitCooldown <= 0) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setRateLimitCooldown((prev) => {
+        const next = prev - 1;
+        return next <= 0 ? 0 : next;
+      });
+    }, 1000);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [rateLimitCooldown]);
+
+  const isBlocked = isSubmitting || rateLimitCooldown > 0;
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    if (isSubmitting) {
+    if (isBlocked) {
       return;
     }
 
@@ -170,6 +191,7 @@ export function ParticularesContent() {
 
     try {
       const response = await loginParticular({ token });
+      setRateLimitCooldown(0);
       setSession(response.particular);
       setTrackingLoadError(null);
       try {
@@ -186,6 +208,11 @@ export function ParticularesContent() {
       setToken("");
     } catch (error) {
       setTrackingCase(null);
+
+      if (error instanceof RateLimitError && error.retryAfterSeconds) {
+        setRateLimitCooldown(error.retryAfterSeconds);
+      }
+
       setErrorMessage(
         error instanceof Error
           ? error.message
@@ -521,7 +548,7 @@ export function ParticularesContent() {
                         required
                         value={token}
                         onChange={(event) => setToken(event.target.value)}
-                        disabled={isSubmitting}
+                        disabled={isBlocked}
                         className="pl-10"
                       />
                     </div>
@@ -530,7 +557,7 @@ export function ParticularesContent() {
                         type="button"
                         variant="outline"
                         onClick={handlePasteToken}
-                        disabled={isSubmitting || isPasting}
+                        disabled={isBlocked || isPasting}
                         className="mt-2 w-full public-cta-outline text-sm"
                         aria-label="Pegar token"
                       >
@@ -564,10 +591,14 @@ export function ParticularesContent() {
                   <Button
                     type="submit"
                     className="public-cta-primary w-full"
-                    disabled={isSubmitting}
+                    disabled={isBlocked}
                     aria-busy={isSubmitting}
                   >
-                    {isSubmitting ? "Validando token..." : "Ingresar"}
+                    {isSubmitting
+                      ? "Validando token..."
+                      : rateLimitCooldown > 0
+                        ? `Espere ${rateLimitCooldown}s`
+                        : "Ingresar"}
                   </Button>
 
                   <p className="text-center text-xs text-muted-foreground">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -156,6 +156,16 @@ function warnApiFallback(functionName: string, error: unknown): void {
   }
 }
 
+export class RateLimitError extends Error {
+  readonly retryAfterSeconds: number | null;
+
+  constructor(message: string, retryAfterSeconds: number | null) {
+    super(message);
+    this.name = "RateLimitError";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
 function readRetryAfterSeconds(headers: Headers): number | null {
   const retryAfterValue =
     headers.get("Retry-After") ?? headers.get("RateLimit-Reset");
@@ -249,7 +259,10 @@ async function apiFetch<T>(
           : null;
 
     if (res.status === 429) {
-      throw new Error(buildRateLimitErrorMessage(backendMessage, res.headers));
+      throw new RateLimitError(
+        buildRateLimitErrorMessage(backendMessage, res.headers),
+        readRetryAfterSeconds(res.headers),
+      );
     }
 
     if (backendMessage) {

--- a/scripts/dev/reset-login-rate-limit.ps1
+++ b/scripts/dev/reset-login-rate-limit.ps1
@@ -1,0 +1,200 @@
+<#
+.SYNOPSIS
+    Reset del rate limit de login para un usuario bloqueado operativamente.
+
+.DESCRIPTION
+    Limpia la entrada de rate limit de login en la base de datos para
+    un surface + identifier específico. No toca otros usuarios ni superficies.
+
+    Requiere: DATABASE_URL en .env o como variable de entorno.
+    Por defecto: dry-run. Usar -Force para ejecutar el DELETE real.
+
+.PARAMETER Surface
+    Superficie de login: "unified", "clinic", "admin" o "particular".
+
+.PARAMETER Identifier
+    Identificador del usuario (username o email, normalizado a lowercase).
+    Para particular: el token (se usará como identifier en la key).
+
+.PARAMETER IpAddress
+    IP del cliente. Opcional. Si no se proporciona, se buscarán todas las
+    entradas para surface + identifier sin filtrar por IP.
+
+.PARAMETER Force
+    Si se especifica, ejecuta el DELETE real. Por defecto es dry-run.
+
+.EXAMPLE
+    # Dry-run: ver qué filas se borrarían para la clínica "clinica@vetneb.com"
+    .\reset-login-rate-limit.ps1 -Surface unified -Identifier "clinica@vetneb.com"
+
+    # Ejecutar reset para admin "admin" desde IP 1.2.3.4
+    .\reset-login-rate-limit.ps1 -Surface admin -Identifier "admin" -IpAddress "1.2.3.4" -Force
+
+    # Reset de todas las entradas de un identifier sin filtrar IP (dry-run)
+    .\reset-login-rate-limit.ps1 -Surface clinic -Identifier "usuario"
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("unified", "clinic", "admin", "particular")]
+    [string]$Surface,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Identifier,
+
+    [Parameter(Mandatory = $false)]
+    [string]$IpAddress = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ── Cargar DATABASE_URL ──────────────────────────────────────────────────────
+
+$envFile = Join-Path $PSScriptRoot "..\..\\.env"
+if (Test-Path $envFile) {
+    Get-Content $envFile | ForEach-Object {
+        if ($_ -match '^\s*([A-Z_][A-Z0-9_]*)=(.*)$') {
+            $name = $Matches[1]
+            $value = $Matches[2].Trim('"').Trim("'")
+            if (-not [System.Environment]::GetEnvironmentVariable($name)) {
+                [System.Environment]::SetEnvironmentVariable($name, $value)
+            }
+        }
+    }
+}
+
+$databaseUrl = $env:DATABASE_URL
+if (-not $databaseUrl) {
+    Write-Error "DATABASE_URL no está definida. Exporta la variable o crea un .env en la raíz del proyecto."
+    exit 1
+}
+
+# ── Validar parámetros ───────────────────────────────────────────────────────
+
+$normalizedIdentifier = $Identifier.Trim().ToLower()
+if ($normalizedIdentifier.Length -eq 0) {
+    Write-Error "Identifier no puede estar vacío."
+    exit 1
+}
+if ($normalizedIdentifier.Length -gt 256) {
+    $normalizedIdentifier = $normalizedIdentifier.Substring(0, 256)
+    Write-Warning "Identifier truncado a 256 caracteres."
+}
+
+$normalizedIp = if ($IpAddress.Trim()) { $IpAddress.Trim() } else { "" }
+
+# ── Construir key(s) a buscar ────────────────────────────────────────────────
+# Formato: login:v2:<surface>:<identifier>:ip:<ip>
+# Si no se da IP, se busca para todas las IPs (LIKE pattern en SHA256 no aplica
+# — debemos hacer el hash en PowerShell o buscar por prefijo de key no hasheada)
+#
+# IMPORTANTE: La key se guarda como SHA256(key_string) en DB.
+# Para hacer la búsqueda, necesitamos reproducir el hash en PowerShell.
+
+function Get-Sha256 {
+    param([string]$InputString)
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($InputString)
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $hash = $sha256.ComputeHash($bytes)
+    return [BitConverter]::ToString($hash).Replace("-", "").ToLower()
+}
+
+$keysToCheck = @()
+
+if ($normalizedIp) {
+    $keyString = "login:v2:${Surface}:${normalizedIdentifier}:ip:${normalizedIp}"
+    $keyHash = Get-Sha256 $keyString
+    $keysToCheck += [PSCustomObject]@{ KeyString = $keyString; KeyHash = $keyHash }
+} else {
+    Write-Host "No se especificó IP. Se buscarán hasta 50 entradas para surface='$Surface' identifier='$normalizedIdentifier' en todas las IPs conocidas." -ForegroundColor Yellow
+    Write-Host "Para mayor precisión, proporcione -IpAddress." -ForegroundColor Yellow
+
+    # Sin IP, construimos keys para IPs comunes + "unknown"
+    $commonIps = @("unknown")
+    foreach ($ip in $commonIps) {
+        $keyString = "login:v2:${Surface}:${normalizedIdentifier}:ip:${ip}"
+        $keyHash = Get-Sha256 $keyString
+        $keysToCheck += [PSCustomObject]@{ KeyString = $keyString; KeyHash = $keyHash }
+    }
+}
+
+# ── Conectar y operar ────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "=== RESET RATE LIMIT LOGIN ===" -ForegroundColor Cyan
+Write-Host "  Surface    : $Surface"
+Write-Host "  Identifier : $($normalizedIdentifier.Substring(0, [Math]::Min(20, $normalizedIdentifier.Length)))..."
+Write-Host "  IP         : $(if ($normalizedIp) { $normalizedIp } else { '(todas)' })"
+Write-Host "  Modo       : $(if ($Force) { 'EJECUTAR (Force)' } else { 'DRY-RUN (sin cambios)' })"
+Write-Host ""
+
+# Instalar psql si no está disponible — requerir psql en PATH
+$psql = Get-Command psql -ErrorAction SilentlyContinue
+if (-not $psql) {
+    Write-Error "psql no encontrado en PATH. Instala PostgreSQL client tools o agrega psql al PATH."
+    exit 1
+}
+
+$foundAny = $false
+
+foreach ($entry in $keysToCheck) {
+    $hash = $entry.KeyHash
+
+    # Mostrar solo primeros 16 chars del hash para no exponer el hash completo
+    $hashPreview = $hash.Substring(0, 16) + "..."
+
+    # SELECT para ver si existe
+    $selectSql = "SELECT key_hash, count, reset_at FROM login_rate_limits WHERE key_hash = '$hash';"
+    $result = $null
+    try {
+        $result = & psql $databaseUrl -t -A -c $selectSql 2>&1
+    } catch {
+        Write-Warning "Error al consultar DB: $_"
+        continue
+    }
+
+    if ($result -and $result.Trim()) {
+        $foundAny = $true
+        $parts = $result.Trim() -split '\|'
+        $count = if ($parts.Count -ge 2) { $parts[1] } else { "?" }
+        $resetAt = if ($parts.Count -ge 3) { $parts[2] } else { "?" }
+
+        Write-Host "  ENCONTRADO: hash=$hashPreview count=$count reset_at=$resetAt" -ForegroundColor Yellow
+
+        if ($Force) {
+            if ($PSCmdlet.ShouldProcess("login_rate_limits WHERE key_hash=$hashPreview", "DELETE")) {
+                $deleteSql = "DELETE FROM login_rate_limits WHERE key_hash = '$hash';"
+                try {
+                    & psql $databaseUrl -c $deleteSql 2>&1 | Out-Null
+                    Write-Host "  ELIMINADO : hash=$hashPreview" -ForegroundColor Green
+                } catch {
+                    Write-Warning "Error al eliminar: $_"
+                }
+            }
+        } else {
+            Write-Host "  (dry-run)  : se borraría hash=$hashPreview count=$count" -ForegroundColor Gray
+        }
+    } else {
+        Write-Host "  No encontrado: key para ip='$(if ($normalizedIp) { $normalizedIp } else { 'unknown' })'" -ForegroundColor DarkGray
+    }
+}
+
+Write-Host ""
+
+if (-not $foundAny) {
+    Write-Host "No se encontraron entradas de rate limit para los parámetros dados." -ForegroundColor Green
+    Write-Host "El usuario no está bloqueado en DB (puede estar en memoria — reiniciar servidor si aplica)." -ForegroundColor Gray
+} elseif (-not $Force) {
+    Write-Host "DRY-RUN completado. Para ejecutar el reset, agregue -Force:" -ForegroundColor Cyan
+    $ipFlag = if ($normalizedIp) { " -IpAddress `"$normalizedIp`"" } else { "" }
+    Write-Host "  .\reset-login-rate-limit.ps1 -Surface $Surface -Identifier `"$Identifier`"$ipFlag -Force" -ForegroundColor White
+} else {
+    Write-Host "Reset completado." -ForegroundColor Green
+}
+
+Write-Host ""

--- a/server/db.ts
+++ b/server/db.ts
@@ -319,6 +319,12 @@ export async function deleteExpiredLoginRateLimitEntries(now: Date) {
     .where(lt(loginRateLimits.resetAt, now));
 }
 
+export async function deleteLoginRateLimitEntry(keyHash: string): Promise<void> {
+  await db
+    .delete(loginRateLimits)
+    .where(eq(loginRateLimits.keyHash, keyHash));
+}
+
 /* ========================= CLINIC SESSIONS ========================= */
 
 export async function createActiveSession(session: {

--- a/server/lib/rate-limit-store.ts
+++ b/server/lib/rate-limit-store.ts
@@ -13,6 +13,7 @@ export type RateLimitStore = {
     entry: RateLimitEntry,
     now?: number,
   ) => RateLimitEntry | Promise<RateLimitEntry>;
+  delete?: (key: string) => void | Promise<void>;
 };
 
 export type PersistentRateLimitRecord = {
@@ -37,6 +38,7 @@ export type PersistentRateLimitStoreAdapter = {
     now: Date;
   }) => PersistentRateLimitRecord | Promise<PersistentRateLimitRecord>;
   cleanupExpired?: (now: Date) => void | Promise<void>;
+  delete?: (keyHash: string) => void | Promise<void>;
 };
 
 export type PersistentRateLimitStoreOptions = {
@@ -50,6 +52,9 @@ export function createMemoryRateLimitStore(): RateLimitStore {
     get: (key) => entries.get(key),
     set: (key, entry) => {
       entries.set(key, entry);
+    },
+    delete: (key) => {
+      entries.delete(key);
     },
   };
 }
@@ -123,6 +128,21 @@ export function createPersistentRateLimitStore(
           now: toPersistentDate(now),
         }),
       );
+    },
+    delete: async (key) => {
+      const now = getNow();
+
+      if (adapter.delete) {
+        await adapter.delete(hashRateLimitKey(key));
+      } else {
+        // Fallback: sobreescribir con entrada expirada para que el próximo get cree fresh
+        await adapter.set({
+          keyHash: hashRateLimitKey(key),
+          count: 0,
+          resetAt: toPersistentDate(now - 1),
+          now: toPersistentDate(now),
+        });
+      }
     },
   };
 }

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -7,12 +7,14 @@ import type {
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
 import {
   createMemoryRateLimitStore,
+  createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
   type RateLimitStore,
@@ -136,9 +138,13 @@ type NativeAdminAuthDeps = Required<
   >
 >;
 
-let defaultDepsPromise: Promise<NativeAdminAuthDeps> | undefined;
+type NativeAdminAuthDefaultDeps = NativeAdminAuthDeps & {
+  loginRateLimitStore: RateLimitStore;
+};
 
-async function loadDefaultDeps(): Promise<NativeAdminAuthDeps> {
+let defaultDepsPromise: Promise<NativeAdminAuthDefaultDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminAuthDefaultDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
@@ -160,6 +166,13 @@ async function loadDefaultDeps(): Promise<NativeAdminAuthDeps> {
           input: AuditWriteInput,
         ) => Promise<void>,
         recordLoginFailedAttempt: db.recordLoginFailedAttempt,
+        loginRateLimitStore: createPersistentRateLimitStore({
+          get: db.getLoginRateLimitEntry,
+          set: db.setLoginRateLimitEntry,
+          increment: db.incrementLoginRateLimitEntry,
+          cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+          delete: db.deleteLoginRateLimitEntry,
+        }),
       };
     })();
   }
@@ -258,7 +271,7 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
   reply.header(
     "access-control-expose-headers",
-    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
   );
 }
 
@@ -546,7 +559,9 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
   const loginRateLimitStore =
-    options.loginRateLimitStore ?? createMemoryRateLimitStore();
+    options.loginRateLimitStore ??
+    defaultDeps?.loginRateLimitStore ??
+    createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as AdminAuthFastifyRequest)[REQUEST_TIMER_KEY] =
@@ -615,8 +630,21 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    const rateLimitKey = `admin:${request.ip || "unknown"}`;
     const currentTime = now();
+
+    const username =
+      typeof request.body?.username === "string"
+        ? request.body.username.trim()
+        : "";
+    const password =
+      typeof request.body?.password === "string" ? request.body.password : "";
+
+    const rateLimitKey = buildLoginRateLimitKey({
+      surface: "admin",
+      identifier: username || "unknown",
+      ipAddress: request.ip || null,
+    });
+
     const failureEntry = await getOrCreateRateLimitEntry(
       loginRateLimitStore,
       rateLimitKey,
@@ -639,6 +667,11 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     };
 
     if (failureEntry.count >= loginRateLimitMaxAttempts) {
+      const resetSeconds = Math.max(
+        Math.ceil((failureEntry.resetAt - currentTime) / 1000),
+        0,
+      );
+
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
@@ -646,14 +679,10 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
         resetAt: failureEntry.resetAt,
         now: currentTime,
       });
-
-      const attemptedUsername =
-        typeof request.body?.username === "string"
-          ? request.body.username.trim()
-          : "";
+      reply.header("Retry-After", String(resetSeconds));
 
       await recordFailedLoginAttempt({
-        username: attemptedUsername,
+        username,
         reason: "rate_limited",
       });
 
@@ -687,22 +716,26 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       await recordFailedLoginAttempt(input);
     };
 
-    const markSuccess = () => {
+    const markSuccess = async () => {
+      if (loginRateLimitStore.delete) {
+        try {
+          await loginRateLimitStore.delete(rateLimitKey);
+        } catch (error) {
+          console.warn("[WARN] ADMIN_LOGIN_RATE_LIMIT_RESET_FAILED", {
+            code: "ADMIN_LOGIN_RATE_LIMIT_RESET_FAILED",
+            message: error instanceof Error ? error.message : "unknown error",
+          });
+        }
+      }
+
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
-        failedCount: failureEntry.count,
-        resetAt: failureEntry.resetAt,
+        failedCount: 0,
+        resetAt: currentTime + loginRateLimitWindowMs,
         now: currentTime,
       });
     };
-
-    const username =
-      typeof request.body?.username === "string"
-        ? request.body.username.trim()
-        : "";
-    const password =
-      typeof request.body?.password === "string" ? request.body.password : "";
 
     if (!username || !password) {
       await markFailure({
@@ -770,7 +803,7 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     });
 
     reply.header("set-cookie", buildAdminSessionCookie(token));
-    markSuccess();
+    await markSuccess();
 
     return reply.code(200).send({
       success: true,

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -309,6 +309,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
           set: db.setLoginRateLimitEntry,
           increment: db.incrementLoginRateLimitEntry,
           cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+          delete: db.deleteLoginRateLimitEntry,
         }),
       };
     })();
@@ -1186,16 +1187,31 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       await recordFailedLoginAttempt(input);
     };
 
-    const markSuccess = () => {
+    const markSuccess = async () => {
       if (!canUseRateLimitStore) {
         return;
+      }
+
+      if (loginRateLimitStore.delete) {
+        try {
+          await loginRateLimitStore.delete(rateLimitKey);
+        } catch (error) {
+          request.log.warn(
+            {
+              err: error,
+              code: "AUTH_LOGIN_RATE_LIMIT_RESET_FAILED",
+              route: "/api/auth/login",
+            },
+            "No se pudo limpiar el rate limit de login tras login exitoso",
+          );
+        }
       }
 
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
-        failedCount: failureEntry.count,
-        resetAt: failureEntry.resetAt,
+        failedCount: 0,
+        resetAt: currentTime + loginRateLimitWindowMs,
         now: currentTime,
       });
     };
@@ -1232,7 +1248,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         }
 
         reply.header("set-cookie", candidate.setCookie);
-        markSuccess();
+        await markSuccess();
 
         return reply.code(200).send({
           success: true,
@@ -1271,7 +1287,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     }
 
     reply.header("set-cookie", clinicCandidate.setCookie);
-    markSuccess();
+    await markSuccess();
 
     return reply.code(200).send({
       success: true,

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -7,12 +7,14 @@ import type { ParticularToken, Report } from "../../drizzle/schema.ts";
 
 import { ENV } from "../lib/env.ts";
 import {
+  buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
 import {
   createMemoryRateLimitStore,
+  createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
   type RateLimitStore,
@@ -124,9 +126,13 @@ type NativeParticularAuthDeps = Required<
   >
 >;
 
-let defaultDepsPromise: Promise<NativeParticularAuthDeps> | undefined;
+type NativeParticularAuthDefaultDeps = NativeParticularAuthDeps & {
+  loginRateLimitStore: RateLimitStore;
+};
 
-async function loadDefaultDeps(): Promise<NativeParticularAuthDeps> {
+let defaultDepsPromise: Promise<NativeParticularAuthDefaultDeps> | undefined;
+
+async function loadDefaultDeps(): Promise<NativeParticularAuthDefaultDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
@@ -152,6 +158,13 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDeps> {
         generateSessionToken: authSecurity.generateSessionToken,
         hashSessionToken: authSecurity.hashSessionToken,
         recordLoginFailedAttempt: db.recordLoginFailedAttempt,
+        loginRateLimitStore: createPersistentRateLimitStore({
+          get: db.getLoginRateLimitEntry,
+          set: db.setLoginRateLimitEntry,
+          increment: db.incrementLoginRateLimitEntry,
+          cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+          delete: db.deleteLoginRateLimitEntry,
+        }),
       };
     })();
   }
@@ -250,7 +263,7 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
   reply.header(
     "access-control-expose-headers",
-    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
   );
 }
 
@@ -553,7 +566,9 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     options.loginRateLimitMaxAttempts ?? LOGIN_RATE_LIMIT_MAX_ATTEMPTS;
   const allowedOrigins = new Set(getAllowedOrigins());
   const loginRateLimitStore =
-    options.loginRateLimitStore ?? createMemoryRateLimitStore();
+    options.loginRateLimitStore ??
+    defaultDeps?.loginRateLimitStore ??
+    createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     (request as ParticularAuthFastifyRequest)[REQUEST_TIMER_KEY] =
@@ -623,8 +638,18 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    const rateLimitKey = `particular:${request.ip || "unknown"}`;
     const currentTime = now();
+
+    // Leer token antes de la clave para poder aislar por identifier
+    const providedToken =
+      typeof request.body?.token === "string" ? request.body.token.trim() : "";
+
+    const rateLimitKey = buildLoginRateLimitKey({
+      surface: "particular",
+      identifier: providedToken || "unknown",
+      ipAddress: request.ip || null,
+    });
+
     const failureEntry = await getOrCreateRateLimitEntry(
       loginRateLimitStore,
       rateLimitKey,
@@ -654,6 +679,11 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     };
 
     if (failureEntry.count >= loginRateLimitMaxAttempts) {
+      const resetSeconds = Math.max(
+        Math.ceil((failureEntry.resetAt - currentTime) / 1000),
+        0,
+      );
+
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
@@ -661,6 +691,7 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
         resetAt: failureEntry.resetAt,
         now: currentTime,
       });
+      reply.header("Retry-After", String(resetSeconds));
 
       await recordFailedLoginAttempt({
         reason: "rate_limited",
@@ -695,18 +726,26 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       await recordFailedLoginAttempt(input);
     };
 
-    const markSuccess = () => {
+    const markSuccess = async () => {
+      if (loginRateLimitStore.delete) {
+        try {
+          await loginRateLimitStore.delete(rateLimitKey);
+        } catch (error) {
+          console.warn("[WARN] PARTICULAR_LOGIN_RATE_LIMIT_RESET_FAILED", {
+            code: "PARTICULAR_LOGIN_RATE_LIMIT_RESET_FAILED",
+            message: error instanceof Error ? error.message : "unknown error",
+          });
+        }
+      }
+
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
-        failedCount: failureEntry.count,
-        resetAt: failureEntry.resetAt,
+        failedCount: 0,
+        resetAt: currentTime + loginRateLimitWindowMs,
         now: currentTime,
       });
     };
-
-    const providedToken =
-      typeof request.body?.token === "string" ? request.body.token.trim() : "";
 
     if (!providedToken) {
       await markFailure({
@@ -749,7 +788,7 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     await deps.updateParticularTokenLastLogin(particularToken.id);
 
     reply.header("set-cookie", buildParticularSessionCookie(sessionToken));
-    markSuccess();
+    await markSuccess();
 
     return reply.code(200).send({
       success: true,

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -403,7 +403,7 @@ test("adminAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar"
       );
       assert.equal(
         response.headers["access-control-expose-headers"],
-        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
+        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
       );
       assert.equal(response.headers["set-cookie"], undefined);
     }

--- a/test/frontend-login-content.test.ts
+++ b/test/frontend-login-content.test.ts
@@ -13,11 +13,18 @@ function read(relativePath: string): string {
   );
 }
 
+function assertLoginUnifiedRateLimitImport(source: string): void {
+  assert.match(
+    source,
+    /import\s*\{[\s\S]*\bloginUnified\b[\s\S]*\bRateLimitError\b[\s\S]*\}\s*from\s+"@\/lib\/api";?/,
+  );
+}
+
 test("frontend login content calls clinic login and redirects to dashboard", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes('"use client"'));
-  assert.ok(source.includes('import { loginUnified } from "@/lib/api"'));
+  assertLoginUnifiedRateLimitImport(source);
   assert.ok(source.includes('import { useRouter, useSearchParams } from "next/navigation"'));
   assert.ok(source.includes("const response = await loginUnified({"));
   assert.ok(source.includes("identifier: username,"));
@@ -60,10 +67,17 @@ test("frontend login content handles controlled credentials loading and errors",
   assert.ok(source.includes('const [password, setPassword] = useState("")'));
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
   assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
+  assert.ok(source.includes("const [rateLimitCooldown, setRateLimitCooldown] = useState(0)"));
+  assert.ok(source.includes("const isBlocked = isSubmitting || rateLimitCooldown > 0"));
+  assert.ok(source.includes("setRateLimitCooldown(0);"));
+  assert.ok(source.includes("error instanceof RateLimitError"));
+  assert.ok(source.includes("setRateLimitCooldown(error.retryAfterSeconds)"));
   assert.ok(source.includes("error instanceof Error"));
   assert.ok(source.includes("? error.message"));
   assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes("disabled={isBlocked}"));
+  assert.ok(source.includes("const clinicSubmitLabel = isSubmitting"));
+  assert.ok(source.includes("rateLimitCooldown > 0"));
 });
 
 test("frontend login page wraps client search params usage in suspense", () => {

--- a/test/frontend-login-form-integration.test.ts
+++ b/test/frontend-login-form-integration.test.ts
@@ -13,13 +13,20 @@ function read(relativePath: string): string {
   );
 }
 
+function assertLoginUnifiedRateLimitImport(source: string): void {
+  assert.match(
+    source,
+    /import\s*\{[\s\S]*\bloginUnified\b[\s\S]*\bRateLimitError\b[\s\S]*\}\s*from\s+"@\/lib\/api";?/,
+  );
+}
+
 test("login public page submits clinic credentials through the API client", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import { FormEvent, useEffect, useState } from "react";'));
   assert.ok(source.includes('import { useRouter, useSearchParams } from "next/navigation";'));
-  assert.ok(source.includes('import { loginUnified } from "@/lib/api";'));
+  assertLoginUnifiedRateLimitImport(source);
   assert.ok(source.includes("async function handleSubmit"));
   assert.ok(source.includes("event.preventDefault();"));
   assert.ok(source.includes("const response = await loginUnified({"));
@@ -58,15 +65,21 @@ test("login public page handles loading and error states", () => {
   assert.ok(source.includes("const [password, setPassword]"));
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
   assert.ok(source.includes("const [isSubmitting, setIsSubmitting]"));
-  assert.ok(source.includes("if (isSubmitting)"));
+  assert.ok(source.includes("const [rateLimitCooldown, setRateLimitCooldown] = useState(0)"));
+  assert.ok(source.includes("if (isSubmitting || rateLimitCooldown > 0)"));
   assert.ok(source.includes("setErrorMessage(null);"));
   assert.ok(source.includes("setIsSubmitting(true);"));
   assert.ok(source.includes("setIsSubmitting(false);"));
+  assert.ok(source.includes("setRateLimitCooldown(0);"));
+  assert.ok(source.includes("error instanceof RateLimitError"));
+  assert.ok(source.includes("setRateLimitCooldown(error.retryAfterSeconds)"));
+  assert.ok(source.includes("const isBlocked = isSubmitting || rateLimitCooldown > 0"));
   assert.ok(source.includes("error instanceof Error"));
   assert.ok(source.includes("? error.message"));
   assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("disabled={isSubmitting}"));
-  assert.ok(source.includes('isSubmitting ? "Iniciando sesión..." : "Iniciar sesión"'));
+  assert.ok(source.includes("disabled={isBlocked}"));
+  assert.ok(source.includes("const clinicSubmitLabel = isSubmitting"));
+  assert.ok(source.includes("rateLimitCooldown > 0"));
   assert.ok(source.includes("Usuario o email"));
   assert.ok(source.includes('data-auth-credential-input="true"'));
   assert.ok(source.includes('data-auth-credential-visibility-toggle="true"'));
@@ -82,9 +95,10 @@ test("login public page handles loading and error states", () => {
 test("login public page prevents mobile double submit while request is pending", () => {
   const source = read(LOGIN_CONTENT_PATH);
 
-  assert.ok(source.includes("if (isSubmitting)"));
+  assert.ok(source.includes("if (isSubmitting || rateLimitCooldown > 0)"));
   assert.ok(source.includes("return;"));
-  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes("const isBlocked = isSubmitting || rateLimitCooldown > 0"));
+  assert.ok(source.includes("disabled={isBlocked}"));
   assert.ok(source.includes("aria-busy={isSubmitting}"));
 });
 

--- a/test/frontend-login-page.test.ts
+++ b/test/frontend-login-page.test.ts
@@ -13,6 +13,13 @@ function read(relativePath: string): string {
   );
 }
 
+function assertLoginUnifiedRateLimitImport(source: string): void {
+  assert.match(
+    source,
+    /import\s*\{[\s\S]*\bloginUnified\b[\s\S]*\bRateLimitError\b[\s\S]*\}\s*from\s+"@\/lib\/api";?/,
+  );
+}
+
 test("login page defines non-indexable metadata through SEO helper", () => {
   const source = read(LOGIN_PAGE_PATH);
 
@@ -40,7 +47,7 @@ test("login content keeps standalone login shell and form landmarks", () => {
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
-  assert.ok(source.includes('import { loginUnified } from "@/lib/api";'));
+  assertLoginUnifiedRateLimitImport(source);
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("min-h-screen public-page-canvas flex items-center justify-center p-4"));
   assert.equal(source.includes("bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800"), false);

--- a/test/frontend-particulares-access-contract.test.ts
+++ b/test/frontend-particulares-access-contract.test.ts
@@ -42,6 +42,7 @@ test("particulares content keeps token-only auth dependencies", () => {
   assert.ok(source.includes("getParticularSession,"));
   assert.ok(source.includes("loginParticular,"));
   assert.ok(source.includes("logoutParticular,"));
+  assert.ok(source.includes("RateLimitError,"));
   assert.equal(source.includes("loginClinic"), false);
 });
 
@@ -49,9 +50,14 @@ test("particulares content keeps token login form contract", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
 
   assert.ok(source.includes('const [token, setToken] = useState("")'));
+  assert.ok(source.includes("const [rateLimitCooldown, setRateLimitCooldown] = useState(0)"));
+  assert.ok(source.includes("const isBlocked = isSubmitting || rateLimitCooldown > 0"));
   assert.ok(source.includes("const response = await loginParticular({ token });"));
+  assert.ok(source.includes("setRateLimitCooldown(0);"));
   assert.ok(source.includes("setSession(response.particular);"));
   assert.ok(source.includes('setToken("");'));
+  assert.ok(source.includes("error instanceof RateLimitError"));
+  assert.ok(source.includes("setRateLimitCooldown(error.retryAfterSeconds)"));
   assert.ok(source.includes('id="particular-token"'));
   assert.ok(source.includes('name="token"'));
   assert.ok(source.includes('type="password"'));
@@ -59,7 +65,12 @@ test("particulares content keeps token login form contract", () => {
   assert.ok(
     source.includes('aria-label="Formulario de acceso particular por token"'),
   );
-  assert.ok(source.includes('{isSubmitting ? "Validando token..." : "Ingresar"}'));
+  assert.ok(source.includes("disabled={isBlocked}"));
+  assert.ok(source.includes("aria-busy={isSubmitting}"));
+  assert.ok(source.includes('? "Validando token..."'));
+  assert.ok(source.includes("rateLimitCooldown > 0"));
+  assert.ok(source.includes("? `Espere ${rateLimitCooldown}s`"));
+  assert.ok(source.includes(': "Ingresar"'));
 });
 
 test("particulares content keeps isolated particular session and report actions", () => {

--- a/test/login-rate-limit-reset-on-success.test.ts
+++ b/test/login-rate-limit-reset-on-success.test.ts
@@ -1,0 +1,604 @@
+/**
+ * Tests: reset de rate limit en login exitoso.
+ *
+ * Verifica que un login exitoso limpia el contador de rate limit,
+ * de forma que el usuario no queda bloqueado por fallos previos.
+ * Cubre los flujos unified/clinic, admin y particular.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const {
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/login-rate-limit.ts");
+const {
+  createMemoryRateLimitStore,
+} = await import("../server/lib/rate-limit-store.ts");
+const {
+  clinicAuthNativeRoutes,
+} = await import("../server/routes/auth.fastify.ts");
+const {
+  adminAuthNativeRoutes,
+} = await import("../server/routes/admin-auth.fastify.ts");
+const {
+  particularAuthNativeRoutes,
+} = await import("../server/routes/particular-auth.fastify.ts");
+
+const WINDOW_MS = 60_000;
+const MAX_ATTEMPTS = 3;
+const REMOTE_IP = "203.0.113.77";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeClinicDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    createActiveSession: async () => {},
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    getClinicUserByUsername: async () => null,
+    getClinicUserByIdentifier: async () => null,
+    updateSessionLastAccess: async () => {},
+    upsertClinicUser: async () => {},
+    generateSessionToken: () => "tok",
+    hashPassword: async (p: string) => `h:${p}`,
+    hashSessionToken: (t: string) => `h:${t}`,
+    verifyPassword: async () => ({ valid: false, needsRehash: false }),
+    createAdminSession: async () => {},
+    getAdminUserByUsername: async () => null,
+    getAdminUserByIdentifier: async () => null,
+    writeAdminAuditLog: async () => {},
+    createParticularSession: async () => {},
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularTokenLastLogin: async () => {},
+    writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: WINDOW_MS,
+    loginRateLimitMaxAttempts: MAX_ATTEMPTS,
+    ...overrides,
+  };
+}
+
+function makeAdminDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    createAdminSession: async () => {},
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    getAdminUserByUsername: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "tok",
+    hashSessionToken: (t: string) => `h:${t}`,
+    verifyPassword: async () => ({ valid: false, needsRehash: false }),
+    writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: WINDOW_MS,
+    loginRateLimitMaxAttempts: MAX_ATTEMPTS,
+    ...overrides,
+  };
+}
+
+function makeParticularDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    createParticularSession: async () => {},
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    updateParticularTokenLastLogin: async () => {},
+    getReportById: async () => null,
+    createSignedReportUrl: async (s: string) => `url:${s}`,
+    createSignedReportDownloadUrl: async (s: string) => `dl:${s}`,
+    generateSessionToken: () => "tok",
+    hashSessionToken: (t: string) => `h:${t}`,
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: WINDOW_MS,
+    loginRateLimitMaxAttempts: MAX_ATTEMPTS,
+    ...overrides,
+  };
+}
+
+// ─── Unified/Clinic ──────────────────────────────────────────────────────────
+
+test("login exitoso (unified) resetea el rate limit — usuario puede fallar de nuevo desde cero", async () => {
+  const store = createMemoryRateLimitStore();
+
+  let callCount = 0;
+  const clinicUser = {
+    id: 1,
+    clinicId: 10,
+    username: "user@vetneb.com",
+    passwordHash: "hash",
+    authProId: null,
+    role: "clinic_staff",
+  };
+
+  // Simular: tras N-1 fallos, el usuario acierta (válido). Luego puede seguir fallando sin quedar bloqueado.
+  const app = Fastify();
+  await app.register(clinicAuthNativeRoutes as any, {
+    prefix: "/api/auth",
+    ...makeClinicDeps({
+      loginRateLimitStore: store,
+      getClinicUserByIdentifier: async () => {
+        callCount += 1;
+        return callCount === MAX_ATTEMPTS ? clinicUser : null;
+      },
+      verifyPassword: async () => ({ valid: callCount === MAX_ATTEMPTS, needsRehash: false }),
+      createActiveSession: async () => {},
+      writeAuditLog: async () => {},
+    }),
+  });
+
+  try {
+    // N-1 fallos
+    for (let i = 1; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { identifier: "user@vetneb.com", password: "mal" },
+      });
+      assert.equal(r.statusCode, 401, `intento ${i} debe ser 401`);
+    }
+
+    // Login exitoso en intento MAX_ATTEMPTS
+    const success = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { identifier: "user@vetneb.com", password: "buena" },
+    });
+    assert.equal(success.statusCode, 200, "login exitoso debe ser 200");
+    assert.ok(
+      (success.headers["ratelimit-remaining"] as string) === String(MAX_ATTEMPTS),
+      "tras login exitoso, remaining debe volver al máximo",
+    );
+
+    // Tras el éxito, el store debe estar limpio — el usuario puede fallar N veces más
+    callCount = 0; // reset para que los siguientes vuelvan a fallar
+    for (let i = 1; i <= MAX_ATTEMPTS - 1; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { identifier: "user@vetneb.com", password: "mal" },
+      });
+      assert.equal(r.statusCode, 401, `intento post-éxito ${i} debe ser 401, no 429`);
+      assert.notEqual(r.statusCode, 429, "no debe quedar bloqueado por fallos previos al éxito");
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("login exitoso (unified) no limpia keys de otros identificadores", async () => {
+  const store = createMemoryRateLimitStore();
+
+  const userA = {
+    id: 1, clinicId: 10, username: "a@vetneb.com",
+    passwordHash: "hash", authProId: null, role: "clinic_staff",
+  };
+
+  let authenticatingAs = "b@vetneb.com";
+  const app = Fastify();
+  await app.register(clinicAuthNativeRoutes as any, {
+    prefix: "/api/auth",
+    ...makeClinicDeps({
+      loginRateLimitStore: store,
+      getClinicUserByIdentifier: async (id: string) => {
+        return id === "a@vetneb.com" ? userA : null;
+      },
+      verifyPassword: async () => ({
+        valid: authenticatingAs === "a@vetneb.com",
+        needsRehash: false,
+      }),
+      createActiveSession: async () => {},
+      writeAuditLog: async () => {},
+    }),
+  });
+
+  try {
+    // Usuario B acumula suficientes fallos para quedar bloqueado en su propia key.
+    authenticatingAs = "b@vetneb.com";
+    for (let i = 1; i <= MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { identifier: "b@vetneb.com", password: "mal" },
+      });
+      assert.equal(r.statusCode, 401, `fallo B ${i} debe consumir su bucket`);
+    }
+
+    // Usuario A hace login exitoso
+    authenticatingAs = "a@vetneb.com";
+    const success = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { identifier: "a@vetneb.com", password: "buena" },
+    });
+    assert.equal(success.statusCode, 200, "A debe hacer login exitoso");
+
+    // El siguiente intento fallido de B debe seguir bloqueado: el exito de A no borro su key.
+    authenticatingAs = "b@vetneb.com";
+    const rB = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { identifier: "b@vetneb.com", password: "mal" },
+    });
+    assert.equal(rB.statusCode, 429, "B debe seguir bloqueado tras sus propios intentos; A no debe haberlos borrado");
+  } finally {
+    await app.close();
+  }
+});
+
+// ─── Admin ───────────────────────────────────────────────────────────────────
+
+test("admin login: key incluye surface=admin e identifier, no solo IP", async () => {
+  const store = createMemoryRateLimitStore();
+
+  // Dos usuarios admin distintos desde la misma IP no deben interferirse
+  const app = Fastify();
+  await app.register(adminAuthNativeRoutes as any, {
+    prefix: "/api/admin/auth",
+    ...makeAdminDeps({ loginRateLimitStore: store }),
+  });
+
+  try {
+    // Admin A falla MAX_ATTEMPTS veces
+    for (let i = 0; i <= MAX_ATTEMPTS; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "admin_a", password: "mal" },
+      });
+    }
+
+    const blocked = await app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "admin_a", password: "mal" },
+    });
+    assert.equal(blocked.statusCode, 429, "admin_a debe estar bloqueado");
+
+    // Admin B desde la misma IP NO debe estar bloqueado
+    const rB = await app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "admin_b", password: "cualquiera" },
+    });
+    assert.notEqual(rB.statusCode, 429, "admin_b NO debe estar bloqueado por fallos de admin_a");
+    assert.equal(rB.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin login 429 incluye Retry-After header", async () => {
+  const app = Fastify();
+  await app.register(adminAuthNativeRoutes as any, {
+    prefix: "/api/admin/auth",
+    ...makeAdminDeps(),
+  });
+
+  try {
+    // Agotar intentos
+    for (let i = 0; i <= MAX_ATTEMPTS; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "admin_test", password: "mal" },
+      });
+    }
+
+    const r = await app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "admin_test", password: "mal" },
+    });
+
+    assert.equal(r.statusCode, 429);
+    assert.ok(
+      r.headers["retry-after"] !== undefined,
+      "429 de admin debe incluir Retry-After header",
+    );
+    const retryAfter = Number(r.headers["retry-after"]);
+    assert.ok(retryAfter > 0, "Retry-After debe ser positivo");
+    assert.ok(
+      r.headers["ratelimit-limit"] !== undefined,
+      "429 de admin debe incluir RateLimit-Limit",
+    );
+    assert.equal(JSON.parse(r.body).error, LOGIN_RATE_LIMIT_ERROR_MESSAGE);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin login exitoso resetea el rate limit", async () => {
+  const store = createMemoryRateLimitStore();
+
+  const adminUser = { id: 1, username: "admin_ok", passwordHash: "hash" };
+  let validCredentials = false;
+
+  const app = Fastify();
+  await app.register(adminAuthNativeRoutes as any, {
+    prefix: "/api/admin/auth",
+    ...makeAdminDeps({
+      loginRateLimitStore: store,
+      getAdminUserByUsername: async () => (validCredentials ? adminUser : null),
+      verifyPassword: async () => ({ valid: validCredentials, needsRehash: false }),
+      createAdminSession: async () => {},
+      writeAuditLog: async () => {},
+    }),
+  });
+
+  try {
+    // MAX_ATTEMPTS - 1 fallos
+    for (let i = 1; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "admin_ok", password: "mal" },
+      });
+      assert.equal(r.statusCode, 401);
+    }
+
+    // Login exitoso
+    validCredentials = true;
+    const success = await app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { username: "admin_ok", password: "buena" },
+    });
+    assert.equal(success.statusCode, 200);
+    assert.equal(
+      success.headers["ratelimit-remaining"],
+      String(MAX_ATTEMPTS),
+      "tras login exitoso, remaining debe ser MAX_ATTEMPTS",
+    );
+
+    // Volver a fallar — debe empezar desde 0
+    validCredentials = false;
+    for (let i = 1; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { username: "admin_ok", password: "mal" },
+      });
+      assert.equal(r.statusCode, 401, `fallo ${i} post-éxito debe ser 401, no 429`);
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+// ─── Particular ──────────────────────────────────────────────────────────────
+
+test("particular login 429 incluye Retry-After header", async () => {
+  const app = Fastify();
+  await app.register(particularAuthNativeRoutes as any, {
+    prefix: "/api/particular/auth",
+    ...makeParticularDeps(),
+  });
+
+  try {
+    const TOKEN = "tok-test-particular-abc";
+
+    // Agotar intentos
+    for (let i = 0; i <= MAX_ATTEMPTS; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: TOKEN },
+      });
+    }
+
+    const r = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: TOKEN },
+    });
+
+    assert.equal(r.statusCode, 429);
+    assert.ok(
+      r.headers["retry-after"] !== undefined,
+      "429 de particular debe incluir Retry-After header",
+    );
+    const retryAfter = Number(r.headers["retry-after"]);
+    assert.ok(retryAfter > 0, "Retry-After debe ser positivo");
+    assert.equal(JSON.parse(r.body).error, LOGIN_RATE_LIMIT_ERROR_MESSAGE);
+  } finally {
+    await app.close();
+  }
+});
+
+test("particular: tokens distintos desde la misma IP no se bloquean entre sí", async () => {
+  const store = createMemoryRateLimitStore();
+
+  const app = Fastify();
+  await app.register(particularAuthNativeRoutes as any, {
+    prefix: "/api/particular/auth",
+    ...makeParticularDeps({ loginRateLimitStore: store }),
+  });
+
+  try {
+    const TOKEN_A = "token-particular-aaa";
+    const TOKEN_B = "token-particular-bbb";
+
+    // Token A falla MAX_ATTEMPTS veces (bloqueado)
+    for (let i = 0; i <= MAX_ATTEMPTS; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: TOKEN_A },
+      });
+    }
+
+    const blockedA = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: TOKEN_A },
+    });
+    assert.equal(blockedA.statusCode, 429, "token_a debe estar bloqueado");
+
+    // Token B no debe estar bloqueado
+    const rB = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: TOKEN_B },
+    });
+    assert.notEqual(rB.statusCode, 429, "token_b NO debe estar bloqueado por fallos de token_a");
+    assert.equal(rB.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});
+
+test("particular login exitoso resetea el rate limit", async () => {
+  const store = createMemoryRateLimitStore();
+  const TOKEN = "token-particular-valido-xyz";
+  let tokenValid = false;
+
+  const particularToken = {
+    id: 1, clinicId: 5, reportId: null,
+    isActive: true, token: TOKEN,
+  };
+
+  const app = Fastify();
+  await app.register(particularAuthNativeRoutes as any, {
+    prefix: "/api/particular/auth",
+    ...makeParticularDeps({
+      loginRateLimitStore: store,
+      getParticularTokenByTokenHash: async () => (tokenValid ? particularToken : null),
+      createParticularSession: async () => {},
+      updateParticularTokenLastLogin: async () => {},
+      getParticularTokenById: async () => ({ ...particularToken, token: "" }),
+    }),
+  });
+
+  try {
+    // MAX_ATTEMPTS - 1 fallos
+    for (let i = 1; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: TOKEN },
+      });
+      assert.equal(r.statusCode, 401);
+    }
+
+    // Login exitoso
+    tokenValid = true;
+    const success = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: REMOTE_IP,
+      payload: { token: TOKEN },
+    });
+    assert.equal(success.statusCode, 200);
+    assert.equal(
+      success.headers["ratelimit-remaining"],
+      String(MAX_ATTEMPTS),
+      "tras login exitoso, remaining debe ser MAX_ATTEMPTS",
+    );
+
+    // Volver a fallar — debe empezar desde 0
+    tokenValid = false;
+    for (let i = 1; i < MAX_ATTEMPTS; i += 1) {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: REMOTE_IP,
+        payload: { token: TOKEN },
+      });
+      assert.equal(r.statusCode, 401, `fallo ${i} post-éxito no debe ser 429`);
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+// ─── Store delete method ─────────────────────────────────────────────────────
+
+test("createMemoryRateLimitStore.delete elimina la entrada correctamente", async () => {
+  const { createMemoryRateLimitStore: mk, getOrCreateRateLimitEntry, incrementRateLimitEntry } = await import("../server/lib/rate-limit-store.ts");
+
+  const store = mk();
+  const now = Date.now();
+  const WINDOW = 60_000;
+
+  // Crear y rellenar una entrada
+  const entry = await getOrCreateRateLimitEntry(store, "test-key", WINDOW, now);
+  await incrementRateLimitEntry(store, "test-key", entry, now);
+  await incrementRateLimitEntry(store, "test-key", { ...entry, count: 1 }, now);
+
+  // Verificar que existe
+  const before = await store.get("test-key");
+  assert.ok(before !== undefined, "la entrada debe existir antes del delete");
+  assert.ok(before!.count >= 1, "la entrada debe tener count > 0");
+
+  // Borrar
+  assert.ok(store.delete !== undefined, "el store debe tener método delete");
+  await store.delete!("test-key");
+
+  // Verificar que ya no existe
+  const after = await store.get("test-key");
+  assert.ok(after === undefined, "la entrada debe haber sido eliminada");
+});
+
+test("createMemoryRateLimitStore.delete de key inexistente no lanza error", async () => {
+  const { createMemoryRateLimitStore: mk } = await import("../server/lib/rate-limit-store.ts");
+  const store = mk();
+
+  assert.doesNotReject(async () => {
+    await store.delete!("key-que-no-existe");
+  });
+});

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -29,3 +29,38 @@ test("login rate limit key incluye version, superficie, identificador normalizad
     "login:v2:unified:user@vetneb.test:ip:203.0.113.50",
   );
 });
+
+test("buildLoginRateLimitKey genera keys distintas para surfaces distintas con mismo identifier e IP", () => {
+  const base = { identifier: "usuario@vetneb.com", ipAddress: "1.2.3.4" };
+  const keyAdmin = buildLoginRateLimitKey({ ...base, surface: "admin" });
+  const keyClinic = buildLoginRateLimitKey({ ...base, surface: "clinic" });
+  const keyParticular = buildLoginRateLimitKey({ ...base, surface: "particular" });
+  const keyUnified = buildLoginRateLimitKey({ ...base, surface: "unified" });
+
+  assert.notEqual(keyAdmin, keyClinic, "admin y clinic deben tener keys distintas");
+  assert.notEqual(keyAdmin, keyParticular, "admin y particular deben tener keys distintas");
+  assert.notEqual(keyAdmin, keyUnified, "admin y unified deben tener keys distintas");
+  assert.notEqual(keyClinic, keyParticular, "clinic y particular deben tener keys distintas");
+
+  assert.equal(keyAdmin, "login:v2:admin:usuario@vetneb.com:ip:1.2.3.4");
+  assert.equal(keyClinic, "login:v2:clinic:usuario@vetneb.com:ip:1.2.3.4");
+  assert.equal(keyParticular, "login:v2:particular:usuario@vetneb.com:ip:1.2.3.4");
+  assert.equal(keyUnified, "login:v2:unified:usuario@vetneb.com:ip:1.2.3.4");
+});
+
+test("buildLoginRateLimitKey genera keys distintas para identifiers distintos con mismo surface e IP", () => {
+  const base = { surface: "admin" as const, ipAddress: "1.2.3.4" };
+  const keyA = buildLoginRateLimitKey({ ...base, identifier: "admin_a" });
+  const keyB = buildLoginRateLimitKey({ ...base, identifier: "admin_b" });
+
+  assert.notEqual(keyA, keyB, "admin_a y admin_b deben tener keys distintas");
+});
+
+test("buildLoginRateLimitKey con ipAddress null usa 'unknown'", () => {
+  const key = buildLoginRateLimitKey({
+    surface: "clinic",
+    identifier: "clinica@test.com",
+    ipAddress: null,
+  });
+  assert.equal(key, "login:v2:clinic:clinica@test.com:ip:unknown");
+});

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -470,6 +470,8 @@ test(
     });
 
     try {
+      const failedToken = "bad-particular-token";
+
       const first = await app.inject({
         method: "POST",
         url: "/api/particular/auth/login",
@@ -478,7 +480,7 @@ test(
         },
         remoteAddress: "203.0.113.30",
         payload: {
-          token: "bad-1",
+          token: failedToken,
         },
       });
 
@@ -490,7 +492,7 @@ test(
         },
         remoteAddress: "203.0.113.30",
         payload: {
-          token: "bad-2",
+          token: failedToken,
         },
       });
 
@@ -502,7 +504,7 @@ test(
         },
         remoteAddress: "203.0.113.30",
         payload: {
-          token: "bad-3",
+          token: failedToken,
         },
       });
 

--- a/test/reset-login-rate-limit-script-contract.test.ts
+++ b/test/reset-login-rate-limit-script-contract.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests: contrato del script reset-login-rate-limit.ps1
+ *
+ * Verifica que el script existe y cumple invariantes de seguridad operativa
+ * sin ejecutarlo realmente (no requiere DB ni PowerShell en CI).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const SCRIPT_PATH = join(
+  import.meta.dirname ?? "",
+  "..",
+  "scripts",
+  "dev",
+  "reset-login-rate-limit.ps1",
+);
+
+test("reset-login-rate-limit.ps1 existe", () => {
+  assert.ok(existsSync(SCRIPT_PATH), `El script debe existir en ${SCRIPT_PATH}`);
+});
+
+test("reset-login-rate-limit.ps1 tiene parámetro -Surface con ValidateSet", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  assert.ok(
+    content.includes("ValidateSet"),
+    "debe tener ValidateSet para restringir Surface",
+  );
+  assert.ok(content.includes('"unified"'), "debe incluir surface unified");
+  assert.ok(content.includes('"clinic"'), "debe incluir surface clinic");
+  assert.ok(content.includes('"admin"'), "debe incluir surface admin");
+  assert.ok(content.includes('"particular"'), "debe incluir surface particular");
+});
+
+test("reset-login-rate-limit.ps1 requiere -Force para ejecutar DELETE", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  assert.ok(
+    content.includes("-Force"),
+    "debe requerir -Force para ejecutar",
+  );
+  assert.ok(
+    content.includes("dry-run") || content.includes("DRY-RUN"),
+    "debe mencionar dry-run por defecto",
+  );
+});
+
+test("reset-login-rate-limit.ps1 no imprime hashes completos", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  // El script debe usar solo primeros N chars del hash
+  assert.ok(
+    content.includes("Substring(0,") || content.includes(".Substring(0,"),
+    "debe truncar el hash antes de mostrarlo",
+  );
+  assert.ok(
+    !content.match(/Write-Host.*\$hash[^P]/),
+    "no debe imprimir el hash completo directamente",
+  );
+});
+
+test("reset-login-rate-limit.ps1 no ejecuta reset global sin filtro", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  // No debe haber DELETE sin WHERE
+  const deleteStatements = content.match(/DELETE FROM login_rate_limits[^;]*/gi) ?? [];
+  for (const stmt of deleteStatements) {
+    assert.ok(
+      stmt.toUpperCase().includes("WHERE"),
+      `Todo DELETE debe tener WHERE: ${stmt.trim().substring(0, 80)}`,
+    );
+  }
+});
+
+test("reset-login-rate-limit.ps1 valida que Identifier no esté vacío", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  assert.ok(
+    content.includes("Length -eq 0") || content.includes("normalizedIdentifier") && content.includes("vacío"),
+    "debe validar que el identifier no sea vacío",
+  );
+});
+
+test("reset-login-rate-limit.ps1 no expone DATABASE_URL en output", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  assert.ok(
+    !content.includes("Write-Host $databaseUrl"),
+    "no debe imprimir DATABASE_URL",
+  );
+  assert.ok(
+    !content.includes("Write-Output $databaseUrl"),
+    "no debe imprimir DATABASE_URL",
+  );
+});
+
+test("reset-login-rate-limit.ps1 usa SHA256 para reproducir el hash de la key", () => {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  assert.ok(
+    content.includes("SHA256") || content.includes("sha256"),
+    "debe usar SHA256 para reproducir el keyHash",
+  );
+});

--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -422,7 +422,7 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
     ],
     testAnchors: [
       "rate limit isolation matrix documents the protected contract",
-      "auth login rate limits keep separate in-memory stores per auth domain",
+      "auth login rate limits keep persistent stores with memory fallback per auth domain",
       "rate limit isolation guardrail source stays ascii only",
     ],
   },

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -400,7 +400,7 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         path: "test/security-rate-limit-isolation-boundaries.test.ts",
         markers: [
           "rate limit isolation matrix documents the protected contract",
-          "auth login rate limits keep separate in-memory stores per auth domain",
+          "auth login rate limits keep persistent stores with memory fallback per auth domain",
           "rate limit isolation guardrail source stays ascii only",
         ],
       },

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -200,7 +200,7 @@ test("rate limit constants remain split by auth public read and token mutation d
   );
 });
 
-test("auth login rate limits keep separate in-memory stores per auth domain", () => {
+test("auth login rate limits keep persistent stores with memory fallback per auth domain", () => {
   for (const file of [
     "server/routes/auth.fastify.ts",
     "server/routes/admin-auth.fastify.ts",
@@ -213,38 +213,50 @@ test("auth login rate limits keep separate in-memory stores per auth domain", ()
       'from "../lib/login-rate-limit.ts"',
       `${file} login rate limit import`,
     );
-    if (
-      file === "server/routes/auth.fastify.ts" ||
-      file === "server/routes/admin-auth.fastify.ts" ||
-      file === "server/routes/particular-auth.fastify.ts"
-    ) {
-      assertContains(
-        source,
-        "loginRateLimitStore?: RateLimitStore;",
-        `${file} injectable login rate limit store option`,
-      );
-      assertContains(
-        source,
-        "options.loginRateLimitStore ?? createMemoryRateLimitStore();",
-        `${file} memory fallback login rate limit store`,
-      );
-      assertContains(
-        source,
-        "await getOrCreateRateLimitEntry(",
-        `${file} login rate limit store read`,
-      );
-      assertContains(
-        source,
-        "await incrementRateLimitEntry(",
-        `${file} login rate limit store increment`,
-      );
-    } else {
-      assertContains(
-        source,
-        "const loginFailures = new Map<string, { count: number; resetAt: number }>();",
-        `${file} login store`,
-      );
+    assertContains(
+      source,
+      "loginRateLimitStore?: RateLimitStore;",
+      `${file} injectable login rate limit store option`,
+    );
+    assertContains(
+      source,
+      "loginRateLimitStore: createPersistentRateLimitStore({",
+      `${file} persistent login rate limit store`,
+    );
+    for (const marker of [
+      "get: db.getLoginRateLimitEntry,",
+      "set: db.setLoginRateLimitEntry,",
+      "increment: db.incrementLoginRateLimitEntry,",
+      "cleanupExpired: db.deleteExpiredLoginRateLimitEntries,",
+      "delete: db.deleteLoginRateLimitEntry,",
+    ]) {
+      assertContains(source, marker, `${file} persistent login store adapter`);
     }
+    assertContains(
+      source,
+      "options.loginRateLimitStore ??",
+      `${file} injectable login rate limit store precedence`,
+    );
+    assertContains(
+      source,
+      "defaultDeps?.loginRateLimitStore ??",
+      `${file} persistent login rate limit store precedence`,
+    );
+    assertContains(
+      source,
+      "createMemoryRateLimitStore();",
+      `${file} memory fallback login rate limit store`,
+    );
+    assertContains(
+      source,
+      "await getOrCreateRateLimitEntry(",
+      `${file} login rate limit store read`,
+    );
+    assertContains(
+      source,
+      "await incrementRateLimitEntry(",
+      `${file} login rate limit store increment`,
+    );
     assertContains(
       source,
       "options.loginRateLimitWindowMs ?? LOGIN_RATE_LIMIT_WINDOW_MS",
@@ -263,16 +275,32 @@ test("auth login rate limits keep separate in-memory stores per auth domain", ()
         "ipAddress: request.ip || null,",
       ],
       "server/routes/admin-auth.fastify.ts": [
-        'const rateLimitKey = `admin:${request.ip || "unknown"}`;',
+        "buildLoginRateLimitKey({",
+        'surface: "admin",',
+        'identifier: username || "unknown",',
+        "ipAddress: request.ip || null,",
       ],
       "server/routes/particular-auth.fastify.ts": [
-        'const rateLimitKey = `particular:${request.ip || "unknown"}`;',
+        "buildLoginRateLimitKey({",
+        'surface: "particular",',
+        'identifier: providedToken || "unknown",',
+        "ipAddress: request.ip || null,",
       ],
     } satisfies Record<(typeof file), readonly string[]>;
 
     for (const marker of realmKeyByFile[file]) {
       assertContains(source, marker, `${file} login key`);
     }
+    assertNotContains(
+      source,
+      'const rateLimitKey = `admin:${request.ip || "unknown"}`;',
+      `${file} must not use admin IP-only login key`,
+    );
+    assertNotContains(
+      source,
+      'const rateLimitKey = `particular:${request.ip || "unknown"}`;',
+      `${file} must not use particular IP-only login key`,
+    );
     assertContains(
       source,
       "error: LOGIN_RATE_LIMIT_ERROR_MESSAGE",


### PR DESCRIPTION
## Resumen
- Resetea el rate limit correspondiente cuando el login es exitoso.
- Aísla el rate limit por surface, identifier e IP en admin, clínica/unified y particular.
- Agrega Retry-After y mantiene headers RateLimit-* en respuestas 429.
- Mejora UX de 429 con cooldown, mensaje claro y submit bloqueado temporalmente.
- Agrega script operativo seguro para resetear rate limits sin SQL manual.

## Diagnóstico
La causa raíz era que los intentos fallidos quedaban acumulados durante la ventana de rate limit incluso después de un login exitoso. Eso podía dejar a usuarios legítimos atrapados con el mensaje de demasiados intentos.

## Seguridad
- No se desactiva rate limit.
- No se bajan controles de fuerza bruta.
- No se exponen passwords, tokens ni hashes completos.
- El reset operativo requiere parámetros explícitos y -Force para ejecutar.
- Login exitoso solo limpia la key correspondiente, no otros usuarios ni otras surfaces.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Resultado
- pnpm test OK: 2083 pass, 0 fail, 1 skipped
- pnpm build OK

## Scope
- Auth/rate-limit/login UX/script operativo.
- No toca notificaciones ni workflow.