### PR TITLE
fix(auth): include retry headers on login rate limits

### DIFF
--- a/docs/pr-history/PR-fix-login-rate-limit-retry-headers.md
+++ b/docs/pr-history/PR-fix-login-rate-limit-retry-headers.md
@@ -1,0 +1,126 @@
+# PR: fix(login): rate limit retry headers completos
+
+## Resumen
+
+Se aseguró que todo `429` de login devuelva los headers obligatorios para que el frontend no muestre el mensaje de headers faltantes cuando el backend informa correctamente el cooldown.
+
+Superficies cubiertas:
+
+- Clinica/unified: `POST /api/auth/login`
+- Admin: `POST /api/admin/auth/login`
+- Particular: `POST /api/particular/auth/login`
+
+## Archivos tocados
+
+- `server/lib/login-rate-limit.ts`
+- `server/routes/auth.fastify.ts`
+- `server/routes/admin-auth.fastify.ts`
+- `server/routes/particular-auth.fastify.ts`
+- `frontend/src/lib/api.ts`
+- `test/login-rate-limit.test.ts`
+- `test/auth.fastify.test.ts`
+- `test/admin-auth.fastify.test.ts`
+- `test/particular-auth.fastify.test.ts`
+- `test/frontend-api-client-request.test.ts`
+- `docs/pr-history/PR-fix-login-rate-limit-retry-headers.md`
+
+## Implementacion
+
+- `buildLoginRateLimitHeaders` ahora calcula una sola vez los segundos de reset y puede incluir `Retry-After` con `includeRetryAfter: true`.
+- Las tres rutas de login llaman a `setLoginRateLimitHeaders(..., includeRetryAfter: true)` antes de cada `reply.code(429).send(...)`.
+- Se removio el seteo manual separado de `Retry-After` en las rutas para evitar divergencias con `RateLimit-Reset`.
+- El frontend sigue exigiendo los cinco headers en rutas de login, pero acepta `Retry-After: 0` como valor valido. Con headers presentes y `0`, conserva el mensaje del backend sin mostrar `LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE`.
+- No se cambiaron limites, ventanas, cookies, sesiones, trusted-origin, CSRF, CORS, CSP, DB schema, indices ni WebAuthn.
+
+## Tests
+
+- Helper central:
+  - Verifica que `buildLoginRateLimitHeaders(..., includeRetryAfter: true)` emite `Retry-After` junto con `RateLimit-Policy`, `RateLimit-Limit`, `RateLimit-Remaining` y `RateLimit-Reset`.
+  - Verifica que `Retry-After: 0` y `RateLimit-Reset: 0` son coherentes.
+- Clinica/unified:
+  - `429` en `/api/auth/login` contiene los cinco headers obligatorios.
+  - `Retry-After` es entero y mayor o igual a cero.
+- Admin:
+  - `429` en `/api/admin/auth/login` contiene los cinco headers obligatorios.
+- Particular:
+  - `429` en `/api/particular/auth/login` contiene los cinco headers obligatorios.
+- Frontend:
+  - El contrato conserva la exigencia de headers completos.
+  - El cliente no usa truthiness de `retryAfterSeconds`, evitando mostrar `LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE` cuando el backend entrega los cinco headers y `Retry-After` es `0`.
+
+## Comandos/resultados
+
+```powershell
+node --experimental-strip-types --experimental-specifier-resolution=node --test test/login-rate-limit.test.ts test/auth.fastify.test.ts test/admin-auth.fastify.test.ts test/particular-auth.fastify.test.ts test/frontend-api-client-request.test.ts
+```
+
+Resultado: OK, `78` tests pass.
+
+```powershell
+pnpm typecheck
+```
+
+Resultado: OK.
+
+```powershell
+pnpm typecheck:test
+```
+
+Resultado: OK.
+
+```powershell
+pnpm test
+```
+
+Resultado: OK, `2147` tests, `2146` pass, `1` skipped, `0` fail.
+
+```powershell
+pnpm build
+```
+
+Resultado: OK, `dist/index.js 877.8kb`.
+
+```powershell
+pnpm security:public-surface
+```
+
+Resultado: OK, `PASS security/public-surface`. Reporto solo findings `server-only` por identifiers sensibles en `frontend/src/middleware.ts`.
+
+```powershell
+pnpm --dir frontend lint
+```
+
+Resultado: exit `0`, con `1` warning existente: `frontend/src/app/api/security/csp-report/route.ts:177` tiene un `eslint-disable` sin uso.
+
+```powershell
+pnpm --dir frontend typecheck
+```
+
+Resultado: OK.
+
+No se ejecuto `pnpm --dir frontend build`, respetando la instruccion de no correrlo si puede pedir red por Google Fonts.
+
+## Riesgos
+
+- Bajo: el cambio centraliza `Retry-After` solo cuando las rutas 429 lo solicitan con `includeRetryAfter`, por lo que no agrega `Retry-After` a respuestas no limitadas.
+- Bajo: el frontend acepta `Retry-After: 0` como valor valido, manteniendo la validacion de los cinco headers obligatorios.
+- Bajo: las pruebas cubren los caminos runtime de login y el contrato frontend.
+
+## Rollback
+
+- Revertir `includeRetryAfter` en `buildLoginRateLimitHeaders`.
+- Restaurar el seteo manual previo de `Retry-After` en las tres rutas si se necesitara volver al comportamiento anterior.
+- Revertir el ajuste frontend de `retryAfterSeconds === null` para volver a tratar `0` como ausencia.
+- Revertir las aserciones agregadas en tests.
+
+## Estado final
+
+Implementado y validado localmente. No se hizo `git add`, commit, push, PR ni merge.
+
+Confirmacion explicita: todo `429` de login en `POST /api/auth/login`, `POST /api/admin/auth/login` y `POST /api/particular/auth/login` incluye los cinco headers obligatorios:
+
+- `Retry-After`
+- `RateLimit-Policy`
+- `RateLimit-Limit`
+- `RateLimit-Remaining`
+- `RateLimit-Reset`

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -186,7 +186,7 @@ function readRetryAfterSeconds(headers: Headers): number | null {
 
   const retryAfterSeconds = Number.parseInt(retryAfterValue, 10);
 
-  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds < 0) {
     return null;
   }
 
