### PR TITLE
perf(frontend): reduce public client boundaries

### DIFF
--- a/docs/pr-history/PR-perf-frontend-client-boundaries.md
+++ b/docs/pr-history/PR-perf-frontend-client-boundaries.md
@@ -1,0 +1,72 @@
+# PR: perf/frontend-client-boundaries
+
+## Resumen
+
+Optimización chica y segura de boundaries cliente en frontend público, sin cambios visibles de diseño, rutas, API, auth, sesiones ni cookies.
+
+## Hallazgos
+
+- `Navbar` y `Footer` estaban marcados como client components solo para usar `useRouter` en navegación pública.
+- La navegación pública mantiene un contrato de seguridad sin `<a>` ni `next/link`; por eso se conservaron `PublicRouteControl` y `PublicExternalControl`.
+- `ParticularesContent` cargaba estáticamente `DashboardNotificationsBell`, aunque la campana solo se renderiza con sesión particular activa.
+- Los paneles admin y report actions tienen contratos fuente existentes y flujos interactivos sensibles; se revisaron y no se hicieron dynamic imports allí para mantener el PR pequeño.
+- Los imports de `lucide-react` ya son named imports; solo se consolidó el import duplicado de `Bell` y `X`.
+
+## Archivos Tocados
+
+- `frontend/src/components/layout/Navbar.tsx`
+- `frontend/src/components/layout/Footer.tsx`
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `frontend/src/components/dashboard/DashboardNotificationsBell.tsx`
+- `test/frontend-public-layout-navigation.test.ts`
+- `test/frontend-particulares-content.test.ts`
+- `test/frontend-notifications-bell.test.ts`
+- `test/frontend-admin-report-workflow.test.ts`
+
+## Implementación
+
+- Se removió `"use client"` de `Navbar` y `Footer`.
+- Se reemplazó navegación local con `useRouter` por `PublicRouteControl`, manteniendo botones y clases visuales existentes.
+- Se mantuvo `PublicExternalControl` para navegación externa del footer y el contrato sin anchors.
+- Se agregó `next/dynamic` para cargar `DashboardNotificationsBell` en `ParticularesContent` solo cuando existe sesión particular activa.
+- Se agregó placeholder reservado de `9x9` para evitar salto visual mientras carga la campana.
+- Se consolidó el import de iconos de notificaciones en una sola línea.
+- Se actualizaron tests fuente para reflejar que el contrato ahora prefiere boundaries parciales en vez de hidratar navbar/footer completos.
+
+## Tests/Comandos
+
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+
+No se ejecutó `pnpm --dir frontend build`; no hubo bloqueo por Google Fonts.
+
+## Resultados
+
+- `pnpm --dir frontend lint`: PASS
+- `pnpm --dir frontend typecheck`: PASS
+- `pnpm typecheck`: PASS
+- `pnpm typecheck:test`: PASS
+- `pnpm test`: PASS, 2146 pass / 1 skipped / 0 fail
+- `pnpm build`: PASS
+- `pnpm security:public-surface`: PASS, sin findings públicos
+
+## Riesgos
+
+- `ParticularNotificationsBell` puede mostrarse con un placeholder breve hasta cargar el chunk cliente.
+- `Navbar` y `Footer` siguen usando boundaries cliente para botones puntuales por el contrato `PublicRouteControl`, pero ya no hidratan el componente completo.
+- No se cambió lazy loading de paneles admin por riesgo de ampliar contratos y comportamiento operativo.
+
+## Rollback
+
+Revertir los cambios de los archivos listados en este documento. El rollback vuelve a importar `useRouter` en `Navbar`/`Footer`, restaura el import estático de `DashboardNotificationsBell` en `ParticularesContent` y revierte los contratos fuente actualizados.
+
+## Estado Final
+
+Listo para revisión local. No se hizo `git add`, commit, push, PR, merge ni cambios de backend.
+
+Se confirma que no cambia contratos API, auth, sesiones, cookies, CSP, CORS, CSRF, DB schema, índices, storagePath, signed URLs ni WebAuthn.

