### PR TITLE
audit(global): execute full end-to-end web security production audit

### DIFF
--- a/docs/audit/global-e2e-extreme-production-audit.md
+++ b/docs/audit/global-e2e-extreme-production-audit.md
@@ -1,0 +1,113 @@
+# Global E2E extreme production audit
+
+Fecha: 2026-06-03
+Rama: `audit/global-e2e-extreme-production-readiness`
+Scope: G1 a G6 en un bloque de auditoria contractual, sin cambios de schema, migraciones, indices, WebAuthn, redisenos ni configuracion productiva innecesaria.
+
+## Executive summary
+
+Se audito la superficie web y backend de Portal Vetneb con foco en seguridad publica, auth, formularios/uploads, storage/signed URLs, performance/resiliencia y accesibilidad/mobile/UX critica.
+
+El estado observado ya tenia una base fuerte: Fastify centraliza `X-Request-ID`, headers API, trusted-origin, no-store en APIs sensibles y sanitizacion de errores; el frontend mantiene headers de seguridad en `next.config.ts`; y la suite existente cubre cookies, CORS, rate limits, storage privado, errores sin secretos, errores sin stack traces, paginacion y boundaries de roles.
+
+La accion aplicada en este PR es tests/docs only. Se agregaron guardrails globales para unir esas coberturas por G1-G6 y evitar regresiones entre familias de rutas. No se aplicaron cambios productivos porque la auditoria no encontro una falla real que exigiera ajuste de backend o frontend dentro del scope minimo permitido.
+
+## Audited surfaces
+
+- Backend app: `server/fastify-app.ts`
+- Backend routes: `server/routes/*.fastify.ts`
+- Backend middlewares: `server/middlewares/auth.ts`, `server/middlewares/admin-auth.ts`, `server/middlewares/particular-auth.ts`, `server/middlewares/trusted-origin.ts`, `server/middlewares/error-handler.ts`, `server/middlewares/request-logger.ts`
+- Backend libs: `server/lib/api-request-id.ts`, `server/lib/api-response-security.ts`, `server/lib/sensitive-response-cache.ts`, `server/lib/supabase.ts`, `server/lib/report-access-token.ts`, `server/lib/list-pagination.ts`, rate-limit helpers, auth/security helpers
+- DB access modules: `server/db*.ts`
+- Frontend app: `frontend/src/app`, `frontend/src/components`, `frontend/src/lib`, `frontend/src/middleware.ts`
+- Frontend config: `frontend/next.config.ts`, `frontend/playwright.config.ts`, `frontend/package.json`
+- Security scripts: `scripts/security/audit-public-devtools-surface.mjs`
+- Existing tests: `test/**/*.test.ts`
+- Existing docs: `docs/security`, `docs/audit`, `docs/pr-817` through `docs/pr-825`, `docs/pr-history`
+
+## Route inventory
+
+| Surface | Runtime registration | Classification | Notes |
+| --- | --- | --- | --- |
+| `/`, `/health`, `/api/health` | `server/fastify-app.ts` | public/internal health | Public service and health responses keep JSON behavior through Fastify. |
+| `/api/public/professionals` | `public-professionals.fastify.ts` | public | Search/detail with fixed-window public rate limits and CORS allowlist. |
+| `/api/public/pricing` | `public-pricing.fastify.ts` | public | Cached public pricing snapshot with public cache headers. |
+| `/api/public/report-access/:token` | `public-report-access.fastify.ts` | public token | Raw token validation, rate limit, token lifecycle, lazy signed URLs, audit. |
+| `/api/contact` | `contact.fastify.ts` | public mutation | Contact payload validation and safe transport handling. |
+| `/api/auth` | `auth.fastify.ts` | clinic auth | Clinic login/me/logout plus session cookie contract. |
+| `/api/admin/*` | `admin-*.fastify.ts` | admin | Admin auth, reports, tokens, audit, sessions, maintenance, health, pricing, users/roles. |
+| `/api/clinic/*` | `clinic-*.fastify.ts` | clinic | Clinic audit/profile management with clinic session and permission boundaries. |
+| `/api/reports`, `/api/report-access-tokens`, `/api/particular-tokens`, `/api/study-tracking` | route-specific Fastify modules | clinic | Clinic scoped reads/writes with owner checks, pagination, signed URL laziness and audit. |
+| `/api/particular/*` | `particular-*.fastify.ts` | particular | Particular token session, report URL access, study tracking and audit. |
+| `/api/logistics/*` | logistics Fastify modules | clinic | Clinic logistics with role permissions and bounded list helpers. |
+| `/dashboard/*` | `frontend/src/middleware.ts` | frontend protected | Clinic dashboard redirects to login; admin dashboard hides as 404 without admin cookie. |
+| public pages | `frontend/src/app/*` | public web | SEO/metadata, public layout, contact, professionals, pricing and service pages. |
+
+## Risk matrix
+
+| Surface | Routes/pattern | Classification | Risk | Severity | Existing coverage | Gap | Action in this PR | Future PR if out of scope |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Public pages and bundle | `frontend/src/app`, `.next/static`, public layout | public | Secret marker, debug leak, source-map or unsafe HTML exposure | high | `frontend-public-devtools-exposure-contract`, security auditor script | Global G1 link to backend route evidence was implicit | Added `global-public-surface-hardening-contract` and G1 registry | Add browser e2e production smoke against deployed build if needed |
+| Public API headers | `/api/public/*`, `/api/health` | public | Missing nosniff/referrer or accidental session cookie | medium | API header tests, public route tests | Cross-route public API assertion was fragmented | Added runtime checks for public pricing/professionals/report-access | Add CDN/header staging evidence |
+| Admin auth | `/api/admin/*` | admin | Admin route accidentally accepts wrong cookie or misses auth | critical | session/cross-auth boundary suites | Global PR-level auth registry was implicit | Added `global-auth-boundary-contract` | Add staging auth smoke with real admin account |
+| Clinic auth | `/api/reports`, `/api/study-tracking`, logistics, clinic profile | clinic | Cross-clinic IDOR, permission bypass, unsafe mutation origin | critical | IDOR, mutation permission, trusted-origin, cookie boundaries | Route-family inventory needed one global guardrail | Added G2 auth registry | Add negative staging smoke for selected clinic pairs |
+| Particular token auth | `/api/particular/*` | particular | Token session reuse or wrong cookie domain | high | particular auth/session tests, cross-auth tests | Global registry across particular routes was implicit | Added G2 auth registry | Add token rotation lifecycle audit later |
+| Contact form | `/api/contact` | public mutation | Invalid payload, secret leak in errors, email failure handling | medium | contact-route and email-safe tests | Global G3 mapping was doc-only | Added G3 inventory in readiness contract | Add external mail provider staging failure drill |
+| Uploads | `/api/admin/reports/upload`, clinic avatar upload | admin/clinic | Size limit, MIME bypass, path traversal, storage overwrite | high | multer/file size tests, supabase upload tests | Storage safety scattered across suites | Added `global-storage-report-safety-contract` anchors | Add malware scanning or content sniffing in future PR |
+| Storage paths | reports and avatars in Supabase bucket | internal | Private `storagePath` exposure in JSON | critical | serializers, storage suite, public report tests | Need global lazy signing assertion | Added runtime serializer/list/public access checks | Add periodic object ACL audit |
+| Signed URLs | preview/download endpoints | clinic/admin/particular/public token | Mass URL generation or stale TTL | high | signed URL tests, lazy signed URL PR history | Cross-surface lazy behavior needed one contract | Added storage report safety test | Add signed URL TTL observability |
+| Access tokens | report access and particular tokens | clinic/admin/particular/public token | Raw token leakage, tokenHash leak, lifecycle bypass | critical | lifecycle, redaction, token route tests | Global G4 docs and runtime invalid-token check missing | Added invalid-token and valid public-access runtime checks | Add token replay telemetry |
+| Heavy admin lists | admin clinics/sessions/audit/tokens/users | admin | Unbounded reads or massive exports | high | pagination contract, admin list tests | Need global G5 registry of DB surfaces | Added performance/resilience contract | Add query latency budget tests with seeded DB |
+| Public rate limits | professionals and report access | public | Enumeration and availability degradation | medium | public rate-limit tests | Global isolation link was implicit | Added G5 registry and public invalid-token cut-off | Add external WAF/rate-limit staging evidence |
+| Error responses | all API | all | Stack traces, secrets, missing requestId | high | API error no-stack/no-secret/content-type/request-id tests | No new runtime gap | Referenced in global contracts/docs | Keep expanding on new route families |
+| Logging/audit | request logger and audit logs | all | Token/query leak in logs | high | sensitive log redaction boundaries | No new runtime gap | Referenced in G4/G5 contracts | Add log sink sampling in staging |
+| Mobile/dashboard UX | `/dashboard`, public responsive pages | public/clinic/admin | Broken auth redirect/hide, invalid nesting, mobile layout regressions | medium | frontend mobile/public semantics tests | Global G6 readiness link was implicit | Added G6 registry | Add Playwright mobile smoke for authenticated dashboard |
+| Frontend middleware | `/dashboard/:path*` | frontend protected | Admin dashboard discovery without admin cookie | medium | frontend middleware tests | Covered, but not linked to G6 matrix | Added auth/readiness registry anchor | Add route-level screenshot evidence |
+
+## Findings corrected
+
+- No backend/frontend production defect was corrected in this PR.
+- No product source file was changed.
+- No DB schema, migration, index, WebAuthn, UI redesign, productive config or dependency was changed.
+
+## Accepted and documented findings
+
+- Public professionals intentionally signs avatar URLs during public serialization. This is accepted as an existing public profile behavior and remains bounded by route rate limits; it is not the report signed URL lazy contract.
+- Public pricing intentionally uses public cache headers instead of `no-store`.
+- `/api/public/report-access/:token` intentionally exposes signed preview/download URLs only after token validation, lifecycle checks and access recording.
+- Frontend admin dashboard without admin cookie intentionally returns 404 instead of redirecting, reducing route discovery.
+- Staging/deployed evidence is out of this local PR scope and remains documented as future operational validation.
+
+## Guardrails added
+
+- `test/global-e2e-production-readiness-contract.test.ts`
+  - G1-G6 registry tying runtime files, existing guardrails, docs and validation scripts.
+- `test/global-public-surface-hardening-contract.test.ts`
+  - Runtime public API checks for headers, no session cookies, no public body leaks, public professionals storage path hiding and invalid report-token cut-off.
+- `test/global-auth-boundary-contract.test.ts`
+  - Route-family auth registry for admin, clinic, particular and public surfaces.
+- `test/global-storage-report-safety-contract.test.ts`
+  - Runtime checks for safe report serialization, bounded report list with no eager signed URLs and public report access without `storagePath` or `tokenHash`.
+- `test/global-performance-resilience-contract.test.ts`
+  - Global pagination clamps, heavy-surface markers, sensitive no-store boundaries, request-id/security/logging wiring and validation scripts.
+
+## Validation evidence
+
+Commands required for this PR:
+
+- `pnpm test` - passed, 2240 passed, 1 skipped, 0 failed.
+- `pnpm build` - passed, backend bundle generated successfully.
+- `pnpm security:public-surface` - passed, no public exposure findings. The auditor reported the documented server-only cookie-name identifiers in `frontend/src/middleware.ts`.
+- `pnpm typecheck` - passed.
+- `pnpm typecheck:test` - passed.
+- `git diff --check` - passed.
+
+The local validation run was completed on 2026-06-03.
+
+## Prioritized recommendations
+
+1. Keep the new global guardrails as the PR-level map and continue putting detailed route behavior in focused route tests.
+2. Add staging evidence for auth boundaries, public headers and no-leak behavior once a stable staging environment is available.
+3. Add latency/query-budget tests with seeded DB only in a future performance PR, because that exceeds this tests/docs-only scope.
+4. Add operational storage ACL review outside the app test suite, because object-store permission drift is environment-level.
+5. Keep signed URL generation lazy for report files; if a future UI needs mass previews, require explicit pagination and audit evidence first.