@@ -215,7 +215,7 @@ function buildRateLimitErrorMessage(
   const baseMessage = backendMessage ?? LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE;
   const retryAfterSeconds = readRetryAfterSeconds(headers);
 
-  if (!retryAfterSeconds) {
+  if (retryAfterSeconds === null || retryAfterSeconds === 0) {
     return baseMessage;
   }
 
@@ -288,7 +288,8 @@ async function apiFetch<T>(
 
       if (
         isLoginRateLimitPath(path) &&
-        (!retryAfterSeconds || !hasRequiredLoginRateLimitHeaders(res.headers))
+        (retryAfterSeconds === null ||
+          !hasRequiredLoginRateLimitHeaders(res.headers))
       ) {
         throw new RateLimitError(
           LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE,

--- a/server/lib/login-rate-limit.ts
+++ b/server/lib/login-rate-limit.ts
@@ -152,19 +152,29 @@ export function getLoginRateLimitResetSeconds(input: {
   return Math.max(Math.ceil((input.resetAt - input.now) / 1000), 0);
 }
 
-export function buildLoginRateLimitHeaders(input: {
+export type LoginRateLimitHeaderInput = {
   max: number;
   windowMs: number;
   failedCount: number;
   resetAt: number;
   now: number;
-}) {
-  return {
+  includeRetryAfter?: boolean;
+};
+
+export function buildLoginRateLimitHeaders(input: LoginRateLimitHeaderInput) {
+  const resetSeconds = getLoginRateLimitResetSeconds(input);
+  const headers: Record<string, string> = {
     "RateLimit-Policy": `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
     "RateLimit-Limit": String(input.max),
     "RateLimit-Remaining": String(
       Math.max(input.max - input.failedCount, 0),
     ),
-    "RateLimit-Reset": String(getLoginRateLimitResetSeconds(input)),
+    "RateLimit-Reset": String(resetSeconds),
   };
+
+  if (input.includeRetryAfter) {
+    headers["Retry-After"] = String(resetSeconds);
+  }
+
+  return headers;
 }

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -11,7 +11,6 @@ import {
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
   getLoginRateLimitKeyMetadata,
-  getLoginRateLimitResetSeconds,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -414,6 +413,7 @@ function setLoginRateLimitHeaders(
     failedCount: number;
     resetAt: number;
     now: number;
+    includeRetryAfter?: boolean;
   },
 ) {
   for (const [headerName, headerValue] of Object.entries(
@@ -755,19 +755,14 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
     }
 
     if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
-      const resetSeconds = getLoginRateLimitResetSeconds({
-        resetAt: failureEntry.resetAt,
-        now: currentTime,
-      });
-
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
         failedCount: failureEntry.count,
         resetAt: failureEntry.resetAt,
         now: currentTime,
+        includeRetryAfter: true,
       });
-      reply.header("Retry-After", String(resetSeconds));
 
       await recordFailedLoginAttempt({
         username,

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -11,7 +11,6 @@ import {
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
   getLoginRateLimitKeyMetadata,
-  getLoginRateLimitResetSeconds,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -570,6 +569,7 @@ function setLoginRateLimitHeaders(
     failedCount: number;
     resetAt: number;
     now: number;
+    includeRetryAfter?: boolean;
   },
 ) {
   for (const [headerName, headerValue] of Object.entries(
@@ -1166,16 +1166,8 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         failedCount: failureEntry.count,
         resetAt: failureEntry.resetAt,
         now: currentTime,
+        includeRetryAfter: true,
       });
-      reply.header(
-        "Retry-After",
-        String(
-          getLoginRateLimitResetSeconds({
-            resetAt: failureEntry.resetAt,
-            now: currentTime,
-          }),
-        ),
-      );
 
       await recordFailedLoginAttempt({
         username: loginIdentifier,

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -11,7 +11,6 @@ import {
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
   getLoginRateLimitKeyMetadata,
-  getLoginRateLimitResetSeconds,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
@@ -406,6 +405,7 @@ function setLoginRateLimitHeaders(
     failedCount: number;
     resetAt: number;
     now: number;
+    includeRetryAfter?: boolean;
   },
 ) {
   for (const [headerName, headerValue] of Object.entries(
@@ -758,19 +758,14 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
     }
 
     if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
-      const resetSeconds = getLoginRateLimitResetSeconds({
-        resetAt: failureEntry.resetAt,
-        now: currentTime,
-      });
-
       setLoginRateLimitHeaders(reply, {
         max: loginRateLimitMaxAttempts,
         windowMs: loginRateLimitWindowMs,
         failedCount: failureEntry.count,
         resetAt: failureEntry.resetAt,
         now: currentTime,
+        includeRetryAfter: true,
       });
-      reply.header("Retry-After", String(resetSeconds));
 
       await recordFailedLoginAttempt({
         reason: "rate_limited",

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -350,8 +350,18 @@ test(
       assert.equal(first.statusCode, 401);
       assert.equal(second.statusCode, 401);
       assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["retry-after"], "60");
+      assert.equal(third.headers["ratelimit-policy"], "2;w=60");
       assert.equal(third.headers["ratelimit-limit"], "2");
       assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.equal(third.headers["ratelimit-reset"], "60");
+      assert.equal(
+        third.headers["access-control-expose-headers"],
+        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+      );
+      const retryAfter = Number(third.headers["retry-after"]);
+      assert.ok(Number.isInteger(retryAfter));
+      assert.ok(retryAfter >= 0);
       assert.deepEqual(JSON.parse(third.body), {
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
@@ -441,8 +451,10 @@ test(
 
       assert.equal(response.statusCode, 429);
       assert.equal(response.headers["retry-after"], "60");
+      assert.equal(response.headers["ratelimit-policy"], "1;w=60");
       assert.equal(response.headers["ratelimit-limit"], "1");
       assert.equal(response.headers["ratelimit-remaining"], "0");
+      assert.equal(response.headers["ratelimit-reset"], "60");
       assert.deepEqual(JSON.parse(response.body), {
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -1481,9 +1481,18 @@ test("clinicAuthNativeRoutes bloquea login al superar límite persistente", asyn
       success: false,
       error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
     });
+    assert.equal(third.headers["retry-after"], "60");
+    assert.equal(third.headers["ratelimit-policy"], "2;w=60");
     assert.equal(third.headers["ratelimit-limit"], "2");
     assert.equal(third.headers["ratelimit-remaining"], "0");
-    assert.equal(third.headers["retry-after"], "60");
+    assert.equal(third.headers["ratelimit-reset"], "60");
+    assert.equal(
+      third.headers["access-control-expose-headers"],
+      "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+    );
+    const retryAfter = Number(third.headers["retry-after"]);
+    assert.ok(Number.isInteger(retryAfter));
+    assert.ok(retryAfter >= 0);
   } finally {
     await app.close();
   }

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -97,10 +97,19 @@ test("frontend API client formats 429 login rate-limit guidance from headers", (
     assert.ok(source.includes(`"${headerName}"`), `missing ${headerName}`);
   }
   assert.ok(source.includes('headers.get("Retry-After") ?? headers.get("RateLimit-Reset")'));
+  assert.ok(source.includes("retryAfterSeconds < 0"));
+  assert.equal(source.includes("retryAfterSeconds <= 0"), false);
   assert.ok(source.includes("function isLoginRateLimitPath("));
   assert.ok(source.includes("function hasRequiredLoginRateLimitHeaders("));
   assert.ok(source.includes("LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE"));
+  assert.ok(source.includes("retryAfterSeconds === null ||"));
+  assert.ok(source.includes("!hasRequiredLoginRateLimitHeaders(res.headers)"));
+  assert.equal(
+    source.includes("!retryAfterSeconds || !hasRequiredLoginRateLimitHeaders"),
+    false,
+  );
   assert.ok(source.includes("function buildRateLimitErrorMessage("));
+  assert.ok(source.includes("retryAfterSeconds === null || retryAfterSeconds === 0"));
   assert.ok(source.includes("Reintente en"));
 });
 

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -1,9 +1,11 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildLoginRateLimitHeaders,
   buildLoginRateLimitKeyMetadata,
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
+  getLoginRateLimitResetSeconds,
   getLoginRateLimitKeyMetadata,
   hashLoginRateLimitIdentifier,
   hashLoginRateLimitIpAddress,
@@ -21,6 +23,47 @@ test("constantes de login rate limit son estables", () => {
     LOGIN_RATE_LIMIT_ERROR_MESSAGE,
     "Demasiados intentos de inicio de sesión. Intente más tarde.",
   );
+});
+
+test("buildLoginRateLimitHeaders incluye Retry-After para respuestas 429 de login", () => {
+  const headers = buildLoginRateLimitHeaders({
+    max: 2,
+    windowMs: 60_000,
+    failedCount: 2,
+    resetAt: 60_000,
+    now: 0,
+    includeRetryAfter: true,
+  });
+
+  assert.deepEqual(headers, {
+    "RateLimit-Policy": "2;w=60",
+    "RateLimit-Limit": "2",
+    "RateLimit-Remaining": "0",
+    "RateLimit-Reset": "60",
+    "Retry-After": "60",
+  });
+});
+
+test("login rate limit reset y Retry-After permiten cero segundos coherentes", () => {
+  assert.equal(
+    getLoginRateLimitResetSeconds({
+      resetAt: 1_000,
+      now: 1_000,
+    }),
+    0,
+  );
+
+  const headers = buildLoginRateLimitHeaders({
+    max: 1,
+    windowMs: 60_000,
+    failedCount: 1,
+    resetAt: 1_000,
+    now: 1_000,
+    includeRetryAfter: true,
+  });
+
+  assert.equal(headers["RateLimit-Reset"], "0");
+  assert.equal(headers["Retry-After"], "0");
 });
 
 test("login rate limit key incluye version, superficie, identificador normalizado e IP", () => {

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -516,8 +516,18 @@ test(
       assert.equal(first.statusCode, 401);
       assert.equal(second.statusCode, 401);
       assert.equal(third.statusCode, 429);
+      assert.equal(third.headers["retry-after"], "60");
+      assert.equal(third.headers["ratelimit-policy"], "2;w=60");
       assert.equal(third.headers["ratelimit-limit"], "2");
       assert.equal(third.headers["ratelimit-remaining"], "0");
+      assert.equal(third.headers["ratelimit-reset"], "60");
+      assert.equal(
+        third.headers["access-control-expose-headers"],
+        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+      );
+      const retryAfter = Number(third.headers["retry-after"]);
+      assert.ok(Number.isInteger(retryAfter));
+      assert.ok(retryAfter >= 0);
       assert.deepEqual(JSON.parse(third.body), {
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,
@@ -565,8 +575,10 @@ test(
 
       assert.equal(response.statusCode, 429);
       assert.equal(response.headers["retry-after"], "60");
+      assert.equal(response.headers["ratelimit-policy"], "1;w=60");
       assert.equal(response.headers["ratelimit-limit"], "1");
       assert.equal(response.headers["ratelimit-remaining"], "0");
+      assert.equal(response.headers["ratelimit-reset"], "60");
       assert.deepEqual(JSON.parse(response.body), {
         success: false,
         error: LOGIN_RATE_LIMIT_ERROR_MESSAGE,


### PR DESCRIPTION
# PR: fix(login): rate limit retry headers completos

## Resumen

Se aseguró que todo `429` de login devuelva los headers obligatorios para que el frontend no muestre el mensaje de headers faltantes cuando el backend informa correctamente el cooldown.

Superficies cubiertas:

- Clinica/unified: `POST /api/auth/login`
- Admin: `POST /api/admin/auth/login`
- Particular: `POST /api/particular/auth/login`

## Archivos tocados

- `server/lib/login-rate-limit.ts`
- `server/routes/auth.fastify.ts`
- `server/routes/admin-auth.fastify.ts`
- `server/routes/particular-auth.fastify.ts`
- `frontend/src/lib/api.ts`
- `test/login-rate-limit.test.ts`
- `test/auth.fastify.test.ts`
- `test/admin-auth.fastify.test.ts`
- `test/particular-auth.fastify.test.ts`
- `test/frontend-api-client-request.test.ts`
- `docs/pr-history/PR-fix-login-rate-limit-retry-headers.md`

## Implementacion

- `buildLoginRateLimitHeaders` ahora calcula una sola vez los segundos de reset y puede incluir `Retry-After` con `includeRetryAfter: true`.
- Las tres rutas de login llaman a `setLoginRateLimitHeaders(..., includeRetryAfter: true)` antes de cada `reply.code(429).send(...)`.
- Se removio el seteo manual separado de `Retry-After` en las rutas para evitar divergencias con `RateLimit-Reset`.
- El frontend sigue exigiendo los cinco headers en rutas de login, pero acepta `Retry-After: 0` como valor valido. Con headers presentes y `0`, conserva el mensaje del backend sin mostrar `LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE`.
- No se cambiaron limites, ventanas, cookies, sesiones, trusted-origin, CSRF, CORS, CSP, DB schema, indices ni WebAuthn.

## Tests

- Helper central:
  - Verifica que `buildLoginRateLimitHeaders(..., includeRetryAfter: true)` emite `Retry-After` junto con `RateLimit-Policy`, `RateLimit-Limit`, `RateLimit-Remaining` y `RateLimit-Reset`.
  - Verifica que `Retry-After: 0` y `RateLimit-Reset: 0` son coherentes.
- Clinica/unified:
  - `429` en `/api/auth/login` contiene los cinco headers obligatorios.
  - `Retry-After` es entero y mayor o igual a cero.
- Admin:
  - `429` en `/api/admin/auth/login` contiene los cinco headers obligatorios.
- Particular:
  - `429` en `/api/particular/auth/login` contiene los cinco headers obligatorios.
- Frontend:
  - El contrato conserva la exigencia de headers completos.
  - El cliente no usa truthiness de `retryAfterSeconds`, evitando mostrar `LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE` cuando el backend entrega los cinco headers y `Retry-After` es `0`.

## Comandos/resultados

```powershell
node --experimental-strip-types --experimental-specifier-resolution=node --test test/login-rate-limit.test.ts test/auth.fastify.test.ts test/admin-auth.fastify.test.ts test/particular-auth.fastify.test.ts test/frontend-api-client-request.test.ts
```

Resultado: OK, `78` tests pass.

```powershell
pnpm typecheck
```

Resultado: OK.

```powershell
pnpm typecheck:test
```

Resultado: OK.

```powershell
pnpm test
```

Resultado: OK, `2147` tests, `2146` pass, `1` skipped, `0` fail.

```powershell
pnpm build
```

Resultado: OK, `dist/index.js 877.8kb`.

```powershell
pnpm security:public-surface
```

Resultado: OK, `PASS security/public-surface`. Reporto solo findings `server-only` por identifiers sensibles en `frontend/src/middleware.ts`.

```powershell
pnpm --dir frontend lint
```

Resultado: exit `0`, con `1` warning existente: `frontend/src/app/api/security/csp-report/route.ts:177` tiene un `eslint-disable` sin uso.

```powershell
pnpm --dir frontend typecheck
```

Resultado: OK.

No se ejecuto `pnpm --dir frontend build`, respetando la instruccion de no correrlo si puede pedir red por Google Fonts.

## Riesgos

- Bajo: el cambio centraliza `Retry-After` solo cuando las rutas 429 lo solicitan con `includeRetryAfter`, por lo que no agrega `Retry-After` a respuestas no limitadas.
- Bajo: el frontend acepta `Retry-After: 0` como valor valido, manteniendo la validacion de los cinco headers obligatorios.
- Bajo: las pruebas cubren los caminos runtime de login y el contrato frontend.

## Rollback

- Revertir `includeRetryAfter` en `buildLoginRateLimitHeaders`.
- Restaurar el seteo manual previo de `Retry-After` en las tres rutas si se necesitara volver al comportamiento anterior.
- Revertir el ajuste frontend de `retryAfterSeconds === null` para volver a tratar `0` como ausencia.
- Revertir las aserciones agregadas en tests.

## Estado final

Implementado y validado localmente. No se hizo `git add`, commit, push, PR ni merge.

Confirmacion explicita: todo `429` de login en `POST /api/auth/login`, `POST /api/admin/auth/login` y `POST /api/particular/auth/login` incluye los cinco headers obligatorios:

- `Retry-After`
- `RateLimit-Policy`
- `RateLimit-Limit`
- `RateLimit-Remaining`
- `RateLimit-Reset`
