### PR TITLE
fix(security): enforce trusted origin and hide storage paths

### DIFF
--- a/docs/pr-history/PR-fix-security-trusted-origin-storagepath.md
+++ b/docs/pr-history/PR-fix-security-trusted-origin-storagepath.md
@@ -1,0 +1,131 @@
+# PR fix/security-trusted-origin-storagepath
+
+## Resumen
+
+Este PR aplica el alcance PR-A de seguridad:
+
+- Refuerza `trusted-origin` como control global para mutaciones Fastify.
+- Bloquea mutaciones sin `Origin`/`Referer` cuando viajan con cookies de sesion conocidas.
+- Mantiene permitidas las mutaciones sin `Origin`/`Referer` solo para clientes sin cookie de sesion.
+- Elimina `storagePath` de payloads publicos/privados de reportes.
+- Expone `hasFile` como indicador seguro para acciones de preview/download.
+- Conserva signed URLs como unica superficie para acceder a archivos.
+
+No se tocaron fuentes, configuracion de `next/font`, despliegue, ni logica ajena a trusted-origin/CSRF y payloads de reportes.
+
+## Archivos tocados
+
+- `server/middlewares/trusted-origin.ts`
+- `server/fastify-app.ts`
+- `server/lib/reports.ts`
+- `server/lib/report-access-token.ts`
+- `server/lib/particular-token.ts`
+- `server/routes/reports.fastify.ts`
+- `server/routes/reports-status.fastify.ts`
+- `server/routes/admin-reports.fastify.ts`
+- `frontend/src/types/index.ts`
+- `frontend/src/components/dashboard/ReportDownloadButton.tsx`
+- `frontend/src/app/dashboard/informes/page.tsx`
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `scripts/smoke/smoke-upload.mjs`
+- Tests de backend, frontend contracts, smoke contracts y guardrails de seguridad relacionados.
+
+## Implementacion realizada
+
+### Trusted origin / CSRF
+
+- `requireTrustedOrigin` ahora centraliza el analisis de `Origin` y `Referer`.
+- `Origin` tiene prioridad sobre `Referer`.
+- Un `Origin` invalido o no permitido bloquea la mutacion aunque exista `Referer`.
+- Metodos inseguros (`POST`, `PUT`, `PATCH`, `DELETE`) con cookie de sesion conocida y sin `Origin`/`Referer` responden `403`.
+- Metodos inseguros sin `Origin`/`Referer` siguen permitidos cuando no hay cookies de sesion conocidas.
+- Se agrego `requireTrustedOriginForFastify`.
+- `createFastifyApp` registra el hook global con `app.addHook("onRequest", requireTrustedOriginForFastify)`.
+- La respuesta de bloqueo mantiene contrato estable: `{ success: false, error: "Origen no permitido" }`.
+
+### Reportes sin `storagePath`
+
+- Se agrego `serializeSafeReport(report)` como serializador seguro.
+- Las respuestas de reportes conservan campos publicos de estado y archivo:
+  - `status`
+  - `currentStatus`
+  - `fileName`
+  - `hasFile`
+- `storagePath` queda solo como dato interno para firmar preview/download.
+- Public access, token access, particular token detail, clinic reports y admin reports usan serializacion segura.
+- La auditoria de upload admin ya no guarda `storagePath` en metadata.
+
+### Frontend y smoke
+
+- El tipo `Report` elimina `storagePath` y agrega `hasFile`.
+- `ReportDownloadButton` decide disponibilidad con `hasFile`.
+- La pagina de informes pasa `report.hasFile`.
+- El dashboard admin suma `storage` al guard de metadata sensible.
+- El smoke de upload valida `report.hasFile === true` y signed URLs, sin imprimir ni resolver rutas de storage.
+
+## Tests agregados o reforzados
+
+- Unit tests de `trusted-origin` para:
+  - mutaciones sin origin/referer y sin cookie.
+  - mutaciones sin origin/referer y con cookie de sesion.
+  - prioridad de `Origin` sobre `Referer`.
+  - origin invalido.
+  - ausencia de logs con cookies o tokens.
+- Test de `createFastifyApp` para confirmar hook global antes de rutas mutables.
+- Guardrail de produccion para exigir import y registro de `requireTrustedOriginForFastify`.
+- Tests de serializers y rutas para verificar que no sale `storagePath` y si sale `hasFile`.
+- Tests frontend para confirmar que las acciones de archivo usan `hasFile`.
+- Tests de audit metadata y smoke local actualizados al nuevo contrato.
+
+## Comandos ejecutados
+
+| Comando | Resultado |
+| --- | --- |
+| `pnpm --dir frontend build` | Bloqueado localmente. `next/font` intento descargar `Inter` y `Source Sans 3` desde Google Fonts; sin red permitida fallo con `EACCES`. No se pidio ni se habilito red despues de la instruccion explicita. |
+| `pnpm typecheck` | OK. |
+| `pnpm typecheck:test` | OK. |
+| `pnpm test` | OK. 2142 pass, 0 fail. |
+| `pnpm build` | OK. Genero `dist/index.js` (`878.9kb`). |
+| `pnpm security:public-surface` | OK. PASS sin findings de exposicion publica. Nota: `.next/static` no existe porque el build frontend local quedo bloqueado; reporta markers `[server-only]` esperados en `frontend/src/middleware.ts`. |
+| `pnpm --dir frontend lint` | OK con warning no relacionado: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts:177`. |
+| `pnpm --dir frontend typecheck` | OK. |
+| `node --experimental-strip-types --experimental-specifier-resolution=node --test test\fastify-app.test.ts` | OK. 23 pass, 0 fail. |
+| `git diff --check` | OK. Solo warnings LF/CRLF en archivos frontend. |
+
+## Validacion alternativa frontend sin red
+
+Como `pnpm --dir frontend build` depende de descarga de Google Fonts durante `next build`, la validacion local sin red se cubrio con:
+
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- contratos frontend incluidos en `pnpm test`
+
+El build frontend completo debe ejecutarse en CI/Render/GitHub Actions donde la red para Google Fonts este permitida, o en una validacion posterior autorizada.
+
+## Riesgos
+
+- El bloqueo global de trusted-origin cambia el comportamiento de mutaciones con cookies de sesion y sin `Origin`/`Referer`; esto es intencional para cerrar CSRF.
+- Clientes no-browser autenticados con cookies que no manden `Origin`/`Referer` deberan adaptarse o usar un flujo sin cookie de sesion.
+- `hasFile` reemplaza la inferencia frontend basada en `storagePath`; los consumidores externos que dependian de `storagePath` deben migrar.
+- `pnpm security:public-surface` no pudo auditar assets compilados de `.next/static` localmente porque el build frontend sin red no se completo.
+
+## Rollback
+
+Para revertir este PR:
+
+- Quitar el hook `requireTrustedOriginForFastify` de `server/fastify-app.ts`.
+- Revertir `server/middlewares/trusted-origin.ts` al control previo por ruta.
+- Quitar `serializeSafeReport` y restaurar serializers anteriores.
+- Restaurar `storagePath` en tipos y contratos frontend si se necesitara volver al contrato anterior.
+- Revertir tests y smoke contracts asociados.
+
+## Estado final
+
+- Cambios implementados en la rama `fix/security-trusted-origin-storagepath`.
+- Validaciones principales de backend y contratos pasan.
+- Build frontend local documentado como bloqueado por descarga de Google Fonts sin red.
+- No se hizo `git add`.
+- No se hizo commit.
+- No se hizo push.
+- No se creo PR.
+- No se hizo merge.

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -202,6 +202,7 @@ const SENSITIVE_AUDIT_METADATA_KEY_PARTS = [
   "cookie",
   "auth",
   "hash",
+  "storage",
 ] as const;
 
 function isSensitiveAuditMetadataKey(key: string) {

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -212,7 +212,7 @@ export default async function InformesPage({
                       <TableCell className="text-right">
                         <ReportFileActions
                           reportId={report.id}
-                          hasStoragePath={Boolean(report.storagePath)}
+                          hasFile={report.hasFile}
                         />
                       </TableCell>
                     </TableRow>

--- a/frontend/src/components/dashboard/ReportDownloadButton.tsx
+++ b/frontend/src/components/dashboard/ReportDownloadButton.tsx
@@ -10,17 +10,17 @@ type ReportAction = "preview" | "download";
 
 type ReportFileActionsProps = {
   reportId: number | null;
-  hasStoragePath?: boolean;
+  hasFile?: boolean;
   scope?: "clinic" | "admin";
   align?: "start" | "end";
 };
 
-function getUnavailableLabel(reportId: number | null, hasStoragePath: boolean) {
+function getUnavailableLabel(reportId: number | null, hasFile: boolean) {
   if (typeof reportId !== "number") {
     return "Informe no disponible.";
   }
 
-  if (!hasStoragePath) {
+  if (!hasFile) {
     return "Archivo no disponible.";
   }
 
@@ -29,14 +29,14 @@ function getUnavailableLabel(reportId: number | null, hasStoragePath: boolean) {
 
 export function ReportFileActions({
   reportId,
-  hasStoragePath = true,
+  hasFile = true,
   scope = "clinic",
   align = "end",
 }: ReportFileActionsProps) {
   const [loadingAction, setLoadingAction] = useState<ReportAction | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const unavailableLabel = getUnavailableLabel(reportId, hasStoragePath);
+  const unavailableLabel = getUnavailableLabel(reportId, hasFile);
   const unavailableTitle = unavailableLabel ?? "Informe no disponible.";
   const isAvailable = unavailableLabel === null;
   const isLoading = loadingAction !== null;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -89,8 +89,10 @@ export type Report = {
   patientName: string | null;
   studyType: string | null;
   status: ReportStatus;
+  currentStatus?: ReportStatus;
   uploadDate: string | null;
-  storagePath: string | null;
+  fileName?: string | null;
+  hasFile: boolean;
   createdAt: string;
   updatedAt: string;
 };

--- a/scripts/smoke/smoke-upload.mjs
+++ b/scripts/smoke/smoke-upload.mjs
@@ -97,22 +97,6 @@ function hasCookieFlag(setCookieHeader, flag) {
   return new RegExp(`(?:^|;)\\s*${flag}(?:;|$)`, "i").test(setCookieHeader);
 }
 
-function summarizeStoragePath(storagePath) {
-  if (typeof storagePath !== "string" || storagePath.trim() === "") {
-    return "missing";
-  }
-
-  if (/^https?:\/\//i.test(storagePath)) {
-    return "url-redacted";
-  }
-
-  if (/[?&](?:token|sig|signature|x-amz-signature|x-amz-security-token)=/i.test(storagePath)) {
-    return "sanitized";
-  }
-
-  return storagePath;
-}
-
 function resolveSignedUrl(payload) {
   if (!payload || typeof payload !== "object") {
     return "";
@@ -124,20 +108,6 @@ function resolveSignedUrl(payload) {
     payload.url ??
     payload.previewUrl ??
     payload.data?.signedUrl ??
-    ""
-  );
-}
-
-function resolveStoragePath(payload) {
-  if (!payload || typeof payload !== "object") {
-    return "";
-  }
-
-  return (
-    payload?.report?.storagePath ??
-    payload?.report?.storage_path ??
-    payload?.storagePath ??
-    payload?.storage_path ??
     ""
   );
 }
@@ -306,8 +276,8 @@ async function run() {
     assert(uploadJson?.success === true, "UPLOAD NO DEVOLVIO success=true");
     assert(uploadJson?.report?.id, "UPLOAD NO DEVOLVIO report.id");
     assert(
-      uploadJson?.report?.storagePath || uploadJson?.report?.storage_path,
-      "UPLOAD NO DEVOLVIO report.storagePath"
+      uploadJson?.report?.hasFile === true,
+      "UPLOAD NO DEVOLVIO report.hasFile=true"
     );
     assert(
       uploadJson?.report?.previewUrl || uploadJson?.previewUrl,
@@ -319,14 +289,11 @@ async function run() {
     );
 
     const reportId = resolveReportId(uploadJson);
-    const storagePath = resolveStoragePath(uploadJson);
 
     assert(reportId, "UPLOAD NO DEVOLVIO reportId equivalente");
-    assert(storagePath, "UPLOAD NO DEVOLVIO storagePath/storage_path equivalente");
 
     console.log("OK /api/admin/reports/upload");
     console.log(`reportId=${reportId}`);
-    console.log(`storagePath=${summarizeStoragePath(storagePath)}`);
 
     const reportDownloadUrlRes = await fetchOrExplain(
       `${BASE_URL}/api/reports/${reportId}/download-url`,

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -140,6 +140,7 @@ import {
   logisticsSlaNativeRoutes,
   type LogisticsSlaNativeRoutesOptions,
 } from "./routes/logistics-sla.fastify.ts";
+import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -250,6 +251,8 @@ export async function createFastifyApp(
     logger: false,
     trustProxy: ENV.trustProxy,
   });
+
+  app.addHook("onRequest", requireTrustedOriginForFastify);
 
   // Garantiza que rutas API autenticadas no sean cacheadas por proxies ni
   // navegador. Las rutas públicas con caché propia (ej. /api/public/pricing)

--- a/server/lib/particular-token.ts
+++ b/server/lib/particular-token.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ParticularToken, Report } from "../../drizzle/schema.ts";
+import { serializeSafeReport } from "./reports.ts";
 
 const requiredText = (max: number, label: string) =>
   z.string().trim().min(1, `${label} es obligatorio`).max(max);
@@ -127,17 +128,6 @@ export function serializeParticularTokenDetail(
 ) {
   return {
     ...serializeParticularToken(token),
-    report: report
-      ? {
-          id: report.id,
-          clinicId: report.clinicId,
-          uploadDate: report.uploadDate,
-          studyType: report.studyType,
-          patientName: report.patientName,
-          fileName: report.fileName,
-          createdAt: report.createdAt,
-          updatedAt: report.updatedAt,
-        }
-      : null,
+    report: report ? serializeSafeReport(report) : null,
   };
 }

--- a/server/lib/report-access-token.ts
+++ b/server/lib/report-access-token.ts
@@ -4,6 +4,7 @@ import type {
   ReportAccessToken,
   ReportStatus,
 } from "../../drizzle/schema.ts";
+import { serializeSafeReport } from "./reports.ts";
 
 const rawTokenPattern = /^[a-f0-9]{64}$/i;
 
@@ -153,20 +154,7 @@ export function serializeReportAccessTokenDetail(
 ) {
   return {
     ...serializeReportAccessToken(token),
-    report: report
-      ? {
-          id: report.id,
-          clinicId: report.clinicId,
-          uploadDate: report.uploadDate,
-          studyType: report.studyType,
-          patientName: report.patientName,
-          fileName: report.fileName,
-          currentStatus: report.currentStatus,
-          statusChangedAt: report.statusChangedAt,
-          createdAt: report.createdAt,
-          updatedAt: report.updatedAt,
-        }
-      : null,
+    report: report ? serializeSafeReport(report) : null,
   };
 }
 
@@ -176,16 +164,7 @@ export function serializePublicReportAccess(input: {
   downloadUrl: string;
 }) {
   return {
-    id: input.report.id,
-    clinicId: input.report.clinicId,
-    uploadDate: input.report.uploadDate,
-    studyType: input.report.studyType,
-    patientName: input.report.patientName,
-    fileName: input.report.fileName,
-    currentStatus: input.report.currentStatus,
-    statusChangedAt: input.report.statusChangedAt,
-    createdAt: input.report.createdAt,
-    updatedAt: input.report.updatedAt,
+    ...serializeSafeReport(input.report),
     previewUrl: input.previewUrl,
     downloadUrl: input.downloadUrl,
   };

--- a/server/lib/reports.ts
+++ b/server/lib/reports.ts
@@ -1,5 +1,9 @@
-import type { ReportStatus } from "../../drizzle/schema.ts";
+import type { Report, ReportStatus } from "../../drizzle/schema.ts";
 import { normalizeReportStatus } from "./report-status.ts";
+
+type ReportWithDisplayFields = Report & {
+  clinicName?: string | null;
+};
 
 export function parsePositiveInt(value: unknown, fallback: number, max?: number) {
   const parsed = Number(value);
@@ -80,4 +84,22 @@ export function getReadClinicScope(reqClinicId: unknown, authClinicId: number) {
 export function parseReportId(value: unknown): number | undefined {
   const reportId = Number(value);
   return Number.isInteger(reportId) && reportId > 0 ? reportId : undefined;
+}
+
+export function serializeSafeReport(report: ReportWithDisplayFields) {
+  return {
+    id: report.id,
+    clinicId: report.clinicId,
+    clinicName: report.clinicName,
+    patientName: report.patientName,
+    studyType: report.studyType,
+    status: report.currentStatus,
+    currentStatus: report.currentStatus,
+    uploadDate: report.uploadDate,
+    fileName: report.fileName,
+    createdAt: report.createdAt,
+    updatedAt: report.updatedAt,
+    statusChangedAt: report.statusChangedAt,
+    hasFile: Boolean(report.storagePath),
+  };
 }

--- a/server/middlewares/trusted-origin.ts
+++ b/server/middlewares/trusted-origin.ts
@@ -1,7 +1,19 @@
-﻿import type { NextFunction, Request, Response } from "../lib/http-types.ts";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { NextFunction, Request, Response } from "../lib/http-types.ts";
 import { ENV } from "../lib/env.ts";
 
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_COOKIE_NAMES = [
+  ENV.cookieName,
+  ENV.adminCookieName,
+  ENV.particularCookieName,
+];
+
+type HeaderGetterRequest = {
+  method: string;
+  headers?: Record<string, string | string[] | undefined>;
+  get?: (name: string) => string | undefined;
+};
 
 function getAllowedOrigins(): string[] {
   const configuredOrigins = ENV.corsOrigins.map((origin) =>
@@ -36,20 +48,106 @@ function normalizeOrigin(value: string): string | null {
   }
 }
 
-function getRequestOrigin(req: Request): string | null {
-  const originHeader = req.get("origin");
+function getHeader(req: HeaderGetterRequest, name: string): string | undefined {
+  const directValue = req.get?.(name);
+
+  if (typeof directValue === "string") {
+    return directValue;
+  }
+
+  const headerValue = req.headers?.[name.toLowerCase()];
+
+  if (typeof headerValue === "string") {
+    return headerValue;
+  }
+
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  return undefined;
+}
+
+function getRequestOrigin(req: HeaderGetterRequest): {
+  present: boolean;
+  origin: string | null;
+} {
+  const originHeader = getHeader(req, "origin");
 
   if (typeof originHeader === "string" && originHeader.trim()) {
-    return normalizeOrigin(originHeader);
+    return {
+      present: true,
+      origin: normalizeOrigin(originHeader),
+    };
   }
 
-  const refererHeader = req.get("referer");
+  const refererHeader = getHeader(req, "referer");
 
   if (typeof refererHeader === "string" && refererHeader.trim()) {
-    return normalizeOrigin(refererHeader);
+    return {
+      present: true,
+      origin: normalizeOrigin(refererHeader),
+    };
   }
 
-  return null;
+  return {
+    present: false,
+    origin: null,
+  };
+}
+
+function safeDecodeCookiePart(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseCookies(cookieHeader: string | undefined): Record<string, string> {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    cookieHeader
+      .split(";")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const separatorIndex = part.indexOf("=");
+
+        if (separatorIndex === -1) {
+          return [safeDecodeCookiePart(part), ""];
+        }
+
+        return [
+          safeDecodeCookiePart(part.slice(0, separatorIndex).trim()),
+          safeDecodeCookiePart(part.slice(separatorIndex + 1).trim()),
+        ];
+      }),
+  );
+}
+
+function hasSessionCookie(req: HeaderGetterRequest) {
+  const cookies = parseCookies(getHeader(req, "cookie"));
+  return SESSION_COOKIE_NAMES.some((name) => Boolean(cookies[name]));
+}
+
+function isTrustedOriginRequest(req: HeaderGetterRequest) {
+  if (!UNSAFE_METHODS.has(req.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(req);
+
+  if (requestOrigin.present) {
+    return Boolean(
+      requestOrigin.origin && allowedOrigins.has(requestOrigin.origin),
+    );
+  }
+
+  return !hasSessionCookie(req);
 }
 
 export function requireTrustedOrigin(
@@ -57,19 +155,7 @@ export function requireTrustedOrigin(
   res: Response,
   next: NextFunction,
 ) {
-  if (!UNSAFE_METHODS.has(req.method.toUpperCase())) {
-    next();
-    return;
-  }
-
-  const requestOrigin = getRequestOrigin(req);
-
-  if (!requestOrigin) {
-    next();
-    return;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
+  if (isTrustedOriginRequest(req)) {
     next();
     return;
   }
@@ -80,3 +166,16 @@ export function requireTrustedOrigin(
   });
 }
 
+export async function requireTrustedOriginForFastify(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  if (isTrustedOriginRequest(request)) {
+    return undefined;
+  }
+
+  return reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+}

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -20,6 +20,7 @@ import {
   normalizeSearchText,
   parseOptionalDate,
   parseReportId,
+  serializeSafeReport,
 } from "../lib/reports.ts";
 import {
   buildRequestLogLine,
@@ -736,7 +737,7 @@ async function serializeReport(report: Report, deps: NativeAdminReportsDeps) {
   ]);
 
   return {
-    ...report,
+    ...serializeSafeReport(report),
     previewUrl,
     downloadUrl,
   };
@@ -1051,7 +1052,6 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
       metadata: {
         fileName: file.originalname,
         mimeType: file.mimetype,
-        storagePath,
         patientName: patientName ?? null,
         studyType: studyType ?? null,
         uploadDate: uploadDate ?? null,

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -11,6 +11,7 @@ import {
   normalizeOptionalNote,
   parseReportId,
   parseReportStatus,
+  serializeSafeReport,
 } from "../lib/reports.ts";
 import {
   REPORT_STATUSES,
@@ -540,7 +541,7 @@ async function serializeReport(report: Report, deps: NativeReportsStatusDeps) {
   ]);
 
   return {
-    ...report,
+    ...serializeSafeReport(report),
     previewUrl,
     downloadUrl,
   };

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -14,6 +14,7 @@ import {
   parsePositiveInt,
   parseReportId,
   parseReportStatus,
+  serializeSafeReport,
 } from "../lib/reports.ts";
 import { REPORT_STATUSES } from "../lib/report-status.ts";
 import { normalizeClinicUserRole } from "../lib/permissions.ts";
@@ -440,7 +441,7 @@ async function serializeReport(report: Report, deps: NativeReportsDeps) {
   ]);
 
   return {
-    ...report,
+    ...serializeSafeReport(report),
     previewUrl,
     downloadUrl,
   };

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -660,11 +660,16 @@ test(
             studyType: "Histopatología",
             patientName: "Luna",
             fileName: "luna-report.pdf",
+            status: "ready",
+            currentStatus: "ready",
+            statusChangedAt: "2026-04-22T09:30:00.000Z",
             createdAt: "2026-04-22T09:00:00.000Z",
             updatedAt: "2026-04-22T09:30:00.000Z",
+            hasFile: true,
           },
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
     } finally {
       await app.close();
     }

--- a/test/admin-report-access-tokens.fastify.test.ts
+++ b/test/admin-report-access-tokens.fastify.test.ts
@@ -357,13 +357,16 @@ test(
             studyType: "Histopatología",
             patientName: "Luna",
             fileName: "luna-report.pdf",
+            status: "ready",
             currentStatus: "ready",
             statusChangedAt: "2026-04-22T09:30:00.000Z",
             createdAt: "2026-04-22T09:00:00.000Z",
             updatedAt: "2026-04-22T09:30:00.000Z",
+            hasFile: true,
           },
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
     } finally {
       await app.close();
     }
@@ -435,13 +438,16 @@ test(
             studyType: "Histopatología",
             patientName: "Luna",
             fileName: "luna-report.pdf",
+            status: "ready",
             currentStatus: "ready",
             statusChangedAt: "2026-04-22T09:30:00.000Z",
             createdAt: "2026-04-22T09:00:00.000Z",
             updatedAt: "2026-04-22T09:30:00.000Z",
+            hasFile: true,
           },
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
 
       assert.equal(auditCalls.length, 1);
       assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED);

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -466,7 +466,6 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
             metadata: {
               fileName: "luna-report.pdf",
               mimeType: "application/pdf",
-              storagePath: "reports/3/luna-report.pdf",
               patientName: "Luna",
               studyType: "histopatologia",
               uploadDate: "2026-04-22T09:00:00.000Z",
@@ -487,6 +486,11 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
     assert.equal(body.report.clinicId, 3);
     assert.equal(body.report.patientName, "Luna");
     assert.equal(body.report.studyType, "histopatologia");
+    assert.equal(body.report.status, "uploaded");
+    assert.equal(body.report.currentStatus, "uploaded");
+    assert.equal(body.report.hasFile, true);
+    assert.equal(body.report.storagePath, undefined);
+    assert.equal(response.body.includes("storagePath"), false);
     assert.equal(body.report.previewUrl, "signed-preview:reports/3/luna-report.pdf");
     assert.equal(
       body.report.downloadUrl,

--- a/test/audit-critical-flow-writes.test.ts
+++ b/test/audit-critical-flow-writes.test.ts
@@ -282,10 +282,14 @@ test("admin report upload audita creación exitosa de informe por admin", () => 
       "reportId: report.id",
       "fileName: file.originalname",
       "mimeType: file.mimetype",
-      "storagePath,",
       "uploadedVia: \"admin\"",
     ],
     "admin report upload audit payload",
+  );
+  assert.equal(
+    source.includes("storagePath,\n        patientName"),
+    false,
+    "admin report upload audit payload no debe exponer storagePath",
   );
 
   assertContainsInOrder(

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -765,6 +765,110 @@ function buildFastifyDispatchRouteStubs() {
     logisticsSlaRoutes: buildLogisticsSlaRouteStubs(),
   };
 }
+
+test(
+  "createFastifyApp aplica trusted origin global antes de rutas mutables",
+  async () => {
+    const app = await createFastifyApp(buildFastifyDispatchRouteStubs());
+    const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
+    const secretSessionToken = "secret-session-token";
+    const consoleCalls: string[] = [];
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const capture = (...args: unknown[]) => {
+      consoleCalls.push(args.map(String).join(" "));
+    };
+
+    console.log = capture;
+    console.warn = capture;
+    console.error = capture;
+
+    try {
+      const blockedPostWithoutOrigin = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/logout",
+        headers: {
+          cookie: `${ENV.adminCookieName}=${secretSessionToken}`,
+        },
+      });
+
+      const blockedPatchWithoutOrigin = await app.inject({
+        method: "PATCH",
+        url: "/api/reports/55/status",
+        headers: {
+          cookie: `${ENV.cookieName}=clinic-session-token`,
+        },
+        payload: {
+          status: "ready",
+        },
+      });
+
+      const blockedDeleteWithoutOrigin = await app.inject({
+        method: "DELETE",
+        url: "/api/admin/particular-tokens/7",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      const blockedPostWithBadOrigin = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/logout",
+        headers: {
+          origin: "https://blocked.invalid",
+        },
+      });
+
+      const allowedPostWithOrigin = await app.inject({
+        method: "POST",
+        url: "/api/admin/auth/logout",
+        headers: {
+          origin: allowedOrigin,
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      const getWithoutOrigin = await app.inject({
+        method: "GET",
+        url: "/api/reports",
+      });
+
+      const optionsWithoutOrigin = await app.inject({
+        method: "OPTIONS",
+        url: "/api/admin/auth/logout",
+      });
+
+      for (const response of [
+        blockedPostWithoutOrigin,
+        blockedPatchWithoutOrigin,
+        blockedDeleteWithoutOrigin,
+        blockedPostWithBadOrigin,
+      ]) {
+        assert.equal(response.statusCode, 403);
+        assert.deepEqual(JSON.parse(response.body), {
+          success: false,
+          error: "Origen no permitido",
+        });
+      }
+
+      assert.notEqual(allowedPostWithOrigin.statusCode, 403);
+      assert.equal(getWithoutOrigin.statusCode, 401);
+      assert.equal(optionsWithoutOrigin.statusCode, 204);
+
+      const serializedConsoleCalls = consoleCalls.join("\n");
+      assert.equal(serializedConsoleCalls.includes(secretSessionToken), false);
+      assert.equal(serializedConsoleCalls.includes(ENV.adminCookieName), false);
+      assert.equal(serializedConsoleCalls.toLowerCase().includes("cookie"), false);
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      console.error = originalError;
+      await app.close();
+    }
+  },
+);
+
 test(
   "createFastifyApp expone root y health nativos",
   async () => {

--- a/test/frontend-admin-metadata-guard.test.ts
+++ b/test/frontend-admin-metadata-guard.test.ts
@@ -40,6 +40,7 @@ test("frontend admin metadata keeps sensitive key guard centralized", () => {
     "cookie",
     "auth",
     "hash",
+    "storage",
   ]) {
     assertIncludes(source, `"${sensitiveKeyPart}"`, adminPage);
   }

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -116,7 +116,8 @@ test("dashboard informes keeps row rendering badges dates and report actions", (
   assert.ok(source.includes("getReportStatusLabel(report.status)"));
   assert.ok(source.includes("<ReportFileActions"));
   assert.ok(source.includes("reportId={report.id}"));
-  assert.ok(source.includes("hasStoragePath={Boolean(report.storagePath)}"));
+  assert.ok(source.includes("hasFile={report.hasFile}"));
+  assert.equal(source.includes("storagePath"), false);
 });
 
 test("dashboard informes keeps empty state and avoids client-side fetch literals", () => {

--- a/test/frontend-report-actions.test.ts
+++ b/test/frontend-report-actions.test.ts
@@ -161,7 +161,7 @@ test("report file actions are client-side and keep typed props", () => {
   assert.ok(source.includes('import { Download, Eye } from "lucide-react";'));
   assert.ok(source.includes("type ReportFileActionsProps = {"));
   assert.ok(source.includes("reportId: number | null;"));
-  assert.ok(source.includes("hasStoragePath?: boolean;"));
+  assert.ok(source.includes("hasFile?: boolean;"));
   assert.ok(source.includes('scope?: "clinic" | "admin";'));
   assert.ok(source.includes('align?: "start" | "end";'));
 });
@@ -200,7 +200,7 @@ test("report file actions render labels titles disabled and alert state", () => 
   assert.ok(source.includes('isLoading'));
   assert.ok(source.includes('"Abriendo..."'));
   assert.ok(source.includes('"Preparando..."'));
-  assert.ok(source.includes('hasStoragePath'));
+  assert.ok(source.includes('hasFile'));
   assert.ok(source.includes('"Ver informe"'));
   assert.ok(source.includes('"Descargar"'));
   assert.ok(source.includes('"Archivo no disponible."'));

--- a/test/frontend-report-download-action.test.ts
+++ b/test/frontend-report-download-action.test.ts
@@ -34,7 +34,7 @@ test("frontend report actions handles unavailable loading and error states", () 
   assert.ok(source.includes("const [loadingAction, setLoadingAction]"));
   assert.ok(source.includes("const [errorMessage, setErrorMessage]"));
   assert.ok(source.includes('reportId: number | null;'));
-  assert.ok(source.includes('hasStoragePath?: boolean;'));
+  assert.ok(source.includes('hasFile?: boolean;'));
   assert.ok(source.includes('scope?: "clinic" | "admin";'));
   assert.ok(source.includes("Informe no disponible para visualizar."));
   assert.ok(source.includes("Informe no disponible para descarga."));
@@ -52,6 +52,7 @@ test("frontend informes page uses report file actions", () => {
   );
   assert.ok(source.includes("<ReportFileActions"));
   assert.ok(source.includes("reportId={report.id}"));
-  assert.ok(source.includes("hasStoragePath={Boolean(report.storagePath)}"));
+  assert.ok(source.includes("hasFile={report.hasFile}"));
+  assert.equal(source.includes("storagePath"), false);
   assert.equal(source.includes("<button"), false);
 });

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -212,9 +212,11 @@ test(
             fileName: report.fileName,
             createdAt: report.createdAt.toISOString(),
             updatedAt: report.updatedAt.toISOString(),
+            hasFile: true,
           },
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
     } finally {
       await app.close();
     }
@@ -302,6 +304,9 @@ test(
       assert.equal(body.success, true);
       assert.equal(body.particular.id, particularToken.id);
       assert.equal(body.particular.report.id, report.id);
+      assert.equal(body.particular.report.hasFile, true);
+      assert.equal(body.particular.report.storagePath, undefined);
+      assert.equal(response.body.includes("storagePath"), false);
       assert.equal(body.particular.hasLinkedReport, true);
     } finally {
       await app.close();

--- a/test/particular-tokens.fastify.test.ts
+++ b/test/particular-tokens.fastify.test.ts
@@ -477,6 +477,11 @@ test(
       assert.equal(body.particularToken.clinicId, 3);
       assert.equal(body.particularToken.reportId, 55);
       assert.equal(body.particularToken.report.id, 55);
+      assert.equal(body.particularToken.report.status, "ready");
+      assert.equal(body.particularToken.report.currentStatus, "ready");
+      assert.equal(body.particularToken.report.hasFile, true);
+      assert.equal(body.particularToken.report.storagePath, undefined);
+      assert.equal(response.body.includes("storagePath"), false);
     } finally {
       await app.close();
     }

--- a/test/public-report-access.fastify.test.ts
+++ b/test/public-report-access.fastify.test.ts
@@ -140,10 +140,12 @@ test(
           studyType: report.studyType,
           patientName: report.patientName,
           fileName: report.fileName,
+          status: report.currentStatus,
           currentStatus: report.currentStatus,
           statusChangedAt: report.statusChangedAt.toISOString(),
           createdAt: report.createdAt.toISOString(),
           updatedAt: report.updatedAt.toISOString(),
+          hasFile: true,
           previewUrl: "https://signed.example/preview",
           downloadUrl: "https://signed.example/download",
         },
@@ -153,6 +155,7 @@ test(
           expiresAt: token.expiresAt.toISOString(),
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
 
       assert.equal(auditCalls.length, 1);
       assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_PUBLIC_ACCESSED);

--- a/test/report-access-token-serializers.test.ts
+++ b/test/report-access-token-serializers.test.ts
@@ -123,7 +123,10 @@ test("serializeReportAccessTokenDetail incluye reporte cuando existe", () => {
   assert.equal(detailed.state, "active");
   assert.equal(detailed.report?.id, 22);
   assert.equal(detailed.report?.studyType, "Histopatología");
+  assert.equal(detailed.report?.status, "ready");
   assert.equal(detailed.report?.currentStatus, "ready");
+  assert.equal(detailed.report?.hasFile, false);
+  assert.equal((detailed.report as any)?.storagePath, undefined);
 });
 
 test("serializeReportAccessTokenDetail devuelve report null cuando no existe", () => {
@@ -174,7 +177,10 @@ test("serializePublicReportAccess expone urls y datos públicos del reporte", ()
   assert.equal(serialized.id, 22);
   assert.equal(serialized.clinicId, 3);
   assert.equal(serialized.patientName, "Luna");
+  assert.equal(serialized.status, "ready");
   assert.equal(serialized.currentStatus, "ready");
+  assert.equal(serialized.hasFile, false);
+  assert.equal((serialized as any).storagePath, undefined);
   assert.equal(serialized.previewUrl, "https://example.com/preview");
   assert.equal(serialized.downloadUrl, "https://example.com/download");
 });

--- a/test/report-access-tokens.fastify.test.ts
+++ b/test/report-access-tokens.fastify.test.ts
@@ -349,13 +349,16 @@ test(
             studyType: "Histopatología",
             patientName: "Luna",
             fileName: "luna-report.pdf",
+            status: "ready",
             currentStatus: "ready",
             statusChangedAt: "2026-04-22T09:30:00.000Z",
             createdAt: "2026-04-22T09:00:00.000Z",
             updatedAt: "2026-04-22T09:30:00.000Z",
+            hasFile: true,
           },
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
     } finally {
       await app.close();
     }
@@ -427,13 +430,16 @@ test(
             studyType: "Histopatología",
             patientName: "Luna",
             fileName: "luna-report.pdf",
+            status: "ready",
             currentStatus: "ready",
             statusChangedAt: "2026-04-22T09:30:00.000Z",
             createdAt: "2026-04-22T09:00:00.000Z",
             updatedAt: "2026-04-22T09:30:00.000Z",
+            hasFile: true,
           },
         },
       });
+      assert.equal(response.body.includes("storagePath"), false);
 
       assert.equal(auditCalls.length, 1);
       assert.equal(auditCalls[0].event, AUDIT_EVENTS.REPORT_ACCESS_TOKEN_REVOKED);

--- a/test/reports-status.fastify.test.ts
+++ b/test/reports-status.fastify.test.ts
@@ -129,7 +129,11 @@ test("reportsStatusNativeRoutes actualiza PATCH /:reportId/status y escribe audi
     const body = JSON.parse(response.body);
     assert.equal(body.success, true);
     assert.equal(body.message, "Estado de informe actualizado correctamente");
+    assert.equal(body.report.status, "ready");
     assert.equal(body.report.currentStatus, "ready");
+    assert.equal(body.report.hasFile, true);
+    assert.equal(body.report.storagePath, undefined);
+    assert.equal(response.body.includes("storagePath"), false);
     assert.equal(body.report.previewUrl, "preview:reports/3/luna.pdf");
     assert.equal(
       body.report.downloadUrl,

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -153,6 +153,11 @@ test("reportsNativeRoutes expone GET / con lista clinic-scoped", async () => {
     assert.equal(body.success, true);
     assert.equal(body.count, 1);
     assert.equal(body.reports[0].id, 55);
+    assert.equal(body.reports[0].status, "ready");
+    assert.equal(body.reports[0].currentStatus, "ready");
+    assert.equal(body.reports[0].hasFile, true);
+    assert.equal(body.reports[0].storagePath, undefined);
+    assert.equal(response.body.includes("storagePath"), false);
     assert.equal(body.reports[0].previewUrl, "preview:reports/3/luna.pdf");
     assert.equal(
       body.reports[0].downloadUrl,
@@ -206,6 +211,10 @@ test("reportsNativeRoutes expone GET /search con filtros normalizados", async ()
     const body = JSON.parse(response.body);
     assert.equal(body.success, true);
     assert.equal(body.reports[0].id, 56);
+    assert.equal(body.reports[0].status, "ready");
+    assert.equal(body.reports[0].hasFile, true);
+    assert.equal(body.reports[0].storagePath, undefined);
+    assert.equal(response.body.includes("storagePath"), false);
     assert.equal(body.filters.query, "Luna");
     assert.equal(body.filters.studyType, "histopatologia");
     assert.equal(body.filters.status, "ready");

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -226,6 +226,19 @@ test("origin/CORS bloquea métodos inseguros con Origin no permitido y no usa wi
     middlewareFile,
   );
   assertContains(middlewareSource, 'error: "Origen no permitido"', middlewareFile);
+
+  const fastifyAppFile = "server/fastify-app.ts";
+  const fastifyAppSource = read(fastifyAppFile);
+  assertContains(
+    fastifyAppSource,
+    'import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";',
+    fastifyAppFile,
+  );
+  assertContains(
+    fastifyAppSource,
+    'app.addHook("onRequest", requireTrustedOriginForFastify);',
+    fastifyAppFile,
+  );
 });
 
 test("Fastify usa trust proxy configurado por ENV y no hardcodea proxies productivos", () => {

--- a/test/smoke-local-contract.test.ts
+++ b/test/smoke-local-contract.test.ts
@@ -160,7 +160,7 @@ test("upload local smoke keeps temp artifacts outside the repo and covers admin 
     "uploadRes.status === 201",
     "uploadJson?.success === true",
     "uploadJson?.report?.id",
-    "uploadJson?.report?.storagePath",
+    "uploadJson?.report?.hasFile === true",
     "uploadJson?.report?.previewUrl",
     "uploadJson?.report?.downloadUrl",
   ]) {

--- a/test/trusted-origin-edge.test.ts
+++ b/test/trusted-origin-edge.test.ts
@@ -140,7 +140,7 @@ test("requireTrustedOrigin prioriza origin sobre referer cuando origin está blo
   });
 });
 
-test("requireTrustedOrigin ignora origin inválido y deja pasar aunque exista referer", () => {
+test("requireTrustedOrigin bloquea origin inválido aunque exista referer", () => {
   const req = createRequest("POST", {
     origin: "::::origin-invalido::::",
     referer: "https://blocked.invalid/panel",
@@ -153,8 +153,10 @@ test("requireTrustedOrigin ignora origin inválido y deja pasar aunque exista re
     nextCalls.push(error);
   }) as any);
 
-  assert.equal(nextCalls.length, 1);
-  assert.equal(nextCalls[0], undefined);
-  assert.equal(res.statusCode, 200);
-  assert.equal(res.jsonPayload, undefined);
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Origen no permitido",
+  });
 });

--- a/test/trusted-origin.test.ts
+++ b/test/trusted-origin.test.ts
@@ -60,7 +60,7 @@ test("requireTrustedOrigin deja pasar métodos seguros aunque el origin sea exte
   assert.equal(res.jsonPayload, undefined);
 });
 
-test("requireTrustedOrigin deja pasar métodos inseguros sin origin ni referer", () => {
+test("requireTrustedOrigin deja pasar métodos inseguros sin origin ni referer cuando no hay cookie de sesion", () => {
   const req = createRequest("POST");
 
   const res = createMockResponse();
@@ -74,6 +74,67 @@ test("requireTrustedOrigin deja pasar métodos inseguros sin origin ni referer",
   assert.equal(nextCalls[0], undefined);
   assert.equal(res.statusCode, 200);
   assert.equal(res.jsonPayload, undefined);
+});
+
+test("requireTrustedOrigin bloquea métodos inseguros con cookie de sesión y sin origin ni referer", () => {
+  const req = createRequest("POST", {
+    cookie: `${ENV.cookieName}=clinic-session-token`,
+  });
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+
+  requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+    nextCalls.push(error);
+  }) as any);
+
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Origen no permitido",
+  });
+});
+
+test("requireTrustedOrigin no loguea cookies ni tokens al bloquear origin", () => {
+  const secretCookieValue = "clinic-session-secret-token";
+  const req = createRequest("POST", {
+    cookie: `${ENV.cookieName}=${secretCookieValue}`,
+    origin: "https://blocked.invalid",
+  });
+
+  const res = createMockResponse();
+  const nextCalls: unknown[] = [];
+  const consoleCalls: string[] = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const capture = (...args: unknown[]) => {
+    consoleCalls.push(args.map(String).join(" "));
+  };
+
+  console.log = capture;
+  console.warn = capture;
+  console.error = capture;
+
+  try {
+    requireTrustedOrigin(req as any, res as any, ((error?: unknown) => {
+      nextCalls.push(error);
+    }) as any);
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+
+  const serializedConsoleCalls = consoleCalls.join("\n");
+
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.equal(serializedConsoleCalls.includes(secretCookieValue), false);
+  assert.equal(serializedConsoleCalls.includes(ENV.cookieName), false);
+  assert.equal(serializedConsoleCalls.toLowerCase().includes("cookie"), false);
+  assert.equal(serializedConsoleCalls.toLowerCase().includes("token"), false);
 });
 
 test("requireTrustedOrigin deja pasar referer permitido cuando existe allowlist", (t) => {
@@ -123,7 +184,7 @@ test("requireTrustedOrigin bloquea origin no permitido en métodos inseguros", (
   });
 });
 
-test("requireTrustedOrigin ignora referer inválido y deja pasar", () => {
+test("requireTrustedOrigin bloquea referer inválido en métodos inseguros", () => {
   const req = createRequest("PATCH", {
     referer: "::::referer-invalido::::",
   });
@@ -135,8 +196,10 @@ test("requireTrustedOrigin ignora referer inválido y deja pasar", () => {
     nextCalls.push(error);
   }) as any);
 
-  assert.equal(nextCalls.length, 1);
-  assert.equal(nextCalls[0], undefined);
-  assert.equal(res.statusCode, 200);
-  assert.equal(res.jsonPayload, undefined);
+  assert.equal(nextCalls.length, 0);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.jsonPayload, {
+    success: false,
+    error: "Origen no permitido",
+  });
 });


### PR DESCRIPTION
# PR fix/security-trusted-origin-storagepath

## Resumen

Este PR aplica el alcance PR-A de seguridad:

- Refuerza `trusted-origin` como control global para mutaciones Fastify.
- Bloquea mutaciones sin `Origin`/`Referer` cuando viajan con cookies de sesion conocidas.
- Mantiene permitidas las mutaciones sin `Origin`/`Referer` solo para clientes sin cookie de sesion.
- Elimina `storagePath` de payloads publicos/privados de reportes.
- Expone `hasFile` como indicador seguro para acciones de preview/download.
- Conserva signed URLs como unica superficie para acceder a archivos.

No se tocaron fuentes, configuracion de `next/font`, despliegue, ni logica ajena a trusted-origin/CSRF y payloads de reportes.

## Archivos tocados

- `server/middlewares/trusted-origin.ts`
- `server/fastify-app.ts`
- `server/lib/reports.ts`
- `server/lib/report-access-token.ts`
- `server/lib/particular-token.ts`
- `server/routes/reports.fastify.ts`
- `server/routes/reports-status.fastify.ts`
- `server/routes/admin-reports.fastify.ts`
- `frontend/src/types/index.ts`
- `frontend/src/components/dashboard/ReportDownloadButton.tsx`
- `frontend/src/app/dashboard/informes/page.tsx`
- `frontend/src/app/dashboard/admin/page.tsx`
- `scripts/smoke/smoke-upload.mjs`
- Tests de backend, frontend contracts, smoke contracts y guardrails de seguridad relacionados.

## Implementacion realizada

### Trusted origin / CSRF

- `requireTrustedOrigin` ahora centraliza el analisis de `Origin` y `Referer`.
- `Origin` tiene prioridad sobre `Referer`.
- Un `Origin` invalido o no permitido bloquea la mutacion aunque exista `Referer`.
- Metodos inseguros (`POST`, `PUT`, `PATCH`, `DELETE`) con cookie de sesion conocida y sin `Origin`/`Referer` responden `403`.
- Metodos inseguros sin `Origin`/`Referer` siguen permitidos cuando no hay cookies de sesion conocidas.
- Se agrego `requireTrustedOriginForFastify`.
- `createFastifyApp` registra el hook global con `app.addHook("onRequest", requireTrustedOriginForFastify)`.
- La respuesta de bloqueo mantiene contrato estable: `{ success: false, error: "Origen no permitido" }`.

### Reportes sin `storagePath`

- Se agrego `serializeSafeReport(report)` como serializador seguro.
- Las respuestas de reportes conservan campos publicos de estado y archivo:
  - `status`
  - `currentStatus`
  - `fileName`
  - `hasFile`
- `storagePath` queda solo como dato interno para firmar preview/download.
- Public access, token access, particular token detail, clinic reports y admin reports usan serializacion segura.
- La auditoria de upload admin ya no guarda `storagePath` en metadata.

### Frontend y smoke

- El tipo `Report` elimina `storagePath` y agrega `hasFile`.
- `ReportDownloadButton` decide disponibilidad con `hasFile`.
- La pagina de informes pasa `report.hasFile`.
- El dashboard admin suma `storage` al guard de metadata sensible.
- El smoke de upload valida `report.hasFile === true` y signed URLs, sin imprimir ni resolver rutas de storage.

## Tests agregados o reforzados

- Unit tests de `trusted-origin` para:
  - mutaciones sin origin/referer y sin cookie.
  - mutaciones sin origin/referer y con cookie de sesion.
  - prioridad de `Origin` sobre `Referer`.
  - origin invalido.
  - ausencia de logs con cookies o tokens.
- Test de `createFastifyApp` para confirmar hook global antes de rutas mutables.
- Guardrail de produccion para exigir import y registro de `requireTrustedOriginForFastify`.
- Tests de serializers y rutas para verificar que no sale `storagePath` y si sale `hasFile`.
- Tests frontend para confirmar que las acciones de archivo usan `hasFile`.
- Tests de audit metadata y smoke local actualizados al nuevo contrato.

## Comandos ejecutados

| Comando | Resultado |
| --- | --- |
| `pnpm --dir frontend build` | Bloqueado localmente. `next/font` intento descargar `Inter` y `Source Sans 3` desde Google Fonts; sin red permitida fallo con `EACCES`. No se pidio ni se habilito red despues de la instruccion explicita. |
| `pnpm typecheck` | OK. |
| `pnpm typecheck:test` | OK. |
| `pnpm test` | OK. 2142 pass, 0 fail. |
| `pnpm build` | OK. Genero `dist/index.js` (`878.9kb`). |
| `pnpm security:public-surface` | OK. PASS sin findings de exposicion publica. Nota: `.next/static` no existe porque el build frontend local quedo bloqueado; reporta markers `[server-only]` esperados en `frontend/src/middleware.ts`. |
| `pnpm --dir frontend lint` | OK con warning no relacionado: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts:177`. |
| `pnpm --dir frontend typecheck` | OK. |
| `node --experimental-strip-types --experimental-specifier-resolution=node --test test\fastify-app.test.ts` | OK. 23 pass, 0 fail. |
| `git diff --check` | OK. Solo warnings LF/CRLF en archivos frontend. |

