### PR TITLE
fix(auth): prevent admin and particular login 500s

### DIFF
--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -17,6 +17,7 @@ import {
   createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
+  type RateLimitEntry,
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
 import {
@@ -645,28 +646,61 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       ipAddress: request.ip || null,
     });
 
-    const failureEntry = await getOrCreateRateLimitEntry(
-      loginRateLimitStore,
-      rateLimitKey,
-      loginRateLimitWindowMs,
-      currentTime,
-    );
+    const failureEntry: RateLimitEntry = {
+      count: 0,
+      resetAt: currentTime + loginRateLimitWindowMs,
+    };
+    let canUseRateLimitStore = true;
+
+    try {
+      const existingEntry = await getOrCreateRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        loginRateLimitWindowMs,
+        currentTime,
+      );
+
+      failureEntry.count = existingEntry.count;
+      failureEntry.resetAt = existingEntry.resetAt;
+    } catch (error) {
+      canUseRateLimitStore = false;
+      request.log.error(
+        {
+          err: error,
+          code: "ADMIN_LOGIN_RATE_LIMIT_GET_FAILED",
+          route: "/api/admin/auth/login",
+        },
+        "No se pudo leer el rate limit de login admin",
+      );
+    }
 
     const recordFailedLoginAttempt = async (input: {
       username?: string | null;
       reason: LoginFailedAttemptReason;
     }) => {
-      await deps.recordLoginFailedAttempt({
-        surface: "admin",
-        username: input.username?.trim() || null,
-        reason: input.reason,
-        ipAddress: request.ip || null,
-        userAgent: getUserAgent(request),
-        createdAt: new Date(currentTime),
-      });
+      try {
+        await deps.recordLoginFailedAttempt({
+          surface: "admin",
+          username: input.username?.trim() || null,
+          reason: input.reason,
+          ipAddress: request.ip || null,
+          userAgent: getUserAgent(request),
+          createdAt: new Date(currentTime),
+        });
+      } catch (error) {
+        request.log.warn(
+          {
+            err: error,
+            code: "ADMIN_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
+            surface: "admin",
+            reason: input.reason,
+          },
+          "No se pudo persistir intento fallido de login admin",
+        );
+      }
     };
 
-    if (failureEntry.count >= loginRateLimitMaxAttempts) {
+    if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
       const resetSeconds = Math.max(
         Math.ceil((failureEntry.resetAt - currentTime) / 1000),
         0,
@@ -696,35 +730,58 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       username?: string | null;
       reason: LoginFailedAttemptReason;
     }) => {
-      const updatedEntry = await incrementRateLimitEntry(
-        loginRateLimitStore,
-        rateLimitKey,
-        failureEntry,
-      );
+      if (canUseRateLimitStore) {
+        try {
+          const updatedEntry = await incrementRateLimitEntry(
+            loginRateLimitStore,
+            rateLimitKey,
+            failureEntry,
+            currentTime,
+          );
 
-      failureEntry.count = updatedEntry.count;
-      failureEntry.resetAt = updatedEntry.resetAt;
+          failureEntry.count = updatedEntry.count;
+          failureEntry.resetAt = updatedEntry.resetAt;
 
-      setLoginRateLimitHeaders(reply, {
-        max: loginRateLimitMaxAttempts,
-        windowMs: loginRateLimitWindowMs,
-        failedCount: failureEntry.count,
-        resetAt: failureEntry.resetAt,
-        now: currentTime,
-      });
+          setLoginRateLimitHeaders(reply, {
+            max: loginRateLimitMaxAttempts,
+            windowMs: loginRateLimitWindowMs,
+            failedCount: failureEntry.count,
+            resetAt: failureEntry.resetAt,
+            now: currentTime,
+          });
+        } catch (error) {
+          canUseRateLimitStore = false;
+          request.log.error(
+            {
+              err: error,
+              code: "ADMIN_LOGIN_RATE_LIMIT_INCREMENT_FAILED",
+              route: "/api/admin/auth/login",
+            },
+            "No se pudo actualizar el rate limit de login admin",
+          );
+        }
+      }
 
       await recordFailedLoginAttempt(input);
     };
 
     const markSuccess = async () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
       if (loginRateLimitStore.delete) {
         try {
           await loginRateLimitStore.delete(rateLimitKey);
         } catch (error) {
-          console.warn("[WARN] ADMIN_LOGIN_RATE_LIMIT_RESET_FAILED", {
-            code: "ADMIN_LOGIN_RATE_LIMIT_RESET_FAILED",
-            message: error instanceof Error ? error.message : "unknown error",
-          });
+          request.log.warn(
+            {
+              err: error,
+              code: "ADMIN_LOGIN_RATE_LIMIT_RESET_FAILED",
+              route: "/api/admin/auth/login",
+            },
+            "No se pudo limpiar el rate limit de login admin tras login exitoso",
+          );
         }
       }
 

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -17,6 +17,7 @@ import {
   createPersistentRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
+  type RateLimitEntry,
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
 import { serializeParticularTokenDetail } from "../lib/particular-token.ts";
@@ -650,12 +651,33 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       ipAddress: request.ip || null,
     });
 
