### PR TITLE
security(api): enforce referrer policy on API responses

### DIFF
--- a/docs/pr-818-api-referrer-policy-responses.md
+++ b/docs/pr-818-api-referrer-policy-responses.md
@@ -1,0 +1,81 @@
+# PR 818 - API Referrer-Policy responses
+
+## Resumen
+
+Se extendio el helper backend central de headers de seguridad API para aplicar `Referrer-Policy: no-referrer` junto con `X-Content-Type-Options: nosniff` en respuestas Fastify bajo `/api` y `/api/*`.
+
+No se tocaron schema de DB, migraciones, indices, WebAuthn, frontend UI, CSP/frontend ni logica de negocio.
+
+## Rutas auditadas
+
+- `server/lib/api-response-security.ts`: helper central creado en PR 817 para headers de respuestas API.
+- `server/fastify-app.ts`: hook global `onRequest`, `requireTrustedOriginForFastify`, handlers globales de 404/error, `/`, `/health` y `/api/health`.
+- `server/lib/sensitive-response-cache.ts`: helper backend existente para `Cache-Control: no-store` en API sensible.
+- `server/routes/*.fastify.ts`: rutas Fastify registradas bajo `/api/admin/*`, `/api/auth`, `/api/clinic/*`, `/api/particular/*`, `/api/public/*`, `/api/report-access-tokens`, `/api/reports`, `/api/study-tracking` y `/api/logistics/*`.
+- `test/backend-api-nosniff-responses-contract.test.ts`: contrato del helper/hook central.
+- `test/fastify-app.test.ts`: contratos de respuestas publicas, autenticadas, error y raw API.
+- `frontend/next.config.ts`: contiene `Referrer-Policy` frontend existente; no se modifico.
+
+## Headers actuales auditados
+
+- API Fastify: `X-Content-Type-Options: nosniff` ya se aplicaba desde `server/lib/api-response-security.ts`.
+- API sensible: `Cache-Control: no-store` ya se aplicaba desde `server/lib/sensitive-response-cache.ts`.
+- Frontend Next: `Referrer-Policy: strict-origin-when-cross-origin` existe en `frontend/next.config.ts`; queda fuera del cambio.
+
+## Superficie API mapeada
+
+Publica:
+
+- `/api/health`
+- `/api/contact`
+- `/api/public/professionals`
+- `/api/public/pricing`
+- `/api/public/report-access`
+
+Autenticada o sensible:
+
+- `/api/admin/*`
+- `/api/auth`
+- `/api/clinic/*`
+- `/api/particular/*`
+- `/api/particular-tokens`
+- `/api/report-access-tokens`
+- `/api/reports`
+- `/api/study-tracking`
+- `/api/logistics/*`
+
+Errores API:
+
+- 404 global para rutas `/api/*` no registradas.
+- Handler global de errores no capturados para rutas `/api/*`.
+
+Fuera de API:
+
+- `/`
+- `/health`
+- Assets estaticos o HTML publico fuera de `/api`, si existen.
+
+## Header aplicado
+
+- `Referrer-Policy: no-referrer`
+
+El header se aplica desde el hook central `onRequest` solo cuando el path es `/api` o empieza con `/api/`. El helper escribe en `FastifyReply` y `reply.raw` para conservar cobertura en respuestas que terminan con `reply.raw.end`, como `/api/health`.
+
+## Implementacion
+
+- `server/lib/api-response-security.ts`: agrega constantes de `Referrer-Policy`, clasificacion general `shouldApplyApiSecurityHeaders` y aplicacion central de headers API.
+- `server/fastify-app.ts`: reutiliza el hook central temprano con `applyApiSecurityHeaders(request, reply)`.
+
+## Tests agregados o ajustados
+
+- `test/backend-api-nosniff-responses-contract.test.ts`
+  - Cubre constantes `Referrer-Policy: no-referrer`.
+  - Cubre clasificacion del helper para API y no API.
+  - Verifica registro central del hook antes de cortes tempranos.
+  - Verifica que no se introduzca dependencia frontend/UI.
+- `test/fastify-app.test.ts`
+  - Cubre endpoint admin autenticado: `GET /api/admin/system/health`.
+  - Cubre endpoint API publico: `GET /api/public/pricing`.
+  - Cubre respuesta API de error: `GET /api/no-existe`.
+  - Cubre endpoint raw API: `GET /api/health`.
+  - Verifica que `/` no reciba `Referrer-Policy` por estar fuera de `/api`.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -142,7 +142,7 @@ import {
 } from "./routes/logistics-sla.fastify.ts";
 import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";
 import { applySensitiveApiNoStoreHeaders } from "./lib/sensitive-response-cache.ts";
