### PR TITLE
fix(particulares): stabilize mobile render artifacts

### DIFF
--- a/docs/pr-history/PR-fix-particulares-mobile-render-artifacts.md
+++ b/docs/pr-history/PR-fix-particulares-mobile-render-artifacts.md
@@ -1,0 +1,104 @@
+# PR fix particulares mobile render artifacts
+
+## Resumen
+
+Se reforzo el render mobile del dashboard de particulares en `/particulares` cuando existe una sesion particular activa. El cambio apunta a eliminar ghosting, duplicacion visual y artefactos de composicion en Android sin ocultar campos ni modificar contratos de datos.
+
+El fix queda aislado al panel particular autenticado mediante los selectores existentes:
+
+- `data-particular-session-panel="true"`
+- `data-particular-session-summary="true"`
+- `data-particular-session-field="true"`
+
+## Causa probable
+
+La corrupcion observada parece consistente con composicion CSS/GPU en mobile, no con datos duplicados. El panel activo combinaba superficies anidadas con opacidades, sombras, gradientes suaves y clases como `render-gpu-soft`, `surface-soft` y `clinical-muted-band`. En ciertos Android/WebView, esa mezcla puede promover capas y dejar restos visuales al repintar cards dentro del panel.
+
+## Archivos tocados
+
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `frontend/src/app/globals.css`
+- `test/frontend-particulares-mobile-session-card-render.test.ts`
+- `docs/pr-history/PR-fix-particulares-mobile-render-artifacts.md`
+
+No se tocaron backend, auth, cookies, CSRF, CORS, CSP, storagePath, signed URLs, DB schema, indices, WebAuthn, Navbar ni Footer.
+
+## Implementacion
+
+- Se mantuvo el import dinamico de `DashboardNotificationsBell`.
+- Se aislo la campana particular en `particular-notifications-bell-layer`.
+- El placeholder de la campana paso de `bg-card/95` a `bg-card` y quedo targeteable por CSS.
+- En `@media (max-width: 639px)`, el panel particular activo ahora fuerza:
+  - backgrounds opacos con `hsl(var(--card))` y `hsl(var(--vetneb-surface-raised))`.
+  - `background-image: none !important`.
+  - `backdrop-filter` y `-webkit-backdrop-filter` en `none`.
+  - `filter`, `transform` y `will-change` neutralizados.
+  - `backface-visibility`, `perspective`, `mix-blend-mode` y `text-shadow` estables.
+  - `contain: layout` en panel y `contain: layout paint` en resumen/fields.
+  - sombras simples dentro del panel particular mobile.
+- No se redefinio `.surface-soft` globalmente.
+- Se conservaron Tutor, Mascota, Especie, Raza, Extraccion, Envio, Seguimiento del estudio, Informe vinculado, Ver informe, Descargar, links de WhatsApp/email y campana particular.
+
+## Tests y comandos
+
+Comando enfocado:
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particulares-mobile-session-card-render.test.ts`: PASS, 5/5.
+
+Validacion solicitada:
+
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm typecheck`: PASS.
+- `pnpm typecheck:test`: PASS.
+- `pnpm test`: PASS, 2146 pass, 1 skipped, 0 fail.
+- `pnpm build`: PASS. Build root backend con `esbuild`; genero `dist/index.js`.
+- `pnpm security:public-surface`: PASS, sin public devtools exposure findings. Conserva dos findings informativos `server-only` preexistentes en `frontend/src/middleware.ts`.
+
+No se ejecuto `pnpm --dir frontend build`.
+
+## Verificacion browser
+
+Se levanto temporalmente `pnpm --dir frontend dev -- -p 3000 -H 127.0.0.1` y se abrio `http://127.0.0.1:3000/particulares` en el navegador integrado.
+
+Resultado:
+
+- `/particulares` respondio 200.
+- Viewport mobile `390x844` activo; `window.matchMedia("(max-width: 639px)").matches === true`.
+- Sin sesion real disponible, se verifico el estado sin sesion: formulario de token visible y sin errores de consola del navegador.
+- El servidor frontend reporto `ECONNREFUSED` al proxy de `/api/particular/auth/me` porque el backend local no estaba corriendo en la URL configurada. Esto no bloqueo el render del formulario.
+
+La sesion particular activa queda cubierta por contratos fuente porque este entorno no tenia token real para autenticar un caso.
+
+## Resultados
+
+El fix queda aplicado y cubierto por contratos que verifican:
+
+- Los tres `data-*` de sesion particular siguen presentes.
+- Existen exactamente seis fields visibles.
+- Siguen los anchors `particular-study-tracking` y `particular-report`.
+- El bloque CSS esta dentro de `@media (max-width: 639px)`.
+- El bloque mobile neutraliza `backdrop-filter`, `-webkit-backdrop-filter`, `filter`, `transform` y `will-change`.
+- Resumen y fields usan fondos opacos.
+- `.surface-soft` no fue redefinida globalmente.
+- La campana particular sigue presente y aislada con wrapper estable.
+
+## Riesgos
+
+- La validacion definitiva del bug visual requiere repetir en un Android real con sesion particular activa y datos reales del caso.
+- En mobile, las superficies del panel activo quedan deliberadamente mas planas para reducir capas GPU. Desktop no cambia.
+
+## Rollback
+
+Revertir los cambios de:
+
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `frontend/src/app/globals.css`
+- `test/frontend-particulares-mobile-session-card-render.test.ts`
+- `docs/pr-history/PR-fix-particulares-mobile-render-artifacts.md`
+
+## Estado final
+
+Implementado y validado localmente. No se ejecuto `git add`, commit, push, PR ni merge.
+
+Confirmacion: el fix CSS es mobile-only y esta aislado al panel de particulares autenticado.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -605,28 +605,89 @@
       position: relative;
       z-index: 1;
       isolation: isolate;
