### PR TITLE
security(api): assert no secrets in API error responses

### DIFF
--- a/docs/pr-824-api-error-no-secrets.md
+++ b/docs/pr-824-api-error-no-secrets.md
@@ -1,0 +1,35 @@
+# PR 824 - API error no-secrets contract
+
+## Summary
+
+This change adds an explicit contract for API/Fastify JSON error bodies: error responses keep public fields such as `error`, `details`, `path`, and `requestId`, but must not echo sensitive request headers, payload values, cookie names, token names, environment-variable prefixes, or stack traces.
+
+The audit found one central Fastify disclosure path: `path: request.url` could include query strings in 400/404/500 JSON error bodies. The backend adjustment is limited to the central Fastify error and not-found handlers, where the response path now uses only the URL pathname.
+
+## Audited Surface
+
+- `server/fastify-app.ts` central Fastify error handler and not-found handler.
+- `server/lib/api-request-id.ts` request id generation and response propagation.
+- `test/api-request-id-observability-contract.test.ts` request id body/header/log contract.
+- `test/api-error-no-stack-traces-contract.test.ts` existing stack trace disclosure contract.
+- Existing tests around secrets, authorization, cookie, token, password, and API error bodies.
+
+## Applied Contract
+
+API JSON error bodies must not include:
+
+- `Authorization`, `Cookie`, `Set-Cookie`, or `Bearer`.
+- `token`, `access_token`, `refresh_token`, `password`, `secret`, `session`, or `api_key`.
+- `SUPABASE_`, `GMAIL_`, `SMTP_`, `ADMIN_SESSION_COOKIE_NAME`, or `CLINIC_SESSION_COOKIE_NAME`.
+- Sensitive values sent through request headers, payload, or sensitive query parameters.
+
+The contract preserves `X-Request-ID` and `body.requestId`; both must continue to match.
+
+## Tests Added
+
+- `test/api-error-no-secrets-contract.test.ts`
+  - Covers a generic API 500 response with sensitive headers, payload, and query values.
+  - Covers a controlled API 400 response with the same sensitive inputs.
+  - Covers an API 404 response with the same sensitive inputs.
+  - Asserts `requestId` remains in the JSON body and matches `X-Request-ID`.
+  - Asserts no frontend/UI dependencies were introduced.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -250,6 +250,16 @@ function getPayloadText(payload: unknown): string | null {
   return null;
 }
 
+function getFastifyErrorResponsePath(request: FastifyRequest) {
+  const url = request.url ?? "";
+
+  try {
+    return new URL(url, "http://portal-vetneb.local").pathname;
+  } catch {
+    return url.split("?")[0] ?? "";
+  }
+}
+
 function addApiErrorRequestIdToJsonPayload(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -352,7 +362,7 @@ export async function createFastifyApp(
     return reply.code(404).send({
       success: false,
       error: "Ruta no encontrada",
-      path: request.url,
+      path: getFastifyErrorResponsePath(request),
     });
   });
 
@@ -374,7 +384,7 @@ export async function createFastifyApp(
       success: false,
       error: status >= 500 ? "Error interno del servidor" : message,
       details: status >= 500 ? undefined : message,
-      path: request.url,
+      path: getFastifyErrorResponsePath(request),
     });
   });
 

