### PR TITLE
feat(professionals): add scalable public directory

### DIFF
--- a/docs/implementation/professionals-scalable-directory.md
+++ b/docs/implementation/professionals-scalable-directory.md
@@ -1,0 +1,62 @@
+# Banco de Profesionales publico escalable
+
+## Problema resuelto
+
+La busqueda publica de profesionales mostraba el perfil completo dentro de cada resultado. Esa experiencia no escala para miles de clinicas porque cada item repetia datos de detalle y contacto en el listado.
+
+Este cambio separa el banco publico en dos superficies:
+
+- Listado liviano con cards compactas por perfil.
+- Detalle aislado por `clinicId` en `/profesionales/[clinicId]`.
+
+## Archivos modificados
+
+- `frontend/src/components/public/ProfesionalesSearchContent.tsx`
+- `frontend/src/components/public/ProfesionalDetailContent.tsx`
+- `frontend/src/app/profesionales/[clinicId]/page.tsx`
+- `frontend/src/lib/api.ts`
+- `frontend/src/lib/public-professionals.ts`
+- `test/frontend-profesionales-page-content.test.ts`
+- `test/frontend-native-link-preview-contract.test.ts`
+- `test/frontend-public-page-semantics.test.ts`
+- `test/frontend-public-seo-contract.test.ts`
+- `test/frontend-public-professionals-scalable-directory.test.ts`
+
+## Arquitectura UI/listado/detalle
+
+El listado sigue usando `/api/public/professionals/search` con `limit` y `offset`, pero renderiza solo avatar, nombre, localidad, badge de perfil verificado y un resumen breve de especialidades/servicios. Ya no pinta `aboutText`, email, telefono, direccion ni mapa en cada resultado.
+
+Cada card usa `clinicId` como `key` e identidad de navegacion. La ruta se construye con `buildProfessionalDetailHref(clinicId)` y abre `/profesionales/[clinicId]`.
+
+El detalle usa `getPublicProfessional(parsedClinicId)` contra `/api/public/professionals/:clinicId`. El estado vive dentro de `ProfesionalDetailContent`, se invalida por `clinicId`, y no depende del array del listado ni de estado global compartido.
+
+## Avatar fallback
+
+Si `avatarUrl` existe, se muestra con `next/image` y alt `Logo o avatar de ...`.
+
+Si no existe, se muestra un fallback local estable con icono `BriefcaseMedical`, clase `professional-avatar-fallback` y `aria-hidden="true"`. No se agregaron URLs externas nuevas para el fallback.
+
+## Pruebas agregadas
+
+Se agrego `test/frontend-public-professionals-scalable-directory.test.ts` con cobertura para:
+
+- Listado compacto con nombre, avatar/fallback, localidad, verificacion y resumen.
+- Ausencia de datos completos de contacto/detalle en el listado.
+- Fallback local sin avatar.
+- Navegacion desde card hacia detalle por `clinicId`.
+- Aislamiento con dos clinicas similares y datos exclusivos.
+- Contrato de seguridad UI/API publica contra filtrado de paths privados, tokens, cookies y scripts inline.
+
+Tambien se actualizaron contratos existentes de SEO, semantica publica y links externos para reflejar que email, telefono y mapa viven en el detalle.
+
+## Validaciones ejecutadas
+
+- `pnpm test`: OK, 2256 tests passing.
+- `pnpm build`: OK, backend bundle generado.
+- `pnpm -C frontend build`: OK. El primer intento sin red fallo por descarga de Google Fonts en `next/font`; se reejecuto con permiso de red y paso.
+- `pnpm security:public-surface`: OK, sin public devtools exposure findings. Mantiene dos findings `server-only` existentes en `frontend/src/middleware.ts` para nombres de cookies de sesion.
+
+## Riesgos residuales
+
+- El endpoint de busqueda sigue serializando los campos completos porque ese contrato ya existia; la UI publica ya no los renderiza en el listado. Una optimizacion futura podria agregar un DTO de listado mas chico en backend sin cambiar elegibilidad.
+- El detalle muestra `displayName` como responsable/perfil porque no hay un campo publico separado de responsable en el modelo actual.

