### PR TITLE
fix(notifications): render mobile panel as overlay

### DIFF
--- a/docs/pr-history/PR-fix-notifications-mobile-overlay-layer.md
+++ b/docs/pr-history/PR-fix-notifications-mobile-overlay-layer.md
@@ -1,0 +1,75 @@
+# PR fix notifications mobile overlay layer
+
+## Resumen
+
+Se corrigio la apertura manual de notificaciones en mobile para que el panel se renderice como overlay fijo y portaleado a `document.body`, por encima del dashboard de particulares. Desktop conserva el dropdown anclado a la campana.
+
+## Causa probable
+
+El banner mobile de auto-show ya estaba portaleado, pero el panel que se abre al tocar la campana seguia usando el dropdown absoluto dentro del wrapper local. En `/particulares`, ese wrapper queda dentro del panel de sesion y de sus reglas mobile de overflow, contain, isolation y z-index, por lo que el dropdown podia quedar mezclado visualmente con el resumen del caso o atrapado por stacking contexts.
+
+## Por que #810 no era suficiente
+
+#810 estabilizo el resumen mobile de la sesion particular, pero no cambiaba la capa donde se monta el panel manual de `DashboardNotificationsBell`. El origen restante no era el resumen en si, sino el dropdown de notificaciones renderizado dentro del layout particular.
+
+## Implementacion
+
+- `DashboardNotificationsBell` ahora comparte el contenido del panel en `renderPanelContent`.
+- Desktop mantiene el dropdown absoluto existente, oculto bajo `sm`.
+- Mobile monta el panel manual con `createPortal` hacia `document.body`.
+- El overlay mobile usa `position: fixed`, `z-[90]`, fondo opaco para el sheet y selector estable `data-dashboard-notifications-mobile-overlay`.
+- El panel mobile incluye boton de cierre accesible, cierre por backdrop y cierre por Escape.
+- Al abrir manualmente el panel se oculta el banner mobile para evitar capas superpuestas.
+- El panel manual se monta solo con `isOpen`; al cerrar se desmonta.
+- El banner mobile de auto-show conserva la navegacion existente y sube a `z-[80]`.
+
+## Archivos tocados
+
+- `frontend/src/components/dashboard/DashboardNotificationsBell.tsx`
+- `test/frontend-notifications-bell.test.ts`
+- `test/frontend-admin-report-workflow.test.ts`
+- `docs/pr-history/PR-fix-notifications-mobile-overlay-layer.md`
+
+## Tests y comandos
+
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-notifications-bell.test.ts test/frontend-particulares-content.test.ts test/frontend-notification-click-anchors.test.ts test/frontend-particulares-mobile-session-card-render.test.ts`
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-report-workflow.test.ts test/frontend-notifications-bell.test.ts`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- Browser local en `http://127.0.0.1:3000/particulares` con viewport mobile `390x844`
+
+## Resultados
+
+- Tests focalizados de notificaciones y particulares: pass.
+- Frontend lint: pass.
+- Frontend typecheck: pass.
+- Typecheck raiz: pass.
+- Typecheck de tests: pass.
+- Suite completa: pass, `2153` tests pasados y `1` skip existente.
+- Build raiz: pass.
+- Auditoria `security:public-surface`: pass, sin findings de exposicion publica; mantiene los avisos esperados `server-only` en `frontend/src/middleware.ts`.
+- Browser local: `/particulares` compilo y respondio `200`, sin errores de consola en el cliente; la verificacion quedo limitada al render publico sin sesion porque el backend/proxy de `/api/particular/auth/me` no estaba disponible localmente.
+- No se ejecuto `pnpm --dir frontend build`.
+
+## Riesgos
+
+- El panel mobile manual ahora es modal. Si en el futuro se necesita interaccion simultanea con contenido del dashboard mientras esta abierto, habria que ajustar el comportamiento de backdrop.
+- El contenido del panel se comparte entre desktop y mobile; cambios futuros en acciones o lista impactan ambas superficies.
+
+## Rollback
+
+Revertir los cambios de `DashboardNotificationsBell.tsx` y restaurar el dropdown absoluto unico para `isOpen`. Luego revertir los tests agregados/actualizados y eliminar este documento.
+
+## Estado final
+
+- Mobile usa overlay/sheet fijo portaleado sobre el dashboard.
+- El close desmonta u oculta completamente el panel al cambiar `isOpen` a `false`.
+- La navegacion contextual de notificaciones se mantiene.
+- Abrir el panel no marca notificaciones como leidas.
+- Particular, clinica y admin mantienen la campana funcional.
+- No se tocaron backend, API, auth, cookies, CSRF, CORS, CSP, storage, signed URLs, DB schema, indices, WebAuthn, Navbar ni Footer.

