### PR TITLE
copy(profesionales): frame bank as verified network

### DIFF
--- a/docs/implementation/profesionales-verified-network-framing.md
+++ b/docs/implementation/profesionales-verified-network-framing.md
@@ -1,0 +1,83 @@
+# Banco de Profesionales como red verificada
+
+## Objetivo
+
+Alinear el copy publico de `/profesionales` con `docs/product/vetneb-platform-blueprint.md`: VETNEB se presenta primero como laboratorio, luego como portal operativo, y el Banco de Profesionales como una red verificada de clinicas y profesionales que trabajan con VETNEB.
+
+## Archivo modificado
+
+- `frontend/src/components/public/ProfesionalesSearchContent.tsx`
+- `frontend/src/app/profesionales/page.tsx`
+- `frontend/src/lib/seo.ts`
+- `test/frontend-profesionales-page-content.test.ts`
+- `test/frontend-public-page-semantics.test.ts`
+- `test/frontend-public-page-ctas.test.ts`
+- `test/frontend-public-page-metadata.test.ts`
+- `test/frontend-public-seo-contract.test.ts`
+- `test/frontend-public-professionals-scalable-directory.test.ts`
+
+## Copy anterior
+
+Hero visible:
+
+> Red de profesionales veterinarios
+
+> Banco publico de profesionales vinculados a VETNEB, con busqueda directa, clara y optimizada para coordinar derivaciones e interconsultas con datos verificables.
+
+Bloque de consulta:
+
+> Buscar profesionales
+
+> Ingrese texto libre, incluso una sola letra. La busqueda admite coincidencias por nombre, especialidad, servicios, localidad, pais, email, telefono o descripcion, y facilita la coordinacion profesional con trazabilidad de contacto.
+
+## Copy nuevo
+
+Hero visible:
+
+> Clínicas y profesionales verificados que trabajan con VETNEB.
+
+> Cada ficha forma parte de una red vinculada al laboratorio y se muestra bajo criterios operativos verificables, no por ranking comercial.
+
+Bloque de consulta:
+
+> Consultar la red verificada
+
+> Ingrese texto libre, incluso una sola letra. La consulta admite coincidencias por nombre, especialidad, servicios, localidad, pais o descripcion para ubicar perfiles institucionales dentro de la red VETNEB.
+
+Metadata publica:
+
+> Clínicas y Profesionales Verificados VETNEB
+
+> Clínicas y profesionales verificados que trabajan con VETNEB dentro de una red vinculada al laboratorio.
+
+## Por que se evita lenguaje marketplace/directorio
+
+El Banco no debe comunicar busqueda comercial de veterinarios, posicionamiento pago, rankings, reseñas, reservas ni telemedicina. El nuevo texto enfatiza relacion con el laboratorio, verificacion operativa y fichas institucionales dentro de una red VETNEB.
+
+La unica negacion visible conservada es "no por ranking comercial", porque aclara el criterio operativo sin convertir la pagina en una lista de exclusiones.
+
+## Pruebas agregadas
+
+- `/profesionales` renderiza el framing de red verificada.
+- El copy menciona que clinicas y profesionales trabajan con VETNEB.
+- El copy visible evita lenguaje de marketplace/directorio comercial.
+- El listado compacto no expone email, telefono ni direccion completa.
+- El detalle aislado por `clinicId` conserva su contrato.
+- La busqueda conserva `q`, `limit`, `offset`, helper y endpoints publicos existentes.
+- La UI publica no expone `storagePath`, `signedUrl`, `token`, `cookie`, `session` ni `service_role`.
+
+## Validaciones ejecutadas
+
+- `pnpm test`: OK, 2260 tests passing y 1 skipped.
+- `pnpm build`: OK, backend bundle generado en `dist/index.js`.
+- `pnpm security:public-surface`: OK, sin public devtools exposure findings. Mantiene dos findings `server-only` existentes en `frontend/src/middleware.ts` para `CLINIC_SESSION_COOKIE_NAME` y `ADMIN_SESSION_COOKIE_NAME`.
+- `pnpm -C frontend build`: pendiente de autorizacion para red, porque `frontend/src/app/layout.tsx` usa `next/font/google`.
+
+## Riesgos residuales
+
+- El endpoint publico mantiene el contrato de busqueda existente. Este cambio no reduce ni amplia campos de backend; solo ajusta copy y guardrails source-level.
+- La pagina sigue teniendo formulario de consulta porque la funcionalidad actual de busqueda permanece vigente.
+
+## Confirmacion de alcance
+
+No se cambio elegibilidad del Banco de Profesionales, backend ni API publica. No se modifico `/api/public/professionals`, detalle por `clinicId`, precios, home, particulares, dashboard ni auth.