--- a/test/api-error-no-secrets-contract.test.ts
+++ b/test/api-error-no-secrets-contract.test.ts
@@ -1,0 +1,218 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const repoRoot = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+const { ENV } = await import("../server/lib/env.ts");
+const { createFastifyApp } = await import("../server/fastify-app.ts");
+const { assertBodyRequestIdMatchesHeader } = await import(
+  "./helpers/api-request-id-contract.ts"
+);
+
+const sensitiveHeaderValues = {
+  authorization: "Bearer contract-header-authorization-value",
+  cookie:
+    "app_session_id=contract-clinic-cookie-value; admin_session_id=contract-admin-cookie-value",
+  "set-cookie": "refresh_session=contract-set-cookie-value",
+};
+
+const sensitivePayload = {
+  token: "contract-body-token-value",
+  access_token: "contract-body-access-token-value",
+  refresh_token: "contract-body-refresh-token-value",
+  password: "contract-body-password-value",
+  secret: "contract-body-secret-value",
+  session: "contract-body-session-value",
+  api_key: "contract-body-api-key-value",
+  SUPABASE_SERVICE_ROLE_KEY: "contract-body-supabase-value",
+  GMAIL_REFRESH_TOKEN: "contract-body-gmail-value",
+  SMTP_PASS: "contract-body-smtp-value",
+  ADMIN_SESSION_COOKIE_NAME: "contract-body-admin-cookie-name-value",
+  CLINIC_SESSION_COOKIE_NAME: "contract-body-clinic-cookie-name-value",
+};
+
+const sensitiveQuery =
+  "access_token=contract-query-access-token-value" +
+  "&refresh_token=contract-query-refresh-token-value" +
+  "&password=contract-query-password-value" +
+  "&secret=contract-query-secret-value" +
+  "&session=contract-query-session-value" +
+  "&api_key=contract-query-api-key-value";
+
+const forbiddenErrorBodyMarkers = [
+  "Authorization",
+  "Cookie",
+  "Set-Cookie",
+  "Bearer",
+  "token",
+  "access_token",
+  "refresh_token",
+  "password",
+  "secret",
+  "session",
+  "api_key",
+  "SUPABASE_",
+  "GMAIL_",
+  "SMTP_",
+  "ADMIN_SESSION_COOKIE_NAME",
+  "CLINIC_SESSION_COOKIE_NAME",
+  ...Object.values(sensitiveHeaderValues),
+  ...Object.values(sensitivePayload),
+  ...sensitiveQuery.split("&").flatMap((part) => {
+    const [name, value] = part.split("=");
+
+    return [name, value];
+  }),
+];
+
+function assertJsonErrorBodyDoesNotExposeSecrets(rawBody: string, label: string) {
+  const normalizedBody = rawBody.toLowerCase();
+
+  for (const marker of forbiddenErrorBodyMarkers) {
+    assert.equal(
+      normalizedBody.includes(marker.toLowerCase()),
+      false,
+      `${label} no debe incluir ${marker}`,
+    );
+  }
+}
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8");
+}
+
+function listImportSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    ),
+    (match) => match[1] ?? match[2] ?? "",
+  );
+}
+
+test(
+  "API error responses no exponen secretos ni headers sensibles en body JSON",
+  async () => {
+    const app = await createFastifyApp();
+    const originalConsoleError = console.error;
+    const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
+
+    console.error = () => {};
+
+    try {
+      app.post("/api/__contract/internal-error", async () => {
+        throw new Error("internal message with contract-body-secret-value");
+      });
+
+      app.post("/api/__contract/bad-request", async () => {
+        const error = new Error("Payload invalido") as Error & {
+          statusCode: number;
+        };
+
+        error.statusCode = 400;
+        throw error;
+      });
+
+      const internalError = await app.inject({
+        method: "POST",
+        url: `/api/__contract/internal-error?${sensitiveQuery}`,
+        headers: {
+          ...sensitiveHeaderValues,
+          origin: allowedOrigin,
+        },
+        payload: sensitivePayload,
+      });
+
+      assert.equal(internalError.statusCode, 500);
+      const { body: internalBody, requestId: internalRequestId } =
+        assertBodyRequestIdMatchesHeader(internalError, "internalError");
+      assert.deepEqual(internalBody, {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__contract/internal-error",
+        requestId: internalRequestId,
+      });
+      assertJsonErrorBodyDoesNotExposeSecrets(
+        internalError.body,
+        "internalError",
+      );
+
+      const badRequest = await app.inject({
+        method: "POST",
+        url: `/api/__contract/bad-request?${sensitiveQuery}`,
+        headers: {
+          ...sensitiveHeaderValues,
+          origin: allowedOrigin,
+        },
+        payload: sensitivePayload,
+      });
+
+      assert.equal(badRequest.statusCode, 400);
+      const { body: badRequestBody, requestId: badRequestId } =
+        assertBodyRequestIdMatchesHeader(badRequest, "badRequest");
+      assert.deepEqual(badRequestBody, {
+        success: false,
+        error: "Payload invalido",
+        details: "Payload invalido",
+        path: "/api/__contract/bad-request",
+        requestId: badRequestId,
+      });
+      assertJsonErrorBodyDoesNotExposeSecrets(badRequest.body, "badRequest");
+
+      const notFound = await app.inject({
+        method: "POST",
+        url: `/api/__contract/not-found?${sensitiveQuery}`,
+        headers: {
+          ...sensitiveHeaderValues,
+          origin: allowedOrigin,
+        },
+        payload: sensitivePayload,
+      });
+
+      assert.equal(notFound.statusCode, 404);
+      const { body: notFoundBody, requestId: notFoundRequestId } =
+        assertBodyRequestIdMatchesHeader(notFound, "notFound");
+      assert.deepEqual(notFoundBody, {
+        success: false,
+        error: "Ruta no encontrada",
+        path: "/api/__contract/not-found",
+        requestId: notFoundRequestId,
+      });
+      assertJsonErrorBodyDoesNotExposeSecrets(notFound.body, "notFound");
+    } finally {
+      console.error = originalConsoleError;
+      await app.close();
+    }
+  },
+);
+
+test("API error no-secrets contract no introduce dependencia frontend/UI", () => {
+  const importSpecifiers = [
+    ...listImportSpecifiers(readSource("server/fastify-app.ts")),
+    ...listImportSpecifiers(
+      readSource("test/api-error-no-secrets-contract.test.ts"),
+    ),
+  ];
+  const forbiddenImports = importSpecifiers.filter((specifier) =>
+    specifier === "next" ||
+    specifier.startsWith("next/") ||
+    specifier === "react" ||
+    specifier.startsWith("react/") ||
+    specifier.startsWith("@/") ||
+    specifier.includes("frontend") ||
+    specifier.includes("components") ||
+    specifier.includes("client")
+  );
+
+  assert.deepEqual(forbiddenImports, []);
+});

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -269,7 +269,8 @@ test("errores internos se loguean, pero la respuesta 500 no expone detalles", ()
     "details: status >= 500 ? undefined : message",
     file,
   );
-  assertContains(source, "path: request.url", file);
+  assertContains(source, "function getFastifyErrorResponsePath", file);
+  assertContains(source, "path: getFastifyErrorResponsePath(request)", file);
 });
 
 test("logs de request sanitizan tokens y accesos públicos antes de escribir consola", () => {


### PR DESCRIPTION
## Resumen
- Agrega contrato para evitar exposición de secretos en cuerpos de errores API.
- Verifica headers sensibles, cookies, tokens, passwords y variables sensibles.
- Mantiene requestId correlacionable y sin exposición de secretos en body.

## Cambios
- Nueva suite contractual: test/api-error-no-secrets-contract.test.ts.
- Refuerzo acotado en invariantes de producción.
- Ajuste backend mínimo compatible si fue requerido por el contrato.
- Documento de implementación en docs.

## Scope
- Tests/docs focused con ajuste backend mínimo si fue necesario.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin frontend UI.
- Sin CSP/frontend.

## Contrato
- No Authorization/Cookie/Bearer/token/password/secret/session en body de errores API.
- No variables sensibles SUPABASE/GMAIL/SMTP en body.
- requestId preservado y consistente.

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check