### PR TITLE
fix(particulares): include case context in special stain contact

### DIFF
--- a/docs/pr-history/PR-fix-particulares-special-stain-whatsapp-context.md
+++ b/docs/pr-history/PR-fix-particulares-special-stain-whatsapp-context.md
@@ -1,0 +1,104 @@
+# PR: fix/particulares-special-stain-whatsapp-context
+
+## Resumen
+
+Actualiza los enlaces de contacto por tinción especial del dashboard de particulares para que WhatsApp y email generen un mensaje dinámico con contexto del caso autenticado. El texto visible de los botones y el diseño mobile/desktop se mantienen.
+
+## Problema
+
+El enlace de WhatsApp usaba un mensaje genérico hardcodeado:
+
+```text
+Hola VETNEB, consulto por una solicitud de tinción especial de mi caso.
+```
+
+Ese mensaje no incluía datos suficientes para que administración identifique el caso sin pedir información adicional.
+
+## Implementación
+
+- Se reemplazaron los hrefs hardcodeados por helpers dinámicos:
+  - `buildSpecialStainContactMessage(trackingCase, session)`
+  - `buildSpecialStainWhatsAppHref(trackingCase, session)`
+  - `buildSpecialStainEmailHref(trackingCase, session)`
+- WhatsApp construye `https://wa.me/5493534138946?text=${encodeURIComponent(message)}`.
+- Email mantiene el subject `Consulta tinción especial` y usa el mismo contexto en `body` con `encodeURIComponent`.
+- Los campos vacíos, `null` o `undefined` se omiten antes de armar cada línea.
+- Se reutilizan `formatDate` y `getTrackingStageLabel` para fechas y estado.
+
+## Datos incluidos
+
+- Token disponible como terminación `tokenLast4`.
+- ID de caso de seguimiento.
+- `ReportId` disponible desde tracking, sesión o informe vinculado.
+- Clínica como ID visible disponible en frontend.
+- Tutor.
+- Paciente.
+- Especie.
+- Raza.
+- Fecha de extracción.
+- Fecha de envío.
+- Estado actual del estudio.
+- Fecha de actualización.
+- Informe vinculado como ID y tipo de estudio, sin rutas ni URLs.
+
+## Datos excluidos por seguridad
+
+- Cookies.
+- Session tokens.
+- Headers.
+- `Authorization`.
+- `storagePath`.
+- `signedUrl`.
+- `previewUrl`.
+- `downloadUrl`.
+- Rutas internas privadas.
+- Secretos.
+
+## Archivos tocados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/components/public/ParticularesContent.tsx` | Helpers dinámicos y hrefs de WhatsApp/email con contexto del caso |
+| `test/frontend-particulares-content.test.ts` | Contratos actualizados para helpers, contexto dinámico, encoding y exclusiones sensibles |
+| `docs/pr-history/PR-fix-particulares-special-stain-whatsapp-context.md` | Documento de entrega |
+
+## Tests y comandos
+
+| Comando | Resultado |
+|---|---|
+| `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particulares-content.test.ts` | PASS, 8/8 |
+| `pnpm --dir frontend lint` | PASS |
+| `pnpm --dir frontend typecheck` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm typecheck:test` | PASS |
+| `pnpm test` | PASS, 2242/2242 |
+| `pnpm build` | PASS |
+| `pnpm security:public-surface` | PASS |
+
+Nota: no se ejecutó `pnpm --dir frontend build` por la restricción explícita sobre posible red de Google Fonts. El auditor `security:public-surface` pasó sobre fuentes y avisó que `.next` no estaba disponible para auditar assets compilados.
+
+## Riesgos
+
+- La clínica se identifica por ID porque el nombre de clínica no está disponible en el payload frontend actual.
+- El token se informa solo como terminación `tokenLast4`; si administración requiere el token completo, debería exponerse explícitamente en un payload seguro del backend antes de usarlo.
+- El mensaje de contacto depende de que `trackingCase` y `session` estén cargados, que es la misma condición en la que se renderiza la alerta.
+
+## Rollback
+
+Revertir los cambios en:
+
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `test/frontend-particulares-content.test.ts`
+- `docs/pr-history/PR-fix-particulares-special-stain-whatsapp-context.md`
+
+No hay migraciones, cambios de base de datos ni cambios de backend asociados.
+
+## Estado final
+
+- Sin cambios de backend.
+- Sin cambios de API.
+- Sin cambios de auth/cookies/sesiones.
+- Sin cambios de storage.
+- Sin cambios en preview/download ni signed URLs.
+- Sin cambios de notificaciones.
+- Sin `git add`, commit, push, PR ni merge.

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -94,10 +94,142 @@ function getTrackingStageLabel(
   return TRACKING_STAGE_LABELS[stage] ?? stage;
 }
 
-const SPECIAL_STAIN_WHATSAPP_HREF =
-  "https://wa.me/5493534138946?text=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
-const SPECIAL_STAIN_EMAIL_HREF =
-  "mailto:lab.vetneb@gmail.com?subject=Consulta%20tinción%20especial&body=Hola%20VETNEB%2C%20consulto%20por%20una%20solicitud%20de%20tinción%20especial%20de%20mi%20caso.";
+const SPECIAL_STAIN_WHATSAPP_PHONE = "5493534138946";
+const SPECIAL_STAIN_EMAIL_ADDRESS = "lab.vetneb@gmail.com";
+const SPECIAL_STAIN_EMAIL_SUBJECT = "Consulta tinción especial";
+
+type SpecialStainContactValue = string | number | null | undefined;
+
+function formatSpecialStainContactValue(value: SpecialStainContactValue) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const text = String(value).trim();
+  return text.length > 0 ? text : null;
+}
+
+function formatSpecialStainContactDate(value: string | null | undefined) {
+  return value ? formatDate(value) : null;
+}
+
+function formatSpecialStainContactId(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? `#${value}`
+    : null;
+}
+
+function appendSpecialStainContactLine(
+  lines: string[],
+  label: string,
+  value: SpecialStainContactValue,
+) {
+  const formattedValue = formatSpecialStainContactValue(value);
+
+  if (!formattedValue) {
+    return;
+  }
+
+  lines.push(`${label}: ${formattedValue}`);
+}
+
+function buildSpecialStainReportSummary(session: ParticularSession) {
+  if (!session.report) {
+    return null;
+  }
+
+  return [
+    formatSpecialStainContactId(session.report.id),
+    formatSpecialStainContactValue(session.report.studyType),
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" - ");
+}
+
+function buildSpecialStainContactMessage(
+  trackingCase: AdminStudyTrackingCaseSummary,
+  session: ParticularSession,
+) {
+  const lines = [
+    "Hola VETNEB, consulto por una solicitud de tinción especial.",
+    "",
+    "Datos del caso:",
+  ];
+  const reportId =
+    trackingCase.reportId ?? session.reportId ?? session.report?.id ?? null;
+  const clinicId = trackingCase.clinicId ?? session.clinicId;
+
+  appendSpecialStainContactLine(
+    lines,
+    "Token",
+    session.tokenLast4 ? `terminación ${session.tokenLast4}` : null,
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "Caso",
+    formatSpecialStainContactId(trackingCase.id),
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "ReportId",
+    formatSpecialStainContactId(reportId),
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "Clínica",
+    formatSpecialStainContactId(clinicId),
+  );
+  appendSpecialStainContactLine(lines, "Tutor", session.tutorLastName);
+  appendSpecialStainContactLine(lines, "Paciente", session.petName);
+  appendSpecialStainContactLine(lines, "Especie", session.petSpecies);
+  appendSpecialStainContactLine(lines, "Raza", session.petBreed);
+  appendSpecialStainContactLine(
+    lines,
+    "Extracción",
+    formatSpecialStainContactDate(session.extractionDate),
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "Envío",
+    formatSpecialStainContactDate(session.shippingDate),
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "Estado",
+    getTrackingStageLabel(trackingCase.currentStage),
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "Actualizado",
+    formatSpecialStainContactDate(trackingCase.updatedAt),
+  );
+  appendSpecialStainContactLine(
+    lines,
+    "Informe vinculado",
+    buildSpecialStainReportSummary(session),
+  );
+
+  lines.push("", "Por favor, indíquenme cómo continuar.");
+  return lines.join("\n");
+}
+
+function buildSpecialStainWhatsAppHref(
+  trackingCase: AdminStudyTrackingCaseSummary,
+  session: ParticularSession,
+) {
+  const message = buildSpecialStainContactMessage(trackingCase, session);
+  return `https://wa.me/${SPECIAL_STAIN_WHATSAPP_PHONE}?text=${encodeURIComponent(message)}`;
+}
+
+function buildSpecialStainEmailHref(
+  trackingCase: AdminStudyTrackingCaseSummary,
+  session: ParticularSession,
+) {
+  const message = buildSpecialStainContactMessage(trackingCase, session);
+  return `mailto:${SPECIAL_STAIN_EMAIL_ADDRESS}?subject=${encodeURIComponent(
+    SPECIAL_STAIN_EMAIL_SUBJECT,
+  )}&body=${encodeURIComponent(message)}`;
+}
 
 const accessHighlights = [
   {
@@ -568,7 +700,7 @@ export function ParticularesContent() {
                             </div>
                             <div className="flex flex-col gap-2">
                               <PublicExternalControl
-                                href={SPECIAL_STAIN_WHATSAPP_HREF}
+                                href={buildSpecialStainWhatsAppHref(trackingCase, session)}
                                 target="_blank"
                                 className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
                                 aria-label="Consultar por WhatsApp sobre tinción especial"
@@ -577,7 +709,7 @@ export function ParticularesContent() {
                                 Consultar por WhatsApp
                               </PublicExternalControl>
                               <PublicExternalControl
-                                href={SPECIAL_STAIN_EMAIL_HREF}
+                                href={buildSpecialStainEmailHref(trackingCase, session)}
                                 target="_self"
                                 className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
                                 aria-label="Enviar email a VETNEB sobre tinción especial"
@@ -622,7 +754,7 @@ export function ParticularesContent() {
                             </div>
                             <div className="flex flex-col gap-2 sm:flex-row">
                               <PublicExternalControl
-                                href={SPECIAL_STAIN_WHATSAPP_HREF}
+                                href={buildSpecialStainWhatsAppHref(trackingCase, session)}
                                 target="_blank"
                                 className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
                                 aria-label="Consultar por WhatsApp sobre tinción especial"
@@ -631,7 +763,7 @@ export function ParticularesContent() {
                                 Consultar por WhatsApp
                               </PublicExternalControl>
                               <PublicExternalControl
-                                href={SPECIAL_STAIN_EMAIL_HREF}
+                                href={buildSpecialStainEmailHref(trackingCase, session)}
                                 target="_self"
                                 className="inline-flex items-center justify-center gap-2 rounded-md border border-vetneb-line/90 bg-card/95 px-4 py-2 text-sm font-semibold text-vetneb-navy shadow-sm hover:border-vetneb-teal/45 hover:bg-vetneb-surface-raised"
                                 aria-label="Enviar email a VETNEB sobre tinción especial"

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -13,6 +13,33 @@ function read(relativePath: string): string {
   );
 }
 
+function extractFunctionBlock(source: string, functionName: string): string {
+  const start = source.indexOf(`function ${functionName}`);
+  assert.notEqual(start, -1, `missing function: ${functionName}`);
+
+  const firstBrace = source.indexOf("{", start);
+  assert.notEqual(firstBrace, -1, `missing function body: ${functionName}`);
+
+  let depth = 0;
+  for (let index = firstBrace; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (char === "{") {
+      depth += 1;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+    }
+
+    if (depth === 0) {
+      return source.slice(start, index + 1);
+    }
+  }
+
+  throw new Error(`unterminated function body: ${functionName}`);
+}
+
 test("particulares content keeps refreshSession wired to particular auth me helper", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
 
@@ -75,37 +102,139 @@ test("particulares content muestra enlace WhatsApp y email solo bajo alerta de t
   const source = read(PARTICULARES_CONTENT_PATH);
 
   assert.ok(source.includes("Alerta: Solicitud de tinción especial."));
-  assert.ok(source.includes("https://wa.me/5493534138946"));
-  assert.ok(source.includes("mailto:lab.vetneb@gmail.com"));
+  assert.ok(source.includes("https://wa.me/${SPECIAL_STAIN_WHATSAPP_PHONE}"));
+  assert.ok(source.includes('SPECIAL_STAIN_WHATSAPP_PHONE = "5493534138946"'));
+  assert.ok(source.includes("mailto:${SPECIAL_STAIN_EMAIL_ADDRESS}"));
+  assert.ok(source.includes('SPECIAL_STAIN_EMAIL_ADDRESS = "lab.vetneb@gmail.com"'));
   assert.ok(source.includes("Consultar por WhatsApp"));
   assert.ok(source.includes("Enviar email"));
   assert.ok(source.includes("trackingCase.specialStainRequired"));
-  assert.ok(source.includes("SPECIAL_STAIN_WHATSAPP_HREF"));
-  assert.ok(source.includes("SPECIAL_STAIN_EMAIL_HREF"));
+  assert.ok(source.includes("buildSpecialStainWhatsAppHref(trackingCase, session)"));
+  assert.ok(source.includes("buildSpecialStainEmailHref(trackingCase, session)"));
   assert.ok(source.includes("PublicExternalControl"));
   assert.ok(source.includes('target="_blank"'));
   assert.ok(source.includes('target="_self"'));
   assert.equal(source.includes("/dashboard/admin"), false);
+  assert.equal(source.includes("SPECIAL_STAIN_WHATSAPP_HREF"), false);
+  assert.equal(source.includes("SPECIAL_STAIN_EMAIL_HREF"), false);
+  assert.equal(source.includes("Hola%20VETNEB"), false);
 });
 
-test("particulares content no expone PII en los hrefs de tincion especial", () => {
+test("particulares content arma mensajes de tincion especial con contexto dinamico", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
+  const messageBlock = extractFunctionBlock(
+    source,
+    "buildSpecialStainContactMessage",
+  );
+  const whatsAppBlock = extractFunctionBlock(
+    source,
+    "buildSpecialStainWhatsAppHref",
+  );
+  const emailBlock = extractFunctionBlock(source, "buildSpecialStainEmailHref");
 
-  const waHrefMatch = source.match(/SPECIAL_STAIN_WHATSAPP_HREF\s*=\s*"([^"\n]+)"/);
-  const emailHrefMatch = source.match(/SPECIAL_STAIN_EMAIL_HREF\s*=\s*"([^"\n]+)"/);
+  assert.ok(
+    messageBlock.includes(
+      "Hola VETNEB, consulto por una solicitud de tinción especial.",
+    ),
+  );
+  assert.ok(messageBlock.includes("Datos del caso:"));
+  assert.ok(messageBlock.includes("Por favor, indíquenme cómo continuar."));
 
-  assert.ok(waHrefMatch !== null, "SPECIAL_STAIN_WHATSAPP_HREF debe estar definida");
-  assert.ok(emailHrefMatch !== null, "SPECIAL_STAIN_EMAIL_HREF debe estar definida");
-
-  const waHref = waHrefMatch[1];
-  const emailHref = emailHrefMatch[1];
-
-  const piiKeywords = ["tutorLastName", "petName", "petSpecies", "petBreed", "extractionDate", "shippingDate"];
-  for (const kw of piiKeywords) {
-    assert.equal(waHref.toLowerCase().includes(kw.toLowerCase()), false, `WHATSAPP_HREF no debe contener "${kw}"`);
-    assert.equal(emailHref.toLowerCase().includes(kw.toLowerCase()), false, `EMAIL_HREF no debe contener "${kw}"`);
+  for (const label of [
+    "Token",
+    "Caso",
+    "ReportId",
+    "Clínica",
+    "Tutor",
+    "Paciente",
+    "Especie",
+    "Raza",
+    "Extracción",
+    "Envío",
+    "Estado",
+    "Actualizado",
+    "Informe vinculado",
+  ]) {
+    assert.ok(
+      messageBlock.includes(`"${label}"`),
+      `mensaje debe incluir la etiqueta ${label}`,
+    );
   }
 
-  assert.ok(waHref.startsWith("https://wa.me/5493534138946"), "WhatsApp href debe apuntar al numero oficial");
-  assert.ok(emailHref.startsWith("mailto:lab.vetneb@gmail.com"), "Email href debe apuntar al correo oficial");
+  for (const field of [
+    "session.tokenLast4",
+    "trackingCase.id",
+    "trackingCase.reportId",
+    "session.reportId",
+    "trackingCase.clinicId",
+    "session.clinicId",
+    "session.tutorLastName",
+    "session.petName",
+    "session.petSpecies",
+    "session.petBreed",
+    "session.extractionDate",
+    "session.shippingDate",
+    "trackingCase.currentStage",
+    "trackingCase.updatedAt",
+    "session.report",
+  ]) {
+    assert.ok(
+      messageBlock.includes(field),
+      `mensaje debe usar el campo disponible ${field}`,
+    );
+  }
+
+  assert.ok(messageBlock.includes("formatSpecialStainContactDate"));
+  assert.ok(messageBlock.includes("getTrackingStageLabel(trackingCase.currentStage)"));
+  assert.ok(whatsAppBlock.includes("encodeURIComponent(message)"));
+  assert.match(
+    emailBlock,
+    /encodeURIComponent\(\s*SPECIAL_STAIN_EMAIL_SUBJECT,\s*\)/,
+  );
+  assert.ok(emailBlock.includes("encodeURIComponent(message)"));
+});
+
+test("particulares content omite datos ausentes y sensibles en mensaje de tincion especial", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+  const valueBlock = extractFunctionBlock(
+    source,
+    "formatSpecialStainContactValue",
+  );
+  const appendBlock = extractFunctionBlock(
+    source,
+    "appendSpecialStainContactLine",
+  );
+  const messageBlock = extractFunctionBlock(
+    source,
+    "buildSpecialStainContactMessage",
+  );
+  const reportBlock = extractFunctionBlock(
+    source,
+    "buildSpecialStainReportSummary",
+  );
+  const contactBlocks = [valueBlock, appendBlock, messageBlock, reportBlock].join(
+    "\n",
+  );
+
+  assert.ok(valueBlock.includes("value === null || value === undefined"));
+  assert.ok(valueBlock.includes("String(value).trim()"));
+  assert.ok(valueBlock.includes("text.length > 0 ? text : null"));
+  assert.ok(appendBlock.includes("if (!formattedValue)"));
+
+  for (const forbidden of [
+    "storagePath",
+    "signedUrl",
+    "previewUrl",
+    "downloadUrl",
+    "cookie",
+    "sessionToken",
+    "authorization",
+    "headers",
+  ]) {
+    assert.equal(
+      contactBlocks.toLowerCase().includes(forbidden.toLowerCase()),
+      false,
+      `mensaje no debe incluir ${forbidden}`,
+    );
+  }
 });


### PR DESCRIPTION
# PR: fix/particulares-special-stain-whatsapp-context

## Resumen

Actualiza los enlaces de contacto por tinción especial del dashboard de particulares para que WhatsApp y email generen un mensaje dinámico con contexto del caso autenticado. El texto visible de los botones y el diseño mobile/desktop se mantienen.

## Problema

El enlace de WhatsApp usaba un mensaje genérico hardcodeado:

```text
Hola VETNEB, consulto por una solicitud de tinción especial de mi caso.
```

Ese mensaje no incluía datos suficientes para que administración identifique el caso sin pedir información adicional.

## Implementación

- Se reemplazaron los hrefs hardcodeados por helpers dinámicos:
  - `buildSpecialStainContactMessage(trackingCase, session)`
  - `buildSpecialStainWhatsAppHref(trackingCase, session)`
  - `buildSpecialStainEmailHref(trackingCase, session)`
- WhatsApp construye `https://wa.me/5493534138946?text=${encodeURIComponent(message)}`.
- Email mantiene el subject `Consulta tinción especial` y usa el mismo contexto en `body` con `encodeURIComponent`.
- Los campos vacíos, `null` o `undefined` se omiten antes de armar cada línea.
- Se reutilizan `formatDate` y `getTrackingStageLabel` para fechas y estado.

## Datos incluidos

- Token disponible como terminación `tokenLast4`.
- ID de caso de seguimiento.
- `ReportId` disponible desde tracking, sesión o informe vinculado.
- Clínica como ID visible disponible en frontend.
- Tutor.
- Paciente.
- Especie.
- Raza.
- Fecha de extracción.
- Fecha de envío.
- Estado actual del estudio.
- Fecha de actualización.
- Informe vinculado como ID y tipo de estudio, sin rutas ni URLs.

## Datos excluidos por seguridad

- Cookies.
- Session tokens.
- Headers.
- `Authorization`.
- `storagePath`.
- `signedUrl`.
- `previewUrl`.
- `downloadUrl`.
- Rutas internas privadas.
- Secretos.

## Archivos tocados

| Archivo | Cambio |
|---|---|
| `frontend/src/components/public/ParticularesContent.tsx` | Helpers dinámicos y hrefs de WhatsApp/email con contexto del caso |
| `test/frontend-particulares-content.test.ts` | Contratos actualizados para helpers, contexto dinámico, encoding y exclusiones sensibles |
| `docs/pr-history/PR-fix-particulares-special-stain-whatsapp-context.md` | Documento de entrega |

## Tests y comandos

| Comando | Resultado |
|---|---|
| `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particulares-content.test.ts` | PASS, 8/8 |
| `pnpm --dir frontend lint` | PASS |
| `pnpm --dir frontend typecheck` | PASS |
| `pnpm typecheck` | PASS |
| `pnpm typecheck:test` | PASS |
| `pnpm test` | PASS, 2242/2242 |
| `pnpm build` | PASS |
| `pnpm security:public-surface` | PASS |

Nota: no se ejecutó `pnpm --dir frontend build` por la restricción explícita sobre posible red de Google Fonts. El auditor `security:public-surface` pasó sobre fuentes y avisó que `.next` no estaba disponible para auditar assets compilados.

## Riesgos

- La clínica se identifica por ID porque el nombre de clínica no está disponible en el payload frontend actual.
- El token se informa solo como terminación `tokenLast4`; si administración requiere el token completo, debería exponerse explícitamente en un payload seguro del backend antes de usarlo.
- El mensaje de contacto depende de que `trackingCase` y `session` estén cargados, que es la misma condición en la que se renderiza la alerta.

## Rollback

Revertir los cambios en:

- `frontend/src/components/public/ParticularesContent.tsx`
- `test/frontend-particulares-content.test.ts`
- `docs/pr-history/PR-fix-particulares-special-stain-whatsapp-context.md`

No hay migraciones, cambios de base de datos ni cambios de backend asociados.

## Estado final

- Sin cambios de backend.
- Sin cambios de API.
- Sin cambios de auth/cookies/sesiones.
- Sin cambios de storage.
- Sin cambios en preview/download ni signed URLs.
- Sin cambios de notificaciones.
- Sin `git add`, commit, push, PR ni merge.
