### PR TITLE
feat(home): add final CTA section with dark background

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -520,8 +520,8 @@ export default function HomePage() {
                 Empezá a trabajar con VETNEB
               </h2>
               <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-primary-foreground/78 md:text-lg">
-                Conocé los servicios diagnósticos o contactanos para coordinar el
-                envío de muestras.
+                Sumá a tu clínica a un flujo de diagnóstico anatomopatológico
+                claro, seguro y pensado para la operación veterinaria.
               </p>
               <div className="mt-8">
                 <div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -328,8 +328,16 @@ test("home page exposes final conversion CTA without private route metadata", ()
   assert.ok(source.includes('aria-labelledby="cta-heading"'));
   assert.ok(source.includes('id="cta-heading"'));
   assert.ok(source.includes("Empezá a trabajar con VETNEB"));
-  assert.ok(source.includes("Conocé los servicios diagnósticos o contactanos para coordinar el"));
-  assert.ok(source.includes("envío de muestras."));
+  assert.ok(
+    source.includes(
+      "Sumá a tu clínica a un flujo de diagnóstico anatomopatológico",
+    ),
+  );
+  assert.ok(
+    source.includes(
+      "claro, seguro y pensado para la operación veterinaria.",
+    ),
+  );
   assert.ok(finalCtaSection.includes("Contactanos"));
   assert.ok(finalCtaSection.includes("Ver servicios"));
   assert.ok(finalCtaSection.includes("href={ROUTES.contacto}"));


### PR DESCRIPTION
## Summary
- add a dark final CTA section to the public home
- provide direct paths to contact VETNEB and review diagnostic services

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e
- pnpm test
- pnpm build
- pnpm security:public-surface