### PR TITLE
copy(profesionales): update verified network intro

### DIFF
--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -122,9 +122,7 @@ export function ProfesionalesSearchContent() {
             Clínicas y profesionales verificados que trabajan con VETNEB.
           </h1>
           <p className="max-w-2xl public-copy text-xl text-primary-foreground/92">
-            Cada ficha forma parte de una red vinculada al laboratorio y se
-            muestra bajo criterios operativos verificables, no por ranking
-            comercial.
+            Cada ficha fue revisada y confirmada por el laboratorio.
           </p>
         </div>
       </section>

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -40,9 +40,7 @@ test("profesionales search content renders verified network framing", () => {
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
   assert.ok(source.includes("<PublicLayout>"));
   assert.ok(source.includes("Clínicas y profesionales verificados que trabajan con VETNEB."));
-  assert.ok(source.includes("Cada ficha forma parte de una red vinculada al laboratorio"));
-  assert.ok(source.includes("criterios operativos verificables"));
-  assert.ok(source.includes("no por ranking"));
+  assert.ok(source.includes("Cada ficha fue revisada y confirmada por el laboratorio."));
   assert.ok(source.includes("Consultar la red verificada"));
   assert.ok(source.includes("Ingrese texto libre, incluso una sola letra"));
   assert.ok(source.includes("para ubicar perfiles"));
@@ -66,9 +64,14 @@ test("profesionales public copy avoids marketplace and commercial directory lang
     "directorio",
     "reviews",
     "reseñas",
+    "opiniones",
+    "ranking",
+    "calificaciones",
     "estrellas",
     "telemedicina",
     "reservas online",
+    "directorio de veterinarios",
+    "encontrá al mejor veterinario",
     "mejores veterinarios",
     "buscá veterinario",
     "busca veterinario",

--- a/test/frontend-public-page-semantics.test.ts
+++ b/test/frontend-public-page-semantics.test.ts
@@ -97,7 +97,7 @@ test("profesionales content keeps semantic search/result structure and map safet
   assert.ok(source.includes("<h1"));
   assert.ok(source.includes("<h2"));
   assert.ok(source.includes("Clínicas y profesionales verificados que trabajan con VETNEB."));
-  assert.ok(source.includes("Cada ficha forma parte de una red vinculada al laboratorio"));
+  assert.ok(source.includes("Cada ficha fue revisada y confirmada por el laboratorio."));
   assert.ok(source.includes("<section"));
   assert.ok(source.includes("state.professionals.map((professional) =>"));
   assert.ok(source.includes("<article"));


### PR DESCRIPTION
## Summary
- align profesionales intro copy with the verified VETNEB network framing
- avoid marketplace, ranking or generic directory language

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e
- pnpm test
- pnpm build
- pnpm security:public-surface