### PR TITLE
perf(admin): join session and user auth lookup

### DIFF
--- a/docs/pr-history/PR-perf-admin-auth-session-user-join.md
+++ b/docs/pr-history/PR-perf-admin-auth-session-user-join.md
@@ -1,0 +1,66 @@
+# PR: perf admin auth session user join
+
+## Resumen
+- `requireAdminAuth` ahora consulta sesion admin y usuario admin con un helper DB unico.
+- El helper `getAdminSessionWithUser(tokenHash)` hace JOIN entre `admin_sessions` y `admin_users` en una sola consulta.
+- Se conserva validacion de cookie, hash de token, expiracion, limpieza de cookie, revocacion inmediata y forma de `request.adminAuth`.
+- No se tocaron cookies, TTL, SameSite, CORS, trusted-origin, storagePath, CSP, WebAuthn ni schema DB.
+
+## Archivos tocados
+- `server/db.ts`
+- `server/middlewares/admin-auth.ts`
+- `server/lib/fastify-admin-auth.ts`
+- `server/routes/admin-clinics.fastify.ts`
+- `server/routes/admin-report-workflow.fastify.ts`
+- `server/routes/admin-users-roles.fastify.ts`
+- `test/admin-auth-middleware.test.ts`
+- `test/admin-auth-session-user-join-contract.test.ts`
+- `test/admin-clinics.fastify.test.ts`
+- `test/admin-users-roles.fastify.test.ts`
+- `test/admin-report-workflow.fastify.test.ts`
+- `test/admin-clinics-auth-contract.test.ts`
+- `test/security-session-cookie-boundaries.test.ts`
+- `docs/pr-history/PR-perf-admin-auth-session-user-join.md`
+
+## Implementacion realizada
+- Se agrego `getAdminSessionWithUser(tokenHash)` en `server/db.ts`.
+- El helper selecciona `session` y `adminUser` con `leftJoin(adminUsers, eq(adminSessions.adminUserId, adminUsers.id))`.
+- El `leftJoin` permite detectar sesiones huerfanas y mantener la revocacion inmediata con `deleteAdminSession` y `clearCookie`.
+- `requireAdminAuth` dejo de combinar `getAdminSessionByToken` + `getAdminUserById`.
+- El adaptador `authenticateFastifyAdmin` y sus rutas consumidoras ahora inyectan `getAdminSessionWithUser`.
+
+## Tests agregados/modificados
+- Contrato del helper: devuelve forma `session + adminUser`.
+- Contrato del helper: devuelve `null` si no hay fila para `tokenHash`.
+- Middleware: sin cookie.
+- Middleware: cookie invalida.
+- Middleware: sesion expirada.
+- Middleware: sesion valida.
+- Contrato anti-regresion: `requireAdminAuth` usa `getAdminSessionWithUser` y no combina helpers separados.
+- Builders de rutas Fastify admin actualizados al nuevo contrato.
+
+## Comandos ejecutados
+- Subconjunto dirigido auth/admin: PASS, 51/51.
+- `pnpm typecheck`: PASS.
+- `pnpm typecheck:test`: PASS.
+- `pnpm test`: PASS, 2145/2145.
+- `pnpm build`: PASS, `dist/index.js` generado por esbuild.
+- `pnpm security:public-surface`: PASS. Notas: `.next/static` ausente porque no se ejecuto build frontend; dos findings informativos `server-only` en `frontend/src/middleware.ts`.
+- `pnpm --dir frontend lint`: PASS con warning no fatal: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts`.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend build`: no ejecutado; no formaba parte de VALIDAR y se evito por la restriccion sobre Google Fonts/red.
+
+## Riesgos
+- Las rutas admin nativas que no usan `requireAdminAuth` conservan su flujo actual; este cambio apunta al middleware compartido pedido.
+- No hay cache de sesion ni usuario.
+- No hay migraciones ni cambios de schema.
+
+## Rollback
+- Revertir los archivos listados en "Archivos tocados".
+- No hay cambios de datos que revertir.
+- No se hizo `git add`, commit, push, PR ni merge.
+
+## Estado final
+- Implementacion completa.
+- Validaciones obligatorias en verde.
+- Cambios locales sin stagear.

