### PR TITLE
security(api): enforce nosniff on API responses

### DIFF
--- a/docs/pr-817-api-nosniff-responses.md
+++ b/docs/pr-817-api-nosniff-responses.md
@@ -1,0 +1,69 @@
+# PR 817 - API nosniff responses
+
+## Resumen
+
+Se agrego un helper backend minimo para aplicar `X-Content-Type-Options: nosniff` a respuestas de la superficie API Fastify. La aplicacion se hace desde un hook central `onRequest` en `createFastifyApp`, filtrado por rutas `/api` y `/api/*`.
+
+No se tocaron schema de DB, migraciones, indices, WebAuthn, frontend UI, CSP/frontend ni logica de negocio.
+
+## Auditoria
+
+- `server/fastify-app.ts`: registro central Fastify, hooks globales `onRequest` y `onSend`, handlers globales de 404/error, `/`, `/health` y `/api/health`.
+- `server/middlewares/trusted-origin.ts`: middleware global existente para origen confiable.
+- `server/lib/sensitive-response-cache.ts`: helper backend existente para `Cache-Control: no-store` en API sensible.
+- `server/routes/*.fastify.ts`: rutas nativas Fastify publicas, admin, clinic, particular, reports y logistics.
+- `frontend/next.config.ts`: ya tenia `X-Content-Type-Options: nosniff` para frontend; no se modifico.
+
+No se encontro helper backend compatible para `X-Content-Type-Options`, ni uso de `helmet` en backend.
+
+## Superficie API mapeada
+
+Publica:
+
+- `/api/health`
+- `/api/contact`
+- `/api/public/professionals`
+- `/api/public/pricing`
+- `/api/public/report-access`
+
+Autenticada o sensible:
+
+- `/api/admin/*`
+- `/api/auth`
+- `/api/clinic/*`
+- `/api/particular/*`
+- `/api/particular-tokens`
+- `/api/report-access-tokens`
+- `/api/reports`
+- `/api/study-tracking`
+- `/api/logistics/*`
+
+Fuera de API:
+
+- `/`
+- `/health`
+- Assets estaticos o HTML publico fuera de `/api`, si existen.
+
+## Header aplicado
+
+- `X-Content-Type-Options: nosniff`
+
+El helper escribe el header en `FastifyReply` y tambien en `reply.raw` para conservar cobertura en endpoints que terminan con `reply.raw.end`, como `/api/health`.
+
+## Implementacion
+
+- `server/lib/api-response-security.ts`: nuevo helper backend con constantes, clasificacion de path API y aplicacion del header.
+- `server/fastify-app.ts`: registro de hook global `onRequest` antes de `requireTrustedOriginForFastify`, para cubrir respuestas tempranas de API.
+
+## Tests agregados o ajustados
+
+- `test/backend-api-nosniff-responses-contract.test.ts`
+  - Cubre clasificacion del helper para API y no API.
+  - Verifica registro central del hook antes de cortes tempranos.
+  - Verifica que no se introduzca dependencia frontend/UI.
+- `test/fastify-app.test.ts`
+  - Cubre endpoint admin autenticado: `GET /api/admin/system/health`.
+  - Cubre endpoint API publico: `GET /api/public/pricing`.
+  - Cubre respuesta API de error: `GET /api/no-existe`.
+  - Cubre endpoint raw API: `GET /api/health`.
+  - Verifica que `/` no reciba el header por estar fuera de `/api`.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -142,6 +142,7 @@ import {
 } from "./routes/logistics-sla.fastify.ts";
 import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";
 import { applySensitiveApiNoStoreHeaders } from "./lib/sensitive-response-cache.ts";
+import { applyApiNosniffHeader } from "./lib/api-response-security.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -251,6 +252,10 @@ export async function createFastifyApp(
   const app = Fastify({
     logger: false,
     trustProxy: ENV.trustProxy,
+  });
+
+  app.addHook("onRequest", async (request, reply) => {
+    applyApiNosniffHeader(request, reply);
   });
 
   app.addHook("onRequest", requireTrustedOriginForFastify);

--- a/server/lib/api-response-security.ts
+++ b/server/lib/api-response-security.ts
@@ -1,0 +1,35 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+export const API_NOSNIFF_HEADER_NAME = "X-Content-Type-Options";
+export const API_NOSNIFF_HEADER_VALUE = "nosniff";
+
+function getRequestPath(url: string): string {
+  try {
+    return new URL(url, "http://portal-vetneb.local").pathname;
+  } catch {
+    return url.split("?")[0] ?? "";
+  }
+}
+
+export function shouldApplyApiNosniff(url: string): boolean {
+  const path = getRequestPath(url);
+
+  return path === "/api" || path.startsWith("/api/");
+}
+
+export function applyApiNosniffHeader(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  if (!shouldApplyApiNosniff(request.url ?? "")) {
+    return;
+  }
+
+  if (!reply.hasHeader(API_NOSNIFF_HEADER_NAME)) {
+    reply.header(API_NOSNIFF_HEADER_NAME, API_NOSNIFF_HEADER_VALUE);
+  }
+
+  if (!reply.raw.hasHeader(API_NOSNIFF_HEADER_NAME)) {
+    reply.raw.setHeader(API_NOSNIFF_HEADER_NAME, API_NOSNIFF_HEADER_VALUE);
+  }
+}

