### PR TITLE
fix(e2e): isolate playwright api env

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   },
   webServer: {
     command: "pnpm dev --hostname 127.0.0.1",
+    env: {
+      NEXT_PUBLIC_API_URL: "",
+    },
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
## Summary
- prevent Playwright webServer from inheriting local NEXT_PUBLIC_API_URL from frontend/.env.local
- keep e2e dev server isolated from LAN backend rewrites

## Validation
- pnpm --dir frontend e2e
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build