### PR TITLE
fix(frontend): escape admin upload header quotes

### DIFF
--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -406,7 +406,7 @@ export default async function AdminPage({
               </h2>
               <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
                 La carga de informes se realiza desde cada token administrado
-                en "Últimos tokens administrados", para vincular clínica y token
+                en &quot;Últimos tokens administrados&quot;, para vincular clínica y token
                 sin búsqueda manual.
               </p>
             </div>


### PR DESCRIPTION
## Resumen
- Escapa comillas en texto JSX del header admin para cumplir react/no-unescaped-entities.
- Desbloquea next build en staging.

## Validación
- pnpm --dir frontend build
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface