### PR TITLE
perf(reports): use lazy signed URLs

### DIFF
--- a/docs/pr-history/PR-perf-reports-lazy-signed-urls.md
+++ b/docs/pr-history/PR-perf-reports-lazy-signed-urls.md
@@ -1,0 +1,65 @@
+﻿# PR: perf(reports): lazy signed URLs
+
+## Resumen
+- Elimina generación eager de `previewUrl` y `downloadUrl` en payloads internos de reportes.
+- Mantiene `hasFile` como indicador seguro para frontend.
+- Mantiene endpoints bajo demanda `preview-url` y `download-url` para Ver informe / Descargar.
+- Mantiene intacto el flujo público/particular `public-report-access`, donde las URLs firmadas son parte del contrato.
+
+## Archivos tocados
+- server/routes/reports.fastify.ts
+- server/routes/admin-reports.fastify.ts
+- server/routes/reports-status.fastify.ts
+- test/reports.fastify.test.ts
+- test/admin-reports.fastify.test.ts
+- test/reports-status.fastify.test.ts
+- test/auth-authorization-integration.fastify.test.ts
+- test/report-write-surface-ownership.test.ts
+
+## Implementación
+- `reports.fastify.ts`: los listados `/api/reports` y `/api/reports/search` ahora serializan con `serializeSafeReport`.
+- `admin-reports.fastify.ts`: la respuesta de upload admin ya no embebe URLs firmadas eager.
+- `reports-status.fastify.ts`: la respuesta de actualización de estado ya no embebe URLs firmadas eager.
+- Los endpoints dedicados `preview-url` y `download-url` siguen generando URLs firmadas bajo demanda.
+
+## Tests
+- Actualizados contratos para confirmar ausencia de `previewUrl` / `downloadUrl` eager.
+- Se mantiene `hasFile`.
+- Se mantiene bloqueo de `storagePath` en payloads.
+- Se conserva el flujo de endpoints bajo demanda.
+
+## Comandos ejecutados
+- node --experimental-strip-types --experimental-specifier-resolution=node --test test/reports.fastify.test.ts test/admin-reports.fastify.test.ts test/reports-status.fastify.test.ts test/auth-authorization-integration.fastify.test.ts test/report-write-surface-ownership.test.ts
+- pnpm typecheck
+- pnpm typecheck:test
+- pnpm test
+- pnpm build
+- pnpm security:public-surface
+- pnpm --dir frontend lint
+- pnpm --dir frontend typecheck
+
+## Resultados
+- Tests dirigidos: PASS
+- pnpm typecheck: PASS
+- pnpm typecheck:test: PASS
+- pnpm test: PASS, 2145 pass, 0 fail
+- pnpm build: PASS
+- pnpm security:public-surface: PASS
+- pnpm --dir frontend lint: PASS con 1 warning preexistente en `frontend/src/app/api/security/csp-report/route.ts`
+- pnpm --dir frontend typecheck: PASS
+- No se ejecutó `pnpm --dir frontend build` por restricción de red/Google Fonts.
+
+## Riesgos
+- Bajo: el frontend ya usa endpoints bajo demanda para Ver informe y Descargar.
+- Bajo: `public-report-access` no se modifica.
+- Bajo: no cambia auth, cookies, CORS, CSRF, CSP, DB schema ni índices.
+
+## Rollback
+- Revertir el commit del PR.
+- Eso restauraría `previewUrl` / `downloadUrl` eager en payloads internos.
+
+## Estado final
+- Validación local completa en PASS.
+- Sin cambios de schema.
+- Sin migraciones.
+- Sin cambios de seguridad/autenticación.

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -727,20 +727,8 @@ async function createReportDeliveredNotificationSafely(
   }
 }
 
-async function serializeReport(report: Report, deps: NativeAdminReportsDeps) {
-  const [previewUrl, downloadUrl] = await Promise.all([
-    deps.createSignedReportUrl(report.storagePath),
-    deps.createSignedReportDownloadUrl(
-      report.storagePath,
-      report.fileName ?? undefined,
-    ),
-  ]);
-
-  return {
-    ...serializeSafeReport(report),
-    previewUrl,
-    downloadUrl,
-  };
+function serializeReport(report: Report, _deps: NativeAdminReportsDeps) {
+  return serializeSafeReport(report);
 }
 
 export const adminReportsNativeRoutes: FastifyPluginAsync<

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -531,20 +531,8 @@ async function getAuthorizedReport(
   };
 }
 
-async function serializeReport(report: Report, deps: NativeReportsStatusDeps) {
-  const [previewUrl, downloadUrl] = await Promise.all([
-    deps.createSignedReportUrl(report.storagePath),
-    deps.createSignedReportDownloadUrl(
-      report.storagePath,
-      report.fileName ?? undefined,
-    ),
-  ]);
-
-  return {
-    ...serializeSafeReport(report),
-    previewUrl,
-    downloadUrl,
-  };
+function serializeReport(report: Report, _deps: NativeReportsStatusDeps) {
+  return serializeSafeReport(report);
 }
 
 export const reportsStatusNativeRoutes: FastifyPluginAsync<

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -431,24 +431,8 @@ async function authenticateClinicUser(
   };
 }
 
-async function serializeReport(report: Report, deps: NativeReportsDeps) {
-  const [previewUrl, downloadUrl] = await Promise.all([
-    deps.createSignedReportUrl(report.storagePath),
-    deps.createSignedReportDownloadUrl(
-      report.storagePath,
-      report.fileName ?? undefined,
-    ),
-  ]);
-
-  return {
-    ...serializeSafeReport(report),
-    previewUrl,
-    downloadUrl,
-  };
-}
-
-async function serializeReports(reports: Report[], deps: NativeReportsDeps) {
-  return Promise.all(reports.map((report) => serializeReport(report, deps)));
+function serializeReports(reports: Report[], _deps: NativeReportsDeps) {
+  return reports.map((report) => serializeSafeReport(report));
 }
 
 async function getAuthorizedReport(

--- a/test/admin-reports.fastify.test.ts
+++ b/test/admin-reports.fastify.test.ts
@@ -491,11 +491,10 @@ test("adminReportsNativeRoutes crea POST /upload con clinicId explicito y metada
     assert.equal(body.report.hasFile, true);
     assert.equal(body.report.storagePath, undefined);
     assert.equal(response.body.includes("storagePath"), false);
-    assert.equal(body.report.previewUrl, "signed-preview:reports/3/luna-report.pdf");
-    assert.equal(
-      body.report.downloadUrl,
-      "signed-download:reports/3/luna-report.pdf:luna-report.pdf",
-    );
+    assert.equal(body.report.previewUrl, undefined);
+    assert.equal(body.report.downloadUrl, undefined);
+    assert.equal(response.body.includes("previewUrl"), false);
+    assert.equal(response.body.includes("downloadUrl"), false);
   } finally {
     await app.close();
   }

--- a/test/auth-authorization-integration.fastify.test.ts
+++ b/test/auth-authorization-integration.fastify.test.ts
@@ -246,8 +246,10 @@ test("auth integration permite usar cookie de login en endpoint protegido y resp
     assert.equal(reportsBody.success, true);
     assert.equal(reportsBody.count, 1);
     assert.equal(reportsBody.reports[0].id, 55);
-    assert.equal(reportsBody.reports[0].previewUrl, "preview:reports/3/luna.pdf");
-    assert.equal(reportsBody.reports[0].downloadUrl, "download:reports/3/luna.pdf:luna.pdf");
+    assert.equal(reportsBody.reports[0].previewUrl, undefined);
+    assert.equal(reportsBody.reports[0].downloadUrl, undefined);
+    assert.equal(reportsResponse.body.includes("previewUrl"), false);
+    assert.equal(reportsResponse.body.includes("downloadUrl"), false);
 
     assert.deepEqual(reportCalls, [
       {

--- a/test/report-write-surface-ownership.test.ts
+++ b/test/report-write-surface-ownership.test.ts
@@ -306,7 +306,8 @@ test("admin autenticado puede subir informe y queda como owner de escritura", as
     const body = JSON.parse(response.body);
     assert.equal(body.success, true);
     assert.equal(body.report.clinicId, 3);
-    assert.equal(body.report.previewUrl, "signed-preview:reports/3/luna-report.pdf");
+    assert.equal(body.report.previewUrl, undefined);
+    assert.equal(response.body.includes("previewUrl"), false);
   } finally {
     await app.close();
   }

--- a/test/reports-status.fastify.test.ts
+++ b/test/reports-status.fastify.test.ts
@@ -134,11 +134,10 @@ test("reportsStatusNativeRoutes actualiza PATCH /:reportId/status y escribe audi
     assert.equal(body.report.hasFile, true);
     assert.equal(body.report.storagePath, undefined);
     assert.equal(response.body.includes("storagePath"), false);
-    assert.equal(body.report.previewUrl, "preview:reports/3/luna.pdf");
-    assert.equal(
-      body.report.downloadUrl,
-      "download:reports/3/luna.pdf:luna.pdf",
-    );
+    assert.equal(body.report.previewUrl, undefined);
+    assert.equal(body.report.downloadUrl, undefined);
+    assert.equal(response.body.includes("previewUrl"), false);
+    assert.equal(response.body.includes("downloadUrl"), false);
   } finally {
     await app.close();
   }

--- a/test/reports.fastify.test.ts
+++ b/test/reports.fastify.test.ts
@@ -158,11 +158,10 @@ test("reportsNativeRoutes expone GET / con lista clinic-scoped", async () => {
     assert.equal(body.reports[0].hasFile, true);
     assert.equal(body.reports[0].storagePath, undefined);
     assert.equal(response.body.includes("storagePath"), false);
-    assert.equal(body.reports[0].previewUrl, "preview:reports/3/luna.pdf");
-    assert.equal(
-      body.reports[0].downloadUrl,
-      "download:reports/3/luna.pdf:luna.pdf",
-    );
+    assert.equal(body.reports[0].previewUrl, undefined);
+    assert.equal(body.reports[0].downloadUrl, undefined);
+    assert.equal(response.body.includes("previewUrl"), false);
+    assert.equal(response.body.includes("downloadUrl"), false);
     assert.equal(body.filters.status, "ready");
     assert.equal(body.pagination.limit, 5);
     assert.equal(body.pagination.offset, 2);


### PR DESCRIPTION
﻿# PR: perf(reports): lazy signed URLs

## Resumen
- Elimina generación eager de `previewUrl` y `downloadUrl` en payloads internos de reportes.
- Mantiene `hasFile` como indicador seguro para frontend.
- Mantiene endpoints bajo demanda `preview-url` y `download-url` para Ver informe / Descargar.
- Mantiene intacto el flujo público/particular `public-report-access`, donde las URLs firmadas son parte del contrato.

## Archivos tocados
- server/routes/reports.fastify.ts
- server/routes/admin-reports.fastify.ts
- server/routes/reports-status.fastify.ts
- test/reports.fastify.test.ts
- test/admin-reports.fastify.test.ts
- test/reports-status.fastify.test.ts
- test/auth-authorization-integration.fastify.test.ts
- test/report-write-surface-ownership.test.ts

## Implementación
- `reports.fastify.ts`: los listados `/api/reports` y `/api/reports/search` ahora serializan con `serializeSafeReport`.
- `admin-reports.fastify.ts`: la respuesta de upload admin ya no embebe URLs firmadas eager.
- `reports-status.fastify.ts`: la respuesta de actualización de estado ya no embebe URLs firmadas eager.
- Los endpoints dedicados `preview-url` y `download-url` siguen generando URLs firmadas bajo demanda.

## Tests
- Actualizados contratos para confirmar ausencia de `previewUrl` / `downloadUrl` eager.
- Se mantiene `hasFile`.
- Se mantiene bloqueo de `storagePath` en payloads.
- Se conserva el flujo de endpoints bajo demanda.

## Comandos ejecutados
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/reports.fastify.test.ts test/admin-reports.fastify.test.ts test/reports-status.fastify.test.ts test/auth-authorization-integration.fastify.test.ts test/report-write-surface-ownership.test.ts
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck

## Resultados
- Tests dirigidos: PASS
- pnpm typecheck: PASS
- pnpm typecheck:test: PASS
- pnpm test: PASS, 2145 pass, 0 fail
- pnpm build: PASS
- pnpm security:public-surface: PASS
- pnpm --dir frontend lint: PASS con 1 warning preexistente en `frontend/src/app/api/security/csp-report/route.ts`
- pnpm --dir frontend typecheck: PASS
- No se ejecutó `pnpm --dir frontend build` por restricción de red/Google Fonts.

## Riesgos
- Bajo: el frontend ya usa endpoints bajo demanda para Ver informe y Descargar.
- Bajo: `public-report-access` no se modifica.
- Bajo: no cambia auth, cookies, CORS, CSRF, CSP, DB schema ni índices.

## Rollback
- Revertir el commit del PR.
- Eso restauraría `previewUrl` / `downloadUrl` eager en payloads internos.

## Estado final
- Validación local completa en PASS.
- Sin cambios de schema.
- Sin migraciones.
- Sin cambios de seguridad/autenticación.
