### PR TITLE
ops(api): expose request id on API responses

### DIFF
--- a/docs/pr-819-api-request-id-responses.md
+++ b/docs/pr-819-api-request-id-responses.md
@@ -1,0 +1,53 @@
+# PR 819 - API request id responses
+
+## Resumen
+
+Se agrego `X-Request-ID` a respuestas Fastify bajo `/api` y `/api/*`, reutilizando `request.id` de Fastify con generacion segura cuando no hay un id entrante valido.
+
+No se tocaron schema de DB, migraciones, indices, WebAuthn, frontend UI, CSP/frontend, assets estaticos ni logica de negocio.
+
+## Superficie auditada
+
+- `server/fastify-app.ts`: configuracion `Fastify({ logger: false, trustProxy })`, hook global temprano `onRequest`, `requireTrustedOriginForFastify`, handlers globales de 404/error, `/`, `/health` y `/api/health`.
+- `server/lib/api-response-security.ts`: helper central de PR 817/818 para headers API bajo `/api` y `/api/*`, con escritura en `FastifyReply` y `reply.raw`.
+- `server/lib/sensitive-response-cache.ts`: helper backend existente para `Cache-Control: no-store` en API sensible.
+- `server/routes/*.fastify.ts`: rutas nativas registradas bajo `/api/admin/*`, `/api/auth`, `/api/clinic/*`, `/api/particular/*`, `/api/public/*`, `/api/report-access-tokens`, `/api/reports`, `/api/study-tracking` y `/api/logistics/*`.
+- `server/lib/audit.ts`, `server/lib/http-types.ts` y rutas admin/clinic/particular de auditoria: ya consumian `request.id` como request id para auditoria.
+- `node_modules/fastify/docs/Reference/Server.md` y tipos Fastify locales: Fastify provee `request.id`, `genReqId` y `requestIdHeader`; `requestIdHeader` no valida el valor entrante.
+- `test/backend-api-nosniff-responses-contract.test.ts` y `test/fastify-app.test.ts`: contratos existentes de headers API, endpoints publicos, autenticados, errores y respuestas raw.
+
+## Decision
+
+- Se reutiliza el `request.id` nativo de Fastify como fuente del header.
+- Se configura `genReqId` con `generateFastifyRequestId` para aceptar `X-Request-ID` entrante solo si cumple formato seguro.
+- No se usa `requestIdHeader` porque Fastify no valida ese valor.
+- Si el header entrante falta, viene duplicado o no cumple formato seguro, se genera un UUID con `crypto.randomUUID()`.
+- El formato aceptado queda limitado a 1-128 caracteres `[A-Za-z0-9._:-]`, sin espacios, saltos de linea ni caracteres de control.
+
+## Header aplicado
+
+- `X-Request-ID: <request.id seguro>`
+
+El header se aplica desde el hook central `onRequest` solo cuando el path es `/api` o empieza con `/api/`. El helper escribe en `FastifyReply` y `reply.raw` para conservar cobertura en respuestas que terminan con `reply.raw.end`, como `/api/health`.
+
+## Implementacion
+
+- `server/lib/api-request-id.ts`: nuevo helper backend para validar ids entrantes, generar fallback seguro, configurar `genReqId` y aplicar `X-Request-ID`.
+- `server/fastify-app.ts`: conecta `genReqId: generateFastifyRequestId` y aplica `applyApiRequestIdHeader(request, reply)` en el hook temprano existente antes de cortes tempranos.
+
+## Tests agregados o ajustados
+
+- `test/backend-api-nosniff-responses-contract.test.ts`
+  - Cubre constantes de `X-Request-ID`.
+  - Cubre validacion de formato seguro.
+  - Cubre preservacion de request id entrante valido y reemplazo de invalido.
+  - Verifica que Fastify use `genReqId` y no `requestIdHeader`.
+  - Verifica que no se introduzca dependencia frontend/UI.
+- `test/fastify-app.test.ts`
+  - Cubre endpoint admin/autenticado: `GET /api/admin/system/health`.
+  - Cubre endpoint API publico: `GET /api/public/pricing`.
+  - Cubre respuesta API de error: `GET /api/no-existe`.
+  - Cubre endpoint raw API: `GET /api/health`.
+  - Cubre preservacion de `X-Request-ID` entrante valido.
+  - Cubre reemplazo de `X-Request-ID` entrante invalido.
+  - Verifica que `/` no reciba `X-Request-ID` por estar fuera de `/api`.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -143,6 +143,10 @@ import {
 import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";
 import { applySensitiveApiNoStoreHeaders } from "./lib/sensitive-response-cache.ts";
 import { applyApiSecurityHeaders } from "./lib/api-response-security.ts";
+import {
+  applyApiRequestIdHeader,
+  generateFastifyRequestId,
+} from "./lib/api-request-id.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -250,11 +254,13 @@ export async function createFastifyApp(
   options: CreateFastifyAppOptions = {},
 ): Promise<FastifyInstance> {
   const app = Fastify({
+    genReqId: generateFastifyRequestId,
     logger: false,
     trustProxy: ENV.trustProxy,
   });
 
   app.addHook("onRequest", async (request, reply) => {
+    applyApiRequestIdHeader(request, reply);
     applyApiSecurityHeaders(request, reply);
   });
 

--- a/server/lib/api-request-id.ts
+++ b/server/lib/api-request-id.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { shouldApplyApiSecurityHeaders } from "./api-response-security.ts";
+
+export const API_REQUEST_ID_HEADER_NAME = "X-Request-ID";
+export const API_REQUEST_ID_HEADER_KEY = "x-request-id";
+export const API_REQUEST_ID_MAX_LENGTH = 128;
+const API_REQUEST_ID_ALLOWED_CHARACTERS = /^[A-Za-z0-9._:-]+$/;
+
+export function isSafeRequestId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= API_REQUEST_ID_MAX_LENGTH &&
+    API_REQUEST_ID_ALLOWED_CHARACTERS.test(value)
+  );
+}
+
+export function getSafeIncomingRequestId(
+  headers: IncomingHttpHeaders,
+): string | null {
+  const value = headers[API_REQUEST_ID_HEADER_KEY];
+
+  return isSafeRequestId(value) ? value : null;
+}
+
+export function generateSafeRequestId(): string {
+  return randomUUID();
+}
+
+export function generateFastifyRequestId(request: IncomingMessage): string {
+  return getSafeIncomingRequestId(request.headers) ?? generateSafeRequestId();
+}
+
+function setReplyHeaderIfUnset(
+  reply: FastifyReply,
+  name: string,
+  value: string,
+) {
+  if (!reply.hasHeader(name)) {
+    reply.header(name, value);
+  }
+
+  if (!reply.raw.hasHeader(name)) {
+    reply.raw.setHeader(name, value);
+  }
+}
+
+export function applyApiRequestIdHeader(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  if (!shouldApplyApiSecurityHeaders(request.url ?? "")) {
+    return;
+  }
+
+  const requestId = isSafeRequestId(request.id)
+    ? request.id
+    : generateSafeRequestId();
+
+  setReplyHeaderIfUnset(reply, API_REQUEST_ID_HEADER_NAME, requestId);
+}

