### PR TITLE
fix(next): migrate middleware convention to proxy

### DIFF
--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -18,7 +18,7 @@ function getRequiredSessionCookieName(pathname: string): string {
     : CLINIC_SESSION_COOKIE_NAME;
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const requiredCookieName = getRequiredSessionCookieName(pathname);
   const hasRequiredSession = Boolean(

--- a/scripts/security/audit-public-devtools-surface.mjs
+++ b/scripts/security/audit-public-devtools-surface.mjs
@@ -8,7 +8,7 @@ const ROOT = process.cwd();
 const JSON_OUTPUT = process.argv.includes("--json");
 
 const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
-const KNOWN_SERVER_ONLY_FRONTEND_FILES = new Set(["frontend/src/middleware.ts"]);
+const KNOWN_SERVER_ONLY_FRONTEND_FILES = new Set(["frontend/src/middleware.ts", "frontend/src/proxy.ts"]);
 
 const SURFACE_TARGETS = [
   { path: "frontend/src", label: "frontend/src", public: true, type: "dir" },

--- a/test/auth-cookie-persistence-contract.test.ts
+++ b/test/auth-cookie-persistence-contract.test.ts
@@ -257,11 +257,11 @@ test("cookie persistence contract: ParticularesContent calls backend on mount to
 });
 
 // ---------------------------------------------------------------------------
-// 7. Middleware protects /dashboard/* using cookies (not memory state)
+// 7. proxy protects /dashboard/* using cookies (not memory state)
 // ---------------------------------------------------------------------------
 
-test("cookie persistence contract: Next.js middleware guards dashboard using cookie presence", () => {
-  const source = readSource("frontend/src/middleware.ts");
+test("cookie persistence contract: Next.js proxy guards dashboard using cookie presence", () => {
+  const source = readSource("frontend/src/proxy.ts");
 
   assert.ok(
     source.includes("request.cookies.get"),

--- a/test/auth-session-boundaries.test.ts
+++ b/test/auth-session-boundaries.test.ts
@@ -435,9 +435,9 @@ test("endpoints /me respetan límites de sesión por superficie sin fallback cru
   }
 });
 
-test("frontend middleware mantiene separación dashboard/admin y deja particulares fuera", () => {
+test("frontend proxy mantiene separación dashboard/admin y deja particulares fuera", () => {
   const source = readFileSync(
-    resolve(process.cwd(), "frontend/src/middleware.ts"),
+    resolve(process.cwd(), "frontend/src/proxy.ts"),
     "utf8",
   ).replace(/\r\n/g, "\n");
 

--- a/test/frontend-dashboard-middleware.test.ts
+++ b/test/frontend-dashboard-middleware.test.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
-const MIDDLEWARE_PATH = "frontend/src/middleware.ts";
+const MIDDLEWARE_PATH = "frontend/src/proxy.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -12,11 +12,11 @@ function read(relativePath: string): string {
   );
 }
 
-test("frontend dashboard middleware exists and protects dashboard routes", () => {
+test("frontend dashboard proxy exists and protects dashboard routes", () => {
   assert.equal(
     existsSync(resolve(process.cwd(), MIDDLEWARE_PATH)),
     true,
-    "frontend dashboard middleware must exist",
+    "frontend dashboard proxy must exist",
   );
 
   const source = read(MIDDLEWARE_PATH);
@@ -32,7 +32,7 @@ test("frontend dashboard middleware exists and protects dashboard routes", () =>
   assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
 });
 
-test("frontend dashboard middleware separates clinic and admin sessions", () => {
+test("frontend dashboard proxy separates clinic and admin sessions", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("function isAdminDashboardPath(pathname: string): boolean"));
@@ -49,7 +49,7 @@ test("frontend dashboard middleware separates clinic and admin sessions", () => 
   assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
-test("frontend dashboard middleware blocks unauthenticated admin dashboard from public login", () => {
+test("frontend dashboard proxy blocks unauthenticated admin dashboard from public login", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("const pathname = request.nextUrl.pathname;"));
@@ -58,7 +58,7 @@ test("frontend dashboard middleware blocks unauthenticated admin dashboard from 
   assert.equal(source.includes("loginUrl.pathname = LOGIN_PATH;\\n  loginUrl.searchParams.set"), false);
 });
 
-test("frontend dashboard middleware preserves requested clinic dashboard path on login redirect", () => {
+test("frontend dashboard proxy preserves requested clinic dashboard path on login redirect", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("request.nextUrl.clone()"));
@@ -70,7 +70,7 @@ test("frontend dashboard middleware preserves requested clinic dashboard path on
   assert.ok(source.includes('loginUrl.searchParams.set("next", nextPath)'));
 });
 
-test("frontend dashboard middleware stays scoped to frontend route protection", () => {
+test("frontend dashboard proxy stays scoped to frontend route protection", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.equal(source.includes("fetch("), false);

--- a/test/frontend-extreme-speed-guardrails.test.ts
+++ b/test/frontend-extreme-speed-guardrails.test.ts
@@ -319,8 +319,8 @@ test("next.config applies security headers to all routes", () => {
 // 7. Middleware — separación de sesiones
 // ---------------------------------------------------------------------------
 
-test("middleware protects /dashboard and /dashboard/admin with correct cookies", () => {
-  const source = read("frontend/src/middleware.ts");
+test("proxy protects /dashboard and /dashboard/admin with correct cookies", () => {
+  const source = read("frontend/src/proxy.ts");
 
   assert.ok(
     source.includes('app_session_id'),

--- a/test/frontend-middleware.test.ts
+++ b/test/frontend-middleware.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
-const MIDDLEWARE_PATH = "frontend/src/middleware.ts";
+const MIDDLEWARE_PATH = "frontend/src/proxy.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -12,14 +12,14 @@ function read(relativePath: string): string {
   );
 }
 
-test("frontend middleware imports Next response and request types", () => {
+test("frontend proxy imports Next response and request types", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('import { NextResponse, type NextRequest } from "next/server";'));
-  assert.ok(source.includes("export function middleware(request: NextRequest)"));
+  assert.ok(source.includes("export function proxy(request: NextRequest)"));
 });
 
-test("frontend middleware separates clinic and admin dashboard session cookies", () => {
+test("frontend proxy separates clinic and admin dashboard session cookies", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('const CLINIC_SESSION_COOKIE_NAME = "app_session_id";'));
@@ -37,7 +37,7 @@ test("frontend middleware separates clinic and admin dashboard session cookies",
   assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
-test("frontend middleware blocks unauthenticated admin dashboard without public login redirect", () => {
+test("frontend proxy blocks unauthenticated admin dashboard without public login redirect", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("if (isAdminDashboardPath(pathname)) {"));
@@ -47,7 +47,7 @@ test("frontend middleware blocks unauthenticated admin dashboard without public 
   assert.equal(source.includes('loginUrl.searchParams.set("next", nextPath);\\n\\n  return NextResponse.redirect(loginUrl);\\n}'), false);
 });
 
-test("frontend middleware redirects unauthenticated clinic dashboard requests to login with next path", () => {
+test("frontend proxy redirects unauthenticated clinic dashboard requests to login with next path", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('const LOGIN_PATH = "/login";'));
@@ -58,7 +58,7 @@ test("frontend middleware redirects unauthenticated clinic dashboard requests to
   assert.ok(source.includes("return NextResponse.redirect(loginUrl);"));
 });
 
-test("frontend middleware remains scoped to dashboard routes only", () => {
+test("frontend proxy remains scoped to dashboard routes only", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("export const config = {"));

--- a/test/frontend-next-config-security-headers.test.ts
+++ b/test/frontend-next-config-security-headers.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 
 const CONFIG_PATH = "frontend/next.config.ts";
 const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
-const MIDDLEWARE_PATH = "frontend/src/middleware.ts";
+const MIDDLEWARE_PATH = "frontend/src/proxy.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(

--- a/test/frontend-pwa-global-operational-contract.test.ts
+++ b/test/frontend-pwa-global-operational-contract.test.ts
@@ -235,7 +235,7 @@ test("service worker no contiene el patrón inseguro de clone después de await"
 test("superficies clínica, admin, particular, logística y backend siguen declaradas para operación online", () => {
   const fastifySource = read("server/fastify-app.ts");
   const apiSource = read("frontend/src/lib/api.ts");
-  const middlewareSource = read("frontend/src/middleware.ts");
+  const middlewareSource = read("frontend/src/proxy.ts");
 
   assert.equal(existsSync(resolve(process.cwd(), "frontend/src/app/dashboard/admin/page.tsx")), true);
 

--- a/test/global-auth-boundary-contract.test.ts
+++ b/test/global-auth-boundary-contract.test.ts
@@ -124,9 +124,9 @@ test("public route families do not accept browser session authenticators", () =>
   );
 });
 
-test("session cookie names remain separated across backend and dashboard middleware", () => {
+test("session cookie names remain separated across backend and dashboard proxy", () => {
   const envSource = read("server/lib/env.ts");
-  const middlewareSource = read("frontend/src/middleware.ts");
+  const middlewareSource = read("frontend/src/proxy.ts");
 
   assertContains(envSource, 'cookieName: rawEnv.COOKIE_NAME ?? "app_session_id"', "env clinic cookie");
   assertContains(

--- a/test/global-e2e-production-readiness-contract.test.ts
+++ b/test/global-e2e-production-readiness-contract.test.ts
@@ -188,7 +188,7 @@ const GLOBAL_SURFACES: readonly GlobalSurface[] = [
       "Public, dashboard and particular UX surfaces keep route guards, mobile parity and semantic frontend checks.",
     runtimeFiles: [
       {
-        path: "frontend/src/middleware.ts",
+        path: "frontend/src/proxy.ts",
         markers: ["ADMIN_DASHBOARD_PATH_PREFIX", "NextResponse.redirect"],
       },
       {


### PR DESCRIPTION
Migrates the deprecated Next.js middleware convention to proxy after the Next 16 upgrade. Updates internal auth/security contracts and public-surface audit classification so proxy remains treated as server-only. Validated locally with root tests/build/security and frontend lint/typecheck/build/e2e.