--- a/docs/pr-826-global-e2e-extreme-production-readiness.md
+++ b/docs/pr-826-global-e2e-extreme-production-readiness.md
@@ -1,0 +1,114 @@
+# PR 826 - Global E2E extreme production readiness
+
+## Objective
+
+Execute a senior-level global end-to-end production audit for Portal Vetneb across:
+
+- G1 public security
+- G2 auth, sessions and permissions
+- G3 forms, uploads and inputs
+- G4 sensitive data, storage and signed URLs
+- G5 performance and resilience
+- G6 accessibility, mobile and critical UX
+
+## Scope
+
+This PR is intentionally tests/docs focused.
+
+In scope:
+
+- Global inventory of public, admin, clinic, particular and internal surfaces.
+- Contractual tests that validate stable production/security invariants.
+- Risk matrix and PR documentation.
+- Minimal backend/frontend fixes only if a test reveals a real defect.
+
+Out of scope:
+
+- DB schema changes.
+- Migrations.
+- Indexes.
+- WebAuthn.
+- UI redesigns.
+- Productive config changes.
+- New dependencies.
+- Git add, commit, push or PR creation.
+
+## Files touched
+
+- `test/global-e2e-production-readiness-contract.test.ts`
+- `test/global-public-surface-hardening-contract.test.ts`
+- `test/global-auth-boundary-contract.test.ts`
+- `test/global-storage-report-safety-contract.test.ts`
+- `test/global-performance-resilience-contract.test.ts`
+- `docs/audit/global-e2e-extreme-production-audit.md`
+- `docs/pr-826-global-e2e-extreme-production-readiness.md`
+
+No product runtime files were intentionally modified.
+
+## Tests added
+
+### `test/global-e2e-production-readiness-contract.test.ts`
+
+Validates the G1-G6 registry, required local validation scripts and audit/PR documentation anchors.
+
+### `test/global-public-surface-hardening-contract.test.ts`
+
+Validates public API hardening:
+
+- security headers on public API responses
+- no session cookies on public responses
+- public pricing does not receive sensitive no-store behavior
+- public professionals does not expose private avatar storage paths
+- invalid public report access tokens reject before hashing, lookup, signing or audit
+
+### `test/global-auth-boundary-contract.test.ts`
+
+Validates global auth boundaries:
+
+- admin route families keep `authenticateFastifyAdmin`
+- clinic route families keep `authenticateClinicUser`
+- particular route families keep `authenticateParticularUser`
+- public route families do not accept browser session authenticators
+- backend/frontend session cookie names stay separated
+- global trusted-origin hook is installed before route registration
+
+### `test/global-storage-report-safety-contract.test.ts`
+
+Validates storage/report safety:
+
+- `serializeSafeReport` removes private `storagePath`
+- clinic report list is bounded and does not eagerly sign URLs
+- public report access signs lazily after validation and does not return raw token, `tokenHash` or private storage path
+- Supabase storage remains private, no-upsert and TTL-based for signed URLs
+
+### `test/global-performance-resilience-contract.test.ts`
+
+Validates global performance/resilience:
+
+- shared pagination clamps defaults, max limit and max offset
+- heavy DB/list surfaces keep pagination markers
+- sensitive `no-store` applies only to non-public APIs
+- request id, security headers and safe logging remain wired
+- local validation scripts remain explicit
+
+## Product changes
+
+None expected. The audit did not identify a real production defect requiring a backend or frontend fix during implementation.
+
+## Validation commands
+
+Executed locally on 2026-06-03:
+
+- `pnpm test` - passed, 2240 passed, 1 skipped, 0 failed.
+- `pnpm build` - passed.
+- `pnpm security:public-surface` - passed, no public exposure findings. The auditor preserved the documented server-only cookie-name findings in `frontend/src/middleware.ts`.
+- `pnpm typecheck` - passed.
+- `pnpm typecheck:test` - passed.
+- `git diff --check` - passed.
+
+## Suggested next PRs
+
+1. Add staging/deployed evidence for public headers, auth boundary negatives and no-leak behavior.
+2. Add seeded DB query-budget tests for heavy admin/report/logistics endpoints.
+3. Add environment-level Supabase bucket ACL review and signed URL TTL evidence.
+4. Add authenticated Playwright mobile smoke for dashboard flows once test credentials are available.

