### PR TITLE
feat(home): add how-it-works section

### DIFF
--- a/docs/implementation/home-how-it-works-section.md
+++ b/docs/implementation/home-how-it-works-section.md
@@ -1,0 +1,77 @@
+# Home: sección Cómo funciona
+
+## Objetivo
+
+Agregar en la home pública una sección sobria y mobile-first que explique el flujo operativo crítico para clínicas y profesionales que trabajan con VETNEB: envío de muestra, análisis anatomopatológico y descarga del informe.
+
+La sección mantiene a VETNEB como laboratorio primero, portal operativo segundo y red profesional verificada como contexto posterior.
+
+## Archivo modificado
+
+- `frontend/src/app/page.tsx`
+- `test/frontend-home-page-content.test.ts`
+
+## Ubicación de la sección
+
+La sección `Cómo funciona` se ubicó inmediatamente después de `Servicios del laboratorio patológico veterinario` y antes de `Trabajo interdisciplinario y criterio diagnóstico`.
+
+La home actual no contiene una sección desktop del Banco de Profesionales después de servicios; por eso la nueva sección se insertó en el punto equivalente del flujo público sin reordenar navegación ni otras áreas.
+
+## Copy implementado
+
+Título:
+
+> Cómo funciona
+
+Subtexto:
+
+> Trabajar con VETNEB es simple: la muestra llega al laboratorio, se analiza con criterio anatomopatológico y el informe queda disponible en el portal.
+
+Paso 1:
+
+> Enviás la muestra
+
+> Preparás la muestra según el protocolo de VETNEB y la enviás con los datos del caso y de la clínica.
+
+Paso 2:
+
+> VETNEB analiza
+
+> El anatomopatólogo examina el tejido o la muestra citológica y elabora el informe diagnóstico.
+
+Paso 3:
+
+> Recibís el informe
+
+> La clínica lo descarga directamente desde el portal. Si corresponde, el tutor del animal recibe acceso con un código privado.
+
+CTA:
+
+> Contactanos para empezar
+
+## Pruebas agregadas
+
+Se actualizó `test/frontend-home-page-content.test.ts` para confirmar:
+
+- La home contiene el título `Cómo funciona`.
+- La sección se ubica después de servicios y antes de beneficios.
+- La definición de pasos contiene exactamente 3 títulos y 3 copies.
+- Los pasos esperados se renderizan desde una única fuente de datos.
+- La sección no incorpora los términos públicos prohibidos definidos para este alcance.
+- Los contratos SEO/home existentes siguen cubiertos por los tests previos del mismo archivo.
+
+## Validaciones ejecutadas
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-home-page-content.test.ts` - OK.
+- `pnpm test` - OK, 2258 tests pasados y 1 skipped.
+- `pnpm build` - OK.
+- `pnpm security:public-surface` - OK, sin hallazgos de exposición pública de devtools.
+
+Pendiente de autorización:
+
+- `pnpm -C frontend build`: el frontend usa `next/font/google` en `frontend/src/app/layout.tsx`, por lo que el build puede requerir red para Google Fonts.
+
+## Riesgos residuales
+
+- No se ejecutó todavía el build frontend por la condición explícita de autorización de red para Google Fonts.
+- La home no tiene actualmente una sección desktop del Banco de Profesionales ubicada después de servicios; la nueva sección quedó en el punto más cercano al blueprint sin reordenar secciones existentes.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { ClipboardCheck, FlaskConical, Microscope, Network } from "lucide-react";
+import {
+  ClipboardCheck,
+  FileText,
+  FlaskConical,
+  Microscope,
+  Network,
+  PackageCheck,
+} from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
@@ -47,6 +54,27 @@ const services = [
     title: "Diagnóstico Integral",
     description:
       "Integración de datos clínicos con evaluación histológica y citológica para orientar decisiones diagnósticas y terapéuticas.",
+  },
+];
+
+const howItWorksSteps = [
+  {
+    icon: PackageCheck,
+    title: "Enviás la muestra",
+    description:
+      "Preparás la muestra según el protocolo de VETNEB y la enviás con los datos del caso y de la clínica.",
+  },
+  {
+    icon: Microscope,
+    title: "VETNEB analiza",
+    description:
+      "El anatomopatólogo examina el tejido o la muestra citológica y elabora el informe diagnóstico.",
+  },
+  {
+    icon: FileText,
+    title: "Recibís el informe",
+    description:
+      "La clínica lo descarga directamente desde el portal. Si corresponde, el tutor del animal recibe acceso con un código privado.",
   },
 ];
 
@@ -245,6 +273,84 @@ export default function HomePage() {
                   className="border-vetneb-line/80 bg-transparent text-vetneb-ink hover:bg-accent/60 hover:border-vetneb-teal/45"
                 >
                   Ver todos los servicios
+                </PublicRouteControl>
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        <section
+          className="border-y border-vetneb-line/70 bg-card/72 py-14 md:py-20"
+          aria-labelledby="how-it-works-heading"
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal>
+              <div className="mx-auto mb-10 max-w-2xl text-center">
+                <h2
+                  id="how-it-works-heading"
+                  className="text-3xl font-bold text-vetneb-ink md:text-4xl"
+                >
+                  Cómo funciona
+                </h2>
+                <p className="mt-4 text-base leading-relaxed text-muted-foreground md:text-lg">
+                  Trabajar con VETNEB es simple: la muestra llega al laboratorio,
+                  se analiza con criterio anatomopatológico y el informe queda
+                  disponible en el portal.
+                </p>
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal staggerChildren>
+              <div className="grid grid-cols-1 gap-5 md:grid-cols-3 md:gap-6">
+                {howItWorksSteps.map((step, index) => {
+                  const StepIcon = step.icon;
+                  const stepHeadingId = `home-how-it-works-step-${index + 1}`;
+
+                  return (
+                    <article
+                      key={step.title}
+                      data-scroll-reveal-item
+                      data-home-how-it-works-step
+                      aria-labelledby={stepHeadingId}
+                      className="h-full rounded-lg border border-vetneb-line/80 bg-card p-5 shadow-sm"
+                    >
+                      <div className="flex items-center gap-4">
+                        <span
+                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground"
+                          aria-hidden="true"
+                        >
+                          {index + 1}
+                        </span>
+                        <span
+                          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-vetneb-line/80 bg-secondary/60 text-vetneb-teal"
+                          aria-hidden="true"
+                        >
+                          <StepIcon className="h-5 w-5" />
+                        </span>
+                      </div>
+                      <h3
+                        id={stepHeadingId}
+                        className="mt-5 text-xl font-semibold text-vetneb-ink"
+                      >
+                        {step.title}
+                      </h3>
+                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                        {step.description}
+                      </p>
+                    </article>
+                  );
+                })}
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal>
+              <div className="mt-8 text-center">
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="primaryDark"
+                  className="public-cta-primary w-full sm:w-auto"
+                >
+                  Contactanos para empezar
                 </PublicRouteControl>
               </div>
             </PublicScrollReveal>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -12,6 +12,20 @@ function read(relativePath: string): string {
   );
 }
 
+function count(source: string, pattern: string): number {
+  return source.split(pattern).length - 1;
+}
+
+function extractBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing start marker: ${start}`);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `missing end marker: ${end}`);
+
+  return source.slice(startIndex, endIndex);
+}
+
 test("home page defines public metadata — organization JSON-LD is emitted by root layout", () => {
   const source = read(HOME_PAGE_PATH);
 
@@ -98,6 +112,78 @@ test("home page lists core laboratory services and services route CTA", () => {
   assert.ok(source.includes("Diagnóstico Integral"));
   assert.ok(source.includes('href={ROUTES.servicios}'));
   assert.ok(source.includes("Ver todos los servicios"));
+});
+
+test("home page renders how it works section with exactly three operational steps", () => {
+  const source = read(HOME_PAGE_PATH);
+  const servicesIndex = source.indexOf('aria-labelledby="services-heading"');
+  const howItWorksIndex = source.indexOf('aria-labelledby="how-it-works-heading"');
+  const benefitsIndex = source.indexOf('aria-labelledby="benefits-heading"');
+  const stepData = extractBetween(
+    source,
+    "const howItWorksSteps = [",
+    "const benefits = [",
+  );
+  const sectionSource = extractBetween(
+    source,
+    'aria-labelledby="how-it-works-heading"',
+    "{/* Beneficios */}",
+  );
+  const forbiddenWords = [
+    "marketplace",
+    "ranking",
+    "reviews",
+    "estrellas",
+    "telemedicina",
+  ];
+
+  assert.ok(servicesIndex !== -1);
+  assert.ok(howItWorksIndex !== -1);
+  assert.ok(benefitsIndex !== -1);
+  assert.ok(servicesIndex < howItWorksIndex);
+  assert.ok(howItWorksIndex < benefitsIndex);
+  assert.ok(source.includes("Cómo funciona"));
+  assert.ok(source.includes("Trabajar con VETNEB es simple"));
+  assert.ok(source.includes('id="how-it-works-heading"'));
+  assert.ok(source.includes("grid grid-cols-1 gap-5 md:grid-cols-3"));
+  assert.ok(source.includes("Contactanos para empezar"));
+  assert.ok(source.includes("href={ROUTES.contacto}"));
+
+  assert.equal(count(stepData, "title:"), 3);
+  assert.equal(count(stepData, "description:"), 3);
+  assert.equal(count(stepData, 'title: "Enviás la muestra"'), 1);
+  assert.equal(count(stepData, 'title: "VETNEB analiza"'), 1);
+  assert.equal(count(stepData, 'title: "Recibís el informe"'), 1);
+  assert.equal(
+    count(
+      stepData,
+      "Preparás la muestra según el protocolo de VETNEB y la enviás con los datos del caso y de la clínica.",
+    ),
+    1,
+  );
+  assert.equal(
+    count(
+      stepData,
+      "El anatomopatólogo examina el tejido o la muestra citológica y elabora el informe diagnóstico.",
+    ),
+    1,
+  );
+  assert.equal(
+    count(
+      stepData,
+      "La clínica lo descarga directamente desde el portal. Si corresponde, el tutor del animal recibe acceso con un código privado.",
+    ),
+    1,
+  );
+
+  const howItWorksSurface = `${stepData}\n${sectionSource}`.toLowerCase();
+  for (const forbiddenWord of forbiddenWords) {
+    assert.equal(
+      howItWorksSurface.includes(forbiddenWord),
+      false,
+      `how it works section must not contain ${forbiddenWord}`,
+    );
+  }
 });
 
 test("home page lists benefits for clinics and professionals", () => {


### PR DESCRIPTION
## Summary
- Add a public home section explaining the VETNEB workflow in 3 steps
- Align home content with the product blueprint: lab first, portal second, verified network third
- Add tests for expected copy and prohibited marketplace language
- Document implementation in docs/implementation/home-how-it-works-section.md

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm -C frontend build