### PR TITLE
perf(admin): audit heavy list pagination defaults

### DIFF
--- a/docs/pr-815-admin-heavy-list-pagination-defaults.md
+++ b/docs/pr-815-admin-heavy-list-pagination-defaults.md
@@ -1,0 +1,72 @@
+# PR 815 - Admin heavy list pagination defaults
+
+## Resumen
+
+Se auditaron listados admin que pueden crecer con el uso operativo y se reforzo la paginacion en backend sin tocar schema, migraciones, indices, WebAuthn ni UI.
+
+Cambios aplicados:
+
+- Helper backend `normalizeListPagination` con default conservador, max limit y max offset.
+- Clamp backend en listadores compartidos usados por endpoints admin.
+- `admin users roles` pagina las consultas DB antes de combinar usuarios admin y clinic.
+- Tests de contrato para defaults, max limit, valores invalidos y consultas DB con limite.
+
+## Defaults y limites
+
+| Superficie | Default limit | Max limit | Offset |
+| --- | ---: | ---: | --- |
+| Listados admin generales | 50 | 100 | default 0, max backend 100000 |
+| Admin report workflow | 20 | 20 en contrato HTTP | backend fetch max 21 para sentinel `hasMore` |
+| Export admin audit | n/a | 10000 filas | offset 0 |
+| Export failed login alerts | n/a | 10000 filas | offset 0 |
+
+Valores invalidos se mantienen segun la convencion existente:
+
+- Tokens/report access/study tracking: se normalizan a defaults.
+- Clinics/sessions/users-roles/failed-login-alerts/report-workflow: la ruta rechaza query invalida con 400.
+- En backend, los listadores normalizan de forma defensiva antes de llamar `.limit()` y `.offset()`.
+
+## Endpoints auditados
+
+| Endpoint | Estado |
+| --- | --- |
+| `GET /api/admin/audit-log` | Ya tenia default 50, max 100 y export max 10000. |
+| `GET /api/admin/failed-login-alerts` | Ruta con default 50/max 100; backend ahora usa helper compartido. |
+| `GET /api/admin/clinics` | Ruta con default 50/max 100; backend ahora usa helper compartido. |
+| `GET /api/admin/sessions` | Ruta con default 50/max 100; backend ahora usa helper compartido y mantiene `fetchLimit`. |
+| `GET /api/admin/users-roles` | Ruta con default 50/max 100; backend ahora limita consultas DB antes de combinar resultados. |
+| `GET /api/admin/particular-tokens` | Ruta con default 50/max 100; backend compartido ahora clampa limit/offset. |
+| `GET /api/admin/report-access-tokens` | Ruta con default 50/max 100; backend compartido ahora clampa limit/offset. |
+| `GET /api/admin/study-tracking` | Ruta con default 50/max 100; backend compartido ahora clampa limit/offset. |
+| `GET /api/admin/study-tracking/notifications` | Ruta con default 50/max 100; backend compartido ahora clampa limit/offset. |
+| `GET /api/admin/report-workflow` | Default 20/max 20; backend clampa a max 21 por overfetch de `hasMore`. |
+| `GET /api/admin/pricing` | Catalogo acotado; sin cambio de paginacion. |
+| `GET /api/admin/reports/:id/preview-url` y `download-url` | No son listados. |
+| Admin system health/schema/maintenance | No son listados pesados. |
+
+## Tests agregados o ajustados
+
+- `test/admin-heavy-list-pagination-contract.test.ts`
+  - default limit/offset del helper.
+  - max limit y max offset.
+  - limit/offset invalidos.
+  - listadores backend auditados usan `normalizeListPagination`.
+  - `admin users roles` limita queries DB con `adminLimit/clinicLimit`.
+- `test/admin-particular-tokens.fastify.test.ts`
+  - `GET /api/admin/particular-tokens` aplica default 50/0 sin query params.
+  - clampa `limit=999` a 100.
+  - normaliza `limit=abc&offset=-2` a 50/0.
+
+## Archivos de implementacion
+
+- `server/lib/list-pagination.ts`
+- `server/db-admin-clinics.ts`
+- `server/db-admin-failed-login-alerts.ts`
+- `server/db-admin-sessions.ts`
+- `server/db-admin-users-roles.ts`
+- `server/db-particular.ts`
+- `server/db-report-access.ts`
+- `server/db-study-tracking.ts`
+- `server/db-report-workflow.ts`
+- `test/admin-heavy-list-pagination-contract.test.ts`
+- `test/admin-particular-tokens.fastify.test.ts`

