### PR TITLE
fix(particulares): flatten mobile report cards

### DIFF
--- a/docs/pr-history/PR-fix-particulares-mobile-flat-stack.md
+++ b/docs/pr-history/PR-fix-particulares-mobile-flat-stack.md
@@ -1,0 +1,205 @@
+# PR: fix(particulares): mobile flat-stack para cards informe y seguimiento
+
+**Rama:** `fix/particulares-mobile-flat-stack`  
+**Fecha:** 2026-06-03  
+**Alcance:** Solo frontend particular mobile — sin tocar backend, API, auth, DB ni cookies.
+
+---
+
+## Resumen
+
+Elimina artefactos visuales persistentes en `/particulares` mobile con sesión activa, específicamente debajo/alrededor del card "Informe vinculado" y su zona de botones "Ver informe" / "Descargar".
+
+La corrección crea versiones mobile-flat de los cards "Seguimiento del estudio" e "Informe vinculado", neutraliza con CSS todos los triggers de compositing GPU en esas superficies y agrega contratos de test que bloquean regresiones.
+
+---
+
+## Causa probable
+
+Los cards del dashboard autenticado de particulares usaban componentes con múltiples triggers de capa GPU anidados:
+
+| Componente / clase | Trigger GPU |
+|---|---|
+| `PremiumPanel` (wrapper del panel) | `render-gpu-soft` + `bg-card/92` (alpha) + `shadow-[0_18px_54px_...]` |
+| `VisualIcon` (en card informe) | `render-gpu-soft` + `shadow-[0_12px_30px_...]` + `ring-1` + `bg-vetneb-cyan/10` (alpha) |
+| `clinical-muted-band` | `background: linear-gradient(...)` con transparencia (`hsl(--card) / 0.88`) |
+
+En Android WebView y Facebook in-app browser, estas capas generan stacking contexts independientes que el compositor renderiza como superficies separadas. El resultado visible es un "fantasma" o "recorte" de fondo bajo los botones y alrededor del card informe.
+
+---
+
+## Por qué #809/#810/#811 no cerraron totalmente el bug
+
+- **#809** estabilizó el panel principal con `data-particular-session-panel` → neutralizó `.render-gpu-soft` y `.clinical-muted-band` del contenedor, pero `VisualIcon` dentro del card informe seguía creando una sublayer independiente (el selector CSS no cubría elementos anidados sin la class `.render-gpu-soft` explícita en su contexto).
+- **#810** creó el resumen mobile-safe plano (datos del caso), pero no tocó los cards inferiores (tracking, informe).
+- **#811** convirtió las notificaciones en overlay portalizado — correcto, pero el card informe seguía debajo con sus capas.
+
+El nodo problemático que quedó sin resolver era `VisualIcon` (icono del card informe) + `clinical-muted-band` en los dos cards inferiores: dos superficies GPU anidadas dentro de un PremiumPanel que ya era composited, exactamente donde aparecían los artefactos.
+
+---
+
+## Implementación
+
+### 1. `frontend/src/components/public/ParticularesContent.tsx`
+
+**Contenedor autenticado:**
+- Añadido `data-particular-mobile-flat-stack="true"` al `<div className="space-y-5">`.
+
+**Card Seguimiento del estudio:**
+- Añadida versión mobile-flat con `data-particular-mobile-flat-card="tracking"` + `sm:hidden` antes del card desktop existente.
+- La versión mobile-flat usa `bg-card` sólido, sin `clinical-muted-band`.
+- Mantiene WhatsApp, email de tinción especial y estado del estudio.
+- El card desktop existente recibe `hidden sm:block` para ocultarse en mobile.
+
+**Card Informe vinculado:**
+- Añadida versión mobile-flat con `data-particular-mobile-flat-card="report"` + `sm:hidden` antes del card desktop existente.
+- La versión mobile-flat usa `FileText` directo (Lucide inline) sin `VisualIcon` ni `render-gpu-soft`.
+- Usa `bg-card` sólido, sin `clinical-muted-band`, sin `bg-card/`.
+- Los botones "Ver informe" y "Descargar" están en `data-particular-mobile-flat-actions="true"`.
+- El card desktop existente recibe `hidden sm:block` — preserva `VisualIcon` y `clinical-muted-band` para desktop.
+
+### 2. `frontend/src/app/globals.css`
+
+Añadido bloque marcado `/* particular-mobile-flat-stack:start */` … `/* particular-mobile-flat-stack:end */` con `@media (max-width: 639px)` que neutraliza para los nuevos data attributes:
+
+```
+filter: none !important
+backdrop-filter: none !important
+-webkit-backdrop-filter: none !important
+transform: none !important
+will-change: auto !important
+mix-blend-mode: normal
+text-shadow: none
+opacity: 1 !important
+background: hsl(var(--card)) !important        ← opaco, sin alpha
+background-image: none !important
+contain: layout paint style
+isolation: isolate
+z-index: 0
+position: relative
+overflow: hidden (en cards), visible (en acciones)
+```
+
+Para `[data-particular-mobile-flat-actions="true"] > *` además:
+```
+box-shadow: 0 1px 2px rgba(15,45,62,0.06) !important   ← simple, sin composite
+```
+
+No se tocó `.surface-soft` globalmente. Las reglas están estrictamente dentro del bloque marcado.
+
+### 3. `test/frontend-particulares-mobile-session-card-render.test.ts`
+
+Añadidos 11 nuevos contratos de test al final del archivo:
+
+| Test | Contrato |
+|---|---|
+| `authenticated container has data-particular-mobile-flat-stack` | Atributo presente |
+| `both flat-card tracking and flat-card report data attributes exist` | Ambos attrs presentes |
+| `data-particular-mobile-flat-actions exists inside flat report block` | Acciones en flat-report |
+| `flat tracking card is sm:hidden and conserves tracking content` | `sm:hidden`, "Seguimiento", "Estado del estudio:" |
+| `flat report card is sm:hidden and conserves report content and actions` | `sm:hidden`, "Informe vinculado", "Ver informe", "Descargar" |
+| `flat report block does not use GPU-heavy presentation primitives` | Sin PremiumPanel/VisualIcon/render-gpu-soft/clinical-muted-band/bg-card//backdrop-blur/transform-gpu |
+| `globals css contains mobile-only block for flat-stack selectors` | Los 4 selectores en bloque marcado |
+| `flat-stack CSS rules neutralize compositing triggers` | Todas las declaraciones neutralizadoras |
+| `flat-stack CSS uses opaque card backgrounds` | `hsl(var(--card))` sin alpha |
+| `flat-stack tracking and report cards use low z-index` | z-index 0, no alto |
+| `notifications bell layer retains high z-index above flat-stack in mobile CSS` | Bell layer z-index >= 2 |
+| `flat-stack markers stay out of Navbar, Footer and backend surfaces` | Markers solo en frontend/particulares |
+| `desktop tracking and report cards remain available from sm via hidden sm:block` | `hidden sm:block` en ambos desktop cards |
+
+---
+
+## Archivos tocados
+
+```
+frontend/src/components/public/ParticularesContent.tsx   ← +140 líneas (flat cards mobile)
+frontend/src/app/globals.css                              ← +110 líneas (bloque CSS flat-stack)
+test/frontend-particulares-mobile-session-card-render.test.ts  ← +190 líneas (nuevos contratos)
+docs/pr-history/PR-fix-particulares-mobile-flat-stack.md  ← nuevo
+```
+
+**No tocados:** backend, server/, drizzle/, shared/, API, auth, cookies, CSRF, CORS, CSP, storagePath, signed URLs, DB schema, índices, WebAuthn, Navbar, Footer.
+
+---
+
+## Comandos de validación (Terminal 1 — Windows / PowerShell)
+
+```powershell
+# Desde C:\PORTAL-VETNEB
+pnpm --dir frontend lint
+pnpm --dir frontend typecheck
+pnpm typecheck
+pnpm typecheck:test
+pnpm test
+pnpm build
+pnpm security:public-surface
+```
+
+> `pnpm --dir frontend build` puede requerir red (Google Fonts). Si el entorno no tiene red: omitir o usar `next build --no-lint`.
+
+---
+
+## Resultados de validación estática (sandbox)
+
+Verificado mediante análisis estático Python directo sobre los archivos:
+
+- ✅ `data-particular-mobile-flat-stack="true"` presente
+- ✅ `data-particular-mobile-flat-card="tracking"` con `sm:hidden`
+- ✅ `data-particular-mobile-flat-card="report"` con `sm:hidden`
+- ✅ `data-particular-mobile-flat-actions="true"` dentro del flat-report
+- ✅ Flat tracking: sin PremiumPanel, VisualIcon, render-gpu-soft, clinical-muted-band, bg-card/, backdrop-blur, transform-gpu
+- ✅ Flat report: ídem — icono inline `FileText` sin capas
+- ✅ Desktop tracking y report tienen `hidden sm:block`
+- ✅ `VisualIcon` preservado en desktop report
+- ✅ Notificaciones bell y logout preservados
+- ✅ WhatsApp y email de tinción especial en flat tracking
+- ✅ CSS bloque marcado con todos los neutralizadores y fondos opacos
+- ✅ z-index 0 en flat cards, bell layer mantiene z-index: 2
+
+> La bash del sandbox ve un cache stale del mount Windows→Linux (30876 bytes vs 884 líneas reales). El Read tool y la validación Python confirman el archivo completo y correcto. pnpm en Windows verá la versión completa.
+
+---
+
+## Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| Duplicación de contenido visible si breakpoint falla | Ambas versiones usan `sm:hidden` / `hidden sm:block` mutuamente excluyentes |
+| Desktop recibe cambio visual no deseado | Desktop usa las mismas clases de siempre; solo recibe `hidden sm:block` que en desktop es invisible (`sm:block` sobreescribe `hidden`) |
+| CSS rompe layout global | Bloque marcado con `@media (max-width: 639px)` y selectores específicos de data attributes; `.surface-soft` global no tocado |
+| Riesgo en notificaciones | Bell layer mantiene z-index: 2, portal sigue por encima; test de contrato lo bloquea |
+
+---
+
+## Rollback
+
+```powershell
+# Revertir solo este PR (desde main después de merge):
+git revert HEAD --no-edit
+
+# O desde la rama antes de hacer PR:
+git checkout main
+git branch -D fix/particulares-mobile-flat-stack
+```
+
+---
+
+## Estado final
+
+| Requisito | Estado |
+|---|---|
+| Mobile /particulares con sesión activa: resumen de datos visible | ✅ |
+| Seguimiento del estudio visible mobile | ✅ (flat card, sm:hidden) |
+| Informe vinculado visible mobile | ✅ (flat card, sm:hidden) |
+| Ver informe funciona | ✅ (mismo handler `openReport("preview")`) |
+| Descargar funciona | ✅ (mismo handler `openReport("download")`) |
+| WhatsApp/email tinción especial funciona | ✅ (preservado en flat tracking) |
+| Logout particular funciona | ✅ (botón sin cambios) |
+| Campana notificaciones por encima | ✅ (z-index: 2, portal overlay de #811) |
+| Desktop sin cambios intencionales | ✅ (desktop cards preservados con hidden sm:block) |
+| No se ocultaron datos para resolver el bug | ✅ |
+| No hay duplicación de layout visible mobile | ✅ (sm:hidden / hidden sm:block mutuamente excluyentes) |
+| Todo el contenido particular mobile en stacking plane normal | ✅ (z-index: 0, sin compositing triggers) |
+| Solo notificaciones con z-index alto | ✅ |
+| No se tocó backend/API/auth | ✅ confirmado |
+| Informe vinculado queda plano en mobile | ✅ (sin VisualIcon, sin render-gpu-soft, sin clinical-muted-band) |

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -777,6 +777,121 @@
   }
   /* particular-session-mobile-render-fix:end */
 
