### PR TITLE
feat(home): add clinical trust stats section

### DIFF
--- a/docs/implementation/home-clinical-trust-stats.md
+++ b/docs/implementation/home-clinical-trust-stats.md
@@ -1,0 +1,83 @@
+# Home: sección Confianza clínica
+
+## Objetivo
+
+Agregar en la home pública una sección sobria, mobile-first y no comercial que refuerce la autoridad clínica de VETNEB como laboratorio de anatomía patológica veterinaria especializado.
+
+La sección mantiene la jerarquía definida en `docs/product/vetneb-platform-blueprint.md`: laboratorio primero, portal operativo segundo y red profesional verificada como contexto institucional.
+
+## Archivo modificado
+
+- `frontend/src/app/page.tsx`
+- `test/frontend-home-page-content.test.ts`
+
+## Ubicación de la sección
+
+La sección `Confianza clínica` se ubicó inmediatamente después del hero, dentro de `public-soft-canvas`, y antes del bloque móvil `Red de profesionales veterinarios` y de `Servicios del laboratorio patológico veterinario`.
+
+Esta ubicación refuerza primero el carácter de laboratorio y diagnóstico, antes de presentar servicios o red profesional.
+
+## Textos implementados
+
+Título:
+
+> Confianza clínica
+
+Intro:
+
+> Diagnóstico microscópico riguroso para la medicina veterinaria, con portal operativo e información pública como soporte del trabajo clínico.
+
+Dato institucional 1:
+
+> Diagnóstico histopatológico y citológico
+
+> Evaluación microscópica de tejidos y muestras celulares con criterio anatomopatológico veterinario.
+
+Dato institucional 2:
+
+> Informes digitales con acceso seguro
+
+> Entrega institucional de informes para clínicas y acceso privado por caso cuando corresponde.
+
+Dato institucional 3:
+
+> Red de clínicas y profesionales vinculados
+
+> Relación operativa con equipos veterinarios que trabajan con VETNEB para sus diagnósticos.
+
+Dato institucional 4:
+
+> Precios públicos y comunicación directa
+
+> Información clara para coordinar muestras, consultas y estudios sin ambigüedad operativa.
+
+## Por qué no se usaron métricas numéricas
+
+El blueprint menciona datos institucionales en formato stat, pero este alcance pide explícitamente no inventar métricas numéricas. Por eso la sección usa datos cualitativos verificables desde el producto actual: tipos de diagnóstico, entrega segura de informes, red vinculada y precios públicos.
+
+No se agregaron claims como cantidad de clínicas, cantidad de casos, años de experiencia, rankings ni volúmenes de informes porque no hay una fuente institucional validada para sostenerlos en la home pública.
+
+## Pruebas agregadas
+
+Se actualizó `test/frontend-home-page-content.test.ts` para confirmar:
+
+- La home contiene el título `Confianza clínica`.
+- La sección se ubica antes del bloque móvil de profesionales y antes de servicios.
+- Se renderizan los 4 datos institucionales esperados.
+- La fuente de datos contiene exactamente 4 títulos y 4 descripciones.
+- No se incorporan palabras prohibidas: `marketplace`, `ranking`, `reviews`, `estrellas`, `telemedicina`.
+- No se incorporan claims numéricos no verificados como `+100`, años de experiencia, cantidad de clínicas, profesionales, casos o informes.
+- Los contratos existentes de home siguen cubiertos por los tests previos del mismo archivo.
+
+## Validaciones ejecutadas
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-home-page-content.test.ts` - OK, 8 tests pasados.
+- `pnpm test` - OK, 2259 tests pasados y 1 skipped.
+- `pnpm build` - OK, backend bundle generado en `dist/index.js`.
+- `pnpm security:public-surface` - OK, sin hallazgos de exposición pública de devtools. Mantiene 2 findings `server-only` existentes en `frontend/src/middleware.ts` para nombres de cookies de sesión.
+- `pnpm -C frontend build` - OK, Next.js compiló y generó 26 páginas estáticas.
+
+## Riesgos residuales
+
+- La sección usa datos cualitativos estáticos; si VETNEB decide publicar métricas reales en el futuro, deberán venir de una fuente validada y actualizarse junto con tests.
+- El build frontend usa `next/font/google`; en esta validación se ejecutó con autorización explícita para permitir el acceso de red necesario.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -57,6 +57,37 @@ const services = [
   },
 ];
 
+const clinicalTrustItems = [
+  {
+    icon: Microscope,
+    tone: "blue" as const,
+    title: "Diagnóstico histopatológico y citológico",
+    description:
+      "Evaluación microscópica de tejidos y muestras celulares con criterio anatomopatológico veterinario.",
+  },
+  {
+    icon: FileText,
+    tone: "slate" as const,
+    title: "Informes digitales con acceso seguro",
+    description:
+      "Entrega institucional de informes para clínicas y acceso privado por caso cuando corresponde.",
+  },
+  {
+    icon: Network,
+    tone: "blue" as const,
+    title: "Red de clínicas y profesionales vinculados",
+    description:
+      "Relación operativa con equipos veterinarios que trabajan con VETNEB para sus diagnósticos.",
+  },
+  {
+    icon: ClipboardCheck,
+    tone: "slate" as const,
+    title: "Precios públicos y comunicación directa",
+    description:
+      "Información clara para coordinar muestras, consultas y estudios sin ambigüedad operativa.",
+  },
+];
+
 const howItWorksSteps = [
   {
     icon: PackageCheck,
@@ -184,6 +215,60 @@ export default function HomePage() {
       </section>
 
       <div className="public-soft-canvas">
+        <section
+          className="border-b border-vetneb-line/80 bg-white py-12 md:py-16"
+          aria-labelledby="clinical-trust-heading"
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal>
+              <div className="mx-auto mb-8 max-w-3xl text-center md:mb-10">
+                <p className="text-sm font-semibold uppercase tracking-[0.08em] text-vetneb-teal">
+                  Laboratorio primero
+                </p>
+                <h2
+                  id="clinical-trust-heading"
+                  className="mt-3 text-3xl font-bold text-vetneb-ink md:text-4xl"
+                >
+                  Confianza clínica
+                </h2>
+                <p className="mt-4 text-base leading-relaxed text-muted-foreground md:text-lg">
+                  Diagnóstico microscópico riguroso para la medicina veterinaria,
+                  con portal operativo e información pública como soporte del
+                  trabajo clínico.
+                </p>
+              </div>
+            </PublicScrollReveal>
+
+            <PublicScrollReveal staggerChildren>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                {clinicalTrustItems.map((item) => {
+                  const itemHeadingId = `home-clinical-trust-${item.title.toLowerCase().replace(/\s+/g, "-")}`;
+
+                  return (
+                    <article
+                      key={item.title}
+                      data-scroll-reveal-item
+                      aria-labelledby={itemHeadingId}
+                      className="h-full rounded-lg border border-vetneb-line/80 bg-card p-5 shadow-sm"
+                    >
+                      <VisualIcon icon={item.icon} tone={item.tone} className="mb-4" />
+                      <h3
+                        id={itemHeadingId}
+                        className="text-lg font-semibold leading-snug text-vetneb-ink"
+                      >
+                        {item.title}
+                      </h3>
+                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                        {item.description}
+                      </p>
+                    </article>
+                  );
+                })}
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
         <section
           className="border-b border-vetneb-line/80 bg-card/72 py-8 md:py-10 lg:hidden"
           aria-labelledby="mobile-professionals-heading"

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -98,6 +98,90 @@ test("home page exposes mobile professionals block before services", () => {
   assert.equal(source.includes("<Link"), false);
 });
 
+test("home page exposes clinical trust institutional data before services", () => {
+  const source = read(HOME_PAGE_PATH);
+  const clinicalTrustIndex = source.indexOf('aria-labelledby="clinical-trust-heading"');
+  const professionalsIndex = source.indexOf("Red de profesionales veterinarios");
+  const servicesIndex = source.indexOf(
+    "Servicios del laboratorio patológico veterinario",
+  );
+  const clinicalTrustData = extractBetween(
+    source,
+    "const clinicalTrustItems = [",
+    "const howItWorksSteps = [",
+  );
+  const forbiddenWords = [
+    "marketplace",
+    "ranking",
+    "reviews",
+    "estrellas",
+    "telemedicina",
+  ];
+  const unverifiedNumericClaims = [
+    /\+\s*\d+/,
+    /\d+\s*años?\s+de\s+experiencia/i,
+    /\d+\s+cl[ií]nicas/i,
+    /\d+\s+profesionales/i,
+    /\d+\s+casos/i,
+    /\d+\s+informes/i,
+  ];
+
+  assert.ok(clinicalTrustIndex !== -1);
+  assert.ok(professionalsIndex !== -1);
+  assert.ok(servicesIndex !== -1);
+  assert.ok(clinicalTrustIndex < professionalsIndex);
+  assert.ok(clinicalTrustIndex < servicesIndex);
+  assert.ok(source.includes('id="clinical-trust-heading"'));
+  assert.ok(source.includes("Laboratorio primero"));
+  assert.ok(source.includes("Confianza clínica"));
+  assert.ok(
+    source.includes(
+      "Diagnóstico microscópico riguroso para la medicina veterinaria,",
+    ),
+  );
+  assert.ok(source.includes("portal operativo e información pública"));
+  assert.ok(source.includes("grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"));
+
+  assert.equal(count(clinicalTrustData, "title:"), 4);
+  assert.equal(count(clinicalTrustData, "description:"), 4);
+  assert.equal(
+    count(clinicalTrustData, 'title: "Diagnóstico histopatológico y citológico"'),
+    1,
+  );
+  assert.equal(
+    count(clinicalTrustData, 'title: "Informes digitales con acceso seguro"'),
+    1,
+  );
+  assert.equal(
+    count(
+      clinicalTrustData,
+      'title: "Red de clínicas y profesionales vinculados"',
+    ),
+    1,
+  );
+  assert.equal(
+    count(clinicalTrustData, 'title: "Precios públicos y comunicación directa"'),
+    1,
+  );
+
+  const clinicalTrustSurface = clinicalTrustData.toLowerCase();
+  for (const forbiddenWord of forbiddenWords) {
+    assert.equal(
+      clinicalTrustSurface.includes(forbiddenWord),
+      false,
+      `clinical trust section must not contain ${forbiddenWord}`,
+    );
+  }
+
+  for (const unverifiedNumericClaim of unverifiedNumericClaims) {
+    assert.equal(
+      unverifiedNumericClaim.test(clinicalTrustData),
+      false,
+      `clinical trust section must not contain unverified numeric claim ${unverifiedNumericClaim}`,
+    );
+  }
+});
+
 test("home page lists core laboratory services and services route CTA", () => {
   const source = read(HOME_PAGE_PATH);
 


### PR DESCRIPTION
## Summary
- Add a public home section with qualitative clinical trust signals
- Reinforce VETNEB as a laboratory-first platform without invented metrics
- Add tests for expected copy, section placement and prohibited marketplace language
- Document implementation in docs/implementation/home-clinical-trust-stats.md

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm -C frontend build