### PR TITLE
security(admin): enforce no-store on sensitive admin responses

### DIFF
--- a/docs/pr-816-admin-no-store-sensitive-responses.md
+++ b/docs/pr-816-admin-no-store-sensitive-responses.md
@@ -1,0 +1,44 @@
+# PR 816 - Admin no-store sensitive responses
+
+## Resumen
+
+- Se centralizo el header defensivo de cache en `server/lib/sensitive-response-cache.ts`.
+- `createFastifyApp()` mantiene el hook global `onSend` y delega alli la aplicacion de `Cache-Control: no-store`.
+- La politica existente queda limitada a API no publica: rutas `/api/*` salvo `/api/public/*`.
+- No se tocaron DB schema, migraciones, indices, frontend, WebAuthn ni logica de negocio.
+
+## Rutas auditadas
+
+| Superficie | Prefijos revisados | Resultado |
+| --- | --- | --- |
+| Admin auth | `/api/admin/auth` | Cubierta por hook global. |
+| Admin audit | `/api/admin/audit-log` | Cubierta por hook global. |
+| Admin listados sensibles | `/api/admin/failed-login-alerts`, `/api/admin/sessions`, `/api/admin/users-roles`, `/api/admin/clinics`, `/api/admin/particular-tokens`, `/api/admin/report-access-tokens`, `/api/admin/study-tracking` | Cubiertas por hook global. |
+| Admin informes/workflow | `/api/admin/reports`, `/api/admin/report-workflow` | Cubiertas por hook global. |
+| Admin sistema | `/api/admin/system/health`, `/api/admin/system/maintenance`, `/api/admin/system/schema-health` | Cubiertas por hook global. |
+| Auth clinica | `/api/auth`, `/api/clinic/audit-log`, `/api/clinic/profile` | Cubiertas por hook global. |
+| Auth particular | `/api/particular/auth`, `/api/particular/audit-log`, `/api/particular/study-tracking`, `/api/particular-tokens` | Cubiertas por hook global. |
+| Informes/tokens clinica | `/api/reports`, `/api/report-access-tokens`, `/api/study-tracking` | Cubiertas por hook global. |
+| Logistica autenticada | `/api/logistics/field-visits`, `/api/logistics/route-plans`, `/api/logistics/route-events`, `/api/logistics/sla` | Cubiertas por hook global. |
+| Publicas | `/api/public/pricing`, `/api/public/professionals`, `/api/public/report-access` | No se modifican por este PR. |
+
+## Headers aplicados
+
+- `Cache-Control: no-store` en respuestas API no publicas cuando el handler no declaro su propio `Cache-Control`.
+- `Pragma: no-cache` no se agrego: no hay patron backend compatible para respuestas API, solo usos de `Expires` en cookies/logout.
+- `Expires: 0` no se agrego por la misma razon.
+
+## Tests
+
+- `test/backend-api-no-store-cache-contract.test.ts`
+  - Valida el helper centralizado y la clasificacion de rutas sensibles.
+  - Verifica que `fastify-app.ts` delega el hook `onSend` al helper.
+  - Verifica que rutas admin/autenticadas criticas no setean `Cache-Control` propio.
+  - Verifica que `public-pricing` conserva cache publica propia.
+  - Verifica que no se introduce dependencia de frontend/UI.
+- `test/fastify-app.test.ts`
+  - Verifica `Cache-Control: no-store` en `/api/admin/auth/me`.
+  - Verifica `Cache-Control: no-store` en `/api/admin/system/health` con respuesta 200.
+  - Verifica `Cache-Control: no-store` en `/api/admin/failed-login-alerts` con respuesta 200 de listado.
+  - Verifica que `/api/public/professionals/search` no recibe `no-store` global.
+  - Verifica que `/api/public/pricing` conserva `public, max-age=60, stale-while-revalidate=300`.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -141,6 +141,7 @@ import {
   type LogisticsSlaNativeRoutesOptions,
 } from "./routes/logistics-sla.fastify.ts";
 import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";
+import { applySensitiveApiNoStoreHeaders } from "./lib/sensitive-response-cache.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -254,25 +255,10 @@ export async function createFastifyApp(
 
   app.addHook("onRequest", requireTrustedOriginForFastify);
 
-  // Garantiza que rutas API autenticadas no sean cacheadas por proxies ni
-  // navegador. Las rutas públicas con caché propia (ej. /api/public/pricing)
-  // ya setean su propio Cache-Control y no son sobreescritas.
   app.addHook(
     "onSend",
     async (request: FastifyRequest, reply: FastifyReply, _payload) => {
-      const url = request.url ?? "";
-
-      if (!url.startsWith("/api/")) {
-        return;
-      }
-
-      if (url.startsWith("/api/public/")) {
-        return;
-      }
-
-      if (!reply.hasHeader("cache-control")) {
-        reply.header("cache-control", "no-store");
-      }
+      applySensitiveApiNoStoreHeaders(request, reply);
     },
   );
 