--- a/test/global-auth-boundary-contract.test.ts
+++ b/test/global-auth-boundary-contract.test.ts
@@ -1,0 +1,191 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+type AuthSurface = {
+  label: string;
+  files: readonly string[];
+  markers: readonly string[];
+};
+
+const AUTH_SURFACES: readonly AuthSurface[] = [
+  {
+    label: "admin",
+    files: [
+      "server/routes/admin-audit.fastify.ts",
+      "server/routes/admin-auth.fastify.ts",
+      "server/routes/admin-clinics.fastify.ts",
+      "server/routes/admin-failed-login-alerts.fastify.ts",
+      "server/routes/admin-particular-tokens.fastify.ts",
+      "server/routes/admin-pricing.fastify.ts",
+      "server/routes/admin-report-access-tokens.fastify.ts",
+      "server/routes/admin-report-workflow.fastify.ts",
+      "server/routes/admin-reports.fastify.ts",
+      "server/routes/admin-sessions.fastify.ts",
+      "server/routes/admin-study-tracking.fastify.ts",
+      "server/routes/admin-system-health.fastify.ts",
+      "server/routes/admin-system-maintenance.fastify.ts",
+      "server/routes/admin-system-schema-health.fastify.ts",
+      "server/routes/admin-users-roles.fastify.ts",
+    ],
+    markers: ["authenticateFastifyAdmin"],
+  },
+  {
+    label: "clinic",
+    files: [
+      "server/routes/auth.fastify.ts",
+      "server/routes/clinic-audit.fastify.ts",
+      "server/routes/clinic-public-profile.fastify.ts",
+      "server/routes/logistics-field-visits.fastify.ts",
+      "server/routes/logistics-route-events.fastify.ts",
+      "server/routes/logistics-route-plans.fastify.ts",
+      "server/routes/logistics-sla.fastify.ts",
+      "server/routes/particular-tokens.fastify.ts",
+      "server/routes/report-access-tokens.fastify.ts",
+      "server/routes/reports.fastify.ts",
+      "server/routes/reports-status.fastify.ts",
+      "server/routes/study-tracking.fastify.ts",
+    ],
+    markers: ["authenticateClinicUser"],
+  },
+  {
+    label: "particular",
+    files: [
+      "server/routes/particular-audit.fastify.ts",
+      "server/routes/particular-auth.fastify.ts",
+      "server/routes/particular-study-tracking.fastify.ts",
+    ],
+    markers: ["authenticateParticularUser", "ENV.particularCookieName"],
+  },
+];
+
+const PUBLIC_ROUTE_FILES = [
+  "server/routes/contact.fastify.ts",
+  "server/routes/public-pricing.fastify.ts",
+  "server/routes/public-professionals.fastify.ts",
+  "server/routes/public-report-access.fastify.ts",
+] as const;
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertContains(source: string, marker: string, context: string): void {
+  assert.ok(source.includes(marker), `${context} must contain ${marker}`);
+}
+
+test("global auth boundary keeps route families behind expected authenticators", () => {
+  for (const surface of AUTH_SURFACES) {
+    for (const file of surface.files) {
+      const source = read(file);
+
+      for (const marker of surface.markers) {
+        assertContains(source, marker, `${surface.label} ${file}`);
+      }
+    }
+  }
+});
+
+test("public route families do not accept browser session authenticators", () => {
+  for (const file of PUBLIC_ROUTE_FILES) {
+    const source = read(file);
+
+    assert.equal(
+      source.includes("authenticateFastifyAdmin"),
+      false,
+      `${file} must not accept admin sessions`,
+    );
+    assert.equal(
+      source.includes("authenticateClinicUser"),
+      false,
+      `${file} must not accept clinic sessions`,
+    );
+    assert.equal(
+      source.includes("authenticateParticularUser"),
+      false,
+      `${file} must not accept particular sessions`,
+    );
+  }
+
+  const publicReportAccess = read("server/routes/public-report-access.fastify.ts");
+  assertContains(
+    publicReportAccess,
+    "reportAccessTokenRawTokenSchema.safeParse",
+    "public report access token validation",
+  );
+  assertContains(
+    publicReportAccess,
+    "hashSessionToken(parsed.data)",
+    "public report access token hashing",
+  );
+});
+
+test("session cookie names remain separated across backend and dashboard middleware", () => {
+  const envSource = read("server/lib/env.ts");
+  const middlewareSource = read("frontend/src/middleware.ts");
+
+  assertContains(envSource, 'cookieName: rawEnv.COOKIE_NAME ?? "app_session_id"', "env clinic cookie");
+  assertContains(
+    envSource,
+    'adminCookieName: rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id"',
+    "env admin cookie",
+  );
+  assertContains(envSource, "PARTICULAR_COOKIE_NAME", "env particular cookie");
+
+  assertContains(
+    middlewareSource,
+    'const CLINIC_SESSION_COOKIE_NAME = "app_session_id"',
+    "frontend clinic cookie",
+  );
+  assertContains(
+    middlewareSource,
+    'const ADMIN_SESSION_COOKIE_NAME = "admin_session_id"',
+    "frontend admin cookie",
+  );
+  assertContains(
+    middlewareSource,
+    "ADMIN_DASHBOARD_PATH_PREFIX",
+    "frontend admin dashboard boundary",
+  );
+  assertContains(
+    middlewareSource,
+    'return new NextResponse("Not Found", { status: 404 })',
+    "frontend admin dashboard unauth response",
+  );
+});
+
+test("trusted-origin hook stays global and precedes registered route surfaces", () => {
+  const fastifyApp = read("server/fastify-app.ts");
+  const trustedOriginIndex = fastifyApp.indexOf(
+    'app.addHook("onRequest", requireTrustedOriginForFastify);',
+  );
+  const firstRouteRegistrationIndex = fastifyApp.indexOf(
+    "await app.register(adminAuditNativeRoutes",
+  );
+
+  assert.notEqual(trustedOriginIndex, -1);
+  assert.notEqual(firstRouteRegistrationIndex, -1);
+  assert.ok(
+    trustedOriginIndex < firstRouteRegistrationIndex,
+    "trusted-origin must be installed before route registration",
+  );
+  assertContains(fastifyApp, "applyApiRequestIdHeader", "fastify request id hook");
+  assertContains(fastifyApp, "applyApiSecurityHeaders", "fastify security header hook");
+  assertContains(fastifyApp, "applySensitiveApiNoStoreHeaders", "fastify no-store hook");
+});
+
+test("global auth boundary guardrail source stays ascii only", () => {
+  const source = read("test/global-auth-boundary-contract.test.ts");
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `global auth boundary source must stay ascii-only at index ${index}`,
+    );
+  }
+});