## Validacion alternativa frontend sin red

Como `pnpm --dir frontend build` depende de descarga de Google Fonts durante `next build`, la validacion local sin red se cubrio con:

- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck`
- contratos frontend incluidos en `pnpm test`

El build frontend completo debe ejecutarse en CI/Render/GitHub Actions donde la red para Google Fonts este permitida, o en una validacion posterior autorizada.

## Riesgos

- El bloqueo global de trusted-origin cambia el comportamiento de mutaciones con cookies de sesion y sin `Origin`/`Referer`; esto es intencional para cerrar CSRF.
- Clientes no-browser autenticados con cookies que no manden `Origin`/`Referer` deberan adaptarse o usar un flujo sin cookie de sesion.
- `hasFile` reemplaza la inferencia frontend basada en `storagePath`; los consumidores externos que dependian de `storagePath` deben migrar.
- `pnpm security:public-surface` no pudo auditar assets compilados de `.next/static` localmente porque el build frontend sin red no se completo.

## Rollback

Para revertir este PR:

- Quitar el hook `requireTrustedOriginForFastify` de `server/fastify-app.ts`.
- Revertir `server/middlewares/trusted-origin.ts` al control previo por ruta.
- Quitar `serializeSafeReport` y restaurar serializers anteriores.
- Restaurar `storagePath` en tipos y contratos frontend si se necesitara volver al contrato anterior.
- Revertir tests y smoke contracts asociados.

## Estado final

- Cambios implementados en la rama `fix/security-trusted-origin-storagepath`.
- Validaciones principales de backend y contratos pasan.
- Build frontend local documentado como bloqueado por descarga de Google Fonts sin red.
- No se hizo `git add`.
- No se hizo commit.
- No se hizo push.
- No se creo PR.
- No se hizo merge.