--- a/server/lib/sensitive-response-cache.ts
+++ b/server/lib/sensitive-response-cache.ts
@@ -1,0 +1,19 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+export const SENSITIVE_API_CACHE_CONTROL = "no-store";
+
+export function shouldApplySensitiveApiNoStore(url: string): boolean {
+  return url.startsWith("/api/") && !url.startsWith("/api/public/");
+}
+
+export function applySensitiveApiNoStoreHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  if (
+    shouldApplySensitiveApiNoStore(request.url ?? "") &&
+    !reply.hasHeader("cache-control")
+  ) {
+    reply.header("cache-control", SENSITIVE_API_CACHE_CONTROL);
+  }
+}

--- a/test/backend-api-no-store-cache-contract.test.ts
+++ b/test/backend-api-no-store-cache-contract.test.ts
@@ -1,14 +1,3 @@
-/**
- * backend-api-no-store-cache-contract.test.ts
- *
- * Garantiza que las rutas API autenticadas del backend responden con
- * Cache-Control: no-store para evitar que proxies o el navegador cacheen
- * respuestas sensibles (sesiones, informes, tokens, admin, particular).
- *
- * Las rutas públicas con caché propia (/api/public/*) quedan excluidas
- * intencionalmente — cada una gestiona su propio Cache-Control.
- */
-
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -17,49 +6,37 @@ import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
 
+const {
+  SENSITIVE_API_CACHE_CONTROL,
+  shouldApplySensitiveApiNoStore,
+} = await import("../server/lib/sensitive-response-cache.ts");
+
 function readSource(relativePath: string): string {
   return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
 }
 