--- a/test/global-e2e-production-readiness-contract.test.ts
+++ b/test/global-e2e-production-readiness-contract.test.ts
@@ -1,0 +1,348 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+type FileExpectation = {
+  path: string;
+  markers: readonly string[];
+};
+
+type GlobalSurface = {
+  group: "G1" | "G2" | "G3" | "G4" | "G5" | "G6";
+  purpose: string;
+  runtimeFiles: readonly FileExpectation[];
+  guardrailFiles: readonly FileExpectation[];
+};
+
+const GLOBAL_SURFACES: readonly GlobalSurface[] = [
+  {
+    group: "G1",
+    purpose:
+      "Public web and API surface keeps headers, safe metadata, public route limits and bundle exposure guardrails.",
+    runtimeFiles: [
+      {
+        path: "server/fastify-app.ts",
+        markers: [
+          'prefix: "/api/public/professionals"',
+          'prefix: "/api/public/pricing"',
+          'prefix: "/api/public/report-access"',
+        ],
+      },
+      {
+        path: "frontend/next.config.ts",
+        markers: [
+          "buildSecurityHeaders",
+          "Content-Security-Policy-Report-Only",
+          "X-Content-Type-Options",
+        ],
+      },
+      {
+        path: "scripts/security/audit-public-devtools-surface.mjs",
+        markers: [
+          "DANGEROUSLY_SET_INNER_HTML_REGEX",
+          "EXPLICIT_BLOCKED_IDENTIFIERS",
+          "publicExposure",
+        ],
+      },
+    ],
+    guardrailFiles: [
+      {
+        path: "test/frontend-public-devtools-exposure-contract.test.ts",
+        markers: ["public devtools auditor script passes with no exposure findings"],
+      },
+      {
+        path: "test/frontend-next-config-security-headers.test.ts",
+        markers: ["X-Content-Type-Options", "Content-Security-Policy-Report-Only"],
+      },
+    ],
+  },
+  {
+    group: "G2",
+    purpose:
+      "Admin, clinic and particular auth boundaries keep session cookies, role checks, trusted origin and CORS separated.",
+    runtimeFiles: [
+      {
+        path: "server/fastify-app.ts",
+        markers: [
+          "requireTrustedOriginForFastify",
+          'prefix: "/api/admin/auth"',
+          'prefix: "/api/auth"',
+          'prefix: "/api/particular/auth"',
+        ],
+      },
+      {
+        path: "server/lib/env.ts",
+        markers: ["cookieName", "adminCookieName", "particularCookieName"],
+      },
+      {
+        path: "server/lib/fastify-admin-auth.ts",
+        markers: ["authenticateFastifyAdmin", "ENV.adminCookieName"],
+      },
+    ],
+    guardrailFiles: [
+      {
+        path: "test/security-session-cookie-boundaries.test.ts",
+        markers: ["session cookie boundary matrix documents separated auth domains"],
+      },
+      {
+        path: "test/security-cross-auth-surface-boundaries.test.ts",
+        markers: ["cross auth surface registry keeps every protected route family explicit"],
+      },
+    ],
+  },
+  {
+    group: "G3",
+    purpose:
+      "Contact, uploads and input parsers reject unsafe payloads before DB storage signing or audit side effects.",
+    runtimeFiles: [
+      {
+        path: "server/routes/contact.fastify.ts",
+        markers: ["contactNativeRoutes", "safeParse"],
+      },
+      {
+        path: "server/routes/admin-reports.fastify.ts",
+        markers: ["multer", "fileSize", "Tipo de archivo no permitido"],
+      },
+      {
+        path: "server/lib/supabase.ts",
+        markers: ["sanitizeFileName(fileName: string, fallback: string)", "upsert: false"],
+      },
+    ],
+    guardrailFiles: [
+      {
+        path: "test/security-validation-cutoff-boundaries.test.ts",
+        markers: ["validation cut-off matrix documents the protected contract"],
+      },
+      {
+        path: "test/supabase-upload-success.test.ts",
+        markers: ["neutraliza path traversal"],
+      },
+    ],
+  },
+  {
+    group: "G4",
+    purpose:
+      "Private report storage paths, access tokens and signed URLs stay lazy, scoped and absent from public JSON.",
+    runtimeFiles: [
+      {
+        path: "server/lib/report-access-token.ts",
+        markers: ["serializePublicReportAccess", "serializeReportAccessToken"],
+      },
+      {
+        path: "server/routes/public-report-access.fastify.ts",
+        markers: [
+          "reportAccessTokenRawTokenSchema.safeParse",
+          "createSignedReportUrl",
+          "createSignedReportDownloadUrl",
+        ],
+      },
+      {
+        path: "server/lib/supabase.ts",
+        markers: ["ENV.signedUrlExpiresInSeconds", "createSignedUrl"],
+      },
+    ],
+    guardrailFiles: [
+      {
+        path: "test/storage-suite-completeness.test.ts",
+        markers: ["Public report access and public professionals tests keep signed URLs delegated"],
+      },
+      {
+        path: "test/security-sensitive-log-redaction-boundaries.test.ts",
+        markers: ["sensitive log redaction matrix documents protected boundaries"],
+      },
+    ],
+  },
+  {
+    group: "G5",
+    purpose:
+      "Heavy lists, cache policy, rate limits and local validation gates keep production behavior bounded and observable.",
+    runtimeFiles: [
+      {
+        path: "server/lib/list-pagination.ts",
+        markers: ["DEFAULT_LIST_LIMIT", "MAX_LIST_LIMIT", "MAX_LIST_OFFSET"],
+      },
+      {
+        path: "server/lib/sensitive-response-cache.ts",
+        markers: ["SENSITIVE_API_CACHE_CONTROL", "!url.startsWith(\"/api/public/\")"],
+      },
+      {
+        path: "package.json",
+        markers: ["\"test\"", "\"build\"", "\"typecheck\"", "\"security:public-surface\""],
+      },
+    ],
+    guardrailFiles: [
+      {
+        path: "test/admin-heavy-list-pagination-contract.test.ts",
+        markers: ["normalizeListPagination clampa max limit y offset"],
+      },
+      {
+        path: "test/security-rate-limit-isolation-boundaries.test.ts",
+        markers: ["rate limit isolation matrix documents the protected contract"],
+      },
+    ],
+  },
+  {
+    group: "G6",
+    purpose:
+      "Public, dashboard and particular UX surfaces keep route guards, mobile parity and semantic frontend checks.",
+    runtimeFiles: [
+      {
+        path: "frontend/src/middleware.ts",
+        markers: ["ADMIN_DASHBOARD_PATH_PREFIX", "NextResponse.redirect"],
+      },
+      {
+        path: "frontend/src/app/layout.tsx",
+        markers: ["metadata", "viewport"],
+      },
+      {
+        path: "frontend/src/components/public/PublicAction.tsx",
+        markers: ["PublicRouteControl", "PublicExternalControl", "aria-hidden"],
+      },
+    ],
+    guardrailFiles: [
+      {
+        path: "test/mobile-production-parity-invariants.test.ts",
+        markers: ["mobile"],
+      },
+      {
+        path: "test/frontend-public-page-semantics.test.ts",
+        markers: [
+          "home page keeps one clear h1 and institutional section hierarchy",
+          "profesionales content keeps semantic search/result structure and map safety",
+        ],
+      },
+    ],
+  },
+];
+
+const REQUIRED_VALIDATION_SCRIPTS = [
+  "test",
+  "build",
+  "security:public-surface",
+  "typecheck",
+  "typecheck:test",
+] as const;
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertFileContains(expectation: FileExpectation): void {
+  assert.equal(
+    existsSync(resolve(process.cwd(), expectation.path)),
+    true,
+    `${expectation.path} must exist`,
+  );
+
+  const source = read(expectation.path);
+
+  for (const marker of expectation.markers) {
+    assert.ok(
+      source.includes(marker),
+      `${expectation.path} must contain marker: ${marker}`,
+    );
+  }
+}
+
+test("global e2e readiness registry covers G1 to G6 production surfaces", () => {
+  assert.deepEqual(
+    GLOBAL_SURFACES.map((surface) => surface.group),
+    ["G1", "G2", "G3", "G4", "G5", "G6"],
+  );
+
+  for (const surface of GLOBAL_SURFACES) {
+    assert.ok(surface.purpose.length >= 80);
+    assert.ok(surface.runtimeFiles.length >= 3);
+    assert.ok(surface.guardrailFiles.length >= 2);
+
+    for (const file of surface.runtimeFiles) {
+      assertFileContains(file);
+    }
+
+    for (const file of surface.guardrailFiles) {
+      assertFileContains(file);
+    }
+  }
+});
+
+test("global e2e readiness keeps required local validation gates", () => {
+  const packageJson = JSON.parse(read("package.json")) as {
+    scripts?: Record<string, string>;
+  };
+
+  for (const script of REQUIRED_VALIDATION_SCRIPTS) {
+    assert.equal(
+      typeof packageJson.scripts?.[script],
+      "string",
+      `package.json must expose pnpm ${script}`,
+    );
+  }
+
+  assert.ok(
+    packageJson.scripts?.["validate:local"]?.includes("pnpm typecheck"),
+    "validate:local must keep typecheck in the local gate",
+  );
+  assert.ok(
+    packageJson.scripts?.["validate:local"]?.includes("pnpm test"),
+    "validate:local must keep test in the local gate",
+  );
+  assert.ok(
+    packageJson.scripts?.["validate:local"]?.includes("pnpm build"),
+    "validate:local must keep build in the local gate",
+  );
+});
+
+test("global e2e readiness docs keep audit matrix evidence and PR scope", () => {
+  const auditDocPath = "docs/audit/global-e2e-extreme-production-audit.md";
+  const prDocPath = "docs/pr-826-global-e2e-extreme-production-readiness.md";
+
+  assert.equal(existsSync(resolve(process.cwd(), auditDocPath)), true);
+  assert.equal(existsSync(resolve(process.cwd(), prDocPath)), true);
+
+  const auditDoc = read(auditDocPath);
+  const prDoc = read(prDocPath);
+
+  for (const marker of [
+    "## Executive summary",
+    "## Risk matrix",
+    "## Findings corrected",
+    "## Accepted and documented findings",
+    "## Validation evidence",
+    "G1",
+    "G2",
+    "G3",
+    "G4",
+    "G5",
+    "G6",
+  ]) {
+    assert.ok(auditDoc.includes(marker), `${auditDocPath} must contain ${marker}`);
+  }
+
+  for (const command of [
+    "pnpm test",
+    "pnpm build",
+    "pnpm security:public-surface",
+    "pnpm typecheck",
+    "pnpm typecheck:test",
+    "git diff --check",
+  ]) {
+    assert.ok(auditDoc.includes(command), `${auditDocPath} must mention ${command}`);
+    assert.ok(prDoc.includes(command), `${prDocPath} must mention ${command}`);
+  }
+});
+
+test("global e2e readiness guardrail source stays ascii only", () => {
+  const source = read("test/global-e2e-production-readiness-contract.test.ts");
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `global e2e readiness source must stay ascii-only at index ${index}`,
+    );
+  }
+});

