### PR TITLE
test(api): consolidate request id observability contracts

### DIFF
--- a/docs/pr-822-api-request-id-observability-contracts.md
+++ b/docs/pr-822-api-request-id-observability-contracts.md
@@ -1,0 +1,50 @@
+# PR 822 - API request id observability contracts
+
+## Resumen
+
+Se consolido en una suite contractual dedicada la observabilidad de `X-Request-ID` agregada en PR 819, PR 820 y PR 821.
+
+El cambio es tests/docs only: no modifica handlers de negocio, configuracion productiva, DB schema, migraciones, indices, WebAuthn, frontend UI, CSP/frontend ni contratos visuales. Los asserts de request id que ya vivian en `test/fastify-app.test.ts` se movieron a un helper compartido de test para evitar repetir la misma validacion.
+
+## Invariantes cubiertos
+
+1. Toda respuesta API relevante expone `X-Request-ID` no vacio.
+2. Errores API JSON incluyen `body.requestId`.
+3. `body.requestId` coincide exactamente con `X-Request-ID`.
+4. Logs de errores API incluyen el mismo `requestId`.
+5. `X-Request-ID` entrante valido se preserva en header, body y log.
+6. `X-Request-ID` entrante invalido con caracteres peligrosos se reemplaza por un id seguro.
+7. Los logs capturados no incluyen `Authorization`, `Cookie`, tokens, passwords ni secretos enviados en request.
+8. Respuestas API exitosas no agregan `requestId` al body.
+9. Superficie fuera de `/api` no recibe `X-Request-ID` ni `body.requestId`.
+10. La superficie de request id API no introduce dependencia frontend/UI.
+
+## Tests agregados o ajustados
+
+- `test/helpers/api-request-id-contract.ts`
+  - Centraliza asserts de `X-Request-ID`, parsing JSON object, igualdad `body.requestId`/header, ausencia de `requestId` en bodies exitosos y validacion del payload de log `[API ERROR]`.
+
+- `test/fastify-app.test.ts`
+  - Reutiliza el helper compartido en vez de mantener asserts inline duplicados.
+  - Mantiene la cobertura dinamica existente de trusted origin, errores API y headers de seguridad.
+
+- `test/api-request-id-observability-contract.test.ts`
+  - Agrega una suite especifica para los contratos de observabilidad API request id.
+  - Cubre un endpoint publico API (`/api/public/pricing`).
+  - Cubre un endpoint admin/protegido (`/api/admin/system/health`).
+  - Cubre error API 404, error generico 500 y error admin 401.
+  - Cubre `X-Request-ID` entrante valido preservado.
+  - Cubre `X-Request-ID` entrante invalido reemplazado.
+  - Cubre headers y payload sensibles presentes en el request sin filtrarse al log.
+  - Cubre respuesta exitosa API sin `body.requestId`.
+  - Cubre respuesta fuera de `/api` sin contrato request id API.
+  - Cubre ausencia de imports frontend/UI en la superficie backend relevante.
+
+## Validaciones
+
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `git diff --check`