--- a/server/db.ts
+++ b/server/db.ts
@@ -427,6 +427,47 @@ export async function createAdminSession(session: {
   return result[0];
 }
 
+export type AdminSessionWithUserRecord = {
+  session: {
+    id: number;
+    adminUserId: number;
+    tokenHash: string;
+    lastAccess: Date | null;
+    expiresAt: Date | null;
+    createdAt: Date;
+  };
+  adminUser: {
+    id: number;
+    username: string;
+  } | null;
+};
+
+export async function getAdminSessionWithUser(
+  tokenHash: string,
+): Promise<AdminSessionWithUserRecord | null> {
+  const result = await db
+    .select({
+      session: {
+        id: adminSessions.id,
+        adminUserId: adminSessions.adminUserId,
+        tokenHash: adminSessions.tokenHash,
+        lastAccess: adminSessions.lastAccess,
+        expiresAt: adminSessions.expiresAt,
+        createdAt: adminSessions.createdAt,
+      },
+      adminUser: {
+        id: adminUsers.id,
+        username: adminUsers.username,
+      },
+    })
+    .from(adminSessions)
+    .leftJoin(adminUsers, eq(adminSessions.adminUserId, adminUsers.id))
+    .where(eq(adminSessions.tokenHash, tokenHash))
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
 export async function getAdminSessionByToken(tokenHash: string) {
   const result = await db
     .select()

--- a/server/lib/fastify-admin-auth.ts
+++ b/server/lib/fastify-admin-auth.ts
@@ -6,16 +6,16 @@ import { ENV } from "./env.ts";
 
 export type FastifyAdminAuthDeps = {
   deleteAdminSession: (tokenHash: string) => Promise<void>;
-  getAdminSessionByToken: (
+  getAdminSessionWithUser: (
     tokenHash: string,
   ) => Promise<{
-    adminUserId: number;
-    expiresAt: Date | null;
-    lastAccess?: Date | null;
+    session: {
+      adminUserId: number;
+      expiresAt: Date | null;
+      lastAccess?: Date | null;
+    };
+    adminUser: { id: number; username: string } | null;
   } | null>;
-  getAdminUserById: (
-    adminUserId: number,
-  ) => Promise<{ id: number; username: string } | null>;
   updateAdminSessionLastAccess: (tokenHash: string) => Promise<void>;
   hashSessionToken: (token: string) => string;
   now: () => number;

--- a/server/middlewares/admin-auth.ts
+++ b/server/middlewares/admin-auth.ts
@@ -20,10 +20,16 @@ type AdminUserRecord = {
   username: string;
 };
 
+type AdminSessionWithUserRecord = {
+  session: AdminSessionRecord;
+  adminUser: AdminUserRecord | null;
+};
+
 type AdminAuthDeps = {
   deleteAdminSession: (tokenHash: string) => Promise<void>;
-  getAdminSessionByToken: (tokenHash: string) => Promise<AdminSessionRecord | null>;
-  getAdminUserById: (id: number) => Promise<AdminUserRecord | null>;
+  getAdminSessionWithUser: (
+    tokenHash: string,
+  ) => Promise<AdminSessionWithUserRecord | null>;
   updateAdminSessionLastAccess: (tokenHash: string) => Promise<void>;
   hashSessionToken: (token: string) => string;
   cookieName: string;
@@ -57,8 +63,7 @@ async function loadDefaultDeps(): Promise<AdminAuthDeps> {
 
       return {
         deleteAdminSession: db.deleteAdminSession,
-        getAdminSessionByToken: db.getAdminSessionByToken,
-        getAdminUserById: db.getAdminUserById,
+        getAdminSessionWithUser: db.getAdminSessionWithUser,
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         cookieName: envModule.ENV.adminCookieName,
@@ -92,14 +97,16 @@ export function createRequireAdminAuth(
       }
 
       const tokenHash = deps.hashSessionToken(token);
-      const session = await deps.getAdminSessionByToken(tokenHash);
+      const sessionWithUser = await deps.getAdminSessionWithUser(tokenHash);
 
-      if (!session) {
+      if (!sessionWithUser) {
         return res.status(401).json({
           success: false,
           error: "Sesión admin inválida",
         });
       }
+
+      const { session, adminUser } = sessionWithUser;
 
       if (session.expiresAt && session.expiresAt.getTime() <= deps.now()) {
         await deps.deleteAdminSession(tokenHash);
@@ -116,8 +123,6 @@ export function createRequireAdminAuth(
           error: "Sesión admin expirada",
         });
       }
-
-      const adminUser = await deps.getAdminUserById(session.adminUserId);
 
       if (!adminUser) {
         await deps.deleteAdminSession(tokenHash);

--- a/server/routes/admin-clinics.fastify.ts
+++ b/server/routes/admin-clinics.fastify.ts
@@ -34,6 +34,11 @@ type SessionAdminUserRecord = {
   username: string;
 };
 
+type AdminSessionWithUserRecord = {
+  session: AdminSessionRecord;
+  adminUser: SessionAdminUserRecord | null;
+};
+
 type AdminClinicsQuery = {
   limit?: string;
   offset?: string;
@@ -68,12 +73,9 @@ function getAllowedOrigins() {
 
 export type AdminClinicsNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
-  getAdminSessionByToken?: (
+  getAdminSessionWithUser?: (
     tokenHash: string,
-  ) => Promise<AdminSessionRecord | null>;
-  getAdminUserById?: (
-    adminUserId: number,
-  ) => Promise<SessionAdminUserRecord | null>;
+  ) => Promise<AdminSessionWithUserRecord | null>;
   updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
   hashSessionToken?: (token: string) => string;
   hashPassword?: (password: string) => Promise<string>;
@@ -99,8 +101,7 @@ type NativeAdminClinicsDeps = Required<
   Pick<
     AdminClinicsNativeRoutesOptions,
     | "deleteAdminSession"
-    | "getAdminSessionByToken"
-    | "getAdminUserById"
+    | "getAdminSessionWithUser"
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "hashPassword"
@@ -141,8 +142,7 @@ async function loadDefaultDeps(): Promise<NativeAdminClinicsDeps> {
 
       return {
         deleteAdminSession: db.deleteAdminSession,
-        getAdminSessionByToken: db.getAdminSessionByToken,
-        getAdminUserById: db.getAdminUserById,
+        getAdminSessionWithUser: db.getAdminSessionWithUser,
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         hashPassword: authSecurity.hashPassword,
@@ -663,8 +663,7 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
   async function resolveDeps(): Promise<NativeAdminClinicsDeps> {
     const hasAllInjectedDeps =
       !!options.deleteAdminSession &&
-      !!options.getAdminSessionByToken &&
-      !!options.getAdminUserById &&
+      !!options.getAdminSessionWithUser &&
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
       !!options.hashPassword &&
@@ -679,10 +678,9 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
     return {
       deleteAdminSession:
         options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
-      getAdminSessionByToken:
-        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
-      getAdminUserById:
-        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      getAdminSessionWithUser:
+        options.getAdminSessionWithUser ??
+        defaultDeps!.getAdminSessionWithUser,
       updateAdminSessionLastAccess:
         options.updateAdminSessionLastAccess ??
         defaultDeps!.updateAdminSessionLastAccess,

--- a/server/routes/admin-report-workflow.fastify.ts
+++ b/server/routes/admin-report-workflow.fastify.ts
@@ -28,6 +28,11 @@ type AuthenticatedAdminUser = {
   username: string;
 };
 
+type AdminSessionWithUserRecord = {
+  session: AdminSessionRecord;
+  adminUser: AuthenticatedAdminUser | null;
+};
+
 type WorkflowQuery = {
   limit?: unknown;
   offset?: unknown;
@@ -39,12 +44,9 @@ type WorkflowParams = {
 
 export type AdminReportWorkflowNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
-  getAdminSessionByToken?: (
+  getAdminSessionWithUser?: (
     tokenHash: string,
-  ) => Promise<AdminSessionRecord | null>;
-  getAdminUserById?: (
-    adminUserId: number,
-  ) => Promise<AuthenticatedAdminUser | null>;
+  ) => Promise<AdminSessionWithUserRecord | null>;
   updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
   hashSessionToken?: (token: string) => string;
   listAdminReportWorkflowItems?: (input: {
@@ -72,8 +74,7 @@ type NativeAdminReportWorkflowDeps = Required<
   Pick<
     AdminReportWorkflowNativeRoutesOptions,
     | "deleteAdminSession"
-    | "getAdminSessionByToken"
-    | "getAdminUserById"
+    | "getAdminSessionWithUser"
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "listAdminReportWorkflowItems"
@@ -96,8 +97,7 @@ async function loadDefaultDeps(): Promise<NativeAdminReportWorkflowDeps> {
 
       return {
         deleteAdminSession: db.deleteAdminSession,
-        getAdminSessionByToken: db.getAdminSessionByToken,
-        getAdminUserById: db.getAdminUserById,
+        getAdminSessionWithUser: db.getAdminSessionWithUser,
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         listAdminReportWorkflowItems: workflow.listAdminReportWorkflowItems,
@@ -279,8 +279,7 @@ export const adminReportWorkflowNativeRoutes: FastifyPluginAsync<
   async function resolveDeps(): Promise<NativeAdminReportWorkflowDeps> {
     const hasAllInjectedDeps =
       !!options.deleteAdminSession &&
-      !!options.getAdminSessionByToken &&
-      !!options.getAdminUserById &&
+      !!options.getAdminSessionWithUser &&
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
       !!options.listAdminReportWorkflowItems &&
@@ -293,10 +292,9 @@ export const adminReportWorkflowNativeRoutes: FastifyPluginAsync<
     return {
       deleteAdminSession:
         options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
-      getAdminSessionByToken:
-        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
-      getAdminUserById:
-        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      getAdminSessionWithUser:
+        options.getAdminSessionWithUser ??
+        defaultDeps!.getAdminSessionWithUser,
       updateAdminSessionLastAccess:
         options.updateAdminSessionLastAccess ??
         defaultDeps!.updateAdminSessionLastAccess,
@@ -325,8 +323,7 @@ export const adminReportWorkflowNativeRoutes: FastifyPluginAsync<
   ) {
     return authenticateFastifyAdmin(request, reply, {
       deleteAdminSession: deps.deleteAdminSession,
-      getAdminSessionByToken: deps.getAdminSessionByToken,
-      getAdminUserById: deps.getAdminUserById,
+      getAdminSessionWithUser: deps.getAdminSessionWithUser,
       updateAdminSessionLastAccess: deps.updateAdminSessionLastAccess,
       hashSessionToken: deps.hashSessionToken,
       now,

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -36,6 +36,11 @@ type SessionAdminUserRecord = {
   username: string;
 };
 
+type AdminSessionWithUserRecord = {
+  session: AdminSessionRecord;
+  adminUser: SessionAdminUserRecord | null;
+};
+
 type AuthenticatedAdminUser = {
   id: number;
   username: string;
@@ -67,12 +72,9 @@ type AdminUsersRolesCredentialsChangeBody = {
 
 export type AdminUsersRolesNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
-  getAdminSessionByToken?: (
+  getAdminSessionWithUser?: (
     tokenHash: string,
-  ) => Promise<AdminSessionRecord | null>;
-  getAdminUserById?: (
-    adminUserId: number,
-  ) => Promise<SessionAdminUserRecord | null>;
+  ) => Promise<AdminSessionWithUserRecord | null>;
   updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
   hashSessionToken?: (token: string) => string;
   getAdminUsersRolesSnapshot?: (
@@ -93,8 +95,7 @@ type NativeAdminUsersRolesDeps = Required<
   Pick<
     AdminUsersRolesNativeRoutesOptions,
     | "deleteAdminSession"
-    | "getAdminSessionByToken"
-    | "getAdminUserById"
+    | "getAdminSessionWithUser"
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "getAdminUsersRolesSnapshot"
@@ -118,8 +119,7 @@ async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
 
       return {
         deleteAdminSession: db.deleteAdminSession,
-        getAdminSessionByToken: db.getAdminSessionByToken,
-        getAdminUserById: db.getAdminUserById,
+        getAdminSessionWithUser: db.getAdminSessionWithUser,
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         getAdminUsersRolesSnapshot: usersRoles.getAdminUsersRolesSnapshot,
@@ -232,8 +232,7 @@ async function authenticateAdminUser(
 ): Promise<AuthenticatedAdminUser | null> {
   return authenticateFastifyAdmin(request, reply, {
     deleteAdminSession: deps.deleteAdminSession,
-    getAdminSessionByToken: deps.getAdminSessionByToken,
-    getAdminUserById: deps.getAdminUserById,
+    getAdminSessionWithUser: deps.getAdminSessionWithUser,
     updateAdminSessionLastAccess: deps.updateAdminSessionLastAccess,
     hashSessionToken: deps.hashSessionToken,
     now,
@@ -543,8 +542,7 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
   async function resolveDeps(): Promise<NativeAdminUsersRolesDeps> {
     const hasAllInjectedDeps =
       !!options.deleteAdminSession &&
-      !!options.getAdminSessionByToken &&
-      !!options.getAdminUserById &&
+      !!options.getAdminSessionWithUser &&
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
       !!options.getAdminUsersRolesSnapshot &&
@@ -558,10 +556,9 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
     return {
       deleteAdminSession:
         options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
-      getAdminSessionByToken:
-        options.getAdminSessionByToken ?? defaultDeps!.getAdminSessionByToken,
-      getAdminUserById:
-        options.getAdminUserById ?? defaultDeps!.getAdminUserById,
+      getAdminSessionWithUser:
+        options.getAdminSessionWithUser ??
+        defaultDeps!.getAdminSessionWithUser,
       updateAdminSessionLastAccess:
         options.updateAdminSessionLastAccess ??
         defaultDeps!.updateAdminSessionLastAccess,

--- a/test/admin-auth-middleware.test.ts
+++ b/test/admin-auth-middleware.test.ts
@@ -1,5 +1,7 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
 process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
@@ -10,6 +12,13 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { createRequireAdminAuth } = await import(
   "../server/middlewares/admin-auth.ts"
 );
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
 
 function createMockResponse() {
   return {
@@ -34,8 +43,7 @@ function createMockResponse() {
 function createDeps(
   overrides?: Partial<{
     deleteAdminSession: (tokenHash: string) => Promise<void>;
-    getAdminSessionByToken: (tokenHash: string) => Promise<any>;
-    getAdminUserById: (id: number) => Promise<any>;
+    getAdminSessionWithUser: (tokenHash: string) => Promise<any>;
     updateAdminSessionLastAccess: (tokenHash: string) => Promise<void>;
     hashSessionToken: (token: string) => string;
     cookieName: string;
@@ -46,8 +54,7 @@ function createDeps(
 ) {
   const calls = {
     deleteAdminSession: [] as string[],
-    getAdminSessionByToken: [] as string[],
-    getAdminUserById: [] as number[],
+    getAdminSessionWithUser: [] as string[],
     updateAdminSessionLastAccess: [] as string[],
     hashSessionToken: [] as string[],
   };
@@ -56,12 +63,8 @@ function createDeps(
     deleteAdminSession: async (tokenHash: string) => {
       calls.deleteAdminSession.push(tokenHash);
     },
-    getAdminSessionByToken: async (tokenHash: string) => {
-      calls.getAdminSessionByToken.push(tokenHash);
-      return null;
-    },
-    getAdminUserById: async (id: number) => {
-      calls.getAdminUserById.push(id);
+    getAdminSessionWithUser: async (tokenHash: string) => {
+      calls.getAdminSessionWithUser.push(tokenHash);
       return null;
     },
     updateAdminSessionLastAccess: async (tokenHash: string) => {
@@ -107,7 +110,7 @@ test("requireAdminAuth responde 401 cuando no hay cookie", async () => {
   assert.deepEqual(calls.hashSessionToken, []);
 });
 
-test("requireAdminAuth responde 401 cuando la sesión no existe", async () => {
+test("requireAdminAuth responde 401 cuando la cookie es inválida", async () => {
   const { deps, calls } = createDeps();
   const middleware = createRequireAdminAuth(deps as any);
 
@@ -127,7 +130,7 @@ test("requireAdminAuth responde 401 cuando la sesión no existe", async () => {
   );
 
   assert.deepEqual(calls.hashSessionToken, ["raw-admin-token"]);
-  assert.deepEqual(calls.getAdminSessionByToken, ["hashed:raw-admin-token"]);
+  assert.deepEqual(calls.getAdminSessionWithUser, ["hashed:raw-admin-token"]);
   assert.equal(res.statusCode, 401);
   assert.deepEqual(res.jsonPayload, {
     success: false,
@@ -138,12 +141,18 @@ test("requireAdminAuth responde 401 cuando la sesión no existe", async () => {
 
 test("requireAdminAuth elimina y limpia cookie cuando la sesión expiró", async () => {
   const { deps, calls } = createDeps({
-    getAdminSessionByToken: async (tokenHash: string) => {
-      calls.getAdminSessionByToken.push(tokenHash);
+    getAdminSessionWithUser: async (tokenHash: string) => {
+      calls.getAdminSessionWithUser.push(tokenHash);
       return {
-        adminUserId: 77,
-        expiresAt: new Date("2026-04-21T11:59:59.000Z"),
-        lastAccess: null,
+        session: {
+          adminUserId: 77,
+          expiresAt: new Date("2026-04-21T11:59:59.000Z"),
+          lastAccess: null,
+        },
+        adminUser: {
+          id: 77,
+          username: "ADMIN",
+        },
       };
     },
   });
@@ -186,17 +195,16 @@ test("requireAdminAuth elimina y limpia cookie cuando la sesión expiró", async
 
 test("requireAdminAuth elimina sesión cuando el usuario admin no existe", async () => {
   const { deps, calls } = createDeps({
-    getAdminSessionByToken: async (tokenHash: string) => {
-      calls.getAdminSessionByToken.push(tokenHash);
+    getAdminSessionWithUser: async (tokenHash: string) => {
+      calls.getAdminSessionWithUser.push(tokenHash);
       return {
-        adminUserId: 88,
-        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
-        lastAccess: null,
+        session: {
+          adminUserId: 88,
+          expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+          lastAccess: null,
+        },
+        adminUser: null,
       };
-    },
-    getAdminUserById: async (id: number) => {
-      calls.getAdminUserById.push(id);
-      return null;
     },
   });
 
@@ -217,7 +225,7 @@ test("requireAdminAuth elimina sesión cuando el usuario admin no existe", async
     ((error?: unknown) => nextCalls.push(error)) as any,
   );
 
-  assert.deepEqual(calls.getAdminUserById, [88]);
+  assert.deepEqual(calls.getAdminSessionWithUser, ["hashed:token-sin-usuario"]);
   assert.deepEqual(calls.deleteAdminSession, ["hashed:token-sin-usuario"]);
   assert.equal(res.clearedCookies.length, 1);
   assert.equal(res.statusCode, 401);
@@ -230,19 +238,18 @@ test("requireAdminAuth elimina sesión cuando el usuario admin no existe", async
 
 test("requireAdminAuth autentica y refresca lastAccess cuando corresponde", async () => {
   const { deps, calls } = createDeps({
-    getAdminSessionByToken: async (tokenHash: string) => {
-      calls.getAdminSessionByToken.push(tokenHash);
+    getAdminSessionWithUser: async (tokenHash: string) => {
+      calls.getAdminSessionWithUser.push(tokenHash);
       return {
-        adminUserId: 99,
-        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
-        lastAccess: new Date("2026-04-21T11:00:00.000Z"),
-      };
-    },
-    getAdminUserById: async (id: number) => {
-      calls.getAdminUserById.push(id);
-      return {
-        id,
-        username: "VETNEB",
+        session: {
+          adminUserId: 99,
+          expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+          lastAccess: new Date("2026-04-21T11:00:00.000Z"),
+        },
+        adminUser: {
+          id: 99,
+          username: "VETNEB",
+        },
       };
     },
   });
@@ -277,19 +284,18 @@ test("requireAdminAuth autentica y refresca lastAccess cuando corresponde", asyn
 
 test("requireAdminAuth autentica sin refrescar lastAccess si aún no corresponde", async () => {
   const { deps, calls } = createDeps({
-    getAdminSessionByToken: async (tokenHash: string) => {
-      calls.getAdminSessionByToken.push(tokenHash);
+    getAdminSessionWithUser: async (tokenHash: string) => {
+      calls.getAdminSessionWithUser.push(tokenHash);
       return {
-        adminUserId: 44,
-        expiresAt: new Date("2026-04-21T13:00:00.000Z"),
-        lastAccess: new Date("2026-04-21T11:55:00.000Z"),
-      };
-    },
-    getAdminUserById: async (id: number) => {
-      calls.getAdminUserById.push(id);
-      return {
-        id,
-        username: "ADMIN",
+        session: {
+          adminUserId: 44,
+          expiresAt: new Date("2026-04-21T13:00:00.000Z"),
+          lastAccess: new Date("2026-04-21T11:55:00.000Z"),
+        },
+        adminUser: {
+          id: 44,
+          username: "ADMIN",
+        },
       };
     },
   });
@@ -324,7 +330,7 @@ test("requireAdminAuth propaga errores inesperados a next", async () => {
   const expectedError = new Error("fallo db");
 
   const { deps } = createDeps({
-    getAdminSessionByToken: async () => {
+    getAdminSessionWithUser: async () => {
       throw expectedError;
     },
   });
@@ -349,4 +355,20 @@ test("requireAdminAuth propaga errores inesperados a next", async () => {
   assert.equal(res.statusCode, 200);
   assert.equal(res.jsonPayload, undefined);
   assert.deepEqual(nextCalls, [expectedError]);
+});
+
+test("requireAdminAuth usa getAdminSessionWithUser y no combina helpers separados", () => {
+  const source = readSource("server/middlewares/admin-auth.ts");
+  const fnStart = source.indexOf("return async function requireAdminAuth");
+  const fnEnd = source.indexOf("} catch", fnStart);
+  const fnBody = source.slice(fnStart, fnEnd);
+
+  assert.ok(
+    source.includes("getAdminSessionWithUser: db.getAdminSessionWithUser"),
+  );
+  assert.ok(fnBody.includes("deps.getAdminSessionWithUser(tokenHash)"));
+  assert.equal(fnBody.includes("deps.getAdminSessionByToken"), false);
+  assert.equal(fnBody.includes("deps.getAdminUserById"), false);
+  assert.equal(fnBody.includes("getAdminSessionByToken"), false);
+  assert.equal(fnBody.includes("getAdminUserById"), false);
 });

--- a/test/admin-auth-session-user-join-contract.test.ts
+++ b/test/admin-auth-session-user-join-contract.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function getExportedFunctionBody(source: string, name: string): string {
+  const fnStart = source.indexOf(`export async function ${name}(`);
+  assert.ok(fnStart >= 0, `${name} debe estar exportada`);
+
+  const fnEnd = source.indexOf("\nexport ", fnStart + 1);
+  return source.slice(fnStart, fnEnd === -1 ? source.length : fnEnd);
+}
+
+test("getAdminSessionWithUser devuelve sesión+usuario con JOIN admin_sessions + admin_users", () => {
+  const source = readSource("server/db.ts");
+  const fnBody = getExportedFunctionBody(source, "getAdminSessionWithUser");
+
+  assert.ok(fnBody.includes(".select({"));
+  assert.ok(fnBody.includes("session: {"));
+  assert.ok(fnBody.includes("id: adminSessions.id"));
+  assert.ok(fnBody.includes("adminUserId: adminSessions.adminUserId"));
+  assert.ok(fnBody.includes("tokenHash: adminSessions.tokenHash"));
+  assert.ok(fnBody.includes("lastAccess: adminSessions.lastAccess"));
+  assert.ok(fnBody.includes("expiresAt: adminSessions.expiresAt"));
+  assert.ok(fnBody.includes("adminUser: {"));
+  assert.ok(fnBody.includes("id: adminUsers.id"));
+  assert.ok(fnBody.includes("username: adminUsers.username"));
+  assert.ok(fnBody.includes(".from(adminSessions)"));
+  assert.ok(
+    fnBody.includes(
+      ".leftJoin(adminUsers, eq(adminSessions.adminUserId, adminUsers.id))",
+    ),
+  );
+  assert.ok(fnBody.includes(".where(eq(adminSessions.tokenHash, tokenHash))"));
+  assert.ok(fnBody.includes(".limit(1)"));
+});
+
+test("getAdminSessionWithUser devuelve null si no existe sesión para tokenHash", () => {
+  const source = readSource("server/db.ts");
+  const fnBody = getExportedFunctionBody(source, "getAdminSessionWithUser");
+
+  assert.ok(fnBody.includes("return result[0] ?? null;"));
+});

--- a/test/admin-clinics-auth-contract.test.ts
+++ b/test/admin-clinics-auth-contract.test.ts
@@ -24,7 +24,7 @@ test("admin clinics route authenticates through requireAdminAuth adapter", () =>
   assert.ok(routeSource.includes("authenticateFastifyAdmin(request, reply"));
   assert.ok(adapterSource.includes("createRequireAdminAuth"));
   assert.ok(adapterSource.includes("ENV.adminCookieName"));
-  assert.ok(adapterSource.includes("getAdminSessionByToken"));
+  assert.ok(adapterSource.includes("getAdminSessionWithUser"));
 });
 
 test("admin users credentials route keeps admin auth before mutation", () => {

--- a/test/admin-clinics.fastify.test.ts
+++ b/test/admin-clinics.fastify.test.ts
@@ -52,15 +52,17 @@ function buildDeps(
 ): AdminClinicsNativeRoutesOptions {
   return {
     deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => ({
-      id: 1,
-      adminUserId: 1,
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-      lastAccess: new Date("2026-05-07T00:00:00.000Z"),
-    }),
-    getAdminUserById: async () => ({
-      id: 1,
-      username: "VETNEB",
+    getAdminSessionWithUser: async () => ({
+      session: {
+        id: 1,
+        adminUserId: 1,
+        expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+        lastAccess: new Date("2026-05-07T00:00:00.000Z"),
+      },
+      adminUser: {
+        id: 1,
+        username: "VETNEB",
+      },
     }),
     updateAdminSessionLastAccess: async () => {},
     hashSessionToken: (token: string) => `hash:${token}`,
@@ -97,7 +99,7 @@ test("admin clinics requiere sesión admin", async () => {
   await app.register(
     adminClinicsNativeRoutes,
     buildDeps({
-      getAdminSessionByToken: async () => null,
+      getAdminSessionWithUser: async () => null,
     }),
   );
 

--- a/test/admin-report-workflow.fastify.test.ts
+++ b/test/admin-report-workflow.fastify.test.ts
@@ -47,12 +47,14 @@ function buildDeps(
 ): AdminReportWorkflowNativeRoutesOptions {
   return {
     deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => ({
-      adminUserId: 1,
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-      lastAccess: new Date("2026-05-20T09:00:00.000Z"),
+    getAdminSessionWithUser: async () => ({
+      session: {
+        adminUserId: 1,
+        expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+        lastAccess: new Date("2026-05-20T09:00:00.000Z"),
+      },
+      adminUser: { id: 1, username: "ADMIN" },
     }),
-    getAdminUserById: async () => ({ id: 1, username: "ADMIN" }),
     updateAdminSessionLastAccess: async () => {},
     hashSessionToken: (token: string) => `hash:${token}`,
     listAdminReportWorkflowItems: async () => [createWorkflowItem()],
@@ -93,7 +95,7 @@ const adminHeaders = {
 
 test("admin report workflow requiere autenticación admin para lectura y mutación", async () => {
   const app = await createApp({
-    getAdminSessionByToken: async () => null,
+    getAdminSessionWithUser: async () => null,
   });
 
   try {

--- a/test/admin-users-roles.fastify.test.ts
+++ b/test/admin-users-roles.fastify.test.ts
@@ -52,15 +52,17 @@ function buildDeps(
 ): AdminUsersRolesNativeRoutesOptions {
   return {
     deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => ({
-      id: 1,
-      adminUserId: 1,
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-      lastAccess: new Date("2026-05-07T00:00:00.000Z"),
-    }),
-    getAdminUserById: async () => ({
-      id: 1,
-      username: "VETNEB",
+    getAdminSessionWithUser: async () => ({
+      session: {
+        id: 1,
+        adminUserId: 1,
+        expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+        lastAccess: new Date("2026-05-07T00:00:00.000Z"),
+      },
+      adminUser: {
+        id: 1,
+        username: "VETNEB",
+      },
     }),
     updateAdminSessionLastAccess: async () => {},
     hashSessionToken: (token: string) => `hash:${token}`,
@@ -103,7 +105,7 @@ test("admin users roles requiere sesión admin", async () => {
   await app.register(
     adminUsersRolesNativeRoutes,
     buildDeps({
-      getAdminSessionByToken: async () => null,
+      getAdminSessionWithUser: async () => null,
     }),
   );
 

--- a/test/security-session-cookie-boundaries.test.ts
+++ b/test/security-session-cookie-boundaries.test.ts
@@ -216,7 +216,7 @@ test("session lookup hash delete and clear-cookie flows stay domain specific", (
         `${ADMIN_FASTIFY_AUTH_ADAPTER_FILE} admin clear cookie header`,
       );
       assertContains(middlewareSource, "hashSessionToken(token)", `${ADMIN_AUTH_MIDDLEWARE_FILE} hashes admin session token`);
-      assertContains(middlewareSource, "getAdminSessionByToken", `${ADMIN_AUTH_MIDDLEWARE_FILE} admin session lookup`);
+      assertContains(middlewareSource, "getAdminSessionWithUser", `${ADMIN_AUTH_MIDDLEWARE_FILE} admin session lookup`);
       assertContains(middlewareSource, "deleteAdminSession", `${ADMIN_AUTH_MIDDLEWARE_FILE} admin session delete`);
       assertContains(middlewareSource, "session.expiresAt", `${ADMIN_AUTH_MIDDLEWARE_FILE} admin expiration check`);
       continue;


### PR DESCRIPTION
# PR: perf admin auth session user join

## Resumen
- `requireAdminAuth` ahora consulta sesion admin y usuario admin con un helper DB unico.
- El helper `getAdminSessionWithUser(tokenHash)` hace JOIN entre `admin_sessions` y `admin_users` en una sola consulta.
- Se conserva validacion de cookie, hash de token, expiracion, limpieza de cookie, revocacion inmediata y forma de `request.adminAuth`.
- No se tocaron cookies, TTL, SameSite, CORS, trusted-origin, storagePath, CSP, WebAuthn ni schema DB.

## Archivos tocados
- `server/db.ts`
- `server/middlewares/admin-auth.ts`
- `server/lib/fastify-admin-auth.ts`
- `server/routes/admin-clinics.fastify.ts`
- `server/routes/admin-report-workflow.fastify.ts`
- `server/routes/admin-users-roles.fastify.ts`
- `test/admin-auth-middleware.test.ts`
- `test/admin-auth-session-user-join-contract.test.ts`
- `test/admin-clinics.fastify.test.ts`
- `test/admin-users-roles.fastify.test.ts`
- `test/admin-report-workflow.fastify.test.ts`
- `test/admin-clinics-auth-contract.test.ts`
- `test/security-session-cookie-boundaries.test.ts`
- `docs/pr-history/PR-perf-admin-auth-session-user-join.md`

## Implementacion realizada
- Se agrego `getAdminSessionWithUser(tokenHash)` en `server/db.ts`.
- El helper selecciona `session` y `adminUser` con `leftJoin(adminUsers, eq(adminSessions.adminUserId, adminUsers.id))`.
- El `leftJoin` permite detectar sesiones huerfanas y mantener la revocacion inmediata con `deleteAdminSession` y `clearCookie`.
- `requireAdminAuth` dejo de combinar `getAdminSessionByToken` + `getAdminUserById`.
- El adaptador `authenticateFastifyAdmin` y sus rutas consumidoras ahora inyectan `getAdminSessionWithUser`.

## Tests agregados/modificados
- Contrato del helper: devuelve forma `session + adminUser`.
- Contrato del helper: devuelve `null` si no hay fila para `tokenHash`.
- Middleware: sin cookie.
- Middleware: cookie invalida.
- Middleware: sesion expirada.
- Middleware: sesion valida.
- Contrato anti-regresion: `requireAdminAuth` usa `getAdminSessionWithUser` y no combina helpers separados.
- Builders de rutas Fastify admin actualizados al nuevo contrato.

## Comandos ejecutados
- Subconjunto dirigido auth/admin: PASS, 51/51.
- `pnpm typecheck`: PASS.
- `pnpm typecheck:test`: PASS.
- `pnpm test`: PASS, 2145/2145.
- `pnpm build`: PASS, `dist/index.js` generado por esbuild.
- `pnpm security:public-surface`: PASS. Notas: `.next/static` ausente porque no se ejecuto build frontend; dos findings informativos `server-only` en `frontend/src/middleware.ts`.
- `pnpm --dir frontend lint`: PASS con warning no fatal: unused eslint-disable en `frontend/src/app/api/security/csp-report/route.ts`.
- `pnpm --dir frontend typecheck`: PASS.
- `pnpm --dir frontend build`: no ejecutado; no formaba parte de VALIDAR y se evito por la restriccion sobre Google Fonts/red.

## Riesgos
- Las rutas admin nativas que no usan `requireAdminAuth` conservan su flujo actual; este cambio apunta al middleware compartido pedido.
- No hay cache de sesion ni usuario.
- No hay migraciones ni cambios de schema.

## Rollback
- Revertir los archivos listados en "Archivos tocados".
- No hay cambios de datos que revertir.
- No se hizo `git add`, commit, push, PR ni merge.

## Estado final
- Implementacion completa.
- Validaciones obligatorias en verde.
- Cambios locales sin stagear.