--- a/test/backend-api-nosniff-responses-contract.test.ts
+++ b/test/backend-api-nosniff-responses-contract.test.ts
@@ -13,6 +13,13 @@ const {
   API_REFERRER_POLICY_HEADER_VALUE,
   shouldApplyApiSecurityHeaders,
 } = await import("../server/lib/api-response-security.ts");
+const {
+  API_REQUEST_ID_HEADER_KEY,
+  API_REQUEST_ID_HEADER_NAME,
+  API_REQUEST_ID_MAX_LENGTH,
+  generateFastifyRequestId,
+  isSafeRequestId,
+} = await import("../server/lib/api-request-id.ts");
 
 function readSource(relativePath: string): string {
   return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
@@ -23,6 +30,9 @@ test("api security headers helper clasifica solo superficie API", () => {
   assert.equal(API_NOSNIFF_HEADER_VALUE, "nosniff");
   assert.equal(API_REFERRER_POLICY_HEADER_NAME, "Referrer-Policy");
   assert.equal(API_REFERRER_POLICY_HEADER_VALUE, "no-referrer");
+  assert.equal(API_REQUEST_ID_HEADER_NAME, "X-Request-ID");
+  assert.equal(API_REQUEST_ID_HEADER_KEY, "x-request-id");
+  assert.equal(API_REQUEST_ID_MAX_LENGTH, 128);
   assert.equal(shouldApplyApiSecurityHeaders("/api"), true);
   assert.equal(shouldApplyApiSecurityHeaders("/api/health"), true);
   assert.equal(shouldApplyApiSecurityHeaders("/api/admin/system/health"), true);
@@ -36,8 +46,42 @@ test("api security headers helper clasifica solo superficie API", () => {
   assert.equal(shouldApplyApiSecurityHeaders("/"), false);
 });
 
+test("api request id helper valida formato seguro y genera fallback", () => {
+  const validRequestId = "client-req_123.abc:456";
+  const invalidRequestId = "client request id";
+  const generatedWithoutHeader = generateFastifyRequestId({
+    headers: {},
+  } as any);
+  const generatedFromInvalidHeader = generateFastifyRequestId({
+    headers: {
+      [API_REQUEST_ID_HEADER_KEY]: invalidRequestId,
+    },
+  } as any);
+
+  assert.equal(isSafeRequestId(validRequestId), true);
+  assert.equal(isSafeRequestId(invalidRequestId), false);
+  assert.equal(isSafeRequestId(`req-${"a".repeat(129)}`), false);
+  assert.equal(
+    generateFastifyRequestId({
+      headers: {
+        [API_REQUEST_ID_HEADER_KEY]: validRequestId,
+      },
+    } as any),
+    validRequestId,
+  );
+  assert.equal(isSafeRequestId(generatedWithoutHeader), true);
+  assert.equal(isSafeRequestId(generatedFromInvalidHeader), true);
+  assert.notEqual(generatedFromInvalidHeader, invalidRequestId);
+});
+
 test("fastify-app registra hook central de security headers antes de cortes tempranos", () => {
   const source = readSource("server/fastify-app.ts");
+  const requestIdGeneratorIndex = source.indexOf(
+    "genReqId: generateFastifyRequestId",
+  );
+  const requestIdHookIndex = source.indexOf(
+    "applyApiRequestIdHeader(request, reply)",
+  );
   const securityHeadersHookIndex = source.indexOf(
     "applyApiSecurityHeaders(request, reply)",
   );
@@ -45,15 +89,20 @@ test("fastify-app registra hook central de security headers antes de cortes temp
     'app.addHook("onRequest", requireTrustedOriginForFastify);',
   );
 
+  assert.ok(requestIdGeneratorIndex > 0);
+  assert.ok(requestIdHookIndex > 0);
   assert.ok(securityHeadersHookIndex > 0);
   assert.ok(trustedOriginHookIndex > 0);
+  assert.ok(requestIdHookIndex < trustedOriginHookIndex);
   assert.ok(securityHeadersHookIndex < trustedOriginHookIndex);
+  assert.equal(source.includes("requestIdHeader"), false);
 });
 
 test("api security headers no introduce dependencia de frontend o UI", () => {
   const helperSource = readSource("server/lib/api-response-security.ts");
+  const requestIdSource = readSource("server/lib/api-request-id.ts");
   const fastifyAppSource = readSource("server/fastify-app.ts");
-  const combined = `${helperSource}\n${fastifyAppSource}`;
+  const combined = `${helperSource}\n${requestIdSource}\n${fastifyAppSource}`;
 
   assert.equal(combined.includes("frontend"), false);
   assert.equal(combined.includes(".tsx"), false);

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -12,6 +12,7 @@ const { ENV } = await import("../server/lib/env.ts");
 const { createFastifyApp } = await import("../server/fastify-app.ts");
 const { API_NOSNIFF_HEADER_VALUE, API_REFERRER_POLICY_HEADER_VALUE } =
   await import("../server/lib/api-response-security.ts");
+const { isSafeRequestId } = await import("../server/lib/api-request-id.ts");
 
 function buildExpectedContactServiceSnapshot() {
   const explicitRecipients = Array.from(
@@ -737,6 +738,27 @@ function buildAdminSystemHealthRouteStubs() {
     }),
     getBackendVersion: () => "test-version",
   };
+}
+
+function assertRequestIdHeader(
+  response: { headers: Record<string, string | string[] | number | undefined> },
+  label: string,
+) {
+  const requestId = response.headers["x-request-id"];
+
+  assert.equal(typeof requestId, "string", `${label} debe incluir X-Request-ID`);
+  if (typeof requestId !== "string") {
+    throw new Error(`${label} debe incluir X-Request-ID`);
+  }
+
+  assert.ok(requestId.length > 0, `${label} debe incluir X-Request-ID no vacio`);
+  assert.equal(
+    isSafeRequestId(requestId),
+    true,
+    `${label} debe incluir X-Request-ID seguro`,
+  );
+
+  return requestId;
 }
 function buildFastifyDispatchRouteStubs() {
   return {
@@ -2525,6 +2547,22 @@ test(
         url: "/api/health",
       });
 
+      const apiHealthWithValidRequestId = await app.inject({
+        method: "GET",
+        url: "/api/health",
+        headers: {
+          "x-request-id": "client-req_123.abc:456",
+        },
+      });
+
+      const apiHealthWithInvalidRequestId = await app.inject({
+        method: "GET",
+        url: "/api/health",
+        headers: {
+          "x-request-id": "client request id",
+        },
+      });
+
       const publicRoot = await app.inject({
         method: "GET",
         url: "/",
@@ -2553,10 +2591,22 @@ test(
           API_REFERRER_POLICY_HEADER_VALUE,
           `${label} debe incluir Referrer-Policy`,
         );
+        assertRequestIdHeader(response, label);
       }
+
+      assert.equal(
+        apiHealthWithValidRequestId.headers["x-request-id"],
+        "client-req_123.abc:456",
+      );
+      const replacementRequestId = assertRequestIdHeader(
+        apiHealthWithInvalidRequestId,
+        "apiHealthWithInvalidRequestId",
+      );
+      assert.notEqual(replacementRequestId, "client request id");
 
       assert.equal(publicRoot.headers["x-content-type-options"], undefined);
       assert.equal(publicRoot.headers["referrer-policy"], undefined);
+      assert.equal(publicRoot.headers["x-request-id"], undefined);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## Resumen
- Expone X-Request-ID en respuestas API para trazabilidad operativa.
- Cubre respuestas públicas, admin/protegidas, errores y respuestas raw.
- Valida request ids entrantes y genera uno seguro cuando falta o es inválido.

## Cambios
- Helper/hook backend para request id de API.
- Tests contractuales/runtime para X-Request-ID.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Header
- X-Request-ID

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check