### PR TITLE
feat(home): add clinical trust stats section

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   Microscope,
   Network,
   PackageCheck,
+  ShieldCheck,
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
@@ -61,30 +62,28 @@ const clinicalTrustItems = [
   {
     icon: Microscope,
     tone: "blue" as const,
-    title: "Diagnóstico histopatológico y citológico",
-    description:
-      "Evaluación microscópica de tejidos y muestras celulares con criterio anatomopatológico veterinario.",
+    title: "Anatomía patológica veterinaria",
+    description: "Diagnóstico histopatológico y citológico como servicio central.",
   },
   {
-    icon: FileText,
+    icon: ShieldCheck,
     tone: "slate" as const,
-    title: "Informes digitales con acceso seguro",
+    title: "Informes con acceso seguro",
     description:
-      "Entrega institucional de informes para clínicas y acceso privado por caso cuando corresponde.",
+      "Entrega directa a clínicas y acceso privado por token para tutores.",
   },
   {
     icon: Network,
     tone: "blue" as const,
-    title: "Red de clínicas y profesionales vinculados",
-    description:
-      "Relación operativa con equipos veterinarios que trabajan con VETNEB para sus diagnósticos.",
+    title: "Red profesional verificada",
+    description: "Clínicas y profesionales confirmados por el laboratorio.",
   },
   {
-    icon: ClipboardCheck,
+    icon: PackageCheck,
     tone: "slate" as const,
-    title: "Precios públicos y comunicación directa",
+    title: "Flujo operativo claro",
     description:
-      "Información clara para coordinar muestras, consultas y estudios sin ambigüedad operativa.",
+      "Envío de muestra, análisis anatomopatológico e informe descargable.",
   },
 ];
 
@@ -223,18 +222,18 @@ export default function HomePage() {
             <PublicScrollReveal>
               <div className="mx-auto mb-8 max-w-3xl text-center md:mb-10">
                 <p className="text-sm font-semibold uppercase tracking-[0.08em] text-vetneb-teal">
-                  Laboratorio primero
+                  Confianza clínica
                 </p>
                 <h2
                   id="clinical-trust-heading"
                   className="mt-3 text-3xl font-bold text-vetneb-ink md:text-4xl"
                 >
-                  Confianza clínica
+                  Diagnóstico microscópico riguroso para la medicina veterinaria
                 </h2>
                 <p className="mt-4 text-base leading-relaxed text-muted-foreground md:text-lg">
-                  Diagnóstico microscópico riguroso para la medicina veterinaria,
-                  con portal operativo e información pública como soporte del
-                  trabajo clínico.
+                  Una plataforma operativa al servicio del laboratorio: estudios
+                  histopatológicos y citológicos, informes seguros y una red de
+                  clínicas verificadas.
                 </p>
               </div>
             </PublicScrollReveal>

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -132,36 +132,62 @@ test("home page exposes clinical trust institutional data before services", () =
   assert.ok(clinicalTrustIndex < professionalsIndex);
   assert.ok(clinicalTrustIndex < servicesIndex);
   assert.ok(source.includes('id="clinical-trust-heading"'));
-  assert.ok(source.includes("Laboratorio primero"));
   assert.ok(source.includes("Confianza clínica"));
   assert.ok(
     source.includes(
-      "Diagnóstico microscópico riguroso para la medicina veterinaria,",
+      "Diagnóstico microscópico riguroso para la medicina veterinaria",
     ),
   );
-  assert.ok(source.includes("portal operativo e información pública"));
+  assert.ok(
+    source.includes(
+      "Una plataforma operativa al servicio del laboratorio: estudios",
+    ),
+  );
+  assert.ok(
+    source.includes(
+      "histopatológicos y citológicos, informes seguros y una red de",
+    ),
+  );
+  assert.ok(source.includes("clínicas verificadas."));
   assert.ok(source.includes("grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"));
 
   assert.equal(count(clinicalTrustData, "title:"), 4);
   assert.equal(count(clinicalTrustData, "description:"), 4);
   assert.equal(
-    count(clinicalTrustData, 'title: "Diagnóstico histopatológico y citológico"'),
+    count(clinicalTrustData, 'title: "Anatomía patológica veterinaria"'),
     1,
   );
   assert.equal(
-    count(clinicalTrustData, 'title: "Informes digitales con acceso seguro"'),
+    count(clinicalTrustData, 'title: "Informes con acceso seguro"'),
     1,
   );
   assert.equal(
-    count(
-      clinicalTrustData,
-      'title: "Red de clínicas y profesionales vinculados"',
+    count(clinicalTrustData, 'title: "Red profesional verificada"'),
+    1,
+  );
+  assert.equal(
+    count(clinicalTrustData, 'title: "Flujo operativo claro"'),
+    1,
+  );
+  assert.ok(
+    clinicalTrustData.includes(
+      "Diagnóstico histopatológico y citológico como servicio central.",
     ),
-    1,
   );
-  assert.equal(
-    count(clinicalTrustData, 'title: "Precios públicos y comunicación directa"'),
-    1,
+  assert.ok(
+    clinicalTrustData.includes(
+      "Entrega directa a clínicas y acceso privado por token para tutores.",
+    ),
+  );
+  assert.ok(
+    clinicalTrustData.includes(
+      "Clínicas y profesionales confirmados por el laboratorio.",
+    ),
+  );
+  assert.ok(
+    clinicalTrustData.includes(
+      "Envío de muestra, análisis anatomopatológico e informe descargable.",
+    ),
   );
 
   const clinicalTrustSurface = clinicalTrustData.toLowerCase();


### PR DESCRIPTION
## Summary
- align the public home clinical trust stats section with the VETNEB Platform Blueprint
- reinforce VETNEB as a veterinary pathology laboratory with secure report delivery and verified professional network

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e
- pnpm test
- pnpm build
- pnpm security:public-surface