### PR TITLE
feat(home): add final CTA section

### DIFF
--- a/docs/implementation/home-final-cta-section.md
+++ b/docs/implementation/home-final-cta-section.md
@@ -1,0 +1,59 @@
+# Home: sección CTA final
+
+## Objetivo
+
+Agregar una sección final sobria en la home pública para mejorar la conversión de clínicas y profesionales que llegaron al cierre de la página, manteniendo a VETNEB como laboratorio diagnóstico y portal operativo.
+
+La sección sigue `docs/product/vetneb-platform-blueprint.md`: cierre institucional, fondo de contraste azul profundo, dos CTAs y sin formulario inline.
+
+## Archivo modificado
+
+- `frontend/src/app/page.tsx`
+- `test/frontend-home-page-content.test.ts`
+
+## Ubicación de la sección
+
+La sección `CTA final` quedó cerca del final de la home, después de `Trabajo interdisciplinario y criterio diagnóstico`, reutilizando el cierre público existente sin mover navegación ni secciones previas.
+
+## Copy implementado
+
+Headline:
+
+> Empezá a trabajar con VETNEB
+
+Subtítulo:
+
+> Conocé los servicios diagnósticos o contactanos para coordinar el envío de muestras.
+
+## CTAs implementados
+
+- `Contactanos` -> `/contacto`
+- `Ver servicios` -> `/servicios`
+
+No se agregó formulario inline ni copy asociado a marketplace, ranking, reviews, estrellas, telemedicina o reservas online.
+
+## Pruebas agregadas
+
+Se actualizó `test/frontend-home-page-content.test.ts` para confirmar:
+
+- La home renderiza `Empezá a trabajar con VETNEB`.
+- La sección final renderiza los CTAs `Contactanos` y `Ver servicios`.
+- Los CTAs usan las rutas públicas `ROUTES.contacto` y `ROUTES.servicios`, respaldadas por `/contacto` y `/servicios`.
+- La sección final contiene exactamente dos `PublicRouteControl`.
+- La sección final no contiene formulario inline, inputs, textareas ni `react-hook-form`.
+- La sección final no introduce las palabras prohibidas del alcance.
+- Los contratos existentes de home siguen cubiertos por el mismo archivo de tests.
+
+## Validaciones ejecutadas
+
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-home-page-content.test.ts` - OK, 8 tests pasados.
+- `pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-visual-consistency.test.ts` - OK, 14 tests pasados.
+- `pnpm test` - OK, 2259 tests pasados y 1 skipped.
+- `pnpm build` - OK.
+- `pnpm security:public-surface` - OK, sin exposición pública de devtools. Mantiene 2 findings `server-only` existentes en `frontend/src/middleware.ts` para nombres de cookies de sesión.
+- `pnpm -C frontend build` - OK, Next.js compiló y generó 26 páginas estáticas.
+
+## Riesgos residuales
+
+- El CTA final usa copy estático; si cambia el modelo operativo de contacto o servicios, habrá que actualizar esta sección y sus tests.
+- El build frontend usa `next/font/google`; se ejecutó con autorización explícita por el posible acceso de red.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -507,38 +507,38 @@ export default function HomePage() {
 
         {/* CTA final */}
         <section
-          className="py-16 md:py-20"
+          className="bg-vetneb-navy py-16 text-primary-foreground md:py-20"
           aria-labelledby="cta-heading"
         >
           <PublicScrollReveal>
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div className="container mx-auto px-4 text-center sm:px-6 lg:px-8">
               <h2
                 id="cta-heading"
-                className="text-3xl md:text-4xl font-bold mb-4 text-vetneb-ink"
+                className="mx-auto max-w-3xl text-3xl font-bold leading-tight md:text-4xl"
               >
-                Seguimos trabajando en mejorar
+                Empezá a trabajar con VETNEB
               </h2>
-              <p className="mx-auto mb-8 max-w-xl text-lg text-muted-foreground">
-                Agilizamos la recepción y entrega de informes, mantenemos
-                trazabilidad durante todo el proceso y coordinamos con clínicas y
-                profesionales para sostener decisiones terapéuticas con mayor
-                claridad.
+              <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-primary-foreground/78 md:text-lg">
+                Conocé los servicios diagnósticos o contactanos para coordinar el
+                envío de muestras.
               </p>
-              <div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
-                <PublicRouteControl
-                  href={ROUTES.login}
-                  variant="primaryDark"
-                  className="public-cta-primary w-full sm:w-auto"
-                >
-                  Ingresar al portal de informes
-                </PublicRouteControl>
-                <PublicRouteControl
-                  href={ROUTES.contacto}
-                  variant="primaryLight"
-                  className="public-cta-outline w-full sm:w-auto"
-                >
-                  Coordinar muestras y consultas
-                </PublicRouteControl>
+              <div className="mt-8">
+                <div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
+                  <PublicRouteControl
+                    href={ROUTES.contacto}
+                    variant="primaryLight"
+                    className="public-cta-outline w-full sm:w-auto"
+                  >
+                    Contactanos
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href={ROUTES.servicios}
+                    variant="secondaryOutline"
+                    className="w-full border-white/55 bg-white/10 text-primary-foreground shadow-none hover:border-white/75 hover:bg-white/16 hover:text-primary-foreground active:text-primary-foreground focus-visible:text-primary-foreground sm:w-auto"
+                  >
+                    Ver servicios
+                  </PublicRouteControl>
+                </div>
               </div>
             </div>
           </PublicScrollReveal>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -284,17 +284,49 @@ test("home page lists benefits for clinics and professionals", () => {
 
 test("home page exposes final conversion CTA without private route metadata", () => {
   const source = read(HOME_PAGE_PATH);
+  const routesSource = read("frontend/src/lib/routes.ts");
+  const finalCtaSection = extractBetween(
+    source,
+    'className="bg-vetneb-navy py-16 text-primary-foreground md:py-20"',
+    "</section>",
+  );
+  const forbiddenWords = [
+    "marketplace",
+    "ranking",
+    "reviews",
+    "estrellas",
+    "telemedicina",
+    "reservas online",
+  ];
 
   assert.ok(source.includes('aria-labelledby="cta-heading"'));
   assert.ok(source.includes('id="cta-heading"'));
-  assert.ok(source.includes("Seguimos trabajando en mejorar"));
-  assert.ok(source.includes("Ingresar al portal de informes"));
-  assert.ok(source.includes("Coordinar muestras y consultas"));
-  assert.ok(source.includes("public-cta-primary"));
-  assert.ok(source.includes("public-cta-on-hero"));
+  assert.ok(source.includes("Empezá a trabajar con VETNEB"));
+  assert.ok(source.includes("Conocé los servicios diagnósticos o contactanos para coordinar el"));
+  assert.ok(source.includes("envío de muestras."));
+  assert.ok(finalCtaSection.includes("Contactanos"));
+  assert.ok(finalCtaSection.includes("Ver servicios"));
+  assert.ok(finalCtaSection.includes("href={ROUTES.contacto}"));
+  assert.ok(finalCtaSection.includes("href={ROUTES.servicios}"));
+  assert.ok(routesSource.includes('contacto: "/contacto"'));
+  assert.ok(routesSource.includes('servicios: "/servicios"'));
   assert.ok(source.includes("public-cta-outline"));
-  assert.ok(source.includes('variant="primaryLight"'));
+  assert.ok(finalCtaSection.includes('variant="primaryLight"'));
+  assert.ok(finalCtaSection.includes('variant="secondaryOutline"'));
+  assert.ok(finalCtaSection.includes("bg-vetneb-navy"));
+  assert.equal(count(finalCtaSection, "<PublicRouteControl"), 2);
+  assert.equal(/<form\b/i.test(finalCtaSection), false);
+  assert.equal(/<input\b|<textarea\b|react-hook-form/i.test(finalCtaSection), false);
   assert.equal(source.includes("bg-primary py-16 text-white md:py-20"), false);
   assert.equal(source.includes('"/dashboard"'), false);
   assert.equal(source.includes('"/api"'), false);
+
+  const finalCtaSurface = finalCtaSection.toLowerCase();
+  for (const forbiddenWord of forbiddenWords) {
+    assert.equal(
+      finalCtaSurface.includes(forbiddenWord),
+      false,
+      `final CTA section must not contain ${forbiddenWord}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- Add a dark final CTA section to the public home
- Align closing copy with the product blueprint: laboratory-first, professional and non-marketplace
- Add tests for CTA copy, routes, exact CTA count, no inline form and prohibited terms
- Document implementation in docs/implementation/home-final-cta-section.md

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm -C frontend build