--- a/frontend/src/app/profesionales/page.tsx
+++ b/frontend/src/app/profesionales/page.tsx
@@ -5,8 +5,8 @@ import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSea
 import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata(
-  "Red de Profesionales Veterinarios",
-  "Banco público de profesionales vinculados a VETNEB. Búsqueda por texto libre con coincidencias aproximadas.",
+  "Clínicas y Profesionales Verificados VETNEB",
+  "Clínicas y profesionales verificados que trabajan con VETNEB dentro de una red vinculada al laboratorio.",
   "/profesionales",
 );
 

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -119,12 +119,12 @@ export function ProfesionalesSearchContent() {
             id="professionals-page-title"
             className="mb-4 max-w-4xl text-4xl font-bold md:text-5xl"
           >
-            Red de profesionales veterinarios
+            Clínicas y profesionales verificados que trabajan con VETNEB.
           </h1>
           <p className="max-w-2xl public-copy text-xl text-primary-foreground/92">
-            Banco público de profesionales vinculados a VETNEB, con búsqueda
-            directa, clara y optimizada para coordinar derivaciones e
-            interconsultas con datos verificables.
+            Cada ficha forma parte de una red vinculada al laboratorio y se
+            muestra bajo criterios operativos verificables, no por ranking
+            comercial.
           </p>
         </div>
       </section>
@@ -147,13 +147,13 @@ export function ProfesionalesSearchContent() {
                     id="professionals-search-heading"
                     className="mb-3 text-2xl font-bold text-vetneb-ink"
                   >
-                    Buscar profesionales
+                    Consultar la red verificada
                   </h2>
                   <p className="public-copy-tight text-sm text-muted-foreground">
-                    Ingrese texto libre, incluso una sola letra. La búsqueda
+                    Ingrese texto libre, incluso una sola letra. La consulta
                     admite coincidencias por nombre, especialidad, servicios,
-                    localidad, país, email, teléfono o descripción, y facilita la
-                    coordinación profesional con trazabilidad de contacto.
+                    localidad, país o descripción para ubicar perfiles
+                    institucionales dentro de la red VETNEB.
                   </p>
                 </div>
               </div>
@@ -161,11 +161,11 @@ export function ProfesionalesSearchContent() {
 
             <form
               className="premium-card flex flex-col gap-3 p-4 sm:flex-row"
-              aria-label="Buscador de profesionales"
+              aria-label="Consulta de la red profesional"
               onSubmit={handleSubmit}
             >
               <label htmlFor="professional-search" className="sr-only">
-                Buscar profesional
+                Consultar profesional
               </label>
               <div className="relative flex-1">
                 <Search
@@ -178,12 +178,12 @@ export function ProfesionalesSearchContent() {
                   type="search"
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Buscar desde una letra: nombre, especialidad, localidad o dato asociado"
+                  placeholder="Nombre, especialidad, localidad o dato operativo de la red"
                   className="h-11 w-full rounded-xl border border-input bg-white/90 pl-10 pr-3 text-sm shadow-inner ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 />
               </div>
               <Button type="submit" className="public-cta-primary h-11">
-                Buscar
+                Consultar
               </Button>
             </form>
 
@@ -197,14 +197,14 @@ export function ProfesionalesSearchContent() {
               </h2>
               {!currentQuery ? (
                 <div className="surface-empty p-6">
-                  Realice una búsqueda para consultar el banco público y
-                  coordinar contacto profesional.
+                  Realice una consulta para revisar clínicas y profesionales
+                  verificados de la red VETNEB.
                 </div>
               ) : null}
 
               {state.status === "loading" ? (
                 <div className="clinical-alert-info p-6">
-                  Buscando profesionales vinculados a VETNEB...
+                  Consultando la red de profesionales vinculados a VETNEB...
                 </div>
               ) : null}
 
@@ -225,7 +225,7 @@ export function ProfesionalesSearchContent() {
                 <div>
                   <p className="mb-4 text-sm text-muted-foreground">
                     {state.total} resultado(s) para “{currentQuery}”. Seleccione
-                    un perfil para ver sus datos completos de contacto y
+                    un perfil para ver la ficha institucional y sus datos de
                     coordinación clínica.
                   </p>
                   <div className="space-y-3">

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -368,9 +368,9 @@ export function getProfessionalsPageJsonLd() {
         "@type": ["WebPage", "SearchResultsPage"],
         "@id": searchPageId,
         url: pageUrl,
-        name: "Red de Profesionales Veterinarios",
+        name: "Clínicas y Profesionales Verificados VETNEB",
         description:
-          "Banco público de profesionales vinculados a VETNEB con búsqueda por texto libre y coincidencias aproximadas.",
+          "Clínicas y profesionales verificados que trabajan con VETNEB dentro de una red vinculada al laboratorio.",
         inLanguage: "es-AR",
         isPartOf: {
           "@id": websiteId,
@@ -399,4 +399,3 @@ export function getProfessionalsPageJsonLd() {
     ],
   };
 }
-

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -26,34 +26,64 @@ test("profesionales page defines metadata and delegates to search content", () =
   assert.ok(source.includes('import { ProfesionalesSearchContent } from "@/components/public/ProfesionalesSearchContent";'));
   assert.ok(source.includes('import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Red de Profesionales Veterinarios"'));
-  assert.ok(source.includes('"Banco público de profesionales vinculados a VETNEB'));
+  assert.ok(source.includes('"Clínicas y Profesionales Verificados VETNEB"'));
+  assert.ok(source.includes('"Clínicas y profesionales verificados que trabajan con VETNEB'));
   assert.ok(source.includes('"/profesionales"'));
   assert.ok(source.includes("<Suspense fallback={null}>"));
   assert.ok(source.includes("<ProfesionalesSearchContent />"));
 });
 
-test("profesionales search content renders only the professional bank search surface", () => {
+test("profesionales search content renders verified network framing", () => {
   const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes("<PublicLayout>"));
-  assert.ok(source.includes("Red de profesionales veterinarios"));
-  assert.ok(source.includes("Banco público de profesionales"));
-  assert.ok(source.includes("Buscar profesionales"));
+  assert.ok(source.includes("Clínicas y profesionales verificados que trabajan con VETNEB."));
+  assert.ok(source.includes("Cada ficha forma parte de una red vinculada al laboratorio"));
+  assert.ok(source.includes("criterios operativos verificables"));
+  assert.ok(source.includes("no por ranking"));
+  assert.ok(source.includes("Consultar la red verificada"));
   assert.ok(source.includes("Ingrese texto libre, incluso una sola letra"));
-  assert.ok(source.includes("Buscar desde una letra: nombre, especialidad, localidad o dato asociado"));
-  assert.ok(source.includes('aria-label="Buscador de profesionales"'));
+  assert.ok(source.includes("para ubicar perfiles"));
+  assert.ok(source.includes("institucionales dentro de la red VETNEB"));
+  assert.ok(source.includes("Nombre, especialidad, localidad o dato operativo de la red"));
+  assert.ok(source.includes('aria-label="Consulta de la red profesional"'));
   assert.ok(source.includes('type="search"'));
   assert.equal(source.includes("minLength"), false);
   assert.equal(source.includes("minlength"), false);
   assert.ok(source.includes('name="q"'));
-  assert.ok(source.includes("Buscar desde una letra: nombre, especialidad, localidad o dato asociado"));
   assert.equal(source.includes("Herramientas para el profesional"), false);
   assert.equal(source.includes("Especialidades atendidas"), false);
   assert.equal(source.includes("const benefits = ["), false);
   assert.equal(source.includes("const specialties = ["), false);
+});
+
+test("profesionales public copy avoids marketplace and commercial directory language", () => {
+  const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
+  const forbiddenVisibleCopy = [
+    "marketplace",
+    "directorio",
+    "reviews",
+    "reseñas",
+    "estrellas",
+    "telemedicina",
+    "reservas online",
+    "mejores veterinarios",
+    "buscá veterinario",
+    "busca veterinario",
+    "anuncios",
+    "publicidad paga",
+    "destacados",
+  ];
+
+  for (const forbidden of forbiddenVisibleCopy) {
+    assert.equal(
+      source.toLowerCase().includes(forbidden),
+      false,
+      `copy visible de /profesionales no debe incluir ${forbidden}`,
+    );
+  }
 });
 
 test("profesionales search content uses free text query and approximate backend search helper", () => {
@@ -67,6 +97,7 @@ test("profesionales search content uses free text query and approximate backend 
   assert.ok(source.includes("limit: PUBLIC_PROFESSIONALS_PAGE_SIZE"));
   assert.ok(source.includes('{ cache: "no-store" }'));
   assert.ok(source.includes("coincidencias por nombre"));
+  assert.ok(source.includes("router.push(`${ROUTES.profesionales}${params.size ? `?${params}` : \"\"}`)"));
   assert.ok(apiSource.includes("export async function searchPublicProfessionals("));
   assert.ok(apiSource.includes("export async function getPublicProfessional("));
   assert.ok(apiSource.includes("q"));
@@ -93,6 +124,9 @@ test("profesionales search content renders compact professional result cards", (
   assert.equal(source.includes("professional.phone"), false);
   assert.equal(source.includes("professional.publicAddress"), false);
   assert.equal(source.includes("professional.mapLink"), false);
+  assert.equal(source.includes("email"), false);
+  assert.equal(source.includes("teléfono"), false);
+  assert.equal(source.includes("Dirección"), false);
   assert.equal(source.includes("<PublicExternalControl"), false);
   assert.equal(source.includes("mailto:${professional.email}"), false);
   assert.equal(source.includes("https://wa.me/549"), false);
@@ -124,7 +158,23 @@ test("profesionales page remains public and avoids private route literals", () =
   const contentSource = read(PROFESIONALES_SEARCH_CONTENT_PATH);
   const detailSource = read(PROFESIONAL_DETAIL_CONTENT_PATH);
   const combined = [pageSource, contentSource, detailSource].join("\n");
+  const forbiddenPublicUiMarkers = [
+    "storagePath",
+    "signedUrl",
+    "token",
+    "cookie",
+    "session",
+    "service_role",
+  ];
 
   assert.equal(combined.includes('"/dashboard"'), false);
   assert.equal(combined.includes("admin_session_id"), false);
+
+  for (const marker of forbiddenPublicUiMarkers) {
+    assert.equal(
+      combined.includes(marker),
+      false,
+      `UI pública de profesionales no debe exponer ${marker}`,
+    );
+  }
 });

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -21,8 +21,8 @@ test("profesionales public page exposes search instead of conversion CTAs", () =
   const combined = [pageSource, contentSource].join("\n");
 
   assert.ok(combined.includes("ProfesionalesSearchContent"));
-  assert.ok(combined.includes("Buscar profesionales"));
-  assert.ok(combined.includes('aria-label="Buscador de profesionales"'));
+  assert.ok(combined.includes("Consultar la red verificada"));
+  assert.ok(combined.includes('aria-label="Consulta de la red profesional"'));
   assert.ok(combined.includes('name="q"'));
   assert.equal(combined.includes("¿Querés integrar tu práctica a Portal VETNEB?"), false);
   assert.equal(combined.includes("Contactar a VETNEB"), false);

--- a/test/frontend-public-page-metadata.test.ts
+++ b/test/frontend-public-page-metadata.test.ts
@@ -33,8 +33,8 @@ test("profesionales public page defines SEO metadata", () => {
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { createPageMetadata, getProfessionalsPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Red de Profesionales Veterinarios"'));
-  assert.ok(source.includes('"Banco público de profesionales vinculados a VETNEB'));
+  assert.ok(source.includes('"Clínicas y Profesionales Verificados VETNEB"'));
+  assert.ok(source.includes('"Clínicas y profesionales verificados que trabajan con VETNEB'));
   assert.ok(source.includes('"/profesionales"'));
 });
 

--- a/test/frontend-public-page-semantics.test.ts
+++ b/test/frontend-public-page-semantics.test.ts
@@ -96,6 +96,8 @@ test("profesionales content keeps semantic search/result structure and map safet
 
   assert.ok(source.includes("<h1"));
   assert.ok(source.includes("<h2"));
+  assert.ok(source.includes("Clínicas y profesionales verificados que trabajan con VETNEB."));
+  assert.ok(source.includes("Cada ficha forma parte de una red vinculada al laboratorio"));
   assert.ok(source.includes("<section"));
   assert.ok(source.includes("state.professionals.map((professional) =>"));
   assert.ok(source.includes("<article"));

--- a/test/frontend-public-professionals-scalable-directory.test.ts
+++ b/test/frontend-public-professionals-scalable-directory.test.ts
@@ -40,6 +40,7 @@ function extractSerializeProfessional(source: string) {
 test("public professionals listing renders compact cards without contact detail payload", () => {
   const source = read(PROFESIONALES_SEARCH_CONTENT_PATH);
 
+  assert.ok(source.includes("Clínicas y profesionales verificados que trabajan con VETNEB."));
   assert.ok(source.includes("state.professionals.map((professional) =>"));
   assert.ok(source.includes("key={professional.clinicId}"));
   assert.ok(source.includes("professional.displayName"));
@@ -53,6 +54,9 @@ test("public professionals listing renders compact cards without contact detail 
   assert.equal(source.includes("professional.phone"), false);
   assert.equal(source.includes("professional.publicAddress"), false);
   assert.equal(source.includes("professional.mapLink"), false);
+  assert.equal(source.includes("email"), false);
+  assert.equal(source.includes("teléfono"), false);
+  assert.equal(source.includes("Dirección"), false);
 });
 
 test("public professionals listing has stable local avatar fallback", () => {

--- a/test/frontend-public-seo-contract.test.ts
+++ b/test/frontend-public-seo-contract.test.ts
@@ -120,6 +120,12 @@ test("professionals public page exposes verifiable structured data", () => {
   assert.ok(seoSource.includes('name: "Profesionales"'));
   assert.ok(seoSource.includes("item: SITE_URL"));
   assert.ok(seoSource.includes("item: pageUrl"));
+  assert.ok(seoSource.includes('name: "Clínicas y Profesionales Verificados VETNEB"'));
+  assert.ok(
+    seoSource.includes(
+      '"Clínicas y profesionales verificados que trabajan con VETNEB dentro de una red vinculada al laboratorio."',
+    ),
+  );
   assert.ok(seoSource.includes('"@id": websiteId'));
   assert.ok(seoSource.includes('"@id": organizationId'));
   assert.ok(seoSource.includes('"@id": breadcrumbId'));


### PR DESCRIPTION
## Summary
- Update public professionals copy to frame the bank as a verified VETNEB-linked network
- Align professionals page metadata and SEO structured data with verified-network framing
- Avoid marketplace, ranking, reviews, reservation and paid-advertising language
- Preserve compact listing, search behavior, public API contract and derived eligibility
- Add/update tests for verified-network framing, metadata and public-surface safety
- Document implementation in docs/implementation/profesionales-verified-network-framing.md

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm -C frontend build