--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -52,6 +52,8 @@ export function DashboardNotificationsBell({
     (notification) => !notification.isRead,
   ).length;
   const unreadNotifications = notifications.filter((n) => !n.isRead);
+  const desktopPanelTitleId = `dashboard-notifications-${surface}-title`;
+  const mobilePanelTitleId = `dashboard-notifications-${surface}-mobile-title`;
 
   // Initialise portal target (SSR-safe) and mobile breakpoint tracking.
   useEffect(() => {
@@ -135,11 +137,16 @@ export function DashboardNotificationsBell({
       const next = !current;
 
       if (next) {
+        setMobileBannerVisible(false);
         void loadNotifications();
       }
 
       return next;
     });
+  }
+
+  function handleClosePanel() {
+    setIsOpen(false);
   }
 
   function handleEnableNotifications() {
@@ -150,6 +157,24 @@ export function DashboardNotificationsBell({
   function handleCloseMobileBanner() {
     setMobileBannerVisible(false);
   }
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   function scrollToHashDestination(destination: string) {
     if (typeof window === "undefined") {
@@ -250,6 +275,116 @@ export function DashboardNotificationsBell({
     }
   }
 
+  function renderPanelContent({
+    titleId,
+    listClassName,
+    showCloseButton = false,
+  }: {
+    titleId: string;
+    listClassName: string;
+    showCloseButton?: boolean;
+  }) {
+    return (
+      <>
+        <div className="mb-2 flex flex-col gap-2">
+          <div className="flex items-start justify-between gap-2">
+            <p id={titleId} className="text-sm font-semibold text-vetneb-ink">
+              Notificaciones
+            </p>
+            {showCloseButton ? (
+              <button
+                type="button"
+                aria-label="Cerrar panel de notificaciones"
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/70 hover:text-foreground"
+                onClick={handleClosePanel}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
+              onClick={handleEnableNotifications}
+              disabled={isPollingEnabled}
+            >
+              {isPollingEnabled
+                ? "Notificaciones activadas"
+                : "Activar notificaciones"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
+              onClick={() => void loadNotifications()}
+              disabled={isLoading}
+            >
+              {isLoading ? "Actualizando..." : "Actualizar"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
+              onClick={() => void handleMarkAllAsRead()}
+              disabled={
+                isLoading ||
+                isMarkingAllAsRead ||
+                updatingNotificationId !== null ||
+                unreadCount === 0
+              }
+            >
+              {isMarkingAllAsRead ? "Marcando..." : "Marcar todo como leído"}
+            </Button>
+          </div>
+        </div>
+
+        {errorMessage ? (
+          <p className="clinical-alert-warning px-3 py-2 text-xs" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {!errorMessage && !isLoading && notifications.length === 0 ? (
+          <p className="surface-empty py-3 text-sm">No hay notificaciones.</p>
+        ) : null}
+
+        <ul className={listClassName}>
+          {notifications.map((notification) => (
+            <li key={notification.id}>
+              <button
+                type="button"
+                aria-label={`Abrir notificación: ${notification.title}`}
+                className="w-full cursor-pointer rounded-md border border-vetneb-line/70 bg-vetneb-surface-raised/78 px-3 py-2 text-left transition-colors hover:border-vetneb-teal/45 disabled:cursor-wait disabled:opacity-60"
+                onClick={() => void handleNotificationClick(notification)}
+                disabled={updatingNotificationId === notification.id}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-xs font-semibold text-vetneb-ink">
+                    {notification.title}
+                  </p>
+                  <span className="text-[0.66rem] text-muted-foreground">
+                    {notification.isRead ? "Leída" : "No leída"}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {notification.message}
+                </p>
+                <p className="mt-1 text-[0.66rem] text-muted-foreground">
+                  {formatDateTime(notification.createdAt)}
+                </p>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </>
+    );
+  }
+
   return (
     <div className="relative">
       <button
@@ -267,90 +402,42 @@ export function DashboardNotificationsBell({
       </button>
 
       {isOpen ? (
-        <div className="absolute right-0 z-50 mt-2 w-[min(28rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl">
-          <div className="mb-2 flex flex-col gap-2">
-            <p className="text-sm font-semibold text-vetneb-ink">Notificaciones</p>
-            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
-                onClick={handleEnableNotifications}
-                disabled={isPollingEnabled}
-              >
-                {isPollingEnabled
-                  ? "Notificaciones activadas"
-                  : "Activar notificaciones"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
-                onClick={() => void loadNotifications()}
-                disabled={isLoading}
-              >
-                {isLoading ? "Actualizando..." : "Actualizar"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"
-                onClick={() => void handleMarkAllAsRead()}
-                disabled={
-                  isLoading ||
-                  isMarkingAllAsRead ||
-                  updatingNotificationId !== null ||
-                  unreadCount === 0
-                }
-              >
-                {isMarkingAllAsRead ? "Marcando..." : "Marcar todo como leído"}
-              </Button>
-            </div>
-          </div>
-
-          {errorMessage ? (
-            <p className="clinical-alert-warning px-3 py-2 text-xs" role="alert">
-              {errorMessage}
-            </p>
-          ) : null}
-
-          {!errorMessage && !isLoading && notifications.length === 0 ? (
-            <p className="surface-empty py-3 text-sm">No hay notificaciones.</p>
-          ) : null}
-
-          <ul className="max-h-72 space-y-2 overflow-y-auto pr-1">
-            {notifications.map((notification) => (
-              <li key={notification.id}>
-                <button
-                  type="button"
-                  aria-label={`Abrir notificación: ${notification.title}`}
-                  className="w-full cursor-pointer rounded-md border border-vetneb-line/70 bg-vetneb-surface-raised/78 px-3 py-2 text-left transition-colors hover:border-vetneb-teal/45 disabled:cursor-wait disabled:opacity-60"
-                  onClick={() => void handleNotificationClick(notification)}
-                  disabled={updatingNotificationId === notification.id}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <p className="text-xs font-semibold text-vetneb-ink">
-                      {notification.title}
-                    </p>
-                    <span className="text-[0.66rem] text-muted-foreground">
-                      {notification.isRead ? "Leída" : "No leída"}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {notification.message}
-                  </p>
-                  <p className="mt-1 text-[0.66rem] text-muted-foreground">
-                    {formatDateTime(notification.createdAt)}
-                  </p>
-                </button>
-              </li>
-            ))}
-          </ul>
+        <div
+          className="absolute right-0 z-50 mt-2 hidden w-[min(28rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl sm:block"
+          data-dashboard-notifications-desktop-panel="true"
+        >
+          {renderPanelContent({
+            titleId: desktopPanelTitleId,
+            listClassName: "max-h-72 space-y-2 overflow-y-auto pr-1",
+          })}
         </div>
       ) : null}
+
+      {portalContainer && isOpen
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[90] bg-vetneb-navy/30 sm:hidden"
+              data-dashboard-notifications-mobile-overlay="true"
+              onClick={handleClosePanel}
+            >
+              <div
+                className="fixed inset-x-3 top-3 flex max-h-[calc(100vh-1.5rem)] flex-col overflow-hidden rounded-lg border border-vetneb-line/85 bg-card p-3 shadow-2xl"
+                data-dashboard-notifications-mobile-panel="true"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={mobilePanelTitleId}
+                onClick={(event) => event.stopPropagation()}
+              >
+                {renderPanelContent({
+                  titleId: mobilePanelTitleId,
+                  listClassName: "min-h-0 flex-1 space-y-2 overflow-y-auto pr-1",
+                  showCloseButton: true,
+                })}
+              </div>
+            </div>,
+            portalContainer,
+          )
+        : null}
 
       {/* Mobile auto-show banner: visible only on narrow viewports (< 640 px).
           Portaled to document.body to avoid stacking-context clipping from the
@@ -358,7 +445,7 @@ export function DashboardNotificationsBell({
       {portalContainer && mobileBannerVisible && unreadCount > 0
         ? createPortal(
             <div
-              className="sm:hidden fixed inset-x-0 top-0 z-[60] border-b border-vetneb-teal/30 bg-card shadow-xl"
+              className="fixed inset-x-0 top-0 z-[80] border-b border-vetneb-teal/30 bg-card shadow-xl sm:hidden"
               role="region"
               aria-label="Notificaciones no leidas"
             >

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -143,7 +143,14 @@ test("campana mantiene dropdown responsive y acciones sin overflow", () => {
       'className="w-full whitespace-normal sm:w-auto sm:whitespace-nowrap"',
     ),
   );
-  assert.ok(bell.includes('className="max-h-72 space-y-2 overflow-y-auto pr-1"'));
+  assert.ok(
+    bell.includes('listClassName: "max-h-72 space-y-2 overflow-y-auto pr-1"'),
+  );
+  assert.ok(
+    bell.includes("hidden w-[min(28rem,calc(100vw-2rem))]"),
+    "desktop dropdown must be hidden on mobile",
+  );
+  assert.ok(bell.includes("sm:block"));
 });
 
 test("api frontend expone funciones de notificaciones por surface y compat admin", () => {

--- a/test/frontend-notifications-bell.test.ts
+++ b/test/frontend-notifications-bell.test.ts
@@ -119,6 +119,116 @@ test("notifications bell shows visible mobile banner as auto-show surface", () =
     source.includes("fixed inset-x-0"),
     "mobile banner must use fixed full-width positioning",
   );
+  assert.ok(
+    source.includes("z-[80]"),
+    "mobile banner must use a high z-index above dashboard content",
+  );
+});
+
+test("notifications bell opens manual mobile panel as fixed body portal", () => {
+  const source = read(BELL_PATH);
+  const mobilePanelPortal = sectionBetween(
+    source,
+    "portalContainer && isOpen",
+    "{/* Mobile auto-show banner",
+  );
+
+  assert.ok(
+    mobilePanelPortal.includes("createPortal("),
+    "manual mobile panel must be portaled out of parent stacking contexts",
+  );
+  assert.ok(
+    mobilePanelPortal.includes(
+      'data-dashboard-notifications-mobile-overlay="true"',
+    ),
+    "manual mobile panel must expose a stable overlay selector",
+  );
+  assert.ok(
+    mobilePanelPortal.includes(
+      'data-dashboard-notifications-mobile-panel="true"',
+    ),
+    "manual mobile panel must expose a stable panel selector",
+  );
+  assert.ok(
+    mobilePanelPortal.includes("fixed inset-0 z-[90]"),
+    "manual mobile overlay must be fixed with a z-index above dashboard chrome",
+  );
+  assert.ok(
+    mobilePanelPortal.includes("fixed inset-x-3 top-3"),
+    "manual mobile sheet must be fixed to the viewport, not the bell wrapper",
+  );
+  assert.ok(
+    mobilePanelPortal.includes("bg-card"),
+    "manual mobile sheet must use an opaque background",
+  );
+  assert.ok(
+    mobilePanelPortal.includes("sm:hidden"),
+    "manual mobile overlay must stay mobile-only",
+  );
+  assert.ok(
+    mobilePanelPortal.includes('role="dialog"'),
+    "manual mobile panel must be exposed as a dialog",
+  );
+  assert.ok(
+    mobilePanelPortal.includes('aria-modal="true"'),
+    "manual mobile panel must mark modal semantics",
+  );
+});
+
+test("notifications bell closes manual mobile panel cleanly", () => {
+  const source = read(BELL_PATH);
+  const closeFn = sectionBetween(
+    source,
+    "function handleClosePanel()",
+    "function handleEnableNotifications()",
+  );
+
+  assert.ok(
+    closeFn.includes("setIsOpen(false);"),
+    "close handler must hide the manual panel",
+  );
+  assert.ok(
+    source.includes("portalContainer && isOpen"),
+    "manual mobile portal must be conditionally mounted only while open",
+  );
+  assert.ok(
+    source.includes('aria-label="Cerrar panel de notificaciones"'),
+    "manual mobile panel must include an accessible close button",
+  );
+  assert.ok(
+    source.includes("onClick={handleClosePanel}"),
+    "manual mobile overlay and close button must use the close handler",
+  );
+  assert.ok(
+    source.includes("event.stopPropagation()"),
+    "manual mobile panel clicks must not close via backdrop bubbling",
+  );
+  assert.ok(
+    source.includes('event.key === "Escape"'),
+    "manual panel must close on Escape",
+  );
+  assert.ok(
+    source.includes('window.addEventListener("keydown", handleKeyDown)'),
+    "Escape listener must be registered while the panel is open",
+  );
+  assert.ok(
+    source.includes('window.removeEventListener("keydown", handleKeyDown)'),
+    "Escape listener must be removed when the panel closes",
+  );
+});
+
+test("notifications bell keeps desktop dropdown desktop-only", () => {
+  const source = read(BELL_PATH);
+
+  assert.ok(
+    source.includes('data-dashboard-notifications-desktop-panel="true"'),
+    "desktop dropdown must expose a stable selector",
+  );
+  assert.match(
+    source,
+    /className="[^"]*\babsolute\b[^"]*\bright-0\b[^"]*\bz-50\b[^"]*\bhidden\b[^"]*\bsm:block\b[^"]*"/,
+    "desktop dropdown must remain absolute on desktop and hidden below sm",
+  );
 });
 
 // ── 4. Badge renders unread count correctly ──────────────────────────────────
@@ -309,6 +419,35 @@ test("notifications bell uses the same contextual click handler on mobile and de
   assert.ok(
     source.includes("setMobileBannerVisible(false);"),
     "mobile banner must close on notification navigation",
+  );
+});
+
+test("notifications mobile panel does not depend on Particulares layout wrapper", () => {
+  const bellSource = read(BELL_PATH);
+  const particularesSource = read(PARTICULARES_PATH);
+
+  assert.ok(
+    particularesSource.includes(
+      'className="particular-notifications-bell-layer shrink-0"',
+    ),
+    "ParticularesContent must keep the session bell wrapper",
+  );
+  assert.ok(
+    bellSource.includes("setPortalContainer(document.body);"),
+    "DashboardNotificationsBell must target document.body for overlays",
+  );
+  assert.ok(
+    bellSource.includes(
+      'data-dashboard-notifications-mobile-overlay="true"',
+    ),
+    "manual mobile overlay must be owned by the bell component",
+  );
+  assert.equal(
+    particularesSource.includes(
+      "data-dashboard-notifications-mobile-overlay",
+    ),
+    false,
+    "ParticularesContent must not own the notification overlay layer",
   );
 });
 


### PR DESCRIPTION
# PR fix notifications mobile overlay layer

## Resumen

Se corrigio la apertura manual de notificaciones en mobile para que el panel se renderice como overlay fijo y portaleado a `document.body`, por encima del dashboard de particulares. Desktop conserva el dropdown anclado a la campana.

## Causa probable

El banner mobile de auto-show ya estaba portaleado, pero el panel que se abre al tocar la campana seguia usando el dropdown absoluto dentro del wrapper local. En `/particulares`, ese wrapper queda dentro del panel de sesion y de sus reglas mobile de overflow, contain, isolation y z-index, por lo que el dropdown podia quedar mezclado visualmente con el resumen del caso o atrapado por stacking contexts.

## Por que #810 no era suficiente

#810 estabilizo el resumen mobile de la sesion particular, pero no cambiaba la capa donde se monta el panel manual de `DashboardNotificationsBell`. El origen restante no era el resumen en si, sino el dropdown de notificaciones renderizado dentro del layout particular.

## Implementacion

- `DashboardNotificationsBell` ahora comparte el contenido del panel en `renderPanelContent`.
- Desktop mantiene el dropdown absoluto existente, oculto bajo `sm`.
- Mobile monta el panel manual con `createPortal` hacia `document.body`.
- El overlay mobile usa `position: fixed`, `z-[90]`, fondo opaco para el sheet y selector estable `data-dashboard-notifications-mobile-overlay`.
- El panel mobile incluye boton de cierre accesible, cierre por backdrop y cierre por Escape.
- Al abrir manualmente el panel se oculta el banner mobile para evitar capas superpuestas.
- El panel manual se monta solo con `isOpen`; al cerrar se desmonta.
- El banner mobile de auto-show conserva la navegacion existente y sube a `z-[80]`.

## Archivos tocados

- `frontend/src/components/dashboard/DashboardNotificationsBell.tsx`
- `test/frontend-notifications-bell.test.ts`
- `test/frontend-admin-report-workflow.test.ts`
- `docs/pr-history/PR-fix-notifications-mobile-overlay-layer.md`

## Tests y comandos

- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-notifications-bell.test.ts test/frontend-particulares-content.test.ts test/frontend-notification-click-anchors.test.ts test/frontend-particulares-mobile-session-card-render.test.ts`
- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-report-workflow.test.ts test/frontend-notifications-bell.test.ts`
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck`
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm test`
- `pnpm build`
- `pnpm security:public-surface`
- Browser local en `http://127.0.0.1:3000/particulares` con viewport mobile `390x844`

## Resultados

- Tests focalizados de notificaciones y particulares: pass.
- Frontend lint: pass.
- Frontend typecheck: pass.
- Typecheck raiz: pass.
- Typecheck de tests: pass.
- Suite completa: pass, `2153` tests pasados y `1` skip existente.
- Build raiz: pass.
- Auditoria `security:public-surface`: pass, sin findings de exposicion publica; mantiene los avisos esperados `server-only` en `frontend/src/middleware.ts`.
- Browser local: `/particulares` compilo y respondio `200`, sin errores de consola en el cliente; la verificacion quedo limitada al render publico sin sesion porque el backend/proxy de `/api/particular/auth/me` no estaba disponible localmente.
- No se ejecuto `pnpm --dir frontend build`.

## Riesgos

- El panel mobile manual ahora es modal. Si en el futuro se necesita interaccion simultanea con contenido del dashboard mientras esta abierto, habria que ajustar el comportamiento de backdrop.
- El contenido del panel se comparte entre desktop y mobile; cambios futuros en acciones o lista impactan ambas superficies.

## Rollback

Revertir los cambios de `DashboardNotificationsBell.tsx` y restaurar el dropdown absoluto unico para `isOpen`. Luego revertir los tests agregados/actualizados y eliminar este documento.

## Estado final

- Mobile usa overlay/sheet fijo portaleado sobre el dashboard.
- El close desmonta u oculta completamente el panel al cambiar `isOpen` a `false`.
- La navegacion contextual de notificaciones se mantiene.
- Abrir el panel no marca notificaciones como leidas.
- Particular, clinica y admin mantienen la campana funcional.
- No se tocaron backend, API, auth, cookies, CSRF, CORS, CSP, storage, signed URLs, DB schema, indices, WebAuthn, Navbar ni Footer.
