### PR TITLE
fix(admin): scope report upload and status per token

### DIFF
--- a/PR-fix-admin-token-scoped-report-upload-status.md
+++ b/PR-fix-admin-token-scoped-report-upload-status.md
@@ -1,0 +1,59 @@
+# PR: fix admin token-scoped report upload status
+
+## Resumen
+- La carga de informes del panel admin se movio desde el header global hacia cada token en "Ultimos tokens administrados".
+- Cada token ahora abre `UploadReportModal` con clinica y token preconfigurados.
+- El estado de seguimiento usa select con borrador local y boton individual "Actualizar estado".
+- El vinculo y titulo del token usan nombre de clinica cuando esta disponible, con fallback seguro a `Clinica #id`.
+
+## Archivos tocados
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/UploadReportModal.tsx`
+- `test/frontend-admin-particular-tokens.test.ts`
+- `test/frontend-admin-report-workflow.test.ts`
+- `test/frontend-dashboard-admin.test.ts`
+- `test/frontend-report-actions.test.ts`
+- `test/frontend-report-upload-modal.test.ts`
+- `PR-fix-admin-token-scoped-report-upload-status.md`
+
+## Implementacion realizada
+- Se quito el boton operativo global del header "Carga de informes" y se dejo copy informativo.
+- Se agrego accion visible por token: "Subir informe para este token".
+- `UploadReportModal` ahora acepta `triggerLabel`, `presetClinic`, `presetParticularToken` y `onUploaded`.
+- En modo preset, el modal no pide buscar clinica ni seleccionar token; muestra resumen read-only y envia `clinicId` + `particularTokenId` en `FormData`.
+- Al subir desde token, se ejecuta `loadTokens` para refrescar badges y `reportId`.
+- Se reutiliza la carga de clinicas via `getAdminUsersRoles` para resolver nombre por `clinicId`.
+- Se agrego tracking de etapa por borrador local y PATCH solo al presionar "Actualizar estado".
+- Se mantuvo la accion individual de solicitar/resolver tincion especial.
+
+## Tests agregados/modificados
+- Tests para accion de upload por token y presets del modal.
+- Tests para `FormData` con `clinicId` y `particularTokenId` desde presets.
+- Tests para vinculo con nombre de clinica y fallback.
+- Tests para estado con select + boton individual.
+- Tests actualizados para remover dependencia del modal global en `page.tsx`.
+
+## Comandos ejecutados
+- `pnpm --dir frontend typecheck`: PASS.
+- Subconjunto frontend: PASS, 68/68.
+- `pnpm typecheck`: PASS.
+- `pnpm typecheck:test`: PASS.
+- `pnpm test`: PASS, 2119 passed, 1 skipped, 0 failed.
+- `pnpm build`: PASS, `dist/index.js` generado por esbuild.
+- `pnpm security:public-surface`: PASS, sin hallazgos de exposicion publica; conserva dos findings informativos `server-only` en `frontend/src/middleware.ts`.
+
+## Riesgos
+- No se tocaron endpoints backend, auth, cookies, sesiones, roles, DB ni migraciones.
+- La verificacion fue por typecheck y tests de contrato/runtime; no se ejecuto navegador visual.
+- Si el catalogo de clinicas no trae nombre real, la UI cae al fallback `Clinica #id`.
+
+## Rollback
+- Revertir los archivos listados en "Archivos tocados".
+- No hay migraciones ni cambios de datos que revertir.
+- No se hizo `git add`, commit, push, PR ni merge.
+
+## Estado final
+- Implementacion completa.
+- Validaciones obligatorias en verde.
+- Cambios locales sin stagear.

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import {
   Card,
   CardContent,
@@ -45,6 +46,7 @@ type AdminParticularTokenFormState = {
 type ClinicOption = {
   id: number;
   name: string;
+  hasResolvedName: boolean;
   usernames: string[];
   locality: string | null;
 };
@@ -162,7 +164,8 @@ function dedupeClinicOptions(options: ClinicOption[]): ClinicOption[] {
 
     byId.set(option.id, {
       ...current,
-      name: current.name || option.name,
+      name: current.hasResolvedName ? current.name : option.name,
+      hasResolvedName: current.hasResolvedName || option.hasResolvedName,
       locality: current.locality ?? option.locality,
       usernames: Array.from(
         new Set([...current.usernames, ...option.usernames]),
@@ -280,6 +283,47 @@ function getTrackingStageLabel(
   return TRACKING_STAGE_LABELS[stage] ?? stage;
 }
 
+function resolveClinicName(
+  clinicOptions: ClinicOption[],
+  clinicId: number,
+): string | null {
+  const clinic = clinicOptions.find((option) => option.id === clinicId);
+
+  return clinic?.hasResolvedName ? clinic.name : null;
+}
+
+function formatTokenTitle(
+  clinicOptions: ClinicOption[],
+  token: AdminParticularTokenSummary,
+): string {
+  const clinicName = resolveClinicName(clinicOptions, token.clinicId);
+
+  return `${clinicName ?? `Clínica #${token.clinicId}`} · ${token.petName}`;
+}
+
+function formatTokenClinicLink(
+  clinicOptions: ClinicOption[],
+  clinicId: number,
+): string {
+  const clinicName = resolveClinicName(clinicOptions, clinicId);
+
+  return clinicName
+    ? `Clínica: ${clinicName} (#${clinicId})`
+    : `Clínica #${clinicId}`;
+}
+
+function buildTokenPresetClinic(
+  clinicOptions: ClinicOption[],
+  token: AdminParticularTokenSummary,
+) {
+  const clinicName = resolveClinicName(clinicOptions, token.clinicId);
+
+  return {
+    id: token.clinicId,
+    name: clinicName ?? `Clínica #${token.clinicId}`,
+  };
+}
+
 export function AdminParticularTokensCard() {
   const [formState, setFormState] =
     useState<AdminParticularTokenFormState>(INITIAL_FORM_STATE);
@@ -308,6 +352,8 @@ export function AdminParticularTokensCard() {
   const [updatingTrackingCaseIds, setUpdatingTrackingCaseIds] = useState<
     Record<number, boolean>
   >({});
+  const [trackingStageDraftsByCaseId, setTrackingStageDraftsByCaseId] =
+    useState<Record<number, AdminStudyTrackingStage>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -334,6 +380,7 @@ export function AdminParticularTokensCard() {
 
       if (snapshot.particularTokens.length === 0) {
         setTrackingCasesByTokenId({});
+        setTrackingStageDraftsByCaseId({});
         return;
       }
 
@@ -351,16 +398,24 @@ export function AdminParticularTokensCard() {
         );
 
         const nextTrackingByTokenId: Record<number, AdminStudyTrackingCaseSummary> = {};
+        const nextTrackingStageDraftsByCaseId: Record<
+          number,
+          AdminStudyTrackingStage
+        > = {};
 
         for (const [tokenId, trackingCase] of trackingEntries) {
           if (trackingCase) {
             nextTrackingByTokenId[tokenId] = trackingCase;
+            nextTrackingStageDraftsByCaseId[trackingCase.id] =
+              trackingCase.currentStage;
           }
         }
 
         setTrackingCasesByTokenId(nextTrackingByTokenId);
+        setTrackingStageDraftsByCaseId(nextTrackingStageDraftsByCaseId);
       } catch (error) {
         setTrackingCasesByTokenId({});
+        setTrackingStageDraftsByCaseId({});
         setTrackingLoadError(
           error instanceof Error
             ? error.message
@@ -374,6 +429,7 @@ export function AdminParticularTokensCard() {
           : "No se pudieron cargar los tokens particulares.",
       );
       setTrackingCasesByTokenId({});
+      setTrackingStageDraftsByCaseId({});
     } finally {
       setIsLoadingTokens(false);
     }
@@ -412,7 +468,8 @@ export function AdminParticularTokensCard() {
 
             options.push({
               id: user.clinicId,
-              name: user.clinicName ?? `Clínica #${user.clinicId}`,
+              name: user.clinicName?.trim() || `Clínica #${user.clinicId}`,
+              hasResolvedName: Boolean(user.clinicName?.trim()),
               usernames: [user.username],
               locality: user.clinicLocality ?? null,
             });
@@ -610,6 +667,16 @@ export function AdminParticularTokensCard() {
         delete next[token.id];
         return next;
       });
+      setTrackingStageDraftsByCaseId((current) => {
+        const next = { ...current };
+        const trackingCase = trackingCasesByTokenId[token.id];
+
+        if (trackingCase) {
+          delete next[trackingCase.id];
+        }
+
+        return next;
+      });
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -621,11 +688,24 @@ export function AdminParticularTokensCard() {
     }
   }
 
-  async function handleTrackingStageChange(
-    tokenId: number,
+  function handleTrackingStageDraftChange(
     trackingCase: AdminStudyTrackingCaseSummary,
     nextStage: AdminStudyTrackingStage,
   ) {
+    setTrackingStageDraftsByCaseId((current) => ({
+      ...current,
+      [trackingCase.id]: nextStage,
+    }));
+    setErrorMessage(null);
+  }
+
+  async function handleTrackingStageUpdate(
+    tokenId: number,
+    trackingCase: AdminStudyTrackingCaseSummary,
+  ) {
+    const nextStage =
+      trackingStageDraftsByCaseId[trackingCase.id] ?? trackingCase.currentStage;
+
     if (trackingCase.currentStage === nextStage) {
       return;
     }
@@ -644,6 +724,10 @@ export function AdminParticularTokensCard() {
       setTrackingCasesByTokenId((current) => ({
         ...current,
         [tokenId]: response.trackingCase,
+      }));
+      setTrackingStageDraftsByCaseId((current) => ({
+        ...current,
+        [response.trackingCase.id]: response.trackingCase.currentStage,
       }));
     } catch {
       setErrorMessage("No se pudo cambiar la etapa del seguimiento.");
@@ -1163,6 +1247,13 @@ export function AdminParticularTokensCard() {
                 const isUpdatingTrackingCase = trackingCase
                   ? Boolean(updatingTrackingCaseIds[trackingCase.id])
                   : false;
+                const trackingStageDraft = trackingCase
+                  ? trackingStageDraftsByCaseId[trackingCase.id] ??
+                    trackingCase.currentStage
+                  : null;
+                const hasTrackingStageChange = trackingCase
+                  ? trackingStageDraft !== trackingCase.currentStage
+                  : false;
 
                 return (
                   <div
@@ -1172,7 +1263,7 @@ export function AdminParticularTokensCard() {
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="space-y-1">
                       <p className="text-sm font-semibold text-vetneb-ink">
-                        Clínica #{token.clinicId} · {token.petName}
+                        {formatTokenTitle(clinicOptions, token)}
                       </p>
                       <p className="text-xs text-muted-foreground">
                         Tutor: {token.tutorLastName} · Token ****{token.tokenLast4}
@@ -1243,7 +1334,9 @@ export function AdminParticularTokensCard() {
                       <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                         Vínculo
                       </p>
-                      <p className="mt-1 text-xs text-muted-foreground">Clínica #{token.clinicId}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {formatTokenClinicLink(clinicOptions, token.clinicId)}
+                      </p>
                       <p className="mt-1 text-xs text-muted-foreground">
                         Origen: {formatTokenSource(token)}
                       </p>
@@ -1267,10 +1360,9 @@ export function AdminParticularTokensCard() {
                           <select
                             id={`admin-tracking-stage-${trackingCase.id}`}
                             className="field-select mt-1 text-xs"
-                            value={trackingCase.currentStage}
+                            value={trackingStageDraft ?? trackingCase.currentStage}
                             onChange={(event) =>
-                              void handleTrackingStageChange(
-                                token.id,
+                              handleTrackingStageDraftChange(
                                 trackingCase,
                                 event.target.value as AdminStudyTrackingStage,
                               )
@@ -1283,6 +1375,22 @@ export function AdminParticularTokensCard() {
                               </option>
                             ))}
                           </select>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="mt-2 w-full"
+                            onClick={() =>
+                              void handleTrackingStageUpdate(token.id, trackingCase)
+                            }
+                            disabled={
+                              !hasTrackingStageChange || isUpdatingTrackingCase
+                            }
+                          >
+                            {isUpdatingTrackingCase
+                              ? "Actualizando..."
+                              : "Actualizar estado"}
+                          </Button>
                           <p className="mt-1 text-xs text-muted-foreground">
                             {trackingCase.specialStainRequired
                               ? "Alerta: Solicitud de tinción especial"
@@ -1311,7 +1419,13 @@ export function AdminParticularTokensCard() {
                     </div>
                   </div>
 
-                  <div className="mt-3 flex justify-end">
+                  <div className="mt-3 flex flex-wrap justify-end gap-2">
+                    <UploadReportModal
+                      triggerLabel="Subir informe para este token"
+                      presetClinic={buildTokenPresetClinic(clinicOptions, token)}
+                      presetParticularToken={token}
+                      onUploaded={loadTokens}
+                    />
                     <Button
                       type="button"
                       variant="destructive"

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -26,7 +26,6 @@ import { AdminPricingEditorCard } from "./AdminPricingEditorCard";
 import { AdminSchemaHealthStatusCard } from "./AdminSchemaHealthStatusCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
-import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 
@@ -406,12 +405,10 @@ export default async function AdminPage({
                 Carga de informes
               </h2>
               <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-                Suba PDFs, asócielos a una clínica y vincule tokens particulares
-                desde una única superficie administrativa.
+                La carga de informes se realiza desde cada token administrado
+                en "Últimos tokens administrados", para vincular clínica y token
+                sin búsqueda manual.
               </p>
-            </div>
-            <div className="shrink-0">
-              <UploadReportModal />
             </div>
           </div>
         </section>

--- a/frontend/src/components/dashboard/UploadReportModal.tsx
+++ b/frontend/src/components/dashboard/UploadReportModal.tsx
@@ -20,6 +20,18 @@ type ClinicOption = {
   usernames: string[];
 };
 
+type PresetClinic = {
+  id: number;
+  name: string;
+};
+
+type UploadReportModalProps = {
+  triggerLabel?: string;
+  presetClinic?: PresetClinic;
+  presetParticularToken?: AdminParticularTokenSummary;
+  onUploaded?: () => void | Promise<void>;
+};
+
 const STUDY_TYPE_OPTIONS = [
   { value: "histopatologia", label: "Histopatología" },
   { value: "citologia", label: "Citología" },
@@ -89,7 +101,16 @@ function buildParticularTokenLabel(token: AdminParticularTokenSummary) {
   return `Token ****${token.tokenLast4} · ${token.petName} · ${token.tutorLastName} · ${linkedLabel}`;
 }
 
-export function UploadReportModal() {
+function buildPresetPatientName(token: AdminParticularTokenSummary) {
+  return `${token.petName} / ${token.tutorLastName}`;
+}
+
+export function UploadReportModal({
+  triggerLabel = "Subir informe",
+  presetClinic,
+  presetParticularToken,
+  onUploaded,
+}: UploadReportModalProps) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [isMounted, setIsMounted] = useState(false);
@@ -116,15 +137,21 @@ export function UploadReportModal() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const selectedClinic = clinicOptions.find(
+  const hasPresetClinic = typeof presetClinic?.id === "number";
+  const hasPresetParticularToken =
+    typeof presetParticularToken?.id === "number";
+  const isPresetMode = hasPresetClinic && hasPresetParticularToken;
+
+  const selectedClinicOption = clinicOptions.find(
     (option) => String(option.id) === clinicId,
   );
+  const selectedClinic = presetClinic ?? selectedClinicOption;
 
   const selectedClinicId = selectedClinic?.id;
 
-  const selectedParticularToken = particularTokens.find(
-    (token) => String(token.id) === particularTokenId,
-  );
+  const selectedParticularToken =
+    presetParticularToken ??
+    particularTokens.find((token) => String(token.id) === particularTokenId);
 
   const hasClinicQuery = normalizeSearchText(clinicSearch).length > 0;
 
@@ -136,8 +163,8 @@ export function UploadReportModal() {
     ? clinicOptions
         .filter((option) => matchClinicOption(option, clinicSearch))
         .slice(0, 20)
-    : selectedClinic
-      ? [selectedClinic]
+    : selectedClinicOption
+      ? [selectedClinicOption]
       : [];
 
   useEffect(() => {
@@ -145,7 +172,7 @@ export function UploadReportModal() {
   }, []);
 
   useEffect(() => {
-    if (!isOpen || isLoadingClinics) {
+    if (!isOpen || isLoadingClinics || hasPresetClinic) {
       return;
     }
 
@@ -225,10 +252,16 @@ export function UploadReportModal() {
   }, [isOpen]);
 
   useEffect(() => {
-    if (!isOpen || typeof selectedClinicId !== "number") {
-      setParticularTokens([]);
-      setParticularTokenId("");
-      setParticularTokenLoadError(null);
+    if (
+      !isOpen ||
+      hasPresetParticularToken ||
+      typeof selectedClinicId !== "number"
+    ) {
+      if (!hasPresetParticularToken) {
+        setParticularTokens([]);
+        setParticularTokenId("");
+        setParticularTokenLoadError(null);
+      }
       return;
     }
 
@@ -283,16 +316,22 @@ export function UploadReportModal() {
     return () => {
       cancelled = true;
     };
-  }, [isOpen, selectedClinicId]);
+  }, [isOpen, selectedClinicId, hasPresetParticularToken]);
 
   function resetForm() {
-    setClinicId("");
-    setClinicSearch("");
-    setParticularTokenId("");
+    setClinicId(presetClinic ? String(presetClinic.id) : "");
+    setClinicSearch(presetClinic?.name ?? "");
+    setParticularTokenId(
+      presetParticularToken ? String(presetParticularToken.id) : "",
+    );
     setParticularTokens([]);
     setParticularTokenLoadError(null);
     setSelectedFileName("");
-    setPatientName("");
+    setPatientName(
+      presetParticularToken
+        ? buildPresetPatientName(presetParticularToken)
+        : "",
+    );
     setStudyType(STUDY_TYPE_OPTIONS[0].value);
     setUploadDate("");
 
@@ -309,6 +348,20 @@ export function UploadReportModal() {
     setIsOpen(false);
     setErrorMessage(null);
     setSuccessMessage(null);
+  }
+
+  function openModal() {
+    if (presetClinic) {
+      setClinicId(String(presetClinic.id));
+      setClinicSearch(presetClinic.name);
+    }
+
+    if (presetParticularToken) {
+      setParticularTokenId(String(presetParticularToken.id));
+      setPatientName(buildPresetPatientName(presetParticularToken));
+    }
+
+    setIsOpen(true);
   }
 
   function selectClinic(option: ClinicOption) {
@@ -354,8 +407,19 @@ export function UploadReportModal() {
       return;
     }
 
-    if (!clinicId || !selectedClinic) {
-      setErrorMessage("Seleccione una clínica registrada del listado.");
+    if (!presetClinic) {
+      if (!clinicId || !selectedClinic) {
+        setErrorMessage("Seleccione una clínica registrada del listado.");
+        return;
+      }
+    }
+
+    if (
+      presetClinic &&
+      presetParticularToken &&
+      presetParticularToken.clinicId !== presetClinic.id
+    ) {
+      setErrorMessage("El token preseleccionado no pertenece a la clínica indicada.");
       return;
     }
 
@@ -371,7 +435,13 @@ export function UploadReportModal() {
     setIsSubmitting(true);
 
     const formData = new FormData();
-    formData.append("clinicId", clinicId);
+
+    if (presetClinic) {
+      formData.append("clinicId", String(presetClinic.id));
+    } else {
+      formData.append("clinicId", clinicId);
+    }
+
     formData.append("file", file);
 
     if (patientName.trim()) {
@@ -386,7 +456,9 @@ export function UploadReportModal() {
       formData.append("uploadDate", uploadDate);
     }
 
-    if (selectedParticularToken) {
+    if (presetParticularToken) {
+      formData.append("particularTokenId", String(presetParticularToken.id));
+    } else if (selectedParticularToken) {
       formData.append("particularTokenId", String(selectedParticularToken.id));
     }
 
@@ -394,6 +466,7 @@ export function UploadReportModal() {
       const response = await uploadAdminReport(formData);
       setSuccessMessage(response.message);
 
+      await onUploaded?.();
       resetForm();
       router.refresh();
     } catch (error) {
@@ -427,7 +500,9 @@ export function UploadReportModal() {
               Subir informe
             </h2>
             <p className="text-sm text-muted-foreground">
-              Cargue un PDF y asócielo a una clínica.
+              {isPresetMode
+                ? "Cargue un PDF para vincularlo al token seleccionado."
+                : "Cargue un PDF y asócielo a una clínica."}
             </p>
           </div>
           <Button
@@ -442,147 +517,165 @@ export function UploadReportModal() {
         </div>
 
         <form className="space-y-4" onSubmit={handleSubmit}>
-          <div>
-            <label htmlFor="upload-clinic-search" className="field-label">
-              Clínica
-            </label>
-            <Input
-              id="upload-clinic-search"
-              name="clinicSearch"
-              type="text"
-              placeholder="Buscar clínica registrada por nombre, usuario o ID..."
-              autoComplete="off"
-              required
-              value={clinicSearch}
-              onChange={(event) => handleClinicSearchChange(event.target.value)}
-              disabled={isSubmitting}
-              aria-describedby="upload-clinic-help"
-            />
-            <input
-              id="upload-clinic-id"
-              name="clinicId"
-              type="hidden"
-              value={clinicId}
-              readOnly
-            />
-            <p id="upload-clinic-help" className="mt-1 text-xs text-muted-foreground">
-              Seleccione una clínica del listado desplegado. La búsqueda admite
-              texto parcial, acentos, ID y usuarios asociados.
-            </p>
-
-            {clinicLoadError ? (
-              <p
-                className="mt-2 clinical-alert-error px-3 py-2"
-                role="alert"
-              >
-                {clinicLoadError}
+          {presetClinic && presetParticularToken ? (
+            <div className="clinical-muted-band space-y-2 rounded-lg px-3 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                Carga preconfigurada
               </p>
-            ) : null}
-
-            <div
-              className="mt-2 max-h-44 overflow-y-auto rounded-lg border border-vetneb-line/80 bg-card/92"
-              role="listbox"
-              aria-label="Clínicas registradas"
-            >
-              {isLoadingClinics ? (
-                <p className="surface-empty m-2 py-3">
-                  Cargando clínicas registradas...
-                </p>
-              ) : null}
-
-              {!isLoadingClinics && hasClinicQuery && filteredClinicOptions.length === 0 ? (
-                <p className="surface-empty m-2 py-3">
-                  No hay clínicas registradas que coincidan con la búsqueda.
-                </p>
-              ) : null}
-
-              {!isLoadingClinics
-                ? filteredClinicOptions.map((option) => (
-                    <button
-                      key={option.id}
-                      type="button"
-                      className={`clinical-hover-row flex w-full items-center justify-between gap-2 border-b border-vetneb-line/35 px-3 py-2 text-left text-sm last:border-b-0 ${
-                        String(option.id) === clinicId
-                          ? "bg-vetneb-teal/12 text-vetneb-navy shadow-[inset_0_0_0_1px_rgba(16,60,96,0.28)]"
-                          : "text-vetneb-ink/88"
-                      }`}
-                      onClick={() => selectClinic(option)}
-                      disabled={isSubmitting}
-                      role="option"
-                      aria-selected={String(option.id) === clinicId}
-                    >
-                      <span className="min-w-0">
-                        <span className="block truncate font-medium">
-                          {option.name}
-                        </span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          ID #{option.id}
-                          {option.usernames.length
-                            ? ` · ${option.usernames.join(", ")}`
-                            : ""}
-                        </span>
-                      </span>
-                      {String(option.id) === clinicId ? (
-                        <span className="clinical-pill shrink-0 px-2 py-0.5 text-xs tracking-normal">
-                          Seleccionada
-                        </span>
-                      ) : null}
-                    </button>
-                  ))
-                : null}
+              <p className="text-sm text-vetneb-ink">
+                Clínica: {presetClinic.name} (#{presetClinic.id})
+              </p>
+              <p className="text-sm text-vetneb-ink">
+                Token: ****{presetParticularToken.tokenLast4} ·{" "}
+                {presetParticularToken.petName} ·{" "}
+                {presetParticularToken.tutorLastName}
+              </p>
             </div>
-          </div>
+          ) : (
+            <>
+              <div>
+                <label htmlFor="upload-clinic-search" className="field-label">
+                  Clínica
+                </label>
+                <Input
+                  id="upload-clinic-search"
+                  name="clinicSearch"
+                  type="text"
+                  placeholder="Buscar clínica registrada por nombre, usuario o ID..."
+                  autoComplete="off"
+                  required
+                  value={clinicSearch}
+                  onChange={(event) => handleClinicSearchChange(event.target.value)}
+                  disabled={isSubmitting}
+                  aria-describedby="upload-clinic-help"
+                />
+                <input
+                  id="upload-clinic-id"
+                  name="clinicId"
+                  type="hidden"
+                  value={clinicId}
+                  readOnly
+                />
+                <p id="upload-clinic-help" className="mt-1 text-xs text-muted-foreground">
+                  Seleccione una clínica del listado desplegado. La búsqueda admite
+                  texto parcial, acentos, ID y usuarios asociados.
+                </p>
 
-          <div>
-            <label htmlFor="upload-particular-token-id" className="field-label">
-              Token particular
-            </label>
-            <select
-              id="upload-particular-token-id"
-              name="particularTokenId"
-              className="field-select"
-              value={particularTokenId}
-              onChange={(event) => handleParticularTokenChange(event.target.value)}
-              disabled={!selectedClinic || isLoadingParticularTokens || isSubmitting}
-            >
-              <option value="">
-                Sin token particular vinculado
-              </option>
-              {particularTokens.map((token) => (
-                <option key={token.id} value={token.id}>
-                  {buildParticularTokenLabel(token)}
-                </option>
-              ))}
-            </select>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Seleccione un token existente para que el informe quede disponible
-              en Particulares. Puede cambiar el token antes de subir el informe.
-            </p>
+                {clinicLoadError ? (
+                  <p
+                    className="mt-2 clinical-alert-error px-3 py-2"
+                    role="alert"
+                  >
+                    {clinicLoadError}
+                  </p>
+                ) : null}
 
-            {isLoadingParticularTokens ? (
-              <p className="mt-2 surface-empty py-3">
-                Cargando tokens particulares...
-              </p>
-            ) : null}
+                <div
+                  className="mt-2 max-h-44 overflow-y-auto rounded-lg border border-vetneb-line/80 bg-card/92"
+                  role="listbox"
+                  aria-label="Clínicas registradas"
+                >
+                  {isLoadingClinics ? (
+                    <p className="surface-empty m-2 py-3">
+                      Cargando clínicas registradas...
+                    </p>
+                  ) : null}
 
-            {particularTokenLoadError ? (
-              <p
-                className="mt-2 clinical-alert-error px-3 py-2"
-                role="alert"
-              >
-                {particularTokenLoadError}
-              </p>
-            ) : null}
+                  {!isLoadingClinics && hasClinicQuery && filteredClinicOptions.length === 0 ? (
+                    <p className="surface-empty m-2 py-3">
+                      No hay clínicas registradas que coincidan con la búsqueda.
+                    </p>
+                  ) : null}
 
-            {selectedClinic &&
-            !isLoadingParticularTokens &&
-            !particularTokenLoadError &&
-            particularTokens.length === 0 ? (
-              <p className="mt-2 clinical-alert-warning px-3 py-2">
-                Esta clínica no tiene tokens particulares disponibles.
-              </p>
-            ) : null}
-          </div>
+                  {!isLoadingClinics
+                    ? filteredClinicOptions.map((option) => (
+                        <button
+                          key={option.id}
+                          type="button"
+                          className={`clinical-hover-row flex w-full items-center justify-between gap-2 border-b border-vetneb-line/35 px-3 py-2 text-left text-sm last:border-b-0 ${
+                            String(option.id) === clinicId
+                              ? "bg-vetneb-teal/12 text-vetneb-navy shadow-[inset_0_0_0_1px_rgba(16,60,96,0.28)]"
+                              : "text-vetneb-ink/88"
+                          }`}
+                          onClick={() => selectClinic(option)}
+                          disabled={isSubmitting}
+                          role="option"
+                          aria-selected={String(option.id) === clinicId}
+                        >
+                          <span className="min-w-0">
+                            <span className="block truncate font-medium">
+                              {option.name}
+                            </span>
+                            <span className="block truncate text-xs text-muted-foreground">
+                              ID #{option.id}
+                              {option.usernames.length
+                                ? ` · ${option.usernames.join(", ")}`
+                                : ""}
+                            </span>
+                          </span>
+                          {String(option.id) === clinicId ? (
+                            <span className="clinical-pill shrink-0 px-2 py-0.5 text-xs tracking-normal">
+                              Seleccionada
+                            </span>
+                          ) : null}
+                        </button>
+                      ))
+                    : null}
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="upload-particular-token-id" className="field-label">
+                  Token particular
+                </label>
+                <select
+                  id="upload-particular-token-id"
+                  name="particularTokenId"
+                  className="field-select"
+                  value={particularTokenId}
+                  onChange={(event) => handleParticularTokenChange(event.target.value)}
+                  disabled={!selectedClinic || isLoadingParticularTokens || isSubmitting}
+                >
+                  <option value="">
+                    Sin token particular vinculado
+                  </option>
+                  {particularTokens.map((token) => (
+                    <option key={token.id} value={token.id}>
+                      {buildParticularTokenLabel(token)}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Seleccione un token existente para que el informe quede disponible
+                  en Particulares. Puede cambiar el token antes de subir el informe.
+                </p>
+
+                {isLoadingParticularTokens ? (
+                  <p className="mt-2 surface-empty py-3">
+                    Cargando tokens particulares...
+                  </p>
+                ) : null}
+
+                {particularTokenLoadError ? (
+                  <p
+                    className="mt-2 clinical-alert-error px-3 py-2"
+                    role="alert"
+                  >
+                    {particularTokenLoadError}
+                  </p>
+                ) : null}
+
+                {selectedClinic &&
+                !isLoadingParticularTokens &&
+                !particularTokenLoadError &&
+                particularTokens.length === 0 ? (
+                  <p className="mt-2 clinical-alert-warning px-3 py-2">
+                    Esta clínica no tiene tokens particulares disponibles.
+                  </p>
+                ) : null}
+              </div>
+            </>
+          )}
 
           <div>
             <label htmlFor="upload-file" className="field-label">
@@ -682,7 +775,7 @@ export function UploadReportModal() {
             </p>
           ) : null}
 
-                    <Button type="submit" className="w-full" disabled={isSubmitting}>
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
             {isSubmitting ? "Subiendo informe..." : "Subir informe"}
           </Button>
         </form>
@@ -692,8 +785,8 @@ export function UploadReportModal() {
 
   return (
     <div>
-      <Button type="button" onClick={() => setIsOpen(true)}>
-        Subir informe
+      <Button type="button" onClick={openModal}>
+        {triggerLabel}
       </Button>
 
       {isMounted && modal ? createPortal(modal, document.body) : null}

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -443,3 +443,51 @@ test("admin token card consume seguimiento por token desde study-tracking", () =
   assert.ok(card.includes("No se pudo actualizar la alerta de tinción especial."));
   assert.ok(api.includes("export async function getAdminStudyTrackingCases("));
 });
+
+test("admin token card exposes report upload action scoped to each token", () => {
+  const card = read(ADMIN_CARD_PATH);
+  const uploadModal = read("frontend/src/components/dashboard/UploadReportModal.tsx");
+
+  assert.ok(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
+  assert.ok(card.includes('triggerLabel="Subir informe para este token"'));
+  assert.ok(card.includes("presetClinic={buildTokenPresetClinic(clinicOptions, token)}"));
+  assert.ok(card.includes("presetParticularToken={token}"));
+  assert.ok(card.includes("onUploaded={loadTokens}"));
+  assert.ok(uploadModal.includes("presetParticularToken?: AdminParticularTokenSummary;"));
+  assert.ok(uploadModal.includes('formData.append("clinicId", String(presetClinic.id));'));
+  assert.ok(uploadModal.includes('formData.append("particularTokenId", String(presetParticularToken.id));'));
+  assert.equal(card.includes("tokenHash"), false);
+  assert.ok(card.includes("Token ****{token.tokenLast4}"));
+});
+
+test("admin token card renders clinic name in title and vínculo with fallback", () => {
+  const card = read(ADMIN_CARD_PATH);
+
+  assert.ok(card.includes("hasResolvedName: boolean;"));
+  assert.ok(card.includes("hasResolvedName: Boolean(user.clinicName?.trim()),"));
+  assert.ok(card.includes("function resolveClinicName("));
+  assert.ok(card.includes("return clinic?.hasResolvedName ? clinic.name : null;"));
+  assert.ok(card.includes("function formatTokenTitle("));
+  assert.ok(card.includes("`${clinicName ?? `Clínica #${token.clinicId}`} · ${token.petName}`"));
+  assert.ok(card.includes("function formatTokenClinicLink("));
+  assert.ok(card.includes("`Clínica: ${clinicName} (#${clinicId})`"));
+  assert.ok(card.includes("`Clínica #${clinicId}`"));
+  assert.ok(card.includes("{formatTokenTitle(clinicOptions, token)}"));
+  assert.ok(card.includes("{formatTokenClinicLink(clinicOptions, token.clinicId)}"));
+});
+
+test("admin token tracking stage uses local draft and explicit update button", () => {
+  const card = read(ADMIN_CARD_PATH);
+
+  assert.ok(card.includes("trackingStageDraftsByCaseId"));
+  assert.ok(card.includes("function handleTrackingStageDraftChange("));
+  assert.ok(card.includes("function handleTrackingStageUpdate("));
+  assert.ok(card.includes("currentStage: nextStage"));
+  assert.ok(card.includes("value={trackingStageDraft ?? trackingCase.currentStage}"));
+  assert.ok(card.includes("handleTrackingStageDraftChange("));
+  assert.ok(card.includes("void handleTrackingStageUpdate(token.id, trackingCase)"));
+  assert.ok(card.includes("disabled={"));
+  assert.ok(card.includes("!hasTrackingStageChange || isUpdatingTrackingCase"));
+  assert.ok(card.includes('"Actualizar estado"'));
+  assert.ok(card.includes('"Actualizando..."'));
+});

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -20,8 +20,9 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard admin elimina la sección de seguimiento redundante sin tocar la carga de informes", () => {
+test("dashboard admin elimina seguimiento redundante y mueve carga de informes al token", () => {
   const page = read(PAGE_PATH);
+  const card = read(ADMIN_PARTICULAR_TOKENS_CARD_PATH);
 
   assert.equal(
     page.includes(
@@ -31,12 +32,20 @@ test("dashboard admin elimina la sección de seguimiento redundante sin tocar la
   );
   assert.equal(page.includes('id="admin-report-workflow"'), false);
   assert.equal(page.includes("<AdminReportWorkflowViewerCard />"), false);
-  assert.ok(
+  assert.equal(
     page.includes(
       'import { UploadReportModal } from "@/components/dashboard/UploadReportModal";',
     ),
+    false,
   );
-  assert.ok(page.includes("<UploadReportModal />"));
+  assert.equal(page.includes("<UploadReportModal />"), false);
+  assert.ok(
+    card.includes(
+      'import { UploadReportModal } from "@/components/dashboard/UploadReportModal";',
+    ),
+  );
+  assert.ok(card.includes('triggerLabel="Subir informe para este token"'));
+  assert.ok(card.includes("presetParticularToken={token}"));
 });
 
 test("sidebar admin no muestra seguimiento de informes y conserva anclas operativas", () => {

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -34,7 +34,7 @@ test("dashboard admin includes read-only admin cards", () => {
   assert.ok(source.includes('import { AdminParticularTokensCard } from "./AdminParticularTokensCard";'));
   assert.ok(source.includes('import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";'));
   assert.ok(source.includes('import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";'));
-  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
+  assert.equal(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'), false);
   assert.ok(source.includes("<AdminMaintenanceDryRunCard />"));
   assert.ok(source.includes("<AdminClinicsManagementCard />"));
   assert.ok(source.includes("<AdminParticularTokensCard />"));
@@ -142,8 +142,9 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes("Estado del sistema"));
   assert.ok(source.includes('id="admin-report-upload"'));
   assert.ok(source.includes("Panel administrador"));
-  assert.ok(source.includes("única superficie administrativa"));
-  assert.ok(source.includes("<UploadReportModal />"));
+  assert.ok(source.includes("cada token administrado"));
+  assert.ok(source.includes("sin búsqueda manual"));
+  assert.equal(source.includes("<UploadReportModal />"), false);
   assert.ok(source.includes('id="admin-health"'));
   assert.ok(source.includes("<AdminClinicsManagementCard />"));
   assert.ok(source.includes('id="admin-maintenance"'));
@@ -206,6 +207,7 @@ test("dashboard admin removes horizontal quick actions and preserves admin secti
 
   assert.ok(source.includes('id="admin-report-upload"'));
   assert.ok(source.includes("Carga de informes"));
+  assert.ok(source.includes("cada token administrado"));
   assert.ok(source.includes("Eventos de auditoría"));
   assert.ok(source.includes("Tipos de evento"));
   assert.ok(source.includes("Estado del sistema"));

--- a/test/frontend-report-actions.test.ts
+++ b/test/frontend-report-actions.test.ts
@@ -255,11 +255,11 @@ test("upload modal clinic loader: guard prevents duplicate load while in flight"
   const source = read(UPLOAD_REPORT_MODAL_PATH);
 
   // The guard inside the effect (not in deps) short-circuits concurrent re-entry
-  // using isLoadingClinics. clinicOptions.length > 0 has been removed to allow
-  // refreshing the catalog on every open.
+  // using isLoadingClinics. Preset token uploads skip the catalog load entirely.
+  // clinicOptions.length > 0 has been removed to allow refreshing on every open.
   assert.ok(
-    source.includes("if (!isOpen || isLoadingClinics) {"),
-    "guard must check isLoadingClinics to block duplicate concurrent loads — clinicOptions.length > 0 must be absent",
+    source.includes("if (!isOpen || isLoadingClinics || hasPresetClinic) {"),
+    "guard must check isLoadingClinics and skip preset clinic uploads — clinicOptions.length > 0 must be absent",
   );
   assert.equal(
     source.includes("clinicOptions.length > 0"),
@@ -329,12 +329,14 @@ test("upload modal submit: no validation error when clinicId and selectedClinic 
   assert.ok(source.includes('if (!clinicId || !selectedClinic) {'));
   assert.ok(source.includes('"Seleccione una clínica registrada del listado."'));
 
-  // selectedClinic is derived — not a separate state — to stay consistent.
+  // selectedClinic is derived from either preset props or the option list — not
+  // a separate state — to stay consistent.
   assert.ok(
-    source.includes('const selectedClinic = clinicOptions.find('),
-    "selectedClinic must be derived from clinicOptions so it resolves once clinicId is set",
+    source.includes('const selectedClinicOption = clinicOptions.find('),
+    "selectedClinicOption must be derived from clinicOptions so it resolves once clinicId is set",
   );
   assert.ok(source.includes('(option) => String(option.id) === clinicId,'));
+  assert.ok(source.includes("const selectedClinic = presetClinic ?? selectedClinicOption;"));
 });
 
 test("upload modal clinic loader: deduplicates and sorts options by clinic id", () => {
@@ -481,8 +483,8 @@ test("upload modal catalog refresh: no clinicOptions.length guard that blocks re
     "clinicOptions.length > 0 guard must be removed — new clinics must appear on next modal open",
   );
   assert.ok(
-    source.includes("if (!isOpen || isLoadingClinics) {"),
-    "only isOpen and isLoadingClinics should guard the load",
+    source.includes("if (!isOpen || isLoadingClinics || hasPresetClinic) {"),
+    "isOpen, isLoadingClinics and preset clinic mode should guard the load",
   );
 });
 
@@ -556,12 +558,12 @@ test("upload modal: no-match message shown when search has text and no matches",
 test("upload modal: selected clinic remains visible when search is cleared", () => {
   const source = read(UPLOAD_REPORT_MODAL_PATH);
   assert.ok(
-    source.includes(": selectedClinic"),
-    "when query is empty and a clinic is selected, filteredClinicOptions must return [selectedClinic]",
+    source.includes(": selectedClinicOption"),
+    "when query is empty and a clinic is selected, filteredClinicOptions must return [selectedClinicOption]",
   );
   assert.ok(
-    source.includes("? [selectedClinic]"),
-    "selectedClinic entry must be wrapped in an array",
+    source.includes("? [selectedClinicOption]"),
+    "selectedClinicOption entry must be wrapped in an array",
   );
 });
 
@@ -683,12 +685,14 @@ test("upload modal: valid token ID is appended to upload payload when selected",
     "when a token is selected, its ID must be sent in multipart upload",
   );
   assert.equal(source.includes("createAdminStudyTrackingCase"), false);
+  assert.ok(source.includes("const selectedParticularToken ="));
+  assert.ok(source.includes("presetParticularToken ??"));
   assert.ok(
-    source.includes("const selectedParticularToken = particularTokens.find("),
-    "selectedParticularToken must be derived from particularTokenId state",
+    source.includes("particularTokens.find((token) => String(token.id) === particularTokenId);"),
+    "selectedParticularToken must fall back to particularTokenId state when no preset token is supplied",
   );
   assert.ok(
-    source.includes("(token) => String(token.id) === particularTokenId,"),
+    source.includes("(token) => String(token.id) === particularTokenId"),
     "lookup must compare by string-coerced ID",
   );
 });

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 const UPLOAD_MODAL_PATH = "frontend/src/components/dashboard/UploadReportModal.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const ADMIN_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -72,11 +74,34 @@ test("frontend informes page does not expose admin upload modal in clinic dashbo
   assert.equal(source.includes("dashboard administrador"), false);
 });
 
-test("frontend admin dashboard exposes upload report modal only in admin surface", () => {
-  const source = read(ADMIN_PAGE_PATH);
+test("frontend admin dashboard routes upload report modal through token cards", () => {
+  const page = read(ADMIN_PAGE_PATH);
+  const card = read(ADMIN_CARD_PATH);
 
-  assert.ok(source.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
-  assert.ok(source.includes('id="admin-report-upload"'));
-  assert.ok(source.includes("<UploadReportModal />"));
-  assert.ok(source.includes("Carga de informes"));
+  assert.equal(page.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'), false);
+  assert.ok(page.includes('id="admin-report-upload"'));
+  assert.equal(page.includes("<UploadReportModal />"), false);
+  assert.ok(page.includes("Carga de informes"));
+  assert.ok(page.includes("cada token administrado"));
+  assert.ok(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
+  assert.ok(card.includes('triggerLabel="Subir informe para este token"'));
+  assert.ok(card.includes("presetParticularToken={token}"));
+});
+
+test("frontend upload report modal supports preset particular token uploads", () => {
+  const source = read(UPLOAD_MODAL_PATH);
+
+  assert.ok(source.includes("type UploadReportModalProps = {"));
+  assert.ok(source.includes("triggerLabel?: string;"));
+  assert.ok(source.includes("presetClinic?: PresetClinic;"));
+  assert.ok(source.includes("presetParticularToken?: AdminParticularTokenSummary;"));
+  assert.ok(source.includes("onUploaded?: () => void | Promise<void>;"));
+  assert.ok(source.includes("const isPresetMode = hasPresetClinic && hasPresetParticularToken;"));
+  assert.ok(source.includes("Carga preconfigurada"));
+  assert.ok(source.includes("Clínica: {presetClinic.name} (#{presetClinic.id})"));
+  assert.ok(source.includes("Token: ****{presetParticularToken.tokenLast4}"));
+  assert.ok(source.includes("buildPresetPatientName(presetParticularToken)"));
+  assert.ok(source.includes('formData.append("clinicId", String(presetClinic.id));'));
+  assert.ok(source.includes('formData.append("particularTokenId", String(presetParticularToken.id));'));
+  assert.ok(source.includes("await onUploaded?.();"));
 });


### PR DESCRIPTION
# PR: fix admin token-scoped report upload status

## Resumen
- La carga de informes del panel admin se movio desde el header global hacia cada token en "Ultimos tokens administrados".
- Cada token ahora abre `UploadReportModal` con clinica y token preconfigurados.
- El estado de seguimiento usa select con borrador local y boton individual "Actualizar estado".
- El vinculo y titulo del token usan nombre de clinica cuando esta disponible, con fallback seguro a `Clinica #id`.

## Archivos tocados
- `frontend/src/app/dashboard/admin/page.tsx`
- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
- `frontend/src/components/dashboard/UploadReportModal.tsx`
- `test/frontend-admin-particular-tokens.test.ts`
- `test/frontend-admin-report-workflow.test.ts`
- `test/frontend-dashboard-admin.test.ts`
- `test/frontend-report-actions.test.ts`
- `test/frontend-report-upload-modal.test.ts`
- `PR-fix-admin-token-scoped-report-upload-status.md`

## Implementacion realizada
- Se quito el boton operativo global del header "Carga de informes" y se dejo copy informativo.
- Se agrego accion visible por token: "Subir informe para este token".
- `UploadReportModal` ahora acepta `triggerLabel`, `presetClinic`, `presetParticularToken` y `onUploaded`.
- En modo preset, el modal no pide buscar clinica ni seleccionar token; muestra resumen read-only y envia `clinicId` + `particularTokenId` en `FormData`.
- Al subir desde token, se ejecuta `loadTokens` para refrescar badges y `reportId`.
- Se reutiliza la carga de clinicas via `getAdminUsersRoles` para resolver nombre por `clinicId`.
- Se agrego tracking de etapa por borrador local y PATCH solo al presionar "Actualizar estado".
- Se mantuvo la accion individual de solicitar/resolver tincion especial.

## Tests agregados/modificados
- Tests para accion de upload por token y presets del modal.
- Tests para `FormData` con `clinicId` y `particularTokenId` desde presets.
- Tests para vinculo con nombre de clinica y fallback.
- Tests para estado con select + boton individual.
- Tests actualizados para remover dependencia del modal global en `page.tsx`.

## Comandos ejecutados
- `pnpm --dir frontend typecheck`: PASS.
- Subconjunto frontend: PASS, 68/68.
- `pnpm typecheck`: PASS.
- `pnpm typecheck:test`: PASS.
- `pnpm test`: PASS, 2119 passed, 1 skipped, 0 failed.
- `pnpm build`: PASS, `dist/index.js` generado por esbuild.
- `pnpm security:public-surface`: PASS, sin hallazgos de exposicion publica; conserva dos findings informativos `server-only` en `frontend/src/middleware.ts`.

## Riesgos
- No se tocaron endpoints backend, auth, cookies, sesiones, roles, DB ni migraciones.
- La verificacion fue por typecheck y tests de contrato/runtime; no se ejecuto navegador visual.
- Si el catalogo de clinicas no trae nombre real, la UI cae al fallback `Clinica #id`.

## Rollback
- Revertir los archivos listados en "Archivos tocados".
- No hay migraciones ni cambios de datos que revertir.
- No se hizo `git add`, commit, push, PR ni merge.

## Estado final
- Implementacion completa.
- Validaciones obligatorias en verde.
- Cambios locales sin stagear.
