### PR TITLE
fix(frontend): stabilize particulares token hydration

### DIFF
--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -930,6 +930,7 @@ export function ParticularesContent() {
                       />
                       <Input
                         id="particular-token"
+                        suppressHydrationWarning
                         name="token"
                         type="password"
                         placeholder="Ingrese el token recibido"


### PR DESCRIPTION
## Summary
- add targeted hydration suppression to the public particulares token input affected by external caret-color mutations

## Validation
- pnpm --dir frontend exec playwright test e2e/public-routes.spec.ts --grep particulares
- pnpm --dir frontend exec playwright test e2e/visual-smoke.spec.ts --grep particulares
- pnpm --dir frontend e2e
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build