### PR TITLE
feat(professionals): derive bank eligibility from delivered histopathology

### DIFF
--- a/docs/pr-history/PR-feat-professional-bank-eligibility.md
+++ b/docs/pr-history/PR-feat-professional-bank-eligibility.md
@@ -1,0 +1,141 @@
+# PR feat/professional-bank-eligibility
+
+## Resumen
+
+Se implemento la elegibilidad derivada para el Banco de Profesionales sobre la
+superficie publica existente de profesionales (`/api/public/professionals`).
+La regla ya no usa fecha de carga informativa, fecha de creacion del caso ni
+texto del perfil publico: el filtro deriva de entregas/admin report events
+existentes y se evalua dinamicamente en cada consulta.
+
+## Regla de negocio implementada
+
+Una clinica/profesional aparece en el banco publico solo si:
+
+- tiene perfil publico elegible segun los controles ya existentes;
+- tiene al menos un informe de histopatologia entregado por administracion;
+- la ultima entrega admin de histopatologia esta dentro de una ventana rolling
+  de 3 meses desde `NOW()`.
+
+La condicion efectiva es:
+
+```sql
+lastHistopathologyReportDeliveredAt >= NOW() - INTERVAL '3 months'
+```
+
+## Fuente de verdad para entrega de informe
+
+Fuente primaria:
+
+- `report_status_history.created_at`, filtrado por eventos con
+  `changed_by_admin_user_id IS NOT NULL` y `to_status IN ('uploaded', 'delivered')`.
+
+Fallback de compatibilidad:
+
+- `reports.status_changed_at`, solo cuando `status_changed_by_admin_user_id IS NOT NULL`
+  y `current_status IN ('uploaded', 'delivered')`.
+
+Justificacion: en este repo, la carga admin de informes es la entrega final al
+cliente. El flujo de admin upload persiste `createdByAdminUserId`, escribe
+historial de estado en la misma transaccion y dispara el flujo
+`report_delivered`/tracking entregado cuando corresponde.
+
+No se usa `reports.upload_date`, `reports.created_at`, fecha de caso de
+seguimiento, texto de especialidad publica ni estado manual de perfil.
+
+## Definicion de estudio histopatologico
+
+La definicion usa el catalogo canonico existente en
+`server/lib/report-study-types.ts`:
+
+- `histopatologia`
+
+Se agrego `isHistopathologyReport(report)` para mantener la regla testeable y
+evitar inferencias por texto libre como `ILIKE '%histopat%'`.
+
+## Aprobacion inmediata
+
+La aprobacion inmediata se logra por derivacion:
+
+- `adminReportsNativeRoutes` ya llama `upsertReport` con `createdByAdminUserId`.
+- `upsertReport` inserta el evento de estado inicial con atribucion admin.
+- La consulta publica vuelve a evaluar el SQL contra ese dato en la siguiente
+  lectura.
+
+No se agrego booleano persistido ni estado duplicado.
+
+## Salida automatica a los 3 meses
+
+La salida automatica se resuelve dinamicamente con SQL:
+
+```sql
+>= NOW() - INTERVAL '3 months'
+```
+
+No se agrego cron, job ni campo booleano que pueda quedar stale.
+
+## Archivos tocados
+
+- `server/db-public-professionals.ts`
+- `server/lib/professional-bank-eligibility.ts`
+- `test/professional-bank-eligibility.test.ts`
+- `test/public-professionals-db-contract.test.ts`
+- `test/public-professionals-histopathology-eligibility.test.ts`
+- `test/public-professionals-histopathology-sql-drift.test.ts`
+- `docs/pr-history/PR-feat-professional-bank-eligibility.md`
+
+## Tests y comandos
+
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/professional-bank-eligibility.test.ts test/public-professionals-histopathology-eligibility.test.ts test/public-professionals-histopathology-sql-drift.test.ts test/public-professionals-db-contract.test.ts`
+- `pnpm.cmd typecheck`
+- `pnpm.cmd typecheck:test`
+- `pnpm.cmd --dir frontend lint`
+- `pnpm.cmd --dir frontend typecheck`
+- `pnpm.cmd test`
+- `pnpm.cmd build`
+- `pnpm.cmd security:public-surface`
+
+Nota operativa: PowerShell bloqueo `pnpm.ps1` por ExecutionPolicy, por eso se
+uso `pnpm.cmd`.
+
+## Resultados
+
+- Targeted eligibility/SQL tests: 19/19 pass.
+- Backend typecheck: pass.
+- Test typecheck: pass.
+- Frontend lint: pass.
+- Frontend typecheck: pass.
+- Full backend test suite: 2250/2250 pass.
+- Root backend build: pass.
+- Public surface audit: pass.
+
+`pnpm --dir frontend build` no se ejecuto, respetando la instruccion de no
+ejecutarlo si puede pedir red por Google Fonts. El audit de superficie publica
+dejo la nota esperada de que no existen assets `.next` construidos.
+
+## Riesgos
+
+- Informes historicos sin atribucion admin en `report_status_history` o
+  `reports.status_changed_by_admin_user_id` no habilitan el banco. Esto es
+  intencional para no inventar entregas.
+- Si en el futuro "uploaded" deja de significar entrega final por administracion,
+  habra que separar una marca explicita de entrega antes de cambiar esta regla.
+- No se agregaron indices por instruccion de no tocar schema/migraciones.
+
+## Rollback
+
+Revertir los archivos listados arriba. No hay migracion ni cambio de schema que
+deshacer.
+
+## Estado final
+
+Implementado y validado. Elegibilidad derivada, sin cron/job, sin booleano
+persistido y sin migracion.
+
+## Superficies no tocadas
+
+Confirmado: no se tocaron auth, cookies, sesiones, CSRF/trusted-origin, CORS,
+CSP, signed URLs, `storagePath`, WebAuthn/passkeys, mobile fixes, notificaciones
+generales ni WhatsApp de tincion especial.
+
+No hubo migracion. La elegibilidad es derivada desde datos existentes.

--- a/server/db-public-professionals.ts
+++ b/server/db-public-professionals.ts
@@ -8,32 +8,40 @@ import {
   type Clinic,
   type ClinicPublicProfile,
 } from "../drizzle/schema.ts";
+import {
+  HISTOPATHOLOGY_REPORT_STUDY_TYPE,
+  PROFESSIONAL_BANK_ELIGIBILITY_MONTHS,
+} from "./lib/professional-bank-eligibility.ts";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
 export const MIN_PUBLIC_PROFILE_QUALITY_SCORE = 75;
 
-const RECENT_HISTOPATHOLOGY_REPORTS_SQL = `EXISTS (
-  SELECT 1
-  FROM reports recent_histopathology_reports
-  WHERE recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id
-    AND immutable_unaccent(COALESCE(recent_histopathology_reports.study_type, '')) ILIKE '%histopat%'
-    AND COALESCE(
-      recent_histopathology_reports.upload_date,
-      recent_histopathology_reports.created_at
-    ) >= NOW() - INTERVAL '3 months'
+const LAST_HISTOPATHOLOGY_REPORT_DELIVERED_AT_SQL = `(
+  SELECT MAX(professional_bank_delivery_events.delivered_at)
+  FROM (
+    SELECT report_delivery_history.created_at AS delivered_at
+    FROM report_status_history report_delivery_history
+    INNER JOIN reports professional_bank_reports
+      ON professional_bank_reports.id = report_delivery_history.report_id
+    WHERE professional_bank_reports.clinic_id = clinic_public_search.clinic_id
+      AND professional_bank_reports.study_type = '${HISTOPATHOLOGY_REPORT_STUDY_TYPE}'
+      AND report_delivery_history.changed_by_admin_user_id IS NOT NULL
+      AND report_delivery_history.to_status IN ('uploaded', 'delivered')
+    UNION ALL
+    SELECT professional_bank_reports.status_changed_at AS delivered_at
+    FROM reports professional_bank_reports
+    WHERE professional_bank_reports.clinic_id = clinic_public_search.clinic_id
+      AND professional_bank_reports.study_type = '${HISTOPATHOLOGY_REPORT_STUDY_TYPE}'
+      AND professional_bank_reports.status_changed_by_admin_user_id IS NOT NULL
+      AND professional_bank_reports.current_status IN ('uploaded', 'delivered')
+  ) professional_bank_delivery_events
 )`;
 
-const RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL = sql`EXISTS (
-  SELECT 1
-  FROM reports recent_histopathology_reports
-  WHERE recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id
-    AND immutable_unaccent(COALESCE(recent_histopathology_reports.study_type, '')) ILIKE '%histopat%'
-    AND COALESCE(
-      recent_histopathology_reports.upload_date,
-      recent_histopathology_reports.created_at
-    ) >= NOW() - INTERVAL '3 months'
-)`;
+const PROFESSIONAL_BANK_ELIGIBILITY_SQL = `${LAST_HISTOPATHOLOGY_REPORT_DELIVERED_AT_SQL} >= NOW() - INTERVAL '${PROFESSIONAL_BANK_ELIGIBILITY_MONTHS} months'`;
+const PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL = sql.raw(
+  PROFESSIONAL_BANK_ELIGIBILITY_SQL,
+);
 export type UpsertClinicPublicProfileInput = {
   displayName?: string | null;
   avatarStoragePath?: string | null;
@@ -509,7 +517,7 @@ export async function getPublicProfessionalByClinicId(clinicId: number) {
         eq(clinicPublicSearch.clinicId, clinicId),
         eq(clinicPublicSearch.isPublic, true),
         eq(clinicPublicSearch.isSearchEligible, true),
-        RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL,
+        PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL,
       ),
     )
     .limit(1);
@@ -557,7 +565,7 @@ export async function searchPublicProfessionals(
   const conditions = [
     "is_public = true",
     "is_search_eligible = true",
-    RECENT_HISTOPATHOLOGY_REPORTS_SQL,
+    PROFESSIONAL_BANK_ELIGIBILITY_SQL,
   ];
 
   let queryIndex: number | null = null;

--- a/server/lib/professional-bank-eligibility.ts
+++ b/server/lib/professional-bank-eligibility.ts
@@ -1,0 +1,124 @@
+import { isReportStudyType, type ReportStudyType } from "./report-study-types.ts";
+
+export const PROFESSIONAL_BANK_ELIGIBILITY_MONTHS = 3;
+export const HISTOPATHOLOGY_REPORT_STUDY_TYPE =
+  "histopatologia" satisfies ReportStudyType;
+
+export type ProfessionalBankReportDeliveryCandidate = {
+  studyType?: string | null;
+  deliveredAt?: Date | string | number | null;
+  deliveredByAdmin?: boolean | null;
+};
+
+export function isHistopathologyReport(input: {
+  studyType?: string | null;
+}): boolean {
+  return (
+    isReportStudyType(input.studyType) &&
+    input.studyType === HISTOPATHOLOGY_REPORT_STUDY_TYPE
+  );
+}
+
+function normalizeDate(value: Date | string | number | null | undefined): Date | null {
+  if (value == null) {
+    return null;
+  }
+
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getDaysInUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+export function addMonths(date: Date, months: number): Date {
+  const resultMonth = date.getUTCMonth() + months;
+  const resultYear = date.getUTCFullYear() + Math.floor(resultMonth / 12);
+  const normalizedMonth = ((resultMonth % 12) + 12) % 12;
+  const day = Math.min(
+    date.getUTCDate(),
+    getDaysInUtcMonth(resultYear, normalizedMonth),
+  );
+
+  return new Date(
+    Date.UTC(
+      resultYear,
+      normalizedMonth,
+      day,
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ),
+  );
+}
+
+export function getProfessionalBankEligibilityWindow(now: Date) {
+  return {
+    now,
+    deliveredFrom: addMonths(now, -PROFESSIONAL_BANK_ELIGIBILITY_MONTHS),
+  };
+}
+
+export function getEligibleUntil(lastDeliveredAt: Date): Date {
+  return addMonths(lastDeliveredAt, PROFESSIONAL_BANK_ELIGIBILITY_MONTHS);
+}
+
+export function isProfessionalBankEligible(
+  lastDeliveredAt: Date | string | number | null | undefined,
+  now: Date,
+): boolean {
+  const deliveredAt = normalizeDate(lastDeliveredAt);
+
+  if (!deliveredAt) {
+    return false;
+  }
+
+  const { deliveredFrom } = getProfessionalBankEligibilityWindow(now);
+  return deliveredAt.getTime() >= deliveredFrom.getTime();
+}
+
+export function getLastHistopathologyReportDeliveredAt(
+  reports: readonly ProfessionalBankReportDeliveryCandidate[],
+): Date | null {
+  let latest: Date | null = null;
+
+  for (const report of reports) {
+    if (!report.deliveredByAdmin || !isHistopathologyReport(report)) {
+      continue;
+    }
+
+    const deliveredAt = normalizeDate(report.deliveredAt);
+
+    if (!deliveredAt) {
+      continue;
+    }
+
+    if (!latest || deliveredAt.getTime() > latest.getTime()) {
+      latest = deliveredAt;
+    }
+  }
+
+  return latest;
+}
+
+export function getProfessionalBankEligibility(
+  reports: readonly ProfessionalBankReportDeliveryCandidate[],
+  now: Date,
+) {
+  const lastHistopathologyReportDeliveredAt =
+    getLastHistopathologyReportDeliveredAt(reports);
+  const eligible = isProfessionalBankEligible(
+    lastHistopathologyReportDeliveredAt,
+    now,
+  );
+
+  return {
+    eligible,
+    lastHistopathologyReportDeliveredAt,
+    eligibleUntil: lastHistopathologyReportDeliveredAt
+      ? getEligibleUntil(lastHistopathologyReportDeliveredAt)
+      : null,
+  };
+}

--- a/test/professional-bank-eligibility.test.ts
+++ b/test/professional-bank-eligibility.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  addMonths,
+  getEligibleUntil,
+  getLastHistopathologyReportDeliveredAt,
+  getProfessionalBankEligibility,
+  getProfessionalBankEligibilityWindow,
+  isHistopathologyReport,
+  isProfessionalBankEligible,
+} from "../server/lib/professional-bank-eligibility.ts";
+
+const NOW = new Date("2026-06-03T12:00:00.000Z");
+
+test("professional bank eligibility uses a rolling 3 month UTC window", () => {
+  const window = getProfessionalBankEligibilityWindow(NOW);
+
+  assert.equal(window.now.toISOString(), "2026-06-03T12:00:00.000Z");
+  assert.equal(window.deliveredFrom.toISOString(), "2026-03-03T12:00:00.000Z");
+  assert.equal(
+    getEligibleUntil(new Date("2026-04-10T09:30:00.000Z")).toISOString(),
+    "2026-07-10T09:30:00.000Z",
+  );
+});
+
+test("professional bank eligibility includes reports delivered today and inside 3 months", () => {
+  assert.equal(isProfessionalBankEligible(NOW, NOW), true);
+  assert.equal(
+    isProfessionalBankEligible("2026-04-01T08:00:00.000Z", NOW),
+    true,
+  );
+  assert.equal(
+    isProfessionalBankEligible("2026-03-03T12:00:00.000Z", NOW),
+    true,
+  );
+});
+
+test("professional bank eligibility rejects missing, invalid, and expired deliveries", () => {
+  assert.equal(isProfessionalBankEligible(null, NOW), false);
+  assert.equal(isProfessionalBankEligible("not-a-date", NOW), false);
+  assert.equal(
+    isProfessionalBankEligible("2026-03-03T11:59:59.999Z", NOW),
+    false,
+  );
+});
+
+test("professional bank eligibility keeps month-end arithmetic stable", () => {
+  assert.equal(
+    addMonths(new Date("2026-01-31T10:00:00.000Z"), 3).toISOString(),
+    "2026-04-30T10:00:00.000Z",
+  );
+});
+
+test("histopathology definition uses the report study type catalog", () => {
+  assert.equal(isHistopathologyReport({ studyType: "histopatologia" }), true);
+  assert.equal(isHistopathologyReport({ studyType: "citologia" }), false);
+  assert.equal(isHistopathologyReport({ studyType: "Histopatologia" }), false);
+  assert.equal(isHistopathologyReport({ studyType: null }), false);
+});
+
+test("last histopathology delivery ignores non-admin, non-histopathology, and invalid rows", () => {
+  const lastDeliveredAt = getLastHistopathologyReportDeliveredAt([
+    {
+      studyType: "histopatologia",
+      deliveredAt: "2026-04-01T08:00:00.000Z",
+      deliveredByAdmin: false,
+    },
+    {
+      studyType: "citologia",
+      deliveredAt: "2026-05-20T08:00:00.000Z",
+      deliveredByAdmin: true,
+    },
+    {
+      studyType: "histopatologia",
+      deliveredAt: "not-a-date",
+      deliveredByAdmin: true,
+    },
+    {
+      studyType: "histopatologia",
+      deliveredAt: "2026-05-15T08:00:00.000Z",
+      deliveredByAdmin: true,
+    },
+  ]);
+
+  assert.equal(lastDeliveredAt?.toISOString(), "2026-05-15T08:00:00.000Z");
+});
+
+test("professional bank eligibility uses the latest admin histopathology delivery", () => {
+  const expiredOnly = getProfessionalBankEligibility(
+    [
+      {
+        studyType: "histopatologia",
+        deliveredAt: "2026-02-15T12:00:00.000Z",
+        deliveredByAdmin: true,
+      },
+      {
+        studyType: "citologia",
+        deliveredAt: "2026-06-01T12:00:00.000Z",
+        deliveredByAdmin: true,
+      },
+    ],
+    NOW,
+  );
+
+  assert.equal(expiredOnly.eligible, false);
+  assert.equal(
+    expiredOnly.lastHistopathologyReportDeliveredAt?.toISOString(),
+    "2026-02-15T12:00:00.000Z",
+  );
+
+  const refreshed = getProfessionalBankEligibility(
+    [
+      {
+        studyType: "histopatologia",
+        deliveredAt: "2026-02-15T12:00:00.000Z",
+        deliveredByAdmin: true,
+      },
+      {
+        studyType: "histopatologia",
+        deliveredAt: "2026-06-03T12:00:00.000Z",
+        deliveredByAdmin: true,
+      },
+    ],
+    NOW,
+  );
+
+  assert.equal(refreshed.eligible, true);
+  assert.equal(
+    refreshed.lastHistopathologyReportDeliveredAt?.toISOString(),
+    "2026-06-03T12:00:00.000Z",
+  );
+  assert.equal(
+    refreshed.eligibleUntil?.toISOString(),
+    "2026-09-03T12:00:00.000Z",
+  );
+});
+
+test("professional bank eligibility expires automatically without manual state", () => {
+  const delivery = new Date("2026-03-03T12:00:00.000Z");
+
+  assert.equal(
+    isProfessionalBankEligible(delivery, new Date("2026-06-03T12:00:00.000Z")),
+    true,
+  );
+  assert.equal(
+    isProfessionalBankEligible(delivery, new Date("2026-06-03T12:00:00.001Z")),
+    false,
+  );
+});

--- a/test/public-professionals-db-contract.test.ts
+++ b/test/public-professionals-db-contract.test.ts
@@ -17,17 +17,18 @@ function assertContains(source: string, expected: string): void {
 test("public professionals search requires recent histopathology activity", () => {
   const source = readDbPublicProfessionalsSource();
 
-  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORTS_SQL");
-  assertContains(source, "FROM reports recent_histopathology_reports");
+  assertContains(source, "PROFESSIONAL_BANK_ELIGIBILITY_SQL");
+  assertContains(source, "LAST_HISTOPATHOLOGY_REPORT_DELIVERED_AT_SQL");
+  assertContains(source, "FROM report_status_history report_delivery_history");
+  assertContains(source, "INNER JOIN reports professional_bank_reports");
   assertContains(
     source,
-    "recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id",
+    "professional_bank_reports.clinic_id = clinic_public_search.clinic_id",
   );
-  assertContains(source, "recent_histopathology_reports.study_type");
-  assertContains(source, "ILIKE '%histopat%'");
-  assertContains(source, "recent_histopathology_reports.upload_date");
-  assertContains(source, "recent_histopathology_reports.created_at");
-  assertContains(source, "NOW() - INTERVAL '3 months'");
+  assertContains(source, "HISTOPATHOLOGY_REPORT_STUDY_TYPE");
+  assertContains(source, "changed_by_admin_user_id IS NOT NULL");
+  assertContains(source, "status_changed_at AS delivered_at");
+  assertContains(source, "PROFESSIONAL_BANK_ELIGIBILITY_MONTHS");
 });
 
 test("public professionals search keeps public profile eligibility filters", () => {
@@ -35,15 +36,15 @@ test("public professionals search keeps public profile eligibility filters", () 
 
   assertContains(source, '"is_public = true"');
   assertContains(source, '"is_search_eligible = true"');
-  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORTS_SQL,");
+  assertContains(source, "PROFESSIONAL_BANK_ELIGIBILITY_SQL,");
 });
 
 test("public professional detail lookup shares the recent histopathology gate", () => {
   const source = readDbPublicProfessionalsSource();
 
-  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL");
+  assertContains(source, "PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL");
   assertContains(
     source,
-    "RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL,\n      ),",
+    "PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL,\n      ),",
   );
 });

--- a/test/public-professionals-histopathology-eligibility.test.ts
+++ b/test/public-professionals-histopathology-eligibility.test.ts
@@ -18,36 +18,87 @@ function countOccurrences(source: string, needle: string): number {
   return source.split(needle).length - 1;
 }
 
-test("histopathology public-search gate is based on reports activity only", () => {
-  const source = readSource();
+function extractTemplateConstant(source: string, constantName: string): string {
+  const assignmentStart = source.indexOf(`const ${constantName} =`);
 
-  assertContains(source, "FROM reports recent_histopathology_reports");
-  assertContains(
-    source,
-    "recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id",
+  assert.notEqual(
+    assignmentStart,
+    -1,
+    `${constantName}: falta la constante esperada`,
   );
-  assertContains(source, "recent_histopathology_reports.study_type");
-  assertContains(source, "ILIKE '%histopat%'");
+
+  const templateStart = source.indexOf("`", assignmentStart);
+
+  assert.notEqual(
+    templateStart,
+    -1,
+    `${constantName}: falta el inicio del template literal`,
+  );
+
+  const templateEnd = source.indexOf("`;", templateStart + 1);
+
+  assert.notEqual(
+    templateEnd,
+    -1,
+    `${constantName}: falta el cierre del template literal`,
+  );
+
+  return source.slice(templateStart + 1, templateEnd).trim();
+}
+
+test("histopathology public-search gate is based on admin report delivery", () => {
+  const source = readSource();
+  const deliverySql = extractTemplateConstant(
+    source,
+    "LAST_HISTOPATHOLOGY_REPORT_DELIVERED_AT_SQL",
+  );
+
+  assertContains(deliverySql, "FROM report_status_history report_delivery_history");
+  assertContains(deliverySql, "INNER JOIN reports professional_bank_reports");
+  assertContains(
+    deliverySql,
+    "professional_bank_reports.clinic_id = clinic_public_search.clinic_id",
+  );
+  assertContains(
+    deliverySql,
+    "professional_bank_reports.study_type = '${HISTOPATHOLOGY_REPORT_STUDY_TYPE}'",
+  );
+  assertContains(
+    deliverySql,
+    "report_delivery_history.changed_by_admin_user_id IS NOT NULL",
+  );
+  assertContains(
+    deliverySql,
+    "professional_bank_reports.status_changed_by_admin_user_id IS NOT NULL",
+  );
 
   assert.equal(
-    countOccurrences(source, "recent_histopathology_reports.study_type"),
+    countOccurrences(deliverySql, "professional_bank_reports.study_type"),
     2,
-    "search and detail gates must both depend on report study_type",
+    "history and compatibility fallback must both depend on report study_type",
   );
 });
 
-test("histopathology public-search gate uses the required 3 month activity window", () => {
+test("histopathology public-search gate uses the required 3 month delivery window", () => {
   const source = readSource();
+  const eligibilitySql = extractTemplateConstant(
+    source,
+    "PROFESSIONAL_BANK_ELIGIBILITY_SQL",
+  );
 
-  assertContains(source, "COALESCE(");
-  assertContains(source, "recent_histopathology_reports.upload_date");
-  assertContains(source, "recent_histopathology_reports.created_at");
-  assertContains(source, "NOW() - INTERVAL '3 months'");
+  assertContains(
+    eligibilitySql,
+    "LAST_HISTOPATHOLOGY_REPORT_DELIVERED_AT_SQL",
+  );
+  assertContains(
+    eligibilitySql,
+    "NOW() - INTERVAL '${PROFESSIONAL_BANK_ELIGIBILITY_MONTHS} months'",
+  );
 
   assert.equal(
-    countOccurrences(source, "NOW() - INTERVAL '3 months'"),
-    2,
-    "search and detail gates must both use the same 3 month window",
+    countOccurrences(source, "NOW() - INTERVAL"),
+    1,
+    "search and detail gates must share the same derived 3 month expression",
   );
 });
 
@@ -58,7 +109,7 @@ test("search result query and count query share the histopathology eligibility W
     source,
     'const whereSql = `WHERE ${conditions.join(" AND ")}`;',
   );
-  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORTS_SQL,");
+  assertContains(source, "PROFESSIONAL_BANK_ELIGIBILITY_SQL,");
   assertContains(source, "FROM clinic_public_search\n      ${whereSql}");
   assertContains(
     source,
@@ -69,9 +120,10 @@ test("search result query and count query share the histopathology eligibility W
 test("public detail lookup uses the Drizzle histopathology gate", () => {
   const source = readSource();
 
-  assertContains(source, "RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL");
+  assertContains(source, "PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL");
+  assertContains(source, "sql.raw(\n  PROFESSIONAL_BANK_ELIGIBILITY_SQL,");
   assertContains(
     source,
-    "eq(clinicPublicSearch.isSearchEligible, true),\n        RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL,",
+    "eq(clinicPublicSearch.isSearchEligible, true),\n        PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL,",
   );
 });

--- a/test/public-professionals-histopathology-sql-drift.test.ts
+++ b/test/public-professionals-histopathology-sql-drift.test.ts
@@ -47,54 +47,67 @@ function countOccurrences(source: string, needle: string): number {
 }
 
 function getRawGate(source: string): string {
-  return extractTemplateConstant(source, "RECENT_HISTOPATHOLOGY_REPORTS_SQL");
-}
-
-function getDrizzleGate(source: string): string {
   return extractTemplateConstant(
     source,
-    "RECENT_HISTOPATHOLOGY_REPORT_DRIZZLE_SQL",
+    "LAST_HISTOPATHOLOGY_REPORT_DELIVERED_AT_SQL",
+  );
+}
+
+function getEligibilityGate(source: string): string {
+  return extractTemplateConstant(
+    source,
+    "PROFESSIONAL_BANK_ELIGIBILITY_SQL",
   );
 }
 
 test("raw SQL and Drizzle histopathology gates stay equivalent", () => {
   const source = readSource();
-  const rawGate = normalizeSql(getRawGate(source));
-  const drizzleGate = normalizeSql(getDrizzleGate(source));
 
-  assert.equal(
-    rawGate,
-    drizzleGate,
-    "el gate SQL raw y el gate Drizzle no deben divergir",
+  assert.ok(
+    source.includes(
+      "const PROFESSIONAL_BANK_ELIGIBILITY_DRIZZLE_SQL = sql.raw(\n  PROFESSIONAL_BANK_ELIGIBILITY_SQL,",
+    ),
+    "el gate Drizzle debe reutilizar exactamente el SQL raw",
   );
 });
 
-test("histopathology eligibility gate depends only on reports activity", () => {
+test("histopathology eligibility gate depends on admin delivery events", () => {
   const source = readSource();
   const rawGate = getRawGate(source);
 
   assert.equal(
-    countOccurrences(rawGate, "FROM reports recent_histopathology_reports"),
+    countOccurrences(rawGate, "FROM report_status_history report_delivery_history"),
     1,
-    "el gate debe consultar exclusivamente reports como fuente de actividad",
+    "el gate debe consultar historial de estados como fuente primaria",
+  );
+
+  assert.equal(
+    countOccurrences(rawGate, "INNER JOIN reports professional_bank_reports"),
+    1,
+    "el historial debe unirse a reports para clinic_id y study_type",
+  );
+
+  assert.equal(
+    countOccurrences(rawGate, "FROM reports professional_bank_reports"),
+    1,
+    "el gate debe mantener fallback de compatibilidad en reports",
   );
 
   assert.equal(
     countOccurrences(rawGate, "clinic_public_search."),
-    1,
+    2,
     "el gate solo debe referenciar clinic_public_search para correlacionar clinic_id",
   );
 
   assert.ok(
     rawGate.includes(
-      "recent_histopathology_reports.clinic_id = clinic_public_search.clinic_id",
+      "professional_bank_reports.clinic_id = clinic_public_search.clinic_id",
     ),
-    "el gate debe correlacionar reports con clinic_public_search por clinic_id",
+    "el gate debe correlacionar reportes con clinic_public_search por clinic_id",
   );
 
   for (const forbiddenToken of [
     "clinic_public_profiles",
-    "report_status_history",
     "study_tracking",
     "clinic_public_search.specialty_text",
     "clinic_public_search.services_text",
@@ -115,40 +128,66 @@ test("histopathology eligibility gate uses report study_type only", () => {
   const normalizedGate = normalizeSql(rawGate);
 
   assert.equal(
-    countOccurrences(rawGate, "recent_histopathology_reports.study_type"),
-    1,
-    "el gate debe evaluar study_type una sola vez",
+    countOccurrences(rawGate, "professional_bank_reports.study_type"),
+    2,
+    "el gate debe evaluar study_type en historial y fallback",
   );
 
   assert.ok(
     normalizedGate.includes(
-      "immutable_unaccent(COALESCE(recent_histopathology_reports.study_type, '')) ILIKE '%histopat%'",
+      "professional_bank_reports.study_type = '${HISTOPATHOLOGY_REPORT_STUDY_TYPE}'",
     ),
-    "el gate debe usar study_type normalizado para detectar histopatología",
+    "el gate debe usar el tipo de estudio histopatologico del catalogo",
   );
 
   assert.ok(
-    !rawGate.includes("specialty_text"),
-    "el texto de especialidad pública no debe habilitar aparición",
+    !rawGate.includes("ILIKE '%histopat%'"),
+    "el gate no debe inferir histopatologia con busquedas de texto libre",
   );
 });
 
-test("histopathology eligibility gate uses only upload/create report timestamps", () => {
+test("histopathology eligibility gate uses only admin delivery timestamps", () => {
   const source = readSource();
   const rawGate = getRawGate(source);
+  const eligibilityGate = getEligibilityGate(source);
   const normalizedGate = normalizeSql(rawGate);
 
   assert.ok(
+    normalizedGate.includes("report_delivery_history.created_at AS delivered_at"),
+    "el historial de estados debe aportar la fecha de entrega admin",
+  );
+
+  assert.ok(
+    normalizedGate.includes("professional_bank_reports.status_changed_at AS delivered_at"),
+    "reports.status_changed_at queda como fallback de compatibilidad",
+  );
+
+  assert.ok(
     normalizedGate.includes(
-      "COALESCE( recent_histopathology_reports.upload_date, recent_histopathology_reports.created_at ) >= NOW() - INTERVAL '3 months'",
+      "report_delivery_history.changed_by_admin_user_id IS NOT NULL",
     ),
-    "el gate debe usar upload_date/created_at con ventana inclusiva de 3 meses",
+    "el historial debe exigir autor admin",
+  );
+
+  assert.ok(
+    normalizedGate.includes(
+      "professional_bank_reports.status_changed_by_admin_user_id IS NOT NULL",
+    ),
+    "el fallback debe exigir autor admin",
+  );
+
+  assert.ok(
+    normalizeSql(eligibilityGate).includes(
+      "NOW() - INTERVAL '${PROFESSIONAL_BANK_ELIGIBILITY_MONTHS} months'",
+    ),
+    "la ventana debe derivarse del contrato de 3 meses",
   );
 
   for (const forbiddenDateColumn of [
-    "recent_histopathology_reports.updated_at",
-    "recent_histopathology_reports.completed_at",
-    "recent_histopathology_reports.status_changed_at",
+    "professional_bank_reports.upload_date",
+    "professional_bank_reports.created_at",
+    "professional_bank_reports.updated_at",
+    "professional_bank_reports.completed_at",
   ]) {
     assert.ok(
       !rawGate.includes(forbiddenDateColumn),


### PR DESCRIPTION
# PR feat/professional-bank-eligibility

## Resumen

Se implemento la elegibilidad derivada para el Banco de Profesionales sobre la
superficie publica existente de profesionales (`/api/public/professionals`).
La regla ya no usa fecha de carga informativa, fecha de creacion del caso ni
texto del perfil publico: el filtro deriva de entregas/admin report events
existentes y se evalua dinamicamente en cada consulta.

## Regla de negocio implementada

Una clinica/profesional aparece en el banco publico solo si:

- tiene perfil publico elegible segun los controles ya existentes;
- tiene al menos un informe de histopatologia entregado por administracion;
- la ultima entrega admin de histopatologia esta dentro de una ventana rolling
  de 3 meses desde `NOW()`.

La condicion efectiva es:

```sql
lastHistopathologyReportDeliveredAt >= NOW() - INTERVAL '3 months'
```

## Fuente de verdad para entrega de informe

Fuente primaria:

- `report_status_history.created_at`, filtrado por eventos con
  `changed_by_admin_user_id IS NOT NULL` y `to_status IN ('uploaded', 'delivered')`.

Fallback de compatibilidad:

- `reports.status_changed_at`, solo cuando `status_changed_by_admin_user_id IS NOT NULL`
  y `current_status IN ('uploaded', 'delivered')`.

Justificacion: en este repo, la carga admin de informes es la entrega final al
cliente. El flujo de admin upload persiste `createdByAdminUserId`, escribe
historial de estado en la misma transaccion y dispara el flujo
`report_delivered`/tracking entregado cuando corresponde.

No se usa `reports.upload_date`, `reports.created_at`, fecha de caso de
seguimiento, texto de especialidad publica ni estado manual de perfil.

## Definicion de estudio histopatologico

La definicion usa el catalogo canonico existente en
`server/lib/report-study-types.ts`:

- `histopatologia`

Se agrego `isHistopathologyReport(report)` para mantener la regla testeable y
evitar inferencias por texto libre como `ILIKE '%histopat%'`.

## Aprobacion inmediata

La aprobacion inmediata se logra por derivacion:

- `adminReportsNativeRoutes` ya llama `upsertReport` con `createdByAdminUserId`.
- `upsertReport` inserta el evento de estado inicial con atribucion admin.
- La consulta publica vuelve a evaluar el SQL contra ese dato en la siguiente
  lectura.

No se agrego booleano persistido ni estado duplicado.

## Salida automatica a los 3 meses

La salida automatica se resuelve dinamicamente con SQL:

```sql
>= NOW() - INTERVAL '3 months'
```

No se agrego cron, job ni campo booleano que pueda quedar stale.

## Archivos tocados

- `server/db-public-professionals.ts`
- `server/lib/professional-bank-eligibility.ts`
- `test/professional-bank-eligibility.test.ts`
- `test/public-professionals-db-contract.test.ts`
- `test/public-professionals-histopathology-eligibility.test.ts`
- `test/public-professionals-histopathology-sql-drift.test.ts`
- `docs/pr-history/PR-feat-professional-bank-eligibility.md`

## Tests y comandos

- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/professional-bank-eligibility.test.ts test/public-professionals-histopathology-eligibility.test.ts test/public-professionals-histopathology-sql-drift.test.ts test/public-professionals-db-contract.test.ts`
- `pnpm.cmd typecheck`
- `pnpm.cmd typecheck:test`
- `pnpm.cmd --dir frontend lint`
- `pnpm.cmd --dir frontend typecheck`
- `pnpm.cmd test`
- `pnpm.cmd build`
- `pnpm.cmd security:public-surface`

Nota operativa: PowerShell bloqueo `pnpm.ps1` por ExecutionPolicy, por eso se
uso `pnpm.cmd`.

## Resultados

- Targeted eligibility/SQL tests: 19/19 pass.
- Backend typecheck: pass.
- Test typecheck: pass.
- Frontend lint: pass.
- Frontend typecheck: pass.
- Full backend test suite: 2250/2250 pass.
- Root backend build: pass.
- Public surface audit: pass.

`pnpm --dir frontend build` no se ejecuto, respetando la instruccion de no
ejecutarlo si puede pedir red por Google Fonts. El audit de superficie publica
dejo la nota esperada de que no existen assets `.next` construidos.

## Riesgos

- Informes historicos sin atribucion admin en `report_status_history` o
  `reports.status_changed_by_admin_user_id` no habilitan el banco. Esto es
  intencional para no inventar entregas.
- Si en el futuro "uploaded" deja de significar entrega final por administracion,
  habra que separar una marca explicita de entrega antes de cambiar esta regla.
- No se agregaron indices por instruccion de no tocar schema/migraciones.

## Rollback

Revertir los archivos listados arriba. No hay migracion ni cambio de schema que
deshacer.

## Estado final

Implementado y validado. Elegibilidad derivada, sin cron/job, sin booleano
persistido y sin migracion.

## Superficies no tocadas

Confirmado: no se tocaron auth, cookies, sesiones, CSRF/trusted-origin, CORS,
CSP, signed URLs, `storagePath`, WebAuthn/passkeys, mobile fixes, notificaciones
generales ni WhatsApp de tincion especial.

No hubo migracion. La elegibilidad es derivada desde datos existentes.
