### PR TITLE
fix(notifications): keep actions inside dropdown

### DIFF
--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -173,14 +173,15 @@ export function DashboardNotificationsBell({
       </button>
 
       {isOpen ? (
-        <div className="absolute right-0 z-50 mt-2 w-[min(20rem,calc(100vw-1rem))] rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl">
-          <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="absolute right-0 z-50 mt-2 w-[min(28rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl">
+          <div className="mb-2 flex flex-col gap-2">
             <p className="text-sm font-semibold text-vetneb-ink">Notificaciones</p>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
+                className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
                 onClick={handleEnableNotifications}
                 disabled={isPollingEnabled}
               >
@@ -192,6 +193,7 @@ export function DashboardNotificationsBell({
                 type="button"
                 variant="outline"
                 size="sm"
+                className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
                 onClick={() => void loadNotifications()}
                 disabled={isLoading}
               >
@@ -201,6 +203,7 @@ export function DashboardNotificationsBell({
                 type="button"
                 variant="outline"
                 size="sm"
+                className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
                 onClick={() => void handleMarkAllAsRead()}
                 disabled={
                   isLoading ||
@@ -211,7 +214,7 @@ export function DashboardNotificationsBell({
               >
                 {isMarkingAllAsRead
                   ? "Marcando..."
-                  : "Marcar todas como leídas"}
+                  : "Marcar todo como leído"}
               </Button>
             </div>
           </div>

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -92,6 +92,7 @@ test("campana de notificaciones admin existe con UX in-app y polling", () => {
   assert.ok(bell.includes("Notificaciones"));
   assert.ok(bell.includes("Activar notificaciones"));
   assert.ok(bell.includes("Actualizar"));
+  assert.ok(bell.includes("Marcar todo como leído"));
   assert.ok(bell.includes("No hay notificaciones."));
   assert.ok(bell.includes("No se pudieron cargar las notificaciones."));
   assert.ok(bell.includes("POLLING_INTERVAL_MS = 30_000"));
@@ -108,7 +109,30 @@ test("campana usa API de notificaciones por surface para listar y marcar leídas
   assert.ok(bell.includes("markAllDashboardNotificationsRead(surface)"));
   assert.ok(bell.includes("setNotifications(response.notifications);"));
   assert.ok(bell.includes("response.notification"));
-  assert.ok(bell.includes("Marcar todas como leídas"));
+  assert.ok(bell.includes("Marcar todo como leído"));
+});
+
+test("campana mantiene dropdown responsive y acciones sin overflow", () => {
+  const bell = read(BELL_PATH);
+
+  assert.ok(
+    bell.includes(
+      "w-[min(28rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden",
+    ),
+  );
+  assert.ok(bell.includes("absolute right-0 z-50"));
+  assert.ok(bell.includes('className="mb-2 flex flex-col gap-2"'));
+  assert.ok(
+    bell.includes(
+      'className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center"',
+    ),
+  );
+  assert.ok(
+    bell.includes(
+      'className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"',
+    ),
+  );
+  assert.ok(bell.includes('className="max-h-72 space-y-2 overflow-y-auto pr-1"'));
 });
 
 test("api frontend expone funciones de notificaciones por surface y compat admin", () => {


### PR DESCRIPTION
## Resumen
- Corrige el layout responsive del dropdown de notificaciones.
- Evita que los botones Actualizar y Marcar todo como leído se salgan del panel.
- Ajusta el ancho del panel al viewport.
- Permite que las acciones se apilen o hagan wrap en pantallas angostas.
- Mantiene scroll interno del listado de notificaciones.

## Diagnóstico
El dropdown tenía ancho chico y una fila rígida con justify-between más tres botones con whitespace-nowrap. En layouts angostos, la fila no podía comprimirse y las acciones se cortaban o quedaban fuera de pantalla.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Resultado
- pnpm test OK: 2089 pass, 0 fail, 1 skipped
- frontend build OK

## Scope
- Solo frontend/UI de notificaciones.
- No toca backend, auth/rate-limit ni workflow.