+      contain: layout;
       overflow: visible !important;
+      border-color: hsl(var(--vetneb-line) / 0.9) !important;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.06) !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      filter: none !important;
       transform: none !important;
       will-change: auto !important;
       backface-visibility: visible;
-      background: hsl(var(--card)) !important;
-      box-shadow: 0 10px 28px rgba(15, 45, 62, 0.08) !important;
+      -webkit-backface-visibility: visible;
+      perspective: none;
+      mix-blend-mode: normal;
+      text-shadow: none;
     }
 
+    [data-particular-session-panel="true"] > *,
+    [data-particular-session-panel="true"] .clinical-muted-band,
     [data-particular-session-panel="true"] .render-gpu-soft,
+    [data-particular-session-panel="true"] .surface-soft,
+    [data-particular-session-panel="true"] .particular-notifications-bell-layer,
+    [data-particular-session-panel="true"] .particular-notifications-bell-placeholder,
     [data-particular-session-panel="true"] [data-particular-session-summary="true"],
     [data-particular-session-panel="true"] [data-particular-session-field="true"] {
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      filter: none !important;
       transform: none !important;
       will-change: auto !important;
       backface-visibility: visible;
+      -webkit-backface-visibility: visible;
+      perspective: none;
+      mix-blend-mode: normal;
+      text-shadow: none;
+    }
+
+    [data-particular-session-panel="true"] .clinical-muted-band {
+      position: relative;
+      z-index: 1;
+      border-color: hsl(var(--vetneb-line) / 0.88);
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.055) !important;
+    }
+
+    [data-particular-session-panel="true"] .render-gpu-soft {
+      border-color: hsl(var(--vetneb-line) / 0.88);
+      background: hsl(var(--vetneb-surface-raised)) !important;
+      background-image: none !important;
+      box-shadow: none !important;
+    }
+
+    [data-particular-session-panel="true"] .particular-notifications-bell-layer {
+      position: relative;
+      z-index: 2;
+      isolation: isolate;
+      overflow: visible;
+    }
+
+    [data-particular-session-panel="true"] .particular-notifications-bell-layer > div {
+      position: relative;
+      z-index: 1;
+      overflow: visible;
+    }
+
+    [data-particular-session-panel="true"] .particular-notifications-bell-layer > div > button,
+    [data-particular-session-panel="true"] .particular-notifications-bell-placeholder {
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.05) !important;
     }
 
     [data-particular-session-summary="true"] {
       position: relative;
       z-index: 1;
-      overflow: visible;
+      isolation: isolate;
+      contain: layout paint;
+      overflow: hidden;
       border-color: hsl(var(--vetneb-line) / 0.84);
       background: hsl(var(--card)) !important;
+      background-image: none !important;
       box-shadow: 0 1px 2px rgba(15, 45, 62, 0.06) !important;
     }
 