--- a/test/api-request-id-observability-contract.test.ts
+++ b/test/api-request-id-observability-contract.test.ts
@@ -1,0 +1,352 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const repoRoot = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+const { ENV } = await import("../server/lib/env.ts");
+const { createFastifyApp } = await import("../server/fastify-app.ts");
+const { API_REQUEST_ID_HEADER_KEY } = await import(
+  "../server/lib/api-request-id.ts"
+);
+const { clearPublicPricingCache } = await import(
+  "../server/lib/public-pricing-cache.ts"
+);
+const {
+  assertApiErrorLogRequestId,
+  assertBodyDoesNotIncludeRequestId,
+  assertBodyRequestIdMatchesHeader,
+  assertRequestIdHeader,
+  parseJsonObject,
+  serializeConsoleCalls,
+} = await import("./helpers/api-request-id-contract.ts");
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8");
+}
+
+function listImportSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    ),
+    (match) => match[1] ?? match[2] ?? "",
+  );
+}
+
+function buildAdminSystemHealthRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async (tokenHash: string) =>
+      tokenHash === "hash:admin-session-token"
+        ? {
+            id: 10,
+            adminUserId: 1,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            lastAccess: new Date("2026-06-03T00:00:00.000Z"),
+          }
+        : null,
+    getAdminUserById: async (adminUserId: number) =>
+      adminUserId === 1
+        ? {
+            id: 1,
+            username: "VETNEB",
+          }
+        : null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSystemHealthSnapshot: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+        checks: {
+          database: "up",
+          storage: "up",
+        },
+      },
+    }),
+    getBackendVersion: () => "2.1.0-test",
+    now: () => Date.parse("2026-06-03T00:00:00.000Z"),
+  };
+}
+
+function buildContractAppOptions() {
+  return {
+    getNativeHealthCheckResponse: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+      },
+    }),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
+    publicPricingRoutes: {
+      listPublicPricingItems: async () => [
+        {
+          id: 1,
+          category: "Histopatologia",
+          studyName: "Biopsia",
+          priceLabel: "Consultar",
+          displayOrder: 1,
+        },
+      ],
+    },
+  };
+}
+
+test(
+  "API request id observability contracts cubren header body log y limites de superficie",
+  async () => {
+    clearPublicPricingCache();
+
+    const app = await createFastifyApp(buildContractAppOptions());
+    const originalConsoleError = console.error;
+    const consoleErrorCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
+
+    try {
+      const throwInternalError = async () => {
+        throw new Error("detalle interno sensible");
+      };
+      const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
+
+      app.get("/api/__contract/internal-error", throwInternalError);
+      app.post("/api/__contract/internal-error", throwInternalError);
+      app.get("/__contract/internal-error", throwInternalError);
+
+      const publicApiSuccess = await app.inject({
+        method: "GET",
+        url: "/api/public/pricing",
+      });
+      const adminApiSuccess = await app.inject({
+        method: "GET",
+        url: "/api/admin/system/health",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-token`,
+        },
+      });
+      const apiHealthSuccess = await app.inject({
+        method: "GET",
+        url: "/api/health",
+      });
+
+      assert.equal(publicApiSuccess.statusCode, 200);
+      assert.equal(adminApiSuccess.statusCode, 200);
+      assert.equal(apiHealthSuccess.statusCode, 200);
+
+      for (const { label, response } of [
+        { label: "publicApiSuccess", response: publicApiSuccess },
+        { label: "adminApiSuccess", response: adminApiSuccess },
+        { label: "apiHealthSuccess", response: apiHealthSuccess },
+      ]) {
+        assertRequestIdHeader(response, label);
+        assertBodyDoesNotIncludeRequestId(response, label);
+      }
+
+      assert.equal(parseJsonObject(publicApiSuccess, "publicApiSuccess").success, true);
+      assert.equal(parseJsonObject(adminApiSuccess, "adminApiSuccess").success, true);
+      assert.equal(
+        consoleErrorCalls.length,
+        0,
+        "respuestas API exitosas no deben agregar logs de error",
+      );
+
+      const apiNotFound = await app.inject({
+        method: "GET",
+        url: "/api/__contract/no-existe",
+      });
+      const adminMissingAuth = await app.inject({
+        method: "GET",
+        url: "/api/admin/system/health",
+      });
+
+      assert.equal(apiNotFound.statusCode, 404);
+      const { body: apiNotFoundBody, requestId: apiNotFoundRequestId } =
+        assertBodyRequestIdMatchesHeader(apiNotFound, "apiNotFound");
+      assert.deepEqual(apiNotFoundBody, {
+        success: false,
+        error: "Ruta no encontrada",
+        path: "/api/__contract/no-existe",
+        requestId: apiNotFoundRequestId,
+      });
+
+      assert.equal(adminMissingAuth.statusCode, 401);
+      const { body: adminMissingAuthBody, requestId: adminMissingAuthRequestId } =
+        assertBodyRequestIdMatchesHeader(adminMissingAuth, "adminMissingAuth");
+      assert.deepEqual(adminMissingAuthBody, {
+        success: false,
+        error: "Admin no autenticado",
+        requestId: adminMissingAuthRequestId,
+      });
+
+      const genericError = await app.inject({
+        method: "POST",
+        url: "/api/__contract/internal-error",
+        headers: {
+          authorization: "Bearer secret-authorization-token",
+          cookie: `${ENV.cookieName}=secret-cookie-token`,
+          origin: allowedOrigin,
+        },
+        payload: {
+          password: "secret-request-password",
+          token: "secret-request-token",
+          secret: "secret-request-secret",
+        },
+      });
+
+      assert.equal(genericError.statusCode, 500);
+      const { body: genericBody, requestId: genericRequestId } =
+        assertBodyRequestIdMatchesHeader(genericError, "genericError");
+      assert.deepEqual(genericBody, {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__contract/internal-error",
+        requestId: genericRequestId,
+      });
+      assert.doesNotMatch(genericError.body, /detalle interno sensible/);
+      const genericLogPayload = assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        0,
+        genericRequestId,
+        "genericError",
+      );
+      assert.equal(genericLogPayload.method, "POST");
+      assert.equal(genericLogPayload.path, "/api/__contract/internal-error");
+      assert.equal(genericLogPayload.status, 500);
+
+      const validIncomingRequestId = "client-req_123.abc:456";
+      const validIncomingError = await app.inject({
+        method: "GET",
+        url: "/api/__contract/internal-error",
+        headers: {
+          [API_REQUEST_ID_HEADER_KEY]: validIncomingRequestId,
+        },
+      });
+      const { body: validIncomingBody, requestId: validIncomingHeaderId } =
+        assertBodyRequestIdMatchesHeader(
+          validIncomingError,
+          "validIncomingError",
+        );
+
+      assert.equal(validIncomingHeaderId, validIncomingRequestId);
+      assert.equal(validIncomingBody.requestId, validIncomingRequestId);
+      assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        1,
+        validIncomingRequestId,
+        "validIncomingError",
+      );
+
+      const invalidIncomingRequestId =
+        "bad id;Authorization=Bearer secret-dangerous-token";
+      const invalidIncomingError = await app.inject({
+        method: "GET",
+        url: "/api/__contract/internal-error",
+        headers: {
+          [API_REQUEST_ID_HEADER_KEY]: invalidIncomingRequestId,
+        },
+      });
+      const { body: invalidIncomingBody, requestId: invalidIncomingHeaderId } =
+        assertBodyRequestIdMatchesHeader(
+          invalidIncomingError,
+          "invalidIncomingError",
+        );
+
+      assert.notEqual(invalidIncomingHeaderId, invalidIncomingRequestId);
+      assert.equal(invalidIncomingBody.requestId, invalidIncomingHeaderId);
+      assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        2,
+        invalidIncomingHeaderId,
+        "invalidIncomingError",
+      );
+
+      const nonApiRoot = await app.inject({
+        method: "GET",
+        url: "/",
+      });
+      const nonApiError = await app.inject({
+        method: "GET",
+        url: "/__contract/internal-error",
+      });
+
+      assert.equal(nonApiRoot.statusCode, 200);
+      assert.equal(nonApiRoot.headers["x-request-id"], undefined);
+      assertBodyDoesNotIncludeRequestId(nonApiRoot, "nonApiRoot");
+
+      assert.equal(nonApiError.statusCode, 500);
+      assert.equal(nonApiError.headers["x-request-id"], undefined);
+      assert.deepEqual(JSON.parse(nonApiError.body), {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/__contract/internal-error",
+      });
+      assert.equal(
+        (consoleErrorCalls[3]?.[1] as Record<string, unknown> | undefined)
+          ?.requestId,
+        undefined,
+      );
+
+      const serializedConsoleCalls = serializeConsoleCalls(consoleErrorCalls);
+      const lowerSerializedConsoleCalls = serializedConsoleCalls.toLowerCase();
+
+      for (const forbiddenValue of [
+        "secret-authorization-token",
+        "secret-cookie-token",
+        "secret-request-token",
+        "secret-request-password",
+        "secret-request-secret",
+        "secret-dangerous-token",
+        invalidIncomingRequestId,
+      ]) {
+        assert.equal(serializedConsoleCalls.includes(forbiddenValue), false);
+      }
+
+      for (const forbiddenName of [
+        "authorization",
+        "cookie",
+        "password",
+        "token",
+        "secret",
+      ]) {
+        assert.equal(lowerSerializedConsoleCalls.includes(forbiddenName), false);
+      }
+    } finally {
+      console.error = originalConsoleError;
+      await app.close();
+      clearPublicPricingCache();
+    }
+  },
+);
+
+test("API request id observability no introduce dependencia frontend/UI", () => {
+  const importSpecifiers = [
+    ...listImportSpecifiers(readSource("server/lib/api-request-id.ts")),
+    ...listImportSpecifiers(readSource("server/fastify-app.ts")),
+  ];
+  const forbiddenImports = importSpecifiers.filter((specifier) =>
+    specifier === "next" ||
+    specifier.startsWith("next/") ||
+    specifier === "react" ||
+    specifier.startsWith("react/") ||
+    specifier.startsWith("@/") ||
+    specifier.includes("frontend") ||
+    specifier.includes("components") ||
+    specifier.includes("client")
+  );
+
+  assert.deepEqual(forbiddenImports, []);
+});

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -12,7 +12,13 @@ const { ENV } = await import("../server/lib/env.ts");
 const { createFastifyApp } = await import("../server/fastify-app.ts");
 const { API_NOSNIFF_HEADER_VALUE, API_REFERRER_POLICY_HEADER_VALUE } =
   await import("../server/lib/api-response-security.ts");
-const { isSafeRequestId } = await import("../server/lib/api-request-id.ts");
+const {
+  assertApiErrorLogRequestId,
+  assertBodyDoesNotIncludeRequestId,
+  assertBodyRequestIdMatchesHeader,
+  assertRequestIdHeader,
+  serializeConsoleCalls,
+} = await import("./helpers/api-request-id-contract.ts");
 
 function buildExpectedContactServiceSnapshot() {
   const explicitRecipients = Array.from(
@@ -738,138 +744,6 @@ function buildAdminSystemHealthRouteStubs() {
     }),
     getBackendVersion: () => "test-version",
   };
-}
-
-function assertRequestIdHeader(
-  response: { headers: Record<string, string | string[] | number | undefined> },
-  label: string,
-) {
-  const requestId = response.headers["x-request-id"];
-
-  assert.equal(typeof requestId, "string", `${label} debe incluir X-Request-ID`);
-  if (typeof requestId !== "string") {
-    throw new Error(`${label} debe incluir X-Request-ID`);
-  }
-
-  assert.ok(requestId.length > 0, `${label} debe incluir X-Request-ID no vacio`);
-  assert.equal(
-    isSafeRequestId(requestId),
-    true,
-    `${label} debe incluir X-Request-ID seguro`,
-  );
-
-  return requestId;
-}
-
-function parseJsonObject(response: { body: string }, label: string) {
-  const body = JSON.parse(response.body) as unknown;
-
-  assert.equal(
-    body !== null && typeof body === "object" && !Array.isArray(body),
-    true,
-    `${label} debe devolver JSON object`,
-  );
-
-  return body as Record<string, unknown>;
-}
-
-function assertBodyRequestIdMatchesHeader(
-  response: {
-    body: string;
-    headers: Record<string, string | string[] | number | undefined>;
-  },
-  label: string,
-) {
-  const requestId = assertRequestIdHeader(response, label);
-  const body = parseJsonObject(response, label);
-
-  assert.equal(
-    body.requestId,
-    requestId,
-    `${label} debe incluir requestId igual a X-Request-ID`,
-  );
-
-  return { body, requestId };
-}
-
-function assertBodyDoesNotIncludeRequestId(
-  response: { body: string },
-  label: string,
-) {
-  const body = parseJsonObject(response, label);
-
-  assert.equal(
-    "requestId" in body,
-    false,
-    `${label} no debe incluir requestId en body`,
-  );
-
-  return body;
-}
-
-function serializeConsoleCalls(calls: unknown[][]) {
-  return calls
-    .map((args) =>
-      args
-        .map((arg) => {
-          if (arg instanceof Error) {
-            return arg.stack ?? arg.message;
-          }
-
-          try {
-            return JSON.stringify(arg, (_key, value) => {
-              if (value instanceof Error) {
-                return {
-                  name: value.name,
-                  message: value.message,
-                  stack: value.stack,
-                };
-              }
-
-              return value;
-            });
-          } catch {
-            return String(arg);
-          }
-        })
-        .join(" "),
-    )
-    .join("\n");
-}
-
-function assertApiErrorLogRequestId(
-  consoleCalls: unknown[][],
-  index: number,
-  expectedRequestId: string,
-  label: string,
-) {
-  const call = consoleCalls[index];
-
-  assert.ok(call, `${label} debe registrar log de error API`);
-  assert.equal(call[0], "[API ERROR]");
-
-  const payload = call[1];
-
-  assert.equal(
-    payload !== null && typeof payload === "object" && !Array.isArray(payload),
-    true,
-    `${label} debe registrar payload de log estructurado`,
-  );
-
-  const loggedPayload = payload as Record<string, unknown>;
-
-  assert.equal(
-    loggedPayload.requestId,
-    expectedRequestId,
-    `${label} debe registrar el mismo requestId del header/body`,
-  );
-  assert.equal(
-    isSafeRequestId(loggedPayload.requestId),
-    true,
-    `${label} debe registrar requestId seguro`,
-  );
-
-  return loggedPayload;
 }
 
 function buildFastifyDispatchRouteStubs() {

--- a/test/helpers/api-request-id-contract.ts
+++ b/test/helpers/api-request-id-contract.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+
+const { isSafeRequestId } = await import(
+  "../../server/lib/api-request-id.ts"
+);
+
+type ResponseWithHeaders = {
+  headers: Record<string, string | string[] | number | undefined>;
+};
+
+type ResponseWithBody = {
+  body: string;
+};
+
+export function assertRequestIdHeader(
+  response: ResponseWithHeaders,
+  label: string,
+) {
+  const requestId = response.headers["x-request-id"];
+
+  assert.equal(typeof requestId, "string", `${label} debe incluir X-Request-ID`);
+  if (typeof requestId !== "string") {
+    throw new Error(`${label} debe incluir X-Request-ID`);
+  }
+
+  assert.ok(requestId.length > 0, `${label} debe incluir X-Request-ID no vacio`);
+  assert.equal(
+    isSafeRequestId(requestId),
+    true,
+    `${label} debe incluir X-Request-ID seguro`,
+  );
+
+  return requestId;
+}
+
+export function parseJsonObject(response: ResponseWithBody, label: string) {
+  const body = JSON.parse(response.body) as unknown;
+
+  assert.equal(
+    body !== null && typeof body === "object" && !Array.isArray(body),
+    true,
+    `${label} debe devolver JSON object`,
+  );
+
+  return body as Record<string, unknown>;
+}
+
+export function assertBodyRequestIdMatchesHeader(
+  response: ResponseWithBody & ResponseWithHeaders,
+  label: string,
+) {
+  const requestId = assertRequestIdHeader(response, label);
+  const body = parseJsonObject(response, label);
+
+  assert.equal(
+    body.requestId,
+    requestId,
+    `${label} debe incluir requestId igual a X-Request-ID`,
+  );
+
+  return { body, requestId };
+}
+
+export function assertBodyDoesNotIncludeRequestId(
+  response: ResponseWithBody,
+  label: string,
+) {
+  const body = parseJsonObject(response, label);
+
+  assert.equal(
+    "requestId" in body,
+    false,
+    `${label} no debe incluir requestId en body`,
+  );
+
+  return body;
+}
+
+export function serializeConsoleCalls(calls: unknown[][]) {
+  return calls
+    .map((args) =>
+      args
+        .map((arg) => {
+          if (arg instanceof Error) {
+            return arg.stack ?? arg.message;
+          }
+
+          try {
+            return JSON.stringify(arg, (_key, value) => {
+              if (value instanceof Error) {
+                return {
+                  name: value.name,
+                  message: value.message,
+                  stack: value.stack,
+                };
+              }
+
+              return value;
+            });
+          } catch {
+            return String(arg);
+          }
+        })
+        .join(" "),
+    )
+    .join("\n");
+}
+
+export function assertApiErrorLogRequestId(
+  consoleCalls: unknown[][],
+  index: number,
+  expectedRequestId: string,
+  label: string,
+) {
+  const call = consoleCalls[index];
+
+  assert.ok(call, `${label} debe registrar log de error API`);
+  assert.equal(call[0], "[API ERROR]");
+
+  const payload = call[1];
+
+  assert.equal(
+    payload !== null && typeof payload === "object" && !Array.isArray(payload),
+    true,
+    `${label} debe registrar payload de log estructurado`,
+  );
+
+  const loggedPayload = payload as Record<string, unknown>;
+
+  assert.equal(
+    loggedPayload.requestId,
+    expectedRequestId,
+    `${label} debe registrar el mismo requestId del header/body`,
+  );
+  assert.equal(
+    isSafeRequestId(loggedPayload.requestId),
+    true,
+    `${label} debe registrar requestId seguro`,
+  );
+
+  return loggedPayload;
+}


### PR DESCRIPTION
## Resumen
- Consolida contratos de observabilidad request id en API.
- Cubre header, body de error y log de error con el mismo requestId.
- Refuerza casos de request id entrante válido, inválido y no filtrado de secretos.

## Cambios
- Suite contractual de request id observability.
- Documento de implementación en docs.
- Sin cambios productivos salvo ajuste mínimo compatible si fue necesario.

## Scope
- Tests/docs focused.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Contratos
- Header X-Request-ID
- Body JSON de error: requestId
- Log de error API: requestId coincidente
- No secretos en logs
- Éxitos API sin body.requestId nuevo

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check