--- a/frontend/src/app/profesionales/[clinicId]/page.tsx
+++ b/frontend/src/app/profesionales/[clinicId]/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+
+import { ProfesionalDetailContent } from "@/components/public/ProfesionalDetailContent";
+import { createPageMetadata } from "@/lib/seo";
+
+type ProfesionalesDetailPageProps = {
+  params: Promise<{
+    clinicId: string;
+  }>;
+};
+
+export async function generateMetadata({
+  params,
+}: ProfesionalesDetailPageProps): Promise<Metadata> {
+  const { clinicId } = await params;
+
+  return createPageMetadata(
+    "Perfil profesional veterinario",
+    "Detalle público de profesional o clínica veterinaria vinculada a VETNEB.",
+    `/profesionales/${encodeURIComponent(clinicId)}`,
+  );
+}
+
+export default async function ProfesionalesDetailPage({
+  params,
+}: ProfesionalesDetailPageProps) {
+  const { clinicId } = await params;
+
+  return (
+    <Suspense fallback={null}>
+      <ProfesionalDetailContent clinicId={clinicId} />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/public/ProfesionalDetailContent.tsx
+++ b/frontend/src/components/public/ProfesionalDetailContent.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import {
+  ArrowLeft,
+  BriefcaseMedical,
+  ExternalLink,
+  Mail,
+  MapPin,
+  Phone,
+  ShieldCheck,
+  Stethoscope,
+  UserRound,
+} from "lucide-react";
+
+import { PublicLayout } from "@/components/layout/PublicLayout";
+import {
+  PublicExternalControl,
+  PublicRouteControl,
+} from "@/components/public/PublicRouteControl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  getPublicProfessional,
+  type PublicProfessional,
+} from "@/lib/api";
+import {
+  getPublicProfessionalLocation,
+  isVerifiedPublicProfessional,
+  parsePublicProfessionalClinicId,
+} from "@/lib/public-professionals";
+import { ROUTES } from "@/lib/routes";
+
+type DetailState =
+  | { status: "loading"; professional: null }
+  | { status: "success"; professional: PublicProfessional }
+  | { status: "error"; professional: null };
+
+type ProfesionalDetailContentProps = {
+  clinicId: string;
+};
+
+function buildWhatsAppHref(phone: string) {
+  return `https://wa.me/549${phone.replace(/\D/g, "")}`;
+}
+
+export function ProfesionalDetailContent({
+  clinicId,
+}: ProfesionalDetailContentProps) {
+  const parsedClinicId = parsePublicProfessionalClinicId(clinicId);
+  const [state, setState] = useState<DetailState>({
+    status: "loading",
+    professional: null,
+  });
+
+  useEffect(() => {
+    if (parsedClinicId === null) {
+      setState({ status: "error", professional: null });
+      return;
+    }
+
+    let isCurrent = true;
+
+    setState({ status: "loading", professional: null });
+
+    getPublicProfessional(parsedClinicId, { cache: "no-store" })
+      .then((snapshot) => {
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          status: "success",
+          professional: snapshot.professional,
+        });
+      })
+      .catch(() => {
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({ status: "error", professional: null });
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [parsedClinicId]);
+
+  const professional = state.professional;
+  const location = professional
+    ? getPublicProfessionalLocation(professional)
+    : null;
+  const isVerified = professional
+    ? isVerifiedPublicProfessional(professional)
+    : false;
+
+  return (
+    <PublicLayout>
+      <section
+        className="public-secondary-hero-surface py-12 text-white md:py-16"
+        aria-labelledby="professional-detail-page-title"
+      >
+        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+          <PublicRouteControl
+            href={ROUTES.profesionales}
+            variant="textLink"
+            className="mb-6 text-primary-foreground hover:text-primary-foreground focus-visible:text-primary-foreground"
+            icon={<ArrowLeft className="h-4 w-4" aria-hidden="true" />}
+          >
+            Volver a la búsqueda
+          </PublicRouteControl>
+          <h1
+            id="professional-detail-page-title"
+            className="max-w-4xl text-4xl font-bold md:text-5xl"
+          >
+            Perfil profesional
+          </h1>
+        </div>
+      </section>
+
+      <section className="public-soft-canvas py-12 md:py-16">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-4xl">
+            {state.status === "loading" ? (
+              <div className="clinical-alert-info p-6">
+                Cargando detalle del perfil profesional...
+              </div>
+            ) : null}
+
+            {state.status === "error" ? (
+              <div className="surface-empty p-6">
+                No se pudo cargar el perfil profesional solicitado. Vuelva a la
+                búsqueda e intente nuevamente.
+              </div>
+            ) : null}
+
+            {state.status === "success" && professional ? (
+              <article aria-labelledby="professional-detail-title">
+                <Card className="premium-card overflow-hidden">
+                  <CardHeader className="clinical-muted-band border-b">
+                    <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+                      {professional.avatarUrl ? (
+                        <Image
+                          src={professional.avatarUrl}
+                          alt={`Logo o avatar de ${professional.displayName}`}
+                          width={96}
+                          height={96}
+                          className="h-24 w-24 rounded-2xl border border-vetneb-line/70 object-cover"
+                          priority
+                          unoptimized
+                        />
+                      ) : (
+                        <span
+                          className="professional-avatar-fallback flex h-24 w-24 items-center justify-center rounded-2xl border border-vetneb-line/70 bg-vetneb-cyan/12 text-vetneb-navy"
+                          aria-hidden="true"
+                        >
+                          <BriefcaseMedical
+                            className="h-10 w-10"
+                            aria-hidden="true"
+                          />
+                        </span>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div>
+                            <CardTitle
+                              id="professional-detail-title"
+                              className="text-2xl text-vetneb-ink"
+                            >
+                              {professional.displayName}
+                            </CardTitle>
+                            {location ? (
+                              <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                                <MapPin
+                                  className="h-4 w-4 text-primary"
+                                  aria-hidden="true"
+                                />
+                                {location}
+                              </p>
+                            ) : null}
+                          </div>
+                          {isVerified ? (
+                            <span className="clinical-pill inline-flex items-center gap-1 px-2 py-0.5 text-[0.65rem] tracking-[0.08em]">
+                              <ShieldCheck
+                                className="h-3 w-3"
+                                aria-hidden="true"
+                              />
+                              Perfil verificado
+                            </span>
+                          ) : null}
+                        </div>
+                        {professional.aboutText ? (
+                          <p className="mt-4 leading-relaxed text-muted-foreground">
+                            {professional.aboutText}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-6 pt-6">
+                    <section aria-labelledby="professional-care-heading">
+                      <h2
+                        id="professional-care-heading"
+                        className="mb-3 flex items-center gap-2 text-lg font-semibold text-vetneb-ink"
+                      >
+                        <Stethoscope
+                          className="h-5 w-5 text-primary"
+                          aria-hidden="true"
+                        />
+                        Especialidades y servicios
+                      </h2>
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {professional.specialtyText ? (
+                          <div className="surface-soft px-4 py-3">
+                            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              Especialidades
+                            </p>
+                            <p className="mt-2 text-sm leading-relaxed text-vetneb-ink">
+                              {professional.specialtyText}
+                            </p>
+                          </div>
+                        ) : null}
+                        {professional.servicesText ? (
+                          <div className="surface-soft px-4 py-3">
+                            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              Servicios
+                            </p>
+                            <p className="mt-2 text-sm leading-relaxed text-vetneb-ink">
+                              {professional.servicesText}
+                            </p>
+                          </div>
+                        ) : null}
+                      </div>
+                    </section>
+
+                    <section aria-labelledby="professional-contact-heading">
+                      <h2
+                        id="professional-contact-heading"
+                        className="mb-3 flex items-center gap-2 text-lg font-semibold text-vetneb-ink"
+                      >
+                        <UserRound
+                          className="h-5 w-5 text-primary"
+                          aria-hidden="true"
+                        />
+                        Responsable y contacto
+                      </h2>
+                      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <div className="surface-soft px-4 py-3">
+                          <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                            Responsable / perfil
+                          </dt>
+                          <dd className="mt-2 text-sm text-vetneb-ink">
+                            {professional.displayName}
+                          </dd>
+                        </div>
+                        {professional.email ? (
+                          <div className="surface-soft px-4 py-3">
+                            <dt className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              <Mail
+                                className="h-3.5 w-3.5 text-primary"
+                                aria-hidden="true"
+                              />
+                              Email
+                            </dt>
+                            <dd className="mt-2">
+                              <PublicExternalControl
+                                href={`mailto:${professional.email}`}
+                                target="_self"
+                                className="text-sm font-semibold text-vetneb-navy underline underline-offset-2 hover:text-primary"
+                                aria-label={`Enviar email a ${professional.displayName}`}
+                              >
+                                {professional.email}
+                              </PublicExternalControl>
+                            </dd>
+                          </div>
+                        ) : null}
+                        {professional.phone ? (
+                          <div className="surface-soft px-4 py-3">
+                            <dt className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              <Phone
+                                className="h-3.5 w-3.5 text-primary"
+                                aria-hidden="true"
+                              />
+                              Teléfono
+                            </dt>
+                            <dd className="mt-2">
+                              <PublicExternalControl
+                                href={buildWhatsAppHref(professional.phone)}
+                                target="_blank"
+                                className="text-sm font-semibold text-vetneb-navy underline underline-offset-2 hover:text-primary"
+                                aria-label={`Contactar por teléfono a ${professional.displayName}`}
+                              >
+                                {professional.phone}
+                              </PublicExternalControl>
+                            </dd>
+                          </div>
+                        ) : null}
+                      </dl>
+                    </section>
+
+                    <section aria-labelledby="professional-location-heading">
+                      <h2
+                        id="professional-location-heading"
+                        className="mb-3 flex items-center gap-2 text-lg font-semibold text-vetneb-ink"
+                      >
+                        <MapPin
+                          className="h-5 w-5 text-primary"
+                          aria-hidden="true"
+                        />
+                        Ubicación
+                      </h2>
+                      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        {location ? (
+                          <div className="surface-soft px-4 py-3">
+                            <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              Localidad
+                            </dt>
+                            <dd className="mt-2 text-sm text-vetneb-ink">
+                              {location}
+                            </dd>
+                          </div>
+                        ) : null}
+                        {professional.publicAddress ? (
+                          <div className="surface-soft px-4 py-3">
+                            <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              Dirección
+                            </dt>
+                            <dd className="mt-2 text-sm text-vetneb-ink">
+                              {professional.publicAddress}
+                            </dd>
+                          </div>
+                        ) : null}
+                        {professional.mapLink ? (
+                          <div className="surface-soft px-4 py-3 sm:col-span-2">
+                            <dt className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                              <ExternalLink
+                                className="h-3.5 w-3.5 text-primary"
+                                aria-hidden="true"
+                              />
+                              Mapa
+                            </dt>
+                            <dd className="mt-2">
+                              <PublicExternalControl
+                                href={professional.mapLink}
+                                target="_blank"
+                                className="text-sm font-semibold text-vetneb-navy underline underline-offset-2 hover:text-primary"
+                                aria-label={`Abrir mapa de ${professional.displayName}`}
+                              >
+                                Ver ubicación en mapa
+                              </PublicExternalControl>
+                            </dd>
+                          </div>
+                        ) : null}
+                      </dl>
+                    </section>
+                  </CardContent>
+                </Card>
+              </article>
+            ) : null}
+          </div>
+        </div>
+      </section>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -5,24 +5,29 @@ import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   BriefcaseMedical,
-  ExternalLink,
-  Mail,
+  ChevronRight,
   MapPin,
-  Phone,
   Search,
+  ShieldCheck,
   UserRoundSearch,
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
-import { PublicExternalControl } from "@/components/public/PublicRouteControl";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   searchPublicProfessionals,
   type PublicProfessional,
 } from "@/lib/api";
+import {
+  buildProfessionalDetailHref,
+  getPublicProfessionalLocation,
+  isVerifiedPublicProfessional,
+  PUBLIC_PROFESSIONALS_PAGE_SIZE,
+  summarizePublicProfessional,
+} from "@/lib/public-professionals";
 import { ROUTES } from "@/lib/routes";
 
 type SearchState =
@@ -61,7 +66,7 @@ export function ProfesionalesSearchContent() {
     searchPublicProfessionals(
       {
         query: currentQuery,
-        limit: 20,
+        limit: PUBLIC_PROFESSIONALS_PAGE_SIZE,
         offset: 0,
       },
       { cache: "no-store" },
@@ -177,10 +182,7 @@ export function ProfesionalesSearchContent() {
                   className="h-11 w-full rounded-xl border border-input bg-white/90 pl-10 pr-3 text-sm shadow-inner ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 />
               </div>
-              <Button
-                type="submit"
-                className="public-cta-primary h-11"
-              >
+              <Button type="submit" className="public-cta-primary h-11">
                 Buscar
               </Button>
             </form>
@@ -223,152 +225,86 @@ export function ProfesionalesSearchContent() {
                 <div>
                   <p className="mb-4 text-sm text-muted-foreground">
                     {state.total} resultado(s) para “{currentQuery}”. Seleccione
-                    el perfil con los datos de contacto más adecuados para su
+                    un perfil para ver sus datos completos de contacto y
                     coordinación clínica.
                   </p>
-                  <div className="space-y-4">
+                  <div className="space-y-3">
                     {state.professionals.map((professional) => {
-                      const resultHeadingId = `professional-result-${professional.clinicId}`;
+                      const location = getPublicProfessionalLocation(professional);
+                      const summary = summarizePublicProfessional(professional);
+                      const isVerified =
+                        isVerifiedPublicProfessional(professional);
 
                       return (
-                        <article
-                          key={professional.clinicId}
-                          aria-labelledby={resultHeadingId}
-                        >
-                          <Card className="premium-card overflow-hidden">
-                            <CardHeader className="clinical-muted-band border-b">
-                              <div className="flex items-start justify-between gap-3">
-                                <div className="flex items-start gap-3">
-                                  {professional.avatarUrl ? (
-                                    <Image
-                                      src={professional.avatarUrl}
-                                      alt={`Avatar de ${professional.displayName}`}
-                                      width={44}
-                                      height={44}
-                                      className="h-11 w-11 rounded-xl border border-vetneb-line/70 object-cover"
-                                      loading="lazy"
-                                      unoptimized
-                                    />
-                                  ) : (
-                                    <VisualIcon icon={BriefcaseMedical} tone="emerald" className="h-11 w-11 rounded-xl" />
-                                  )}
-                                  <div>
-                                    <CardTitle id={resultHeadingId} className="text-lg text-vetneb-ink">
-                                      {professional.displayName}
-                                    </CardTitle>
-                                    {(professional.locality || professional.country) ? (
-                                      <p className="mt-1 text-xs text-muted-foreground">
-                                        {[professional.locality, professional.country]
-                                          .filter(Boolean)
-                                          .join(", ")}
-                                      </p>
-                                    ) : null}
-                                  </div>
-                                </div>
-                                <span className="clinical-pill px-2 py-0.5 text-[0.65rem] tracking-[0.08em]">
-                                  Perfil verificado
+                        <article key={professional.clinicId}>
+                          <PublicRouteControl
+                            href={buildProfessionalDetailHref(
+                              professional.clinicId,
+                            )}
+                            variant="bare"
+                            aria-label={`Abrir detalle del perfil ${professional.displayName}`}
+                            className="premium-card group flex w-full items-start gap-4 p-4 text-left transition hover:-translate-y-0.5 hover:border-vetneb-teal/45 hover:shadow-lg"
+                          >
+                            <span className="shrink-0">
+                              {professional.avatarUrl ? (
+                                <Image
+                                  src={professional.avatarUrl}
+                                  alt={`Logo o avatar de ${professional.displayName}`}
+                                  width={56}
+                                  height={56}
+                                  className="h-14 w-14 rounded-xl border border-vetneb-line/70 object-cover"
+                                  loading="lazy"
+                                  unoptimized
+                                />
+                              ) : (
+                                <span
+                                  className="professional-avatar-fallback flex h-14 w-14 items-center justify-center rounded-xl border border-vetneb-line/70 bg-vetneb-cyan/12 text-vetneb-navy"
+                                  aria-hidden="true"
+                                >
+                                  <BriefcaseMedical
+                                    className="h-6 w-6"
+                                    aria-hidden="true"
+                                  />
                                 </span>
-                              </div>
-                            </CardHeader>
-                            <CardContent className="space-y-3 pt-5 text-sm text-muted-foreground">
-                              {professional.specialtyText ? (
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="clinical-pill px-2 py-0.5 text-[0.62rem] tracking-[0.08em]">
-                                    Especialidad
-                                  </p>
-                                  <p className="mt-2">{professional.specialtyText}</p>
-                                </div>
+                              )}
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                <span className="min-w-0">
+                                  <span className="block text-base font-semibold text-vetneb-ink">
+                                    {professional.displayName}
+                                  </span>
+                                  {location ? (
+                                    <span className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                                      <MapPin
+                                        className="h-3.5 w-3.5 text-primary"
+                                        aria-hidden="true"
+                                      />
+                                      {location}
+                                    </span>
+                                  ) : null}
+                                </span>
+                                {isVerified ? (
+                                  <span className="clinical-pill inline-flex items-center gap-1 px-2 py-0.5 text-[0.65rem] tracking-[0.08em]">
+                                    <ShieldCheck
+                                      className="h-3 w-3"
+                                      aria-hidden="true"
+                                    />
+                                    Perfil verificado
+                                  </span>
+                                ) : null}
+                              </span>
+                              {summary ? (
+                                <span className="mt-3 block text-sm leading-relaxed text-muted-foreground">
+                                  {summary}
+                                </span>
                               ) : null}
-                              {professional.servicesText ? (
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="clinical-pill px-2 py-0.5 text-[0.62rem] tracking-[0.08em]">
-                                    Servicios
-                                  </p>
-                                  <p className="mt-2">{professional.servicesText}</p>
-                                </div>
-                              ) : null}
-                              {professional.aboutText ? (
-                                <p className="leading-relaxed">
-                                  {professional.aboutText}
-                                </p>
-                              ) : null}
-                              <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                                {professional.locality || professional.country ? (
-                                  <div className="surface-soft px-3 py-2.5">
-                                    <dt className="flex items-center gap-1.5 font-medium text-vetneb-ink">
-                                      <MapPin className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-                                      Ubicación
-                                    </dt>
-                                    <dd className="mt-1 text-muted-foreground">
-                                      {[professional.locality, professional.country]
-                                        .filter(Boolean)
-                                        .join(", ")}
-                                    </dd>
-                                  </div>
-                                ) : null}
-                                {professional.publicAddress ? (
-                                  <div className="surface-soft px-3 py-2.5">
-                                    <dt className="flex items-center gap-1.5 font-medium text-vetneb-ink">
-                                      <MapPin className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-                                      Dirección
-                                    </dt>
-                                    <dd className="mt-1">{professional.publicAddress}</dd>
-                                  </div>
-                                ) : null}
-                                {professional.email ? (
-                                  <div className="surface-soft px-3 py-2.5">
-                                    <dt className="flex items-center gap-1.5 font-medium text-vetneb-ink">
-                                      <Mail className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-                                      Email
-                                    </dt>
-                                    <dd className="mt-1">
-                                      <PublicExternalControl
-                                        href={`mailto:${professional.email}`}
-                                        target="_self"
-                                        className="underline underline-offset-2 hover:text-primary"
-                                      >
-                                        {professional.email}
-                                      </PublicExternalControl>
-                                    </dd>
-                                  </div>
-                                ) : null}
-                                {professional.phone ? (
-                                  <div className="surface-soft px-3 py-2.5">
-                                    <dt className="flex items-center gap-1.5 font-medium text-vetneb-ink">
-                                      <Phone className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-                                      Teléfono
-                                    </dt>
-                                    <dd className="mt-1">
-                                      <PublicExternalControl
-                                        href={`https://wa.me/549${professional.phone.replace(/\D/g, "")}`}
-                                        target="_blank"
-                                        className="underline underline-offset-2 hover:text-primary"
-                                      >
-                                        {professional.phone}
-                                      </PublicExternalControl>
-                                    </dd>
-                                  </div>
-                                ) : null}
-                                {professional.mapLink ? (
-                                  <div className="surface-soft px-3 py-2.5">
-                                    <dt className="flex items-center gap-1.5 font-medium text-vetneb-ink">
-                                      <ExternalLink className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-                                      Mapa
-                                    </dt>
-                                    <dd className="mt-1">
-                                      <PublicExternalControl
-                                        href={professional.mapLink}
-                                        target="_blank"
-                                        className="underline underline-offset-2 hover:text-primary"
-                                      >
-                                        Ver ubicación en mapa
-                                      </PublicExternalControl>
-                                    </dd>
-                                  </div>
-                                ) : null}
-                              </dl>
-                            </CardContent>
-                          </Card>
+                            </span>
+                            <ChevronRight
+                              className="mt-4 h-5 w-5 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-primary"
+                              aria-hidden="true"
+                            />
+                          </PublicRouteControl>
                         </article>
                       );
                     })}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2075,6 +2075,11 @@ export type PublicProfessionalsSearchSnapshot = {
   };
 };
 
+export type PublicProfessionalDetailSnapshot = {
+  success: true;
+  professional: PublicProfessional;
+};
+
 export async function searchPublicProfessionals(
   params: {
     query?: string;
@@ -2101,6 +2106,16 @@ export async function searchPublicProfessionals(
 
   return apiFetch<PublicProfessionalsSearchSnapshot>(
     `/api/public/professionals/search${qs ? `?${qs}` : ""}`,
+    options,
+  );
+}
+
+export async function getPublicProfessional(
+  clinicId: number,
+  options?: RequestInit,
+): Promise<PublicProfessionalDetailSnapshot> {
+  return apiFetch<PublicProfessionalDetailSnapshot>(
+    `/api/public/professionals/${clinicId}`,
     options,
   );
 }

--- a/frontend/src/lib/public-professionals.ts
+++ b/frontend/src/lib/public-professionals.ts
@@ -1,0 +1,67 @@
+const PUBLIC_PROFESSIONALS_BASE_ROUTE = "/profesionales";
+const PROFESSIONAL_SUMMARY_MAX_LENGTH = 170;
+
+export const PUBLIC_PROFESSIONALS_PAGE_SIZE = 20;
+
+export type PublicProfessionalDirectoryEntry = {
+  clinicId: number;
+  specialtyText: string | null;
+  servicesText: string | null;
+  locality: string | null;
+  country: string | null;
+  profileQualityScore: number | null;
+};
+
+function normalizeOptionalText(value: string | null | undefined) {
+  return typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+}
+
+function truncateSummary(value: string, maxLength = PROFESSIONAL_SUMMARY_MAX_LENGTH) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+export function buildProfessionalDetailHref(clinicId: number | string) {
+  return `${PUBLIC_PROFESSIONALS_BASE_ROUTE}/${encodeURIComponent(String(clinicId))}`;
+}
+
+export function summarizePublicProfessional(
+  professional: Pick<PublicProfessionalDirectoryEntry, "specialtyText" | "servicesText">,
+) {
+  const summary = [
+    normalizeOptionalText(professional.specialtyText),
+    normalizeOptionalText(professional.servicesText),
+  ]
+    .filter(Boolean)
+    .join(" - ");
+
+  return summary ? truncateSummary(summary) : null;
+}
+
+export function getPublicProfessionalLocation(
+  professional: Pick<PublicProfessionalDirectoryEntry, "locality" | "country">,
+) {
+  const location = [
+    normalizeOptionalText(professional.locality),
+    normalizeOptionalText(professional.country),
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return location || null;
+}
+
+export function isVerifiedPublicProfessional(
+  professional: Pick<PublicProfessionalDirectoryEntry, "profileQualityScore">,
+) {
+  return typeof professional.profileQualityScore === "number";
+}
+
+export function parsePublicProfessionalClinicId(value: string) {
+  const parsed = Number(value);
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}

--- a/test/frontend-native-link-preview-contract.test.ts
+++ b/test/frontend-native-link-preview-contract.test.ts
@@ -12,6 +12,8 @@ const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
 const CONTACTO_PATH = "frontend/src/components/public/ContactoContent.tsx";
 const PROFESIONALES_PATH =
   "frontend/src/components/public/ProfesionalesSearchContent.tsx";
+const PROFESIONAL_DETAIL_PATH =
+  "frontend/src/components/public/ProfesionalDetailContent.tsx";
 const PUBLIC_ACTION_PATH = "frontend/src/components/public/PublicAction.tsx";
 const PUBLIC_ROUTE_CONTROL_PATH =
   "frontend/src/components/public/PublicRouteControl.tsx";
@@ -137,6 +139,7 @@ test("PublicExternalControl covers WhatsApp, mailto and external map surfaces", 
   const footer = read(FOOTER_PATH);
   const contacto = read(CONTACTO_PATH);
   const profesionales = read(PROFESIONALES_PATH);
+  const profesionalDetail = read(PROFESIONAL_DETAIL_PATH);
 
   assert.ok(home.includes("<PublicExternalControl"));
   assert.ok(home.includes('href="https://wa.me/5493534138946"'));
@@ -154,15 +157,16 @@ test("PublicExternalControl covers WhatsApp, mailto and external map surfaces", 
     contacto.includes('target={info.href.startsWith("http") ? "_blank" : "_self"}'),
   );
 
-  assert.ok(profesionales.includes("<PublicExternalControl"));
-  assert.ok(profesionales.includes("href={`mailto:${professional.email}`}"));
+  assert.equal(profesionales.includes("<PublicExternalControl"), false);
+
+  assert.ok(profesionalDetail.includes("<PublicExternalControl"));
+  assert.ok(profesionalDetail.includes("href={`mailto:${professional.email}`}"));
   assert.ok(
-    profesionales.includes(
-      "href={`https://wa.me/549${professional.phone.replace(/\\D/g, \"\")}`}",
-    ),
+    profesionalDetail.includes("href={buildWhatsAppHref(professional.phone)}"),
   );
-  assert.ok(profesionales.includes("href={professional.mapLink}"));
-  assert.ok(profesionales.includes('target="_blank"'));
+  assert.ok(profesionalDetail.includes("href={professional.mapLink}"));
+  assert.ok(profesionalDetail.includes('target="_blank"'));
+  assert.equal(/<a\b/.test(profesionalDetail), false);
 });
 
 test("footer map surface uses a single non-interactive iframe and keeps external map control", () => {

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -7,6 +7,10 @@ import test from "node:test";
 const PROFESIONALES_PAGE_PATH = "frontend/src/app/profesionales/page.tsx";
 const PROFESIONALES_SEARCH_CONTENT_PATH =
   "frontend/src/components/public/ProfesionalesSearchContent.tsx";
+const PROFESIONAL_DETAIL_CONTENT_PATH =
+  "frontend/src/components/public/ProfesionalDetailContent.tsx";
+const PROFESIONALES_DETAIL_PAGE_PATH =
+  "frontend/src/app/profesionales/[clinicId]/page.tsx";
 const API_PATH = "frontend/src/lib/api.ts";
 
 function read(relativePath: string): string {
@@ -61,38 +65,66 @@ test("profesionales search content uses free text query and approximate backend 
   assert.ok(source.includes("router.push(`${ROUTES.profesionales}${params.size ? `?${params}` : \"\"}`)"));
   assert.ok(source.includes("searchPublicProfessionals("));
   assert.ok(source.includes("query: currentQuery"));
-  assert.ok(source.includes("limit: 20"));
+  assert.ok(source.includes("limit: PUBLIC_PROFESSIONALS_PAGE_SIZE"));
   assert.ok(source.includes('{ cache: "no-store" }'));
   assert.ok(source.includes("coincidencias por nombre"));
   assert.ok(apiSource.includes("export async function searchPublicProfessionals("));
+  assert.ok(apiSource.includes("export async function getPublicProfessional("));
   assert.ok(apiSource.includes("q"));
   assert.ok(apiSource.includes("/api/public/professionals/search"));
+  assert.ok(apiSource.includes("/api/public/professionals/${clinicId}"));
 });
 
-test("profesionales search content renders professional result cards", () => {
+test("profesionales search content renders compact professional result cards", () => {
   const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
 
   assert.ok(source.includes("state.professionals.map((professional) =>"));
   assert.ok(source.includes("professional.displayName"));
-  assert.ok(source.includes("professional.specialtyText"));
-  assert.ok(source.includes("professional.servicesText"));
-  assert.ok(source.includes("professional.aboutText"));
-  assert.ok(source.includes("professional.locality"));
-  assert.ok(source.includes("professional.country"));
-  assert.ok(source.includes("professional.publicAddress"));
-  assert.ok(source.includes("professional.mapLink"));
-  assert.ok(source.includes("Ver ubicación en mapa"));
-  assert.ok(source.includes("<PublicExternalControl"));
-  assert.ok(source.includes('target="_blank"'));
+  assert.ok(source.includes("professional.avatarUrl"));
+  assert.ok(source.includes("professional-avatar-fallback"));
+  assert.ok(source.includes("getPublicProfessionalLocation(professional)"));
+  assert.ok(source.includes("summarizePublicProfessional(professional)"));
+  assert.ok(source.includes("isVerifiedPublicProfessional(professional)"));
+  assert.ok(source.includes("buildProfessionalDetailHref("));
+  assert.ok(source.includes("professional.clinicId"));
+  assert.ok(source.includes("Abrir detalle del perfil"));
   assert.equal(/<a\b/.test(source), false);
-  assert.ok(source.includes("mailto:${professional.email}"));
-  assert.ok(source.includes("https://wa.me/549"));
+  assert.equal(source.includes("professional.aboutText"), false);
+  assert.equal(source.includes("professional.email"), false);
+  assert.equal(source.includes("professional.phone"), false);
+  assert.equal(source.includes("professional.publicAddress"), false);
+  assert.equal(source.includes("professional.mapLink"), false);
+  assert.equal(source.includes("<PublicExternalControl"), false);
+  assert.equal(source.includes("mailto:${professional.email}"), false);
+  assert.equal(source.includes("https://wa.me/549"), false);
+});
+
+test("profesionales detail route renders selected professional data", () => {
+  const pageSource = read(PROFESIONALES_DETAIL_PAGE_PATH);
+  const detailSource = read(PROFESIONAL_DETAIL_CONTENT_PATH);
+
+  assert.ok(pageSource.includes("ProfesionalDetailContent"));
+  assert.ok(pageSource.includes("<ProfesionalDetailContent clinicId={clinicId} />"));
+  assert.ok(pageSource.includes("/profesionales/${encodeURIComponent(clinicId)}"));
+  assert.ok(detailSource.includes("parsePublicProfessionalClinicId(clinicId)"));
+  assert.ok(detailSource.includes("getPublicProfessional(parsedClinicId"));
+  assert.ok(detailSource.includes("professional.displayName"));
+  assert.ok(detailSource.includes("professional.aboutText"));
+  assert.ok(detailSource.includes("professional.specialtyText"));
+  assert.ok(detailSource.includes("professional.servicesText"));
+  assert.ok(detailSource.includes("professional.publicAddress"));
+  assert.ok(detailSource.includes("professional.mapLink"));
+  assert.ok(detailSource.includes("mailto:${professional.email}"));
+  assert.ok(detailSource.includes("buildWhatsAppHref(professional.phone)"));
+  assert.ok(detailSource.includes("Ver ubicación en mapa"));
+  assert.equal(/<a\b/.test(detailSource), false);
 });
 
 test("profesionales page remains public and avoids private route literals", () => {
   const pageSource = read(PROFESIONALES_PAGE_PATH);
   const contentSource = read(PROFESIONALES_SEARCH_CONTENT_PATH);
-  const combined = [pageSource, contentSource].join("\n");
+  const detailSource = read(PROFESIONAL_DETAIL_CONTENT_PATH);
+  const combined = [pageSource, contentSource, detailSource].join("\n");
 
   assert.equal(combined.includes('"/dashboard"'), false);
   assert.equal(combined.includes("admin_session_id"), false);

--- a/test/frontend-public-page-semantics.test.ts
+++ b/test/frontend-public-page-semantics.test.ts
@@ -9,6 +9,8 @@ const CLINICAS_PATH = "frontend/src/app/clinicas/page.tsx";
 const PROFESIONALES_PAGE_PATH = "frontend/src/app/profesionales/page.tsx";
 const PROFESIONALES_CONTENT_PATH =
   "frontend/src/components/public/ProfesionalesSearchContent.tsx";
+const PROFESIONAL_DETAIL_CONTENT_PATH =
+  "frontend/src/components/public/ProfesionalDetailContent.tsx";
 const CONTACTO_PAGE_PATH = "frontend/src/app/contacto/page.tsx";
 const CONTACTO_CONTENT_PATH = "frontend/src/components/public/ContactoContent.tsx";
 const PRECIOS_PATH = "frontend/src/app/precios/page.tsx";
@@ -89,6 +91,7 @@ test("clinicas page keeps semantic headings, sections and reveal policy", () => 
 
 test("profesionales content keeps semantic search/result structure and map safety", () => {
   const source = read(PROFESIONALES_CONTENT_PATH);
+  const detailSource = read(PROFESIONAL_DETAIL_CONTENT_PATH);
 
   assert.ok(source.includes("<h1"));
   assert.ok(source.includes("<h2"));
@@ -97,11 +100,15 @@ test("profesionales content keeps semantic search/result structure and map safet
   assert.ok(source.includes("<article"));
   assert.ok(source.includes("searchPublicProfessionals("));
   assert.ok(source.includes("router.push(`${ROUTES.profesionales}${params.size ? `?${params}` : \"\"}`)"));
-  assert.ok(source.includes("Ver ubicación en mapa"));
-  assert.ok(source.includes("<PublicExternalControl"));
-  assert.ok(source.includes('target="_blank"'));
+  assert.ok(source.includes("buildProfessionalDetailHref("));
+  assert.equal(source.includes("<PublicExternalControl"), false);
+  assert.ok(detailSource.includes("Ver ubicación en mapa"));
+  assert.ok(detailSource.includes("<PublicExternalControl"));
+  assert.ok(detailSource.includes('target="_blank"'));
   assert.equal(/<a\b/.test(source), false);
+  assert.equal(/<a\b/.test(detailSource), false);
   assert.equal(source.includes('from "gsap"'), false);
+  assert.equal(detailSource.includes('from "gsap"'), false);
 });
 
 test("contacto content keeps semantic headings and unchanged contact flow", () => {

--- a/test/frontend-public-professionals-scalable-directory.test.ts
+++ b/test/frontend-public-professionals-scalable-directory.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+  buildProfessionalDetailHref,
+  getPublicProfessionalLocation,
+  isVerifiedPublicProfessional,
+  parsePublicProfessionalClinicId,
+  summarizePublicProfessional,
+} from "../frontend/src/lib/public-professionals.ts";
+
+const PROFESIONALES_SEARCH_CONTENT_PATH =
+  "frontend/src/components/public/ProfesionalesSearchContent.tsx";
+const PROFESIONAL_DETAIL_CONTENT_PATH =
+  "frontend/src/components/public/ProfesionalDetailContent.tsx";
+const PUBLIC_PROFESSIONALS_HELPER_PATH =
+  "frontend/src/lib/public-professionals.ts";
+const PUBLIC_PROFESSIONALS_API_ROUTE_PATH =
+  "server/routes/public-professionals.fastify.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function extractSerializeProfessional(source: string) {
+  const start = source.indexOf("async function serializeProfessional(");
+  assert.notEqual(start, -1, "serializeProfessional must exist");
+
+  const end = source.indexOf("\nfunction applyCorsHeaders", start);
+  assert.notEqual(end, -1, "serializeProfessional block must be bounded");
+
+  return source.slice(start, end);
+}
+
+test("public professionals listing renders compact cards without contact detail payload", () => {
+  const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+
+  assert.ok(source.includes("state.professionals.map((professional) =>"));
+  assert.ok(source.includes("key={professional.clinicId}"));
+  assert.ok(source.includes("professional.displayName"));
+  assert.ok(source.includes("professional.avatarUrl"));
+  assert.ok(source.includes("professional-avatar-fallback"));
+  assert.ok(source.includes("summarizePublicProfessional(professional)"));
+  assert.ok(source.includes("getPublicProfessionalLocation(professional)"));
+  assert.ok(source.includes("isVerifiedPublicProfessional(professional)"));
+  assert.equal(source.includes("professional.aboutText"), false);
+  assert.equal(source.includes("professional.email"), false);
+  assert.equal(source.includes("professional.phone"), false);
+  assert.equal(source.includes("professional.publicAddress"), false);
+  assert.equal(source.includes("professional.mapLink"), false);
+});
+
+test("public professionals listing has stable local avatar fallback", () => {
+  const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+
+  assert.ok(source.includes("professional-avatar-fallback"));
+  assert.ok(source.includes('aria-hidden="true"'));
+  assert.ok(source.includes("BriefcaseMedical"));
+  assert.equal(source.includes("https://"), false);
+});
+
+test("public professionals card navigation opens detail resolved by clinic id", () => {
+  const searchSource = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+  const detailSource = read(PROFESIONAL_DETAIL_CONTENT_PATH);
+
+  assert.ok(searchSource.includes("buildProfessionalDetailHref("));
+  assert.ok(searchSource.includes("professional.clinicId"));
+  assert.ok(searchSource.includes("Abrir detalle del perfil"));
+  assert.ok(detailSource.includes("parsePublicProfessionalClinicId(clinicId)"));
+  assert.ok(detailSource.includes("getPublicProfessional(parsedClinicId"));
+  assert.ok(detailSource.includes('{ cache: "no-store" }'));
+  assert.ok(detailSource.includes("professional.specialtyText"));
+  assert.ok(detailSource.includes("professional.servicesText"));
+  assert.ok(detailSource.includes("professional.aboutText"));
+  assert.ok(detailSource.includes("professional.publicAddress"));
+  assert.ok(detailSource.includes("professional.mapLink"));
+});
+
+test("public professionals detail identity stays isolated for similar clinics", () => {
+  const clinicA = {
+    clinicId: 701,
+    specialtyText: "Dermatopatologia veterinaria compartida",
+    servicesText: "Biopsias cutaneas con informe exclusivo Rosario A",
+    locality: "Rosario",
+    country: "Argentina",
+    profileQualityScore: 82,
+  };
+  const clinicB = {
+    clinicId: 702,
+    specialtyText: "Dermatopatologia veterinaria compartida",
+    servicesText: "Biopsias cutaneas con informe exclusivo Rosario B",
+    locality: "Rosario",
+    country: "Argentina",
+    profileQualityScore: 83,
+  };
+  const searchSource = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+  const detailSource = read(PROFESIONAL_DETAIL_CONTENT_PATH);
+
+  assert.equal(buildProfessionalDetailHref(clinicA.clinicId), "/profesionales/701");
+  assert.equal(buildProfessionalDetailHref(clinicB.clinicId), "/profesionales/702");
+  assert.equal(parsePublicProfessionalClinicId("701"), 701);
+  assert.equal(parsePublicProfessionalClinicId("702"), 702);
+  assert.equal(getPublicProfessionalLocation(clinicA), "Rosario, Argentina");
+  assert.equal(isVerifiedPublicProfessional(clinicA), true);
+  assert.ok(summarizePublicProfessional(clinicA)?.includes("Rosario A"));
+  assert.equal(summarizePublicProfessional(clinicA)?.includes("Rosario B"), false);
+  assert.ok(summarizePublicProfessional(clinicB)?.includes("Rosario B"));
+  assert.equal(summarizePublicProfessional(clinicB)?.includes("Rosario A"), false);
+  assert.equal(searchSource.includes("key={index}"), false);
+  assert.equal(searchSource.includes("selectedProfessional"), false);
+  assert.ok(detailSource.includes("getPublicProfessional(parsedClinicId"));
+});
+
+test("public professionals UI and API contracts avoid private public-surface leaks", () => {
+  const publicUiSource = [
+    read(PROFESIONALES_SEARCH_CONTENT_PATH),
+    read(PROFESIONAL_DETAIL_CONTENT_PATH),
+    read(PUBLIC_PROFESSIONALS_HELPER_PATH),
+  ].join("\n");
+  const serializeProfessional = extractSerializeProfessional(
+    read(PUBLIC_PROFESSIONALS_API_ROUTE_PATH),
+  );
+  const forbiddenPublicUiMarkers = [
+    "avatarStoragePath",
+    "storagePath",
+    "storage_path",
+    "downloadUrl",
+    "previewUrl",
+    "sessionToken",
+    "tokenHash",
+    "admin_session_id",
+    "app_session_id",
+    "particular_session_id",
+    "dangerouslySetInnerHTML",
+    "<script",
+    "onclick=",
+  ];
+
+  for (const marker of forbiddenPublicUiMarkers) {
+    assert.equal(
+      publicUiSource.includes(marker),
+      false,
+      `public UI should not expose ${marker}`,
+    );
+  }
+
+  assert.ok(serializeProfessional.includes("avatarUrl"));
+  assert.equal(serializeProfessional.includes("avatarStoragePath:"), false);
+  assert.equal(serializeProfessional.includes("storagePath"), false);
+  assert.equal(serializeProfessional.includes("token"), false);
+  assert.equal(serializeProfessional.includes("cookie"), false);
+});

--- a/test/frontend-public-seo-contract.test.ts
+++ b/test/frontend-public-seo-contract.test.ts
@@ -163,19 +163,24 @@ test("professionals structured data avoids unverifiable result entities", () => 
   assert.equal(combined.includes("priceRange"), false);
 });
 
-test("professionals structured data stays page-level without public profile route", () => {
+test("professionals structured data stays page-level while detail route is client resolved", () => {
   const seoSource = read(SEO_PATH);
   const profesionalesSource = read(PROFESIONALES_PATH);
+  const profileRouteSource = read(PROFESIONALES_DYNAMIC_PROFILE_PATH);
   const combined = `${seoSource}\n${profesionalesSource}`;
 
   assert.equal(
     existsSync(resolve(process.cwd(), PROFESIONALES_DYNAMIC_PROFILE_PATH)),
-    false,
+    true,
   );
   assert.equal(combined.includes("getPublicProfessional"), false);
   assert.equal(combined.includes("/api/public/professionals/"), false);
   assert.ok(combined.includes('"@type": ["WebPage", "SearchResultsPage"]'));
   assert.ok(combined.includes('"@type": "SearchAction"'));
+  assert.ok(profileRouteSource.includes("ProfesionalDetailContent"));
+  assert.equal(profileRouteSource.includes("fetch("), false);
+  assert.equal(profileRouteSource.includes('type="application/ld+json"'), false);
+  assert.equal(profileRouteSource.includes("dangerouslySetInnerHTML"), false);
 });
 
 test("professionals SEO remains static at page-level without server fetch wiring", () => {


### PR DESCRIPTION
## Summary
- Replace full public professionals results with compact scalable cards
- Add isolated professional detail route by clinicId
- Add avatar fallback and public directory helpers
- Add contracts for list/detail isolation, fallback, navigation, and public-surface safety
- Document implementation in docs/implementation/professionals-scalable-directory.md

## Validation
- pnpm test
- pnpm build
- pnpm -C frontend build
- pnpm security:public-surface