### PR TITLE
fix(reports): add preview and download actions

### DIFF
--- a/PR-fix-reports-preview-download-actions.md
+++ b/PR-fix-reports-preview-download-actions.md
@@ -1,0 +1,80 @@
+# PR fix reports preview download actions
+
+## Resumen
+
+Se corrigieron las acciones de informes para que clínica y administrador puedan abrir una vista previa y descargar archivos mediante URLs firmadas. El frontend ahora lee el contrato principal del backend (`previewUrl` y `downloadUrl`) con fallback defensivo a `url`.
+
+## Archivos tocados
+
+- `frontend/src/lib/api.ts`
+- `frontend/src/components/dashboard/ReportDownloadButton.tsx`
+- `frontend/src/app/dashboard/informes/page.tsx`
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `server/routes/admin-reports.fastify.ts`
+- `test/admin-reports.fastify.test.ts`
+- `test/fastify-app.test.ts`
+- `test/frontend-admin-particular-tokens.test.ts`
+- `test/frontend-admin-report-workflow.test.ts`
+- `test/frontend-dashboard-informes.test.ts`
+- `test/frontend-report-actions.test.ts`
+- `test/frontend-report-download-action.test.ts`
+- `test/frontend-report-upload-modal.test.ts`
+- `test/frontend-reports-api-read.test.ts`
+- `test/report-write-surface-ownership.test.ts`
+
+## Implementación realizada
+
+- `getReportDownloadUrl` ahora lee `downloadUrl` y conserva fallback `url`.
+- Se agregó `getReportPreviewUrl`, que lee `previewUrl` y conserva fallback `url`.
+- Se amplió el componente existente en `ReportDownloadButton.tsx` con `ReportFileActions`, que muestra:
+  - `Ver informe`
+  - `Descargar`
+- Ambas acciones abren URLs firmadas con `window.open(url, "_blank", "noopener,noreferrer")`.
+- El componente muestra estado claro si no hay `reportId` o no hay archivo disponible.
+- La tabla de clínica `/dashboard/informes` usa `ReportFileActions` con `hasStoragePath={Boolean(report.storagePath)}`.
+- En administrador, los tokens con `hasLinkedReport` y `reportId` muestran `Informe: #<id>` y acciones `Ver informe` / `Descargar`.
+- En administrador, el CTA de carga cambia a `Reemplazar informe` cuando ya hay informe vinculado.
+- Se agregaron endpoints admin seguros:
+  - `GET /api/admin/reports/:reportId/preview-url`
+  - `GET /api/admin/reports/:reportId/download-url`
+- Los endpoints admin requieren sesión admin y no exponen `storagePath` en errores.
+
+## Tests agregados/modificados
+
+- API frontend: contrato `downloadUrl` / `previewUrl` y fallback `url`.
+- Acciones de informe: render de `Ver informe` y `Descargar`, preview/download APIs, `noopener,noreferrer`, estados unavailable/error.
+- Clínica informes: uso de `ReportFileActions`.
+- Admin tokens: acciones solo con `reportId`, no exposición de `storagePath` ni `tokenHash`, CTA `Reemplazar informe`.
+- Backend admin reports: preview/download firmados con sesión admin, bloqueo sin sesión, 404 genérico.
+- Fixtures de montaje Fastify actualizados con `getReportById`.
+
+## Comandos ejecutados
+
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-reports-api-read.test.ts test/frontend-report-download-action.test.ts test/frontend-report-actions.test.ts test/frontend-dashboard-informes.test.ts test/frontend-admin-particular-tokens.test.ts test/frontend-admin-report-workflow.test.ts test/frontend-report-upload-modal.test.ts test/admin-reports.fastify.test.ts test/fastify-app.test.ts test/report-write-surface-ownership.test.ts`
+  - Resultado: OK, 139 tests pass.
+- `pnpm --dir frontend build`
+  - Resultado: OK. Warning preexistente: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts`.
+- `pnpm typecheck`
+  - Resultado: OK.
+- `pnpm typecheck:test`
+  - Resultado: OK.
+- `pnpm test`
+  - Resultado: OK, 2125 pass, 1 skipped, 0 fail.
+- `pnpm build`
+  - Resultado: OK, `dist/index.js` generado.
+- `pnpm security:public-surface`
+  - Resultado: OK, sin findings de exposición pública. Reporta marcadores `server-only` esperados en `frontend/src/middleware.ts`.
+
+## Riesgos
+
+- El admin ahora tiene una superficie nueva de lectura firmada por `reportId`; queda protegida por sesión admin y evita reutilizar endpoints clinic-scoped.
+- La UI admin asume que un token con `hasLinkedReport` y `reportId` apunta a un informe con archivo válido; si el informe fue eliminado fuera del flujo, el endpoint responderá error y el componente lo mostrará.
+
+## Rollback
+
+- Revertir los cambios en `ReportDownloadButton.tsx`, `api.ts`, las páginas de clínica/admin y los tests asociados.
+- Remover los endpoints `/:reportId/preview-url` y `/:reportId/download-url` de `server/routes/admin-reports.fastify.ts`.
+
+## Estado final
+
+Implementación y validación completas. No se ejecutó `git add`, `commit`, `push`, PR ni merge.

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import {
   Card,
@@ -1325,6 +1326,18 @@ export function AdminParticularTokensCard() {
                       <p className="mt-1 text-xs text-muted-foreground">
                         Informe: {token.reportId ? `#${token.reportId}` : "—"}
                       </p>
+                      {token.hasLinkedReport && token.reportId ? (
+                        <div className="mt-2">
+                          <p className="mb-1 text-xs font-semibold text-vetneb-navy">
+                            Acciones
+                          </p>
+                          <ReportFileActions
+                            reportId={token.reportId}
+                            scope="admin"
+                            align="start"
+                          />
+                        </div>
+                      ) : null}
                       <p className="mt-1 text-xs text-muted-foreground">
                         Último acceso: {token.lastLoginAt ? formatDate(token.lastLoginAt) : "—"}
                       </p>
@@ -1421,7 +1434,11 @@ export function AdminParticularTokensCard() {
 
                   <div className="mt-3 flex flex-wrap justify-end gap-2">
                     <UploadReportModal
-                      triggerLabel="Subir informe para este token"
+                      triggerLabel={
+                        token.hasLinkedReport && token.reportId
+                          ? "Reemplazar informe"
+                          : "Subir informe para este token"
+                      }
                       presetClinic={buildTokenPresetClinic(clinicOptions, token)}
                       presetParticularToken={token}
                       onUploaded={loadTokens}

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";
+import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -210,7 +210,7 @@ export default async function InformesPage({
                         </Badge>
                       </TableCell>
                       <TableCell className="text-right">
-                        <ReportDownloadButton
+                        <ReportFileActions
                           reportId={report.id}
                           hasStoragePath={Boolean(report.storagePath)}
                         />

--- a/frontend/src/components/dashboard/ReportDownloadButton.tsx
+++ b/frontend/src/components/dashboard/ReportDownloadButton.tsx
@@ -1,35 +1,69 @@
 "use client";
 
 import { useState } from "react";
+import { Download, Eye } from "lucide-react";
 
-import { getReportDownloadUrl } from "@/lib/api";
+import { getReportDownloadUrl, getReportPreviewUrl } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 
-type ReportDownloadButtonProps = {
-  reportId: number;
-  hasStoragePath: boolean;
+type ReportAction = "preview" | "download";
+
+type ReportFileActionsProps = {
+  reportId: number | null;
+  hasStoragePath?: boolean;
+  scope?: "clinic" | "admin";
+  align?: "start" | "end";
 };
 
-export function ReportDownloadButton({
+function getUnavailableLabel(reportId: number | null, hasStoragePath: boolean) {
+  if (typeof reportId !== "number") {
+    return "Informe no disponible.";
+  }
+
+  if (!hasStoragePath) {
+    return "Archivo no disponible.";
+  }
+
+  return null;
+}
+
+export function ReportFileActions({
   reportId,
-  hasStoragePath,
-}: ReportDownloadButtonProps) {
-  const [isLoading, setIsLoading] = useState(false);
+  hasStoragePath = true,
+  scope = "clinic",
+  align = "end",
+}: ReportFileActionsProps) {
+  const [loadingAction, setLoadingAction] = useState<ReportAction | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  async function handleDownload() {
-    if (!hasStoragePath || isLoading) {
+  const unavailableLabel = getUnavailableLabel(reportId, hasStoragePath);
+  const unavailableTitle = unavailableLabel ?? "Informe no disponible.";
+  const isAvailable = unavailableLabel === null;
+  const isLoading = loadingAction !== null;
+  const alignClass =
+    align === "start" ? "items-start text-left" : "items-end text-right";
+  const buttonsAlignClass = align === "start" ? "justify-start" : "justify-end";
+
+  async function openReport(action: ReportAction) {
+    if (!isAvailable || isLoading || typeof reportId !== "number") {
       return;
     }
 
     setErrorMessage(null);
-    setIsLoading(true);
+    setLoadingAction(action);
 
     try {
-      const url = await getReportDownloadUrl(reportId);
+      const url =
+        action === "preview"
+          ? await getReportPreviewUrl(reportId, { scope })
+          : await getReportDownloadUrl(reportId, { scope });
 
       if (!url) {
-        setErrorMessage("Informe no disponible para descarga.");
+        setErrorMessage(
+          action === "preview"
+            ? "Informe no disponible para visualizar."
+            : "Informe no disponible para descarga.",
+        );
         return;
       }
 
@@ -38,36 +72,64 @@ export function ReportDownloadButton({
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : "No se pudo obtener el enlace de descarga.",
+          : action === "preview"
+            ? "No se pudo obtener el enlace de visualización."
+            : "No se pudo obtener el enlace de descarga.",
       );
     } finally {
-      setIsLoading(false);
+      setLoadingAction(null);
     }
   }
 
   return (
-    <div className="flex flex-col items-end gap-1">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-8 px-2 text-xs text-primary hover:text-primary"
-        disabled={!hasStoragePath || isLoading}
-        title={hasStoragePath ? "Descargar informe" : "Informe no disponible aún"}
-        onClick={handleDownload}
-      >
-        {isLoading
-          ? "Preparando..."
-          : hasStoragePath
-            ? "Descargar"
-            : "No disponible"}
-      </Button>
+    <div className={`flex flex-col gap-1 ${alignClass}`}>
+      <div className={`flex flex-wrap gap-2 ${buttonsAlignClass}`}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-2 text-xs text-primary hover:text-primary"
+          disabled={!isAvailable || isLoading}
+          title={isAvailable ? "Ver informe" : unavailableTitle}
+          aria-label={isAvailable ? "Ver informe" : unavailableTitle}
+          onClick={() => void openReport("preview")}
+        >
+          <Eye className="h-3.5 w-3.5" aria-hidden="true" />
+          {loadingAction === "preview" ? "Abriendo..." : "Ver informe"}
+        </Button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-2 text-xs text-primary hover:text-primary"
+          disabled={!isAvailable || isLoading}
+          title={isAvailable ? "Descargar informe" : unavailableTitle}
+          aria-label={isAvailable ? "Descargar informe" : unavailableTitle}
+          onClick={() => void openReport("download")}
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden="true" />
+          {loadingAction === "download" ? "Preparando..." : "Descargar"}
+        </Button>
+      </div>
+
+      {!isAvailable ? (
+        <span className="max-w-48 text-[11px] text-muted-foreground">
+          {unavailableLabel}
+        </span>
+      ) : null}
 
       {errorMessage ? (
-        <span className="max-w-40 text-right text-[11px] text-red-600" role="alert">
+        <span className="max-w-48 text-[11px] text-red-600" role="alert">
           {errorMessage}
         </span>
       ) : null}
     </div>
   );
+}
+
+export function ReportDownloadButton(
+  props: Omit<ReportFileActionsProps, "align">,
+) {
+  return <ReportFileActions {...props} align="end" />;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -510,12 +510,36 @@ type AdminReportUploadResponse = {
 
 export async function getReportDownloadUrl(
   reportId: number,
+  options: { scope?: "clinic" | "admin" } = {},
 ): Promise<string | null> {
-  const res = await apiFetch<{ url: string | null }>(
-    `/api/reports/${reportId}/download-url`,
+  const basePath =
+    options.scope === "admin" ? "/api/admin/reports" : "/api/reports";
+  const res = await apiFetch<{
+    success?: true;
+    downloadUrl?: string | null;
+    url?: string | null;
+  }>(
+    `${basePath}/${reportId}/download-url`,
   );
 
-  return res.url ?? null;
+  return res.downloadUrl ?? res.url ?? null;
+}
+
+export async function getReportPreviewUrl(
+  reportId: number,
+  options: { scope?: "clinic" | "admin" } = {},
+): Promise<string | null> {
+  const basePath =
+    options.scope === "admin" ? "/api/admin/reports" : "/api/reports";
+  const res = await apiFetch<{
+    success?: true;
+    previewUrl?: string | null;
+    url?: string | null;
+  }>(
+    `${basePath}/${reportId}/preview-url`,
+  );
+
+  return res.previewUrl ?? res.url ?? null;
 }
 
 export async function uploadAdminReport(

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -101,6 +101,7 @@ export type AdminReportsNativeRoutesOptions = {
   updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
   hashSessionToken?: (token: string) => string;
   getClinicById?: (clinicId: number) => Promise<ClinicRecord | null>;
+  getReportById?: (reportId: number) => Promise<Report | null>;
   uploadReport?: (input: ReportUploadInput) => Promise<string>;
   upsertReport?: (input: UpsertReportInput) => Promise<Report>;
   getParticularTokenById?: (
@@ -180,6 +181,7 @@ type NativeAdminReportsDeps = Required<
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "getClinicById"
+    | "getReportById"
     | "uploadReport"
     | "upsertReport"
     | "getParticularTokenById"
@@ -214,6 +216,7 @@ async function loadDefaultDeps(): Promise<NativeAdminReportsDeps> {
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         getClinicById: db.getClinicById,
+        getReportById: db.getReportById,
         uploadReport: storage.uploadReport,
         upsertReport: db.upsertReport,
         getParticularTokenById: dbParticular.getParticularTokenById,
@@ -247,6 +250,7 @@ function hasAllInjectedDeps(options: AdminReportsNativeRoutesOptions) {
     !!options.updateAdminSessionLastAccess &&
     !!options.hashSessionToken &&
     !!options.getClinicById &&
+    !!options.getReportById &&
     !!options.uploadReport &&
     !!options.upsertReport &&
     !!options.getParticularTokenById &&
@@ -280,6 +284,7 @@ async function resolveDeps(
     hashSessionToken:
       options.hashSessionToken ?? defaultDeps!.hashSessionToken,
     getClinicById: options.getClinicById ?? defaultDeps!.getClinicById,
+    getReportById: options.getReportById ?? defaultDeps!.getReportById,
     uploadReport: options.uploadReport ?? defaultDeps!.uploadReport,
     upsertReport: options.upsertReport ?? defaultDeps!.upsertReport,
     getParticularTokenById:
@@ -803,6 +808,85 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
   };
 
   app.options("/upload", optionsHandler);
+
+  app.get<{
+    Params: {
+      reportId?: unknown;
+    };
+  }>("/:reportId/preview-url", async (request, reply) => {
+    const deps = await resolveDeps(options);
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const reportId = parseReportId(request.params.reportId);
+
+    if (typeof reportId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de informe invalido",
+      });
+    }
+
+    const report = await deps.getReportById(reportId);
+
+    if (!report) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    const previewUrl = await deps.createSignedReportUrl(report.storagePath);
+
+    return reply.code(200).send({
+      success: true,
+      previewUrl,
+    });
+  });
+
+  app.get<{
+    Params: {
+      reportId?: unknown;
+    };
+  }>("/:reportId/download-url", async (request, reply) => {
+    const deps = await resolveDeps(options);
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const reportId = parseReportId(request.params.reportId);
+
+    if (typeof reportId !== "number") {
+      return reply.code(400).send({
+        success: false,
+        error: "ID de informe invalido",
+      });
+    }
+
+    const report = await deps.getReportById(reportId);
+
+    if (!report) {
+      return reply.code(404).send({
+        success: false,
+        error: "Informe no encontrado",
+      });
+    }
+
+    const downloadUrl = await deps.createSignedReportDownloadUrl(
+      report.storagePath,
+      report.fileName ?? undefined,
+    );
+
+    return reply.code(200).send({
+      success: true,
+      downloadUrl,
+    });
+  });
 
   app.post("/upload", async (request, reply) => {
     if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -130,6 +130,7 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
     prefix: "/api/admin/reports",
     ...createAuthStubs(),
     getClinicById: async () => ({ id: 3 }),
+    getReportById: async () => createReportFixture(),
     uploadReport: async () => "reports/3/luna-report.pdf",
     upsertReport: async () => createReportFixture(),
     getParticularTokenById: async () => null,
@@ -187,6 +188,151 @@ function buildMultipartReportPayload(
     payload: Buffer.from(chunks.join(""), "utf8"),
   };
 }
+
+test("adminReportsNativeRoutes genera signed preview URL para informe con sesion admin", async () => {
+  const reportCalls: number[] = [];
+  const signedCalls: string[] = [];
+
+  const app = await createTestApp({
+    getReportById: async (reportId: number) => {
+      reportCalls.push(reportId);
+      return createReportFixture({ id: reportId });
+    },
+    createSignedReportUrl: async (storagePath: string) => {
+      signedCalls.push(storagePath);
+      return `signed-preview:${storagePath}`;
+    },
+    createSignedReportDownloadUrl: async () => {
+      throw new Error("preview no debe generar downloadUrl");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/reports/88/preview-url",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(reportCalls, [88]);
+    assert.deepEqual(signedCalls, ["reports/3/luna-report.pdf"]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      previewUrl: "signed-preview:reports/3/luna-report.pdf",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes genera signed download URL para informe con sesion admin", async () => {
+  const reportCalls: number[] = [];
+  const signedCalls: Array<{ storagePath: string; fileName?: string }> = [];
+
+  const app = await createTestApp({
+    getReportById: async (reportId: number) => {
+      reportCalls.push(reportId);
+      return createReportFixture({ id: reportId });
+    },
+    createSignedReportUrl: async () => {
+      throw new Error("download no debe generar previewUrl");
+    },
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => {
+      signedCalls.push({ storagePath, fileName });
+      return `signed-download:${storagePath}:${fileName ?? ""}`;
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/reports/88/download-url",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(reportCalls, [88]);
+    assert.deepEqual(signedCalls, [
+      {
+        storagePath: "reports/3/luna-report.pdf",
+        fileName: "luna-report.pdf",
+      },
+    ]);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      downloadUrl: "signed-download:reports/3/luna-report.pdf:luna-report.pdf",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes bloquea signed URLs sin sesion admin antes de leer informe", async () => {
+  let reportCalls = 0;
+
+  const app = await createTestApp({
+    getAdminSessionByToken: async () => null,
+    getReportById: async () => {
+      reportCalls += 1;
+      return createReportFixture();
+    },
+    createSignedReportUrl: async () => {
+      throw new Error("sin sesion admin no debe firmar previewUrl");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/reports/88/preview-url",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(reportCalls, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminReportsNativeRoutes devuelve 404 generico para signed URL de informe inexistente", async () => {
+  const app = await createTestApp({
+    getReportById: async () => null,
+    createSignedReportUrl: async () => {
+      throw new Error("informe inexistente no debe generar signed URL");
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/reports/999/preview-url",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Informe no encontrado",
+    });
+    assert.equal(response.body.includes("storagePath"), false);
+    assert.equal(response.body.includes("reports/"), false);
+  } finally {
+    await app.close();
+  }
+});
 
 test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metadata", async () => {
   const multipart = buildMultipartReportPayload();

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -206,6 +206,7 @@ function buildAdminReportsRouteStubs() {
     updateAdminSessionLastAccess: async () => {},
     hashSessionToken: (token: string) => `hash:${token}`,
     getClinicById: async () => null,
+    getReportById: async () => null,
     uploadReport: async () => "reports/admin-test.pdf",
     upsertReport: async () => ({
       id: 88,

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -449,7 +449,9 @@ test("admin token card exposes report upload action scoped to each token", () =>
   const uploadModal = read("frontend/src/components/dashboard/UploadReportModal.tsx");
 
   assert.ok(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
-  assert.ok(card.includes('triggerLabel="Subir informe para este token"'));
+  assert.ok(card.includes("triggerLabel={"));
+  assert.ok(card.includes('"Subir informe para este token"'));
+  assert.ok(card.includes('"Reemplazar informe"'));
   assert.ok(card.includes("presetClinic={buildTokenPresetClinic(clinicOptions, token)}"));
   assert.ok(card.includes("presetParticularToken={token}"));
   assert.ok(card.includes("onUploaded={loadTokens}"));
@@ -458,6 +460,22 @@ test("admin token card exposes report upload action scoped to each token", () =>
   assert.ok(uploadModal.includes('formData.append("particularTokenId", String(presetParticularToken.id));'));
   assert.equal(card.includes("tokenHash"), false);
   assert.ok(card.includes("Token ****{token.tokenLast4}"));
+});
+
+test("admin token card shows linked report preview and download actions without exposing token", () => {
+  const card = read(ADMIN_CARD_PATH);
+
+  assert.ok(card.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
+  assert.ok(card.includes("token.hasLinkedReport && token.reportId ? ("));
+  assert.ok(card.includes("Informe: {token.reportId ? `#${token.reportId}` : \"—\"}"));
+  assert.ok(card.includes("<ReportFileActions"));
+  assert.ok(card.includes("reportId={token.reportId}"));
+  assert.ok(card.includes('scope="admin"'));
+  assert.ok(card.includes('align="start"'));
+  assert.ok(card.includes("Acciones"));
+  assert.ok(card.includes('"Reemplazar informe"'));
+  assert.equal(card.includes("tokenHash"), false);
+  assert.equal(card.includes("storagePath"), false);
 });
 
 test("admin token card renders clinic name in title and vínculo with fallback", () => {

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -44,7 +44,9 @@ test("dashboard admin elimina seguimiento redundante y mueve carga de informes a
       'import { UploadReportModal } from "@/components/dashboard/UploadReportModal";',
     ),
   );
-  assert.ok(card.includes('triggerLabel="Subir informe para este token"'));
+  assert.ok(card.includes("triggerLabel={"));
+  assert.ok(card.includes('"Subir informe para este token"'));
+  assert.ok(card.includes('"Reemplazar informe"'));
   assert.ok(card.includes("presetParticularToken={token}"));
 });
 

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -22,7 +22,7 @@ test("dashboard informes defines non-indexable metadata and clinic read dependen
   assert.ok(source.includes('title: "Informes — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
-  assert.ok(source.includes('import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton";'));
+  assert.ok(source.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
   assert.equal(source.includes("UploadReportModal"), false);
 });
 
@@ -104,7 +104,7 @@ test("dashboard informes renders filters and reports table columns", () => {
   assert.ok(source.includes('<TableHead className="text-right">Acciones</TableHead>'));
 });
 
-test("dashboard informes keeps row rendering badges dates and download action", () => {
+test("dashboard informes keeps row rendering badges dates and report actions", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("reports.map((report) =>"));
@@ -114,6 +114,7 @@ test("dashboard informes keeps row rendering badges dates and download action", 
   assert.ok(source.includes("formatDate(report.uploadDate)"));
   assert.ok(source.includes("getReportStatusVariant(report.status)"));
   assert.ok(source.includes("getReportStatusLabel(report.status)"));
+  assert.ok(source.includes("<ReportFileActions"));
   assert.ok(source.includes("reportId={report.id}"));
   assert.ok(source.includes("hasStoragePath={Boolean(report.storagePath)}"));
 });

--- a/test/frontend-report-actions.test.ts
+++ b/test/frontend-report-actions.test.ts
@@ -152,52 +152,62 @@ test("upload report modal renders error success and submit states", () => {
   assert.ok(source.includes('{isSubmitting ? "Subiendo informe..." : "Subir informe"}'));
 });
 
-test("report download button is client-side and keeps typed props", () => {
+test("report file actions are client-side and keep typed props", () => {
   const source = read(REPORT_DOWNLOAD_BUTTON_PATH);
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import { useState } from "react";'));
-  assert.ok(source.includes('import { getReportDownloadUrl } from "@/lib/api";'));
-  assert.ok(source.includes("type ReportDownloadButtonProps = {"));
-  assert.ok(source.includes("reportId: number;"));
-  assert.ok(source.includes("hasStoragePath: boolean;"));
+  assert.ok(source.includes("getReportDownloadUrl, getReportPreviewUrl"));
+  assert.ok(source.includes('import { Download, Eye } from "lucide-react";'));
+  assert.ok(source.includes("type ReportFileActionsProps = {"));
+  assert.ok(source.includes("reportId: number | null;"));
+  assert.ok(source.includes("hasStoragePath?: boolean;"));
+  assert.ok(source.includes('scope?: "clinic" | "admin";'));
+  assert.ok(source.includes('align?: "start" | "end";'));
 });
 
-test("report download button blocks unavailable or duplicate download requests", () => {
+test("report file actions block unavailable or duplicate requests", () => {
   const source = read(REPORT_DOWNLOAD_BUTTON_PATH);
 
-  assert.ok(source.includes("const [isLoading, setIsLoading] = useState(false);"));
+  assert.ok(source.includes("const [loadingAction, setLoadingAction] = useState<ReportAction | null>(null);"));
   assert.ok(source.includes("const [errorMessage, setErrorMessage] = useState<string | null>(null);"));
-  assert.ok(source.includes("async function handleDownload()"));
-  assert.ok(source.includes("if (!hasStoragePath || isLoading) {"));
+  assert.ok(source.includes("async function openReport(action: ReportAction)"));
+  assert.ok(source.includes('if (!isAvailable || isLoading || typeof reportId !== "number") {'));
   assert.ok(source.includes("return;"));
   assert.ok(source.includes("setErrorMessage(null);"));
-  assert.ok(source.includes("setIsLoading(true);"));
+  assert.ok(source.includes("setLoadingAction(action);"));
 });
 
-test("report download button retrieves URL and opens it safely", () => {
+test("report file actions retrieve preview/download URLs and open them safely", () => {
   const source = read(REPORT_DOWNLOAD_BUTTON_PATH);
 
-  assert.ok(source.includes("const url = await getReportDownloadUrl(reportId);"));
+  assert.ok(source.includes('await getReportPreviewUrl(reportId, { scope })'));
+  assert.ok(source.includes('await getReportDownloadUrl(reportId, { scope })'));
+  assert.ok(source.includes("Informe no disponible para visualizar."));
   assert.ok(source.includes("Informe no disponible para descarga."));
   assert.ok(source.includes('window.open(url, "_blank", "noopener,noreferrer");'));
+  assert.ok(source.includes("No se pudo obtener el enlace de visualización."));
   assert.ok(source.includes("No se pudo obtener el enlace de descarga."));
-  assert.ok(source.includes("setIsLoading(false);"));
+  assert.ok(source.includes("setLoadingAction(null);"));
 });
 
-test("report download button renders labels titles disabled and alert state", () => {
+test("report file actions render labels titles disabled and alert state", () => {
   const source = read(REPORT_DOWNLOAD_BUTTON_PATH);
 
-  assert.ok(source.includes('disabled={!hasStoragePath || isLoading}'));
-  assert.ok(source.includes('title={hasStoragePath ? "Descargar informe" : "Informe no disponible aún"}'));
+  assert.ok(source.includes('disabled={!isAvailable || isLoading}'));
+  assert.ok(source.includes('title={isAvailable ? "Ver informe" : unavailableTitle}'));
+  assert.ok(source.includes('title={isAvailable ? "Descargar informe" : unavailableTitle}'));
   assert.ok(source.includes('isLoading'));
+  assert.ok(source.includes('"Abriendo..."'));
   assert.ok(source.includes('"Preparando..."'));
   assert.ok(source.includes('hasStoragePath'));
+  assert.ok(source.includes('"Ver informe"'));
   assert.ok(source.includes('"Descargar"'));
-  assert.ok(source.includes('"No disponible"'));
+  assert.ok(source.includes('"Archivo no disponible."'));
   assert.ok(source.includes("errorMessage ? ("));
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("{errorMessage}"));
+  assert.ok(source.includes("export function ReportDownloadButton("));
 });
 
 // --- fix(admin): load registered clinics in report upload modal ---

--- a/test/frontend-report-download-action.test.ts
+++ b/test/frontend-report-download-action.test.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
-const DOWNLOAD_BUTTON_PATH =
+const REPORT_ACTIONS_PATH =
   "frontend/src/components/dashboard/ReportDownloadButton.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
 
@@ -14,38 +14,43 @@ function read(relativePath: string): string {
   );
 }
 
-test("frontend report download button exists and uses download url api", () => {
-  assert.equal(existsSync(resolve(process.cwd(), DOWNLOAD_BUTTON_PATH)), true);
+test("frontend report actions component exists and uses preview/download APIs", () => {
+  assert.equal(existsSync(resolve(process.cwd(), REPORT_ACTIONS_PATH)), true);
 
-  const source = read(DOWNLOAD_BUTTON_PATH);
+  const source = read(REPORT_ACTIONS_PATH);
 
-  assert.ok(source.includes('"use client"'));
-  assert.ok(source.includes('import { getReportDownloadUrl } from "@/lib/api"'));
-  assert.ok(source.includes("async function handleDownload()"));
-  assert.ok(source.includes("await getReportDownloadUrl(reportId)"));
-  assert.ok(source.includes('window.open(url, "_blank", "noopener,noreferrer")'));
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("getReportDownloadUrl, getReportPreviewUrl"));
+  assert.ok(source.includes('import { Download, Eye } from "lucide-react";'));
+  assert.ok(source.includes("export function ReportFileActions("));
+  assert.ok(source.includes('await getReportPreviewUrl(reportId, { scope })'));
+  assert.ok(source.includes('await getReportDownloadUrl(reportId, { scope })'));
+  assert.ok(source.includes('window.open(url, "_blank", "noopener,noreferrer");'));
 });
 
-test("frontend report download button handles loading unavailable and error states", () => {
-  const source = read(DOWNLOAD_BUTTON_PATH);
+test("frontend report actions handles unavailable loading and error states", () => {
+  const source = read(REPORT_ACTIONS_PATH);
 
-  assert.ok(source.includes("const [isLoading, setIsLoading]"));
+  assert.ok(source.includes("const [loadingAction, setLoadingAction]"));
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
-  assert.ok(source.includes("disabled={!hasStoragePath || isLoading}"));
+  assert.ok(source.includes('reportId: number | null;'));
+  assert.ok(source.includes('hasStoragePath?: boolean;'));
+  assert.ok(source.includes('scope?: "clinic" | "admin";'));
+  assert.ok(source.includes("Informe no disponible para visualizar."));
   assert.ok(source.includes("Informe no disponible para descarga."));
-  assert.ok(source.includes("Preparando..."));
+  assert.ok(source.includes("Archivo no disponible."));
   assert.ok(source.includes('role="alert"'));
 });
 
-test("frontend informes page uses report download button", () => {
+test("frontend informes page uses report file actions", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(
     source.includes(
-      'import { ReportDownloadButton } from "@/components/dashboard/ReportDownloadButton"',
+      'import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";',
     ),
   );
-  assert.ok(source.includes("<ReportDownloadButton"));
+  assert.ok(source.includes("<ReportFileActions"));
   assert.ok(source.includes("reportId={report.id}"));
   assert.ok(source.includes("hasStoragePath={Boolean(report.storagePath)}"));
   assert.equal(source.includes("<button"), false);

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -84,7 +84,9 @@ test("frontend admin dashboard routes upload report modal through token cards", 
   assert.ok(page.includes("Carga de informes"));
   assert.ok(page.includes("cada token administrado"));
   assert.ok(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
-  assert.ok(card.includes('triggerLabel="Subir informe para este token"'));
+  assert.ok(card.includes("triggerLabel={"));
+  assert.ok(card.includes('"Subir informe para este token"'));
+  assert.ok(card.includes('"Reemplazar informe"'));
   assert.ok(card.includes("presetParticularToken={token}"));
 });
 

--- a/test/frontend-reports-api-read.test.ts
+++ b/test/frontend-reports-api-read.test.ts
@@ -69,10 +69,29 @@ test("frontend API client requests report download URLs by report id", () => {
 
   assert.ok(functionSource.includes("export async function getReportDownloadUrl("));
   assert.ok(functionSource.includes("reportId: number,"));
+  assert.ok(functionSource.includes('options: { scope?: "clinic" | "admin" } = {},'));
   assert.ok(functionSource.includes("): Promise<string | null>"));
-  assert.ok(functionSource.includes("`/api/reports/${reportId}/download-url`,"));
-  assert.ok(functionSource.includes("const res = await apiFetch<{ url: string | null }>("));
-  assert.ok(functionSource.includes("return res.url ?? null;"));
+  assert.ok(functionSource.includes('options.scope === "admin" ? "/api/admin/reports" : "/api/reports"'));
+  assert.ok(functionSource.includes("`${basePath}/${reportId}/download-url`,"));
+  assert.ok(functionSource.includes("downloadUrl?: string | null;"));
+  assert.ok(functionSource.includes("url?: string | null;"));
+  assert.ok(functionSource.includes("return res.downloadUrl ?? res.url ?? null;"));
+  assert.equal(functionSource.includes("} catch {"), false);
+});
+
+test("frontend API client requests report preview URLs by report id", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = getFunctionSource(source, "getReportPreviewUrl");
+
+  assert.ok(functionSource.includes("export async function getReportPreviewUrl("));
+  assert.ok(functionSource.includes("reportId: number,"));
+  assert.ok(functionSource.includes('options: { scope?: "clinic" | "admin" } = {},'));
+  assert.ok(functionSource.includes("): Promise<string | null>"));
+  assert.ok(functionSource.includes('options.scope === "admin" ? "/api/admin/reports" : "/api/reports"'));
+  assert.ok(functionSource.includes("`${basePath}/${reportId}/preview-url`,"));
+  assert.ok(functionSource.includes("previewUrl?: string | null;"));
+  assert.ok(functionSource.includes("url?: string | null;"));
+  assert.ok(functionSource.includes("return res.previewUrl ?? res.url ?? null;"));
   assert.equal(functionSource.includes("} catch {"), false);
 });
 

--- a/test/report-write-surface-ownership.test.ts
+++ b/test/report-write-surface-ownership.test.ts
@@ -131,6 +131,7 @@ async function createAdminReportUploadApp(overrides: Record<string, unknown> = {
     prefix: "/api/admin/reports",
     ...createAuthStubs(),
     getClinicById: async () => ({ id: 3 }),
+    getReportById: async () => createReportFixture(),
     uploadReport: async () => "reports/3/luna-report.pdf",
     upsertReport: async () => createReportFixture(),
     getParticularTokenById: async () => null,


### PR DESCRIPTION
# PR fix reports preview download actions

## Resumen

Se corrigieron las acciones de informes para que clínica y administrador puedan abrir una vista previa y descargar archivos mediante URLs firmadas. El frontend ahora lee el contrato principal del backend (`previewUrl` y `downloadUrl`) con fallback defensivo a `url`.

## Archivos tocados

- `frontend/src/lib/api.ts`
- `frontend/src/components/dashboard/ReportDownloadButton.tsx`
- `frontend/src/app/dashboard/informes/page.tsx`
- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
- `server/routes/admin-reports.fastify.ts`
- `test/admin-reports.fastify.test.ts`
- `test/fastify-app.test.ts`
- `test/frontend-admin-particular-tokens.test.ts`
- `test/frontend-admin-report-workflow.test.ts`
- `test/frontend-dashboard-informes.test.ts`
- `test/frontend-report-actions.test.ts`
- `test/frontend-report-download-action.test.ts`
- `test/frontend-report-upload-modal.test.ts`
- `test/frontend-reports-api-read.test.ts`
- `test/report-write-surface-ownership.test.ts`

## Implementación realizada

- `getReportDownloadUrl` ahora lee `downloadUrl` y conserva fallback `url`.
- Se agregó `getReportPreviewUrl`, que lee `previewUrl` y conserva fallback `url`.
- Se amplió el componente existente en `ReportDownloadButton.tsx` con `ReportFileActions`, que muestra:
  - `Ver informe`
  - `Descargar`
- Ambas acciones abren URLs firmadas con `window.open(url, "_blank", "noopener,noreferrer")`.
- El componente muestra estado claro si no hay `reportId` o no hay archivo disponible.
- La tabla de clínica `/dashboard/informes` usa `ReportFileActions` con `hasStoragePath={Boolean(report.storagePath)}`.
- En administrador, los tokens con `hasLinkedReport` y `reportId` muestran `Informe: #<id>` y acciones `Ver informe` / `Descargar`.
- En administrador, el CTA de carga cambia a `Reemplazar informe` cuando ya hay informe vinculado.
- Se agregaron endpoints admin seguros:
  - `GET /api/admin/reports/:reportId/preview-url`
  - `GET /api/admin/reports/:reportId/download-url`
- Los endpoints admin requieren sesión admin y no exponen `storagePath` en errores.

## Tests agregados/modificados

- API frontend: contrato `downloadUrl` / `previewUrl` y fallback `url`.
- Acciones de informe: render de `Ver informe` y `Descargar`, preview/download APIs, `noopener,noreferrer`, estados unavailable/error.
- Clínica informes: uso de `ReportFileActions`.
- Admin tokens: acciones solo con `reportId`, no exposición de `storagePath` ni `tokenHash`, CTA `Reemplazar informe`.
- Backend admin reports: preview/download firmados con sesión admin, bloqueo sin sesión, 404 genérico.
- Fixtures de montaje Fastify actualizados con `getReportById`.

## Comandos ejecutados

- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-reports-api-read.test.ts test/frontend-report-download-action.test.ts test/frontend-report-actions.test.ts test/frontend-dashboard-informes.test.ts test/frontend-admin-particular-tokens.test.ts test/frontend-admin-report-workflow.test.ts test/frontend-report-upload-modal.test.ts test/admin-reports.fastify.test.ts test/fastify-app.test.ts test/report-write-surface-ownership.test.ts`
  - Resultado: OK, 139 tests pass.
- `pnpm --dir frontend build`
  - Resultado: OK. Warning preexistente: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts`.
- `pnpm typecheck`
  - Resultado: OK.
- `pnpm typecheck:test`
  - Resultado: OK.
- `pnpm test`
  - Resultado: OK, 2125 pass, 1 skipped, 0 fail.
- `pnpm build`
  - Resultado: OK, `dist/index.js` generado.
- `pnpm security:public-surface`
  - Resultado: OK, sin findings de exposición pública. Reporta marcadores `server-only` esperados en `frontend/src/middleware.ts`.

## Riesgos

- El admin ahora tiene una superficie nueva de lectura firmada por `reportId`; queda protegida por sesión admin y evita reutilizar endpoints clinic-scoped.
- La UI admin asume que un token con `hasLinkedReport` y `reportId` apunta a un informe con archivo válido; si el informe fue eliminado fuera del flujo, el endpoint responderá error y el componente lo mostrará.

## Rollback

- Revertir los cambios en `ReportDownloadButton.tsx`, `api.ts`, las páginas de clínica/admin y los tests asociados.
- Remover los endpoints `/:reportId/preview-url` y `/:reportId/download-url` de `server/routes/admin-reports.fastify.ts`.

## Estado final

Implementación y validación completas. No se ejecutó `git add`, `commit`, `push`, PR ni merge.