--- a/server/db-admin-clinics.ts
+++ b/server/db-admin-clinics.ts
@@ -24,6 +24,7 @@ import {
   type ClinicUserRole,
   visitLocations,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export type AdminClinicUserSummary = {
   userType: "clinic";
@@ -236,28 +237,11 @@ async function getClinicUserRow(
   return rows[0] ?? null;
 }
 
-function normalizeLimit(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 50;
-  }
-
-  return Math.min(Math.max(Math.trunc(value), 1), 100);
-}
-
-function normalizeOffset(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.max(Math.trunc(value), 0);
-}
-
 export async function listAdminClinics(params: {
   limit?: number;
   offset?: number;
 } = {}): Promise<AdminClinicsSnapshot> {
-  const limit = normalizeLimit(params.limit);
-  const offset = normalizeOffset(params.offset);
+  const { limit, offset } = normalizeListPagination(params);
   const [clinicRows, totalRows] = await Promise.all([
     db
       .select({

--- a/server/db-admin-failed-login-alerts.ts
+++ b/server/db-admin-failed-login-alerts.ts
@@ -6,6 +6,7 @@ import {
   type LoginFailedAttemptReason,
   type LoginFailedAttemptSurface,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export type AdminFailedLoginAlertSurface = LoginFailedAttemptSurface;
 export type AdminFailedLoginAlertReason = LoginFailedAttemptReason;
@@ -40,27 +41,10 @@ export type AdminFailedLoginAlertsSnapshot = {
   };
 };
 
-function normalizeLimit(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 50;
-  }
-
-  return Math.min(Math.max(Math.trunc(value), 1), 100);
-}
-
-function normalizeOffset(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.max(Math.trunc(value), 0);
-}
-
 export async function listAdminFailedLoginAlerts(
   params: AdminFailedLoginAlertsQuery = {},
 ): Promise<AdminFailedLoginAlertsSnapshot> {
-  const limit = normalizeLimit(params.limit);
-  const offset = normalizeOffset(params.offset);
+  const { limit, offset } = normalizeListPagination(params);
   const filters = [];
 
   if (params.surface) {

--- a/server/db-admin-sessions.ts
+++ b/server/db-admin-sessions.ts
@@ -6,6 +6,7 @@ import {
   adminSessions,
   particularSessions,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export type AdminSessionType = "admin" | "clinic" | "particular";
 export type AdminSessionStatus = "active" | "expired";
@@ -36,22 +37,6 @@ export type AdminSessionsSnapshot = {
   offset: number;
 };
 
-function normalizeLimit(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 50;
-  }
-
-  return Math.min(Math.max(Math.trunc(value), 1), 100);
-}
-
-function normalizeOffset(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.max(Math.trunc(value), 0);
-}
-
 function toIsoDate(value: Date | null | undefined) {
   return value ? value.toISOString() : null;
 }
@@ -76,8 +61,7 @@ export async function getAdminSessionsSnapshot(
   params: AdminSessionsQuery = {},
   now = new Date(),
 ): Promise<AdminSessionsSnapshot> {
-  const limit = normalizeLimit(params.limit);
-  const offset = normalizeOffset(params.offset);
+  const { limit, offset } = normalizeListPagination(params);
   const fetchLimit = limit + offset;
 
   const includeAdmin =

--- a/server/db-admin-users-roles.ts
+++ b/server/db-admin-users-roles.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, ne } from "drizzle-orm";
+import { and, asc, eq, ne, sql } from "drizzle-orm";
 
 import { db } from "./db.ts";
 import {
@@ -8,6 +8,7 @@ import {
   clinics,
   type ClinicUserRole,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export type AdminRoleUserType = "admin" | "clinic";
 export type AdminRoleUserRole = "admin" | ClinicUserRole;
@@ -83,22 +84,6 @@ type ClinicUserRoleRow = {
   updatedAt: Date;
 };
 
-function normalizeLimit(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 50;
-  }
-
-  return Math.min(Math.max(Math.trunc(value), 1), 100);
-}
-
-function normalizeOffset(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.max(Math.trunc(value), 0);
-}
-
 function toIsoDate(value: Date) {
   return value.toISOString();
 }
@@ -156,16 +141,51 @@ async function getClinicUserRoleRow(
 export async function getAdminUsersRolesSnapshot(
   params: AdminUsersRolesQuery = {},
 ): Promise<AdminUsersRolesSnapshot> {
-  const limit = normalizeLimit(params.limit);
-  const offset = normalizeOffset(params.offset);
+  const { limit, offset } = normalizeListPagination(params);
 
   const includeAdmins =
     params.userType === undefined || params.userType === "admin";
   const includeClinicUsers =
     params.userType === undefined || params.userType === "clinic";
+  const shouldListAdmins =
+    includeAdmins && (params.role === undefined || params.role === "admin");
+  const shouldListClinicUsers = includeClinicUsers && params.role !== "admin";
+  const clinicWhere =
+    params.role && params.role !== "admin"
+      ? eq(clinicUsers.role, params.role)
+      : undefined;
+
+  const [adminCountRows, clinicCountRows] = await Promise.all([
+    shouldListAdmins
+      ? db
+          .select({
+            total: sql<number>`count(*)::int`,
+          })
+          .from(adminUsers)
+      : Promise.resolve([{ total: 0 }]),
+    shouldListClinicUsers
+      ? db
+          .select({
+            total: sql<number>`count(*)::int`,
+          })
+          .from(clinicUsers)
+          .where(clinicWhere)
+      : Promise.resolve([{ total: 0 }]),
+  ]);
+
+  const adminTotal = Number(adminCountRows[0]?.total ?? 0);
+  const clinicTotal = Number(clinicCountRows[0]?.total ?? 0);
+  const adminOffset = shouldListAdmins ? Math.min(offset, adminTotal) : 0;
+  const adminLimit = shouldListAdmins
+    ? Math.min(limit, Math.max(adminTotal - offset, 0))
+    : 0;
+  const clinicOffset = shouldListAdmins
+    ? Math.max(offset - adminTotal, 0)
+    : offset;
+  const clinicLimit = shouldListClinicUsers ? limit - adminLimit : 0;
 
   const [adminRows, clinicRows] = await Promise.all([
-    includeAdmins
+    adminLimit > 0
       ? db
           .select({
             userId: adminUsers.id,
@@ -175,8 +195,10 @@ export async function getAdminUsersRolesSnapshot(
           })
           .from(adminUsers)
           .orderBy(asc(adminUsers.username))
+          .limit(adminLimit)
+          .offset(adminOffset)
       : Promise.resolve([]),
-    includeClinicUsers
+    clinicLimit > 0
       ? db
           .select({
             userId: clinicUsers.id,
@@ -194,7 +216,10 @@ export async function getAdminUsersRolesSnapshot(
             clinicPublicProfiles,
             eq(clinicPublicProfiles.clinicId, clinicUsers.clinicId),
           )
+          .where(clinicWhere)
           .orderBy(asc(clinicUsers.username))
+          .limit(clinicLimit)
+          .offset(clinicOffset)
       : Promise.resolve([]),
   ]);
 
@@ -221,19 +246,17 @@ export async function getAdminUsersRolesSnapshot(
         updatedAt: row.updatedAt,
       }),
     ),
-  ]
-    .filter((user) => (params.role ? user.role === params.role : true))
-    .sort(sortUsers);
+  ].sort(sortUsers);
 
   return {
     success: true,
-    users: users.slice(offset, offset + limit),
-    total: users.length,
+    users,
+    total: adminTotal + clinicTotal,
     limit,
     offset,
     totals: {
-      adminUsers: users.filter((user) => user.userType === "admin").length,
-      clinicUsers: users.filter((user) => user.userType === "clinic").length,
+      adminUsers: adminTotal,
+      clinicUsers: clinicTotal,
     },
   };
 }

--- a/server/db-particular.ts
+++ b/server/db-particular.ts
@@ -6,6 +6,7 @@ import {
   type NewParticularSession,
   type NewParticularToken,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export async function createParticularToken(
   input: Omit<NewParticularToken, "id" | "createdAt" | "updatedAt">,
@@ -49,8 +50,7 @@ export async function listParticularTokens(params?: {
   limit?: number;
   offset?: number;
 }) {
-  const limit = params?.limit ?? 50;
-  const offset = params?.offset ?? 0;
+  const { limit, offset } = normalizeListPagination(params);
 
   if (typeof params?.clinicId === "number") {
     return db

--- a/server/db-report-access.ts
+++ b/server/db-report-access.ts
@@ -5,6 +5,7 @@ import {
   reports,
   type NewReportAccessToken,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export async function createReportAccessToken(
   input: Omit<
@@ -68,8 +69,7 @@ export async function listReportAccessTokens(params?: {
   limit?: number;
   offset?: number;
 }) {
-  const limit = params?.limit ?? 50;
-  const offset = params?.offset ?? 0;
+  const { limit, offset } = normalizeListPagination(params);
   const filters = [] as Array<ReturnType<typeof eq>>;
 
   if (typeof params?.clinicId === "number") {

--- a/server/db-report-workflow.ts
+++ b/server/db-report-workflow.ts
@@ -6,6 +6,7 @@ import {
   reports,
   type ReportWorkflowStage,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 export type AdminReportWorkflowItem = {
   id: number;
@@ -72,16 +73,20 @@ function serializeAdminReportWorkflowItem(
 }
 
 export async function listAdminReportWorkflowItems(input: {
-  limit: number;
-  offset: number;
-}): Promise<AdminReportWorkflowItem[]> {
+  limit?: number;
+  offset?: number;
+} = {}): Promise<AdminReportWorkflowItem[]> {
+  const { limit, offset } = normalizeListPagination(input, {
+    defaultLimit: 20,
+    maxLimit: 21,
+  });
   const rows = await db
     .select(workflowSelection)
     .from(reports)
     .leftJoin(clinics, eq(reports.clinicId, clinics.id))
     .orderBy(desc(reports.uploadDate), desc(reports.createdAt), desc(reports.id))
-    .limit(input.limit)
-    .offset(input.offset);
+    .limit(limit)
+    .offset(offset);
 
   return rows.map((row) =>
     serializeAdminReportWorkflowItem(row as AdminReportWorkflowRow),

--- a/server/db-study-tracking.ts
+++ b/server/db-study-tracking.ts
@@ -6,6 +6,7 @@ import {
   type NewStudyTrackingCase,
   type NewStudyTrackingNotification,
 } from "../drizzle/schema.ts";
+import { normalizeListPagination } from "./lib/list-pagination.ts";
 
 type NotificationScope = {
   clinicId?: number;
@@ -106,8 +107,7 @@ export async function listStudyTrackingCases(params?: {
   limit?: number;
   offset?: number;
 }) {
-  const limit = params?.limit ?? 50;
-  const offset = params?.offset ?? 0;
+  const { limit, offset } = normalizeListPagination(params);
   const filters = [];
 
   if (typeof params?.clinicId === "number") {
@@ -178,8 +178,7 @@ export async function listStudyTrackingNotifications(params?: {
   limit?: number;
   offset?: number;
 }) {
-  const limit = params?.limit ?? 50;
-  const offset = params?.offset ?? 0;
+  const { limit, offset } = normalizeListPagination(params);
   const filters = [];
 
   if (typeof params?.clinicId === "number") {

--- a/server/lib/list-pagination.ts
+++ b/server/lib/list-pagination.ts
@@ -1,0 +1,54 @@
+export const DEFAULT_LIST_LIMIT = 50;
+export const MAX_LIST_LIMIT = 100;
+export const DEFAULT_LIST_OFFSET = 0;
+export const MAX_LIST_OFFSET = 100_000;
+
+export type ListPaginationOptions = {
+  defaultLimit?: number;
+  maxLimit?: number;
+  defaultOffset?: number;
+  maxOffset?: number;
+};
+
+export function normalizeListLimit(
+  value: unknown,
+  options: Pick<ListPaginationOptions, "defaultLimit" | "maxLimit"> = {},
+) {
+  const defaultLimit = options.defaultLimit ?? DEFAULT_LIST_LIMIT;
+  const maxLimit = options.maxLimit ?? MAX_LIST_LIMIT;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return defaultLimit;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), maxLimit);
+}
+
+export function normalizeListOffset(
+  value: unknown,
+  options: Pick<ListPaginationOptions, "defaultOffset" | "maxOffset"> = {},
+) {
+  const defaultOffset = options.defaultOffset ?? DEFAULT_LIST_OFFSET;
+  const maxOffset = options.maxOffset ?? MAX_LIST_OFFSET;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return defaultOffset;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 0), maxOffset);
+}
+
+export function normalizeListPagination(
+  input:
+    | {
+        limit?: unknown;
+        offset?: unknown;
+      }
+    | undefined,
+  options: ListPaginationOptions = {},
+) {
+  return {
+    limit: normalizeListLimit(input?.limit, options),
+    offset: normalizeListOffset(input?.offset, options),
+  };
+}

--- a/test/admin-heavy-list-pagination-contract.test.ts
+++ b/test/admin-heavy-list-pagination-contract.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const { normalizeListPagination } = await import(
+  "../server/lib/list-pagination.ts"
+);
+
+function readSource(path: string) {
+  return readFileSync(resolve(process.cwd(), path), "utf8");
+}
+
+test("normalizeListPagination aplica defaults conservadores", () => {
+  assert.deepEqual(normalizeListPagination(undefined), {
+    limit: 50,
+    offset: 0,
+  });
+});
+
+test("normalizeListPagination clampa max limit y offset", () => {
+  assert.deepEqual(
+    normalizeListPagination({
+      limit: 999,
+      offset: 999_999,
+    }),
+    {
+      limit: 100,
+      offset: 100_000,
+    },
+  );
+});
+
+test("normalizeListPagination normaliza limit y offset inválidos", () => {
+  assert.deepEqual(
+    normalizeListPagination({
+      limit: Number.NaN,
+      offset: -5,
+    }),
+    {
+      limit: 50,
+      offset: 0,
+    },
+  );
+});
+
+test("listadores backend compartidos normalizan paginación antes de consultar", () => {
+  const files = [
+    "server/db-particular.ts",
+    "server/db-report-access.ts",
+    "server/db-study-tracking.ts",
+    "server/db-report-workflow.ts",
+    "server/db-admin-clinics.ts",
+    "server/db-admin-failed-login-alerts.ts",
+  ];
+
+  for (const file of files) {
+    const source = readSource(file);
+    assert.match(source, /normalizeListPagination\(/, file);
+    assert.match(source, /\.limit\(limit\)[\s\S]*\.offset\(offset\)/, file);
+  }
+
+  const sessionsSource = readSource("server/db-admin-sessions.ts");
+  assert.match(sessionsSource, /normalizeListPagination\(/);
+  assert.match(sessionsSource, /const fetchLimit = limit \+ offset/);
+  assert.match(sessionsSource, /\.limit\(fetchLimit\)/);
+});
+
+test("admin users roles pagina consultas DB antes de combinar resultados", () => {
+  const source = readSource("server/db-admin-users-roles.ts");
+
+  assert.match(
+    source,
+    /\.from\(adminUsers\)[\s\S]*\.limit\(adminLimit\)[\s\S]*\.offset\(adminOffset\)/,
+  );
+  assert.match(
+    source,
+    /\.from\(clinicUsers\)[\s\S]*\.limit\(clinicLimit\)[\s\S]*\.offset\(clinicOffset\)/,
+  );
+  assert.match(source, /total: adminTotal \+ clinicTotal/);
+});

--- a/test/admin-particular-tokens.fastify.test.ts
+++ b/test/admin-particular-tokens.fastify.test.ts
@@ -601,6 +601,66 @@ test(
 );
 
 test(
+  "adminParticularTokensNativeRoutes normaliza paginación default, max e inválida",
+  async () => {
+    const listCalls: Array<Record<string, unknown>> = [];
+    const app = await createTestApp({
+      listParticularTokens: async (params: Record<string, unknown>) => {
+        listCalls.push(params);
+        return [];
+      },
+    });
+
+    try {
+      const baseHeaders = {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      };
+      const defaultResponse = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens",
+        headers: baseHeaders,
+      });
+      const maxResponse = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens?limit=999&offset=2",
+        headers: baseHeaders,
+      });
+      const invalidResponse = await app.inject({
+        method: "GET",
+        url: "/api/admin/particular-tokens?limit=abc&offset=-2",
+        headers: baseHeaders,
+      });
+
+      assert.equal(defaultResponse.statusCode, 200);
+      assert.equal(maxResponse.statusCode, 200);
+      assert.equal(invalidResponse.statusCode, 200);
+      assert.equal(listCalls.length, 3);
+      assert.equal(listCalls[0].limit, 50);
+      assert.equal(listCalls[0].offset, 0);
+      assert.equal(listCalls[1].limit, 100);
+      assert.equal(listCalls[1].offset, 2);
+      assert.equal(listCalls[2].limit, 50);
+      assert.equal(listCalls[2].offset, 0);
+
+      assert.deepEqual(JSON.parse(defaultResponse.body).pagination, {
+        limit: 50,
+        offset: 0,
+      });
+      assert.deepEqual(JSON.parse(maxResponse.body).pagination, {
+        limit: 100,
+        offset: 2,
+      });
+      assert.deepEqual(JSON.parse(invalidResponse.body).pagination, {
+        limit: 50,
+        offset: 0,
+      });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "adminParticularTokensNativeRoutes expone GET /:tokenId con detalle y reporte vinculado",
   async () => {
     const token = createParticularTokenFixture();


### PR DESCRIPTION
## Resumen
- Refuerza paginación defensiva en listados admin pesados.
- Centraliza/defaults backend para limit/offset en helpers compartidos.
- Agrega cobertura de contrato para evitar consultas masivas sin límite.

## Cambios
- Nuevo helper backend de paginación.
- Aplicación en listadores admin/compartidos auditados.
- Tests de contrato para default, max limit e inválidos.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test