-    const failureEntry = await getOrCreateRateLimitEntry(
-      loginRateLimitStore,
-      rateLimitKey,
-      loginRateLimitWindowMs,
-      currentTime,
-    );
+    const failureEntry: RateLimitEntry = {
+      count: 0,
+      resetAt: currentTime + loginRateLimitWindowMs,
+    };
+    let canUseRateLimitStore = true;
+
+    try {
+      const existingEntry = await getOrCreateRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        loginRateLimitWindowMs,
+        currentTime,
+      );
+
+      failureEntry.count = existingEntry.count;
+      failureEntry.resetAt = existingEntry.resetAt;
+    } catch (error) {
+      canUseRateLimitStore = false;
+      request.log.error(
+        {
+          err: error,
+          code: "PARTICULAR_LOGIN_RATE_LIMIT_GET_FAILED",
+          route: "/api/particular/auth/login",
+        },
+        "No se pudo leer el rate limit de login particular",
+      );
+    }
 
     const recordFailedLoginAttempt = async (input: {
       reason: LoginFailedAttemptReason;
@@ -670,15 +692,19 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
           createdAt: new Date(currentTime),
         });
       } catch (error) {
-        console.warn("[WARN] PARTICULAR_LOGIN_FAILED_ATTEMPT_RECORD_FAILED", {
-          surface: "particular",
-          reason: input.reason,
-          message: error instanceof Error ? error.message : "unknown error",
-        });
+        request.log.warn(
+          {
+            err: error,
+            code: "PARTICULAR_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
+            surface: "particular",
+            reason: input.reason,
+          },
+          "No se pudo persistir intento fallido de login particular",
+        );
       }
     };
 
-    if (failureEntry.count >= loginRateLimitMaxAttempts) {
+    if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
       const resetSeconds = Math.max(
         Math.ceil((failureEntry.resetAt - currentTime) / 1000),
         0,
@@ -706,35 +732,58 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     const markFailure = async (input: {
       reason: LoginFailedAttemptReason;
     }) => {
-      const updatedEntry = await incrementRateLimitEntry(
-        loginRateLimitStore,
-        rateLimitKey,
-        failureEntry,
-      );
+      if (canUseRateLimitStore) {
+        try {
+          const updatedEntry = await incrementRateLimitEntry(
+            loginRateLimitStore,
+            rateLimitKey,
+            failureEntry,
+            currentTime,
+          );
 
-      failureEntry.count = updatedEntry.count;
-      failureEntry.resetAt = updatedEntry.resetAt;
+          failureEntry.count = updatedEntry.count;
+          failureEntry.resetAt = updatedEntry.resetAt;
 
-      setLoginRateLimitHeaders(reply, {
-        max: loginRateLimitMaxAttempts,
-        windowMs: loginRateLimitWindowMs,
-        failedCount: failureEntry.count,
-        resetAt: failureEntry.resetAt,
-        now: currentTime,
-      });
+          setLoginRateLimitHeaders(reply, {
+            max: loginRateLimitMaxAttempts,
+            windowMs: loginRateLimitWindowMs,
+            failedCount: failureEntry.count,
+            resetAt: failureEntry.resetAt,
+            now: currentTime,
+          });
+        } catch (error) {
+          canUseRateLimitStore = false;
+          request.log.error(
+            {
+              err: error,
+              code: "PARTICULAR_LOGIN_RATE_LIMIT_INCREMENT_FAILED",
+              route: "/api/particular/auth/login",
+            },
+            "No se pudo actualizar el rate limit de login particular",
+          );
+        }
+      }
 
       await recordFailedLoginAttempt(input);
     };
 
     const markSuccess = async () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
       if (loginRateLimitStore.delete) {
         try {
           await loginRateLimitStore.delete(rateLimitKey);
         } catch (error) {
-          console.warn("[WARN] PARTICULAR_LOGIN_RATE_LIMIT_RESET_FAILED", {
-            code: "PARTICULAR_LOGIN_RATE_LIMIT_RESET_FAILED",
-            message: error instanceof Error ? error.message : "unknown error",
-          });
+          request.log.warn(
+            {
+              err: error,
+              code: "PARTICULAR_LOGIN_RATE_LIMIT_RESET_FAILED",
+              route: "/api/particular/auth/login",
+            },
+            "No se pudo limpiar el rate limit de login particular tras login exitoso",
+          );
         }
       }
 
@@ -924,4 +973,3 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     });
   });
 };
