### PR TITLE
fix(notifications): route clicks to context

### DIFF
--- a/docs/pr-history/PR-fix-notifications-click-through-routing.md
+++ b/docs/pr-history/PR-fix-notifications-click-through-routing.md
@@ -1,0 +1,78 @@
+# PR fix notifications click-through routing
+
+## Resumen
+
+Las notificaciones globales ahora navegan al contexto correcto al hacer click, tanto en desktop como en mobile. Si la notificación no está leída, primero se intenta marcar como leída; si esa operación falla, se informa el error y la navegación contextual continúa.
+
+No se hizo `git add`, `commit`, `push`, creación de PR ni merge.
+
+## Archivos tocados
+
+- `frontend/src/lib/notification-destinations.ts`
+- `frontend/src/components/dashboard/DashboardNotificationsBell.tsx`
+- `frontend/src/app/dashboard/informes/page.tsx`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `test/frontend-notification-destinations.test.ts`
+- `test/frontend-notification-click-anchors.test.ts`
+- `test/frontend-notifications-bell.test.ts`
+- `PR-fix-notifications-click-through-routing.md`
+
+## Implementación realizada
+
+- Se agregó `buildNotificationDestination(surface, notification)` como helper puro y testeable.
+- La campana usa `useRouter` y `router.push(destination)` para navegar sin abrir pestañas nuevas.
+- Las notificaciones leídas ya no quedan deshabilitadas: solo se bloquea doble click mientras `updatingNotificationId === notification.id`.
+- Desktop y mobile comparten el mismo handler de click.
+- El dropdown desktop y el banner mobile se cierran al navegar.
+- Si la ruta actual coincide con un destino con hash, se aplica fallback SSR-safe con `window.location.hash` y `scrollIntoView`.
+- No se agregaron querystrings para IDs; se usan hashes internos.
+
+## Anchors agregados/verificados
+
+- `report-${report.id}` en filas de `/dashboard/informes`.
+- `clinic-particular-token-${token.id}` en cada card de tokens de clínica.
+- `particular-study-tracking` en el bloque de seguimiento particular.
+- `particular-report` en el bloque de informe vinculado particular.
+- `admin-particular-tokens` ya existía en la página admin.
+- `admin-notifications` ya existía en la página admin.
+
+## Tests agregados/modificados
+
+- Contratos de routing para `buildNotificationDestination`.
+- Contrato de anchors para las superficies clinic, particular y admin.
+- Contratos de `DashboardNotificationsBell` para:
+  - no deshabilitar notificaciones leídas,
+  - navegar con destino contextual,
+  - compartir comportamiento desktop/mobile,
+  - conservar la garantía de no marcar como leído por auto-show.
+
+## Comandos ejecutados
+
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-notification-destinations.test.ts test/frontend-notification-click-anchors.test.ts test/frontend-notifications-bell.test.ts`
+  - Resultado: OK, 18 tests passing.
+- `pnpm --dir frontend build`
+  - Resultado: OK. Warning existente: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts:177`.
+- `pnpm typecheck`
+  - Resultado: OK.
+- `pnpm typecheck:test`
+  - Resultado: OK.
+- `pnpm test`
+  - Resultado: OK, 2133 passing, 1 skipped, 0 failures.
+- `pnpm build`
+  - Resultado: OK.
+- `pnpm security:public-surface`
+  - Resultado: OK. Reportó findings `[server-only]` esperados sobre nombres de cookies en `frontend/src/middleware.ts`, sin exposición pública de devtools.
+
+## Riesgos
+
+- El fallback de hash usa `scrollIntoView` solo cuando el destino está en la misma ruta actual; en navegación entre rutas se delega el scroll inicial a Next/browser.
+- Si falla el mark-as-read y la navegación cambia de página, el mensaje puede desmontarse junto con la campana, pero la navegación no se bloquea.
+
+## Rollback
+
+Revertir los cambios en los archivos listados arriba restaura el comportamiento anterior: click de notificación solo marcaba como leída y no navegaba por contexto.
+
+## Estado final
+
+Implementación completa, tests actualizados y validación obligatoria ejecutada correctamente. No se realizaron acciones de git ni publicación.

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -188,7 +188,7 @@ export default async function InformesPage({
                   </TableRow>
                 ) : reports.length ? (
                   reports.map((report) => (
-                    <TableRow key={report.id}>
+                    <TableRow key={report.id} id={`report-${report.id}`}>
                       <TableCell className="font-mono text-xs text-muted-foreground">
                         #{report.id}
                       </TableCell>

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -756,6 +756,7 @@ export function ClinicParticularTokensCard() {
                 return (
                   <div
                     key={token.id}
+                    id={`clinic-particular-token-${token.id}`}
                     className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
                   >
                   <div className="flex flex-wrap items-start justify-between gap-2">

--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -3,6 +3,7 @@
 import { createPortal } from "react-dom";
 import { Bell } from "lucide-react";
 import { X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +13,7 @@ import {
   type AdminStudyTrackingNotificationSummary,
   type DashboardNotificationSurface,
 } from "@/lib/api";
+import { buildNotificationDestination } from "@/lib/notification-destinations";
 import { formatDateTime } from "@/lib/utils";
 
 const NOTIFICATIONS_LIMIT = 20;
@@ -24,6 +26,7 @@ type DashboardNotificationsBellProps = {
 export function DashboardNotificationsBell({
   surface,
 }: DashboardNotificationsBellProps) {
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isPollingEnabled, setIsPollingEnabled] = useState(false);
@@ -149,37 +152,74 @@ export function DashboardNotificationsBell({
     setMobileBannerVisible(false);
   }
 
-  async function handleMarkAsRead(
-    notification: AdminStudyTrackingNotificationSummary,
-  ) {
+  function scrollToHashDestination(destination: string) {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const targetUrl = new URL(destination, window.location.origin);
+
     if (
-      notification.isRead ||
-      updatingNotificationId !== null ||
-      isMarkingAllAsRead
+      targetUrl.pathname !== window.location.pathname ||
+      targetUrl.hash.length === 0
     ) {
       return;
     }
 
-    setUpdatingNotificationId(notification.id);
-    setErrorMessage(null);
+    window.setTimeout(() => {
+      if (window.location.hash !== targetUrl.hash) {
+        window.location.hash = targetUrl.hash;
+      }
 
-    try {
-      const response = await markDashboardNotificationRead(
-        surface,
-        notification.id,
-      );
-      setNotifications((current) =>
-        current.map((currentNotification) =>
-          currentNotification.id === notification.id
-            ? response.notification
-            : currentNotification,
-        ),
-      );
-    } catch {
-      setErrorMessage("No se pudieron cargar las notificaciones.");
-    } finally {
-      setUpdatingNotificationId(null);
+      const targetId = decodeURIComponent(targetUrl.hash.slice(1));
+      document.getElementById(targetId)?.scrollIntoView({ block: "start" });
+    }, 0);
+  }
+
+  function navigateToNotificationDestination(destination: string) {
+    router.push(destination);
+    scrollToHashDestination(destination);
+  }
+
+  async function handleNotificationClick(
+    notification: AdminStudyTrackingNotificationSummary,
+  ) {
+    if (updatingNotificationId === notification.id) {
+      return;
     }
+
+    const destination = buildNotificationDestination(surface, notification);
+    const shouldMarkAsRead =
+      !notification.isRead &&
+      updatingNotificationId === null &&
+      !isMarkingAllAsRead;
+
+    if (shouldMarkAsRead) {
+      setUpdatingNotificationId(notification.id);
+      setErrorMessage(null);
+
+      try {
+        const response = await markDashboardNotificationRead(
+          surface,
+          notification.id,
+        );
+        setNotifications((current) =>
+          current.map((currentNotification) =>
+            currentNotification.id === notification.id
+              ? response.notification
+              : currentNotification,
+          ),
+        );
+      } catch {
+        setErrorMessage("No se pudo marcar la notificación como leída.");
+      } finally {
+        setUpdatingNotificationId(null);
+      }
+    }
+
+    setIsOpen(false);
+    setMobileBannerVisible(false);
+    navigateToNotificationDestination(destination);
   }
 
   async function handleMarkAllAsRead() {
@@ -287,12 +327,10 @@ export function DashboardNotificationsBell({
               <li key={notification.id}>
                 <button
                   type="button"
-                  className="w-full rounded-md border border-vetneb-line/70 bg-vetneb-surface-raised/78 px-3 py-2 text-left transition-colors hover:border-vetneb-teal/45"
-                  onClick={() => void handleMarkAsRead(notification)}
-                  disabled={
-                    notification.isRead ||
-                    updatingNotificationId === notification.id
-                  }
+                  aria-label={`Abrir notificación: ${notification.title}`}
+                  className="w-full cursor-pointer rounded-md border border-vetneb-line/70 bg-vetneb-surface-raised/78 px-3 py-2 text-left transition-colors hover:border-vetneb-teal/45 disabled:cursor-wait disabled:opacity-60"
+                  onClick={() => void handleNotificationClick(notification)}
+                  disabled={updatingNotificationId === notification.id}
                 >
                   <div className="flex items-start justify-between gap-2">
                     <p className="text-xs font-semibold text-vetneb-ink">
@@ -352,8 +390,9 @@ export function DashboardNotificationsBell({
                   <li key={notification.id}>
                     <button
                       type="button"
-                      className="w-full px-4 py-3 text-left transition-colors hover:bg-accent/50 disabled:opacity-50"
-                      onClick={() => void handleMarkAsRead(notification)}
+                      aria-label={`Abrir notificación: ${notification.title}`}
+                      className="w-full cursor-pointer px-4 py-3 text-left transition-colors hover:bg-accent/50 disabled:cursor-wait disabled:opacity-60"
+                      onClick={() => void handleNotificationClick(notification)}
                       disabled={updatingNotificationId === notification.id}
                     >
                       <p className="text-xs font-semibold text-vetneb-ink">

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -429,7 +429,10 @@ export function ParticularesContent() {
                     </dl>
                   </div>
 
-                  <div className="clinical-muted-band rounded-lg p-4 shadow-sm">
+                  <div
+                    id="particular-study-tracking"
+                    className="clinical-muted-band rounded-lg p-4 shadow-sm"
+                  >
                     <h3 className="font-semibold text-vetneb-navy">
                       Seguimiento del estudio
                     </h3>
@@ -480,7 +483,10 @@ export function ParticularesContent() {
                   </div>
 
                   {session.report ? (
-                    <div className="clinical-muted-band rounded-lg p-4 shadow-sm">
+                    <div
+                      id="particular-report"
+                      className="clinical-muted-band rounded-lg p-4 shadow-sm"
+                    >
                       <div className="flex items-start gap-3">
                         <VisualIcon
                           icon={FileText}

--- a/frontend/src/lib/notification-destinations.ts
+++ b/frontend/src/lib/notification-destinations.ts
@@ -1,0 +1,58 @@
+import { ROUTES } from "./routes";
+
+export type NotificationDestinationSurface = "admin" | "clinic" | "particular";
+
+export type NotificationDestinationInput = {
+  studyTrackingCaseId?: number | null;
+  reportId?: number | null;
+  particularTokenId?: number | null;
+  type: string;
+};
+
+function isReportNotification(notification: NotificationDestinationInput): boolean {
+  return notification.type.toLowerCase().includes("report");
+}
+
+export function buildNotificationDestination(
+  surface: NotificationDestinationSurface,
+  notification: NotificationDestinationInput,
+): string {
+  switch (surface) {
+    case "admin":
+      if (
+        notification.reportId ||
+        notification.particularTokenId ||
+        isReportNotification(notification)
+      ) {
+        return `${ROUTES.dashboardAdmin}#admin-particular-tokens`;
+      }
+
+      return `${ROUTES.dashboardAdmin}#admin-notifications`;
+
+    case "clinic":
+      if (notification.reportId) {
+        return `${ROUTES.dashboardInformes}#report-${notification.reportId}`;
+      }
+
+      if (notification.particularTokenId) {
+        return `${ROUTES.dashboard}#clinic-particular-token-${notification.particularTokenId}`;
+      }
+
+      if (isReportNotification(notification)) {
+        return ROUTES.dashboardInformes;
+      }
+
+      return ROUTES.dashboard;
+
+    case "particular":
+      if (notification.reportId) {
+        return `${ROUTES.particulares}#particular-report`;
+      }
+
+      if (notification.particularTokenId || notification.studyTrackingCaseId) {
+        return `${ROUTES.particulares}#particular-study-tracking`;
+      }
+
+      return ROUTES.particulares;
+  }
+}

--- a/test/frontend-notification-click-anchors.test.ts
+++ b/test/frontend-notification-click-anchors.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const CLINIC_TOKENS_CARD_PATH =
+  "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
+const PARTICULARES_CONTENT_PATH =
+  "frontend/src/components/public/ParticularesContent.tsx";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("notification click targets render stable clinic, particular, and admin anchors", () => {
+  const informesPage = read(INFORMES_PAGE_PATH);
+  const clinicTokensCard = read(CLINIC_TOKENS_CARD_PATH);
+  const particularesContent = read(PARTICULARES_CONTENT_PATH);
+  const adminPage = read(ADMIN_PAGE_PATH);
+
+  assert.ok(
+    informesPage.includes("id={`report-${report.id}`}"),
+    "clinic informes rows must expose report-{id} anchors",
+  );
+  assert.ok(
+    clinicTokensCard.includes('id="clinic-particular-tokens"'),
+    "clinic token section anchor must remain present",
+  );
+  assert.ok(
+    clinicTokensCard.includes("id={`clinic-particular-token-${token.id}`}"),
+    "clinic token cards must expose clinic-particular-token-{id} anchors",
+  );
+  assert.ok(
+    particularesContent.includes('id="particular-study-tracking"'),
+    "particular study tracking block must expose its anchor",
+  );
+  assert.ok(
+    particularesContent.includes('id="particular-report"'),
+    "particular linked report block must expose its anchor",
+  );
+  assert.ok(
+    adminPage.includes('id="admin-particular-tokens"'),
+    "admin particular token section anchor must exist",
+  );
+  assert.ok(
+    adminPage.includes('id="admin-notifications"'),
+    "admin notifications section anchor must exist",
+  );
+});

--- a/test/frontend-notification-destinations.test.ts
+++ b/test/frontend-notification-destinations.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const DESTINATIONS_PATH = "frontend/src/lib/notification-destinations.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `Missing start marker: ${start}`);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `Missing end marker: ${end}`);
+
+  return source.slice(startIndex, endIndex);
+}
+
+test("buildNotificationDestination uses ROUTES and exposes a pure destination helper", () => {
+  const source = read(DESTINATIONS_PATH);
+
+  assert.ok(source.includes('import { ROUTES } from "./routes";'));
+  assert.ok(source.includes("export function buildNotificationDestination("));
+  assert.ok(source.includes("notification.type.toLowerCase().includes(\"report\")"));
+  assert.equal(source.includes("window."), false);
+  assert.equal(source.includes("router."), false);
+});
+
+test("buildNotificationDestination admin routes report and token notifications to admin tokens", () => {
+  const source = read(DESTINATIONS_PATH);
+  const adminCase = sectionBetween(source, 'case "admin":', 'case "clinic":');
+
+  assert.ok(adminCase.includes("notification.reportId"));
+  assert.ok(adminCase.includes("notification.particularTokenId"));
+  assert.ok(adminCase.includes("isReportNotification(notification)"));
+  assert.ok(
+    adminCase.includes(
+      "`${ROUTES.dashboardAdmin}#admin-particular-tokens`",
+    ),
+  );
+  assert.ok(
+    adminCase.includes("`${ROUTES.dashboardAdmin}#admin-notifications`"),
+  );
+});
+
+test("buildNotificationDestination clinic routes report ids and token ids to anchors", () => {
+  const source = read(DESTINATIONS_PATH);
+  const clinicCase = sectionBetween(
+    source,
+    'case "clinic":',
+    'case "particular":',
+  );
+
+  assert.ok(clinicCase.includes("if (notification.reportId)"));
+  assert.ok(
+    clinicCase.includes(
+      "`${ROUTES.dashboardInformes}#report-${notification.reportId}`",
+    ),
+  );
+  assert.ok(clinicCase.includes("if (notification.particularTokenId)"));
+  assert.ok(
+    clinicCase.includes(
+      "`${ROUTES.dashboard}#clinic-particular-token-${notification.particularTokenId}`",
+    ),
+  );
+  assert.ok(clinicCase.includes("return ROUTES.dashboardInformes;"));
+  assert.ok(clinicCase.includes("return ROUTES.dashboard;"));
+});
+
+test("buildNotificationDestination particular routes report and study tracking notifications", () => {
+  const source = read(DESTINATIONS_PATH);
+  const particularCase = sectionBetween(source, 'case "particular":', "\n  }\n}");
+
+  assert.ok(particularCase.includes("if (notification.reportId)"));
+  assert.ok(
+    particularCase.includes("`${ROUTES.particulares}#particular-report`"),
+  );
+  assert.ok(
+    particularCase.includes(
+      "notification.particularTokenId || notification.studyTrackingCaseId",
+    ),
+  );
+  assert.ok(
+    particularCase.includes(
+      "`${ROUTES.particulares}#particular-study-tracking`",
+    ),
+  );
+  assert.ok(particularCase.includes("return ROUTES.particulares;"));
+});

--- a/test/frontend-notifications-bell.test.ts
+++ b/test/frontend-notifications-bell.test.ts
@@ -17,6 +17,16 @@ function read(relativePath: string): string {
   );
 }
 
+function sectionBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `Missing start marker: ${start}`);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `Missing end marker: ${end}`);
+
+  return source.slice(startIndex, endIndex);
+}
+
 // ── 1. Auto-show panel when unread notifications exist on load ───────────────
 
 test("notifications bell auto-opens desktop panel on mount when unread count > 0", () => {
@@ -211,7 +221,98 @@ test("notifications bell auto-show does not call mark-as-read APIs", () => {
   );
 });
 
-// ── 8. All three roles wire the bell component ───────────────────────────────
+// ── 8. Click-through navigation behavior ────────────────────────────────────
+
+test("notifications bell keeps read desktop notifications clickable for navigation", () => {
+  const source = read(BELL_PATH);
+  const desktopButtonOpening = sectionBetween(
+    source,
+    'aria-label={`Abrir notificación: ${notification.title}`}',
+    '<div className="flex items-start justify-between gap-2">',
+  );
+
+  assert.ok(
+    desktopButtonOpening.includes("cursor-pointer"),
+    "notification button must communicate click affordance",
+  );
+  assert.ok(
+    desktopButtonOpening.includes(
+      "disabled={updatingNotificationId === notification.id}",
+    ),
+    "notification button may only disable while its own update is pending",
+  );
+  assert.equal(
+    desktopButtonOpening.includes("notification.isRead"),
+    false,
+    "read notifications must not be disabled by isRead",
+  );
+});
+
+test("notifications bell routes desktop clicks through contextual destinations", () => {
+  const source = read(BELL_PATH);
+  const handler = sectionBetween(
+    source,
+    "async function handleNotificationClick(",
+    "async function handleMarkAllAsRead()",
+  );
+
+  assert.ok(source.includes('import { useRouter } from "next/navigation";'));
+  assert.ok(
+    source.includes(
+      'import { buildNotificationDestination } from "@/lib/notification-destinations";',
+    ),
+  );
+  assert.ok(source.includes("const router = useRouter();"));
+  assert.ok(
+    handler.includes(
+      "const destination = buildNotificationDestination(surface, notification);",
+    ),
+    "click handler must resolve a contextual destination",
+  );
+  assert.ok(
+    handler.includes("markDashboardNotificationRead("),
+    "unread clicks must still attempt mark-as-read",
+  );
+  assert.ok(
+    handler.includes("setIsOpen(false);"),
+    "desktop dropdown must close on notification click",
+  );
+  assert.ok(
+    handler.includes("navigateToNotificationDestination(destination);"),
+    "click handler must navigate after the mark-as-read attempt",
+  );
+  assert.ok(source.includes("router.push(destination);"));
+  assert.ok(source.includes("scrollToHashDestination(destination);"));
+  assert.equal(
+    handler.includes("notification.isRead ||"),
+    false,
+    "already-read notifications must not return before navigation",
+  );
+  assert.ok(
+    handler.includes('setErrorMessage("No se pudo marcar la notificación como leída.");'),
+    "mark-as-read failures must be surfaced without blocking navigation",
+  );
+});
+
+test("notifications bell uses the same contextual click handler on mobile and desktop", () => {
+  const source = read(BELL_PATH);
+  const clickHandlers =
+    source.match(
+      /onClick=\{\(\) => void handleNotificationClick\(notification\)\}/g,
+    ) ?? [];
+
+  assert.equal(
+    clickHandlers.length,
+    2,
+    "desktop dropdown and mobile banner must use the same click handler",
+  );
+  assert.ok(
+    source.includes("setMobileBannerVisible(false);"),
+    "mobile banner must close on notification navigation",
+  );
+});
+
+// ── 9. All three roles wire the bell component ───────────────────────────────
 
 test("admin role wires notifications bell via DashboardTopbar", () => {
   const source = read(TOPBAR_PATH);


### PR DESCRIPTION
# PR fix notifications click-through routing

## Resumen

Las notificaciones globales ahora navegan al contexto correcto al hacer click, tanto en desktop como en mobile. Si la notificación no está leída, primero se intenta marcar como leída; si esa operación falla, se informa el error y la navegación contextual continúa.

No se hizo `git add`, `commit`, `push`, creación de PR ni merge.

## Archivos tocados

- `frontend/src/lib/notification-destinations.ts`
- `frontend/src/components/dashboard/DashboardNotificationsBell.tsx`
- `frontend/src/app/dashboard/informes/page.tsx`
- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
- `frontend/src/components/public/ParticularesContent.tsx`
- `test/frontend-notification-destinations.test.ts`
- `test/frontend-notification-click-anchors.test.ts`
- `test/frontend-notifications-bell.test.ts`
- `PR-fix-notifications-click-through-routing.md`

## Implementación realizada

- Se agregó `buildNotificationDestination(surface, notification)` como helper puro y testeable.
- La campana usa `useRouter` y `router.push(destination)` para navegar sin abrir pestañas nuevas.
- Las notificaciones leídas ya no quedan deshabilitadas: solo se bloquea doble click mientras `updatingNotificationId === notification.id`.
- Desktop y mobile comparten el mismo handler de click.
- El dropdown desktop y el banner mobile se cierran al navegar.
- Si la ruta actual coincide con un destino con hash, se aplica fallback SSR-safe con `window.location.hash` y `scrollIntoView`.
- No se agregaron querystrings para IDs; se usan hashes internos.

## Anchors agregados/verificados

- `report-${report.id}` en filas de `/dashboard/informes`.
- `clinic-particular-token-${token.id}` en cada card de tokens de clínica.
- `particular-study-tracking` en el bloque de seguimiento particular.
- `particular-report` en el bloque de informe vinculado particular.
- `admin-particular-tokens` ya existía en la página admin.
- `admin-notifications` ya existía en la página admin.

## Tests agregados/modificados

- Contratos de routing para `buildNotificationDestination`.
- Contrato de anchors para las superficies clinic, particular y admin.
- Contratos de `DashboardNotificationsBell` para:
  - no deshabilitar notificaciones leídas,
  - navegar con destino contextual,
  - compartir comportamiento desktop/mobile,
  - conservar la garantía de no marcar como leído por auto-show.

## Comandos ejecutados

- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-notification-destinations.test.ts test/frontend-notification-click-anchors.test.ts test/frontend-notifications-bell.test.ts`
  - Resultado: OK, 18 tests passing.
- `pnpm --dir frontend build`
  - Resultado: OK. Warning existente: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts:177`.
- `pnpm typecheck`
  - Resultado: OK.
- `pnpm typecheck:test`
  - Resultado: OK.
- `pnpm test`
  - Resultado: OK, 2133 passing, 1 skipped, 0 failures.
- `pnpm build`
  - Resultado: OK.
- `pnpm security:public-surface`
  - Resultado: OK. Reportó findings `[server-only]` esperados sobre nombres de cookies en `frontend/src/middleware.ts`, sin exposición pública de devtools.

## Riesgos

- El fallback de hash usa `scrollIntoView` solo cuando el destino está en la misma ruta actual; en navegación entre rutas se delega el scroll inicial a Next/browser.
- Si falla el mark-as-read y la navegación cambia de página, el mensaje puede desmontarse junto con la campana, pero la navegación no se bloquea.

## Rollback

Revertir los cambios en los archivos listados arriba restaura el comportamiento anterior: click de notificación solo marcaba como leída y no navegaba por contexto.

## Estado final

Implementación completa, tests actualizados y validación obligatoria ejecutada correctamente. No se realizaron acciones de git ni publicación.