--- a/test/global-performance-resilience-contract.test.ts
+++ b/test/global-performance-resilience-contract.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const { normalizeListPagination } = await import(
+  "../server/lib/list-pagination.ts"
+);
+const {
+  shouldApplySensitiveApiNoStore,
+  SENSITIVE_API_CACHE_CONTROL,
+} = await import("../server/lib/sensitive-response-cache.ts");
+
+type HeavySurface = {
+  file: string;
+  markers: readonly string[];
+};
+
+const HEAVY_SURFACES: readonly HeavySurface[] = [
+  {
+    file: "server/db-admin-clinics.ts",
+    markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
+  },
+  {
+    file: "server/db-admin-failed-login-alerts.ts",
+    markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
+  },
+  {
+    file: "server/db-admin-sessions.ts",
+    markers: ["normalizeListPagination", "fetchLimit", ".limit(fetchLimit)"],
+  },
+  {
+    file: "server/db-admin-users-roles.ts",
+    markers: ["normalizeListPagination", ".limit(adminLimit)", ".limit(clinicLimit)"],
+  },
+  {
+    file: "server/db-particular.ts",
+    markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
+  },
+  {
+    file: "server/db-report-access.ts",
+    markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
+  },
+  {
+    file: "server/db-report-workflow.ts",
+    markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
+  },
+  {
+    file: "server/db-study-tracking.ts",
+    markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
+  },
+  {
+    file: "server/db-logistics.ts",
+    markers: ["normalizeLogisticsLimit", "normalizeLogisticsOffset"],
+  },
+];
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("global pagination clamps heavy list defaults and extremes", () => {
+  assert.deepEqual(normalizeListPagination(undefined), {
+    limit: 50,
+    offset: 0,
+  });
+  assert.deepEqual(normalizeListPagination({ limit: 999, offset: 999_999 }), {
+    limit: 100,
+    offset: 100_000,
+  });
+  assert.deepEqual(normalizeListPagination({ limit: -5, offset: Number.NaN }), {
+    limit: 1,
+    offset: 0,
+  });
+});
+
+test("global heavy route and DB surfaces stay bounded by pagination markers", () => {
+  for (const surface of HEAVY_SURFACES) {
+    const source = read(surface.file);
+
+    for (const marker of surface.markers) {
+      assert.ok(
+        source.includes(marker),
+        `${surface.file} must contain pagination marker ${marker}`,
+      );
+    }
+  }
+});
+
+test("sensitive no-store applies only to non-public API surfaces", () => {
+  assert.equal(SENSITIVE_API_CACHE_CONTROL, "no-store");
+  assert.equal(shouldApplySensitiveApiNoStore("/api/reports"), true);
+  assert.equal(shouldApplySensitiveApiNoStore("/api/admin/reports"), true);
+  assert.equal(shouldApplySensitiveApiNoStore("/api/clinic/profile"), true);
+  assert.equal(shouldApplySensitiveApiNoStore("/api/particular/auth/me"), true);
+  assert.equal(shouldApplySensitiveApiNoStore("/api/public/pricing"), false);
+  assert.equal(
+    shouldApplySensitiveApiNoStore("/api/public/report-access/token"),
+    false,
+  );
+  assert.equal(shouldApplySensitiveApiNoStore("/health"), false);
+});
+
+test("resilience contracts keep request ids security headers and safe logging wired", () => {
+  const fastifyApp = read("server/fastify-app.ts");
+  const requestLogger = read("server/middlewares/request-logger.ts");
+  const apiRequestId = read("server/lib/api-request-id.ts");
+  const apiResponseSecurity = read("server/lib/api-response-security.ts");
+
+  for (const marker of [
+    "generateFastifyRequestId",
+    "applyApiRequestIdHeader",
+    "applyApiSecurityHeaders",
+    "addApiErrorRequestIdToJsonPayload",
+    "applySensitiveApiNoStoreHeaders",
+  ]) {
+    assert.ok(fastifyApp.includes(marker), `fastify app must contain ${marker}`);
+  }
+
+  for (const marker of ["sanitizeUrlForLogs", "[REDACTED]", "RATE_LIMITED"]) {
+    assert.ok(requestLogger.includes(marker), `request logger must contain ${marker}`);
+  }
+
+  assert.ok(apiRequestId.includes("X-Request-ID"));
+  assert.ok(apiResponseSecurity.includes("X-Content-Type-Options"));
+  assert.ok(apiResponseSecurity.includes("Referrer-Policy"));
+});
+
+test("validation scripts keep production readiness gates explicit", () => {
+  const packageJson = JSON.parse(read("package.json")) as {
+    scripts: Record<string, string>;
+  };
+
+  assert.equal(packageJson.scripts.test, "node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts");
+  assert.equal(packageJson.scripts.build.includes("esbuild server/index.ts"), true);
+  assert.equal(packageJson.scripts.typecheck, "tsc --noEmit");
+  assert.equal(packageJson.scripts["typecheck:test"], "tsc -p ./test/tsconfig.json --noEmit");
+  assert.equal(
+    packageJson.scripts["security:public-surface"],
+    "node scripts/security/audit-public-devtools-surface.mjs",
+  );
+});
+
+test("global performance resilience guardrail source stays ascii only", () => {
+  const source = read("test/global-performance-resilience-contract.test.ts");
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `global performance resilience source must stay ascii-only at index ${index}`,
+    );
+  }
+});