-import { applyApiNosniffHeader } from "./lib/api-response-security.ts";
+import { applyApiSecurityHeaders } from "./lib/api-response-security.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -255,7 +255,7 @@ export async function createFastifyApp(
   });
 
   app.addHook("onRequest", async (request, reply) => {
-    applyApiNosniffHeader(request, reply);
+    applyApiSecurityHeaders(request, reply);
   });
 
   app.addHook("onRequest", requireTrustedOriginForFastify);

--- a/server/lib/api-response-security.ts
+++ b/server/lib/api-response-security.ts
@@ -2,6 +2,8 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 
 export const API_NOSNIFF_HEADER_NAME = "X-Content-Type-Options";
 export const API_NOSNIFF_HEADER_VALUE = "nosniff";
+export const API_REFERRER_POLICY_HEADER_NAME = "Referrer-Policy";
+export const API_REFERRER_POLICY_HEADER_VALUE = "no-referrer";
 
 function getRequestPath(url: string): string {
   try {
@@ -11,25 +13,53 @@ function getRequestPath(url: string): string {
   }
 }
 
-export function shouldApplyApiNosniff(url: string): boolean {
+export function shouldApplyApiSecurityHeaders(url: string): boolean {
   const path = getRequestPath(url);
 
   return path === "/api" || path.startsWith("/api/");
+}
+
+export function shouldApplyApiNosniff(url: string): boolean {
+  return shouldApplyApiSecurityHeaders(url);
+}
+
+function setReplyHeaderIfUnset(
+  reply: FastifyReply,
+  name: string,
+  value: string,
+) {
+  if (!reply.hasHeader(name)) {
+    reply.header(name, value);
+  }
+
+  if (!reply.raw.hasHeader(name)) {
+    reply.raw.setHeader(name, value);
+  }
+}
+
+export function applyApiSecurityHeaders(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  if (!shouldApplyApiSecurityHeaders(request.url ?? "")) {
+    return;
+  }
+
+  setReplyHeaderIfUnset(
+    reply,
+    API_NOSNIFF_HEADER_NAME,
+    API_NOSNIFF_HEADER_VALUE,
+  );
+  setReplyHeaderIfUnset(
+    reply,
+    API_REFERRER_POLICY_HEADER_NAME,
+    API_REFERRER_POLICY_HEADER_VALUE,
+  );
 }
 
 export function applyApiNosniffHeader(
   request: FastifyRequest,
   reply: FastifyReply,
 ) {
-  if (!shouldApplyApiNosniff(request.url ?? "")) {
-    return;
-  }
-
-  if (!reply.hasHeader(API_NOSNIFF_HEADER_NAME)) {
-    reply.header(API_NOSNIFF_HEADER_NAME, API_NOSNIFF_HEADER_VALUE);
-  }
-
-  if (!reply.raw.hasHeader(API_NOSNIFF_HEADER_NAME)) {
-    reply.raw.setHeader(API_NOSNIFF_HEADER_NAME, API_NOSNIFF_HEADER_VALUE);
-  }
+  applyApiSecurityHeaders(request, reply);
 }

--- a/test/backend-api-nosniff-responses-contract.test.ts
+++ b/test/backend-api-nosniff-responses-contract.test.ts
@@ -9,44 +9,48 @@ const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
 const {
   API_NOSNIFF_HEADER_NAME,
   API_NOSNIFF_HEADER_VALUE,
-  shouldApplyApiNosniff,
+  API_REFERRER_POLICY_HEADER_NAME,
+  API_REFERRER_POLICY_HEADER_VALUE,
+  shouldApplyApiSecurityHeaders,
 } = await import("../server/lib/api-response-security.ts");
 
 function readSource(relativePath: string): string {
   return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
 }
 
-test("api nosniff helper clasifica solo superficie API", () => {
+test("api security headers helper clasifica solo superficie API", () => {
   assert.equal(API_NOSNIFF_HEADER_NAME, "X-Content-Type-Options");
   assert.equal(API_NOSNIFF_HEADER_VALUE, "nosniff");
-  assert.equal(shouldApplyApiNosniff("/api"), true);
-  assert.equal(shouldApplyApiNosniff("/api/health"), true);
-  assert.equal(shouldApplyApiNosniff("/api/admin/system/health"), true);
-  assert.equal(shouldApplyApiNosniff("/api/public/pricing"), true);
+  assert.equal(API_REFERRER_POLICY_HEADER_NAME, "Referrer-Policy");
+  assert.equal(API_REFERRER_POLICY_HEADER_VALUE, "no-referrer");
+  assert.equal(shouldApplyApiSecurityHeaders("/api"), true);
+  assert.equal(shouldApplyApiSecurityHeaders("/api/health"), true);
+  assert.equal(shouldApplyApiSecurityHeaders("/api/admin/system/health"), true);
+  assert.equal(shouldApplyApiSecurityHeaders("/api/public/pricing"), true);
   assert.equal(
-    shouldApplyApiNosniff("/api/public/professionals/search?q=histo"),
+    shouldApplyApiSecurityHeaders("/api/public/professionals/search?q=histo"),
     true,
   );
-  assert.equal(shouldApplyApiNosniff("/apiary/public"), false);
-  assert.equal(shouldApplyApiNosniff("/dashboard/admin"), false);
-  assert.equal(shouldApplyApiNosniff("/"), false);
+  assert.equal(shouldApplyApiSecurityHeaders("/apiary/public"), false);
+  assert.equal(shouldApplyApiSecurityHeaders("/dashboard/admin"), false);
+  assert.equal(shouldApplyApiSecurityHeaders("/"), false);
 });
 
-test("fastify-app registra hook central de nosniff antes de cortes tempranos", () => {
+test("fastify-app registra hook central de security headers antes de cortes tempranos", () => {
   const source = readSource("server/fastify-app.ts");
-  const nosniffHookIndex = source.indexOf(
-    "applyApiNosniffHeader(request, reply)",
+  const securityHeadersHookIndex = source.indexOf(
+    "applyApiSecurityHeaders(request, reply)",
   );
   const trustedOriginHookIndex = source.indexOf(
     'app.addHook("onRequest", requireTrustedOriginForFastify);',
   );
 
-  assert.ok(nosniffHookIndex > 0);
+  assert.ok(securityHeadersHookIndex > 0);
   assert.ok(trustedOriginHookIndex > 0);
-  assert.ok(nosniffHookIndex < trustedOriginHookIndex);
+  assert.ok(securityHeadersHookIndex < trustedOriginHookIndex);
 });
 
-test("api nosniff no introduce dependencia de frontend o UI", () => {
+test("api security headers no introduce dependencia de frontend o UI", () => {
   const helperSource = readSource("server/lib/api-response-security.ts");
   const fastifyAppSource = readSource("server/fastify-app.ts");
   const combined = `${helperSource}\n${fastifyAppSource}`;

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -10,9 +10,8 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { ENV } = await import("../server/lib/env.ts");
 const { createFastifyApp } = await import("../server/fastify-app.ts");
-const { API_NOSNIFF_HEADER_VALUE } = await import(
-  "../server/lib/api-response-security.ts"
-);
+const { API_NOSNIFF_HEADER_VALUE, API_REFERRER_POLICY_HEADER_VALUE } =
+  await import("../server/lib/api-response-security.ts");
 
 function buildExpectedContactServiceSnapshot() {
   const explicitRecipients = Array.from(
@@ -2465,7 +2464,7 @@ test(
 );
 
 test(
-  "createFastifyApp aplica nosniff a respuestas API publicas autenticadas y de error",
+  "createFastifyApp aplica security headers a respuestas API publicas autenticadas y de error",
   async () => {
     const app = await createFastifyApp({
       ...buildFastifyDispatchRouteStubs(),
@@ -2549,9 +2548,15 @@ test(
           API_NOSNIFF_HEADER_VALUE,
           `${label} debe incluir X-Content-Type-Options`,
         );
+        assert.equal(
+          response.headers["referrer-policy"],
+          API_REFERRER_POLICY_HEADER_VALUE,
+          `${label} debe incluir Referrer-Policy`,
+        );
       }
 
       assert.equal(publicRoot.headers["x-content-type-options"], undefined);
+      assert.equal(publicRoot.headers["referrer-policy"], undefined);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Resumen
- Agrega Referrer-Policy: no-referrer a respuestas API.
- Reutiliza la capa centralizada de headers de seguridad API.
- Mantiene X-Content-Type-Options: nosniff y aplica ambos headers solo a /api.

## Cambios
- Extiende server/lib/api-response-security.ts.
- Ajusta hook central en server/fastify-app.ts.
- Actualiza contratos/runtime tests para endpoints API públicos, admin/autenticados, errores y respuestas raw.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Header
- Referrer-Policy: no-referrer

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check