-

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -361,6 +361,164 @@ test(
     }
   },
 );
+
+test(
+  "adminAuthNativeRoutes conserva 401 si falla auditoría de credenciales inválidas",
+  async () => {
+    const app = await createTestApp({
+      getAdminUserByUsername: async () => null,
+      recordLoginFailedAttempt: async () => {
+        throw new Error("simulated failed-login persistence error");
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+          "user-agent": "vetneb-test-agent",
+        },
+        remoteAddress: "203.0.113.44",
+        payload: {
+          username: "VETNEB",
+          password: "SUPER-SECRET-PASSWORD",
+        },
+      });
+
+      assert.equal(response.statusCode, 401);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Credenciales inválidas",
+      });
+      assert.equal(response.headers["set-cookie"], undefined);
+      assert.equal(
+        response.body.includes("simulated failed-login persistence error"),
+        false,
+      );
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuthNativeRoutes conserva 429 si falla auditoría de rate limit",
+  async () => {
+    const app = await createTestApp({
+      now: () => 0,
+      loginRateLimitWindowMs: 60_000,
+      loginRateLimitMaxAttempts: 1,
+      loginRateLimitStore: {
+        get: async () => ({
+          count: 1,
+          resetAt: 60_000,
+        }),
+        set: async () => {},
+      },
+      getAdminUserByUsername: async () => {
+        throw new Error("rate limited request must not query admin user");
+      },
+      recordLoginFailedAttempt: async () => {
+        throw new Error("simulated failed-login persistence error");
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.44",
+        payload: {
+          username: "VETNEB",
+          password: "SUPER-SECRET-PASSWORD",
+        },
+      });
+
+      assert.equal(response.statusCode, 429);
+      assert.equal(response.headers["retry-after"], "60");
+      assert.equal(response.headers["ratelimit-limit"], "1");
+      assert.equal(response.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminAuthNativeRoutes conserva 200 si falla reset de rate limit tras login válido",
+  async () => {
+    const sessionCalls: Array<Record<string, unknown>> = [];
+    const resetKeys: string[] = [];
+
+    const app = await createTestApp({
+      now: () => 0,
+      loginRateLimitWindowMs: 60_000,
+      loginRateLimitMaxAttempts: 2,
+      loginRateLimitStore: {
+        get: async () => ({
+          count: 1,
+          resetAt: 60_000,
+        }),
+        set: async () => {},
+        delete: async (key: string) => {
+          resetKeys.push(key);
+          throw new Error("simulated rate-limit reset failure");
+        },
+      },
+      getAdminUserByUsername: async () => ({
+        id: 1,
+        username: "VETNEB",
+        passwordHash: "stored-hash",
+      }),
+      verifyPassword: async () => ({
+        valid: true,
+        needsRehash: false,
+      }),
+      createAdminSession: async (input: Record<string, unknown>) => {
+        sessionCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.44",
+        payload: {
+          username: "VETNEB",
+          password: "31731490Neb",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(resetKeys.length, 1);
+      assert.equal(response.headers["ratelimit-limit"], "2");
+      assert.equal(response.headers["ratelimit-remaining"], "2");
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        admin: {
+          id: 1,
+          username: "VETNEB",
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
 test("adminAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar", async () => {
   const app = await createTestApp({
     getAdminSessionByToken: async () => {

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -524,6 +524,55 @@ test(
 );
 
 test(
+  "particularAuthNativeRoutes conserva 429 si falla auditoría de rate limit",
+  async () => {
+    const app = await createTestApp({
+      now: () => 0,
+      loginRateLimitWindowMs: 60_000,
+      loginRateLimitMaxAttempts: 1,
+      loginRateLimitStore: {
+        get: async () => ({
+          count: 1,
+          resetAt: 60_000,
+        }),
+        set: async () => {},
+      },
+      getParticularTokenByTokenHash: async () => {
+        throw new Error("rate limited request must not query particular token");
+      },
+      recordLoginFailedAttempt: async () => {
+        throw new Error("simulated failed-login persistence error");
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.77",
+        payload: {
+          token: "INVALID-PARTICULAR-TOKEN",
+        },
+      });
+
+      assert.equal(response.statusCode, 429);
+      assert.equal(response.headers["retry-after"], "60");
+      assert.equal(response.headers["ratelimit-limit"], "1");
+      assert.equal(response.headers["ratelimit-remaining"], "0");
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "particularAuthNativeRoutes conserva 401 si falla auditoría de token inválido",
   async () => {
     const app = await createTestApp({
@@ -554,6 +603,67 @@ test(
         error: "Token inválido",
       });
       assert.equal(response.headers["set-cookie"], undefined);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "particularAuthNativeRoutes conserva 200 si falla reset de rate limit tras token válido",
+  async () => {
+    const sessionCalls: Array<Record<string, unknown>> = [];
+    const resetKeys: string[] = [];
+    const particularToken = createParticularTokenFixture({
+      reportId: null,
+    });
+
+    const app = await createTestApp({
+      now: () => 0,
+      loginRateLimitWindowMs: 60_000,
+      loginRateLimitMaxAttempts: 2,
+      loginRateLimitStore: {
+        get: async () => ({
+          count: 1,
+          resetAt: 60_000,
+        }),
+        set: async () => {},
+        delete: async (key: string) => {
+          resetKeys.push(key);
+          throw new Error("simulated rate-limit reset failure");
+        },
+      },
+      getParticularTokenByTokenHash: async () => particularToken,
+      getParticularTokenById: async () => particularToken,
+      createParticularSession: async (input: Record<string, unknown>) => {
+        sessionCalls.push(input);
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/particular/auth/login",
+        headers: {
+          origin: "http://localhost:3000",
+        },
+        remoteAddress: "203.0.113.77",
+        payload: {
+          token: "PARTICULAR-RAW-TOKEN",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(sessionCalls.length, 1);
+      assert.equal(resetKeys.length, 1);
+      assert.equal(response.headers["ratelimit-limit"], "2");
+      assert.equal(response.headers["ratelimit-remaining"], "2");
+
+      const body = JSON.parse(response.body);
+      assert.equal(body.success, true);
+      assert.equal(body.particular.id, particularToken.id);
+      assert.equal(body.particular.reportId, null);
+      assert.equal(body.particular.hasLinkedReport, false);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Resumen
- Evita que fallas secundarias de rate-limit store o failed-login logging rompan el login admin/particular con HTTP 500.
- Mantiene 401 para credenciales inválidas.
- Mantiene 429 para rate limit.
- Mantiene 200 para login válido aun si falla el reset auxiliar del rate limit.
- No toca notificaciones ni workflow.

## Diagnóstico
Después de #791, admin y particular podían devolver HTTP 500 si fallaban operaciones auxiliares de loginRateLimitStore o recordLoginFailedAttempt. Clínica ya tenía un comportamiento más defensivo.

## Seguridad
- No se desactiva rate limit.
- No se eliminan headers RateLimit/Retry-After.
- No se exponen passwords, tokens ni hashes.
- createAdminSession/createParticularSession siguen siendo errores principales si fallan.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build

## Resultado
- pnpm test OK: 2088 pass, 0 fail, 1 skipped
- pnpm build OK

## Scope
- Auth admin/particular únicamente.