### PR TITLE
security(api): assert no stack traces in API error responses

### DIFF
--- a/docs/pr-823-api-error-no-stack-traces.md
+++ b/docs/pr-823-api-error-no-stack-traces.md
@@ -1,0 +1,31 @@
+# PR 823 - API error no stack traces
+
+## Resumen
+
+Se agrego una suite contractual enfocada para confirmar que las respuestas de error API emitidas por `createFastifyApp` no exponen stack traces.
+
+El cambio es tests/docs only: no modifica backend productivo, DB schema, migraciones, indices, WebAuthn, frontend UI, CSP/frontend, assets estaticos ni contratos visuales.
+
+## Invariantes cubiertos
+
+1. Un error API 500 no expone `error.stack` ni el mensaje interno sensible en el body.
+2. Un error API 400 conserva el mensaje publico esperado sin agregar `stack`, `stackTrace` ni `trace`.
+3. Las respuestas de error API mantienen `requestId` en body y `X-Request-ID` mediante el contrato existente.
+4. La traza contaminada artificialmente no aparece como frame, ruta de archivo ni nombre de funcion en el body.
+
+## Tests agregados
+
+- `test/api-error-no-stack-traces-contract.test.ts`
+  - Registra rutas de contrato bajo `/api/__contract/*`.
+  - Fuerza errores con `error.stack` contaminado.
+  - Verifica respuestas 500 y 400.
+  - Reutiliza el helper de request id para mantener el contrato de observabilidad existente sin duplicarlo.
+
+## Validaciones
+
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `git diff --check`

--- a/test/api-error-no-stack-traces-contract.test.ts
+++ b/test/api-error-no-stack-traces-contract.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { createFastifyApp } = await import("../server/fastify-app.ts");
+const { assertBodyRequestIdMatchesHeader } = await import(
+  "./helpers/api-request-id-contract.ts"
+);
+
+function buildErrorWithStack(message: string, statusCode?: number) {
+  const error = new Error(message) as Error & { statusCode?: number };
+
+  if (statusCode) {
+    error.statusCode = statusCode;
+  }
+
+  error.stack = [
+    `Error: ${message}`,
+    "    at sensitiveStackFrame (C:\\portal-vetneb\\server\\secret.ts:10:20)",
+    "    at hiddenApiImplementation (C:\\portal-vetneb\\server\\secret.ts:30:40)",
+  ].join("\n");
+
+  return error;
+}
+
+function assertNoStackTraceDisclosure(
+  body: Record<string, unknown>,
+  rawBody: string,
+  label: string,
+) {
+  assert.equal("stack" in body, false, `${label} no debe incluir stack`);
+  assert.equal("stackTrace" in body, false, `${label} no debe incluir stackTrace`);
+  assert.equal("trace" in body, false, `${label} no debe incluir trace`);
+
+  assert.doesNotMatch(rawBody, /sensitiveStackFrame/);
+  assert.doesNotMatch(rawBody, /hiddenApiImplementation/);
+  assert.doesNotMatch(rawBody, /secret\.ts:\d+:\d+/);
+}
+
+test(
+  "API error responses no exponen stack traces en errores 500 ni 400",
+  async () => {
+    const app = await createFastifyApp();
+    const originalConsoleError = console.error;
+
+    console.error = () => {};
+
+    try {
+      app.get("/api/__contract/internal-crash", async () => {
+        throw buildErrorWithStack("detalle interno con stack sensible");
+      });
+
+      app.get("/api/__contract/bad-request", async () => {
+        throw buildErrorWithStack("Payload invalido", 400);
+      });
+
+      const internalError = await app.inject({
+        method: "GET",
+        url: "/api/__contract/internal-crash",
+      });
+
+      assert.equal(internalError.statusCode, 500);
+      const { body: internalBody, requestId: internalRequestId } =
+        assertBodyRequestIdMatchesHeader(internalError, "internalError");
+      assert.deepEqual(internalBody, {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__contract/internal-crash",
+        requestId: internalRequestId,
+      });
+      assert.equal(
+        internalError.body.includes("detalle interno con stack sensible"),
+        false,
+      );
+      assertNoStackTraceDisclosure(
+        internalBody,
+        internalError.body,
+        "internalError",
+      );
+
+      const badRequest = await app.inject({
+        method: "GET",
+        url: "/api/__contract/bad-request",
+      });
+
+      assert.equal(badRequest.statusCode, 400);
+      const { body: badRequestBody, requestId: badRequestId } =
+        assertBodyRequestIdMatchesHeader(badRequest, "badRequest");
+      assert.deepEqual(badRequestBody, {
+        success: false,
+        error: "Payload invalido",
+        details: "Payload invalido",
+        path: "/api/__contract/bad-request",
+        requestId: badRequestId,
+      });
+      assertNoStackTraceDisclosure(
+        badRequestBody,
+        badRequest.body,
+        "badRequest",
+      );
+    } finally {
+      console.error = originalConsoleError;
+      await app.close();
+    }
+  },
+);


### PR DESCRIPTION
## Resumen
- Agrega contrato para evitar stack traces y detalles internos en errores API.
- Verifica errores API 500 y 400 con error.stack contaminado.
- Mantiene requestId correlacionable y sin exposición de stacks en body.

## Cambios
- Nueva suite contractual: test/api-error-no-stack-traces-contract.test.ts.
- Documento de implementación en docs.

## Scope
- Tests/docs focused.
- Sin cambios productivos.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Contrato
- No stack traces en body de errores API.
- No raw Error stack serializado.
- requestId preservado y consistente.

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check