### PR TITLE
feat(notifications): auto-show unread notifications on entry

### DIFF
--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { createPortal } from "react-dom";
 import { Bell } from "lucide-react";
+import { X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,10 +35,35 @@ export function DashboardNotificationsBell({
   const [updatingNotificationId, setUpdatingNotificationId] = useState<
     number | null
   >(null);
-  const isFetchingRef = useRef(false);
+  const [mobileBannerVisible, setMobileBannerVisible] = useState(false);
+  const [portalContainer, setPortalContainer] = useState<Element | null>(null);
 
-  const unreadCount = notifications.filter((notification) => !notification.isRead)
-    .length;
+  const isFetchingRef = useRef(false);
+  // Tracks the unread count that was last auto-shown.
+  // Re-opens only when new unread notifications arrive beyond this threshold.
+  // Resets to 0 when inbox reaches zero so the next notification triggers
+  // auto-show again.
+  const autoShownUnreadCountRef = useRef(0);
+  const isMobileRef = useRef(false);
+
+  const unreadCount = notifications.filter(
+    (notification) => !notification.isRead,
+  ).length;
+  const unreadNotifications = notifications.filter((n) => !n.isRead);
+
+  // Initialise portal target (SSR-safe) and mobile breakpoint tracking.
+  useEffect(() => {
+    setPortalContainer(document.body);
+
+    const mq = window.matchMedia("(max-width: 639px)");
+    isMobileRef.current = mq.matches;
+
+    const handler = (e: MediaQueryListEvent) => {
+      isMobileRef.current = e.matches;
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
 
   const loadNotifications = useCallback(async () => {
     if (isFetchingRef.current) {
@@ -53,6 +80,24 @@ export function DashboardNotificationsBell({
         offset: 0,
       });
       setNotifications(response.notifications);
+
+      // Auto-show logic: open automatically when the unread count exceeds
+      // what was already shown. Notifications are NOT marked as read by
+      // this action -- only the display surface is opened.
+      const newUnreadCount = response.notifications.filter(
+        (n) => !n.isRead,
+      ).length;
+
+      if (newUnreadCount === 0) {
+        autoShownUnreadCountRef.current = 0;
+      } else if (newUnreadCount > autoShownUnreadCountRef.current) {
+        autoShownUnreadCountRef.current = newUnreadCount;
+        if (isMobileRef.current) {
+          setMobileBannerVisible(true);
+        } else {
+          setIsOpen(true);
+        }
+      }
     } catch {
       setErrorMessage("No se pudieron cargar las notificaciones.");
     } finally {
@@ -60,6 +105,12 @@ export function DashboardNotificationsBell({
       setIsLoading(false);
     }
   }, [surface]);
+
+  // Initial silent load on mount to detect unread notifications and
+  // auto-show the appropriate surface without any manual interaction.
+  useEffect(() => {
+    void loadNotifications();
+  }, [loadNotifications]);
 
   useEffect(() => {
     if (!isPollingEnabled) {
@@ -92,6 +143,10 @@ export function DashboardNotificationsBell({
   function handleEnableNotifications() {
     setIsPollingEnabled(true);
     void loadNotifications();
+  }
+
+  function handleCloseMobileBanner() {
+    setMobileBannerVisible(false);
   }
 
   async function handleMarkAsRead(
@@ -166,8 +221,8 @@ export function DashboardNotificationsBell({
       >
         <Bell className="h-4 w-4" aria-hidden="true" />
         {unreadCount > 0 ? (
-          <span className="absolute -right-1 -top-1 inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-vetneb-teal px-1 text-[0.62rem] font-semibold leading-none text-vetneb-navy">
-            {unreadCount}
+          <span className="absolute -right-1 -top-1 inline-flex min-h-[1.1rem] min-w-[1.1rem] items-center justify-center rounded-full bg-vetneb-teal px-1 text-[0.62rem] font-semibold leading-none text-vetneb-navy">
+            {unreadCount > 99 ? "99+" : unreadCount}
           </span>
         ) : null}
       </button>
@@ -212,9 +267,7 @@ export function DashboardNotificationsBell({
                   unreadCount === 0
                 }
               >
-                {isMarkingAllAsRead
-                  ? "Marcando..."
-                  : "Marcar todo como leído"}
+                {isMarkingAllAsRead ? "Marcando..." : "Marcar todo como leído"}
               </Button>
             </div>
           </div>
@@ -261,6 +314,79 @@ export function DashboardNotificationsBell({
           </ul>
         </div>
       ) : null}
+
+      {/* Mobile auto-show banner: visible only on narrow viewports (< 640 px).
+          Portaled to document.body to avoid stacking-context clipping from the
+          sticky topbar. Notifications are NOT marked as read by appearing here. */}
+      {portalContainer && mobileBannerVisible && unreadCount > 0
+        ? createPortal(
+            <div
+              className="sm:hidden fixed inset-x-0 top-0 z-[60] border-b border-vetneb-teal/30 bg-card shadow-xl"
+              role="region"
+              aria-label="Notificaciones no leidas"
+            >
+              <div className="flex items-center justify-between border-b border-vetneb-line/60 px-4 py-2.5">
+                <div className="flex items-center gap-2">
+                  <Bell className="h-4 w-4 text-vetneb-teal" aria-hidden="true" />
+                  <p className="text-sm font-semibold text-vetneb-ink">
+                    Notificaciones no leidas{" "}
+                    <span className="ml-1 inline-flex min-h-[1.1rem] min-w-[1.1rem] items-center justify-center rounded-full bg-vetneb-teal px-1 text-[0.62rem] font-semibold leading-none text-vetneb-navy">
+                      {unreadCount > 99 ? "99+" : unreadCount}
+                    </span>
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  aria-label="Cerrar notificaciones"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/70 hover:text-foreground"
+                  onClick={handleCloseMobileBanner}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+              <ul
+                className="max-h-52 divide-y divide-vetneb-line/50 overflow-y-auto"
+                aria-label="Lista de notificaciones no leidas"
+              >
+                {unreadNotifications.slice(0, 5).map((notification) => (
+                  <li key={notification.id}>
+                    <button
+                      type="button"
+                      className="w-full px-4 py-3 text-left transition-colors hover:bg-accent/50 disabled:opacity-50"
+                      onClick={() => void handleMarkAsRead(notification)}
+                      disabled={updatingNotificationId === notification.id}
+                    >
+                      <p className="text-xs font-semibold text-vetneb-ink">
+                        {notification.title}
+                      </p>
+                      <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                        {notification.message}
+                      </p>
+                      <p className="mt-0.5 text-[0.66rem] text-muted-foreground">
+                        {formatDateTime(notification.createdAt)}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {unreadNotifications.length > 5 ? (
+                <div className="border-t border-vetneb-line/50 px-4 py-2.5">
+                  <button
+                    type="button"
+                    className="text-xs font-semibold text-vetneb-teal hover:underline"
+                    onClick={() => {
+                      setMobileBannerVisible(false);
+                      setIsOpen(true);
+                    }}
+                  >
+                    Ver mas en el panel
+                  </button>
+                </div>
+              ) : null}
+            </div>,
+            portalContainer,
+          )
+        : null}
     </div>
   );
 }

--- a/test/frontend-notifications-bell.test.ts
+++ b/test/frontend-notifications-bell.test.ts
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const BELL_PATH =
+  "frontend/src/components/dashboard/DashboardNotificationsBell.tsx";
+const TOPBAR_PATH =
+  "frontend/src/components/dashboard/DashboardTopbar.tsx";
+const PARTICULARES_PATH =
+  "frontend/src/components/public/ParticularesContent.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ── 1. Auto-show panel when unread notifications exist on load ───────────────
+
+test("notifications bell auto-opens desktop panel on mount when unread count > 0", () => {
+  const source = read(BELL_PATH);
+
+  // Initial load effect wired to loadNotifications
+  assert.ok(
+    source.includes("void loadNotifications();\n  }, [loadNotifications]);"),
+    "mount effect must call loadNotifications once",
+  );
+
+  // Auto-show logic: opens panel when new unread exceeds tracked threshold
+  assert.ok(
+    source.includes("newUnreadCount > autoShownUnreadCountRef.current"),
+    "auto-show guard must compare against tracked threshold",
+  );
+  assert.ok(
+    source.includes("setIsOpen(true)"),
+    "desktop path must call setIsOpen(true)",
+  );
+  assert.ok(
+    source.includes("autoShownUnreadCountRef.current = newUnreadCount"),
+    "threshold must be updated after auto-show",
+  );
+});
+
+// ── 2. No auto-show when inbox is empty ─────────────────────────────────────
+
+test("notifications bell does not auto-show when unread count is zero", () => {
+  const source = read(BELL_PATH);
+
+  // Guard: auto-show block is inside the `> 0` branch
+  assert.ok(
+    source.includes("if (newUnreadCount === 0)"),
+    "zero-unread path must reset the threshold ref",
+  );
+  assert.ok(
+    source.includes("autoShownUnreadCountRef.current = 0"),
+    "threshold ref must be reset to 0 when inbox is empty",
+  );
+  // The reset and the auto-show are in separate branches (no setIsOpen in the
+  // zero branch). Verify the reset statement is NOT immediately followed by
+  // setIsOpen(true) on the same condition.
+  const zeroBlock = source.slice(
+    source.indexOf("if (newUnreadCount === 0)"),
+    source.indexOf("} else if (newUnreadCount > autoShownUnreadCountRef"),
+  );
+  assert.equal(
+    zeroBlock.includes("setIsOpen(true)"),
+    false,
+    "zero-unread branch must not call setIsOpen(true)",
+  );
+  assert.equal(
+    zeroBlock.includes("setMobileBannerVisible(true)"),
+    false,
+    "zero-unread branch must not show mobile banner",
+  );
+});
+
+// ── 3. Mobile surface: visible banner, not just dropdown ────────────────────
+
+test("notifications bell shows visible mobile banner as auto-show surface", () => {
+  const source = read(BELL_PATH);
+
+  assert.ok(
+    source.includes("mobileBannerVisible"),
+    "mobileBannerVisible state must exist",
+  );
+  assert.ok(
+    source.includes("setMobileBannerVisible(true)"),
+    "mobile path must activate banner",
+  );
+  assert.ok(
+    source.includes('isMobileRef.current'),
+    "component must detect mobile breakpoint via ref",
+  );
+  assert.ok(
+    source.includes("createPortal"),
+    "mobile banner must use createPortal for safe rendering",
+  );
+  assert.ok(
+    source.includes('role="region"'),
+    "mobile banner must carry region role for accessibility",
+  );
+  assert.ok(
+    source.includes("sm:hidden"),
+    "mobile banner must be hidden on desktop (sm:hidden)",
+  );
+  assert.ok(
+    source.includes("fixed inset-x-0"),
+    "mobile banner must use fixed full-width positioning",
+  );
+});
+
+// ── 4. Badge renders unread count correctly ──────────────────────────────────
+
+test("notifications bell badge renders unread count with correct positioning and contrast", () => {
+  const source = read(BELL_PATH);
+
+  // Badge span exists and is positioned correctly
+  assert.ok(
+    source.includes('className="absolute -right-1 -top-1'),
+    "badge must use absolute -right-1 -top-1 positioning",
+  );
+  assert.ok(
+    source.includes("min-h-[1.1rem] min-w-[1.1rem]"),
+    "badge must define both min-height and min-width",
+  );
+  assert.ok(
+    source.includes("rounded-full bg-vetneb-teal"),
+    "badge must use rounded-full with teal background",
+  );
+  assert.ok(
+    source.includes("text-vetneb-navy"),
+    "badge must use navy text for contrast against teal",
+  );
+  assert.ok(
+    source.includes("font-semibold"),
+    "badge text must be semibold for legibility",
+  );
+});
+
+// ── 5. Badge displays 99+ when count exceeds 99 ──────────────────────────────
+
+test("notifications bell badge displays 99+ when unread count exceeds 99", () => {
+  const source = read(BELL_PATH);
+
+  assert.ok(
+    source.includes('unreadCount > 99 ? "99+" : unreadCount'),
+    "badge must cap display at 99+ for counts above 99",
+  );
+  // The 99+ cap must also appear in the mobile banner
+  const mobileBannerSection = source.slice(
+    source.indexOf("portalContainer && mobileBannerVisible"),
+  );
+  assert.ok(
+    mobileBannerSection.includes('unreadCount > 99 ? "99+" : unreadCount'),
+    "mobile banner must also cap badge at 99+",
+  );
+});
+
+// ── 6. Closing auto surface prevents immediate reopen ────────────────────────
+
+test("notifications bell does not reopen panel after user closes it if count unchanged", () => {
+  const source = read(BELL_PATH);
+
+  // The only condition that re-opens is strictly greater-than
+  assert.ok(
+    source.includes("newUnreadCount > autoShownUnreadCountRef.current"),
+    "reopen guard must be strict greater-than, not greater-or-equal",
+  );
+  // handleCloseMobileBanner must NOT reset autoShownUnreadCountRef
+  const closeFnStart = source.indexOf("function handleCloseMobileBanner()");
+  const closeFnEnd = source.indexOf("\n  }", closeFnStart) + 4;
+  const closeFnBody = source.slice(closeFnStart, closeFnEnd);
+  assert.equal(
+    closeFnBody.includes("autoShownUnreadCountRef"),
+    false,
+    "closing mobile banner must not manipulate autoShownUnreadCountRef",
+  );
+});
+
+// ── 7. Auto-show does not mark notifications as read ─────────────────────────
+
+test("notifications bell auto-show does not call mark-as-read APIs", () => {
+  const source = read(BELL_PATH);
+
+  // Locate the auto-show block boundaries
+  const autoShowStart = source.indexOf(
+    "// Auto-show logic: open automatically",
+  );
+  assert.ok(autoShowStart !== -1, "auto-show logic block must exist");
+
+  // The auto-show block ends before the catch
+  const autoShowEnd = source.indexOf("} catch {", autoShowStart);
+  const autoShowBlock = source.slice(autoShowStart, autoShowEnd);
+
+  assert.equal(
+    autoShowBlock.includes("markDashboardNotificationRead"),
+    false,
+    "auto-show block must not call markDashboardNotificationRead",
+  );
+  assert.equal(
+    autoShowBlock.includes("markAllDashboardNotificationsRead"),
+    false,
+    "auto-show block must not call markAllDashboardNotificationsRead",
+  );
+  assert.equal(
+    autoShowBlock.includes("isRead: true"),
+    false,
+    "auto-show block must not mutate isRead state",
+  );
+});
+
+// ── 8. All three roles wire the bell component ───────────────────────────────
+
+test("admin role wires notifications bell via DashboardTopbar", () => {
+  const source = read(TOPBAR_PATH);
+
+  assert.ok(
+    source.includes(
+      'notifications?: "admin" | "clinic" | "particular" | false;',
+    ),
+    "topbar must accept all three surfaces",
+  );
+  assert.ok(
+    source.includes(
+      "{notifications ? <DashboardNotificationsBell surface={notifications} /> : null}",
+    ),
+    "topbar must pass surface to bell",
+  );
+});
+
+test("clinic and admin dashboards pass surface to topbar notifications prop", () => {
+  const clinicPage = readFileSync(
+    resolve(process.cwd(), "frontend/src/app/dashboard/page.tsx"),
+    "utf8",
+  );
+  const adminPage = readFileSync(
+    resolve(process.cwd(), "frontend/src/app/dashboard/admin/page.tsx"),
+    "utf8",
+  );
+
+  assert.ok(
+    clinicPage.includes('notifications="clinic"'),
+    "clinic dashboard must pass notifications='clinic'",
+  );
+  assert.ok(
+    adminPage.includes('notifications="admin"'),
+    "admin dashboard must pass notifications='admin'",
+  );
+});
+
+test("particular role wires notifications bell when session is active", () => {
+  const source = read(PARTICULARES_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";',
+    ),
+    "ParticularesContent must import DashboardNotificationsBell",
+  );
+  assert.ok(
+    source.includes('<DashboardNotificationsBell surface="particular" />'),
+    "ParticularesContent must render bell with particular surface",
+  );
+});


### PR DESCRIPTION
## Resumen
- Carga notificaciones automáticamente al montar la campana.
- Si hay notificaciones no leídas, las muestra automáticamente al ingresar.
- En desktop abre el dropdown existente una vez.
- En mobile muestra un banner/card visible sin depender de abrir la campana.
- Mantiene la campana como acceso manual.
- Mejora el badge para mostrar bien el contador y usar 99+.

## UX
- Desktop: auto-open del centro de notificaciones si unreadCount > 0.
- Mobile: superficie visible tipo banner/card para notificaciones no leídas.
- Anti-loop: no reabre constantemente la misma tanda.
- No marca como leídas solo por mostrarlas automáticamente.

## Validación
- pnpm typecheck
- pnpm typecheck:test
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-notifications-bell.test.ts test/frontend-admin-report-workflow.test.ts
- pnpm test
- pnpm build
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Resultado
- pnpm test OK: 2113 pass, 0 fail, 1 skipped
- pnpm build OK
- frontend typecheck/build OK

## Scope
- Solo frontend de experiencia de notificaciones.
- No toca backend, auth/rate-limit ni workflow.