### PR TITLE
chore: clean code residue after public fixes

### DIFF
--- a/docs/implementation/code-residue-cleanup.md
+++ b/docs/implementation/code-residue-cleanup.md
@@ -1,0 +1,59 @@
+# Limpieza de residuos de codigo
+
+## Objetivo
+
+Eliminar residuos tecnicos posteriores a los PRs #829, #830 y #831 sin cambiar comportamiento funcional del producto.
+
+## Residuos encontrados
+
+- Import no usado de `Suspense` en `test/frontend-profesionales-page-content.test.ts`.
+- Imports duplicados desde `@/lib/seo` en `frontend/src/app/profesionales/page.tsx`.
+- Literal repetido de headers expuestos para `429` de login rate-limit en las rutas de auth clinic, admin y particular.
+- Literales repetidos del mismo contrato de headers en tests de auth.
+
+## Archivos modificados
+
+- `frontend/src/app/profesionales/page.tsx`
+- `server/lib/login-rate-limit.ts`
+- `server/routes/admin-auth.fastify.ts`
+- `server/routes/auth.fastify.ts`
+- `server/routes/particular-auth.fastify.ts`
+- `test/admin-auth.fastify.test.ts`
+- `test/auth.fastify.test.ts`
+- `test/frontend-profesionales-page-content.test.ts`
+- `test/login-rate-limit.test.ts`
+- `test/particular-auth.fastify.test.ts`
+
+## Que se elimino y por que era seguro
+
+- Se elimino un import muerto en un test que solo leia archivos fuente y no usaba React en runtime.
+- Se unificaron dos imports consecutivos desde el mismo modulo SEO sin cambiar el render ni el JSON-LD de `/profesionales`.
+- Se centralizo el valor de `access-control-expose-headers` de login rate-limit en `LOGIN_RATE_LIMIT_EXPOSED_HEADERS`.
+- Los tests de auth ahora comparan contra la constante compartida, y `test/login-rate-limit.test.ts` mantiene fijo el valor exacto del contrato HTTP.
+
+## Que no se toco deliberadamente
+
+- No se modifico `/precios`, su cache local, sus estados vacios ni su mensaje de error real.
+- No se modifico `/profesionales`, su elegibilidad, busqueda, detalle, paginado ni serializacion publica.
+- No se modificaron limites, ventanas, claves ni stores de rate-limit.
+- No se modificaron CORS, cookies, sesiones ni contratos publicos funcionales.
+- No se tocaron migraciones, dependencias, `package.json` ni lockfile.
+- No se borraron tests utiles ni documentacion historica que no contradice el estado actual de #831.
+
+## Pruebas ejecutadas
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/login-rate-limit.test.ts test/admin-auth.fastify.test.ts test/auth.fastify.test.ts test/particular-auth.fastify.test.ts test/frontend-profesionales-page-content.test.ts`
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-public-page-metadata.test.ts test/frontend-public-seo-contract.test.ts test/frontend-profesionales-page-content.test.ts`
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm -C frontend build`
+
+## Riesgos residuales
+
+- La inspeccion estricta con `noUnusedLocals` detecto residuos preexistentes fuera del scope pedido. No se corrigieron para no mezclar limpieza reciente con refactors no relacionados.
+- Los contratos de algunos tests siguen basados en inspeccion de texto fuente. Solo se ajustaron los afectados por esta limpieza.
+
+## Confirmacion funcional
+
+No se cambio comportamiento funcional del producto. La limpieza se limito a imports muertos, imports duplicados y duplicacion de un literal de headers ya cubierto por tests.

--- a/frontend/src/app/profesionales/page.tsx
+++ b/frontend/src/app/profesionales/page.tsx
@@ -2,8 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 
 import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSearchContent";
-import { createPageMetadata } from "@/lib/seo";
-import { getProfessionalsPageJsonLd } from "@/lib/seo";
+import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata(
   "Red de Profesionales Veterinarios",

--- a/server/lib/login-rate-limit.ts
+++ b/server/lib/login-rate-limit.ts
@@ -5,6 +5,8 @@ export const LOGIN_RATE_LIMIT_MAX_ATTEMPTS = 10;
 export const LOGIN_RATE_LIMIT_CODE = "LOGIN_RATE_LIMITED";
 export const LOGIN_RATE_LIMIT_ERROR_MESSAGE =
   "Demasiados intentos de inicio de sesión. Intentá nuevamente más tarde.";
+export const LOGIN_RATE_LIMIT_EXPOSED_HEADERS =
+  "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After";
 
 export const LOGIN_RATE_LIMIT_KEY_VERSION = "v2";
 

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -16,6 +16,7 @@ import {
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
   getLoginRateLimitKeyMetadata,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
@@ -283,7 +284,7 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
   reply.header(
     "access-control-expose-headers",
-    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+    LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   );
 }
 

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -12,6 +12,7 @@ import {
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
   getLoginRateLimitKeyMetadata,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
@@ -422,7 +423,7 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
   reply.header(
     "access-control-expose-headers",
-    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+    LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   );
 }
 

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -12,6 +12,7 @@ import {
   buildLoginRateLimitKey,
   buildMissingCredentialsLoginRateLimitKey,
   getLoginRateLimitKeyMetadata,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
   LOGIN_RATE_LIMIT_WINDOW_MS,
 } from "../lib/login-rate-limit.ts";
@@ -272,7 +273,7 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
   reply.header(
     "access-control-expose-headers",
-    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+    LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   );
 }
 

--- a/test/admin-auth.fastify.test.ts
+++ b/test/admin-auth.fastify.test.ts
@@ -13,6 +13,7 @@ const { ENV } = await import("../server/lib/env.ts");
 const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
 const {
   LOGIN_RATE_LIMIT_CODE,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
 } = await import("../server/lib/login-rate-limit.ts");
 const {
@@ -358,7 +359,7 @@ test(
       assert.equal(third.headers["ratelimit-reset"], "60");
       assert.equal(
         third.headers["access-control-expose-headers"],
-        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+        LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
       );
       const retryAfter = Number(third.headers["retry-after"]);
       assert.ok(Number.isInteger(retryAfter));
@@ -578,7 +579,7 @@ test("adminAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar"
       );
       assert.equal(
         response.headers["access-control-expose-headers"],
-        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+        LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
       );
       assert.equal(response.headers["set-cookie"], undefined);
     }

--- a/test/auth.fastify.test.ts
+++ b/test/auth.fastify.test.ts
@@ -14,6 +14,7 @@ const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
 const {
   buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_CODE,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
 } = await import("../server/lib/login-rate-limit.ts");
 const {
@@ -1491,7 +1492,7 @@ test("clinicAuthNativeRoutes bloquea login al superar límite persistente", asyn
     assert.equal(third.headers["ratelimit-reset"], "60");
     assert.equal(
       third.headers["access-control-expose-headers"],
-      "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+      LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
     );
     const retryAfter = Number(third.headers["retry-after"]);
     assert.ok(Number.isInteger(retryAfter));

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { Suspense } from "react";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
@@ -25,7 +24,7 @@ test("profesionales page defines metadata and delegates to search content", () =
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSearchContent";'));
-  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes('import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
   assert.ok(source.includes('"Red de Profesionales Veterinarios"'));
   assert.ok(source.includes('"Banco público de profesionales vinculados a VETNEB'));

--- a/test/frontend-public-page-metadata.test.ts
+++ b/test/frontend-public-page-metadata.test.ts
@@ -31,7 +31,7 @@ test("profesionales public page defines SEO metadata", () => {
   const source = read(PROFESIONALES_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes('import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
   assert.ok(source.includes('"Red de Profesionales Veterinarios"'));
   assert.ok(source.includes('"Banco público de profesionales vinculados a VETNEB'));

--- a/test/frontend-public-seo-contract.test.ts
+++ b/test/frontend-public-seo-contract.test.ts
@@ -130,7 +130,7 @@ test("professionals public page exposes verifiable structured data", () => {
 
   assert.ok(
     profesionalesSource.includes(
-      'import { getProfessionalsPageJsonLd } from "@/lib/seo";',
+      'import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";',
     ),
   );
   assert.ok(

--- a/test/login-rate-limit.test.ts
+++ b/test/login-rate-limit.test.ts
@@ -11,6 +11,7 @@ import {
   hashLoginRateLimitIdentifier,
   hashLoginRateLimitIpAddress,
   LOGIN_RATE_LIMIT_CODE,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_KEY_VERSION,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
   LOGIN_RATE_LIMIT_MAX_ATTEMPTS,
@@ -24,6 +25,10 @@ test("constantes de login rate limit son estables", () => {
   assert.equal(
     LOGIN_RATE_LIMIT_ERROR_MESSAGE,
     "Demasiados intentos de inicio de sesión. Intentá nuevamente más tarde.",
+  );
+  assert.equal(
+    LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
   );
 });
 

--- a/test/particular-auth.fastify.test.ts
+++ b/test/particular-auth.fastify.test.ts
@@ -12,6 +12,7 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { ENV } = await import("../server/lib/env.ts");
 const {
   LOGIN_RATE_LIMIT_CODE,
+  LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
 } = await import("../server/lib/login-rate-limit.ts");
 const {
@@ -524,7 +525,7 @@ test(
       assert.equal(third.headers["ratelimit-reset"], "60");
       assert.equal(
         third.headers["access-control-expose-headers"],
-        "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+        LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
       );
       const retryAfter = Number(third.headers["retry-after"]);
       assert.ok(Number.isInteger(retryAfter));


### PR DESCRIPTION
## Summary
- Remove dead test import after professionals page refactor
- Unify duplicate SEO imports in professionals page
- Centralize repeated login rate-limit exposed headers literal
- Adjust textual contracts to protect behavior without enforcing duplication
- Document cleanup in docs/implementation/code-residue-cleanup.md

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm -C frontend build