### PR TITLE
fix(auth): make login lockouts observable and operable

### DIFF
--- a/drizzle/migrations/0030_login_rate_limits_metadata.sql
+++ b/drizzle/migrations/0030_login_rate_limits_metadata.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "login_rate_limits"
+  ADD COLUMN IF NOT EXISTS "surface" varchar(32),
+  ADD COLUMN IF NOT EXISTS "identifier_hash" text,
+  ADD COLUMN IF NOT EXISTS "ip_hash" text,
+  ADD COLUMN IF NOT EXISTS "key_version" varchar(16);
+
+CREATE INDEX IF NOT EXISTS "login_rate_limits_surface_identifier_idx"
+  ON "login_rate_limits" ("surface", "identifier_hash");
+
+CREATE INDEX IF NOT EXISTS "login_rate_limits_surface_identifier_ip_idx"
+  ON "login_rate_limits" ("surface", "identifier_hash", "ip_hash");

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
                         "when":  1777125600000,
                         "tag":  "0029_admin_users_email_identifier",
                         "breakpoints":  true
+                    },
+                    {
+                        "idx":  30,
+                        "version":  "7",
+                        "when":  1777129200000,
+                        "tag":  "0030_login_rate_limits_metadata",
+                        "breakpoints":  true
                     }
                 ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -471,6 +471,10 @@ export const loginRateLimits = pgTable(
   "login_rate_limits",
   {
     keyHash: text("key_hash").primaryKey(),
+    surface: varchar("surface", { length: 32 }),
+    identifierHash: text("identifier_hash"),
+    ipHash: text("ip_hash"),
+    keyVersion: varchar("key_version", { length: 16 }),
     count: integer("count").notNull(),
     resetAt: timestamp("reset_at", { mode: "date" }).notNull(),
     createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
@@ -478,6 +482,12 @@ export const loginRateLimits = pgTable(
   },
   (table) => ({
     resetAtIdx: index("login_rate_limits_reset_at_idx").on(table.resetAt),
+    surfaceIdentifierIdx: index(
+      "login_rate_limits_surface_identifier_idx",
+    ).on(table.surface, table.identifierHash),
+    surfaceIdentifierIpIdx: index(
+      "login_rate_limits_surface_identifier_ip_idx",
+    ).on(table.surface, table.identifierHash, table.ipHash),
   }),
 );
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,6 +60,16 @@ export const ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE =
   "Sesión admin no autenticada o inválida. Iniciá sesión nuevamente.";
 export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE =
   "Demasiados intentos de inicio de sesión. Intente más tarde.";
+export const LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE =
+  "El backend no informó cuándo reintentar el inicio de sesión. Reintentá más tarde o contactá a VETNEB.";
+
+const LOGIN_RATE_LIMIT_REQUIRED_HEADERS = [
+  "Retry-After",
+  "RateLimit-Policy",
+  "RateLimit-Limit",
+  "RateLimit-Remaining",
+  "RateLimit-Reset",
+];
 
 function isLocalOrLanHostname(hostname: string): boolean {
   const normalizedHost = hostname.trim().toLowerCase();
@@ -183,6 +193,21 @@ function readRetryAfterSeconds(headers: Headers): number | null {
   return retryAfterSeconds;
 }
 
+function isLoginRateLimitPath(path: string): boolean {
+  return (
+    path === "/api/auth/login" ||
+    path === "/api/admin/auth/login" ||
+    path === "/api/particular/auth/login"
+  );
+}
+
+function hasRequiredLoginRateLimitHeaders(headers: Headers): boolean {
+  return LOGIN_RATE_LIMIT_REQUIRED_HEADERS.every((headerName) => {
+    const value = headers.get(headerName);
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
 function buildRateLimitErrorMessage(
   backendMessage: string | null,
   headers: Headers,
@@ -259,9 +284,21 @@ async function apiFetch<T>(
           : null;
 
     if (res.status === 429) {
+      const retryAfterSeconds = readRetryAfterSeconds(res.headers);
+
+      if (
+        isLoginRateLimitPath(path) &&
+        (!retryAfterSeconds || !hasRequiredLoginRateLimitHeaders(res.headers))
+      ) {
+        throw new RateLimitError(
+          LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE,
+          null,
+        );
+      }
+
       throw new RateLimitError(
         buildRateLimitErrorMessage(backendMessage, res.headers),
-        readRetryAfterSeconds(res.headers),
+        retryAfterSeconds,
       );
     }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck:test": "tsc -p ./test/tsconfig.json --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "auth:reset-login-rate-limit": "tsx scripts/dev/reset-login-rate-limit.ts",
     "smoke:test": "node scripts/smoke/smoke-test.mjs",
     "smoke:upload": "node scripts/smoke/smoke-upload.mjs",
     "smoke:staging": "powershell -ExecutionPolicy Bypass -File scripts/dev/smoke-staging.ps1",

--- a/scripts/dev/reset-login-rate-limit.ps1
+++ b/scripts/dev/reset-login-rate-limit.ps1
@@ -1,40 +1,36 @@
 <#
 .SYNOPSIS
-    Reset del rate limit de login para un usuario bloqueado operativamente.
+    Reset operativo del rate limit de login para un surface + identifier.
 
 .DESCRIPTION
-    Limpia la entrada de rate limit de login en la base de datos para
-    un surface + identifier específico. No toca otros usuarios ni superficies.
+    Wrapper PowerShell del script Node/TypeScript
+    scripts/dev/reset-login-rate-limit.ts. Usa SUPABASE_DB_URL o DATABASE_URL,
+    ejecuta en dry-run por defecto y requiere -Force para borrar filas.
 
-    Requiere: DATABASE_URL en .env o como variable de entorno.
-    Por defecto: dry-run. Usar -Force para ejecutar el DELETE real.
+    No imprime identifier, token, password, URL de DB ni hashes completos.
 
 .PARAMETER Surface
     Superficie de login: "unified", "clinic", "admin" o "particular".
 
 .PARAMETER Identifier
-    Identificador del usuario (username o email, normalizado a lowercase).
-    Para particular: el token (se usará como identifier en la key).
+    Identificador operativo. Para particular puede ser el token recibido por el
+    usuario, pero no se imprime en output.
 
 .PARAMETER IpAddress
-    IP del cliente. Opcional. Si no se proporciona, se buscarán todas las
-    entradas para surface + identifier sin filtrar por IP.
+    IP opcional. Si se omite, borra por surface + identifier_hash en filas con
+    metadata segura. Filas legacy previas a la metadata requieren IP exacta.
 
 .PARAMETER Force
-    Si se especifica, ejecuta el DELETE real. Por defecto es dry-run.
+    Ejecuta el DELETE. Sin -Force es dry-run.
 
 .EXAMPLE
-    # Dry-run: ver qué filas se borrarían para la clínica "clinica@vetneb.com"
     .\reset-login-rate-limit.ps1 -Surface unified -Identifier "clinica@vetneb.com"
 
-    # Ejecutar reset para admin "admin" desde IP 1.2.3.4
+.EXAMPLE
     .\reset-login-rate-limit.ps1 -Surface admin -Identifier "admin" -IpAddress "1.2.3.4" -Force
-
-    # Reset de todas las entradas de un identifier sin filtrar IP (dry-run)
-    .\reset-login-rate-limit.ps1 -Surface clinic -Identifier "usuario"
 #>
 
-[CmdletBinding(SupportsShouldProcess)]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
     [ValidateSet("unified", "clinic", "admin", "particular")]
@@ -53,148 +49,41 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# ── Cargar DATABASE_URL ──────────────────────────────────────────────────────
-
-$envFile = Join-Path $PSScriptRoot "..\..\\.env"
-if (Test-Path $envFile) {
-    Get-Content $envFile | ForEach-Object {
-        if ($_ -match '^\s*([A-Z_][A-Z0-9_]*)=(.*)$') {
-            $name = $Matches[1]
-            $value = $Matches[2].Trim('"').Trim("'")
-            if (-not [System.Environment]::GetEnvironmentVariable($name)) {
-                [System.Environment]::SetEnvironmentVariable($name, $value)
-            }
-        }
-    }
-}
-
-$databaseUrl = $env:DATABASE_URL
-if (-not $databaseUrl) {
-    Write-Error "DATABASE_URL no está definida. Exporta la variable o crea un .env en la raíz del proyecto."
-    exit 1
-}
-
-# ── Validar parámetros ───────────────────────────────────────────────────────
-
-$normalizedIdentifier = $Identifier.Trim().ToLower()
+$normalizedIdentifier = $Identifier.Trim()
 if ($normalizedIdentifier.Length -eq 0) {
     Write-Error "Identifier no puede estar vacío."
     exit 1
 }
-if ($normalizedIdentifier.Length -gt 256) {
-    $normalizedIdentifier = $normalizedIdentifier.Substring(0, 256)
-    Write-Warning "Identifier truncado a 256 caracteres."
-}
 
-$normalizedIp = if ($IpAddress.Trim()) { $IpAddress.Trim() } else { "" }
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$scriptPath = Join-Path $repoRoot "scripts\dev\reset-login-rate-limit.ts"
 
-# ── Construir key(s) a buscar ────────────────────────────────────────────────
-# Formato: login:v2:<surface>:<identifier>:ip:<ip>
-# Si no se da IP, se busca para todas las IPs (LIKE pattern en SHA256 no aplica
-# — debemos hacer el hash en PowerShell o buscar por prefijo de key no hasheada)
-#
-# IMPORTANTE: La key se guarda como SHA256(key_string) en DB.
-# Para hacer la búsqueda, necesitamos reproducir el hash en PowerShell.
-
-function Get-Sha256 {
-    param([string]$InputString)
-    $bytes = [System.Text.Encoding]::UTF8.GetBytes($InputString)
-    $sha256 = [System.Security.Cryptography.SHA256]::Create()
-    $hash = $sha256.ComputeHash($bytes)
-    return [BitConverter]::ToString($hash).Replace("-", "").ToLower()
-}
-
-$keysToCheck = @()
-
-if ($normalizedIp) {
-    $keyString = "login:v2:${Surface}:${normalizedIdentifier}:ip:${normalizedIp}"
-    $keyHash = Get-Sha256 $keyString
-    $keysToCheck += [PSCustomObject]@{ KeyString = $keyString; KeyHash = $keyHash }
-} else {
-    Write-Host "No se especificó IP. Se buscarán hasta 50 entradas para surface='$Surface' identifier='$normalizedIdentifier' en todas las IPs conocidas." -ForegroundColor Yellow
-    Write-Host "Para mayor precisión, proporcione -IpAddress." -ForegroundColor Yellow
-
-    # Sin IP, construimos keys para IPs comunes + "unknown"
-    $commonIps = @("unknown")
-    foreach ($ip in $commonIps) {
-        $keyString = "login:v2:${Surface}:${normalizedIdentifier}:ip:${ip}"
-        $keyHash = Get-Sha256 $keyString
-        $keysToCheck += [PSCustomObject]@{ KeyString = $keyString; KeyHash = $keyHash }
-    }
-}
-
-# ── Conectar y operar ────────────────────────────────────────────────────────
-
-Write-Host ""
-Write-Host "=== RESET RATE LIMIT LOGIN ===" -ForegroundColor Cyan
-Write-Host "  Surface    : $Surface"
-Write-Host "  Identifier : $($normalizedIdentifier.Substring(0, [Math]::Min(20, $normalizedIdentifier.Length)))..."
-Write-Host "  IP         : $(if ($normalizedIp) { $normalizedIp } else { '(todas)' })"
-Write-Host "  Modo       : $(if ($Force) { 'EJECUTAR (Force)' } else { 'DRY-RUN (sin cambios)' })"
-Write-Host ""
-
-# Instalar psql si no está disponible — requerir psql en PATH
-$psql = Get-Command psql -ErrorAction SilentlyContinue
-if (-not $psql) {
-    Write-Error "psql no encontrado en PATH. Instala PostgreSQL client tools o agrega psql al PATH."
+if (-not (Test-Path $scriptPath)) {
+    Write-Error "No se encontró scripts/dev/reset-login-rate-limit.ts."
     exit 1
 }
 
-$foundAny = $false
-
-foreach ($entry in $keysToCheck) {
-    $hash = $entry.KeyHash
-
-    # Mostrar solo primeros 16 chars del hash para no exponer el hash completo
-    $hashPreview = $hash.Substring(0, 16) + "..."
-
-    # SELECT para ver si existe
-    $selectSql = "SELECT key_hash, count, reset_at FROM login_rate_limits WHERE key_hash = '$hash';"
-    $result = $null
-    try {
-        $result = & psql $databaseUrl -t -A -c $selectSql 2>&1
-    } catch {
-        Write-Warning "Error al consultar DB: $_"
-        continue
-    }
-
-    if ($result -and $result.Trim()) {
-        $foundAny = $true
-        $parts = $result.Trim() -split '\|'
-        $count = if ($parts.Count -ge 2) { $parts[1] } else { "?" }
-        $resetAt = if ($parts.Count -ge 3) { $parts[2] } else { "?" }
-
-        Write-Host "  ENCONTRADO: hash=$hashPreview count=$count reset_at=$resetAt" -ForegroundColor Yellow
-
-        if ($Force) {
-            if ($PSCmdlet.ShouldProcess("login_rate_limits WHERE key_hash=$hashPreview", "DELETE")) {
-                $deleteSql = "DELETE FROM login_rate_limits WHERE key_hash = '$hash';"
-                try {
-                    & psql $databaseUrl -c $deleteSql 2>&1 | Out-Null
-                    Write-Host "  ELIMINADO : hash=$hashPreview" -ForegroundColor Green
-                } catch {
-                    Write-Warning "Error al eliminar: $_"
-                }
-            }
-        } else {
-            Write-Host "  (dry-run)  : se borraría hash=$hashPreview count=$count" -ForegroundColor Gray
-        }
-    } else {
-        Write-Host "  No encontrado: key para ip='$(if ($normalizedIp) { $normalizedIp } else { 'unknown' })'" -ForegroundColor DarkGray
-    }
+$pnpm = Get-Command pnpm -ErrorAction SilentlyContinue
+if (-not $pnpm) {
+    Write-Error "pnpm no está disponible en PATH. Ejecute el script Node con el runtime del proyecto."
+    exit 1
 }
 
-Write-Host ""
+$nodeArgs = @(
+    "--dir", $repoRoot.Path,
+    "exec", "tsx", "scripts/dev/reset-login-rate-limit.ts",
+    "--surface", $Surface,
+    "--identifier", $normalizedIdentifier
+)
 
-if (-not $foundAny) {
-    Write-Host "No se encontraron entradas de rate limit para los parámetros dados." -ForegroundColor Green
-    Write-Host "El usuario no está bloqueado en DB (puede estar en memoria — reiniciar servidor si aplica)." -ForegroundColor Gray
-} elseif (-not $Force) {
-    Write-Host "DRY-RUN completado. Para ejecutar el reset, agregue -Force:" -ForegroundColor Cyan
-    $ipFlag = if ($normalizedIp) { " -IpAddress `"$normalizedIp`"" } else { "" }
-    Write-Host "  .\reset-login-rate-limit.ps1 -Surface $Surface -Identifier `"$Identifier`"$ipFlag -Force" -ForegroundColor White
-} else {
-    Write-Host "Reset completado." -ForegroundColor Green
+$normalizedIp = $IpAddress.Trim()
+if ($normalizedIp.Length -gt 0) {
+    $nodeArgs += @("--ip-address", $normalizedIp)
 }
 
-Write-Host ""
+if ($Force) {
+    $nodeArgs += "--force"
+}
+
+& $pnpm.Source @nodeArgs
+exit $LASTEXITCODE

--- a/scripts/dev/reset-login-rate-limit.ts
+++ b/scripts/dev/reset-login-rate-limit.ts
@@ -1,0 +1,278 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import dotenv from "dotenv";
+import postgres from "postgres";
+
+import {
+  buildLoginRateLimitKey,
+  hashLoginRateLimitIdentifier,
+  hashLoginRateLimitIpAddress,
+  LOGIN_RATE_LIMIT_KEY_VERSION,
+  type LoginRateLimitSurface,
+} from "../../server/lib/login-rate-limit.ts";
+import { hashRateLimitKey } from "../../server/lib/rate-limit-store.ts";
+
+type CliOptions = {
+  surface: LoginRateLimitSurface;
+  identifier: string;
+  ipAddress: string | null;
+  force: boolean;
+};
+
+const VALID_SURFACES = new Set<LoginRateLimitSurface>([
+  "admin",
+  "clinic",
+  "particular",
+  "unified",
+]);
+
+function printUsage() {
+  console.log(
+    [
+      "Usage:",
+      "  pnpm exec tsx scripts/dev/reset-login-rate-limit.ts --surface <surface> --identifier <value> [--ip-address <ip>] [--force]",
+      "",
+      "Default mode is dry-run. Use --force to delete matching rows.",
+    ].join("\n"),
+  );
+}
+
+function readRequiredValue(args: string[], index: number, flag: string) {
+  const value = args[index + 1];
+
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requiere un valor.`);
+  }
+
+  return value;
+}
+
+function parseArgs(args: string[]): CliOptions {
+  let surface: LoginRateLimitSurface | null = null;
+  let identifier = "";
+  let ipAddress: string | null = null;
+  let force = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--surface": {
+        const value = readRequiredValue(args, index, arg);
+
+        if (!VALID_SURFACES.has(value as LoginRateLimitSurface)) {
+          throw new Error(
+            `surface invalida. Use: ${Array.from(VALID_SURFACES).join(", ")}`,
+          );
+        }
+
+        surface = value as LoginRateLimitSurface;
+        index += 1;
+        break;
+      }
+      case "--identifier": {
+        identifier = readRequiredValue(args, index, arg);
+        index += 1;
+        break;
+      }
+      case "--ip-address": {
+        const value = readRequiredValue(args, index, arg).trim();
+        ipAddress = value || null;
+        index += 1;
+        break;
+      }
+      case "--force": {
+        force = true;
+        break;
+      }
+      case "--dry-run": {
+        force = false;
+        break;
+      }
+      case "--help":
+      case "-h": {
+        printUsage();
+        process.exit(0);
+      }
+      default:
+        throw new Error(`Argumento no reconocido: ${arg}`);
+    }
+  }
+
+  const normalizedIdentifier = identifier.trim();
+
+  if (!surface) {
+    throw new Error("--surface es requerido.");
+  }
+
+  if (!normalizedIdentifier) {
+    throw new Error("--identifier no puede estar vacio.");
+  }
+
+  return {
+    surface,
+    identifier: normalizedIdentifier,
+    ipAddress,
+    force,
+  };
+}
+
+function loadEnv() {
+  const envPath = resolve(process.cwd(), ".env");
+
+  if (existsSync(envPath)) {
+    dotenv.config({ path: envPath });
+  }
+}
+
+function getDatabaseUrl() {
+  const databaseUrl =
+    process.env.SUPABASE_DB_URL?.trim() || process.env.DATABASE_URL?.trim();
+
+  if (!databaseUrl) {
+    throw new Error("Defina SUPABASE_DB_URL o DATABASE_URL para conectar a DB.");
+  }
+
+  return databaseUrl;
+}
+
+function previewHash(hash: string) {
+  return `${hash.slice(0, 12)}...`;
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  loadEnv();
+
+  const databaseUrl = getDatabaseUrl();
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    idle_timeout: 5,
+    connect_timeout: 10,
+  });
+
+  const identifierHash = hashLoginRateLimitIdentifier(options.identifier);
+  const ipHash = options.ipAddress
+    ? hashLoginRateLimitIpAddress(options.ipAddress)
+    : null;
+
+  console.log("=== RESET LOGIN RATE LIMIT ===");
+  console.log(`Surface        : ${options.surface}`);
+  console.log(`Key version    : ${LOGIN_RATE_LIMIT_KEY_VERSION}`);
+  console.log(`Identifier hash: ${previewHash(identifierHash)}`);
+  console.log(`IP filter      : ${ipHash ? previewHash(ipHash) : "(none)"}`);
+  console.log(`Mode           : ${options.force ? "FORCE" : "DRY-RUN"}`);
+
+  try {
+    const metadataRows = ipHash
+      ? await sql<{
+          key_hash: string;
+          count: number;
+          reset_at: Date;
+          ip_hash: string | null;
+        }[]>`
+          SELECT key_hash, count, reset_at, ip_hash
+          FROM login_rate_limits
+          WHERE surface = ${options.surface}
+            AND identifier_hash = ${identifierHash}
+            AND ip_hash = ${ipHash}
+          ORDER BY reset_at DESC
+        `
+      : await sql<{
+          key_hash: string;
+          count: number;
+          reset_at: Date;
+          ip_hash: string | null;
+        }[]>`
+          SELECT key_hash, count, reset_at, ip_hash
+          FROM login_rate_limits
+          WHERE surface = ${options.surface}
+            AND identifier_hash = ${identifierHash}
+          ORDER BY reset_at DESC
+        `;
+
+    const rows = [...metadataRows];
+
+    if (rows.length === 0 && options.ipAddress) {
+      const legacyKeyHash = hashRateLimitKey(
+        buildLoginRateLimitKey({
+          surface: options.surface,
+          identifier: options.identifier,
+          ipAddress: options.ipAddress,
+        }),
+      );
+      const legacyRows = await sql<{
+        key_hash: string;
+        count: number;
+        reset_at: Date;
+        ip_hash: string | null;
+      }[]>`
+        SELECT key_hash, count, reset_at, ip_hash
+        FROM login_rate_limits
+        WHERE key_hash = ${legacyKeyHash}
+        ORDER BY reset_at DESC
+      `;
+
+      if (legacyRows.length > 0) {
+        console.log(
+          "Legacy fallback: matched a pre-metadata row by exact IP-derived key hash.",
+        );
+        rows.push(...legacyRows);
+      }
+    }
+
+    console.log(`Matched rows   : ${rows.length}`);
+
+    for (const row of rows) {
+      console.log(
+        [
+          `  hash=${previewHash(row.key_hash)}`,
+          `count=${row.count}`,
+          `reset_at=${row.reset_at.toISOString()}`,
+          `ip_hash=${row.ip_hash ? previewHash(row.ip_hash) : "(legacy)"}`,
+        ].join(" "),
+      );
+    }
+
+    if (rows.length === 0) {
+      console.log(
+        options.ipAddress
+          ? "No matching rows found for metadata or exact legacy key."
+          : "No metadata rows found. Legacy rows cannot be reset by identifier without an exact IP.",
+      );
+      return;
+    }
+
+    if (!options.force) {
+      console.log("Dry-run only. Re-run with --force to delete these rows.");
+      return;
+    }
+
+    const keyHashes = rows.map((row) => row.key_hash);
+    const deletedRows = await sql<{ key_hash: string }[]>`
+      DELETE FROM login_rate_limits
+      WHERE key_hash IN ${sql(keyHashes)}
+      RETURNING key_hash
+    `;
+
+    console.log(`Deleted rows   : ${deletedRows.length}`);
+    console.log(
+      `Delete audit   : ${previewHash(sha256(deletedRows.map((row) => row.key_hash).join(":")))}`,
+    );
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`reset-login-rate-limit failed: ${message}`);
+  process.exit(1);
+});

--- a/scripts/dev/smoke-staging.ps1
+++ b/scripts/dev/smoke-staging.ps1
@@ -205,6 +205,24 @@ function Invoke-SmokeRequest {
         }
       }
 
+      if ($statusCode -eq 429) {
+        $retryAfter = Get-HeaderValue -Headers $responseHeaders -Name "Retry-After"
+        $lastError = "HTTP 429 rate limited; no se reintenta"
+        if (-not [string]::IsNullOrWhiteSpace($retryAfter)) {
+          $lastError = $lastError + " retryAfterSec=$retryAfter"
+        }
+
+        return [pscustomobject]@{
+          Success = $false
+          StatusCode = $statusCode
+          Headers = $responseHeaders
+          Body = $body
+          Json = (Try-ParseJson -Text $body)
+          Attempts = $attempt
+          Error = $lastError
+        }
+      }
+
       $lastError = "HTTP $statusCode fuera de codigos esperados ($($ExpectedStatusCodes -join ','))"
     } catch {
       $statusFromException = Get-StatusCodeFromException -ErrorRecord $_
@@ -225,6 +243,24 @@ function Invoke-SmokeRequest {
           Json = (Try-ParseJson -Text $body)
           Attempts = $attempt
           Error = ""
+        }
+      }
+
+      if ($null -ne $statusFromException -and $statusFromException -eq 429) {
+        $retryAfter = Get-HeaderValue -Headers $responseHeaders -Name "Retry-After"
+        $lastError = "HTTP 429 rate limited; no se reintenta"
+        if (-not [string]::IsNullOrWhiteSpace($retryAfter)) {
+          $lastError = $lastError + " retryAfterSec=$retryAfter"
+        }
+
+        return [pscustomobject]@{
+          Success = $false
+          StatusCode = $statusFromException
+          Headers = $responseHeaders
+          Body = $body
+          Json = (Try-ParseJson -Text $body)
+          Attempts = $attempt
+          Error = $lastError
         }
       }
 
@@ -281,6 +317,17 @@ function Mark-CredentialCheckSkipSet {
   }
 }
 
+function Get-SmokeEnvValue {
+  param([string]$Name)
+
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) {
+    return ""
+  }
+
+  return $value.Trim()
+}
+
 $BackendUrl = Normalize-Url -Url $BackendUrl
 $FrontendUrl = Normalize-Url -Url $FrontendUrl
 $ExpectedSecureCookieFlags = $BackendUrl.StartsWith("https://")
@@ -307,6 +354,16 @@ if ($Retries -lt 1) {
 
 $startedAt = Get-Date
 $results = [System.Collections.Generic.List[object]]::new()
+
+$adminUser = Get-SmokeEnvValue -Name "SMOKE_ADMIN_USERNAME"
+$adminPassword = Get-SmokeEnvValue -Name "SMOKE_ADMIN_PASSWORD"
+$clinicUser = Get-SmokeEnvValue -Name "SMOKE_CLINIC_USERNAME"
+$clinicPassword = Get-SmokeEnvValue -Name "SMOKE_CLINIC_PASSWORD"
+$particularToken = Get-SmokeEnvValue -Name "SMOKE_PARTICULAR_TOKEN"
+
+$hasAdminCreds = -not [string]::IsNullOrWhiteSpace($adminUser) -and -not [string]::IsNullOrWhiteSpace($adminPassword)
+$hasClinicCreds = -not [string]::IsNullOrWhiteSpace($clinicUser) -and -not [string]::IsNullOrWhiteSpace($clinicPassword)
+$hasParticularToken = -not [string]::IsNullOrWhiteSpace($particularToken)
 
 Write-Host ""
 Write-Host "=== STAGING SMOKE CHECK ===" -ForegroundColor Cyan
@@ -470,10 +527,6 @@ if ($badOriginCheck.Success) {
     -Detail ("Esperado HTTP 403. " + $badOriginCheck.Error)
 }
 
-$adminUser = [Environment]::GetEnvironmentVariable("SMOKE_ADMIN_USERNAME")
-$adminPassword = [Environment]::GetEnvironmentVariable("SMOKE_ADMIN_PASSWORD")
-$hasAdminCreds = -not [string]::IsNullOrWhiteSpace($adminUser) -and -not [string]::IsNullOrWhiteSpace($adminPassword)
-
 if ($hasAdminCreds) {
   $adminSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
   $adminLogin = Invoke-SmokeRequest `
@@ -572,10 +625,6 @@ if ($hasAdminCreds) {
   ) -MissingReason "faltan env vars SMOKE_ADMIN_USERNAME/SMOKE_ADMIN_PASSWORD"
 }
 
-$clinicUser = [Environment]::GetEnvironmentVariable("SMOKE_CLINIC_USERNAME")
-$clinicPassword = [Environment]::GetEnvironmentVariable("SMOKE_CLINIC_PASSWORD")
-$hasClinicCreds = -not [string]::IsNullOrWhiteSpace($clinicUser) -and -not [string]::IsNullOrWhiteSpace($clinicPassword)
-
 if ($hasClinicCreds) {
   $clinicSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
   $clinicLogin = Invoke-SmokeRequest `
@@ -629,9 +678,6 @@ if ($hasClinicCreds) {
     "Clinic logout (/api/auth/logout)"
   ) -MissingReason "faltan env vars SMOKE_CLINIC_USERNAME/SMOKE_CLINIC_PASSWORD"
 }
-
-$particularToken = [Environment]::GetEnvironmentVariable("SMOKE_PARTICULAR_TOKEN")
-$hasParticularToken = -not [string]::IsNullOrWhiteSpace($particularToken)
 
 if ($hasParticularToken) {
   $particularSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession

--- a/server/db.ts
+++ b/server/db.ts
@@ -246,11 +246,21 @@ export async function setLoginRateLimitEntry(input: {
   count: number;
   resetAt: Date;
   now: Date;
+  metadata?: {
+    surface: string;
+    identifierHash: string;
+    ipHash: string;
+    keyVersion: string;
+  };
 }) {
   const result = await db
     .insert(loginRateLimits)
     .values({
       keyHash: input.keyHash,
+      surface: input.metadata?.surface ?? null,
+      identifierHash: input.metadata?.identifierHash ?? null,
+      ipHash: input.metadata?.ipHash ?? null,
+      keyVersion: input.metadata?.keyVersion ?? null,
       count: input.count,
       resetAt: input.resetAt,
       createdAt: input.now,
@@ -259,6 +269,10 @@ export async function setLoginRateLimitEntry(input: {
     .onConflictDoUpdate({
       target: loginRateLimits.keyHash,
       set: {
+        surface: input.metadata?.surface ?? null,
+        identifierHash: input.metadata?.identifierHash ?? null,
+        ipHash: input.metadata?.ipHash ?? null,
+        keyVersion: input.metadata?.keyVersion ?? null,
         count: input.count,
         resetAt: input.resetAt,
         updatedAt: input.now,
@@ -277,11 +291,21 @@ export async function incrementLoginRateLimitEntry(input: {
   count: number;
   resetAt: Date;
   now: Date;
+  metadata?: {
+    surface: string;
+    identifierHash: string;
+    ipHash: string;
+    keyVersion: string;
+  };
 }) {
   const result = await db
     .insert(loginRateLimits)
     .values({
       keyHash: input.keyHash,
+      surface: input.metadata?.surface ?? null,
+      identifierHash: input.metadata?.identifierHash ?? null,
+      ipHash: input.metadata?.ipHash ?? null,
+      keyVersion: input.metadata?.keyVersion ?? null,
       count: input.count,
       resetAt: input.resetAt,
       createdAt: input.now,
@@ -290,6 +314,10 @@ export async function incrementLoginRateLimitEntry(input: {
     .onConflictDoUpdate({
       target: loginRateLimits.keyHash,
       set: {
+        surface: input.metadata?.surface ?? null,
+        identifierHash: input.metadata?.identifierHash ?? null,
+        ipHash: input.metadata?.ipHash ?? null,
+        keyVersion: input.metadata?.keyVersion ?? null,
         count: sql<number>`
           CASE
             WHEN ${loginRateLimits.resetAt} <= ${input.now} THEN ${input.count}

--- a/server/lib/login-rate-limit.ts
+++ b/server/lib/login-rate-limit.ts
@@ -1,16 +1,28 @@
-﻿export const LOGIN_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+import { createHash } from "node:crypto";
+
+export const LOGIN_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 export const LOGIN_RATE_LIMIT_MAX_ATTEMPTS = 10;
 export const LOGIN_RATE_LIMIT_ERROR_MESSAGE =
   "Demasiados intentos de inicio de sesión. Intente más tarde.";
 
-const LOGIN_RATE_LIMIT_KEY_VERSION = "v2";
+export const LOGIN_RATE_LIMIT_KEY_VERSION = "v2";
+
 const LOGIN_RATE_LIMIT_IDENTIFIER_MAX_LENGTH = 256;
+const LOGIN_RATE_LIMIT_HASH_PREFIX = "login-rate-limit";
+const LOGIN_RATE_LIMIT_MISSING_IDENTIFIER = "missing";
 
 export type LoginRateLimitSurface =
   | "admin"
   | "clinic"
   | "particular"
   | "unified";
+
+export type LoginRateLimitKeyMetadata = {
+  surface: LoginRateLimitSurface;
+  identifierHash: string;
+  ipHash: string;
+  keyVersion: typeof LOGIN_RATE_LIMIT_KEY_VERSION;
+};
 
 export function normalizeLoginRateLimitIdentifier(identifier: string): string {
   return (
@@ -21,6 +33,53 @@ export function normalizeLoginRateLimitIdentifier(identifier: string): string {
   );
 }
 
+export function normalizeLoginRateLimitIpAddress(
+  ipAddress?: string | null,
+): string {
+  return ipAddress?.trim() || "unknown";
+}
+
+export function hashLoginRateLimitIdentifier(identifier: string): string {
+  return createHash("sha256")
+    .update(
+      [
+        LOGIN_RATE_LIMIT_HASH_PREFIX,
+        LOGIN_RATE_LIMIT_KEY_VERSION,
+        "identifier",
+        normalizeLoginRateLimitIdentifier(identifier),
+      ].join(":"),
+    )
+    .digest("hex");
+}
+
+export function hashLoginRateLimitIpAddress(
+  ipAddress?: string | null,
+): string {
+  return createHash("sha256")
+    .update(
+      [
+        LOGIN_RATE_LIMIT_HASH_PREFIX,
+        LOGIN_RATE_LIMIT_KEY_VERSION,
+        "ip",
+        normalizeLoginRateLimitIpAddress(ipAddress),
+      ].join(":"),
+    )
+    .digest("hex");
+}
+
+export function buildLoginRateLimitKeyMetadata(input: {
+  surface: LoginRateLimitSurface;
+  identifier: string;
+  ipAddress?: string | null;
+}): LoginRateLimitKeyMetadata {
+  return {
+    surface: input.surface,
+    identifierHash: hashLoginRateLimitIdentifier(input.identifier),
+    ipHash: hashLoginRateLimitIpAddress(input.ipAddress),
+    keyVersion: LOGIN_RATE_LIMIT_KEY_VERSION,
+  };
+}
+
 export function buildLoginRateLimitKey(input: {
   surface: LoginRateLimitSurface;
   identifier: string;
@@ -29,7 +88,7 @@ export function buildLoginRateLimitKey(input: {
   const normalizedIdentifier = normalizeLoginRateLimitIdentifier(
     input.identifier,
   );
-  const normalizedIpAddress = input.ipAddress?.trim() || "unknown";
+  const normalizedIpAddress = normalizeLoginRateLimitIpAddress(input.ipAddress);
 
   return [
     "login",
@@ -39,4 +98,73 @@ export function buildLoginRateLimitKey(input: {
     "ip",
     normalizedIpAddress,
   ].join(":");
+}
+
+export function buildMissingCredentialsLoginRateLimitKey(input: {
+  surface: LoginRateLimitSurface;
+  ipAddress?: string | null;
+}): string {
+  return buildLoginRateLimitKey({
+    surface: input.surface,
+    identifier: LOGIN_RATE_LIMIT_MISSING_IDENTIFIER,
+    ipAddress: input.ipAddress,
+  });
+}
+
+export function getLoginRateLimitKeyMetadata(
+  key: string,
+): LoginRateLimitKeyMetadata | undefined {
+  const keyPrefix = `login:${LOGIN_RATE_LIMIT_KEY_VERSION}:`;
+  const ipMarker = ":ip:";
+
+  if (!key.startsWith(keyPrefix)) {
+    return undefined;
+  }
+
+  const keyBody = key.slice(keyPrefix.length);
+  const surfaceSeparatorIndex = keyBody.indexOf(":");
+  const ipMarkerIndex = keyBody.lastIndexOf(ipMarker);
+
+  if (surfaceSeparatorIndex <= 0 || ipMarkerIndex <= surfaceSeparatorIndex) {
+    return undefined;
+  }
+
+  const surface = keyBody.slice(
+    0,
+    surfaceSeparatorIndex,
+  ) as LoginRateLimitSurface;
+
+  if (!["admin", "clinic", "particular", "unified"].includes(surface)) {
+    return undefined;
+  }
+
+  return buildLoginRateLimitKeyMetadata({
+    surface,
+    identifier: keyBody.slice(surfaceSeparatorIndex + 1, ipMarkerIndex),
+    ipAddress: keyBody.slice(ipMarkerIndex + ipMarker.length),
+  });
+}
+
+export function getLoginRateLimitResetSeconds(input: {
+  resetAt: number;
+  now: number;
+}) {
+  return Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0);
+}
+
+export function buildLoginRateLimitHeaders(input: {
+  max: number;
+  windowMs: number;
+  failedCount: number;
+  resetAt: number;
+  now: number;
+}) {
+  return {
+    "RateLimit-Policy": `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+    "RateLimit-Limit": String(input.max),
+    "RateLimit-Remaining": String(
+      Math.max(input.max - input.failedCount, 0),
+    ),
+    "RateLimit-Reset": String(getLoginRateLimitResetSeconds(input)),
+  };
 }

--- a/server/lib/rate-limit-store.ts
+++ b/server/lib/rate-limit-store.ts
@@ -21,6 +21,13 @@ export type PersistentRateLimitRecord = {
   resetAt: Date;
 };
 
+export type PersistentRateLimitMetadata = {
+  surface: string;
+  identifierHash: string;
+  ipHash: string;
+  keyVersion: string;
+};
+
 export type PersistentRateLimitStoreAdapter = {
   get: (
     keyHash: string,
@@ -30,12 +37,14 @@ export type PersistentRateLimitStoreAdapter = {
     count: number;
     resetAt: Date;
     now: Date;
+    metadata?: PersistentRateLimitMetadata;
   }) => PersistentRateLimitRecord | undefined | Promise<PersistentRateLimitRecord | undefined>;
   increment: (input: {
     keyHash: string;
     count: number;
     resetAt: Date;
     now: Date;
+    metadata?: PersistentRateLimitMetadata;
   }) => PersistentRateLimitRecord | Promise<PersistentRateLimitRecord>;
   cleanupExpired?: (now: Date) => void | Promise<void>;
   delete?: (keyHash: string) => void | Promise<void>;
@@ -43,6 +52,9 @@ export type PersistentRateLimitStoreAdapter = {
 
 export type PersistentRateLimitStoreOptions = {
   now?: () => number;
+  metadataForKey?: (
+    key: string,
+  ) => PersistentRateLimitMetadata | undefined | null;
 };
 
 export function createMemoryRateLimitStore(): RateLimitStore {
@@ -94,6 +106,8 @@ export function createPersistentRateLimitStore(
   options: PersistentRateLimitStoreOptions = {},
 ): RateLimitStore {
   const getNow = options.now ?? (() => Date.now());
+  const getMetadata = (key: string) =>
+    options.metadataForKey?.(key) ?? undefined;
 
   return {
     get: async (key) => {
@@ -115,6 +129,7 @@ export function createPersistentRateLimitStore(
         count: entry.count,
         resetAt: toPersistentDate(entry.resetAt),
         now: toPersistentDate(now),
+        metadata: getMetadata(key),
       });
     },
     increment: async (key, entry, now = getNow()) => {
@@ -126,6 +141,7 @@ export function createPersistentRateLimitStore(
           count: entry.count + 1,
           resetAt: toPersistentDate(entry.resetAt),
           now: toPersistentDate(now),
+          metadata: getMetadata(key),
         }),
       );
     },
@@ -141,6 +157,7 @@ export function createPersistentRateLimitStore(
           count: 0,
           resetAt: toPersistentDate(now - 1),
           now: toPersistentDate(now),
+          metadata: getMetadata(key),
         });
       }
     },

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -7,7 +7,11 @@ import type {
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  buildLoginRateLimitHeaders,
   buildLoginRateLimitKey,
+  buildMissingCredentialsLoginRateLimitKey,
+  getLoginRateLimitKeyMetadata,
+  getLoginRateLimitResetSeconds,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -167,13 +171,18 @@ async function loadDefaultDeps(): Promise<NativeAdminAuthDefaultDeps> {
           input: AuditWriteInput,
         ) => Promise<void>,
         recordLoginFailedAttempt: db.recordLoginFailedAttempt,
-        loginRateLimitStore: createPersistentRateLimitStore({
-          get: db.getLoginRateLimitEntry,
-          set: db.setLoginRateLimitEntry,
-          increment: db.incrementLoginRateLimitEntry,
-          cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
-          delete: db.deleteLoginRateLimitEntry,
-        }),
+        loginRateLimitStore: createPersistentRateLimitStore(
+          {
+            get: db.getLoginRateLimitEntry,
+            set: db.setLoginRateLimitEntry,
+            increment: db.incrementLoginRateLimitEntry,
+            cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+            delete: db.deleteLoginRateLimitEntry,
+          },
+          {
+            metadataForKey: getLoginRateLimitKeyMetadata,
+          },
+        ),
       };
     })();
   }
@@ -407,19 +416,11 @@ function setLoginRateLimitHeaders(
     now: number;
   },
 ) {
-  reply.header(
-    "RateLimit-Policy",
-    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
-  );
-  reply.header("RateLimit-Limit", String(input.max));
-  reply.header(
-    "RateLimit-Remaining",
-    String(Math.max(input.max - input.failedCount, 0)),
-  );
-  reply.header(
-    "RateLimit-Reset",
-    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
-  );
+  for (const [headerName, headerValue] of Object.entries(
+    buildLoginRateLimitHeaders(input),
+  )) {
+    reply.header(headerName, headerValue);
+  }
 }
 
 
@@ -640,9 +641,88 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     const password =
       typeof request.body?.password === "string" ? request.body.password : "";
 
+    const recordFailedLoginAttempt = async (input: {
+      username?: string | null;
+      reason: LoginFailedAttemptReason;
+    }) => {
+      try {
+        await deps.recordLoginFailedAttempt({
+          surface: "admin",
+          username: input.username?.trim() || null,
+          reason: input.reason,
+          ipAddress: request.ip || null,
+          userAgent: getUserAgent(request),
+          createdAt: new Date(currentTime),
+        });
+      } catch (error) {
+        request.log.warn(
+          {
+            err: error,
+            code: "ADMIN_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
+            surface: "admin",
+            reason: input.reason,
+          },
+          "No se pudo persistir intento fallido de login admin",
+        );
+      }
+    };
+
+    const markMissingCredentials = async () => {
+      const missingRateLimitKey = buildMissingCredentialsLoginRateLimitKey({
+        surface: "admin",
+        ipAddress: request.ip || null,
+      });
+
+      try {
+        const missingEntry = await getOrCreateRateLimitEntry(
+          loginRateLimitStore,
+          missingRateLimitKey,
+          loginRateLimitWindowMs,
+          currentTime,
+        );
+        const updatedMissingEntry = await incrementRateLimitEntry(
+          loginRateLimitStore,
+          missingRateLimitKey,
+          missingEntry,
+          currentTime,
+        );
+
+        setLoginRateLimitHeaders(reply, {
+          max: loginRateLimitMaxAttempts,
+          windowMs: loginRateLimitWindowMs,
+          failedCount: updatedMissingEntry.count,
+          resetAt: updatedMissingEntry.resetAt,
+          now: currentTime,
+        });
+      } catch (error) {
+        request.log.error(
+          {
+            err: error,
+            code: "ADMIN_LOGIN_MISSING_CREDENTIALS_RATE_LIMIT_FAILED",
+            route: "/api/admin/auth/login",
+          },
+          "No se pudo actualizar el rate limit de credenciales faltantes admin",
+        );
+      }
+
+      await recordFailedLoginAttempt({
+        username: null,
+        reason: "missing_credentials",
+      });
+    };
+
+    if (!username || !password) {
+      await markMissingCredentials();
+
+      return reply.code(400).send({
+        success: false,
+        error: "Usuario y contraseña requeridos",
+      });
+    }
+
     const rateLimitKey = buildLoginRateLimitKey({
       surface: "admin",
-      identifier: username || "unknown",
+      identifier: username,
       ipAddress: request.ip || null,
     });
 
@@ -674,37 +754,11 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       );
     }
 
-    const recordFailedLoginAttempt = async (input: {
-      username?: string | null;
-      reason: LoginFailedAttemptReason;
-    }) => {
-      try {
-        await deps.recordLoginFailedAttempt({
-          surface: "admin",
-          username: input.username?.trim() || null,
-          reason: input.reason,
-          ipAddress: request.ip || null,
-          userAgent: getUserAgent(request),
-          createdAt: new Date(currentTime),
-        });
-      } catch (error) {
-        request.log.warn(
-          {
-            err: error,
-            code: "ADMIN_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
-            surface: "admin",
-            reason: input.reason,
-          },
-          "No se pudo persistir intento fallido de login admin",
-        );
-      }
-    };
-
     if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
-      const resetSeconds = Math.max(
-        Math.ceil((failureEntry.resetAt - currentTime) / 1000),
-        0,
-      );
+      const resetSeconds = getLoginRateLimitResetSeconds({
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
 
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -793,18 +847,6 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
     };
-
-    if (!username || !password) {
-      await markFailure({
-        username,
-        reason: "missing_credentials",
-      });
-
-      return reply.code(400).send({
-        success: false,
-        error: "Usuario y contraseña requeridos",
-      });
-    }
 
     const admin = await deps.getAdminUserByUsername(username);
 

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -7,7 +7,11 @@ import type {
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  buildLoginRateLimitHeaders,
   buildLoginRateLimitKey,
+  buildMissingCredentialsLoginRateLimitKey,
+  getLoginRateLimitKeyMetadata,
+  getLoginRateLimitResetSeconds,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -304,13 +308,18 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
           input: AuditWriteInput,
         ) => Promise<void>,
         recordLoginFailedAttempt: db.recordLoginFailedAttempt,
-        loginRateLimitStore: createPersistentRateLimitStore({
-          get: db.getLoginRateLimitEntry,
-          set: db.setLoginRateLimitEntry,
-          increment: db.incrementLoginRateLimitEntry,
-          cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
-          delete: db.deleteLoginRateLimitEntry,
-        }),
+        loginRateLimitStore: createPersistentRateLimitStore(
+          {
+            get: db.getLoginRateLimitEntry,
+            set: db.setLoginRateLimitEntry,
+            increment: db.incrementLoginRateLimitEntry,
+            cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+            delete: db.deleteLoginRateLimitEntry,
+          },
+          {
+            metadataForKey: getLoginRateLimitKeyMetadata,
+          },
+        ),
       };
     })();
   }
@@ -563,26 +572,11 @@ function setLoginRateLimitHeaders(
     now: number;
   },
 ) {
-  reply.header(
-    "RateLimit-Policy",
-    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
-  );
-  reply.header("RateLimit-Limit", String(input.max));
-  reply.header(
-    "RateLimit-Remaining",
-    String(Math.max(input.max - input.failedCount, 0)),
-  );
-  reply.header(
-    "RateLimit-Reset",
-    String(getLoginRateLimitResetSeconds(input)),
-  );
-}
-
-function getLoginRateLimitResetSeconds(input: {
-  resetAt: number;
-  now: number;
-}) {
-  return Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0);
+  for (const [headerName, headerValue] of Object.entries(
+    buildLoginRateLimitHeaders(input),
+  )) {
+    reply.header(headerName, headerValue);
+  }
 }
 
 function getUserAgent(request: FastifyRequest) {
@@ -1050,7 +1044,79 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
     const password =
       typeof request.body?.password === "string" ? request.body.password : "";
 
+    const recordFailedLoginAttempt = async (input: {
+      username?: string | null;
+      reason: LoginFailedAttemptReason;
+    }) => {
+      try {
+        await deps.recordLoginFailedAttempt({
+          surface: "clinic",
+          username: input.username?.trim() || null,
+          reason: input.reason,
+          ipAddress: request.ip || null,
+          userAgent: getUserAgent(request),
+          createdAt: new Date(currentTime),
+        });
+      } catch (error) {
+        request.log.warn(
+          {
+            err: error,
+            code: "AUTH_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
+            surface: "clinic",
+            reason: input.reason,
+          },
+          "No se pudo persistir intento fallido de login clinic",
+        );
+      }
+    };
+
+    const markMissingCredentials = async () => {
+      const missingRateLimitKey = buildMissingCredentialsLoginRateLimitKey({
+        surface: isUnifiedPayload ? "unified" : "clinic",
+        ipAddress: request.ip || null,
+      });
+
+      try {
+        const missingEntry = await getOrCreateRateLimitEntry(
+          loginRateLimitStore,
+          missingRateLimitKey,
+          loginRateLimitWindowMs,
+          currentTime,
+        );
+        const updatedMissingEntry = await incrementRateLimitEntry(
+          loginRateLimitStore,
+          missingRateLimitKey,
+          missingEntry,
+          currentTime,
+        );
+
+        setLoginRateLimitHeaders(reply, {
+          max: loginRateLimitMaxAttempts,
+          windowMs: loginRateLimitWindowMs,
+          failedCount: updatedMissingEntry.count,
+          resetAt: updatedMissingEntry.resetAt,
+          now: currentTime,
+        });
+      } catch (error) {
+        request.log.error(
+          {
+            err: error,
+            code: "AUTH_LOGIN_MISSING_CREDENTIALS_RATE_LIMIT_FAILED",
+            route: "/api/auth/login",
+          },
+          "No se pudo actualizar el rate limit de credenciales faltantes",
+        );
+      }
+
+      await recordFailedLoginAttempt({
+        username: null,
+        reason: "missing_credentials",
+      });
+    };
+
     if (!loginIdentifier || !password) {
+      await markMissingCredentials();
+
       return reply.code(400).send({
         success: false,
         error: isUnifiedPayload
@@ -1092,32 +1158,6 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         "No se pudo leer el rate limit de login unificado",
       );
     }
-
-    const recordFailedLoginAttempt = async (input: {
-      username?: string | null;
-      reason: LoginFailedAttemptReason;
-    }) => {
-      try {
-        await deps.recordLoginFailedAttempt({
-          surface: "clinic",
-          username: input.username?.trim() || null,
-          reason: input.reason,
-          ipAddress: request.ip || null,
-          userAgent: getUserAgent(request),
-          createdAt: new Date(currentTime),
-        });
-      } catch (error) {
-        request.log.warn(
-          {
-            err: error,
-            code: "AUTH_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
-            surface: "clinic",
-            reason: input.reason,
-          },
-          "No se pudo persistir intento fallido de login clinic",
-        );
-      }
-    };
 
     if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
       setLoginRateLimitHeaders(reply, {

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -7,7 +7,11 @@ import type { ParticularToken, Report } from "../../drizzle/schema.ts";
 
 import { ENV } from "../lib/env.ts";
 import {
+  buildLoginRateLimitHeaders,
   buildLoginRateLimitKey,
+  buildMissingCredentialsLoginRateLimitKey,
+  getLoginRateLimitKeyMetadata,
+  getLoginRateLimitResetSeconds,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -159,13 +163,18 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDefaultDeps> {
         generateSessionToken: authSecurity.generateSessionToken,
         hashSessionToken: authSecurity.hashSessionToken,
         recordLoginFailedAttempt: db.recordLoginFailedAttempt,
-        loginRateLimitStore: createPersistentRateLimitStore({
-          get: db.getLoginRateLimitEntry,
-          set: db.setLoginRateLimitEntry,
-          increment: db.incrementLoginRateLimitEntry,
-          cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
-          delete: db.deleteLoginRateLimitEntry,
-        }),
+        loginRateLimitStore: createPersistentRateLimitStore(
+          {
+            get: db.getLoginRateLimitEntry,
+            set: db.setLoginRateLimitEntry,
+            increment: db.incrementLoginRateLimitEntry,
+            cleanupExpired: db.deleteExpiredLoginRateLimitEntries,
+            delete: db.deleteLoginRateLimitEntry,
+          },
+          {
+            metadataForKey: getLoginRateLimitKeyMetadata,
+          },
+        ),
       };
     })();
   }
@@ -399,19 +408,11 @@ function setLoginRateLimitHeaders(
     now: number;
   },
 ) {
-  reply.header(
-    "RateLimit-Policy",
-    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
-  );
-  reply.header("RateLimit-Limit", String(input.max));
-  reply.header(
-    "RateLimit-Remaining",
-    String(Math.max(input.max - input.failedCount, 0)),
-  );
-  reply.header(
-    "RateLimit-Reset",
-    String(Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0)),
-  );
+  for (const [headerName, headerValue] of Object.entries(
+    buildLoginRateLimitHeaders(input),
+  )) {
+    reply.header(headerName, headerValue);
+  }
 }
 
 function getUserAgent(request: FastifyRequest) {
@@ -645,9 +646,86 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     const providedToken =
       typeof request.body?.token === "string" ? request.body.token.trim() : "";
 
+    const recordFailedLoginAttempt = async (input: {
+      reason: LoginFailedAttemptReason;
+    }) => {
+      try {
+        await deps.recordLoginFailedAttempt({
+          surface: "particular",
+          username: null,
+          reason: input.reason,
+          ipAddress: request.ip || null,
+          userAgent: getUserAgent(request),
+          createdAt: new Date(currentTime),
+        });
+      } catch (error) {
+        request.log.warn(
+          {
+            err: error,
+            code: "PARTICULAR_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
+            surface: "particular",
+            reason: input.reason,
+          },
+          "No se pudo persistir intento fallido de login particular",
+        );
+      }
+    };
+
+    const markMissingCredentials = async () => {
+      const missingRateLimitKey = buildMissingCredentialsLoginRateLimitKey({
+        surface: "particular",
+        ipAddress: request.ip || null,
+      });
+
+      try {
+        const missingEntry = await getOrCreateRateLimitEntry(
+          loginRateLimitStore,
+          missingRateLimitKey,
+          loginRateLimitWindowMs,
+          currentTime,
+        );
+        const updatedMissingEntry = await incrementRateLimitEntry(
+          loginRateLimitStore,
+          missingRateLimitKey,
+          missingEntry,
+          currentTime,
+        );
+
+        setLoginRateLimitHeaders(reply, {
+          max: loginRateLimitMaxAttempts,
+          windowMs: loginRateLimitWindowMs,
+          failedCount: updatedMissingEntry.count,
+          resetAt: updatedMissingEntry.resetAt,
+          now: currentTime,
+        });
+      } catch (error) {
+        request.log.error(
+          {
+            err: error,
+            code: "PARTICULAR_LOGIN_MISSING_CREDENTIALS_RATE_LIMIT_FAILED",
+            route: "/api/particular/auth/login",
+          },
+          "No se pudo actualizar el rate limit de token faltante particular",
+        );
+      }
+
+      await recordFailedLoginAttempt({
+        reason: "missing_credentials",
+      });
+    };
+
+    if (!providedToken) {
+      await markMissingCredentials();
+
+      return reply.code(400).send({
+        success: false,
+        error: "Token obligatorio",
+      });
+    }
+
     const rateLimitKey = buildLoginRateLimitKey({
       surface: "particular",
-      identifier: providedToken || "unknown",
+      identifier: providedToken,
       ipAddress: request.ip || null,
     });
 
@@ -679,36 +757,11 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       );
     }
 
-    const recordFailedLoginAttempt = async (input: {
-      reason: LoginFailedAttemptReason;
-    }) => {
-      try {
-        await deps.recordLoginFailedAttempt({
-          surface: "particular",
-          username: null,
-          reason: input.reason,
-          ipAddress: request.ip || null,
-          userAgent: getUserAgent(request),
-          createdAt: new Date(currentTime),
-        });
-      } catch (error) {
-        request.log.warn(
-          {
-            err: error,
-            code: "PARTICULAR_LOGIN_FAILED_ATTEMPT_RECORD_FAILED",
-            surface: "particular",
-            reason: input.reason,
-          },
-          "No se pudo persistir intento fallido de login particular",
-        );
-      }
-    };
-
     if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
-      const resetSeconds = Math.max(
-        Math.ceil((failureEntry.resetAt - currentTime) / 1000),
-        0,
-      );
+      const resetSeconds = getLoginRateLimitResetSeconds({
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+      });
 
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
@@ -795,17 +848,6 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
         now: currentTime,
       });
     };
-
-    if (!providedToken) {
-      await markFailure({
-        reason: "missing_credentials",
-      });
-
-      return reply.code(400).send({
-        success: false,
-        error: "Token obligatorio",
-      });
-    }
 
     const tokenHash = deps.hashSessionToken(providedToken);
     const particularToken = await deps.getParticularTokenByTokenHash(tokenHash);

--- a/test/admin-clinics-db-contract.test.ts
+++ b/test/admin-clinics-db-contract.test.ts
@@ -172,7 +172,7 @@ test("migración 0026 existe y añade contact_email y contact_phone con ADD COLU
   );
 });
 
-test("journal de migraciones conserva 0026 y deja 0029 como última entrada", () => {
+test("journal de migraciones conserva 0026 y 0029 antes de metadata login", () => {
   const raw = read("drizzle/migrations/meta/_journal.json");
   const journal = JSON.parse(raw) as {
     entries: Array<{ idx: number; tag: string }>;
@@ -188,12 +188,20 @@ test("journal de migraciones conserva 0026 y deja 0029 como última entrada", ()
     ),
     "el journal debe conservar 0026_clinics_contact_columns_reconciliation",
   );
+  assert.ok(
+    journal.entries.some(
+      (entry) =>
+        entry.idx === 29 &&
+        entry.tag === "0029_admin_users_email_identifier",
+    ),
+    "el journal debe conservar 0029_admin_users_email_identifier",
+  );
   assert.equal(
     last?.tag,
-    "0029_admin_users_email_identifier",
-    "la última entrada del journal debe ser 0029_admin_users_email_identifier",
+    "0030_login_rate_limits_metadata",
+    "la última entrada del journal debe ser 0030_login_rate_limits_metadata",
   );
-  assert.equal(last?.idx, 29, "idx de la última migración debe ser 29");
+  assert.equal(last?.idx, 30, "idx de la última migración debe ser 30");
 });
 
 test("toIsoDate acepta Date o string devuelto por raw SQL postgres-js", () => {

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -785,7 +785,7 @@ test("clinicAuthNativeRoutes login unificado valida payload inválido sin stackt
   }
 });
 
-test("clinicAuthNativeRoutes login unificado valida payload inválido antes de rate-limit y auditoría", async () => {
+test("clinicAuthNativeRoutes login unificado registra payload inválido como missing_credentials aislado", async () => {
   const rateLimitCalls = {
     get: 0,
     set: 0,
@@ -832,11 +832,13 @@ test("clinicAuthNativeRoutes login unificado valida payload inválido antes de r
       error: "Identificador y contraseña requeridos",
     });
     assert.deepEqual(rateLimitCalls, {
-      get: 0,
+      get: 1,
       set: 0,
       increment: 0,
     });
-    assert.equal(failedAttempts.length, 0);
+    assert.equal(failedAttempts.length, 1);
+    assert.equal(failedAttempts[0].reason, "missing_credentials");
+    assert.equal(failedAttempts[0].username, null);
   } finally {
     await app.close();
   }

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -85,7 +85,21 @@ test("frontend API client formats 429 login rate-limit guidance from headers", (
   const source = read(API_CLIENT_PATH);
 
   assert.ok(source.includes("export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE ="));
+  assert.ok(source.includes("export const LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE ="));
+  assert.ok(source.includes("const LOGIN_RATE_LIMIT_REQUIRED_HEADERS ="));
+  for (const headerName of [
+    "Retry-After",
+    "RateLimit-Policy",
+    "RateLimit-Limit",
+    "RateLimit-Remaining",
+    "RateLimit-Reset",
+  ]) {
+    assert.ok(source.includes(`"${headerName}"`), `missing ${headerName}`);
+  }
   assert.ok(source.includes('headers.get("Retry-After") ?? headers.get("RateLimit-Reset")'));
+  assert.ok(source.includes("function isLoginRateLimitPath("));
+  assert.ok(source.includes("function hasRequiredLoginRateLimitHeaders("));
+  assert.ok(source.includes("LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE"));
   assert.ok(source.includes("function buildRateLimitErrorMessage("));
   assert.ok(source.includes("Reintente en"));
 });
@@ -158,4 +172,25 @@ test("next.config.ts declara rewrites que proxyan /api/** al backend cuando NEXT
     source.includes('destination: `${apiUrl}/api/:path*`'),
     "destination debe proxiar al backend",
   );
+});
+
+test("next API rewrite contract does not shadow login rate-limit headers", () => {
+  const source = read(NEXT_CONFIG_PATH);
+
+  assert.ok(source.includes('source: "/api/:path*"'));
+  assert.ok(source.includes('destination: `${apiUrl}/api/:path*`'));
+
+  for (const headerName of [
+    "Retry-After",
+    "RateLimit-Policy",
+    "RateLimit-Limit",
+    "RateLimit-Remaining",
+    "RateLimit-Reset",
+  ]) {
+    assert.equal(
+      source.includes(`key: "${headerName}"`),
+      false,
+      `next config must not override ${headerName}`,
+    );
+  }
 });

--- a/test/login-rate-limit-operability.test.ts
+++ b/test/login-rate-limit-operability.test.ts
@@ -1,0 +1,405 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import type {
+  RateLimitEntry,
+  RateLimitStore,
+} from "../server/lib/rate-limit-store.ts";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const {
+  buildLoginRateLimitKey,
+  buildMissingCredentialsLoginRateLimitKey,
+  LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+} = await import("../server/lib/login-rate-limit.ts");
+const {
+  clinicAuthNativeRoutes,
+} = await import("../server/routes/auth.fastify.ts");
+const {
+  adminAuthNativeRoutes,
+} = await import("../server/routes/admin-auth.fastify.ts");
+const {
+  particularAuthNativeRoutes,
+} = await import("../server/routes/particular-auth.fastify.ts");
+const REQUIRED_429_HEADERS = [
+  "retry-after",
+  "ratelimit-policy",
+  "ratelimit-limit",
+  "ratelimit-remaining",
+  "ratelimit-reset",
+] as const;
+
+function assertLogin429Headers(
+  response: { headers: Record<string, unknown> },
+  expectedLimit: string,
+) {
+  for (const headerName of REQUIRED_429_HEADERS) {
+    assert.notEqual(
+      response.headers[headerName],
+      undefined,
+      `429 must include ${headerName}`,
+    );
+  }
+
+  assert.equal(response.headers["ratelimit-policy"], `${expectedLimit};w=60`);
+  assert.equal(response.headers["ratelimit-limit"], expectedLimit);
+  assert.equal(response.headers["ratelimit-remaining"], "0");
+  assert.equal(response.headers["ratelimit-reset"], "60");
+  assert.equal(response.headers["retry-after"], "60");
+}
+
+function createTrackingStore() {
+  const entries = new Map<string, RateLimitEntry>();
+  const touchedKeys: string[] = [];
+
+  const store: RateLimitStore = {
+    get: (key) => entries.get(key),
+    set: (key, entry) => {
+      touchedKeys.push(key);
+      entries.set(key, entry);
+    },
+    increment: (key, entry) => {
+      touchedKeys.push(key);
+      const existing = entries.get(key);
+      const updated =
+        !existing || existing.resetAt <= 0
+          ? {
+              count: entry.count + 1,
+              resetAt: entry.resetAt,
+            }
+          : {
+              count: existing.count + 1,
+              resetAt: existing.resetAt,
+            };
+
+      entries.set(key, updated);
+      return updated;
+    },
+    delete: (key) => {
+      touchedKeys.push(key);
+      entries.delete(key);
+    },
+  };
+
+  return { entries, store, touchedKeys };
+}
+
+function baseClinicDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    createActiveSession: async () => {},
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    getClinicUserByUsername: async () => null,
+    getClinicUserByIdentifier: async () => null,
+    updateSessionLastAccess: async () => {},
+    upsertClinicUser: async () => {},
+    generateSessionToken: () => "clinic-session",
+    hashPassword: async () => "rehash",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({ valid: false, needsRehash: false }),
+    createAdminSession: async () => {},
+    getAdminUserByUsername: async () => null,
+    getAdminUserByIdentifier: async () => null,
+    writeAdminAuditLog: async () => {},
+    createParticularSession: async () => {},
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularTokenLastLogin: async () => {},
+    writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 2,
+    now: () => 0,
+    ...overrides,
+  };
+}
+
+function baseAdminDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    createAdminSession: async () => {},
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    getAdminUserByUsername: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "admin-session",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({ valid: false, needsRehash: false }),
+    writeAuditLog: async () => {},
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 2,
+    now: () => 0,
+    ...overrides,
+  };
+}
+
+function baseParticularDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    createParticularSession: async () => {},
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    updateParticularTokenLastLogin: async () => {},
+    getReportById: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (storagePath: string) => `download:${storagePath}`,
+    generateSessionToken: () => "particular-session",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    recordLoginFailedAttempt: async () => {},
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: 2,
+    now: () => 0,
+    ...overrides,
+  };
+}
+
+test("login 429 includes recoverable headers on clinic unified admin and particular surfaces", async () => {
+  const scenarios = [
+    {
+      name: "clinic",
+      prefix: "/api/auth",
+      route: clinicAuthNativeRoutes,
+      deps: baseClinicDeps(),
+      payload: { username: "clinic-user", password: "bad" },
+    },
+    {
+      name: "unified",
+      prefix: "/api/auth",
+      route: clinicAuthNativeRoutes,
+      deps: baseClinicDeps(),
+      payload: { identifier: "clinic-user", password: "bad" },
+    },
+    {
+      name: "admin",
+      prefix: "/api/admin/auth",
+      route: adminAuthNativeRoutes,
+      deps: baseAdminDeps(),
+      payload: { username: "admin-user", password: "bad" },
+    },
+    {
+      name: "particular",
+      prefix: "/api/particular/auth",
+      route: particularAuthNativeRoutes,
+      deps: baseParticularDeps(),
+      payload: { token: "bad-particular-token" },
+    },
+  ] as const;
+
+  for (const scenario of scenarios) {
+    const app = Fastify();
+    await app.register(scenario.route as any, {
+      prefix: scenario.prefix,
+      ...scenario.deps,
+    });
+
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const response = await app.inject({
+          method: "POST",
+          url: `${scenario.prefix}/login`,
+          headers: { origin: "http://localhost:3000" },
+          remoteAddress: "203.0.113.90",
+          payload: scenario.payload,
+        });
+        assert.equal(response.statusCode, 401, scenario.name);
+      }
+
+      const blocked = await app.inject({
+        method: "POST",
+        url: `${scenario.prefix}/login`,
+        headers: { origin: "http://localhost:3000" },
+        remoteAddress: "203.0.113.90",
+        payload: scenario.payload,
+      });
+
+      assert.equal(blocked.statusCode, 429, scenario.name);
+      assertLogin429Headers(blocked, "2");
+      assert.deepEqual(JSON.parse(blocked.body), {
+        success: false,
+        error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    } finally {
+      await app.close();
+    }
+  }
+});
+
+test("empty unified identifier uses missing bucket and does not query real users", async () => {
+  const { store, touchedKeys } = createTrackingStore();
+  const attempts: Array<Record<string, unknown>> = [];
+  const app = Fastify();
+
+  await app.register(clinicAuthNativeRoutes as any, {
+    prefix: "/api/auth",
+    ...baseClinicDeps({
+      loginRateLimitStore: store,
+      getAdminUserByIdentifier: async () => {
+        throw new Error("empty identifier must not query admin users");
+      },
+      getClinicUserByIdentifier: async () => {
+        throw new Error("empty identifier must not query clinic users");
+      },
+      getParticularTokenByTokenHash: async () => {
+        throw new Error("empty identifier must not query particular tokens");
+      },
+      recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+        attempts.push(input);
+      },
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: "203.0.113.91",
+      payload: { identifier: "", password: "present" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(
+      touchedKeys.includes(
+        buildMissingCredentialsLoginRateLimitKey({
+          surface: "unified",
+          ipAddress: "203.0.113.91",
+        }),
+      ),
+      true,
+    );
+    assert.equal(
+      touchedKeys.includes(
+        buildLoginRateLimitKey({
+          surface: "unified",
+          identifier: "unknown",
+          ipAddress: "203.0.113.91",
+        }),
+      ),
+      false,
+    );
+    assert.equal(attempts[0]?.reason, "missing_credentials");
+    assert.equal(attempts[0]?.username, null);
+  } finally {
+    await app.close();
+  }
+});
+
+test("empty admin username uses missing bucket and does not query admin users", async () => {
+  const { store, touchedKeys } = createTrackingStore();
+  const attempts: Array<Record<string, unknown>> = [];
+  const app = Fastify();
+
+  await app.register(adminAuthNativeRoutes as any, {
+    prefix: "/api/admin/auth",
+    ...baseAdminDeps({
+      loginRateLimitStore: store,
+      getAdminUserByUsername: async () => {
+        throw new Error("empty username must not query admin users");
+      },
+      recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+        attempts.push(input);
+      },
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: "203.0.113.92",
+      payload: { username: "", password: "present" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(
+      touchedKeys.includes(
+        buildMissingCredentialsLoginRateLimitKey({
+          surface: "admin",
+          ipAddress: "203.0.113.92",
+        }),
+      ),
+      true,
+    );
+    assert.equal(
+      touchedKeys.includes(
+        buildLoginRateLimitKey({
+          surface: "admin",
+          identifier: "unknown",
+          ipAddress: "203.0.113.92",
+        }),
+      ),
+      false,
+    );
+    assert.equal(attempts[0]?.reason, "missing_credentials");
+    assert.equal(attempts[0]?.username, null);
+  } finally {
+    await app.close();
+  }
+});
+
+test("empty particular token uses missing bucket and does not hash token", async () => {
+  const { store, touchedKeys } = createTrackingStore();
+  const attempts: Array<Record<string, unknown>> = [];
+  const app = Fastify();
+
+  await app.register(particularAuthNativeRoutes as any, {
+    prefix: "/api/particular/auth",
+    ...baseParticularDeps({
+      loginRateLimitStore: store,
+      hashSessionToken: () => {
+        throw new Error("empty token must not be hashed");
+      },
+      getParticularTokenByTokenHash: async () => {
+        throw new Error("empty token must not query particular tokens");
+      },
+      recordLoginFailedAttempt: async (input: Record<string, unknown>) => {
+        attempts.push(input);
+      },
+    }),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/particular/auth/login",
+      headers: { origin: "http://localhost:3000" },
+      remoteAddress: "203.0.113.93",
+      payload: { token: "" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(
+      touchedKeys.includes(
+        buildMissingCredentialsLoginRateLimitKey({
+          surface: "particular",
+          ipAddress: "203.0.113.93",
+        }),
+      ),
+      true,
+    );
+    assert.equal(
+      touchedKeys.includes(
+        buildLoginRateLimitKey({
+          surface: "particular",
+          identifier: "unknown",
+          ipAddress: "203.0.113.93",
+        }),
+      ),
+      false,
+    );
+    assert.equal(attempts[0]?.reason, "missing_credentials");
+    assert.equal(attempts[0]?.username, null);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -1,7 +1,13 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildLoginRateLimitKeyMetadata,
   buildLoginRateLimitKey,
+  buildMissingCredentialsLoginRateLimitKey,
+  getLoginRateLimitKeyMetadata,
+  hashLoginRateLimitIdentifier,
+  hashLoginRateLimitIpAddress,
+  LOGIN_RATE_LIMIT_KEY_VERSION,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -63,4 +69,57 @@ test("buildLoginRateLimitKey con ipAddress null usa 'unknown'", () => {
     ipAddress: null,
   });
   assert.equal(key, "login:v2:clinic:clinica@test.com:ip:unknown");
+});
+
+test("login rate limit metadata usa hashes seguros y version estable", () => {
+  const metadata = buildLoginRateLimitKeyMetadata({
+    surface: "admin",
+    identifier: "  Admin@Vetneb.test ",
+    ipAddress: "203.0.113.50",
+  });
+
+  assert.equal(metadata.surface, "admin");
+  assert.equal(metadata.keyVersion, LOGIN_RATE_LIMIT_KEY_VERSION);
+  assert.equal(metadata.identifierHash.length, 64);
+  assert.equal(metadata.ipHash.length, 64);
+  assert.equal(metadata.identifierHash, hashLoginRateLimitIdentifier("admin@vetneb.test"));
+  assert.equal(metadata.ipHash, hashLoginRateLimitIpAddress("203.0.113.50"));
+  assert.notEqual(metadata.identifierHash, "admin@vetneb.test");
+  assert.notEqual(metadata.ipHash, "203.0.113.50");
+});
+
+test("login rate limit metadata se puede derivar desde la key persistida", () => {
+  const key = buildLoginRateLimitKey({
+    surface: "particular",
+    identifier: "TOKEN-RAW",
+    ipAddress: "2001:db8::51",
+  });
+
+  assert.deepEqual(getLoginRateLimitKeyMetadata(key), {
+    surface: "particular",
+    identifierHash: hashLoginRateLimitIdentifier("token-raw"),
+    ipHash: hashLoginRateLimitIpAddress("2001:db8::51"),
+    keyVersion: LOGIN_RATE_LIMIT_KEY_VERSION,
+  });
+});
+
+test("missing credentials usa bucket separado por surface e IP", () => {
+  assert.equal(
+    buildMissingCredentialsLoginRateLimitKey({
+      surface: "unified",
+      ipAddress: "203.0.113.52",
+    }),
+    "login:v2:unified:missing:ip:203.0.113.52",
+  );
+  assert.notEqual(
+    buildMissingCredentialsLoginRateLimitKey({
+      surface: "unified",
+      ipAddress: "203.0.113.52",
+    }),
+    buildLoginRateLimitKey({
+      surface: "unified",
+      identifier: "usuario@vetneb.com",
+      ipAddress: "203.0.113.52",
+    }),
+  );
 });

--- a/test/login-rate-limits-metadata-migration.test.ts
+++ b/test/login-rate-limits-metadata-migration.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const migrationPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "0030_login_rate_limits_metadata.sql",
+);
+const journalPath = resolve(
+  process.cwd(),
+  "drizzle",
+  "migrations",
+  "meta",
+  "_journal.json",
+);
+const schemaPath = resolve(process.cwd(), "drizzle", "schema.ts");
+
+function readText(path: string) {
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+}
+
+test("login_rate_limits metadata migration exists with safe columns and indexes", () => {
+  assert.ok(existsSync(migrationPath), "missing 0030_login_rate_limits_metadata.sql");
+
+  const source = readText(migrationPath);
+  assert.match(source, /ALTER TABLE "login_rate_limits"/);
+  assert.match(source, /ADD COLUMN IF NOT EXISTS "surface" varchar\(32\)/);
+  assert.match(source, /ADD COLUMN IF NOT EXISTS "identifier_hash" text/);
+  assert.match(source, /ADD COLUMN IF NOT EXISTS "ip_hash" text/);
+  assert.match(source, /ADD COLUMN IF NOT EXISTS "key_version" varchar\(16\)/);
+  assert.match(source, /login_rate_limits_surface_identifier_idx/);
+  assert.match(source, /login_rate_limits_surface_identifier_ip_idx/);
+  assert.doesNotMatch(source, /identifier"\s+text/i);
+  assert.doesNotMatch(source, /ip_address/i);
+});
+
+test("login_rate_limits metadata migration is registered in drizzle journal", () => {
+  const journal = JSON.parse(readText(journalPath)) as {
+    entries?: Array<{ tag?: string }>;
+  };
+  const tags = new Set((journal.entries ?? []).map((entry) => entry.tag));
+
+  assert.ok(
+    tags.has("0030_login_rate_limits_metadata"),
+    "journal missing 0030_login_rate_limits_metadata",
+  );
+});
+
+test("drizzle schema keeps login_rate_limits metadata contract", () => {
+  const schemaSource = readText(schemaPath);
+
+  assert.match(schemaSource, /pgTable\(\s*"login_rate_limits"/);
+  assert.match(schemaSource, /surface:\s+varchar\("surface",\s*\{\s*length:\s*32\s*\}\)/);
+  assert.match(schemaSource, /identifierHash:\s+text\("identifier_hash"\)/);
+  assert.match(schemaSource, /ipHash:\s+text\("ip_hash"\)/);
+  assert.match(schemaSource, /keyVersion:\s+varchar\("key_version",\s*\{\s*length:\s*16\s*\}\)/);
+});

--- a/test/rate-limit-store.test.ts
+++ b/test/rate-limit-store.test.ts
@@ -7,6 +7,7 @@ import {
   getOrCreateRateLimitEntry,
   hashRateLimitKey,
   incrementRateLimitEntry,
+  type PersistentRateLimitMetadata,
   type PersistentRateLimitRecord,
   type RateLimitStore,
 } from "../server/lib/rate-limit-store.ts";
@@ -14,6 +15,7 @@ import {
 type PersistentHarnessRow = PersistentRateLimitRecord & {
   createdAt: Date;
   updatedAt: Date;
+  metadata?: PersistentRateLimitMetadata;
 };
 
 function createPersistentHarness(input?: {
@@ -27,20 +29,21 @@ function createPersistentHarness(input?: {
   const store = createPersistentRateLimitStore(
     {
       get: async (keyHash) => rows.get(keyHash),
-      set: async ({ keyHash, count, resetAt, now }) => {
+      set: async ({ keyHash, count, resetAt, now, metadata }) => {
         const existing = rows.get(keyHash);
         const row = {
           count,
           resetAt,
           createdAt: existing?.createdAt ?? now,
           updatedAt: now,
+          metadata,
         };
 
         rows.set(keyHash, row);
 
         return row;
       },
-      increment: async ({ keyHash, count, resetAt, now }) => {
+      increment: async ({ keyHash, count, resetAt, now, metadata }) => {
         const existing = rows.get(keyHash);
         const row =
           !existing || existing.resetAt.getTime() <= now.getTime()
@@ -49,9 +52,11 @@ function createPersistentHarness(input?: {
                 resetAt,
                 createdAt: existing?.createdAt ?? now,
                 updatedAt: now,
+                metadata,
               }
             : {
                 ...existing,
+                metadata,
                 count: existing.count + 1,
                 updatedAt: now,
               };
@@ -165,6 +170,71 @@ test("rate limit persistent store hashes keys and creates counters", async () =>
   });
   assert.equal(rows.has("ip:raw"), false);
   assert.equal(rows.has(keyHash), true);
+});
+
+test("rate limit persistent store forwards metadata for hashed keys", async () => {
+  const metadata: PersistentRateLimitMetadata = {
+    surface: "clinic",
+    identifierHash: "identifier-hash",
+    ipHash: "ip-hash",
+    keyVersion: "v2",
+  };
+  const { rows, store } = createPersistentHarness({
+    now: () => 10,
+  });
+
+  const entry = await getOrCreateRateLimitEntry(store, "login:key", 1000, 10);
+  await incrementRateLimitEntry(store, "login:key", entry, 10);
+
+  assert.equal(rows.get(hashRateLimitKey("login:key"))?.metadata, undefined);
+
+  const metadataHarness = createPersistentHarness({
+    now: () => 20,
+  });
+  const metadataStore = createPersistentRateLimitStore(
+    {
+      get: async (keyHash) => metadataHarness.rows.get(keyHash),
+      set: async ({ keyHash, count, resetAt, now, metadata }) => {
+        const row = {
+          count,
+          resetAt,
+          createdAt: now,
+          updatedAt: now,
+          metadata,
+        };
+        metadataHarness.rows.set(keyHash, row);
+        return row;
+      },
+      increment: async ({ keyHash, count, resetAt, now, metadata }) => {
+        const row = {
+          count,
+          resetAt,
+          createdAt: now,
+          updatedAt: now,
+          metadata,
+        };
+        metadataHarness.rows.set(keyHash, row);
+        return row;
+      },
+    },
+    {
+      metadataForKey: () => metadata,
+      now: () => 20,
+    },
+  );
+
+  const metadataEntry = await getOrCreateRateLimitEntry(
+    metadataStore,
+    "login:key",
+    1000,
+    20,
+  );
+  await incrementRateLimitEntry(metadataStore, "login:key", metadataEntry, 20);
+
+  assert.deepEqual(
+    metadataHarness.rows.get(hashRateLimitKey("login:key"))?.metadata,
+    metadata,
+  );
 });
 
 test("rate limit persistent store increments active counters", async () => {

--- a/test/reset-login-rate-limit-script-contract.test.ts
+++ b/test/reset-login-rate-limit-script-contract.test.ts
@@ -1,8 +1,7 @@
 /**
- * Tests: contrato del script reset-login-rate-limit.ps1
+ * Tests: contrato operativo del reset de rate limit de login.
  *
- * Verifica que el script existe y cumple invariantes de seguridad operativa
- * sin ejecutarlo realmente (no requiere DB ni PowerShell en CI).
+ * Verifica invariantes de seguridad sin ejecutar DB ni PowerShell en CI.
  */
 
 import test from "node:test";
@@ -10,91 +9,108 @@ import assert from "node:assert/strict";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
-const SCRIPT_PATH = join(
+const PS_SCRIPT_PATH = join(
   import.meta.dirname ?? "",
   "..",
   "scripts",
   "dev",
   "reset-login-rate-limit.ps1",
 );
+const TS_SCRIPT_PATH = join(
+  import.meta.dirname ?? "",
+  "..",
+  "scripts",
+  "dev",
+  "reset-login-rate-limit.ts",
+);
 
-test("reset-login-rate-limit.ps1 existe", () => {
-  assert.ok(existsSync(SCRIPT_PATH), `El script debe existir en ${SCRIPT_PATH}`);
+function read(path: string) {
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+}
+
+test("reset login rate limit scripts exist", () => {
+  assert.ok(existsSync(PS_SCRIPT_PATH), `El wrapper debe existir en ${PS_SCRIPT_PATH}`);
+  assert.ok(existsSync(TS_SCRIPT_PATH), `El script TS debe existir en ${TS_SCRIPT_PATH}`);
 });
 
-test("reset-login-rate-limit.ps1 tiene parámetro -Surface con ValidateSet", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  assert.ok(
-    content.includes("ValidateSet"),
-    "debe tener ValidateSet para restringir Surface",
-  );
-  assert.ok(content.includes('"unified"'), "debe incluir surface unified");
-  assert.ok(content.includes('"clinic"'), "debe incluir surface clinic");
-  assert.ok(content.includes('"admin"'), "debe incluir surface admin");
-  assert.ok(content.includes('"particular"'), "debe incluir surface particular");
+test("PowerShell wrapper validates surface and delegates to pnpm tsx", () => {
+  const content = read(PS_SCRIPT_PATH);
+
+  assert.ok(content.includes("ValidateSet"));
+  assert.ok(content.includes('"unified"'));
+  assert.ok(content.includes('"clinic"'));
+  assert.ok(content.includes('"admin"'));
+  assert.ok(content.includes('"particular"'));
+  assert.ok(content.includes("Get-Command pnpm"));
+  assert.ok(content.includes('"exec", "tsx", "scripts/dev/reset-login-rate-limit.ts"'));
+  assert.ok(content.includes("--surface"));
+  assert.ok(content.includes("--identifier"));
+  assert.ok(content.includes("--ip-address"));
+  assert.ok(content.includes("--force"));
 });
 
-test("reset-login-rate-limit.ps1 requiere -Force para ejecutar DELETE", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  assert.ok(
-    content.includes("-Force"),
-    "debe requerir -Force para ejecutar",
-  );
-  assert.ok(
-    content.includes("dry-run") || content.includes("DRY-RUN"),
-    "debe mencionar dry-run por defecto",
-  );
+test("reset scripts default to dry-run and require force for delete", () => {
+  const psContent = read(PS_SCRIPT_PATH);
+  const tsContent = read(TS_SCRIPT_PATH);
+
+  assert.ok(psContent.includes("-Force"));
+  assert.ok(psContent.includes("dry-run"));
+  assert.ok(tsContent.includes("Default mode is dry-run"));
+  assert.ok(tsContent.includes("--force"));
+  assert.ok(tsContent.includes("if (!options.force)"));
+  assert.ok(tsContent.includes("Dry-run only"));
 });
 
-test("reset-login-rate-limit.ps1 no imprime hashes completos", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  // El script debe usar solo primeros N chars del hash
-  assert.ok(
-    content.includes("Substring(0,") || content.includes(".Substring(0,"),
-    "debe truncar el hash antes de mostrarlo",
-  );
-  assert.ok(
-    !content.match(/Write-Host.*\$hash[^P]/),
-    "no debe imprimir el hash completo directamente",
-  );
+test("reset script uses project DB dependencies, not a local SQL client binary", () => {
+  const psContent = read(PS_SCRIPT_PATH).toLowerCase();
+  const tsContent = read(TS_SCRIPT_PATH).toLowerCase();
+
+  assert.equal(psContent.includes("psql"), false);
+  assert.equal(tsContent.includes("psql"), false);
+  assert.ok(tsContent.includes('from "postgres"'));
+  assert.ok(tsContent.includes('from "dotenv"'));
+  assert.ok(tsContent.includes("process.env.supabase_db_url"));
+  assert.ok(tsContent.includes("process.env.database_url"));
 });
 
-test("reset-login-rate-limit.ps1 no ejecuta reset global sin filtro", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  // No debe haber DELETE sin WHERE
-  const deleteStatements = content.match(/DELETE FROM login_rate_limits[^;]*/gi) ?? [];
-  for (const stmt of deleteStatements) {
+test("reset script deletes only by matched key hashes and never globally", () => {
+  const content = read(TS_SCRIPT_PATH);
+  const deleteStatements = content.match(/DELETE FROM login_rate_limits[\s\S]*?RETURNING key_hash/g) ?? [];
+
+  assert.ok(deleteStatements.length > 0, "debe contener DELETE operativo");
+
+  for (const statement of deleteStatements) {
     assert.ok(
-      stmt.toUpperCase().includes("WHERE"),
-      `Todo DELETE debe tener WHERE: ${stmt.trim().substring(0, 80)}`,
+      statement.toUpperCase().includes("WHERE"),
+      `Todo DELETE debe tener WHERE: ${statement.slice(0, 120)}`,
     );
+    assert.ok(statement.includes("key_hash IN"));
   }
 });
 
-test("reset-login-rate-limit.ps1 valida que Identifier no esté vacío", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  assert.ok(
-    content.includes("Length -eq 0") || content.includes("normalizedIdentifier") && content.includes("vacío"),
-    "debe validar que el identifier no sea vacío",
-  );
+test("reset script resets by metadata and supports exact-IP legacy fallback only", () => {
+  const content = read(TS_SCRIPT_PATH);
+
+  assert.ok(content.includes("hashLoginRateLimitIdentifier"));
+  assert.ok(content.includes("hashLoginRateLimitIpAddress"));
+  assert.ok(content.includes("WHERE surface = ${options.surface}"));
+  assert.ok(content.includes("AND identifier_hash = ${identifierHash}"));
+  assert.ok(content.includes("AND ip_hash = ${ipHash}"));
+  assert.ok(content.includes("Legacy fallback"));
+  assert.ok(content.includes("exact IP"));
+  assert.ok(content.includes("Legacy rows cannot be reset by identifier without an exact IP."));
 });
 
-test("reset-login-rate-limit.ps1 no expone DATABASE_URL en output", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  assert.ok(
-    !content.includes("Write-Host $databaseUrl"),
-    "no debe imprimir DATABASE_URL",
-  );
-  assert.ok(
-    !content.includes("Write-Output $databaseUrl"),
-    "no debe imprimir DATABASE_URL",
-  );
-});
+test("reset scripts validate identifier and avoid sensitive output", () => {
+  const psContent = read(PS_SCRIPT_PATH);
+  const tsContent = read(TS_SCRIPT_PATH);
 
-test("reset-login-rate-limit.ps1 usa SHA256 para reproducir el hash de la key", () => {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  assert.ok(
-    content.includes("SHA256") || content.includes("sha256"),
-    "debe usar SHA256 para reproducir el keyHash",
-  );
+  assert.ok(psContent.includes("Identifier no puede estar vacío"));
+  assert.ok(tsContent.includes("--identifier no puede estar vacio"));
+  assert.ok(tsContent.includes("previewHash"));
+  assert.ok(tsContent.includes("Identifier hash"));
+  assert.equal(tsContent.includes("Identifier :"), false);
+  assert.equal(tsContent.includes("console.log(options.identifier"), false);
+  assert.equal(tsContent.includes("console.log(databaseUrl"), false);
+  assert.equal(psContent.includes("Write-Host $databaseUrl"), false);
 });

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -77,6 +77,11 @@ function assertContainsInOrder(
 }
 
 function assertRateLimitHeaders(source: string, context: string): void {
+  if (source.includes("buildLoginRateLimitHeaders(input)")) {
+    assertContains(source, "buildLoginRateLimitHeaders(input)", context);
+    return;
+  }
+
   for (const marker of [
     '"RateLimit-Policy"',
     '"RateLimit-Limit"',
@@ -220,8 +225,13 @@ test("auth login rate limits keep persistent stores with memory fallback per aut
     );
     assertContains(
       source,
-      "loginRateLimitStore: createPersistentRateLimitStore({",
+      "loginRateLimitStore: createPersistentRateLimitStore(",
       `${file} persistent login rate limit store`,
+    );
+    assertContains(
+      source,
+      "metadataForKey: getLoginRateLimitKeyMetadata",
+      `${file} persistent login metadata`,
     );
     for (const marker of [
       "get: db.getLoginRateLimitEntry,",
@@ -273,18 +283,21 @@ test("auth login rate limits keep persistent stores with memory fallback per aut
         'surface: isUnifiedPayload ? "unified" : "clinic",',
         "identifier: loginIdentifier,",
         "ipAddress: request.ip || null,",
+        "buildMissingCredentialsLoginRateLimitKey({",
       ],
       "server/routes/admin-auth.fastify.ts": [
         "buildLoginRateLimitKey({",
         'surface: "admin",',
-        'identifier: username || "unknown",',
+        "identifier: username,",
         "ipAddress: request.ip || null,",
+        "buildMissingCredentialsLoginRateLimitKey({",
       ],
       "server/routes/particular-auth.fastify.ts": [
         "buildLoginRateLimitKey({",
         'surface: "particular",',
-        'identifier: providedToken || "unknown",',
+        "identifier: providedToken,",
         "ipAddress: request.ip || null,",
+        "buildMissingCredentialsLoginRateLimitKey({",
       ],
     } satisfies Record<(typeof file), readonly string[]>;
 

--- a/test/smoke-staging-script-contract.test.ts
+++ b/test/smoke-staging-script-contract.test.ts
@@ -114,6 +114,7 @@ test("staging smoke script uses SKIP checks when optional credentials are missin
   const source = readSource(SCRIPT_PATH);
 
   assertContains(source, 'Status "SKIP"', "smoke staging script skip status");
+  assertContains(source, "Get-SmokeEnvValue", "smoke staging script env helper");
   assertContains(source, "Mark-CredentialCheckSkipSet", "smoke staging script skip helper");
   assertContains(
     source,
@@ -130,6 +131,58 @@ test("staging smoke script uses SKIP checks when optional credentials are missin
     "falta env var SMOKE_PARTICULAR_TOKEN",
     "smoke staging script particular skip reason",
   );
+});
+
+test("staging smoke script validates credential env vars before any POST", () => {
+  const source = readSource(SCRIPT_PATH);
+  const firstCredentialRead = source.indexOf('$adminUser = Get-SmokeEnvValue -Name "SMOKE_ADMIN_USERNAME"');
+  const firstPost = source.indexOf('-Method "POST"');
+
+  assert.notEqual(firstCredentialRead, -1, "debe leer env vars con helper");
+  assert.notEqual(firstPost, -1, "debe contener POST checks");
+  assert.ok(
+    firstCredentialRead < firstPost,
+    "debe validar env vars antes de cualquier POST real",
+  );
+
+  for (const marker of [
+    '[Environment]::GetEnvironmentVariable("SMOKE_ADMIN_USERNAME")',
+    '[Environment]::GetEnvironmentVariable("SMOKE_ADMIN_PASSWORD")',
+    '[Environment]::GetEnvironmentVariable("SMOKE_CLINIC_USERNAME")',
+    '[Environment]::GetEnvironmentVariable("SMOKE_CLINIC_PASSWORD")',
+    '[Environment]::GetEnvironmentVariable("SMOKE_PARTICULAR_TOKEN")',
+  ]) {
+    assertNotContains(source, marker, "smoke staging script late direct env read");
+  }
+});
+
+test("staging smoke script never builds login payloads unless credential flags are true", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assert.match(
+    source,
+    /if \(\$hasAdminCreds\) \{[\s\S]*?username = \$adminUser[\s\S]*?password = \$adminPassword/,
+    "admin login payload must be inside hasAdminCreds block",
+  );
+  assert.match(
+    source,
+    /if \(\$hasClinicCreds\) \{[\s\S]*?username = \$clinicUser[\s\S]*?password = \$clinicPassword/,
+    "clinic login payload must be inside hasClinicCreds block",
+  );
+  assert.match(
+    source,
+    /if \(\$hasParticularToken\) \{[\s\S]*?token = \$particularToken/,
+    "particular login payload must be inside hasParticularToken block",
+  );
+});
+
+test("staging smoke script stops retrying immediately on unexpected 429", () => {
+  const source = readSource(SCRIPT_PATH);
+
+  assertContains(source, "$statusCode -eq 429", "smoke staging 429 retry stop");
+  assertContains(source, "$statusFromException -eq 429", "smoke staging 429 exception retry stop");
+  assertContains(source, "HTTP 429 rate limited; no se reintenta", "smoke staging 429 detail");
+  assertContains(source, "Attempts = $attempt", "smoke staging 429 returns current attempt");
 });
 
 test("staging smoke script does not contain real secrets or unsafe placeholders", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "include": [
     "server/**/*.ts",
     "drizzle/**/*.ts",
+    "scripts/**/*.ts",
     "*.ts"
   ],
   "exclude": [
@@ -27,4 +28,3 @@
     "legacy"
   ]
 }
-


### PR DESCRIPTION
## Resumen
- Agrega metadata segura a login_rate_limits para operar lockouts por surface/identifier sin guardar valores raw.
- Garantiza headers recuperables en todo 429 de login: Retry-After y RateLimit-*.
- Separa payloads vacíos en bucket missing para no contaminar usuarios reales.
- Reemplaza el reset dependiente de psql por script Node/TS vía pnpm con dry-run por defecto.
- Endurece smoke staging para no enviar login si faltan env vars y cortar retries ante 429.
- Endurece frontend API para tratar 429 sin headers como fallo de contrato.

## Diagnóstico
La causa raíz era operativa: login_rate_limits solo guardaba key_hash, por lo que no había forma real de encontrar y resetear un bucket por usuario sin conocer IP exacta. Además, payloads vacíos podían caer en buckets unknown y el smoke podía multiplicar intentos durante un lockout.

## Seguridad
- No se desactiva rate limit.
- No se suben límites arbitrariamente.
- No se guardan identifiers, tokens, passwords ni IPs raw.
- No se crea endpoint público de reset.
- El reset es dry-run por defecto y requiere --force para borrar.
- No se borran todos los rate limits por defecto.

## Migración
- Agrega columnas nullable seguras a login_rate_limits:
  - surface
  - identifier_hash
  - ip_hash
  - key_version
- Agrega índices para operar por surface/identifier_hash e IP opcional.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm exec tsx scripts/dev/reset-login-rate-limit.ts --help

## Resultado
- pnpm test OK: 2103 pass, 0 fail, 1 skipped
- pnpm build OK

## Scope
- Auth/rate-limit/ops/smoke/frontend API contract.
- No toca notificaciones ni workflow.