--- a/test/global-public-surface-hardening-contract.test.ts
+++ b/test/global-public-surface-hardening-contract.test.ts
@@ -1,0 +1,281 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.CORS_ORIGIN ??= "http://localhost:3000";
+
+const { createFastifyApp } = await import("../server/fastify-app.ts");
+const { clearPublicPricingCache } = await import(
+  "../server/lib/public-pricing-cache.ts"
+);
+const { createMemoryRateLimitStore } = await import(
+  "../server/lib/rate-limit-store.ts"
+);
+
+const FORBIDDEN_PUBLIC_BODY_MARKERS = [
+  "storagePath",
+  "storage_path",
+  "tokenHash",
+  "sessionToken",
+  "passwordHash",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "DATABASE_URL",
+  "SMTP_PASS",
+  "GMAIL_API_REFRESH_TOKEN",
+  "app_session_id",
+  "admin_session_id",
+  "particular_session_id",
+] as const;
+
+type PublicReportAccessCalls = {
+  hash: string[];
+  lookup: string[];
+  record: number[];
+  preview: string[];
+  download: string[];
+  audit: number;
+};
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertPublicApiSecurityHeaders(
+  response: { headers: Record<string, unknown> },
+  label: string,
+): void {
+  assert.equal(response.headers["x-content-type-options"], "nosniff", label);
+  assert.equal(response.headers["referrer-policy"], "no-referrer", label);
+  assert.equal(response.headers["set-cookie"], undefined, label);
+}
+
+function assertBodyDoesNotExposePublicMarkers(rawBody: string, label: string) {
+  for (const marker of FORBIDDEN_PUBLIC_BODY_MARKERS) {
+    assert.equal(
+      rawBody.includes(marker),
+      false,
+      `${label} must not expose ${marker}`,
+    );
+  }
+}
+
+function createPublicReportAccessDeps(calls: PublicReportAccessCalls) {
+  return {
+    getReportAccessTokenWithReportByTokenHash: async (tokenHash: string) => {
+      calls.lookup.push(tokenHash);
+      return null;
+    },
+    recordReportAccessTokenAccess: async (tokenId: number) => {
+      calls.record.push(tokenId);
+      return null;
+    },
+    createSignedReportUrl: async (storagePath: string) => {
+      calls.preview.push(storagePath);
+      return `https://signed.example/preview/${encodeURIComponent(storagePath)}`;
+    },
+    createSignedReportDownloadUrl: async (storagePath: string) => {
+      calls.download.push(storagePath);
+      return `https://signed.example/download/${encodeURIComponent(storagePath)}`;
+    },
+    hashSessionToken: (token: string) => {
+      calls.hash.push(token);
+      return `hash:${token}`;
+    },
+    writeAuditLog: async () => {
+      calls.audit += 1;
+    },
+    publicReportAccessRateLimitMaxAttempts: 100,
+    publicReportAccessRateLimitStore: createMemoryRateLimitStore(),
+    now: () => new Date("2026-06-03T12:00:00.000Z").getTime(),
+  };
+}
+
+async function createContractApp(calls: PublicReportAccessCalls) {
+  return createFastifyApp({
+    publicPricingRoutes: {
+      listPublicPricingItems: async () => [
+        {
+          id: 1,
+          category: "Base",
+          studyName: "Histopathology",
+          priceLabel: "$100",
+          displayOrder: 1,
+        },
+      ],
+    },
+    publicProfessionalsRoutes: {
+      searchRateLimitMaxAttempts: 100,
+      detailRateLimitMaxAttempts: 100,
+      searchRateLimitStore: createMemoryRateLimitStore(),
+      detailRateLimitStore: createMemoryRateLimitStore(),
+      now: () => new Date("2026-06-03T12:00:00.000Z").getTime(),
+      searchPublicProfessionals: async (input) => {
+        assert.equal(input.limit, 50);
+        assert.equal(input.offset, 0);
+
+        return {
+          rows: [
+            {
+              clinicId: 3,
+              displayName: "Clinica Norte",
+              avatarStoragePath: "private/avatars/clinic-norte.webp",
+              aboutText: "Public profile",
+              specialtyText: "Dermatology",
+              servicesText: "Biopsies",
+              email: "public@example.test",
+              phone: "555-0100",
+              locality: "Buenos Aires",
+              country: "AR",
+              updatedAt: new Date("2026-06-03T00:00:00.000Z"),
+              rank: 1,
+              similarity: 0.99,
+              score: 0.8,
+            },
+          ],
+          total: 1,
+          limit: input.limit,
+          offset: input.offset,
+        };
+      },
+      getPublicProfessionalByClinicId: async () => null,
+      createSignedStorageUrl: async (storagePath: string) =>
+        `https://signed.example/avatar/${encodeURIComponent(storagePath)}`,
+    },
+    publicReportAccessRoutes: createPublicReportAccessDeps(calls),
+    adminSystemHealthRoutes: {
+      deleteAdminSession: async () => {},
+      getAdminSessionByToken: async () => null,
+      getAdminUserById: async () => null,
+      updateAdminSessionLastAccess: async () => {},
+      hashSessionToken: (token: string) => `hash:${token}`,
+      getSystemHealthSnapshot: async () => ({
+        statusCode: 200,
+        payload: { status: "ok", checks: {} },
+      }),
+      getBackendVersion: () => "contract",
+    },
+  });
+}
+
+function createEmptyPublicReportAccessCalls(): PublicReportAccessCalls {
+  return {
+    hash: [],
+    lookup: [],
+    record: [],
+    preview: [],
+    download: [],
+    audit: 0,
+  };
+}
+
+test("public API responses keep security headers and avoid session leakage", async () => {
+  clearPublicPricingCache();
+  const calls = createEmptyPublicReportAccessCalls();
+  const app = await createContractApp(calls);
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/public/pricing",
+    });
+
+    assert.equal(response.statusCode, 200);
+    assertPublicApiSecurityHeaders(response, "public pricing");
+    assert.notEqual(response.headers["cache-control"], "no-store");
+    assertBodyDoesNotExposePublicMarkers(response.body, "public pricing");
+  } finally {
+    await app.close();
+  }
+});
+
+test("public professionals serializes signed avatar URL without private storage path", async () => {
+  const calls = createEmptyPublicReportAccessCalls();
+  const app = await createContractApp(calls);
+  const originalConsoleLog = console.log;
+
+  console.log = () => {};
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/public/professionals/search?limit=999&offset=-10",
+      headers: { origin: "http://localhost:3000" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assertPublicApiSecurityHeaders(response, "public professionals search");
+    assert.equal(response.headers["access-control-allow-origin"], "http://localhost:3000");
+    assertBodyDoesNotExposePublicMarkers(response.body, "public professionals search");
+    assert.equal(response.body.includes("private/avatars/clinic-norte.webp"), false);
+    assert.ok(response.body.includes("https://signed.example/avatar/"));
+  } finally {
+    console.log = originalConsoleLog;
+    await app.close();
+  }
+});
+
+test("invalid public report token rejects before hashing lookup signing or audit", async () => {
+  const calls = createEmptyPublicReportAccessCalls();
+  const app = await createContractApp(calls);
+  const originalConsoleLog = console.log;
+
+  console.log = () => {};
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/public/report-access/not-a-token",
+    });
+
+    assert.equal(response.statusCode, 400);
+    assertPublicApiSecurityHeaders(response, "public report invalid token");
+    assert.notEqual(response.headers["cache-control"], "no-store");
+    assert.deepEqual(calls.hash, []);
+    assert.deepEqual(calls.lookup, []);
+    assert.deepEqual(calls.record, []);
+    assert.deepEqual(calls.preview, []);
+    assert.deepEqual(calls.download, []);
+    assert.equal(calls.audit, 0);
+    assert.equal(response.body.includes("not-a-token"), false);
+    assertBodyDoesNotExposePublicMarkers(response.body, "public report invalid token");
+  } finally {
+    console.log = originalConsoleLog;
+    await app.close();
+  }
+});
+
+test("public surface hardening stays connected to frontend bundle auditor", () => {
+  const source = read("scripts/security/audit-public-devtools-surface.mjs");
+
+  for (const marker of [
+    "DANGEROUSLY_SET_INNER_HTML_REGEX",
+    "NON_PUBLIC_API_KEY_IDENTIFIER_REGEX",
+    "SENSITIVE_ATTRIBUTE_VALUE_REGEX",
+    "publicExposure",
+    "NEXT_PUBLIC_",
+  ]) {
+    assert.ok(source.includes(marker), `public auditor must contain ${marker}`);
+  }
+});
+
+test("global public surface guardrail source stays ascii only", () => {
+  const source = read("test/global-public-surface-hardening-contract.test.ts");
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `global public surface source must stay ascii-only at index ${index}`,
+    );
+  }
+});