@@ -640,11 +701,18 @@
       position: relative;
       z-index: 1;
       min-width: 0;
-      overflow: visible;
+      contain: layout paint;
+      overflow: hidden;
       isolation: isolate;
       border-color: hsl(var(--vetneb-line) / 0.88);
       background: hsl(var(--vetneb-surface-raised)) !important;
+      background-image: none !important;
       box-shadow: 0 1px 2px rgba(15, 45, 62, 0.055) !important;
+    }
+
+    [data-particular-session-field="true"] > * {
+      position: relative;
+      z-index: 1;
     }
   }
   /* particular-session-mobile-render-fix:end */

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -55,7 +55,7 @@ const ParticularNotificationsBell = dynamic(
   {
     loading: () => (
       <span
-        className="inline-flex h-9 w-9 rounded-md border border-input bg-card/95 shadow-[0_1px_2px_rgba(15,45,62,0.05)]"
+        className="particular-notifications-bell-placeholder inline-flex h-9 w-9 rounded-md border border-input bg-card shadow-[0_1px_2px_rgba(15,45,62,0.05)]"
         aria-hidden="true"
       />
     ),
@@ -383,7 +383,11 @@ export function ParticularesContent() {
                     </CardDescription>
                   </div>
                 </div>
-                {session ? <ParticularNotificationsBell surface="particular" /> : null}
+                {session ? (
+                  <div className="particular-notifications-bell-layer shrink-0">
+                    <ParticularNotificationsBell surface="particular" />
+                  </div>
+                ) : null}
               </div>
             </CardHeader>
 

--- a/test/frontend-particulares-mobile-session-card-render.test.ts
+++ b/test/frontend-particulares-mobile-session-card-render.test.ts
@@ -31,6 +31,21 @@ function extractMarkedBlock(
   return source.slice(start, end + endMarker.length);
 }
 
+function extractCssRule(source: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|\\n)\\s*${escapedSelector}\\s*\\{`).exec(
+    source,
+  );
+  const start = match?.index ?? -1;
+
+  assert.notEqual(start, -1, `missing CSS rule: ${selector}`);
+
+  const end = source.indexOf("}", start);
+  assert.notEqual(end, -1, `missing CSS rule close: ${selector}`);
+
+  return source.slice(start, end + 1);
+}
+
 test("particulares active session exposes stable mobile render selectors", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
 
@@ -51,6 +66,15 @@ test("particulares active session exposes stable mobile render selectors", () =>
     fieldSelectorCount,
     6,
     "case summary must expose one stable data selector per visible field card",
+  );
+
+  assert.ok(
+    source.includes('className="particular-notifications-bell-layer shrink-0"'),
+    "particular notifications bell must sit in a stable mobile layer",
+  );
+  assert.ok(
+    source.includes("particular-notifications-bell-placeholder"),
+    "particular notifications bell placeholder must be targetable by the mobile render fix",
   );
 });
 
@@ -93,14 +117,49 @@ test("globals css contains mobile-only render fix for particular session selecto
   assert.ok(block.includes('[data-particular-session-panel="true"]'));
   assert.ok(block.includes('[data-particular-session-summary="true"]'));
   assert.ok(block.includes('[data-particular-session-field="true"]'));
-  assert.ok(block.includes("transform: none !important;"));
-  assert.ok(block.includes("will-change: auto !important;"));
-  assert.ok(block.includes("backface-visibility: visible;"));
-  assert.ok(block.includes("background: hsl(var(--card)) !important;"));
+
+  for (const declaration of [
+    "backdrop-filter: none !important;",
+    "-webkit-backdrop-filter: none !important;",
+    "filter: none !important;",
+    "transform: none !important;",
+    "will-change: auto !important;",
+    "backface-visibility: visible;",
+    "perspective: none;",
+    "mix-blend-mode: normal;",
+    "text-shadow: none;",
+  ]) {
+    assert.ok(
+      block.includes(declaration),
+      `mobile particular render fix must include: ${declaration}`,
+    );
+  }
+
+  const panelRule = extractCssRule(
+    block,
+    '[data-particular-session-panel="true"]',
+  );
+  const summaryRule = extractCssRule(
+    block,
+    '[data-particular-session-summary="true"]',
+  );
+  const fieldRule = extractCssRule(
+    block,
+    '[data-particular-session-field="true"]',
+  );
+
+  assert.ok(panelRule.includes("contain: layout;"));
+  assert.ok(panelRule.includes("background: hsl(var(--card)) !important;"));
+  assert.ok(panelRule.includes("background-image: none !important;"));
+  assert.ok(summaryRule.includes("contain: layout paint;"));
+  assert.ok(summaryRule.includes("background: hsl(var(--card)) !important;"));
+  assert.ok(summaryRule.includes("background-image: none !important;"));
+  assert.ok(fieldRule.includes("contain: layout paint;"));
   assert.ok(
-    block.includes("background: hsl(var(--vetneb-surface-raised)) !important;"),
+    fieldRule.includes("background: hsl(var(--vetneb-surface-raised)) !important;"),
     "field cards should use an opaque raised surface on mobile",
   );
+  assert.ok(fieldRule.includes("background-image: none !important;"));
 });
 
 test("globals css keeps particular session fix scoped and avoids global surface-soft override", () => {


### PR DESCRIPTION
# PR fix particulares mobile render artifacts

## Resumen

Se reforzo el render mobile del dashboard de particulares en `/particulares` cuando existe una sesion particular activa. El cambio apunta a eliminar ghosting, duplicacion visual y artefactos de composicion en Android sin ocultar campos ni modificar contratos de datos.

El fix queda aislado al panel particular autenticado mediante los selectores existentes:

- `data-particular-session-panel="true"`
- `data-particular-session-summary="true"`
- `data-particular-session-field="true"`

## Causa probable

La corrupcion observada parece consistente con composicion CSS/GPU en mobile, no con datos duplicados. El panel activo combinaba superficies anidadas con opacidades, sombras, gradientes suaves y clases como `render-gpu-soft`, `surface-soft` y `clinical-muted-band`. En ciertos Android/WebView, esa mezcla puede promover capas y dejar restos visuales al repintar cards dentro del panel.

## Archivos tocados

- `frontend/src/components/public/ParticularesContent.tsx`
- `frontend/src/app/globals.css`
- `test/frontend-particulares-mobile-session-card-render.test.ts`
- `docs/pr-history/PR-fix-particulares-mobile-render-artifacts.md`

No se tocaron backend, auth, cookies, CSRF, CORS, CSP, storagePath, signed URLs, DB schema, indices, WebAuthn, Navbar ni Footer.

## Implementacion

- Se mantuvo el import dinamico de `DashboardNotificationsBell`.
- Se aislo la campana particular en `particular-notifications-bell-layer`.
- El placeholder de la campana paso de `bg-card/95` a `bg-card` y quedo targeteable por CSS.
- En `@media (max-width: 639px)`, el panel particular activo ahora fuerza:
  - backgrounds opacos con `hsl(var(--card))` y `hsl(var(--vetneb-surface-raised))`.
  - `background-image: none !important`.
  - `backdrop-filter` y `-webkit-backdrop-filter` en `none`.
  - `filter`, `transform` y `will-change` neutralizados.
  - `backface-visibility`, `perspective`, `mix-blend-mode` y `text-shadow` estables.
  - `contain: layout` en panel y `contain: layout paint` en resumen/fields.
  - sombras simples dentro del panel particular mobile.
- No se redefinio `.surface-soft` globalmente.
- Se conservaron Tutor, Mascota, Especie, Raza, Extraccion, Envio, Seguimiento del estudio, Informe vinculado, Ver informe, Descargar, links de WhatsApp/email y campana particular.

## Tests y comandos

Comando enfocado:

- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particulares-mobile-session-card-render.test.ts`: PASS, 5/5.

Validacion solicitada:

- `pnpm --dir frontend lint`: PASS.
- `pnpm --dir frontend typecheck`: PASS.
- `pnpm typecheck`: PASS.
- `pnpm typecheck:test`: PASS.
- `pnpm test`: PASS, 2146 pass, 1 skipped, 0 fail.
- `pnpm build`: PASS. Build root backend con `esbuild`; genero `dist/index.js`.
- `pnpm security:public-surface`: PASS, sin public devtools exposure findings. Conserva dos findings informativos `server-only` preexistentes en `frontend/src/middleware.ts`.

No se ejecuto `pnpm --dir frontend build`.

## Verificacion browser

Se levanto temporalmente `pnpm --dir frontend dev -- -p 3000 -H 127.0.0.1` y se abrio `http://127.0.0.1:3000/particulares` en el navegador integrado.

Resultado:

- `/particulares` respondio 200.
- Viewport mobile `390x844` activo; `window.matchMedia("(max-width: 639px)").matches === true`.
- Sin sesion real disponible, se verifico el estado sin sesion: formulario de token visible y sin errores de consola del navegador.
- El servidor frontend reporto `ECONNREFUSED` al proxy de `/api/particular/auth/me` porque el backend local no estaba corriendo en la URL configurada. Esto no bloqueo el render del formulario.

La sesion particular activa queda cubierta por contratos fuente porque este entorno no tenia token real para autenticar un caso.

## Resultados

El fix queda aplicado y cubierto por contratos que verifican:

- Los tres `data-*` de sesion particular siguen presentes.
- Existen exactamente seis fields visibles.
- Siguen los anchors `particular-study-tracking` y `particular-report`.
- El bloque CSS esta dentro de `@media (max-width: 639px)`.
- El bloque mobile neutraliza `backdrop-filter`, `-webkit-backdrop-filter`, `filter`, `transform` y `will-change`.
- Resumen y fields usan fondos opacos.
- `.surface-soft` no fue redefinida globalmente.
- La campana particular sigue presente y aislada con wrapper estable.

## Riesgos

- La validacion definitiva del bug visual requiere repetir en un Android real con sesion particular activa y datos reales del caso.
- En mobile, las superficies del panel activo quedan deliberadamente mas planas para reducir capas GPU. Desktop no cambia.

## Rollback

Revertir los cambios de:

- `frontend/src/components/public/ParticularesContent.tsx`
- `frontend/src/app/globals.css`
- `test/frontend-particulares-mobile-session-card-render.test.ts`
- `docs/pr-history/PR-fix-particulares-mobile-render-artifacts.md`

## Estado final

Implementado y validado localmente. No se ejecuto `git add`, commit, push, PR ni merge.

Confirmacion: el fix CSS es mobile-only y esta aislado al panel de particulares autenticado.