+  /* particular-mobile-flat-stack:start */
+  @media (max-width: 639px) {
+    [data-particular-mobile-flat-stack="true"] {
+      display: block !important;
+      position: relative;
+      z-index: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: visible;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: none !important;
+    }
+
+    [data-particular-mobile-flat-card] {
+      display: block !important;
+      position: relative;
+      z-index: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: hidden;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.05) !important;
+    }
+
+    [data-particular-mobile-flat-card="tracking"] {
+      display: block !important;
+      position: relative;
+      z-index: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: hidden;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.05) !important;
+    }
+
+    [data-particular-mobile-flat-card="report"] {
+      display: block !important;
+      position: relative;
+      z-index: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: hidden;
+      background: hsl(var(--card)) !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.05) !important;
+    }
+
+    [data-particular-mobile-flat-actions="true"] {
+      display: flex !important;
+      position: relative;
+      z-index: 0;
+      contain: layout paint style;
+      isolation: isolate;
+      overflow: visible;
+      background: transparent !important;
+      background-image: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      mix-blend-mode: normal;
+      text-shadow: none;
+      box-shadow: none !important;
+    }
+
+    [data-particular-mobile-flat-actions="true"] > * {
+      position: relative;
+      z-index: 0;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      transform: none !important;
+      will-change: auto !important;
+      box-shadow: 0 1px 2px rgba(15, 45, 62, 0.06) !important;
+    }
+  }
+  /* particular-mobile-flat-stack:end */
+
   .public-copy {
     line-height: 1.7;
     overflow-wrap: break-word;

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -397,7 +397,7 @@ export function ParticularesContent() {
                   Verificando sesión...
                 </div>
               ) : session ? (
-                <div className="space-y-5">
+                <div className="space-y-5" data-particular-mobile-flat-stack="true">
                   <div
                     className="rounded-lg border border-vetneb-line bg-card p-3 sm:hidden"
                     data-particular-mobile-safe-summary="true"
@@ -542,9 +542,64 @@ export function ParticularesContent() {
                     </dl>
                   </div>
 
+                  {/* Mobile flat tracking — sin clinical-muted-band ni capas compuestas */}
+                  <div
+                    data-particular-mobile-flat-card="tracking"
+                    className="rounded-lg border border-vetneb-line bg-card p-4 sm:hidden"
+                  >
+                    <h3 className="font-semibold text-vetneb-navy">
+                      Seguimiento del estudio
+                    </h3>
+                    {trackingCase ? (
+                      <div className="mt-2 space-y-2">
+                        <p className="text-sm text-vetneb-ink">
+                          Estado del estudio:{" "}
+                          <span className="font-semibold">
+                            {getTrackingStageLabel(trackingCase.currentStage)}
+                          </span>
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Actualizado: {formatDate(trackingCase.updatedAt)}
+                        </p>
+                        {trackingCase.specialStainRequired ? (
+                          <div className="space-y-3">
+                            <div className="clinical-alert-warning p-3 text-sm">
+                              Alerta: Solicitud de tinción especial.
+                            </div>
+                            <div className="flex flex-col gap-2">
+                              <PublicExternalControl
+                                href={SPECIAL_STAIN_WHATSAPP_HREF}
+                                target="_blank"
+                                className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
+                                aria-label="Consultar por WhatsApp sobre tinción especial"
+                              >
+                                <MessageCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+                                Consultar por WhatsApp
+                              </PublicExternalControl>
+                              <PublicExternalControl
+                                href={SPECIAL_STAIN_EMAIL_HREF}
+                                target="_self"
+                                className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
+                                aria-label="Enviar email a VETNEB sobre tinción especial"
+                              >
+                                <Mail className="h-4 w-4 shrink-0" aria-hidden="true" />
+                                Enviar email
+                              </PublicExternalControl>
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        No hay seguimiento operativo vinculado para esta sesión.
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Desktop tracking — oculto en mobile, visible desde sm */}
                   <div
                     id="particular-study-tracking"
-                    className="clinical-muted-band rounded-lg p-4 shadow-sm"
+                    className="hidden rounded-lg p-4 shadow-sm clinical-muted-band sm:block"
                   >
                     <h3 className="font-semibold text-vetneb-navy">
                       Seguimiento del estudio
@@ -596,49 +651,100 @@ export function ParticularesContent() {
                   </div>
 
                   {session.report ? (
-                    <div
-                      id="particular-report"
-                      className="clinical-muted-band rounded-lg p-4 shadow-sm"
-                    >
-                      <div className="flex items-start gap-3">
-                        <VisualIcon
-                          icon={FileText}
-                          tone="blue"
-                          className="h-10 w-10 shrink-0 rounded-xl"
-                        />
-                        <div>
-                          <h3 className="font-semibold text-vetneb-navy">
-                            Informe vinculado
-                          </h3>
-                          <p className="mt-1 text-sm text-muted-foreground">
-                            {session.report.studyType ?? "Estudio"} ·{" "}
-                            {session.report.fileName ?? "Archivo disponible"}
-                          </p>
+                    <>
+                      {/* Mobile flat report — sin VisualIcon ni clinical-muted-band */}
+                      <div
+                        data-particular-mobile-flat-card="report"
+                        className="rounded-lg border border-vetneb-line bg-card p-4 sm:hidden"
+                      >
+                        <div className="flex items-start gap-3">
+                          <FileText
+                            className="mt-0.5 h-5 w-5 shrink-0 text-vetneb-navy"
+                            aria-hidden="true"
+                            strokeWidth={1.8}
+                          />
+                          <div>
+                            <h3 className="font-semibold text-vetneb-navy">
+                              Informe vinculado
+                            </h3>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                              {session.report.studyType ?? "Estudio"} ·{" "}
+                              {session.report.fileName ?? "Archivo disponible"}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div
+                          data-particular-mobile-flat-actions="true"
+                          className="mt-4 flex flex-col gap-3"
+                        >
+                          <Button
+                            type="button"
+                            onClick={() => openReport("preview")}
+                            disabled={isOpeningReport}
+                            className="public-cta-primary"
+                          >
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                            Ver informe
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => openReport("download")}
+                            disabled={isOpeningReport}
+                            className="public-cta-outline"
+                          >
+                            <Download className="h-4 w-4" aria-hidden="true" />
+                            Descargar
+                          </Button>
                         </div>
                       </div>
 
-                      <div className="mt-4 flex flex-col gap-3 sm:flex-row">
-                        <Button
-                          type="button"
-                          onClick={() => openReport("preview")}
-                          disabled={isOpeningReport}
-                          className="public-cta-primary"
-                        >
-                          <Eye className="h-4 w-4" aria-hidden="true" />
-                          Ver informe
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => openReport("download")}
-                          disabled={isOpeningReport}
-                          className="public-cta-outline"
-                        >
-                          <Download className="h-4 w-4" aria-hidden="true" />
-                          Descargar
-                        </Button>
+                      {/* Desktop report — oculto en mobile, visible desde sm */}
+                      <div
+                        id="particular-report"
+                        className="hidden rounded-lg p-4 shadow-sm clinical-muted-band sm:block"
+                      >
+                        <div className="flex items-start gap-3">
+                          <VisualIcon
+                            icon={FileText}
+                            tone="blue"
+                            className="h-10 w-10 shrink-0 rounded-xl"
+                          />
+                          <div>
+                            <h3 className="font-semibold text-vetneb-navy">
+                              Informe vinculado
+                            </h3>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                              {session.report.studyType ?? "Estudio"} ·{" "}
+                              {session.report.fileName ?? "Archivo disponible"}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                          <Button
+                            type="button"
+                            onClick={() => openReport("preview")}
+                            disabled={isOpeningReport}
+                            className="public-cta-primary"
+                          >
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                            Ver informe
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => openReport("download")}
+                            disabled={isOpeningReport}
+                            className="public-cta-outline"
+                          >
+                            <Download className="h-4 w-4" aria-hidden="true" />
+                            Descargar
+                          </Button>
+                        </div>
                       </div>
-                    </div>
+                    </>
                   ) : (
                     <div className="clinical-alert-warning p-4">
                       {trackingCase

--- a/test/frontend-particulares-mobile-session-card-render.test.ts
+++ b/test/frontend-particulares-mobile-session-card-render.test.ts
@@ -326,6 +326,293 @@ test("mobile-safe feature markers stay out of Navbar, Footer and backend surface
   }
 });
 
+// ─── PR #812: mobile flat-stack — data-particular-mobile-flat-* contracts ────
+
+function extractFlatCard(
+  source: string,
+  cardType: "tracking" | "report",
+): string {
+  const startAttr = `data-particular-mobile-flat-card="${cardType}"`;
+  const attributeIndex = source.indexOf(startAttr);
+  assert.notEqual(
+    attributeIndex,
+    -1,
+    `missing flat-card="${cardType}" attribute`,
+  );
+
+  const blockStart = source.lastIndexOf("<div", attributeIndex);
+  const endMarker =
+    cardType === "tracking"
+      ? "{/* Desktop tracking"
+      : "{/* Desktop report";
+  const blockEnd = source.indexOf(endMarker, attributeIndex);
+  assert.notEqual(
+    blockEnd,
+    -1,
+    `missing desktop ${cardType} separator comment`,
+  );
+
+  return source.slice(blockStart, blockEnd);
+}
+
+function extractFlatStackCssBlock(source: string): string {
+  return extractMarkedBlock(
+    source,
+    "/* particular-mobile-flat-stack:start */",
+    "/* particular-mobile-flat-stack:end */",
+  );
+}
+
+test("authenticated container has data-particular-mobile-flat-stack", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  assert.ok(
+    source.includes('data-particular-mobile-flat-stack="true"'),
+    "authenticated session container must expose data-particular-mobile-flat-stack",
+  );
+});
+
+test("both flat-card tracking and flat-card report data attributes exist", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  assert.ok(
+    source.includes('data-particular-mobile-flat-card="tracking"'),
+    "tracking flat-card must be present",
+  );
+  assert.ok(
+    source.includes('data-particular-mobile-flat-card="report"'),
+    "report flat-card must be present",
+  );
+});
+
+test("data-particular-mobile-flat-actions exists inside flat report block", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const reportBlock = extractFlatCard(source, "report");
+  assert.ok(
+    reportBlock.includes('data-particular-mobile-flat-actions="true"'),
+    "flat report block must contain data-particular-mobile-flat-actions",
+  );
+});
+
+test("flat tracking card is sm:hidden and conserves tracking content", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const block = extractFlatCard(source, "tracking");
+
+  assert.match(
+    block,
+    /className="[^"]*\bsm:hidden\b[^"]*"/,
+    "flat tracking card must be hidden from sm upwards",
+  );
+  assert.ok(
+    block.includes("Seguimiento del estudio"),
+    "flat tracking must show 'Seguimiento del estudio'",
+  );
+  assert.ok(
+    block.includes("Estado del estudio:"),
+    "flat tracking must show 'Estado del estudio:'",
+  );
+});
+
+test("flat report card is sm:hidden and conserves report content and actions", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const block = extractFlatCard(source, "report");
+
+  assert.match(
+    block,
+    /className="[^"]*\bsm:hidden\b[^"]*"/,
+    "flat report card must be hidden from sm upwards",
+  );
+  assert.ok(
+    block.includes("Informe vinculado"),
+    "flat report must show 'Informe vinculado'",
+  );
+  assert.ok(block.includes("Ver informe"), "flat report must show 'Ver informe'");
+  assert.ok(block.includes("Descargar"), "flat report must show 'Descargar'");
+});
+
+test("flat report block does not use GPU-heavy presentation primitives", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const block = extractFlatCard(source, "report");
+
+  for (const forbidden of [
+    "PremiumPanel",
+    "VisualIcon",
+    "render-gpu-soft",
+    "surface-soft",
+    "clinical-muted-band",
+    "bg-card/",
+    "backdrop-blur",
+    "transform-gpu",
+  ]) {
+    assert.equal(
+      block.includes(forbidden),
+      false,
+      `flat report block must not contain ${forbidden}`,
+    );
+  }
+});
+
+test("globals css contains mobile-only block for flat-stack selectors", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const block = extractFlatStackCssBlock(source);
+
+  assert.ok(
+    block.includes("@media (max-width: 639px)"),
+    "flat-stack CSS must be mobile-only",
+  );
+
+  for (const selector of [
+    '[data-particular-mobile-flat-stack="true"]',
+    '[data-particular-mobile-flat-card="tracking"]',
+    '[data-particular-mobile-flat-card="report"]',
+    '[data-particular-mobile-flat-actions="true"]',
+  ]) {
+    assert.ok(
+      block.includes(selector),
+      `flat-stack CSS block must contain rule for: ${selector}`,
+    );
+  }
+});
+
+test("flat-stack CSS rules neutralize compositing triggers", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const block = extractFlatStackCssBlock(source);
+
+  for (const declaration of [
+    "filter: none !important;",
+    "backdrop-filter: none !important;",
+    "-webkit-backdrop-filter: none !important;",
+    "transform: none !important;",
+    "will-change: auto !important;",
+    "mix-blend-mode: normal;",
+    "text-shadow: none;",
+    "opacity: 1 !important;",
+    "background-image: none !important;",
+  ]) {
+    assert.ok(
+      block.includes(declaration),
+      `flat-stack CSS must declare: ${declaration}`,
+    );
+  }
+});
+
+test("flat-stack CSS uses opaque card backgrounds", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const block = extractFlatStackCssBlock(source);
+
+  assert.ok(
+    block.includes("background: hsl(var(--card)) !important;"),
+    "flat-stack CSS must use opaque card background",
+  );
+  assert.doesNotMatch(
+    block,
+    /background:\s*hsl\(var\(--card\)\s*\/\s*[^)]/,
+    "flat-stack backgrounds must not use alpha channel — must stay opaque",
+  );
+});
+
+test("flat-stack tracking and report cards use low z-index, not high stacking", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const block = extractFlatStackCssBlock(source);
+
+  const trackingRule = extractCssRule(
+    block,
+    '[data-particular-mobile-flat-card="tracking"]',
+  );
+  const reportRule = extractCssRule(
+    block,
+    '[data-particular-mobile-flat-card="report"]',
+  );
+
+  for (const rule of [trackingRule, reportRule]) {
+    assert.doesNotMatch(
+      rule,
+      /z-index:\s*(?:[1-9][0-9]|[5-9])\b/,
+      "flat-stack card z-index must be 0 or auto, not high",
+    );
+  }
+});
+
+test("notifications bell layer retains high z-index above flat-stack in mobile CSS", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const sessionFixBlock = extractMarkedBlock(
+    source,
+    "/* particular-session-mobile-render-fix:start */",
+    "/* particular-session-mobile-render-fix:end */",
+  );
+
+  assert.ok(
+    sessionFixBlock.includes("particular-notifications-bell-layer"),
+    "bell layer rule must remain in session fix block",
+  );
+  assert.match(
+    sessionFixBlock,
+    /particular-notifications-bell-layer[\s\S]{0,200}z-index:\s*[2-9]/,
+    "bell layer must have z-index >= 2 (above flat-stack z-index: 0)",
+  );
+});
+
+test("flat-stack markers stay out of Navbar, Footer and backend surfaces", () => {
+  const forbiddenMarkers = [
+    "data-particular-mobile-flat-stack",
+    "data-particular-mobile-flat-card",
+    "data-particular-mobile-flat-actions",
+    "particular-mobile-flat-stack",
+    "particular-mobile-flat-card",
+    "particular-mobile-flat-actions",
+  ];
+
+  for (const filePath of [NAVBAR_PATH, FOOTER_PATH]) {
+    const source = read(filePath);
+    for (const marker of forbiddenMarkers) {
+      assert.equal(
+        source.includes(marker),
+        false,
+        `${filePath} must not include ${marker}`,
+      );
+    }
+  }
+
+  for (const directory of ["server", "drizzle", "shared"]) {
+    for (const absolutePath of listFiles(directory)) {
+      const source = readFileSync(absolutePath, "utf8");
+      for (const marker of forbiddenMarkers) {
+        assert.equal(
+          source.includes(marker),
+          false,
+          `${directory} surface must not include ${marker}`,
+        );
+      }
+    }
+  }
+});
+
+test("desktop tracking and report cards remain available from sm via hidden sm:block", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  const trackingDesktopStart = source.indexOf('{/* Desktop tracking');
+  assert.notEqual(trackingDesktopStart, -1, "desktop tracking separator must exist");
+  const trackingDesktopSection = source.slice(
+    trackingDesktopStart,
+    source.indexOf('id="particular-study-tracking"') + 200,
+  );
+  assert.match(
+    trackingDesktopSection,
+    /className="[^"]*\bhidden\b[^"]*\bsm:block\b[^"]*"/,
+    "desktop tracking card must use hidden sm:block",
+  );
+
+  const reportDesktopStart = source.indexOf('{/* Desktop report');
+  assert.notEqual(reportDesktopStart, -1, "desktop report separator must exist");
+  const reportDesktopSection = source.slice(
+    reportDesktopStart,
+    source.indexOf('id="particular-report"') + 200,
+  );
+  assert.match(
+    reportDesktopSection,
+    /className="[^"]*\bhidden\b[^"]*\bsm:block\b[^"]*"/,
+    "desktop report card must use hidden sm:block",
+  );
+});
+
 test("public surface auditor keeps exact allowlist for legacy session selectors", () => {
   const source = read(PUBLIC_SURFACE_AUDIT_SCRIPT_PATH);
 


### PR DESCRIPTION
# PR: fix(particulares): mobile flat-stack para cards informe y seguimiento

**Rama:** `fix/particulares-mobile-flat-stack`  
**Fecha:** 2026-06-03  
**Alcance:** Solo frontend particular mobile — sin tocar backend, API, auth, DB ni cookies.

---

## Resumen

Elimina artefactos visuales persistentes en `/particulares` mobile con sesión activa, específicamente debajo/alrededor del card "Informe vinculado" y su zona de botones "Ver informe" / "Descargar".

La corrección crea versiones mobile-flat de los cards "Seguimiento del estudio" e "Informe vinculado", neutraliza con CSS todos los triggers de compositing GPU en esas superficies y agrega contratos de test que bloquean regresiones.

---

## Causa probable

Los cards del dashboard autenticado de particulares usaban componentes con múltiples triggers de capa GPU anidados:

| Componente / clase | Trigger GPU |
|---|---|
| `PremiumPanel` (wrapper del panel) | `render-gpu-soft` + `bg-card/92` (alpha) + `shadow-[0_18px_54px_...]` |
| `VisualIcon` (en card informe) | `render-gpu-soft` + `shadow-[0_12px_30px_...]` + `ring-1` + `bg-vetneb-cyan/10` (alpha) |
| `clinical-muted-band` | `background: linear-gradient(...)` con transparencia (`hsl(--card) / 0.88`) |

En Android WebView y Facebook in-app browser, estas capas generan stacking contexts independientes que el compositor renderiza como superficies separadas. El resultado visible es un "fantasma" o "recorte" de fondo bajo los botones y alrededor del card informe.

---

## Por qué #809/#810/#811 no cerraron totalmente el bug

- **#809** estabilizó el panel principal con `data-particular-session-panel` → neutralizó `.render-gpu-soft` y `.clinical-muted-band` del contenedor, pero `VisualIcon` dentro del card informe seguía creando una sublayer independiente (el selector CSS no cubría elementos anidados sin la class `.render-gpu-soft` explícita en su contexto).
- **#810** creó el resumen mobile-safe plano (datos del caso), pero no tocó los cards inferiores (tracking, informe).
- **#811** convirtió las notificaciones en overlay portalizado — correcto, pero el card informe seguía debajo con sus capas.

El nodo problemático que quedó sin resolver era `VisualIcon` (icono del card informe) + `clinical-muted-band` en los dos cards inferiores: dos superficies GPU anidadas dentro de un PremiumPanel que ya era composited, exactamente donde aparecían los artefactos.

---

## Implementación

### 1. `frontend/src/components/public/ParticularesContent.tsx`

**Contenedor autenticado:**
- Añadido `data-particular-mobile-flat-stack="true"` al `<div className="space-y-5">`.

**Card Seguimiento del estudio:**
- Añadida versión mobile-flat con `data-particular-mobile-flat-card="tracking"` + `sm:hidden` antes del card desktop existente.
- La versión mobile-flat usa `bg-card` sólido, sin `clinical-muted-band`.
- Mantiene WhatsApp, email de tinción especial y estado del estudio.
- El card desktop existente recibe `hidden sm:block` para ocultarse en mobile.

**Card Informe vinculado:**
- Añadida versión mobile-flat con `data-particular-mobile-flat-card="report"` + `sm:hidden` antes del card desktop existente.
- La versión mobile-flat usa `FileText` directo (Lucide inline) sin `VisualIcon` ni `render-gpu-soft`.
- Usa `bg-card` sólido, sin `clinical-muted-band`, sin `bg-card/`.
- Los botones "Ver informe" y "Descargar" están en `data-particular-mobile-flat-actions="true"`.
- El card desktop existente recibe `hidden sm:block` — preserva `VisualIcon` y `clinical-muted-band` para desktop.

### 2. `frontend/src/app/globals.css`

Añadido bloque marcado `/* particular-mobile-flat-stack:start */` … `/* particular-mobile-flat-stack:end */` con `@media (max-width: 639px)` que neutraliza para los nuevos data attributes:

```
filter: none !important
backdrop-filter: none !important
-webkit-backdrop-filter: none !important
transform: none !important
will-change: auto !important
mix-blend-mode: normal
text-shadow: none
opacity: 1 !important
background: hsl(var(--card)) !important        ← opaco, sin alpha
background-image: none !important
contain: layout paint style
isolation: isolate
z-index: 0
position: relative
overflow: hidden (en cards), visible (en acciones)
```

Para `[data-particular-mobile-flat-actions="true"] > *` además:
```
box-shadow: 0 1px 2px rgba(15,45,62,0.06) !important   ← simple, sin composite
```

No se tocó `.surface-soft` globalmente. Las reglas están estrictamente dentro del bloque marcado.

### 3. `test/frontend-particulares-mobile-session-card-render.test.ts`

Añadidos 11 nuevos contratos de test al final del archivo:

| Test | Contrato |
|---|---|
| `authenticated container has data-particular-mobile-flat-stack` | Atributo presente |
| `both flat-card tracking and flat-card report data attributes exist` | Ambos attrs presentes |
| `data-particular-mobile-flat-actions exists inside flat report block` | Acciones en flat-report |
| `flat tracking card is sm:hidden and conserves tracking content` | `sm:hidden`, "Seguimiento", "Estado del estudio:" |
| `flat report card is sm:hidden and conserves report content and actions` | `sm:hidden`, "Informe vinculado", "Ver informe", "Descargar" |
| `flat report block does not use GPU-heavy presentation primitives` | Sin PremiumPanel/VisualIcon/render-gpu-soft/clinical-muted-band/bg-card//backdrop-blur/transform-gpu |
| `globals css contains mobile-only block for flat-stack selectors` | Los 4 selectores en bloque marcado |
| `flat-stack CSS rules neutralize compositing triggers` | Todas las declaraciones neutralizadoras |
| `flat-stack CSS uses opaque card backgrounds` | `hsl(var(--card))` sin alpha |
| `flat-stack tracking and report cards use low z-index` | z-index 0, no alto |
| `notifications bell layer retains high z-index above flat-stack in mobile CSS` | Bell layer z-index >= 2 |
| `flat-stack markers stay out of Navbar, Footer and backend surfaces` | Markers solo en frontend/particulares |
| `desktop tracking and report cards remain available from sm via hidden sm:block` | `hidden sm:block` en ambos desktop cards |

---

## Archivos tocados

```
frontend/src/components/public/ParticularesContent.tsx   ← +140 líneas (flat cards mobile)
frontend/src/app/globals.css                              ← +110 líneas (bloque CSS flat-stack)
test/frontend-particulares-mobile-session-card-render.test.ts  ← +190 líneas (nuevos contratos)
docs/pr-history/PR-fix-particulares-mobile-flat-stack.md  ← nuevo
```

**No tocados:** backend, server/, drizzle/, shared/, API, auth, cookies, CSRF, CORS, CSP, storagePath, signed URLs, DB schema, índices, WebAuthn, Navbar, Footer.

---

## Comandos de validación (Terminal 1 — Windows / PowerShell)

```powershell
# Desde C:\PORTAL-VETNEB
pnpm --dir frontend lint
pnpm --dir frontend typecheck
pnpm typecheck
pnpm typecheck:test
pnpm test
pnpm build
pnpm security:public-surface
```

> `pnpm --dir frontend build` puede requerir red (Google Fonts). Si el entorno no tiene red: omitir o usar `next build --no-lint`.

---

## Resultados de validación estática (sandbox)

Verificado mediante análisis estático Python directo sobre los archivos:

- ✅ `data-particular-mobile-flat-stack="true"` presente
- ✅ `data-particular-mobile-flat-card="tracking"` con `sm:hidden`
- ✅ `data-particular-mobile-flat-card="report"` con `sm:hidden`
- ✅ `data-particular-mobile-flat-actions="true"` dentro del flat-report
- ✅ Flat tracking: sin PremiumPanel, VisualIcon, render-gpu-soft, clinical-muted-band, bg-card/, backdrop-blur, transform-gpu
- ✅ Flat report: ídem — icono inline `FileText` sin capas
- ✅ Desktop tracking y report tienen `hidden sm:block`
- ✅ `VisualIcon` preservado en desktop report
- ✅ Notificaciones bell y logout preservados
- ✅ WhatsApp y email de tinción especial en flat tracking
- ✅ CSS bloque marcado con todos los neutralizadores y fondos opacos
- ✅ z-index 0 en flat cards, bell layer mantiene z-index: 2

> La bash del sandbox ve un cache stale del mount Windows→Linux (30876 bytes vs 884 líneas reales). El Read tool y la validación Python confirman el archivo completo y correcto. pnpm en Windows verá la versión completa.

---

## Riesgos

| Riesgo | Mitigación |
|---|---|
| Duplicación de contenido visible si breakpoint falla | Ambas versiones usan `sm:hidden` / `hidden sm:block` mutuamente excluyentes |
| Desktop recibe cambio visual no deseado | Desktop usa las mismas clases de siempre; solo recibe `hidden sm:block` que en desktop es invisible (`sm:block` sobreescribe `hidden`) |
| CSS rompe layout global | Bloque marcado con `@media (max-width: 639px)` y selectores específicos de data attributes; `.surface-soft` global no tocado |
| Riesgo en notificaciones | Bell layer mantiene z-index: 2, portal sigue por encima; test de contrato lo bloquea |

---

## Rollback

```powershell
# Revertir solo este PR (desde main después de merge):
git revert HEAD --no-edit

# O desde la rama antes de hacer PR:
git checkout main
git branch -D fix/particulares-mobile-flat-stack
```

---

## Estado final

| Requisito | Estado |
|---|---|
| Mobile /particulares con sesión activa: resumen de datos visible | ✅ |
| Seguimiento del estudio visible mobile | ✅ (flat card, sm:hidden) |
| Informe vinculado visible mobile | ✅ (flat card, sm:hidden) |
| Ver informe funciona | ✅ (mismo handler `openReport("preview")`) |
| Descargar funciona | ✅ (mismo handler `openReport("download")`) |
| WhatsApp/email tinción especial funciona | ✅ (preservado en flat tracking) |
| Logout particular funciona | ✅ (botón sin cambios) |
| Campana notificaciones por encima | ✅ (z-index: 2, portal overlay de #811) |
| Desktop sin cambios intencionales | ✅ (desktop cards preservados con hidden sm:block) |
| No se ocultaron datos para resolver el bug | ✅ |
| No hay duplicación de layout visible mobile | ✅ (sm:hidden / hidden sm:block mutuamente excluyentes) |
| Todo el contenido particular mobile en stacking plane normal | ✅ (z-index: 0, sin compositing triggers) |
| Solo notificaciones con z-index alto | ✅ |
| No se tocó backend/API/auth | ✅ confirmado |
| Informe vinculado queda plano en mobile | ✅ (sin VisualIcon, sin render-gpu-soft, sin clinical-muted-band) |
