### PR TITLE
fix(particulares): use mobile safe session summary

### DIFF
--- a/docs/pr-history/PR-fix-particulares-mobile-safe-session-summary.md
+++ b/docs/pr-history/PR-fix-particulares-mobile-safe-session-summary.md
@@ -1,0 +1,88 @@
+# PR fix particulares mobile safe session summary
+
+## Resumen
+
+Implementa un resumen de sesion particular mobile-safe en `/particulares`.
+En mobile, los datos Tutor, Mascota, Especie, Raza, Extraccion y Envio ahora se renderizan en una estructura plana, opaca y sin superficies visuales pesadas. Desktop conserva el resumen previo desde `sm+`.
+
+## Causa probable
+
+La corrupcion persistente en Android real es compatible con artefactos de composicion CSS/GPU en un bloque con capas anidadas, sombras, fondos con opacidad y primitivas visuales promovidas a GPU. El problema no parece ser duplicacion de datos de negocio, sino repaint/composicion inestable del resumen activo.
+
+## Que fallo de #809
+
+#809 reforzo CSS sobre el panel y las superficies existentes, pero el resumen seguia usando la misma estructura visual base: `clinical-muted-band` y campos `surface-soft` dentro de un panel con composicion. Ese enfoque reduce riesgo, pero no elimina la condicion estructural que puede disparar ghosting en Android.
+
+## Implementacion
+
+- `ParticularesContent.tsx` agrega un resumen mobile-only con:
+  - `data-particular-mobile-safe-summary="true"`.
+  - seis `data-particular-mobile-safe-field="true"`.
+  - clases planas con fondo `bg-card`, borde simple y sin `surface-soft`.
+- El resumen desktop anterior queda como `hidden ... sm:block`, por lo que no coexiste visualmente en mobile.
+- El bloque mobile-safe no usa `PremiumPanel`, `VisualIcon`, `render-gpu-soft`, `surface-soft`, `backdrop-blur`, `transform-gpu` ni `bg-card/`.
+- `globals.css` agrega reglas mobile-only para los nuevos data attributes con fondos opacos, neutralizacion de filtros/transform/will-change, `contain: layout paint style`, `isolation: isolate`, borde estable y overflow controlado.
+- Se conserva la campana de notificaciones, seguimiento del estudio, informe vinculado, Ver informe, Descargar, WhatsApp/email de tincion especial y logout particular.
+
+## Archivos tocados
+
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `frontend/src/app/globals.css`
+- `test/frontend-particulares-mobile-session-card-render.test.ts`
+- `docs/pr-history/PR-fix-particulares-mobile-safe-session-summary.md`
+
+No se tocaron backend, API, auth, cookies, CSRF, CORS, CSP, storagePath, signed URLs, DB schema, indices, WebAuthn, Navbar, Footer ni dashboards admin/clinica.
+
+## Tests y comandos
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particulares-mobile-session-card-render.test.ts`: PASS, 8/8.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm typecheck`: PASS.
+- `pnpm typecheck:test`: PASS.
+- `pnpm test`: PASS, 2149 pass, 1 skipped, 0 fail.
+- `pnpm build`: PASS, backend root build con `esbuild`.
+- `pnpm security:public-surface`: PASS, sin public devtools exposure findings. Reporta dos findings `server-only` en `frontend/src/middleware.ts` para nombres de cookies, sin exposicion publica.
+
+No se ejecuto `pnpm --dir frontend build`.
+
+## Resultados
+
+Los contratos verifican:
+
+- existe `data-particular-mobile-safe-summary`.
+- existen seis `data-particular-mobile-safe-field`.
+- el bloque mobile-safe contiene Tutor, Mascota, Especie, Raza, Extraccion y Envio.
+- el bloque mobile-safe no contiene primitivas o clases prohibidas para este fix.
+- el resumen desktop queda oculto en mobile con `hidden`/`sm:block`, no con opacity.
+- el CSS mobile contiene reglas para los nuevos data attributes.
+- el CSS neutraliza `filter`, `backdrop-filter`, `-webkit-backdrop-filter`, `transform`, `will-change`, `mix-blend-mode` y `text-shadow`.
+- los fondos del resumen mobile-safe son opacos.
+- los marcadores mobile-safe no aparecen en Navbar, Footer, server, drizzle ni shared.
+
+## Validacion browser
+
+No se uso navegador local ni token real en esta iteracion. Si se valida en browser, el token debe pegarlo manualmente el usuario en `/particulares`; no debe imprimirse, capturarse ni persistirse.
+
+## Riesgos
+
+- La confirmacion definitiva del bug requiere Android real con sesion particular activa.
+- En mobile, el resumen queda deliberadamente mas plano que desktop para reducir capas y artefactos.
+- El panel contenedor general sigue existiendo, pero las cards del resumen mobile-safe ya no dependen de las superficies visuales previas.
+
+## Rollback
+
+Revertir los cambios en:
+
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `frontend/src/app/globals.css`
+- `test/frontend-particulares-mobile-session-card-render.test.ts`
+- `docs/pr-history/PR-fix-particulares-mobile-safe-session-summary.md`
+
+No hay migraciones, backend, datos ni configuracion de auth para revertir.
+
+## Estado final
+
+Implementado y validado localmente. Mobile usa un layout plano unico para el resumen de sesion particular bajo `640px`. Desktop no cambia intencionalmente y conserva el resumen anterior desde `sm+`.
+
+No se ejecuto `git add`, commit, push, PR, merge ni ninguna accion de publicacion.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -629,6 +629,8 @@
     [data-particular-session-panel="true"] .surface-soft,
     [data-particular-session-panel="true"] .particular-notifications-bell-layer,
     [data-particular-session-panel="true"] .particular-notifications-bell-placeholder,
