### PR TITLE
fix(clinic): sanitize public profile avatar upload errors

### DIFF
--- a/docs/implementation/clinic-public-profile-safe-surface.md
+++ b/docs/implementation/clinic-public-profile-safe-surface.md
@@ -1,0 +1,22 @@
+# Clinic Public Profile Safe Surface
+
+## Context
+
+PR-AC reviewed the authenticated clinic public profile surface for cross-session isolation and response disclosure.
+
+## Finding
+
+`POST /api/clinic/profile/avatar` returned the raw multipart parser message for malformed uploads. A truncated multipart request produced a 400 response with `Unexpected end of form`.
+
+## Change
+
+The avatar upload handler now only forwards explicitly controlled validation messages:
+
+- unsupported avatar MIME type
+- avatar size limit
+
+Other multipart/upload parser errors return `Error al procesar avatar`.
+
+## Contract
+
+`test/clinic-public-profile.fastify.test.ts` now covers malformed multipart avatar uploads and asserts that technical parser details such as `Unexpected end of form`, `stack`, `cause`, and `details` are not exposed in the response body.

--- a/server/routes/clinic-public-profile.fastify.ts
+++ b/server/routes/clinic-public-profile.fastify.ts
@@ -162,6 +162,7 @@ const MIN_AVATAR_DIMENSION = 160;
 const MAX_AVATAR_DIMENSION = 1024;
 const MIN_AVATAR_ASPECT_RATIO = 0.85;
 const MAX_AVATAR_ASPECT_RATIO = 1.15;
+const AVATAR_UNSUPPORTED_MIME_ERROR = "La imagen debe ser JPG, PNG o WebP.";
 const AVATAR_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const AVATAR_FILE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
 const MAP_LINK_ALLOWED_HOSTS = new Set([
@@ -872,7 +873,7 @@ const upload = multer({
   },
   fileFilter: (_req, file, cb) => {
     if (!AVATAR_MIME_TYPES.has(file.mimetype)) {
-      cb(new Error("La imagen debe ser JPG, PNG o WebP."));
+      cb(new Error(AVATAR_UNSUPPORTED_MIME_ERROR));
       return;
     }
 
@@ -1241,8 +1242,11 @@ export const clinicPublicProfileNativeRoutes: FastifyPluginAsync<
 
       if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
         message = "La imagen no debe superar 512 KB.";
-      } else if (error instanceof Error) {
-        message = error.message;
+      } else if (
+        error instanceof Error &&
+        error.message === AVATAR_UNSUPPORTED_MIME_ERROR
+      ) {
+        message = AVATAR_UNSUPPORTED_MIME_ERROR;
       }
 
       return reply.code(400).send({

--- a/test/clinic-public-profile.fastify.test.ts
+++ b/test/clinic-public-profile.fastify.test.ts
@@ -542,6 +542,43 @@ test(
 );
 
 test(
+  "clinicPublicProfileNativeRoutes no expone errores tecnicos de multipart en avatar",
+  async () => {
+    const app = await createTestApp();
+    const boundary = "----vetneb-boundary";
+    const payload = Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="avatar"; filename="avatar.png"\r\nContent-Type: image/png\r\n\r\narchivo-incompleto`,
+      "utf8",
+    );
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/clinic/profile/avatar",
+        headers: {
+          origin: "http://localhost:3000",
+          cookie: `${ENV.cookieName}=session-token`,
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
+        payload,
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), {
+        success: false,
+        error: "Error al procesar avatar",
+      });
+      assert.equal(response.body.includes("Unexpected end of form"), false);
+      assert.equal(response.body.includes("stack"), false);
+      assert.equal(response.body.includes("cause"), false);
+      assert.equal(response.body.includes("details"), false);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
   "clinicPublicProfileNativeRoutes actualiza POST /avatar con upload y reemplazo de avatar previo",
   async () => {
     const uploadCalls: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Sanitize unexpected multipart/avatar upload parser errors in clinic public profile
- Prevent raw technical messages like Unexpected end of form from reaching authenticated clinic UI responses
- Add regression coverage for truncated multipart without stack/cause/details leakage
- Document the security fix in docs/implementation/clinic-public-profile-safe-surface.md

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build