--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { createPortal } from "react-dom";
-import { Bell } from "lucide-react";
-import { X } from "lucide-react";
+import { Bell, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useRouter } from "next/navigation";
 import {
   ChevronDown,
   Mail,
@@ -10,7 +7,10 @@ import {
   Phone,
 } from "lucide-react";
 
-import { PublicExternalControl } from "@/components/public/PublicRouteControl";
+import {
+  PublicExternalControl,
+  PublicRouteControl,
+} from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 
 const faqItems = [
@@ -88,7 +88,6 @@ export function FooterFaq() {
 }
 
 export function Footer() {
-  const router = useRouter();
   const year = new Date().getFullYear();
 
   return (
@@ -153,13 +152,13 @@ export function Footer() {
             <ul className="space-y-3">
               {footerLinks.map((link) => (
                 <li key={link.href}>
-                  <button
-                    type="button"
-                    onClick={() => router.push(link.href)}
+                  <PublicRouteControl
+                    href={link.href}
+                    variant="bare"
                     className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                   >
                     {link.label}
-                  </button>
+                  </PublicRouteControl>
                 </li>
               ))}
             </ul>
@@ -171,32 +170,32 @@ export function Footer() {
             </h3>
             <ul className="space-y-3">
               <li>
-                <button
-                  type="button"
-                  onClick={() => router.push(ROUTES.login)}
+                <PublicRouteControl
+                  href={ROUTES.login}
+                  variant="bare"
                   className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                 >
                   Iniciar sesión
-                </button>
+                </PublicRouteControl>
               </li>
               <li>
-                <button
-                  type="button"
-                  onClick={() => router.push(ROUTES.particulares)}
+                <PublicRouteControl
+                  href={ROUTES.particulares}
+                  variant="bare"
                   className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                 >
                   Acceso particulares
-                </button>
+                </PublicRouteControl>
               </li>
               <li>
-                <button
-                  type="button"
-                  onClick={() => router.push(ROUTES.contacto)}
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="bare"
                   className="inline-flex items-center gap-2 rounded-md border border-white/15 bg-white/8 px-3 py-1.5 text-sm text-white shadow-sm transition-colors hover:bg-white/14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                 >
                   <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
                   Solicitar acceso
-                </button>
+                </PublicRouteControl>
               </li>
             </ul>
           </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,9 +1,6 @@
-"use client";
-
-import { useRouter } from "next/navigation";
 import { ArrowRight, ChevronDown, Microscope } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 
 const navLinks = [
@@ -18,8 +15,6 @@ const navLinks = [
 const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];
 
 export function Navbar() {
-  const router = useRouter();
-
   return (
     <header className="sticky top-0 z-50 w-full border-b border-vetneb-line/80 bg-card/96 shadow-[0_10px_28px_rgba(15,45,62,0.08)]">
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
@@ -40,13 +35,13 @@ export function Navbar() {
               <ul className="flex flex-col gap-1">
                 {mobileNavLinks.map((link) => (
                   <li key={link.href}>
-                    <button
-                      type="button"
-                      onClick={() => router.push(link.href)}
+                    <PublicRouteControl
+                      href={link.href}
+                      variant="bare"
                       className="block w-full rounded-md px-3 py-2.5 text-left text-sm font-medium text-vetneb-ink/85 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
                     >
                       {link.label}
-                    </button>
+                    </PublicRouteControl>
                   </li>
                 ))}
               </ul>
@@ -54,9 +49,9 @@ export function Navbar() {
           </details>
         </div>
 
-        <button
-          type="button"
-          onClick={() => router.push(ROUTES.home)}
+        <PublicRouteControl
+          href={ROUTES.home}
+          variant="bare"
           aria-label="VETNEB — Inicio"
           className="group hidden cursor-pointer items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 lg:flex"
         >
@@ -67,43 +62,40 @@ export function Navbar() {
           <span className="hidden text-xs font-semibold text-muted-foreground lg:inline">
             Patología veterinaria
           </span>
-        </button>
+        </PublicRouteControl>
 
         <nav
           className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 lg:flex"
           aria-label="Navegación principal"
         >
           {navLinks.map((link) => (
-            <button
+            <PublicRouteControl
               key={link.href}
-              type="button"
-              onClick={() => router.push(link.href)}
+              href={link.href}
+              variant="bare"
               className="rounded-md px-3.5 py-2 text-sm font-medium text-vetneb-ink/80 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
             >
               {link.label}
-            </button>
+            </PublicRouteControl>
           ))}
         </nav>
 
         <div className="flex items-center gap-2 sm:gap-3">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="public-cta-outline"
-            onClick={() => router.push(ROUTES.login)}
+          <PublicRouteControl
+            href={ROUTES.login}
+            variant="bare"
+            className="public-cta-outline inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 text-sm font-semibold ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
           >
             Iniciar sesión
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            className="public-cta-primary hidden sm:flex"
-            onClick={() => router.push(ROUTES.contacto)}
+          </PublicRouteControl>
+          <PublicRouteControl
+            href={ROUTES.contacto}
+            variant="bare"
+            className="public-cta-primary hidden h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 text-sm font-semibold ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 sm:flex"
           >
             Solicitar acceso
             <ArrowRight className="h-4 w-4" aria-hidden="true" />
-          </Button>
+          </PublicRouteControl>
         </div>
       </div>
     </header>

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import {
   CalendarDays,
   Clipboard,
@@ -45,7 +46,21 @@ import {
   PublicExternalControl,
   PublicRouteControl,
 } from "@/components/public/PublicRouteControl";
-import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";
+
+const ParticularNotificationsBell = dynamic(
+  () =>
+    import("@/components/dashboard/DashboardNotificationsBell").then(
+      (mod) => mod.DashboardNotificationsBell,
+    ),
+  {
+    loading: () => (
+      <span
+        className="inline-flex h-9 w-9 rounded-md border border-input bg-card/95 shadow-[0_1px_2px_rgba(15,45,62,0.05)]"
+        aria-hidden="true"
+      />
+    ),
+  },
+);
 
 function formatDate(value: string | null | undefined) {
   if (!value) {
@@ -368,7 +383,7 @@ export function ParticularesContent() {
                     </CardDescription>
                   </div>
                 </div>
-                {session ? <DashboardNotificationsBell surface="particular" /> : null}
+                {session ? <ParticularNotificationsBell surface="particular" /> : null}
               </div>
             </CardHeader>
 

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -98,7 +98,7 @@ test("campana de notificaciones admin existe con UX in-app y polling", () => {
   const bell = read(BELL_PATH);
 
   assert.ok(bell.includes('"use client";'));
-  assert.ok(bell.includes('import { Bell } from "lucide-react";'));
+  assert.ok(bell.includes('import { Bell, X } from "lucide-react";'));
   assert.ok(bell.includes("aria-label=\"Notificaciones\""));
   assert.ok(bell.includes("Notificaciones"));
   assert.ok(bell.includes("Activar notificaciones"));

--- a/test/frontend-notifications-bell.test.ts
+++ b/test/frontend-notifications-bell.test.ts
@@ -355,13 +355,18 @@ test("particular role wires notifications bell when session is active", () => {
   const source = read(PARTICULARES_PATH);
 
   assert.ok(
-    source.includes(
-      'import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";',
-    ),
-    "ParticularesContent must import DashboardNotificationsBell",
+    source.includes('import dynamic from "next/dynamic";'),
+    "ParticularesContent must use next/dynamic for the session-only bell",
   );
   assert.ok(
-    source.includes('<DashboardNotificationsBell surface="particular" />'),
+    source.includes(
+      'import("@/components/dashboard/DashboardNotificationsBell").then(',
+    ),
+    "ParticularesContent must dynamically import DashboardNotificationsBell",
+  );
+  assert.ok(source.includes("mod.DashboardNotificationsBell"));
+  assert.ok(
+    source.includes('<ParticularNotificationsBell surface="particular" />'),
     "ParticularesContent must render bell with particular surface",
   );
 });

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -61,12 +61,14 @@ test("particulares content muestra estado y alerta desde study-tracking en sesio
 test("particulares content integra campana token-scoped en sesion activa", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
 
+  assert.ok(source.includes('import dynamic from "next/dynamic";'));
   assert.ok(
     source.includes(
-      'import { DashboardNotificationsBell } from "@/components/dashboard/DashboardNotificationsBell";',
+      'import("@/components/dashboard/DashboardNotificationsBell").then(',
     ),
   );
-  assert.ok(source.includes('<DashboardNotificationsBell surface="particular" />'));
+  assert.ok(source.includes("mod.DashboardNotificationsBell"));
+  assert.ok(source.includes('<ParticularNotificationsBell surface="particular" />'));
 });
 
 test("particulares content muestra enlace WhatsApp y email solo bajo alerta de tincion especial", () => {

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -30,7 +30,8 @@ test("public layout wraps pages with navbar main landmark and footer", () => {
 test("navbar uses centralized public routes for primary navigation", () => {
   const source = read(NAVBAR_PATH);
 
-  assert.ok(source.includes('import { useRouter } from "next/navigation";'));
+  assert.equal(source.includes('"use client";'), false);
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes('const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];'));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
@@ -93,23 +94,24 @@ test("navbar keeps expected public link order including precios", () => {
 test("navbar exposes home login and access CTAs with VETNEB brand", () => {
   const source = read(NAVBAR_PATH);
 
-  assert.ok(source.includes("router.push(ROUTES.home)"));
+  assert.ok(source.includes("href={ROUTES.home}"));
   assert.ok(source.includes('aria-label="VETNEB — Inicio"'));
   assert.ok(source.includes("rounded-md bg-primary px-3"));
   assert.ok(source.includes("font-bold text-primary-foreground"));
   assert.ok(source.includes("VETNEB"));
   assert.equal(source.includes(">VN<"), false);
   assert.equal(source.includes("Portal VETNEB"), false);
-  assert.ok(source.includes("router.push(ROUTES.login)"));
+  assert.ok(source.includes("href={ROUTES.login}"));
   assert.ok(source.includes("Iniciar sesión"));
-  assert.ok(source.includes("router.push(ROUTES.contacto)"));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicitar acceso"));
 });
 
 test("footer uses centralized public routes and contentinfo landmark", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes('import { useRouter } from "next/navigation";'));
+  assert.equal(source.includes('"use client";'), false);
+  assert.ok(source.includes("PublicRouteControl"));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes('role="contentinfo"'));
   assert.ok(source.includes('const footerLinks = ['));
@@ -123,9 +125,9 @@ test("footer uses centralized public routes and contentinfo landmark", () => {
 test("footer exposes access links and legal copy without redundant brand block", () => {
   const source = read(FOOTER_PATH);
 
-  assert.ok(source.includes("router.push(ROUTES.login)"));
+  assert.ok(source.includes("href={ROUTES.login}"));
   assert.ok(source.includes("Iniciar sesión"));
-  assert.ok(source.includes("router.push(ROUTES.contacto)"));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("Solicitar acceso"));
   assert.ok(source.includes("Todos los derechos reservados"));
   assert.equal(source.includes("Laboratorio veterinario digital — Argentina"), false);


### PR DESCRIPTION
# PR: perf/frontend-client-boundaries

## Resumen

Optimización chica y segura de boundaries cliente en frontend público, sin cambios visibles de diseño, rutas, API, auth, sesiones ni cookies.

## Hallazgos

- `Navbar` y `Footer` estaban marcados como client components solo para usar `useRouter` en navegación pública.
- La navegación pública mantiene un contrato de seguridad sin `<a>` ni `next/link`; por eso se conservaron `PublicRouteControl` y `PublicExternalControl`.
- `ParticularesContent` cargaba estáticamente `DashboardNotificationsBell`, aunque la campana solo se renderiza con sesión particular activa.
- Los paneles admin y report actions tienen contratos fuente existentes y flujos interactivos sensibles; se revisaron y no se hicieron dynamic imports allí para mantener el PR pequeño.
- Los imports de `lucide-react` ya son named imports; solo se consolidó el import duplicado de `Bell` y `X`.

## Archivos Tocados

- `frontend/src/components/layout/Navbar.tsx`
- `frontend/src/components/layout/Footer.tsx`
- `frontend/src/components/public/ParticularesContent.tsx`
- `frontend/src/components/dashboard/DashboardNotificationsBell.tsx`
- `test/frontend-public-layout-navigation.test.ts`
- `test/frontend-particulares-content.test.ts`
- `test/frontend-notifications-bell.test.ts`
- `test/frontend-admin-report-workflow.test.ts`

## Implementación

- Se removió `"use client"` de `Navbar` y `Footer`.
- Se reemplazó navegación local con `useRouter` por `PublicRouteControl`, manteniendo botones y clases visuales existentes.
- Se mantuvo `PublicExternalControl` para navegación externa del footer y el contrato sin anchors.
- Se agregó `next/dynamic` para cargar `DashboardNotificationsBell` en `ParticularesContent` solo cuando existe sesión particular activa.
- Se agregó placeholder reservado de `9x9` para evitar salto visual mientras carga la campana.
- Se consolidó el import de iconos de notificaciones en una sola línea.
- Se actualizaron tests fuente para reflejar que el contrato ahora prefiere boundaries parciales en vez de hidratar navbar/footer completos.

## Tests/Comandos

- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`
- `pnpm security:public-surface`

No se ejecutó `pnpm --dir frontend build`; no hubo bloqueo por Google Fonts.

## Resultados

- `pnpm --dir frontend lint`: PASS
- `pnpm --dir frontend typecheck`: PASS
- `pnpm typecheck`: PASS
- `pnpm typecheck:test`: PASS
- `pnpm test`: PASS, 2146 pass / 1 skipped / 0 fail
- `pnpm build`: PASS
- `pnpm security:public-surface`: PASS, sin findings públicos

## Riesgos

- `ParticularNotificationsBell` puede mostrarse con un placeholder breve hasta cargar el chunk cliente.
- `Navbar` y `Footer` siguen usando boundaries cliente para botones puntuales por el contrato `PublicRouteControl`, pero ya no hidratan el componente completo.
- No se cambió lazy loading de paneles admin por riesgo de ampliar contratos y comportamiento operativo.

## Rollback

Revertir los cambios de los archivos listados en este documento. El rollback vuelve a importar `useRouter` en `Navbar`/`Footer`, restaura el import estático de `DashboardNotificationsBell` en `ParticularesContent` y revierte los contratos fuente actualizados.

## Estado Final

Listo para revisión local. No se hizo `git add`, commit, push, PR, merge ni cambios de backend.

Se confirma que no cambia contratos API, auth, sesiones, cookies, CSP, CORS, CSRF, DB schema, índices, storagePath, signed URLs ni WebAuthn.