-// ---------------------------------------------------------------------------
-// 1. El hook onSend está declarado en fastify-app.ts
-// ---------------------------------------------------------------------------
-
-test("fastify-app declara hook onSend que inyecta Cache-Control: no-store en /api/ no-públicas", () => {
-  const source = readSource("server/fastify-app.ts");
-
-  assert.ok(
-    source.includes('app.addHook(\n    "onSend"') ||
-      source.includes("app.addHook('onSend'") ||
-      source.includes('app.addHook("onSend"'),
-    "createFastifyApp debe registrar un hook onSend",
+test("sensitive response cache helper clasifica API no publica para no-store", () => {
+  assert.equal(SENSITIVE_API_CACHE_CONTROL, "no-store");
+  assert.equal(shouldApplySensitiveApiNoStore("/api/admin/auth/me"), true);
+  assert.equal(
+    shouldApplySensitiveApiNoStore("/api/admin/failed-login-alerts?limit=5"),
+    true,
   );
-
-  assert.ok(
-    source.includes('url.startsWith("/api/")'),
-    "el hook debe filtrar rutas /api/",
+  assert.equal(shouldApplySensitiveApiNoStore("/api/reports"), true);
+  assert.equal(shouldApplySensitiveApiNoStore("/api/public/pricing"), false);
+  assert.equal(
+    shouldApplySensitiveApiNoStore("/api/public/professionals/search"),
+    false,
   );
-
-  assert.ok(
-    source.includes('url.startsWith("/api/public/")'),
-    "el hook debe excluir rutas /api/public/ con caché propia",
-  );
-
-  assert.ok(
-    source.includes('"cache-control"') && source.includes('"no-store"'),
-    "el hook debe emitir Cache-Control: no-store",
-  );
-
-  assert.ok(
-    source.includes("reply.hasHeader"),
-    "el hook no debe sobreescribir headers ya seteados",
-  );
+  assert.equal(shouldApplySensitiveApiNoStore("/dashboard/admin"), false);
 });
 
-// ---------------------------------------------------------------------------
-// 2. Rutas autenticadas críticas no setean su propio Cache-Control
-//    (por lo tanto dependen del hook global)
-// ---------------------------------------------------------------------------
+test("fastify-app registra onSend y delega no-store sensible al helper backend", () => {
+  const source = readSource("server/fastify-app.ts");
+
+  assert.ok(source.includes('app.addHook(\n    "onSend"'));
+  assert.ok(source.includes("applySensitiveApiNoStoreHeaders(request, reply)"));
+});
 
 const AUTHENTICATED_ROUTES_WITHOUT_OWN_CACHE_HEADER: readonly {
   file: string;
@@ -72,6 +49,18 @@ const AUTHENTICATED_ROUTES_WITHOUT_OWN_CACHE_HEADER: readonly {
   {
     file: "server/routes/admin-particular-tokens.fastify.ts",
     label: "admin particular tokens",
+  },
+  {
+    file: "server/routes/admin-report-access-tokens.fastify.ts",
+    label: "admin report access tokens",
+  },
+  {
+    file: "server/routes/admin-failed-login-alerts.fastify.ts",
+    label: "admin failed login alerts",
+  },
+  {
+    file: "server/routes/admin-study-tracking.fastify.ts",
+    label: "admin study tracking",
   },
   {
     file: "server/routes/particular-auth.fastify.ts",
@@ -90,25 +79,24 @@ for (const { file, label } of AUTHENTICATED_ROUTES_WITHOUT_OWN_CACHE_HEADER) {
     assert.equal(
       hasOwnCacheControl,
       false,
-      `${file} no debe setear Cache-Control propio — el hook global de fastify-app.ts lo cubre`,
+      `${file} no debe setear Cache-Control propio; el hook global de fastify-app.ts lo cubre`,
     );
   });
 }
 
-// ---------------------------------------------------------------------------
-// 3. La ruta pública de precios SÍ setea su propio Cache-Control (excluida)
-// ---------------------------------------------------------------------------
-
-test("public-pricing setea su propio Cache-Control y no depende del hook global", () => {
+test("public-pricing mantiene Cache-Control publico propio", () => {
   const source = readSource("server/routes/public-pricing.fastify.ts");
 
-  assert.ok(
-    /reply\s*\.\s*header\s*\(\s*["']Cache-Control["']/i.test(source),
-    "public-pricing debe declarar su propio Cache-Control",
-  );
+  assert.ok(/reply\s*\.\s*header\s*\(\s*["']Cache-Control["']/i.test(source));
+  assert.ok(source.includes("public, max-age="));
+});
 
-  assert.ok(
-    source.includes("public, max-age="),
-    "public-pricing debe usar directiva public con max-age",
-  );
+test("no-store sensible no introduce dependencia de frontend o UI", () => {
+  const helperSource = readSource("server/lib/sensitive-response-cache.ts");
+  const fastifyAppSource = readSource("server/fastify-app.ts");
+  const combined = `${helperSource}\n${fastifyAppSource}`;
+
+  assert.equal(combined.includes("frontend"), false);
+  assert.equal(combined.includes(".tsx"), false);
+  assert.equal(combined.includes("components"), false);
 });

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -754,6 +754,9 @@ function buildFastifyDispatchRouteStubs() {
     particularStudyTrackingRoutes: buildParticularStudyTrackingRouteStubs(),
     particularTokensRoutes: buildParticularTokensRouteStubs(),
     publicProfessionalsRoutes: buildPublicProfessionalsRouteStubs(),
+    publicPricingRoutes: {
+      listPublicPricingItems: async () => [],
+    },
     publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
     reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
     reportsRoutes: buildReportsRouteStubs(),
@@ -1114,6 +1117,7 @@ test(
 
       assert.equal(response.headers["x-legacy-bridge"], undefined);
       assert.notEqual(response.statusCode, 418);
+      assert.equal(response.headers["cache-control"], "no-store");
       assert.ok([200, 401].includes(response.statusCode));
 
       if (response.statusCode === 200) {
@@ -2385,6 +2389,7 @@ test(
       });
 
       assert.equal(response.headers["x-legacy-bridge"], undefined);
+      assert.equal(response.headers["cache-control"], undefined);
       assert.equal(response.statusCode, 200);
       assert.equal(detailHelperWasCalled, false);
       assert.deepEqual(receivedSearchInput, {
@@ -2428,6 +2433,28 @@ test(
         },
         profileQualityScore: 0.97,
       });
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp preserva Cache-Control publico de pricing",
+  async () => {
+    const app = await createFastifyApp(buildFastifyDispatchRouteStubs());
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/public/pricing",
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["cache-control"],
+        "public, max-age=60, stale-while-revalidate=300",
+      );
     } finally {
       await app.close();
     }
@@ -2549,6 +2576,7 @@ test(
       });
 
       assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["cache-control"], "no-store");
 
       const body = JSON.parse(response.body);
       assert.equal(body.success, true);
@@ -2625,6 +2653,7 @@ test(
 
       assert.equal(response.headers["x-legacy-bridge"], undefined);
       assert.equal(response.statusCode, 200);
+      assert.equal(response.headers["cache-control"], "no-store");
 
       const body = JSON.parse(response.body);
 


### PR DESCRIPTION
## Resumen
- Centraliza la política anti-cache para respuestas sensibles de API.
- Conecta el hook onSend de Fastify a un helper backend dedicado.
- Refuerza cobertura contractual/runtime para respuestas admin/autenticadas sensibles.

## Cambios
- Nuevo helper backend: server/lib/sensitive-response-cache.ts.
- Ajuste acotado en server/fastify-app.ts.
- Tests reforzados en backend-api-no-store-cache-contract y fastify-app.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.

## Headers
- Cache-Control: no-store.
- No se agregan Pragma/Expires porque no hay patrón backend compatible para respuestas API.

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test