### PR TITLE
feat(profesionales): add vetneb relationship section

### DIFF
--- a/frontend/src/components/public/ProfesionalDetailContent.tsx
+++ b/frontend/src/components/public/ProfesionalDetailContent.tsx
@@ -199,6 +199,24 @@ export function ProfesionalDetailContent({
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-6 pt-6">
+                    <section aria-labelledby="professional-vetneb-relationship-heading">
+                      <h2
+                        id="professional-vetneb-relationship-heading"
+                        className="mb-3 flex items-center gap-2 text-lg font-semibold text-vetneb-ink"
+                      >
+                        <ShieldCheck
+                          className="h-5 w-5 text-primary"
+                          aria-hidden="true"
+                        />
+                        Relación con VETNEB
+                      </h2>
+                      <div className="surface-soft px-4 py-3">
+                        <p className="text-sm leading-relaxed text-vetneb-ink">
+                          Esta clínica trabaja con VETNEB para estudios de anatomía patológica veterinaria.
+                        </p>
+                      </div>
+                    </section>
+
                     <section aria-labelledby="professional-care-heading">
                       <h2
                         id="professional-care-heading"

--- a/test/frontend-profesionales-page-content.test.ts
+++ b/test/frontend-profesionales-page-content.test.ts
@@ -148,6 +148,8 @@ test("profesionales detail route renders selected professional data", () => {
   assert.ok(detailSource.includes("professional.aboutText"));
   assert.ok(detailSource.includes("professional.specialtyText"));
   assert.ok(detailSource.includes("professional.servicesText"));
+  assert.ok(detailSource.includes("Relación con VETNEB"));
+  assert.ok(detailSource.includes("Esta clínica trabaja con VETNEB para estudios de anatomía patológica veterinaria."));
   assert.ok(detailSource.includes("professional.publicAddress"));
   assert.ok(detailSource.includes("professional.mapLink"));
   assert.ok(detailSource.includes("mailto:${professional.email}"));


### PR DESCRIPTION
## Summary
- add a fixed VETNEB relationship section to professional detail pages
- reinforce that listed clinics work with VETNEB for veterinary pathology studies

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e
- pnpm test
- pnpm build
- pnpm security:public-surface