### PR TITLE
ops(api): log request id on API errors

### DIFF
--- a/docs/pr-821-api-error-request-id-logs.md
+++ b/docs/pr-821-api-error-request-id-logs.md
@@ -1,0 +1,61 @@
+# PR 821 - API error request id logs
+
+## Resumen
+
+Se agrego `requestId` al log estructurado `[API ERROR]` emitido por el `setErrorHandler` central de `createFastifyApp`, reutilizando el request id seguro ya creado por PR 819 y agregado al body JSON de errores API por PR 820.
+
+El cambio mantiene el formato publico de respuesta igual salvo el `requestId` ya existente en errores API, no agrega stack traces a respuestas, no toca DB schema, migraciones, indices, WebAuthn, frontend UI, CSP/frontend, assets estaticos ni logica de negocio.
+
+## Superficie auditada
+
+- `server/lib/api-request-id.ts`: validacion de `X-Request-ID` entrante, generacion segura con `crypto.randomUUID()`, `genReqId`, aplicacion del header y helper `getSafeApiResponseRequestId`.
+- `server/fastify-app.ts`: hooks globales `onRequest` y `onSend`, `setNotFoundHandler`, `setErrorHandler`, rutas `/`, `/health`, `/api/health` y registro de routers nativos.
+- `server/middlewares/error-handler.ts`: middleware legado con `[API ERROR]`, fuera del handler Fastify central modificado.
+- `server/middlewares/request-logger.ts`: patron de logging de requests y sanitizacion de URLs con tokens.
+- `server/routes/*.fastify.ts`: patrones existentes de `console.error`, `console.warn`, `console.log` y uso de `request.id`.
+- `test/fastify-app.test.ts`: contratos dinamicos de errores API, `X-Request-ID`, body JSON con `requestId` y captura manual de `console.error`.
+- `test/fastify-only-guardrail.test.ts`: guardrails de runtime backend sin Express directo ni dependencias frontend/UI.
+
+## Contrato aplicado
+
+En errores API manejados por `createFastifyApp`:
+
+- El header `X-Request-ID` debe estar presente y no vacio.
+- El body JSON de error debe incluir `requestId`.
+- El log `[API ERROR]` debe incluir el mismo `requestId`.
+- Si `X-Request-ID` entrante es valido, se conserva en header, body y log.
+- Si `X-Request-ID` entrante es invalido, no se refleja; se usa y se loguea el id seguro generado.
+- Los logs nuevos no incorporan headers, cookies, authorization, passwords ni tokens del request.
+- Las respuestas API exitosas no generan logs de error nuevos.
+- Las respuestas no API, HTML publico y assets estaticos quedan fuera del contrato de request id API.
+
+## Implementacion
+
+- `server/fastify-app.ts`
+  - El `setErrorHandler` obtiene `requestId` mediante `getSafeApiResponseRequestId(request, reply)`.
+  - Ese helper reutiliza primero el header seguro ya fijado en `reply`; si falta, usa `request.id` validado o genera un UUID seguro.
+  - El payload de `console.error("[API ERROR]", ...)` agrega solo `requestId` cuando existe para la superficie API.
+  - No se agregan datos del request, headers, cookies, authorization, payloads ni campos sensibles al log.
+
+## Tests agregados o ajustados
+
+- `test/fastify-app.test.ts`
+  - Agrega helpers para serializar capturas de consola y validar payloads `[API ERROR]`.
+  - Cubre error API generico `500` con `requestId` logueado.
+  - Verifica que el `requestId` logueado coincide con `X-Request-ID` y `body.requestId`.
+  - Cubre `X-Request-ID` entrante valido conservado en header, body y log.
+  - Cubre `X-Request-ID` entrante invalido reemplazado por id seguro en header, body y log.
+  - Verifica que el log no incluya authorization, cookies, passwords ni tokens enviados en el request.
+  - Verifica que una respuesta API exitosa no agregue logs de error.
+
+- `test/fastify-only-guardrail.test.ts`
+  - Agrega guardrail estatica para confirmar que `server/fastify-app.ts` no introduce dependencias frontend/UI, Next o React.
+
+## Validaciones
+
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `git diff --check`

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -359,12 +359,14 @@ export async function createFastifyApp(
   app.setErrorHandler((error, request, reply) => {
     const status = getFastifyErrorStatus(error);
     const message = getFastifyErrorMessage(error);
+    const requestId = getSafeApiResponseRequestId(request, reply);
 
     console.error("[API ERROR]", {
       method: request.method,
       path: request.url,
       status,
       message,
+      ...(requestId ? { requestId } : {}),
       error,
     });
 

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -807,6 +807,71 @@ function assertBodyDoesNotIncludeRequestId(
   return body;
 }
 
+function serializeConsoleCalls(calls: unknown[][]) {
+  return calls
+    .map((args) =>
+      args
+        .map((arg) => {
+          if (arg instanceof Error) {
+            return arg.stack ?? arg.message;
+          }
+
+          try {
+            return JSON.stringify(arg, (_key, value) => {
+              if (value instanceof Error) {
+                return {
+                  name: value.name,
+                  message: value.message,
+                  stack: value.stack,
+                };
+              }
+
+              return value;
+            });
+          } catch {
+            return String(arg);
+          }
+        })
+        .join(" "),
+    )
+    .join("\n");
+}
+
+function assertApiErrorLogRequestId(
+  consoleCalls: unknown[][],
+  index: number,
+  expectedRequestId: string,
+  label: string,
+) {
+  const call = consoleCalls[index];
+
+  assert.ok(call, `${label} debe registrar log de error API`);
+  assert.equal(call[0], "[API ERROR]");
+
+  const payload = call[1];
+
+  assert.equal(
+    payload !== null && typeof payload === "object" && !Array.isArray(payload),
+    true,
+    `${label} debe registrar payload de log estructurado`,
+  );
+
+  const loggedPayload = payload as Record<string, unknown>;
+
+  assert.equal(
+    loggedPayload.requestId,
+    expectedRequestId,
+    `${label} debe registrar el mismo requestId del header/body`,
+  );
+  assert.equal(
+    isSafeRequestId(loggedPayload.requestId),
+    true,
+    `${label} debe registrar requestId seguro`,
+  );
+
+  return loggedPayload;
+}
+
 function buildFastifyDispatchRouteStubs() {
   return {
     adminAuditRoutes: buildAdminAuditRouteStubs(),
@@ -2415,15 +2480,34 @@ test(
         },
       }),
     });
+    const originalConsoleError = console.error;
+    const consoleErrorCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
 
     try {
-      app.get("/api/__test/internal-error", async () => {
+      const throwInternalError = async () => {
         throw new Error("detalle interno sensible");
-      });
+      };
+      const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
+
+      app.get("/api/__test/internal-error", throwInternalError);
+      app.post("/api/__test/internal-error", throwInternalError);
 
       const genericError = await app.inject({
-        method: "GET",
+        method: "POST",
         url: "/api/__test/internal-error",
+        headers: {
+          authorization: "Bearer secret-authorization-token",
+          cookie: `${ENV.cookieName}=secret-cookie-token`,
+          origin: allowedOrigin,
+        },
+        payload: {
+          password: "secret-request-password",
+          token: "secret-request-token",
+        },
       });
 
       assert.equal(genericError.statusCode, 500);
@@ -2436,6 +2520,15 @@ test(
         requestId: genericRequestId,
       });
       assert.doesNotMatch(genericError.body, /detalle interno sensible/);
+      const genericLogPayload = assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        0,
+        genericRequestId,
+        "genericError",
+      );
+      assert.equal(genericLogPayload.method, "POST");
+      assert.equal(genericLogPayload.path, "/api/__test/internal-error");
+      assert.equal(genericLogPayload.status, 500);
 
       const validIncomingRequestId = "client-req_123.abc:456";
       const validIncomingError = await app.inject({
@@ -2453,6 +2546,12 @@ test(
 
       assert.equal(validRequestId, validIncomingRequestId);
       assert.equal(validIncomingBody.requestId, validIncomingRequestId);
+      assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        1,
+        validIncomingRequestId,
+        "validIncomingError",
+      );
 
       const invalidIncomingRequestId = "client request id";
       const invalidIncomingError = await app.inject({
@@ -2470,6 +2569,12 @@ test(
 
       assert.notEqual(invalidRequestId, invalidIncomingRequestId);
       assert.equal(invalidIncomingBody.requestId, invalidRequestId);
+      assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        2,
+        invalidRequestId,
+        "invalidIncomingError",
+      );
 
       const publicApiNotFound = await app.inject({
         method: "GET",
@@ -2497,7 +2602,31 @@ test(
       assert.equal(apiHealth.statusCode, 200);
       assertRequestIdHeader(apiHealth, "apiHealth");
       assertBodyDoesNotIncludeRequestId(apiHealth, "apiHealth");
+      assert.equal(
+        consoleErrorCalls.length,
+        3,
+        "respuesta API exitosa no debe registrar log de error nuevo",
+      );
+
+      const serializedConsoleCalls = serializeConsoleCalls(consoleErrorCalls);
+
+      assert.equal(
+        serializedConsoleCalls.includes("secret-authorization-token"),
+        false,
+      );
+      assert.equal(serializedConsoleCalls.includes("secret-cookie-token"), false);
+      assert.equal(serializedConsoleCalls.includes("secret-request-token"), false);
+      assert.equal(
+        serializedConsoleCalls.includes("secret-request-password"),
+        false,
+      );
+      assert.equal(
+        serializedConsoleCalls.toLowerCase().includes("authorization"),
+        false,
+      );
+      assert.equal(serializedConsoleCalls.toLowerCase().includes("cookie"), false);
     } finally {
+      console.error = originalConsoleError;
       await app.close();
     }
   },

--- a/test/fastify-only-guardrail.test.ts
+++ b/test/fastify-only-guardrail.test.ts
@@ -17,6 +17,15 @@ function readJson(relativePath: string) {
   return JSON.parse(readText(relativePath).replace(/^\uFEFF/, ""));
 }
 
+function listImportSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    ),
+    (match) => match[1] ?? match[2] ?? "",
+  );
+}
+
 function walkFiles(relativeDir: string): string[] {
   const absoluteDir = join(repoRoot, relativeDir);
   const files: string[] = [];
@@ -84,6 +93,26 @@ test("backend Fastify-only no reintroduce runtime Express directo", () => {
   }
 
   assert.deepEqual(violations, []);
+});
+
+test("Fastify API error logging no introduce dependencias frontend o UI", () => {
+  const forbiddenImports = listImportSpecifiers(
+    readText("server/fastify-app.ts"),
+  ).filter((specifier) =>
+    specifier === "next" ||
+    specifier.startsWith("next/") ||
+    specifier === "react" ||
+    specifier.startsWith("react/") ||
+    specifier.startsWith("@/") ||
+    specifier.startsWith("../frontend") ||
+    specifier.startsWith("./frontend") ||
+    specifier.startsWith("../client") ||
+    specifier.startsWith("./client") ||
+    specifier.startsWith("../src/") ||
+    specifier.startsWith("./src/")
+  );
+
+  assert.deepEqual(forbiddenImports, []);
 });
 
 test("configuracion y documentacion declaran Fastify sin Express directo", () => {


### PR DESCRIPTION
## Resumen
- Loguea requestId en errores API para correlación operativa.
- Asegura consistencia entre log, X-Request-ID y body.requestId.
- Evita incluir secretos o headers sensibles en logs nuevos.

## Cambios
- Reutiliza la infraestructura de X-Request-ID.
- Ajusta log central de errores API en Fastify.
- Tests contractuales/runtime para requestId en logs.
- Guardrail para no introducir dependencia frontend/UI.
- Documento de implementación en docs.

## Scope
- Backend/tests/docs only.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Contrato
- Header X-Request-ID
- Body JSON de error: requestId
- Log de error API: requestId coincidente

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check