+    [data-particular-session-panel="true"] [data-particular-mobile-safe-summary="true"],
+    [data-particular-session-panel="true"] [data-particular-mobile-safe-field="true"],
     [data-particular-session-panel="true"] [data-particular-session-summary="true"],
     [data-particular-session-panel="true"] [data-particular-session-field="true"] {
       backdrop-filter: none !important;
@@ -677,6 +679,64 @@
       background: hsl(var(--card)) !important;
       background-image: none !important;
       box-shadow: 0 1px 2px rgba(15, 45, 62, 0.05) !important;
+    }
+
+    [data-particular-mobile-safe-summary="true"] {
+      display: block !important;
+      position: relative;
+      z-index: 1;
+      min-width: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: hidden;
+      border: 1px solid hsl(var(--vetneb-line) / 0.92) !important;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.05) !important;
+    }
+
+    [data-particular-mobile-safe-summary="true"] > dl {
+      display: grid;
+      position: relative;
+      z-index: 1;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+
+    [data-particular-mobile-safe-field="true"] {
+      display: block !important;
+      position: relative;
+      z-index: 1;
+      min-width: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: hidden;
+      border: 1px solid hsl(var(--vetneb-line) / 0.9) !important;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: none !important;
+    }
+
+    [data-particular-mobile-safe-field="true"] > * {
+      position: relative;
+      z-index: 1;
+      min-width: 0;
     }
 
     [data-particular-session-summary="true"] {

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -399,7 +399,77 @@ export function ParticularesContent() {
               ) : session ? (
                 <div className="space-y-5">
                   <div
-                    className="clinical-muted-band rounded-lg p-4"
+                    className="rounded-lg border border-vetneb-line bg-card p-3 sm:hidden"
+                    data-particular-mobile-safe-summary="true"
+                  >
+                    <dl className="grid grid-cols-1 gap-2 text-sm">
+                      <div
+                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        data-particular-mobile-safe-field="true"
+                      >
+                        <dt className="font-medium text-muted-foreground">
+                          Tutor
+                        </dt>
+                        <dd className="mt-1 font-semibold text-vetneb-ink">
+                          {session.tutorLastName}
+                        </dd>
+                      </div>
+                      <div
+                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        data-particular-mobile-safe-field="true"
+                      >
+                        <dt className="font-medium text-muted-foreground">
+                          Mascota
+                        </dt>
+                        <dd className="mt-1 font-semibold text-vetneb-ink">
+                          {session.petName}
+                        </dd>
+                      </div>
+                      <div
+                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        data-particular-mobile-safe-field="true"
+                      >
+                        <dt className="font-medium text-muted-foreground">Especie</dt>
+                        <dd className="mt-1 text-vetneb-ink">
+                          {session.petSpecies}
+                        </dd>
+                      </div>
+                      <div
+                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        data-particular-mobile-safe-field="true"
+                      >
+                        <dt className="font-medium text-muted-foreground">Raza</dt>
+                        <dd className="mt-1 text-vetneb-ink">
+                          {session.petBreed}
+                        </dd>
+                      </div>
+                      <div
+                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        data-particular-mobile-safe-field="true"
+                      >
+                        <dt className="font-medium text-muted-foreground">
+                          Extracción
+                        </dt>
+                        <dd className="mt-1 text-vetneb-ink">
+                          {formatDate(session.extractionDate)}
+                        </dd>
+                      </div>
+                      <div
+                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        data-particular-mobile-safe-field="true"
+                      >
+                        <dt className="font-medium text-muted-foreground">
+                          Envío
+                        </dt>
+                        <dd className="mt-1 text-vetneb-ink">
+                          {formatDate(session.shippingDate)}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  <div
+                    className="hidden clinical-muted-band rounded-lg p-4 sm:block"
                     data-particular-session-summary="true"
                   >
                     <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">

--- a/test/frontend-particulares-mobile-session-card-render.test.ts
+++ b/test/frontend-particulares-mobile-session-card-render.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 const PARTICULARES_CONTENT_PATH =
@@ -8,6 +8,8 @@ const PARTICULARES_CONTENT_PATH =
 const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
 const PUBLIC_SURFACE_AUDIT_SCRIPT_PATH =
   "scripts/security/audit-public-devtools-surface.mjs";
+const NAVBAR_PATH = "frontend/src/components/layout/Navbar.tsx";
+const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -46,40 +48,87 @@ function extractCssRule(source: string, selector: string): string {
   return source.slice(start, end + 1);
 }
 
-test("particulares active session exposes stable mobile render selectors", () => {
+function extractMobileSafeSummary(source: string): string {
+  const attributeIndex = source.indexOf(
+    'data-particular-mobile-safe-summary="true"',
+  );
+  assert.notEqual(attributeIndex, -1, "missing mobile-safe summary attribute");
+
+  const start = source.lastIndexOf("<div", attributeIndex);
+  const desktopAttributeIndex = source.indexOf(
+    'data-particular-session-summary="true"',
+    attributeIndex,
+  );
+  assert.notEqual(
+    desktopAttributeIndex,
+    -1,
+    "missing desktop session summary attribute",
+  );
+
+  const end = source.lastIndexOf("<div", desktopAttributeIndex);
+  assert.ok(start > -1 && end > start, "mobile-safe summary block bounds");
+
+  return source.slice(start, end);
+}
+
+function extractDesktopSummary(source: string): string {
+  const attributeIndex = source.indexOf(
+    'data-particular-session-summary="true"',
+  );
+  assert.notEqual(attributeIndex, -1, "missing desktop session summary");
+
+  const start = source.lastIndexOf("<div", attributeIndex);
+  const end = source.indexOf('id="particular-study-tracking"', attributeIndex);
+  assert.ok(start > -1 && end > start, "desktop summary block bounds");
+
+  return source.slice(start, end);
+}
+
+function listFiles(relativeRoot: string): string[] {
+  const absoluteRoot = resolve(process.cwd(), relativeRoot);
+  const files: string[] = [];
+
+  function walk(absolutePath: string) {
+    for (const entry of readdirSync(absolutePath, { withFileTypes: true })) {
+      const child = join(absolutePath, entry.name);
+      if (entry.isDirectory()) {
+        walk(child);
+        continue;
+      }
+
+      if (statSync(child).isFile()) {
+        files.push(child);
+      }
+    }
+  }
+
+  walk(absoluteRoot);
+  return files;
+}
+
+test("particulares active session renders a single mobile-safe case summary", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
+  const mobileSummary = extractMobileSafeSummary(source);
 
   assert.ok(
-    source.includes('data-particular-session-panel={session ? "true" : undefined}'),
-    "active particular session panel must expose a scoped data selector",
+    mobileSummary.includes('data-particular-mobile-safe-summary="true"'),
+    "mobile case summary must expose the requested stable data selector",
   );
-  assert.ok(
-    source.includes('data-particular-session-summary="true"'),
-    "case summary must expose a stable data selector",
+  assert.match(
+    mobileSummary,
+    /className="[^"]*\bsm:hidden\b[^"]*"/,
+    "mobile-safe summary must be the only summary visible below sm",
   );
 
   const fieldSelectorCount = (
-    source.match(/data-particular-session-field="true"/g) ?? []
+    mobileSummary.match(/data-particular-mobile-safe-field="true"/g) ?? []
   ).length;
 
   assert.equal(
     fieldSelectorCount,
     6,
-    "case summary must expose one stable data selector per visible field card",
+    "mobile-safe case summary must expose one field per visible data point",
   );
-
-  assert.ok(
-    source.includes('className="particular-notifications-bell-layer shrink-0"'),
-    "particular notifications bell must sit in a stable mobile layer",
-  );
-  assert.ok(
-    source.includes("particular-notifications-bell-placeholder"),
-    "particular notifications bell placeholder must be targetable by the mobile render fix",
-  );
-});
-
-test("particulares active session keeps visible case fields and notification anchors", () => {
-  const source = read(PARTICULARES_CONTENT_PATH);
 
   for (const label of [
     "Tutor",
@@ -89,20 +138,76 @@ test("particulares active session keeps visible case fields and notification anc
     "Extracción",
     "Envío",
   ]) {
-    assert.ok(source.includes(label), `must keep visible field: ${label}`);
+    assert.ok(mobileSummary.includes(label), `must keep mobile field: ${label}`);
   }
+});
 
-  assert.ok(
-    source.includes('id="particular-study-tracking"'),
-    "study tracking anchor must remain available for notifications",
+test("mobile-safe summary avoids GPU-heavy presentation primitives", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const mobileSummary = extractMobileSafeSummary(source);
+
+  for (const forbidden of [
+    "PremiumPanel",
+    "VisualIcon",
+    "render-gpu-soft",
+    "surface-soft",
+    "backdrop-blur",
+    "transform-gpu",
+    "bg-card/",
+  ]) {
+    assert.equal(
+      mobileSummary.includes(forbidden),
+      false,
+      `mobile-safe summary must not contain ${forbidden}`,
+    );
+  }
+});
+
+test("desktop summary remains available from sm and is hidden on mobile", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const desktopSummary = extractDesktopSummary(source);
+
+  assert.match(
+    desktopSummary,
+    /className="[^"]*\bhidden\b[^"]*\bsm:block\b[^"]*"/,
+    "desktop summary must use display hiding on mobile, not opacity hiding",
   );
-  assert.ok(
-    source.includes('id="particular-report"'),
-    "linked report anchor must remain available for notifications",
+  assert.equal(
+    /opacity-0|opacity:\s*0/.test(desktopSummary),
+    false,
+    "desktop summary must not rely on opacity to hide from mobile",
+  );
+
+  const desktopFieldSelectorCount = (
+    desktopSummary.match(/data-particular-session-field="true"/g) ?? []
+  ).length;
+
+  assert.equal(
+    desktopFieldSelectorCount,
+    6,
+    "desktop summary must keep the existing six visible field cards",
   );
 });
 
-test("globals css contains mobile-only render fix for particular session selectors", () => {
+test("particulares active session keeps tracking, report, notification and logout flows", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  for (const marker of [
+    'className="particular-notifications-bell-layer shrink-0"',
+    "particular-notifications-bell-placeholder",
+    'id="particular-study-tracking"',
+    'id="particular-report"',
+    "Consultar por WhatsApp",
+    "Enviar email",
+    "Ver informe",
+    "Descargar",
+    "Cerrar sesión particular",
+  ]) {
+    assert.ok(source.includes(marker), `must keep active-session flow: ${marker}`);
+  }
+});
+
+test("globals css contains mobile-only rules for mobile-safe summary selectors", () => {
   const source = read(GLOBALS_CSS_PATH);
   const block = extractMarkedBlock(
     source,
@@ -114,55 +219,55 @@ test("globals css contains mobile-only render fix for particular session selecto
     block.includes("@media (max-width: 639px)"),
     "particular session render fix must be mobile-only",
   );
-  assert.ok(block.includes('[data-particular-session-panel="true"]'));
-  assert.ok(block.includes('[data-particular-session-summary="true"]'));
-  assert.ok(block.includes('[data-particular-session-field="true"]'));
+  assert.ok(block.includes('[data-particular-mobile-safe-summary="true"]'));
+  assert.ok(block.includes('[data-particular-mobile-safe-field="true"]'));
 
-  for (const declaration of [
-    "backdrop-filter: none !important;",
-    "-webkit-backdrop-filter: none !important;",
-    "filter: none !important;",
-    "transform: none !important;",
-    "will-change: auto !important;",
-    "backface-visibility: visible;",
-    "perspective: none;",
-    "mix-blend-mode: normal;",
-    "text-shadow: none;",
-  ]) {
-    assert.ok(
-      block.includes(declaration),
-      `mobile particular render fix must include: ${declaration}`,
-    );
-  }
-
-  const panelRule = extractCssRule(
-    block,
-    '[data-particular-session-panel="true"]',
-  );
   const summaryRule = extractCssRule(
     block,
-    '[data-particular-session-summary="true"]',
+    '[data-particular-mobile-safe-summary="true"]',
   );
   const fieldRule = extractCssRule(
     block,
-    '[data-particular-session-field="true"]',
+    '[data-particular-mobile-safe-field="true"]',
   );
 
-  assert.ok(panelRule.includes("contain: layout;"));
-  assert.ok(panelRule.includes("background: hsl(var(--card)) !important;"));
-  assert.ok(panelRule.includes("background-image: none !important;"));
-  assert.ok(summaryRule.includes("contain: layout paint;"));
-  assert.ok(summaryRule.includes("background: hsl(var(--card)) !important;"));
-  assert.ok(summaryRule.includes("background-image: none !important;"));
-  assert.ok(fieldRule.includes("contain: layout paint;"));
-  assert.ok(
-    fieldRule.includes("background: hsl(var(--vetneb-surface-raised)) !important;"),
-    "field cards should use an opaque raised surface on mobile",
-  );
-  assert.ok(fieldRule.includes("background-image: none !important;"));
+  for (const rule of [summaryRule, fieldRule]) {
+    for (const declaration of [
+      "display: block !important;",
+      "position: relative;",
+      "z-index: 1;",
+      "contain: layout paint style;",
+      "isolation: isolate;",
+      "overflow: hidden;",
+      "background: hsl(var(--card)) !important;",
+      "background-image: none !important;",
+      "opacity: 1 !important;",
+      "filter: none !important;",
+      "backdrop-filter: none !important;",
+      "-webkit-backdrop-filter: none !important;",
+      "transform: none !important;",
+      "will-change: auto !important;",
+      "mix-blend-mode: normal;",
+      "text-shadow: none;",
+    ]) {
+      assert.ok(
+        rule.includes(declaration),
+        `mobile-safe CSS rule must include: ${declaration}`,
+      );
+    }
+
+    assert.doesNotMatch(
+      rule,
+      /background:\s*hsl\(var\(--card\)\s*\//,
+      "mobile-safe backgrounds must stay opaque",
+    );
+  }
+
+  assert.ok(summaryRule.includes("box-shadow: 0 1px 2px"));
+  assert.ok(fieldRule.includes("box-shadow: none !important;"));
 });
 
-test("globals css keeps particular session fix scoped and avoids global surface-soft override", () => {
+test("particular mobile render CSS stays scoped and avoids global surface-soft changes", () => {
   const source = read(GLOBALS_CSS_PATH);
   const startMarker = "/* particular-session-mobile-render-fix:start */";
   const endMarker = "/* particular-session-mobile-render-fix:end */";
@@ -177,18 +282,51 @@ test("globals css keeps particular session fix scoped and avoids global surface-
   );
 
   for (const match of source.matchAll(
-    /\[data-particular-session-(?:panel|summary|field)="true"\]/g,
+    /\[data-particular-mobile-safe-(?:summary|field)="true"\]/g,
   )) {
     const index = match.index ?? -1;
 
     assert.ok(
       index >= blockStart && index < blockEnd,
-      "particular session CSS selectors must stay inside the mobile-only block",
+      "mobile-safe CSS selectors must stay inside the mobile-only block",
     );
   }
 });
 
-test("public surface auditor allowlists only the required particular presentation attributes", () => {
+test("mobile-safe feature markers stay out of Navbar, Footer and backend surfaces", () => {
+  const forbiddenMarkers = [
+    "data-particular-mobile-safe-summary",
+    "data-particular-mobile-safe-field",
+    "particular-mobile-safe-summary",
+    "particular-mobile-safe-field",
+  ];
+
+  for (const filePath of [NAVBAR_PATH, FOOTER_PATH]) {
+    const source = read(filePath);
+    for (const marker of forbiddenMarkers) {
+      assert.equal(
+        source.includes(marker),
+        false,
+        `${filePath} must not include ${marker}`,
+      );
+    }
+  }
+
+  for (const directory of ["server", "drizzle", "shared"]) {
+    for (const absolutePath of listFiles(directory)) {
+      const source = readFileSync(absolutePath, "utf8");
+      for (const marker of forbiddenMarkers) {
+        assert.equal(
+          source.includes(marker),
+          false,
+          `${directory} surface must not include ${marker}`,
+        );
+      }
+    }
+  }
+});
+
+test("public surface auditor keeps exact allowlist for legacy session selectors", () => {
   const source = read(PUBLIC_SURFACE_AUDIT_SCRIPT_PATH);
 
   assert.ok(


### PR DESCRIPTION
# PR fix particulares mobile safe session summary

## Resumen

Implementa un resumen de sesion particular mobile-safe en `/particulares`.
En mobile, los datos Tutor, Mascota, Especie, Raza, Extraccion y Envio ahora se renderizan en una estructura plana, opaca y sin superficies visuales pesadas. Desktop conserva el resumen previo desde `sm+`.

## Causa probable

La corrupcion persistente en Android real es compatible con artefactos de composicion CSS/GPU en un bloque con capas anidadas, sombras, fondos con opacidad y primitivas visuales promovidas a GPU. El problema no parece ser duplicacion de datos de negocio, sino repaint/composicion inestable del resumen activo.

## Que fallo de #809

#809 reforzo CSS sobre el panel y las superficies existentes, pero el resumen seguia usando la misma estructura visual base: `clinical-muted-band` y campos `surface-soft` dentro de un panel con composicion. Ese enfoque reduce riesgo, pero no elimina la condicion estructural que puede disparar ghosting en Android.

## Implementacion

- `ParticularesContent.tsx` agrega un resumen mobile-only con:
  - `data-particular-mobile-safe-summary="true"`.
  - seis `data-particular-mobile-safe-field="true"`.
  - clases planas con fondo `bg-card`, borde simple y sin `surface-soft`.
- El resumen desktop anterior queda como `hidden ... sm:block`, por lo que no coexiste visualmente en mobile.
- El bloque mobile-safe no usa `PremiumPanel`, `VisualIcon`, `render-gpu-soft`, `surface-soft`, `backdrop-blur`, `transform-gpu` ni `bg-card/`.
- `globals.css` agrega reglas mobile-only para los nuevos data attributes con fondos opacos, neutralizacion de filtros/transform/will-change, `contain: layout paint style`, `isolation: isolate`, borde estable y overflow controlado.
- Se conserva la campana de notificaciones, seguimiento del estudio, informe vinculado, Ver informe, Descargar, WhatsApp/email de tincion especial y logout particular.

## Archivos tocados

- `frontend/src/components/public/ParticularesContent.tsx`
- `frontend/src/app/globals.css`
- `test/frontend-particulares-mobile-session-card-render.test.ts`
- `docs/pr-history/PR-fix-particulares-mobile-safe-session-summary.md`

No se tocaron backend, API, auth, cookies, CSRF, CORS, CSP, storagePath, signed URLs, DB schema, indices, WebAuthn, Navbar, Footer ni dashboards admin/clinica.

## Tests y comandos

- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particulares-mobile-session-card-render.test.ts`: PASS, 8/8.
- `pnpm --dir frontend lint`: PASS.
- `pnpm --dir frontend typecheck`: PASS.
- `pnpm typecheck`: PASS.
- `pnpm typecheck:test`: PASS.
- `pnpm test`: PASS, 2149 pass, 1 skipped, 0 fail.
- `pnpm build`: PASS, backend root build con `esbuild`.
- `pnpm security:public-surface`: PASS, sin public devtools exposure findings. Reporta dos findings `server-only` en `frontend/src/middleware.ts` para nombres de cookies, sin exposicion publica.

No se ejecuto `pnpm --dir frontend build`.

## Resultados

Los contratos verifican:

- existe `data-particular-mobile-safe-summary`.
- existen seis `data-particular-mobile-safe-field`.
- el bloque mobile-safe contiene Tutor, Mascota, Especie, Raza, Extraccion y Envio.
- el bloque mobile-safe no contiene primitivas o clases prohibidas para este fix.
- el resumen desktop queda oculto en mobile con `hidden`/`sm:block`, no con opacity.
- el CSS mobile contiene reglas para los nuevos data attributes.
- el CSS neutraliza `filter`, `backdrop-filter`, `-webkit-backdrop-filter`, `transform`, `will-change`, `mix-blend-mode` y `text-shadow`.
- los fondos del resumen mobile-safe son opacos.
- los marcadores mobile-safe no aparecen en Navbar, Footer, server, drizzle ni shared.

## Validacion browser

No se uso navegador local ni token real en esta iteracion. Si se valida en browser, el token debe pegarlo manualmente el usuario en `/particulares`; no debe imprimirse, capturarse ni persistirse.

## Riesgos

- La confirmacion definitiva del bug requiere Android real con sesion particular activa.
- En mobile, el resumen queda deliberadamente mas plano que desktop para reducir capas y artefactos.
- El panel contenedor general sigue existiendo, pero las cards del resumen mobile-safe ya no dependen de las superficies visuales previas.

## Rollback

Revertir los cambios en:

- `frontend/src/components/public/ParticularesContent.tsx`
- `frontend/src/app/globals.css`
- `test/frontend-particulares-mobile-session-card-render.test.ts`
- `docs/pr-history/PR-fix-particulares-mobile-safe-session-summary.md`

No hay migraciones, backend, datos ni configuracion de auth para revertir.

## Estado final

Implementado y validado localmente. Mobile usa un layout plano unico para el resumen de sesion particular bajo `640px`. Desktop no cambia intencionalmente y conserva el resumen anterior desde `sm+`.

No se ejecuto `git add`, commit, push, PR, merge ni ninguna accion de publicacion.
