### PR TITLE
ops(api): include request id in API error responses

### DIFF
--- a/docs/pr-820-api-error-request-id-body.md
+++ b/docs/pr-820-api-error-request-id-body.md
@@ -1,0 +1,64 @@
+# PR 820 - API error request id body
+
+## Resumen
+
+Se agrego `requestId` a cuerpos JSON de error emitidos por `createFastifyApp` bajo `/api` y `/api/*`, reutilizando el `X-Request-ID` seguro introducido en PR 819.
+
+El cambio no altera cuerpos de respuestas exitosas, no modifica mensajes de error existentes, no agrega stack traces y no toca DB schema, migraciones, indices, WebAuthn, frontend UI, CSP/frontend, assets estaticos ni logica de negocio.
+
+## Superficie auditada
+
+- `server/lib/api-request-id.ts`: validacion de ids entrantes, generacion segura con `crypto.randomUUID()`, `genReqId` de Fastify y aplicacion de `X-Request-ID`.
+- `server/lib/api-response-security.ts`: delimitacion de superficie API con `/api` y `/api/*`.
+- `server/fastify-app.ts`: hooks globales `onRequest` y `onSend`, `setNotFoundHandler`, `setErrorHandler`, `/`, `/health`, `/api/health` y registro de routers nativos.
+- `server/routes/*.fastify.ts`: patrones de error con `success`, `error`, `message`, `details`, `code` y `statusCode` bajo rutas API.
+- `server/middlewares/trusted-origin.ts`: error Fastify temprano de origen no permitido.
+- `test/fastify-app.test.ts`: tests dinamicos de `createFastifyApp`, parsing con `JSON.parse(response.body)` y contratos existentes de `X-Request-ID`.
+- `test/backend-api-nosniff-responses-contract.test.ts`: contratos estaticos de helpers API y ausencia de dependencias frontend/UI.
+
+## Contrato aplicado
+
+En respuestas API de error JSON producidas por `createFastifyApp`:
+
+- El header `X-Request-ID` debe estar presente y no vacio.
+- El body JSON debe incluir `requestId`.
+- `body.requestId` debe coincidir exactamente con `X-Request-ID`.
+- Si el request id entrante es valido, se conserva en header y body.
+- Si el request id entrante es invalido, se usa el id seguro generado por `genReqId`.
+- El contrato se aplica solo a respuestas con status `>= 400`, content type JSON y path `/api` o `/api/*`.
+- Las respuestas exitosas API no reciben `requestId` en el body por este cambio.
+- Las respuestas no API, HTML publico y assets estaticos quedan fuera del contrato.
+
+## Implementacion
+
+- `server/lib/api-request-id.ts`
+  - Agrega `getSafeApiResponseRequestId(request, reply)`.
+  - Lee el request id seguro desde `reply` cuando ya existe.
+  - Si falta o no es seguro, reutiliza `request.id` validado o genera un UUID seguro.
+  - Normaliza `X-Request-ID` en `FastifyReply` y `reply.raw` para mantener igualdad con el body.
+
+- `server/fastify-app.ts`
+  - Enriquece centralmente en `onSend` los payloads JSON de error API.
+  - Mantiene intactos los formatos existentes y solo agrega o normaliza `requestId`.
+  - No agrega datos internos ni modifica mensajes.
+
+## Tests agregados o ajustados
+
+- `test/fastify-app.test.ts`
+  - Agrega helpers de contrato para validar que `body.requestId` coincide con `X-Request-ID`.
+  - Ajusta errores tempranos de trusted origin para aceptar `requestId`.
+  - Ajusta 404 API global para validar `requestId`.
+  - Cubre error API generico `500` con `requestId`.
+  - Cubre `X-Request-ID` entrante valido conservado en header y body.
+  - Cubre `X-Request-ID` entrante invalido reemplazado por id seguro en header y body.
+  - Cubre 404 publico API JSON con `requestId`.
+  - Cubre respuesta exitosa API sin `requestId` agregado al body.
+
+## Validaciones
+
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `git diff --check`

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -146,6 +146,7 @@ import { applyApiSecurityHeaders } from "./lib/api-response-security.ts";
 import {
   applyApiRequestIdHeader,
   generateFastifyRequestId,
+  getSafeApiResponseRequestId,
 } from "./lib/api-request-id.ts";
 
 type HealthCheckResponse = {
@@ -211,6 +212,78 @@ function normalizeFastifyErrorStatus(status: number) {
     : 500;
 }
 
+function getHeaderValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    const stringValue = value.find((item) => typeof item === "string");
+
+    return stringValue ?? null;
+  }
+
+  return null;
+}
+
+function isJsonResponse(reply: FastifyReply) {
+  const contentType =
+    getHeaderValue(reply.getHeader("content-type")) ??
+    getHeaderValue(reply.raw.getHeader("content-type"));
+
+  return contentType?.toLowerCase().includes("application/json") ?? false;
+}
+
+function getPayloadText(payload: unknown): string | null {
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    return payload.toString("utf8");
+  }
+
+  return null;
+}
+
+function addApiErrorRequestIdToJsonPayload(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  payload: unknown,
+) {
+  if (reply.statusCode < 400 || !isJsonResponse(reply)) {
+    return payload;
+  }
+
+  const requestId = getSafeApiResponseRequestId(request, reply);
+  const payloadText = getPayloadText(payload);
+
+  if (!requestId || !payloadText) {
+    return payload;
+  }
+
+  let body: unknown;
+
+  try {
+    body = JSON.parse(payloadText);
+  } catch {
+    return payload;
+  }
+
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return payload;
+  }
+
+  return JSON.stringify({
+    ...body,
+    requestId,
+  });
+}
+
 export type CreateFastifyAppOptions = {
   getNativeHealthCheckResponse?: HealthCheckFactory;
   getServiceInfoPayload?: ServiceInfoFactory;
@@ -268,8 +341,10 @@ export async function createFastifyApp(
 
   app.addHook(
     "onSend",
-    async (request: FastifyRequest, reply: FastifyReply, _payload) => {
+    async (request: FastifyRequest, reply: FastifyReply, payload) => {
       applySensitiveApiNoStoreHeaders(request, reply);
+
+      return addApiErrorRequestIdToJsonPayload(request, reply, payload);
     },
   );
 

--- a/server/lib/api-request-id.ts
+++ b/server/lib/api-request-id.ts
@@ -47,6 +47,23 @@ function setReplyHeaderIfUnset(
   }
 }
 
+function setReplyHeader(reply: FastifyReply, name: string, value: string) {
+  reply.header(name, value);
+  reply.raw.setHeader(name, value);
+}
+
+function getSafeReplyRequestId(reply: FastifyReply): string | null {
+  const fastifyHeader = reply.getHeader(API_REQUEST_ID_HEADER_NAME);
+
+  if (isSafeRequestId(fastifyHeader)) {
+    return fastifyHeader;
+  }
+
+  const rawHeader = reply.raw.getHeader(API_REQUEST_ID_HEADER_NAME);
+
+  return isSafeRequestId(rawHeader) ? rawHeader : null;
+}
+
 export function applyApiRequestIdHeader(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -60,4 +77,28 @@ export function applyApiRequestIdHeader(
     : generateSafeRequestId();
 
   setReplyHeaderIfUnset(reply, API_REQUEST_ID_HEADER_NAME, requestId);
+}
+
+export function getSafeApiResponseRequestId(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): string | null {
+  if (!shouldApplyApiSecurityHeaders(request.url ?? "")) {
+    return null;
+  }
+
+  const replyRequestId = getSafeReplyRequestId(reply);
+
+  if (replyRequestId) {
+    setReplyHeader(reply, API_REQUEST_ID_HEADER_NAME, replyRequestId);
+    return replyRequestId;
+  }
+
+  const requestId = isSafeRequestId(request.id)
+    ? request.id
+    : generateSafeRequestId();
+
+  setReplyHeader(reply, API_REQUEST_ID_HEADER_NAME, requestId);
+
+  return requestId;
 }

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -760,6 +760,53 @@ function assertRequestIdHeader(
 
   return requestId;
 }
+
+function parseJsonObject(response: { body: string }, label: string) {
+  const body = JSON.parse(response.body) as unknown;
+
+  assert.equal(
+    body !== null && typeof body === "object" && !Array.isArray(body),
+    true,
+    `${label} debe devolver JSON object`,
+  );
+
+  return body as Record<string, unknown>;
+}
+
+function assertBodyRequestIdMatchesHeader(
+  response: {
+    body: string;
+    headers: Record<string, string | string[] | number | undefined>;
+  },
+  label: string,
+) {
+  const requestId = assertRequestIdHeader(response, label);
+  const body = parseJsonObject(response, label);
+
+  assert.equal(
+    body.requestId,
+    requestId,
+    `${label} debe incluir requestId igual a X-Request-ID`,
+  );
+
+  return { body, requestId };
+}
+
+function assertBodyDoesNotIncludeRequestId(
+  response: { body: string },
+  label: string,
+) {
+  const body = parseJsonObject(response, label);
+
+  assert.equal(
+    "requestId" in body,
+    false,
+    `${label} no debe incluir requestId en body`,
+  );
+
+  return body;
+}
+
 function buildFastifyDispatchRouteStubs() {
   return {
     adminAuditRoutes: buildAdminAuditRouteStubs(),
@@ -866,16 +913,22 @@ test(
         url: "/api/admin/auth/logout",
       });
 
-      for (const response of [
+      for (const [index, response] of [
         blockedPostWithoutOrigin,
         blockedPatchWithoutOrigin,
         blockedDeleteWithoutOrigin,
         blockedPostWithBadOrigin,
-      ]) {
+      ].entries()) {
         assert.equal(response.statusCode, 403);
-        assert.deepEqual(JSON.parse(response.body), {
+        const { body, requestId } = assertBodyRequestIdMatchesHeader(
+          response,
+          `trustedOriginBlocked:${index}`,
+        );
+
+        assert.deepEqual(body, {
           success: false,
           error: "Origen no permitido",
+          requestId,
         });
       }
 
@@ -2309,10 +2362,13 @@ test(
       });
 
       assert.equal(notFoundResponse.statusCode, 404);
-      assert.deepEqual(JSON.parse(notFoundResponse.body), {
+      const { body: notFoundBody, requestId: notFoundRequestId } =
+        assertBodyRequestIdMatchesHeader(notFoundResponse, "apiNotFound");
+      assert.deepEqual(notFoundBody, {
         success: false,
         error: "Ruta no encontrada",
         path: "/api/no-existe",
+        requestId: notFoundRequestId,
       });
 
       const internalResponse = await app.inject({
@@ -2345,6 +2401,108 @@ test(
     }
   },
 );
+
+test(
+  "createFastifyApp incluye requestId en cuerpos JSON de errores API",
+  async () => {
+    const app = await createFastifyApp({
+      ...buildFastifyDispatchRouteStubs(),
+      getNativeHealthCheckResponse: async () => ({
+        statusCode: 200,
+        payload: {
+          success: true,
+          status: "ok",
+        },
+      }),
+    });
+
+    try {
+      app.get("/api/__test/internal-error", async () => {
+        throw new Error("detalle interno sensible");
+      });
+
+      const genericError = await app.inject({
+        method: "GET",
+        url: "/api/__test/internal-error",
+      });
+
+      assert.equal(genericError.statusCode, 500);
+      const { body: genericBody, requestId: genericRequestId } =
+        assertBodyRequestIdMatchesHeader(genericError, "genericError");
+      assert.deepEqual(genericBody, {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__test/internal-error",
+        requestId: genericRequestId,
+      });
+      assert.doesNotMatch(genericError.body, /detalle interno sensible/);
+
+      const validIncomingRequestId = "client-req_123.abc:456";
+      const validIncomingError = await app.inject({
+        method: "GET",
+        url: "/api/__test/internal-error",
+        headers: {
+          "x-request-id": validIncomingRequestId,
+        },
+      });
+      const { body: validIncomingBody, requestId: validRequestId } =
+        assertBodyRequestIdMatchesHeader(
+          validIncomingError,
+          "validIncomingError",
+        );
+
+      assert.equal(validRequestId, validIncomingRequestId);
+      assert.equal(validIncomingBody.requestId, validIncomingRequestId);
+
+      const invalidIncomingRequestId = "client request id";
+      const invalidIncomingError = await app.inject({
+        method: "GET",
+        url: "/api/__test/internal-error",
+        headers: {
+          "x-request-id": invalidIncomingRequestId,
+        },
+      });
+      const { body: invalidIncomingBody, requestId: invalidRequestId } =
+        assertBodyRequestIdMatchesHeader(
+          invalidIncomingError,
+          "invalidIncomingError",
+        );
+
+      assert.notEqual(invalidRequestId, invalidIncomingRequestId);
+      assert.equal(invalidIncomingBody.requestId, invalidRequestId);
+
+      const publicApiNotFound = await app.inject({
+        method: "GET",
+        url: "/api/public/no-existe",
+      });
+
+      assert.equal(publicApiNotFound.statusCode, 404);
+      const { body: publicApiNotFoundBody, requestId: publicApiNotFoundId } =
+        assertBodyRequestIdMatchesHeader(
+          publicApiNotFound,
+          "publicApiNotFound",
+        );
+      assert.deepEqual(publicApiNotFoundBody, {
+        success: false,
+        error: "Ruta no encontrada",
+        path: "/api/public/no-existe",
+        requestId: publicApiNotFoundId,
+      });
+
+      const apiHealth = await app.inject({
+        method: "GET",
+        url: "/api/health",
+      });
+
+      assert.equal(apiHealth.statusCode, 200);
+      assertRequestIdHeader(apiHealth, "apiHealth");
+      assertBodyDoesNotIncludeRequestId(apiHealth, "apiHealth");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
 test(
   "createFastifyApp mantiene search de profesionales pÃºblicos montado en el router nativo",
   async () => {


### PR DESCRIPTION
## Resumen
- Incluye requestId en cuerpos JSON de errores API.
- Asegura que body.requestId coincida con X-Request-ID.
- Mantiene sin cambios los cuerpos de respuestas exitosas.

## Cambios
- Reutiliza la infraestructura de X-Request-ID.
- Ajusta manejo central de errores API.
- Tests contractuales/runtime para errores, request id entrante válido e inválido.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Contrato
- Header X-Request-ID
- Body JSON de error: requestId

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check