--- a/test/global-storage-report-safety-contract.test.ts
+++ b/test/global-storage-report-safety-contract.test.ts
@@ -1,0 +1,276 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.SUPABASE_STORAGE_BUCKET ??= "reports";
+
+const { ENV } = await import("../server/lib/env.ts");
+const { reportsNativeRoutes } = await import("../server/routes/reports.fastify.ts");
+const { publicReportAccessNativeRoutes } = await import(
+  "../server/routes/public-report-access.fastify.ts"
+);
+const { serializeSafeReport } = await import("../server/lib/reports.ts");
+const { createMemoryRateLimitStore } = await import(
+  "../server/lib/rate-limit-store.ts"
+);
+
+const RAW_PUBLIC_TOKEN =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function createReportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 55,
+    clinicId: 3,
+    patientName: "Luna Gomez",
+    studyType: "Histopathology",
+    uploadDate: new Date("2026-04-20T00:00:00.000Z"),
+    fileName: "luna.pdf",
+    storagePath: "private/reports/3/luna.pdf",
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-04-21T00:00:00.000Z"),
+    statusChangedByClinicUserId: 9,
+    statusChangedByAdminUserId: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createReportAccessTokenFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 9,
+    clinicId: 3,
+    reportId: 55,
+    tokenHash: "hash",
+    tokenLast4: "aaaa",
+    accessCount: 2,
+    lastAccessAt: null,
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    revokedAt: null,
+    createdAt: new Date("2026-04-20T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    createdByClinicUserId: 9,
+    createdByAdminUserId: null,
+    revokedByClinicUserId: null,
+    revokedByAdminUserId: null,
+    ...overrides,
+  };
+}
+
+async function createReportsApp(overrides: Record<string, unknown> = {}) {
+  const app = Fastify();
+
+  await app.register(reportsNativeRoutes as any, {
+    prefix: "/api/reports",
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => ({
+      clinicUserId: 9,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-06-03T00:00:00.000Z"),
+    }),
+    getClinicUserById: async () => ({
+      id: 9,
+      clinicId: 3,
+      username: "doctor",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getReportsByClinicId: async (
+      _clinicId: number,
+      limit: number,
+      offset: number,
+    ) => {
+      assert.equal(limit, 100);
+      assert.equal(offset, 2);
+      return [createReportFixture()];
+    },
+    searchReports: async () => [createReportFixture()],
+    getStudyTypes: async () => ["Histopathology"],
+    getReportById: async () => createReportFixture(),
+    getReportStatusHistory: async () => [],
+    createSignedReportUrl: async () => {
+      throw new Error("list routes must not create preview signed URLs");
+    },
+    createSignedReportDownloadUrl: async () => {
+      throw new Error("list routes must not create download signed URLs");
+    },
+    now: () => new Date("2026-06-03T12:00:00.000Z").getTime(),
+    ...overrides,
+  });
+
+  return app;
+}
+
+async function createPublicReportAccessApp(calls: {
+  preview: string[];
+  download: string[];
+  audit: number;
+}) {
+  const app = Fastify();
+
+  await app.register(publicReportAccessNativeRoutes as any, {
+    prefix: "/api/public/report-access",
+    getReportAccessTokenWithReportByTokenHash: async (tokenHash: string) => {
+      assert.equal(tokenHash, `hash:${RAW_PUBLIC_TOKEN}`);
+      return {
+        token: createReportAccessTokenFixture(),
+        report: createReportFixture(),
+      };
+    },
+    recordReportAccessTokenAccess: async () =>
+      createReportAccessTokenFixture({
+        accessCount: 3,
+        lastAccessAt: new Date("2026-06-03T12:00:00.000Z"),
+      }),
+    createSignedReportUrl: async (storagePath: string) => {
+      calls.preview.push(storagePath);
+      return "https://signed.example/preview/luna.pdf";
+    },
+    createSignedReportDownloadUrl: async (storagePath: string) => {
+      calls.download.push(storagePath);
+      return "https://signed.example/download/luna.pdf";
+    },
+    hashSessionToken: (token: string) => `hash:${token}`,
+    writeAuditLog: async () => {
+      calls.audit += 1;
+    },
+    publicReportAccessRateLimitMaxAttempts: 100,
+    publicReportAccessRateLimitStore: createMemoryRateLimitStore(),
+    now: () => new Date("2026-06-03T12:00:00.000Z").getTime(),
+  });
+
+  return app;
+}
+
+test("safe report serializer removes private storage paths from JSON", () => {
+  const serialized = serializeSafeReport(createReportFixture() as any);
+  const raw = JSON.stringify(serialized);
+
+  assert.equal("storagePath" in serialized, false);
+  assert.equal(raw.includes("private/reports/3/luna.pdf"), false);
+  assert.equal(serialized.hasFile, true);
+});
+
+test("clinic report list stays bounded and does not eagerly sign report URLs", async () => {
+  const app = await createReportsApp();
+  const originalConsoleLog = console.log;
+
+  console.log = () => {};
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/reports?limit=999&offset=2",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body.includes("storagePath"), false);
+    assert.equal(response.body.includes("private/reports/3/luna.pdf"), false);
+    assert.equal(response.body.includes("previewUrl"), false);
+    assert.equal(response.body.includes("downloadUrl"), false);
+
+    const body = JSON.parse(response.body) as {
+      pagination: { limit: number; offset: number };
+      reports: Array<{ hasFile: boolean }>;
+    };
+    assert.deepEqual(body.pagination, { limit: 100, offset: 2 });
+    assert.equal(body.reports[0]?.hasFile, true);
+  } finally {
+    console.log = originalConsoleLog;
+    await app.close();
+  }
+});
+
+test("public report access signs lazily and never returns raw storage path or token hash", async () => {
+  const calls = {
+    preview: [] as string[],
+    download: [] as string[],
+    audit: 0,
+  };
+  const app = await createPublicReportAccessApp(calls);
+  const originalConsoleLog = console.log;
+
+  console.log = () => {};
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/public/report-access/${RAW_PUBLIC_TOKEN}`,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls.preview, ["private/reports/3/luna.pdf"]);
+    assert.deepEqual(calls.download, ["private/reports/3/luna.pdf"]);
+    assert.equal(calls.audit, 1);
+    assert.equal(response.body.includes("private/reports/3/luna.pdf"), false);
+    assert.equal(response.body.includes("storagePath"), false);
+    assert.equal(response.body.includes("tokenHash"), false);
+    assert.equal(response.body.includes(RAW_PUBLIC_TOKEN), false);
+    assert.ok(response.body.includes("https://signed.example/preview/luna.pdf"));
+    assert.ok(response.body.includes("https://signed.example/download/luna.pdf"));
+  } finally {
+    console.log = originalConsoleLog;
+    await app.close();
+  }
+});
+
+test("storage report safety remains anchored in private bucket and TTL helpers", () => {
+  const supabaseSource = read("server/lib/supabase.ts");
+  const publicAccessSource = read("server/routes/public-report-access.fastify.ts");
+
+  for (const marker of [
+    "public: false",
+    "upsert: false",
+    "sanitizeFileName(fileName: string, fallback: string)",
+    "ENV.signedUrlExpiresInSeconds",
+    "createSignedUrl",
+  ]) {
+    assert.ok(supabaseSource.includes(marker), `supabase storage must contain ${marker}`);
+  }
+
+  const accessRecordIndex = publicAccessSource.indexOf(
+    "const updatedToken = await deps.recordReportAccessTokenAccess",
+  );
+  const signingIndex = publicAccessSource.indexOf(
+    "const [previewUrl, downloadUrl] = await Promise.all",
+  );
+
+  assert.notEqual(accessRecordIndex, -1);
+  assert.notEqual(signingIndex, -1);
+  assert.ok(
+    accessRecordIndex < signingIndex,
+    "public report access must record access before signing URLs",
+  );
+});
+
+test("global storage report guardrail source stays ascii only", () => {
+  const source = read("test/global-storage-report-safety-contract.test.ts");
+
+  for (let index = 0; index < source.length; index += 1) {
+    assert.equal(
+      source.charCodeAt(index) <= 0x7f,
+      true,
+      `global storage report source must stay ascii-only at index ${index}`,
+    );
+  }
+});


### PR DESCRIPTION
## Resumen
- Ejecuta auditoría global end-to-end extrema de producción.
- Cubre seguridad pública, auth/sesiones/permisos, formularios/uploads, storage/signed URLs, performance/resiliencia y accesibilidad/mobile/UX crítica.
- Agrega inventario, matriz de riesgos, contratos globales y documentación de próximos PRs.

## Bloques cubiertos
- G1 Seguridad pública extrema.
- G2 Auth / sesiones / permisos.
- G3 Formularios / uploads / inputs.
- G4 Datos sensibles / storage / signed URLs.
- G5 Performance y resiliencia.
- G6 Accesibilidad / mobile / UX crítica.

## Scope
- Auditoría/docs/tests focused.
- Ajustes productivos mínimos solo si fueron requeridos por hallazgo real.
- Sin DB schema.
- Sin migraciones.
- Sin índices.
- Sin WebAuthn.
- Sin rediseños UI.
- Sin CSP/frontend innecesario.

## Validaciones
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm typecheck
- pnpm typecheck:test
- git diff --check