### PR TITLE
fix(particulares): add special stain contact links

### DIFF
--- a/PR-fix-particulares-special-stain-contact-links.md
+++ b/PR-fix-particulares-special-stain-contact-links.md
@@ -1,0 +1,181 @@
+# PR: fix/particulares-special-stain-contact-links
+
+## Resumen
+
+Agrega dos enlaces de contacto (WhatsApp y email) en el portal de particulares, exclusivamente debajo de la alerta "Alerta: Solicitud de tinción especial." cuando `trackingCase.specialStainRequired === true`. Sin cambios de backend, base de datos, admin ni clínicas.
+
+---
+
+## Archivos tocados
+
+| Archivo | Tipo de cambio |
+|---|---|
+| `frontend/src/components/public/ParticularesContent.tsx` | Modificado — implementación |
+| `test/frontend-particulares-content.test.ts` | Modificado — 2 tests nuevos |
+
+---
+
+## Implementación realizada
+
+### `ParticularesContent.tsx`
+
+**Imports agregados:**
+- `Mail`, `MessageCircle` desde `lucide-react`
+- `PublicExternalControl` desde `@/components/public/PublicRouteControl` (importación nombrada junto a `PublicRouteControl` ya existente)
+
+**Constantes agregadas (módulo-level, antes del componente):**
+```ts
+const SPECIAL_STAIN_WHATSAPP_HREF =
+  "https://wa.me/5493534138946?text=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
+const SPECIAL_STAIN_EMAIL_HREF =
+  "mailto:lab.vetneb@gmail.com?subject=Consulta%20tinción%20especial&body=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
+```
+
+**JSX modificado — sección `trackingCase.specialStainRequired`:**
+
+Antes:
+```tsx
+{trackingCase.specialStainRequired ? (
+  <div className="clinical-alert-warning p-3 text-sm">
+    Alerta: Solicitud de tinción especial.
+  </div>
+) : null}
+```
+
+Después:
+```tsx
+{trackingCase.specialStainRequired ? (
+  <div className="space-y-3">
+    <div className="clinical-alert-warning p-3 text-sm">
+      Alerta: Solicitud de tinción especial.
+    </div>
+    <div className="flex flex-col gap-2 sm:flex-row">
+      <PublicExternalControl
+        href={SPECIAL_STAIN_WHATSAPP_HREF}
+        target="_blank"
+        className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
+        aria-label="Consultar por WhatsApp sobre tinción especial"
+      >
+        <MessageCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+        Consultar por WhatsApp
+      </PublicExternalControl>
+      <PublicExternalControl
+        href={SPECIAL_STAIN_EMAIL_HREF}
+        target="_self"
+        className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
+        aria-label="Enviar email a VETNEB sobre tinción especial"
+      >
+        <Mail className="h-4 w-4 shrink-0" aria-hidden="true" />
+        Enviar email
+      </PublicExternalControl>
+    </div>
+  </div>
+) : null}
+```
+
+**Comportamiento:**
+- WhatsApp: `target="_blank"` → `window.open(href, "_blank", "noopener,noreferrer")` — nueva pestaña segura.
+- Email: `target="_self"` → `window.location.assign(href)` — abre cliente de correo vía `mailto:`.
+- Mobile-first: `flex-col` en móvil, `sm:flex-row` en desktop ≥640px.
+- Condicionado estrictamente a `trackingCase.specialStainRequired === true`.
+- Solo en `ParticularesContent` — ni admin ni clínicas.
+
+---
+
+## Tests ejecutados
+
+### `test/frontend-particulares-content.test.ts` — 7 tests (2 nuevos)
+
+| # | Nombre | Estado |
+|---|---|---|
+| 1 | keeps refreshSession wired to particular auth me helper | ✅ PASS |
+| 2 | surfaces refreshSession fetch failures instead of silent logout state | ✅ PASS |
+| 3 | keeps neutral logout control and removes resumen label | ✅ PASS |
+| 4 | muestra estado y alerta desde study-tracking en sesion activa | ✅ PASS |
+| 5 | integra campana token-scoped en sesion activa | ✅ PASS |
+| 6 | **muestra enlace WhatsApp y email solo bajo alerta de tincion especial** | ✅ PASS |
+| 7 | **no expone PII en los hrefs de tincion especial** | ✅ PASS |
+
+### Suite frontend completa — 751 tests
+
+```
+# tests 751
+# pass  749
+# fail    2  ← preexistentes, sin relación con este PR
+```
+
+Fallos preexistentes (no introducidos por este PR):
+- `frontend-login-content.test.ts` → `ERR_INVALID_TYPESCRIPT_SYNTAX` en el propio archivo de test (sintaxis TS incompatible con `--experimental-strip-types` de Node 22).
+- `frontend-profesionales-page-content.test.ts` → `Cannot find package 'react'` (importa React directamente; fallo de entorno, no de código).
+
+### Security surface
+
+```
+PASS security/public-surface: no public devtools exposure findings.
+```
+
+Findings listados (`middleware.ts` — server-only) son preexistentes, no modificados por este PR.
+
+---
+
+## Comandos pendientes — ejecutar en Windows (Terminal 1)
+
+```powershell
+# Desde C:\PORTAL-VETNEB
+pnpm typecheck
+pnpm typecheck:test
+pnpm test
+pnpm build
+pnpm security:public-surface
+```
+
+Nota: `typecheck` y `build` requieren los node_modules de Windows accesibles con pnpm. El sandbox Linux no puede ejecutarlos por limitación de mount.
+
+---
+
+## Invariantes de seguridad verificadas
+
+- ✅ Sin PII en querystring de WhatsApp ni mailto.
+- ✅ WhatsApp usa `noopener,noreferrer` vía `PublicExternalControl`.
+- ✅ Sin `dangerouslySetInnerHTML`.
+- ✅ Sin scripts inline.
+- ✅ Sin cambios de backend, DB, auth, admin ni clínicas.
+- ✅ Sin dependencias nuevas (`lucide-react` y `PublicExternalControl` ya eran del proyecto).
+- ✅ `security:public-surface` → PASS.
+
+---
+
+## Riesgos
+
+| Riesgo | Nivel | Mitigación |
+|---|---|---|
+| URL de WhatsApp modificada en el futuro | Bajo | Constante nombrada `SPECIAL_STAIN_WHATSAPP_HREF` — un solo punto de cambio |
+| Email de contacto cambia | Bajo | Constante nombrada `SPECIAL_STAIN_EMAIL_HREF` |
+| `PublicExternalControl` cambia su contrato | Bajo | Componente interno del proyecto, no dependencia externa |
+| PII accidental en URL | Nulo | Test #7 valida que no existan keywords de PII en los hrefs |
+
+---
+
+## Rollback
+
+Revertir el commit de este PR restaura el comportamiento anterior exactamente. No hay cambios de DB ni migraciones.
+
+```powershell
+# Nico ejecuta manualmente si necesita revertir
+git revert <commit-hash>
+```
+
+---
+
+## Estado final
+
+| Validación | Estado | Ejecutado en |
+|---|---|---|
+| `pnpm typecheck` (frontend) | ⏳ Pendiente Windows | — |
+| `pnpm typecheck:test` | ⏳ Pendiente Windows | — |
+| `pnpm test` (frontend-particulares-content) | ✅ 7/7 PASS | Linux sandbox |
+| `pnpm test` (suite frontend) | ✅ 749/751 (2 fallos preexistentes) | Linux sandbox |
+| `pnpm build` | ⏳ Pendiente Windows | — |
+| `pnpm security:public-surface` | ✅ PASS | Linux sandbox |
+
+**Archivos modificados: 2. Líneas añadidas: ~55. Sin cambios de backend.**

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -9,6 +9,8 @@ import {
   FileText,
   KeyRound,
   LogOut,
+  Mail,
+  MessageCircle,
   PawPrint,
   ShieldCheck,
   UserRound,
@@ -39,7 +41,10 @@ import {
   PremiumPanel,
   VisualIcon,
 } from "@/components/public/VisualAccents";
-import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import {
+  PublicExternalControl,
+  PublicRouteControl,
+} from "@/components/public/PublicRouteControl";
 import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";
 
 function formatDate(value: string | null | undefined) {
@@ -73,6 +78,11 @@ function getTrackingStageLabel(
 ) {
   return TRACKING_STAGE_LABELS[stage] ?? stage;
 }
+
+const SPECIAL_STAIN_WHATSAPP_HREF =
+  "https://wa.me/5493534138946?text=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
+const SPECIAL_STAIN_EMAIL_HREF =
+  "mailto:lab.vetneb@gmail.com?subject=Consulta%20tinción%20especial&body=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
 
 const accessHighlights = [
   {
@@ -435,8 +445,30 @@ export function ParticularesContent() {
                           Actualizado: {formatDate(trackingCase.updatedAt)}
                         </p>
                         {trackingCase.specialStainRequired ? (
-                          <div className="clinical-alert-warning p-3 text-sm">
-                            Alerta: Solicitud de tinción especial.
+                          <div className="space-y-3">
+                            <div className="clinical-alert-warning p-3 text-sm">
+                              Alerta: Solicitud de tinción especial.
+                            </div>
+                            <div className="flex flex-col gap-2 sm:flex-row">
+                              <PublicExternalControl
+                                href={SPECIAL_STAIN_WHATSAPP_HREF}
+                                target="_blank"
+                                className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
+                                aria-label="Consultar por WhatsApp sobre tinción especial"
+                              >
+                                <MessageCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+                                Consultar por WhatsApp
+                              </PublicExternalControl>
+                              <PublicExternalControl
+                                href={SPECIAL_STAIN_EMAIL_HREF}
+                                target="_self"
+                                className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
+                                aria-label="Enviar email a VETNEB sobre tinción especial"
+                              >
+                                <Mail className="h-4 w-4 shrink-0" aria-hidden="true" />
+                                Enviar email
+                              </PublicExternalControl>
+                            </div>
                           </div>
                         ) : null}
                       </div>

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -48,7 +48,7 @@ test("particulares content keeps neutral logout control and removes resumen labe
   assert.equal(source.includes("Resumen de caso"), false);
 });
 
-test("particulares content muestra estado y alerta desde study-tracking en sesión activa", () => {
+test("particulares content muestra estado y alerta desde study-tracking en sesion activa", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
 
   assert.ok(source.includes("getParticularStudyTrackingCase"));
@@ -58,7 +58,7 @@ test("particulares content muestra estado y alerta desde study-tracking en sesi�
   assert.ok(source.includes("trackingCase"));
 });
 
-test("particulares content integra campana token-scoped en sesión activa", () => {
+test("particulares content integra campana token-scoped en sesion activa", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
 
   assert.ok(
@@ -67,4 +67,43 @@ test("particulares content integra campana token-scoped en sesión activa", () =
     ),
   );
   assert.ok(source.includes('<DashboardNotificationsBell surface="particular" />'));
+});
+
+test("particulares content muestra enlace WhatsApp y email solo bajo alerta de tincion especial", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("Alerta: Solicitud de tinción especial."));
+  assert.ok(source.includes("https://wa.me/5493534138946"));
+  assert.ok(source.includes("mailto:lab.vetneb@gmail.com"));
+  assert.ok(source.includes("Consultar por WhatsApp"));
+  assert.ok(source.includes("Enviar email"));
+  assert.ok(source.includes("trackingCase.specialStainRequired"));
+  assert.ok(source.includes("SPECIAL_STAIN_WHATSAPP_HREF"));
+  assert.ok(source.includes("SPECIAL_STAIN_EMAIL_HREF"));
+  assert.ok(source.includes("PublicExternalControl"));
+  assert.ok(source.includes('target="_blank"'));
+  assert.ok(source.includes('target="_self"'));
+  assert.equal(source.includes("/dashboard/admin"), false);
+});
+
+test("particulares content no expone PII en los hrefs de tincion especial", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  const waHrefMatch = source.match(/SPECIAL_STAIN_WHATSAPP_HREF\s*=\s*"([^"\n]+)"/);
+  const emailHrefMatch = source.match(/SPECIAL_STAIN_EMAIL_HREF\s*=\s*"([^"\n]+)"/);
+
+  assert.ok(waHrefMatch !== null, "SPECIAL_STAIN_WHATSAPP_HREF debe estar definida");
+  assert.ok(emailHrefMatch !== null, "SPECIAL_STAIN_EMAIL_HREF debe estar definida");
+
+  const waHref = waHrefMatch[1];
+  const emailHref = emailHrefMatch[1];
+
+  const piiKeywords = ["tutorLastName", "petName", "petSpecies", "petBreed", "extractionDate", "shippingDate"];
+  for (const kw of piiKeywords) {
+    assert.equal(waHref.toLowerCase().includes(kw.toLowerCase()), false, `WHATSAPP_HREF no debe contener "${kw}"`);
+    assert.equal(emailHref.toLowerCase().includes(kw.toLowerCase()), false, `EMAIL_HREF no debe contener "${kw}"`);
+  }
+
+  assert.ok(waHref.startsWith("https://wa.me/5493534138946"), "WhatsApp href debe apuntar al numero oficial");
+  assert.ok(emailHref.startsWith("mailto:lab.vetneb@gmail.com"), "Email href debe apuntar al correo oficial");
 });


### PR DESCRIPTION
# PR: fix/particulares-special-stain-contact-links

## Resumen

Agrega dos enlaces de contacto (WhatsApp y email) en el portal de particulares, exclusivamente debajo de la alerta "Alerta: Solicitud de tinción especial." cuando `trackingCase.specialStainRequired === true`. Sin cambios de backend, base de datos, admin ni clínicas.

---

## Archivos tocados

| Archivo | Tipo de cambio |
|---|---|
| `frontend/src/components/public/ParticularesContent.tsx` | Modificado — implementación |
| `test/frontend-particulares-content.test.ts` | Modificado — 2 tests nuevos |

---

## Implementación realizada

### `ParticularesContent.tsx`

**Imports agregados:**
- `Mail`, `MessageCircle` desde `lucide-react`
- `PublicExternalControl` desde `@/components/public/PublicRouteControl` (importación nombrada junto a `PublicRouteControl` ya existente)

**Constantes agregadas (módulo-level, antes del componente):**
```ts
const SPECIAL_STAIN_WHATSAPP_HREF =
  "https://wa.me/5493534138946?text=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
const SPECIAL_STAIN_EMAIL_HREF =
  "mailto:lab.vetneb@gmail.com?subject=Consulta%20tinción%20especial&body=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
```

**JSX modificado — sección `trackingCase.specialStainRequired`:**

Antes:
```tsx
{trackingCase.specialStainRequired ? (
  <div className="clinical-alert-warning p-3 text-sm">
    Alerta: Solicitud de tinción especial.
  </div>
) : null}
```

Después:
```tsx
{trackingCase.specialStainRequired ? (
  <div className="space-y-3">
    <div className="clinical-alert-warning p-3 text-sm">
      Alerta: Solicitud de tinción especial.
    </div>
    <div className="flex flex-col gap-2 sm:flex-row">
      <PublicExternalControl
        href={SPECIAL_STAIN_WHATSAPP_HREF}
        target="_blank"
        className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
        aria-label="Consultar por WhatsApp sobre tinción especial"
      >
        <MessageCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
        Consultar por WhatsApp
      </PublicExternalControl>
      <PublicExternalControl
        href={SPECIAL_STAIN_EMAIL_HREF}
        target="_self"
        className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
        aria-label="Enviar email a VETNEB sobre tinción especial"
      >
        <Mail className="h-4 w-4 shrink-0" aria-hidden="true" />
        Enviar email
      </PublicExternalControl>
    </div>
  </div>
) : null}
```

**Comportamiento:**
- WhatsApp: `target="_blank"` → `window.open(href, "_blank", "noopener,noreferrer")` — nueva pestaña segura.
- Email: `target="_self"` → `window.location.assign(href)` — abre cliente de correo vía `mailto:`.
- Mobile-first: `flex-col` en móvil, `sm:flex-row` en desktop ≥640px.
- Condicionado estrictamente a `trackingCase.specialStainRequired === true`.
- Solo en `ParticularesContent` — ni admin ni clínicas.

---

## Tests ejecutados

### `test/frontend-particulares-content.test.ts` — 7 tests (2 nuevos)

| # | Nombre | Estado |
|---|---|---|
| 1 | keeps refreshSession wired to particular auth me helper | ✅ PASS |
| 2 | surfaces refreshSession fetch failures instead of silent logout state | ✅ PASS |
| 3 | keeps neutral logout control and removes resumen label | ✅ PASS |
| 4 | muestra estado y alerta desde study-tracking en sesion activa | ✅ PASS |
| 5 | integra campana token-scoped en sesion activa | ✅ PASS |
| 6 | **muestra enlace WhatsApp y email solo bajo alerta de tincion especial** | ✅ PASS |
| 7 | **no expone PII en los hrefs de tincion especial** | ✅ PASS |

### Suite frontend completa — 751 tests

```
# tests 751
# pass  749
# fail    2  ← preexistentes, sin relación con este PR
```

Fallos preexistentes (no introducidos por este PR):
- `frontend-login-content.test.ts` → `ERR_INVALID_TYPESCRIPT_SYNTAX` en el propio archivo de test (sintaxis TS incompatible con `--experimental-strip-types` de Node 22).
- `frontend-profesionales-page-content.test.ts` → `Cannot find package 'react'` (importa React directamente; fallo de entorno, no de código).

### Security surface

```
PASS security/public-surface: no public devtools exposure findings.
```

Findings listados (`middleware.ts` — server-only) son preexistentes, no modificados por este PR.

---

## Comandos pendientes — ejecutar en Windows (Terminal 1)

```powershell
# Desde C:\PORTAL-VETNEB
pnpm typecheck
pnpm typecheck:test
pnpm test
pnpm build
pnpm security:public-surface
```

Nota: `typecheck` y `build` requieren los node_modules de Windows accesibles con pnpm. El sandbox Linux no puede ejecutarlos por limitación de mount.

---

## Invariantes de seguridad verificadas

- ✅ Sin PII en querystring de WhatsApp ni mailto.
- ✅ WhatsApp usa `noopener,noreferrer` vía `PublicExternalControl`.
- ✅ Sin `dangerouslySetInnerHTML`.
- ✅ Sin scripts inline.
- ✅ Sin cambios de backend, DB, auth, admin ni clínicas.
- ✅ Sin dependencias nuevas (`lucide-react` y `PublicExternalControl` ya eran del proyecto).
- ✅ `security:public-surface` → PASS.

---

## Riesgos

| Riesgo | Nivel | Mitigación |
|---|---|---|
| URL de WhatsApp modificada en el futuro | Bajo | Constante nombrada `SPECIAL_STAIN_WHATSAPP_HREF` — un solo punto de cambio |
| Email de contacto cambia | Bajo | Constante nombrada `SPECIAL_STAIN_EMAIL_HREF` |
| `PublicExternalControl` cambia su contrato | Bajo | Componente interno del proyecto, no dependencia externa |
| PII accidental en URL | Nulo | Test #7 valida que no existan keywords de PII en los hrefs |

---

## Rollback

Revertir el commit de este PR restaura el comportamiento anterior exactamente. No hay cambios de DB ni migraciones.

```powershell
# Nico ejecuta manualmente si necesita revertir
git revert <commit-hash>
```

---

## Estado final

| Validación | Estado | Ejecutado en |
|---|---|---|
| `pnpm typecheck` (frontend) | ⏳ Pendiente Windows | — |
| `pnpm typecheck:test` | ⏳ Pendiente Windows | — |
| `pnpm test` (frontend-particulares-content) | ✅ 7/7 PASS | Linux sandbox |
| `pnpm test` (suite frontend) | ✅ 749/751 (2 fallos preexistentes) | Linux sandbox |
| `pnpm build` | ⏳ Pendiente Windows | — |
| `pnpm security:public-surface` | ✅ PASS | Linux sandbox |

**Archivos modificados: 2. Líneas añadidas: ~55. Sin cambios de backend.**