--- a/test/backend-api-nosniff-responses-contract.test.ts
+++ b/test/backend-api-nosniff-responses-contract.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+const {
+  API_NOSNIFF_HEADER_NAME,
+  API_NOSNIFF_HEADER_VALUE,
+  shouldApplyApiNosniff,
+} = await import("../server/lib/api-response-security.ts");
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+}
+
+test("api nosniff helper clasifica solo superficie API", () => {
+  assert.equal(API_NOSNIFF_HEADER_NAME, "X-Content-Type-Options");
+  assert.equal(API_NOSNIFF_HEADER_VALUE, "nosniff");
+  assert.equal(shouldApplyApiNosniff("/api"), true);
+  assert.equal(shouldApplyApiNosniff("/api/health"), true);
+  assert.equal(shouldApplyApiNosniff("/api/admin/system/health"), true);
+  assert.equal(shouldApplyApiNosniff("/api/public/pricing"), true);
+  assert.equal(
+    shouldApplyApiNosniff("/api/public/professionals/search?q=histo"),
+    true,
+  );
+  assert.equal(shouldApplyApiNosniff("/apiary/public"), false);
+  assert.equal(shouldApplyApiNosniff("/dashboard/admin"), false);
+  assert.equal(shouldApplyApiNosniff("/"), false);
+});
+
+test("fastify-app registra hook central de nosniff antes de cortes tempranos", () => {
+  const source = readSource("server/fastify-app.ts");
+  const nosniffHookIndex = source.indexOf(
+    "applyApiNosniffHeader(request, reply)",
+  );
+  const trustedOriginHookIndex = source.indexOf(
+    'app.addHook("onRequest", requireTrustedOriginForFastify);',
+  );
+
+  assert.ok(nosniffHookIndex > 0);
+  assert.ok(trustedOriginHookIndex > 0);
+  assert.ok(nosniffHookIndex < trustedOriginHookIndex);
+});
+
+test("api nosniff no introduce dependencia de frontend o UI", () => {
+  const helperSource = readSource("server/lib/api-response-security.ts");
+  const fastifyAppSource = readSource("server/fastify-app.ts");
+  const combined = `${helperSource}\n${fastifyAppSource}`;
+
+  assert.equal(combined.includes("frontend"), false);
+  assert.equal(combined.includes(".tsx"), false);
+  assert.equal(combined.includes("components"), false);
+  assert.equal(combined.includes("next.config"), false);
+});

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -10,6 +10,9 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { ENV } = await import("../server/lib/env.ts");
 const { createFastifyApp } = await import("../server/fastify-app.ts");
+const { API_NOSNIFF_HEADER_VALUE } = await import(
+  "../server/lib/api-response-security.ts"
+);
 
 function buildExpectedContactServiceSnapshot() {
   const explicitRecipients = Array.from(
@@ -2455,6 +2458,100 @@ test(
         response.headers["cache-control"],
         "public, max-age=60, stale-while-revalidate=300",
       );
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp aplica nosniff a respuestas API publicas autenticadas y de error",
+  async () => {
+    const app = await createFastifyApp({
+      ...buildFastifyDispatchRouteStubs(),
+      getNativeHealthCheckResponse: async () => ({
+        statusCode: 200,
+        payload: {
+          success: true,
+          status: "ok",
+        },
+      }),
+      adminSystemHealthRoutes: {
+        ...buildAdminSystemHealthRouteStubs(),
+        getAdminSessionByToken: async () => ({
+          adminUserId: 1,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+          lastAccess: new Date("2026-04-23T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({
+          id: 1,
+          username: "VETNEB",
+        }),
+        getSystemHealthSnapshot: async () => ({
+          statusCode: 200,
+          payload: {
+            success: true,
+            status: "ok",
+            checks: {
+              database: "up",
+              storage: "up",
+            },
+          },
+        }),
+        getBackendVersion: () => "2.1.0-test",
+      },
+    });
+
+    try {
+      const adminAuthenticated = await app.inject({
+        method: "GET",
+        url: "/api/admin/system/health",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+
+      const publicApi = await app.inject({
+        method: "GET",
+        url: "/api/public/pricing",
+      });
+
+      const apiError = await app.inject({
+        method: "GET",
+        url: "/api/no-existe",
+      });
+
+      const apiHealth = await app.inject({
+        method: "GET",
+        url: "/api/health",
+      });
+
+      const publicRoot = await app.inject({
+        method: "GET",
+        url: "/",
+      });
+
+      assert.equal(adminAuthenticated.statusCode, 200);
+      assert.equal(publicApi.statusCode, 200);
+      assert.equal(apiError.statusCode, 404);
+      assert.equal(apiHealth.statusCode, 200);
+
+      const apiResponses = [
+        { label: "adminAuthenticated", response: adminAuthenticated },
+        { label: "publicApi", response: publicApi },
+        { label: "apiError", response: apiError },
+        { label: "apiHealth", response: apiHealth },
+      ];
+
+      for (const { label, response } of apiResponses) {
+        assert.equal(
+          response.headers["x-content-type-options"],
+          API_NOSNIFF_HEADER_VALUE,
+          `${label} debe incluir X-Content-Type-Options`,
+        );
+      }
+
+      assert.equal(publicRoot.headers["x-content-type-options"], undefined);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Resumen
- Agrega X-Content-Type-Options: nosniff a respuestas API.
- Centraliza el header en helper/backend y hook Fastify onRequest.
- Cubre endpoints API públicos, admin/autenticados y respuestas de error/early responses.

## Cambios
- Nuevo helper: server/lib/api-response-security.ts.
- Hook central en server/fastify-app.ts.
- Tests contractuales/runtime para nosniff.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Header
- X-Content-Type-Options: nosniff

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test