### PR TITLE
feat(admin): base delivery estimates on lab receipt date

### DIFF
--- a/docs/implementation/lab-received-date-delivery-estimate.md
+++ b/docs/implementation/lab-received-date-delivery-estimate.md
@@ -1,0 +1,95 @@
+# Entrega en laboratorio y fecha estimada
+
+## Problema corregido
+
+La estimación de entrega/informe no debe gobernarse por la fecha de envío de la muestra. El envío es un dato logístico secundario y puede ocurrir antes de que VETNEB reciba efectivamente la muestra.
+
+La base operativa del SLA queda definida como entrega en laboratorio. En el backend se expone como `labReceivedAt` y se conserva `receptionAt` como alias compatible con la columna existente `study_tracking_cases.reception_at`.
+
+## Fechas del flujo
+
+- Fecha de extracción: dato clínico de toma de muestra.
+- Fecha de envío: dato logístico de traslado, útil para trazabilidad pero no para SLA.
+- Entrega en laboratorio: fecha real en la que VETNEB recibe la muestra; gobierna la estimación.
+- Fecha estimada de entrega/informe: se calcula desde entrega en laboratorio.
+
+## Regla laboral
+
+El helper puro de `server/lib/study-tracking.ts` trabaja con claves `YYYY-MM-DD` para evitar corrimientos por timezone.
+
+- Lunes a viernes no feriados: `1`.
+- Sábado no feriado: `0.5`.
+- Domingo: `0`.
+- Feriados nacionales Argentina y días puente/no operativos configurados: `0`.
+
+En ausencia de una hora confiable de recepción, el conteo empieza desde el día calendario siguiente a `labReceivedAt`.
+
+## Feriados 2026
+
+La configuración inicial vive en `argentinaHolidaysByYear`:
+
+- `2026-01-01`
+- `2026-02-16`
+- `2026-02-17`
+- `2026-03-23`
+- `2026-03-24`
+- `2026-04-02`
+- `2026-04-03`
+- `2026-05-01`
+- `2026-05-25`
+- `2026-06-15`
+- `2026-06-20`
+- `2026-07-09`
+- `2026-07-10`
+- `2026-08-17`
+- `2026-10-12`
+- `2026-11-23`
+- `2026-12-07`
+- `2026-12-08`
+- `2026-12-25`
+
+Para agregar años futuros, sumar la lista anual oficial a `argentinaHolidaysByYear`. No hay reglas perpetuas implícitas.
+
+## Permisos y superficies
+
+Solo el dashboard administrador puede crear o modificar `labReceivedAt`.
+
+Las rutas de clínica y particular no exponen edición de `labReceivedAt`. La clínica puede ver seguimiento ya serializado, y el portal particular solo consulta su seguimiento y notificaciones.
+
+El seguimiento automático creado desde tokens ya no deriva la recepción desde `shippingDate`; usa una fecha operativa interna y queda corregible por admin.
+
+## Rutas y componentes modificados
+
+- `server/lib/study-tracking.ts`
+- `server/lib/token-study-tracking.ts`
+- `server/routes/admin-study-tracking.fastify.ts`
+- `frontend/src/lib/api.ts`
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx`
+- `server/lib/email.ts`
+
+## Tests agregados o actualizados
+
+- Dominio de calendario laboral, sábados, domingos, feriados y días puente.
+- Cálculo desde `labReceivedAt` y no desde `shippingDate`.
+- Recalculo cuando admin modifica `labReceivedAt`.
+- Bloqueo de clínica y particular/token para modificar `labReceivedAt`.
+- UI admin con label "Entrega en laboratorio".
+- Serialización sin campos sensibles como `storagePath`, `signedUrl`, token crudo, cookie, sesión, secretos, stack, cause o details.
+
+## Validaciones
+
+Validaciones solicitadas para ejecutar:
+
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+
+## Riesgos residuales
+
+- Solo está cargado el calendario 2026; los años futuros requieren mantenimiento anual.
+- La columna persistida sigue siendo `reception_at`; `labReceivedAt` es el contrato semántico de API/UI.
+- Los seguimientos automáticos de tokens sin intervención admin usan fecha operativa del backend hasta que admin confirme la entrega real en laboratorio.

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -181,6 +181,24 @@ function toIsoDate(value: string): string {
   return `${value}T00:00:00.000Z`;
 }
 
+function toDateInputValue(value: string | null | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+function toIsoDateFromInput(value: string): string {
+  return `${value}T00:00:00.000Z`;
+}
+
 function normalizeText(value: string): string {
   return value.trim();
 }
@@ -257,6 +275,12 @@ function formatTokenSource(token: AdminParticularTokenSummary): string {
   }
 
   return "Sistema";
+}
+
+function getTrackingLabReceivedAt(
+  trackingCase: AdminStudyTrackingCaseSummary,
+): string {
+  return trackingCase.labReceivedAt ?? trackingCase.receptionAt;
 }
 
 const TRACKING_STAGE_LABELS: Record<AdminStudyTrackingCaseSummary["currentStage"], string> = {
@@ -355,6 +379,9 @@ export function AdminParticularTokensCard() {
   >({});
   const [trackingStageDraftsByCaseId, setTrackingStageDraftsByCaseId] =
     useState<Record<number, AdminStudyTrackingStage>>({});
+  const [labReceivedDraftsByCaseId, setLabReceivedDraftsByCaseId] = useState<
+    Record<number, string>
+  >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -382,6 +409,7 @@ export function AdminParticularTokensCard() {
       if (snapshot.particularTokens.length === 0) {
         setTrackingCasesByTokenId({});
         setTrackingStageDraftsByCaseId({});
+        setLabReceivedDraftsByCaseId({});
         return;
       }
 
@@ -403,20 +431,26 @@ export function AdminParticularTokensCard() {
           number,
           AdminStudyTrackingStage
         > = {};
+        const nextLabReceivedDraftsByCaseId: Record<number, string> = {};
 
         for (const [tokenId, trackingCase] of trackingEntries) {
           if (trackingCase) {
             nextTrackingByTokenId[tokenId] = trackingCase;
             nextTrackingStageDraftsByCaseId[trackingCase.id] =
               trackingCase.currentStage;
+            nextLabReceivedDraftsByCaseId[trackingCase.id] = toDateInputValue(
+              getTrackingLabReceivedAt(trackingCase),
+            );
           }
         }
 
         setTrackingCasesByTokenId(nextTrackingByTokenId);
         setTrackingStageDraftsByCaseId(nextTrackingStageDraftsByCaseId);
+        setLabReceivedDraftsByCaseId(nextLabReceivedDraftsByCaseId);
       } catch (error) {
         setTrackingCasesByTokenId({});
         setTrackingStageDraftsByCaseId({});
+        setLabReceivedDraftsByCaseId({});
         setTrackingLoadError(
           error instanceof Error
             ? error.message
@@ -678,6 +712,16 @@ export function AdminParticularTokensCard() {
 
         return next;
       });
+      setLabReceivedDraftsByCaseId((current) => {
+        const next = { ...current };
+        const trackingCase = trackingCasesByTokenId[token.id];
+
+        if (trackingCase) {
+          delete next[trackingCase.id];
+        }
+
+        return next;
+      });
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -698,6 +742,67 @@ export function AdminParticularTokensCard() {
       [trackingCase.id]: nextStage,
     }));
     setErrorMessage(null);
+  }
+
+  function handleLabReceivedDraftChange(
+    trackingCase: AdminStudyTrackingCaseSummary,
+    nextLabReceivedAt: string,
+  ) {
+    setLabReceivedDraftsByCaseId((current) => ({
+      ...current,
+      [trackingCase.id]: nextLabReceivedAt,
+    }));
+    setErrorMessage(null);
+  }
+
+  async function handleLabReceivedAtUpdate(
+    tokenId: number,
+    trackingCase: AdminStudyTrackingCaseSummary,
+  ) {
+    const currentLabReceivedAt = toDateInputValue(
+      getTrackingLabReceivedAt(trackingCase),
+    );
+    const nextLabReceivedAt =
+      labReceivedDraftsByCaseId[trackingCase.id] ?? currentLabReceivedAt;
+
+    if (!nextLabReceivedAt || nextLabReceivedAt === currentLabReceivedAt) {
+      return;
+    }
+
+    setErrorMessage(null);
+    setUpdatingTrackingCaseIds((current) => ({
+      ...current,
+      [trackingCase.id]: true,
+    }));
+
+    try {
+      const response = await updateAdminStudyTrackingCase(trackingCase.id, {
+        labReceivedAt: toIsoDateFromInput(nextLabReceivedAt),
+      });
+
+      setTrackingCasesByTokenId((current) => ({
+        ...current,
+        [tokenId]: response.trackingCase,
+      }));
+      setTrackingStageDraftsByCaseId((current) => ({
+        ...current,
+        [response.trackingCase.id]: response.trackingCase.currentStage,
+      }));
+      setLabReceivedDraftsByCaseId((current) => ({
+        ...current,
+        [response.trackingCase.id]: toDateInputValue(
+          getTrackingLabReceivedAt(response.trackingCase),
+        ),
+      }));
+    } catch {
+      setErrorMessage("No se pudo actualizar la entrega en laboratorio.");
+    } finally {
+      setUpdatingTrackingCaseIds((current) => {
+        const next = { ...current };
+        delete next[trackingCase.id];
+        return next;
+      });
+    }
   }
 
   async function handleTrackingStageUpdate(
@@ -1255,6 +1360,14 @@ export function AdminParticularTokensCard() {
                 const hasTrackingStageChange = trackingCase
                   ? trackingStageDraft !== trackingCase.currentStage
                   : false;
+                const labReceivedDraft = trackingCase
+                  ? labReceivedDraftsByCaseId[trackingCase.id] ??
+                    toDateInputValue(getTrackingLabReceivedAt(trackingCase))
+                  : "";
+                const hasLabReceivedChange = trackingCase
+                  ? labReceivedDraft !==
+                    toDateInputValue(getTrackingLabReceivedAt(trackingCase))
+                  : false;
 
                 return (
                   <div
@@ -1364,6 +1477,50 @@ export function AdminParticularTokensCard() {
                           <p className="mt-1 text-xs text-vetneb-ink">
                             Etapa: {getTrackingStageLabel(trackingCase.currentStage)}
                           </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Entrega en laboratorio:{" "}
+                            {formatDate(getTrackingLabReceivedAt(trackingCase))}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Estimación informe:{" "}
+                            {formatDate(trackingCase.estimatedDeliveryAt)}
+                          </p>
+                          <label
+                            htmlFor={`admin-tracking-lab-received-${trackingCase.id}`}
+                            className="mt-2 block text-xs font-semibold text-vetneb-navy"
+                          >
+                            Entrega en laboratorio
+                          </label>
+                          <Input
+                            id={`admin-tracking-lab-received-${trackingCase.id}`}
+                            type="date"
+                            className="mt-1 text-xs"
+                            value={labReceivedDraft}
+                            onChange={(event) =>
+                              handleLabReceivedDraftChange(
+                                trackingCase,
+                                event.target.value,
+                              )
+                            }
+                            disabled={isUpdatingTrackingCase}
+                          />
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Impacta la estimación del informe.
+                          </p>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="mt-2 w-full"
+                            onClick={() =>
+                              void handleLabReceivedAtUpdate(token.id, trackingCase)
+                            }
+                            disabled={
+                              !hasLabReceivedChange || isUpdatingTrackingCase
+                            }
+                          >
+                            Actualizar entrega
+                          </Button>
                           <label
                             htmlFor={`admin-tracking-stage-${trackingCase.id}`}
                             className="mt-2 block text-xs font-semibold text-vetneb-navy"

--- a/frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx
+++ b/frontend/src/components/dashboard/AdminReportWorkflowViewerCard.tsx
@@ -237,7 +237,12 @@ export function AdminReportWorkflowViewerCard() {
                       </p>
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
-                      <p>Recepción: {formatReportDate(trackingCase.receptionAt)}</p>
+                      <p>
+                        Entrega en laboratorio:{" "}
+                        {formatReportDate(
+                          trackingCase.labReceivedAt ?? trackingCase.receptionAt,
+                        )}
+                      </p>
                       <p>Actualizado: {formatReportDate(trackingCase.updatedAt)}</p>
                     </TableCell>
                     <TableCell>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -809,6 +809,7 @@ export type AdminStudyTrackingCaseSummary = {
   particularTokenId: number | null;
   createdByAdminId: number | null;
   createdByClinicUserId: number | null;
+  labReceivedAt: string;
   receptionAt: string;
   estimatedDeliveryAt: string;
   estimatedDeliveryAutoCalculatedAt: string;
@@ -832,7 +833,8 @@ export type AdminStudyTrackingCreatePayload = {
   clinicId: number;
   reportId?: number | null;
   particularTokenId?: number | null;
-  receptionAt: string;
+  labReceivedAt: string;
+  receptionAt?: string;
   estimatedDeliveryAt?: string | null;
   currentStage?: AdminStudyTrackingStage;
   specialStainRequired?: boolean;
@@ -875,6 +877,9 @@ export type AdminStudyTrackingSnapshot = {
 export type AdminStudyTrackingUpdatePayload = {
   reportId?: number | null;
   particularTokenId?: number | null;
+  labReceivedAt?: string;
+  receptionAt?: string;
+  estimatedDeliveryAt?: string | null;
   currentStage?: AdminStudyTrackingStage;
   specialStainRequired?: boolean;
   paymentUrl?: string | null;

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -497,7 +497,7 @@ function buildSpecialStainRequiredText(input: {
     `Te informamos que el estudio #${input.trackingCaseId} de la clínica ${input.clinicName} requiere tinción especial.`,
     ``,
     `Estado actual: ${input.currentStage}`,
-    `Recepción de muestra: ${formatDateTime(input.receptionAt)}`,
+    `Entrega en laboratorio: ${formatDateTime(input.receptionAt)}`,
     `Fecha estimada de entrega: ${formatDateTime(input.estimatedDeliveryAt)}`,
   ];
 

--- a/server/lib/study-tracking.ts
+++ b/server/lib/study-tracking.ts
@@ -42,6 +42,20 @@ const optionalDateSchema = z
     return value;
   });
 
+const nullablePatchDateSchema = z
+  .union([z.null(), z.undefined(), z.coerce.date()])
+  .transform((value) => {
+    if (value === null) {
+      return null;
+    }
+
+    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+      return undefined;
+    }
+
+    return value;
+  });
+
 const booleanishSchema = z
   .union([z.boolean(), z.string(), z.number(), z.undefined()])
   .transform((value) => {
@@ -80,13 +94,12 @@ const optionalPositiveEntitySchema = z
     return value;
   });
 
-export const adminCreateStudyTrackingSchema = z.object({
+const createStudyTrackingSchemaBase = z.object({
   clinicId: z.coerce.number().int().positive("clinicId es obligatorio"),
   reportId: optionalPositiveEntitySchema,
   particularTokenId: optionalPositiveEntitySchema,
-  receptionAt: z.coerce.date({
-    invalid_type_error: "receptionAt es obligatorio",
-  }),
+  labReceivedAt: optionalDateSchema,
+  receptionAt: optionalDateSchema,
   estimatedDeliveryAt: optionalDateSchema,
   currentStage: stageSchema.optional().default("reception"),
   processingAt: optionalDateSchema,
@@ -103,10 +116,55 @@ export const adminCreateStudyTrackingSchema = z.object({
   notes: optionalTrimmedText(10000, "notes"),
 });
 
-export const clinicCreateStudyTrackingSchema = adminCreateStudyTrackingSchema.omit({
+function requireLabReceivedAt(
+  value: { labReceivedAt?: Date; receptionAt?: Date },
+  ctx: z.RefinementCtx,
+) {
+  if (value.labReceivedAt instanceof Date || value.receptionAt instanceof Date) {
+    return;
+  }
+
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: ["labReceivedAt"],
+    message: "labReceivedAt es obligatorio",
+  });
+}
+
+function normalizeLabReceivedAt<T extends { labReceivedAt?: Date; receptionAt?: Date }>(
+  value: T,
+): T & { labReceivedAt: Date; receptionAt: Date } {
+  const labReceivedAt = (value.labReceivedAt ?? value.receptionAt) as Date;
+
+  return {
+    ...value,
+    labReceivedAt,
+    receptionAt: labReceivedAt,
+  };
+}
+
+export const adminCreateStudyTrackingSchema = createStudyTrackingSchemaBase
+  .superRefine(requireLabReceivedAt)
+  .transform(normalizeLabReceivedAt);
+
+export const clinicCreateStudyTrackingSchema = createStudyTrackingSchemaBase.omit({
   clinicId: true,
+  labReceivedAt: true,
   estimatedDeliveryAt: true,
-});
+}).superRefine((value, ctx) => {
+  if (value.receptionAt instanceof Date) {
+    return;
+  }
+
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: ["receptionAt"],
+    message: "receptionAt es obligatorio",
+  });
+}).transform((value) => ({
+  ...value,
+  receptionAt: value.receptionAt as Date,
+}));
 
 export const updateStudyTrackingSchema = z.object({
   reportId: z.union([z.coerce.number().int().positive(), z.null(), z.undefined()]),
@@ -115,63 +173,14 @@ export const updateStudyTrackingSchema = z.object({
     z.null(),
     z.undefined(),
   ]),
+  labReceivedAt: optionalDateSchema,
   receptionAt: optionalDateSchema,
-  estimatedDeliveryAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
-    if (value === null) {
-      return null;
-    }
-
-    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-      return undefined;
-    }
-
-    return value;
-  }),
+  estimatedDeliveryAt: nullablePatchDateSchema,
   currentStage: stageSchema.optional(),
-  processingAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
-    if (value === null) {
-      return null;
-    }
-
-    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-      return undefined;
-    }
-
-    return value;
-  }),
-  evaluationAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
-    if (value === null) {
-      return null;
-    }
-
-    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-      return undefined;
-    }
-
-    return value;
-  }),
-  reportDevelopmentAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
-    if (value === null) {
-      return null;
-    }
-
-    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-      return undefined;
-    }
-
-    return value;
-  }),
-  deliveredAt: z.union([z.null(), z.undefined(), z.coerce.date()]).transform((value) => {
-    if (value === null) {
-      return null;
-    }
-
-    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-      return undefined;
-    }
-
-    return value;
-  }),
+  processingAt: nullablePatchDateSchema,
+  evaluationAt: nullablePatchDateSchema,
+  reportDevelopmentAt: nullablePatchDateSchema,
+  deliveredAt: nullablePatchDateSchema,
   specialStainRequired: booleanishSchema.optional(),
   paymentUrl: z.union([z.string(), z.null(), z.undefined()]).transform((value) => {
     if (value === null) {
@@ -236,6 +245,14 @@ export const updateStudyTrackingSchema = z.object({
     (value) => value === null || typeof value === "undefined" || value.length <= 10000,
     "notes no puede superar 10000 caracteres",
   ),
+}).transform((value) => {
+  const labReceivedAt = value.labReceivedAt ?? value.receptionAt;
+
+  return {
+    ...value,
+    labReceivedAt,
+    receptionAt: labReceivedAt,
+  };
 });
 
 export function parsePositiveInt(
@@ -297,30 +314,17 @@ export function buildValidationError(error: z.ZodError): string {
   return error.issues[0]?.message ?? "Datos inválidos";
 }
 
-function getEasterSunday(year: number): Date {
-  const a = year % 19;
-  const b = Math.floor(year / 100);
-  const c = year % 100;
-  const d = Math.floor(b / 4);
-  const e = b % 4;
-  const f = Math.floor((b + 8) / 25);
-  const g = Math.floor((b - f + 1) / 3);
-  const h = (19 * a + b - d - g + 15) % 30;
-  const i = Math.floor(c / 4);
-  const k = c % 4;
-  const l = (32 + 2 * e + 2 * i - h - k) % 7;
-  const m = Math.floor((a + 11 * h + 22 * l) / 451);
-  const month = Math.floor((h + l - 7 * m + 114) / 31);
-  const day = ((h + l - 7 * m + 114) % 31) + 1;
-
-  return new Date(Date.UTC(year, month - 1, day));
-}
+const ISO_DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 function formatHolidayKey(year: number, month: number, day: number): string {
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 
-function dateToHolidayKey(date: Date): string {
+function dateToISODateKey(date: Date): string {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error("labReceivedAt inválido");
+  }
+
   return formatHolidayKey(
     date.getUTCFullYear(),
     date.getUTCMonth() + 1,
@@ -328,111 +332,131 @@ function dateToHolidayKey(date: Date): string {
   );
 }
 
-function addUtcDays(date: Date, days: number): Date {
-  const next = new Date(date.getTime());
-  next.setUTCDate(next.getUTCDate() + days);
-  return next;
+function assertISODateKey(value: string): string {
+  if (!ISO_DATE_KEY_PATTERN.test(value)) {
+    throw new Error("dateISO inválido");
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+
+  if (Number.isNaN(parsed.getTime()) || dateToISODateKey(parsed) !== value) {
+    throw new Error("dateISO inválido");
+  }
+
+  return value;
 }
 
-function getTransferredHoliday(date: Date): Date {
-  const day = date.getUTCDay();
+function normalizeDateKey(value: Date | string): string {
+  if (typeof value === "string") {
+    if (ISO_DATE_KEY_PATTERN.test(value)) {
+      return assertISODateKey(value);
+    }
 
-  if (day === 2) {
-    return addUtcDays(date, -1);
+    const parsed = new Date(value);
+    return dateToISODateKey(parsed);
   }
 
-  if (day === 3) {
-    return addUtcDays(date, -2);
-  }
+  return dateToISODateKey(value);
+}
 
-  if (day === 4) {
-    return addUtcDays(date, 4);
-  }
+function dateKeyToUtcDate(value: string): Date {
+  const key = assertISODateKey(value);
+  const [year, month, day] = key.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
 
-  if (day === 5) {
-    return addUtcDays(date, 3);
-  }
+function addDaysToDateKey(value: string, days: number): string {
+  const next = dateKeyToUtcDate(value);
+  next.setUTCDate(next.getUTCDate() + days);
+  return dateToISODateKey(next);
+}
 
-  return date;
+function getYearFromDateKey(value: string): number {
+  return Number(assertISODateKey(value).slice(0, 4));
+}
+
+export const argentinaHolidaysByYear: Record<number, readonly string[]> = {
+  2026: [
+    "2026-01-01",
+    "2026-02-16",
+    "2026-02-17",
+    "2026-03-23",
+    "2026-03-24",
+    "2026-04-02",
+    "2026-04-03",
+    "2026-05-01",
+    "2026-05-25",
+    "2026-06-15",
+    "2026-06-20",
+    "2026-07-09",
+    "2026-07-10",
+    "2026-08-17",
+    "2026-10-12",
+    "2026-11-23",
+    "2026-12-07",
+    "2026-12-08",
+    "2026-12-25",
+  ],
+};
+
+export function getArgentinaNonWorkingDates(year: number): Set<string> {
+  return new Set(argentinaHolidaysByYear[year] ?? []);
 }
 
 export function getArgentinaNationalHolidayKeys(year: number): Set<string> {
-  const keys = new Set<string>();
-
-  const addFixed = (month: number, day: number) => {
-    keys.add(formatHolidayKey(year, month, day));
-  };
-
-  addFixed(1, 1);
-  addFixed(3, 24);
-  addFixed(4, 2);
-  addFixed(5, 1);
-  addFixed(5, 25);
-  addFixed(6, 20);
-  addFixed(7, 9);
-  addFixed(12, 8);
-  addFixed(12, 25);
-
-  const easterSunday = getEasterSunday(year);
-  const carnivalMonday = addUtcDays(easterSunday, -48);
-  const carnivalTuesday = addUtcDays(easterSunday, -47);
-  const goodFriday = addUtcDays(easterSunday, -2);
-
-  keys.add(dateToHolidayKey(carnivalMonday));
-  keys.add(dateToHolidayKey(carnivalTuesday));
-  keys.add(dateToHolidayKey(goodFriday));
-
-  const transferredHolidays = [
-    new Date(Date.UTC(year, 5, 17)),
-    new Date(Date.UTC(year, 7, 17)),
-    new Date(Date.UTC(year, 9, 12)),
-    new Date(Date.UTC(year, 10, 20)),
-  ];
-
-  for (const holiday of transferredHolidays) {
-    keys.add(dateToHolidayKey(getTransferredHoliday(holiday)));
-  }
-
-  return keys;
+  return getArgentinaNonWorkingDates(year);
 }
 
-export function isArgentinaNationalHoliday(date: Date): boolean {
-  const year = date.getUTCFullYear();
-  const keys = getArgentinaNationalHolidayKeys(year);
-  return keys.has(dateToHolidayKey(date));
+export function isSunday(value: Date | string): boolean {
+  return dateKeyToUtcDate(normalizeDateKey(value)).getUTCDay() === 0;
 }
 
-export function getBusinessDayWeight(date: Date): number {
-  if (isArgentinaNationalHoliday(date)) {
+export function isSaturday(value: Date | string): boolean {
+  return dateKeyToUtcDate(normalizeDateKey(value)).getUTCDay() === 6;
+}
+
+export function isArgentinaNationalHoliday(value: Date | string): boolean {
+  const dateKey = normalizeDateKey(value);
+  const keys = getArgentinaNonWorkingDates(getYearFromDateKey(dateKey));
+  return keys.has(dateKey);
+}
+
+export function getWorkingDayWeight(value: Date | string): 1 | 0.5 | 0 {
+  if (isArgentinaNationalHoliday(value) || isSunday(value)) {
     return 0;
   }
 
-  const day = date.getUTCDay();
-
-  if (day === 0) {
-    return 0;
-  }
-
-  if (day === 6) {
+  if (isSaturday(value)) {
     return 0.5;
   }
 
   return 1;
 }
 
-export function calculateEstimatedDeliveryAt(
-  receptionAt: Date,
-  requiredBusinessDays = 15,
-): Date {
-  if (!(receptionAt instanceof Date) || Number.isNaN(receptionAt.getTime())) {
-    throw new Error("receptionAt inválido");
+export function getBusinessDayWeight(value: Date | string): 1 | 0.5 | 0 {
+  return getWorkingDayWeight(value);
+}
+
+export function addBusinessDaysFromLabReceivedDate(
+  startDateISO: string,
+  amount = 15,
+): string {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error("amount inválido");
   }
 
-  let remaining = requiredBusinessDays;
-  let cursor = new Date(receptionAt.getTime());
+  const startDateKey = assertISODateKey(startDateISO);
+
+  if (amount === 0) {
+    return startDateKey;
+  }
+
+  let remaining = amount;
+  let cursor = addDaysToDateKey(startDateKey, 1);
 
   while (remaining > 0) {
-    const weight = getBusinessDayWeight(cursor);
+    const weight = getWorkingDayWeight(cursor);
 
     if (weight > 0) {
       remaining = Number((remaining - weight).toFixed(2));
@@ -442,18 +466,41 @@ export function calculateEstimatedDeliveryAt(
       }
     }
 
-    cursor = addUtcDays(cursor, 1);
+    cursor = addDaysToDateKey(cursor, 1);
   }
 
   return cursor;
 }
 
+export function calculateEstimatedDeliveryAt(
+  labReceivedAt: Date,
+  requiredBusinessDays = 15,
+): Date {
+  if (!(labReceivedAt instanceof Date) || Number.isNaN(labReceivedAt.getTime())) {
+    throw new Error("labReceivedAt inválido");
+  }
+
+  return dateKeyToUtcDate(
+    addBusinessDaysFromLabReceivedDate(
+      dateToISODateKey(labReceivedAt),
+      requiredBusinessDays,
+    ),
+  );
+}
+
 export function applyEstimatedDeliveryRules(input: {
-  receptionAt: Date;
+  labReceivedAt?: Date;
+  receptionAt?: Date;
   manualEstimatedDeliveryAt?: Date | null;
 }) {
+  const labReceivedAt = input.labReceivedAt ?? input.receptionAt;
+
+  if (!(labReceivedAt instanceof Date) || Number.isNaN(labReceivedAt.getTime())) {
+    throw new Error("labReceivedAt inválido");
+  }
+
   const estimatedDeliveryAutoCalculatedAt = calculateEstimatedDeliveryAt(
-    input.receptionAt,
+    labReceivedAt,
   );
 
   if (input.manualEstimatedDeliveryAt instanceof Date) {
@@ -559,6 +606,7 @@ export function serializeStudyTrackingCase(trackingCase: StudyTrackingCase) {
     particularTokenId: trackingCase.particularTokenId,
     createdByAdminId: trackingCase.createdByAdminId,
     createdByClinicUserId: trackingCase.createdByClinicUserId,
+    labReceivedAt: trackingCase.receptionAt,
     receptionAt: trackingCase.receptionAt,
     estimatedDeliveryAt: trackingCase.estimatedDeliveryAt,
     estimatedDeliveryAutoCalculatedAt:

--- a/server/lib/token-study-tracking.ts
+++ b/server/lib/token-study-tracking.ts
@@ -9,8 +9,6 @@ type TokenTrackingRecord = Pick<
   | "id"
   | "clinicId"
   | "reportId"
-  | "shippingDate"
-  | "extractionDate"
   | "detailsLesion"
   | "createdByAdminId"
   | "createdByClinicUserId"
@@ -38,22 +36,6 @@ type EnsureTokenTrackingDeps = {
     input: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
   ) => Promise<StudyTrackingCase | null | undefined>;
 };
-
-function toSafeDate(value: Date | null | undefined): Date | null {
-  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-    return null;
-  }
-
-  return value;
-}
-
-function getTokenReceptionAt(token: TokenTrackingRecord, now: Date): Date {
-  return (
-    toSafeDate(token.shippingDate) ??
-    toSafeDate(token.extractionDate) ??
-    now
-  );
-}
 
 function hasAnyPatchValue(
   patch: Partial<Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">>,
@@ -139,8 +121,8 @@ export async function ensureStudyTrackingCaseForToken(
     return (await deps.updateStudyTrackingCase(caseByReport.id, patch)) ?? caseByReport;
   }
 
-  const receptionAt = getTokenReceptionAt(token, now);
-  const delivery = applyEstimatedDeliveryRules({ receptionAt });
+  const labReceivedAt = now;
+  const delivery = applyEstimatedDeliveryRules({ labReceivedAt });
   const createdByAdminId =
     input.createdByAdminId ?? token.createdByAdminId ?? null;
   const createdByClinicUserId =
@@ -153,7 +135,7 @@ export async function ensureStudyTrackingCaseForToken(
     particularTokenId: token.id,
     createdByAdminId,
     createdByClinicUserId,
-    receptionAt,
+    receptionAt: labReceivedAt,
     estimatedDeliveryAt: delivery.estimatedDeliveryAt,
     estimatedDeliveryAutoCalculatedAt: delivery.estimatedDeliveryAutoCalculatedAt,
     estimatedDeliveryWasManuallyAdjusted:
@@ -171,4 +153,3 @@ export async function ensureStudyTrackingCaseForToken(
     notes: token.detailsLesion ?? null,
   });
 }
-

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -786,7 +786,7 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
     }
 
     const delivery = applyEstimatedDeliveryRules({
-      receptionAt: parsed.data.receptionAt,
+      labReceivedAt: parsed.data.labReceivedAt,
       manualEstimatedDeliveryAt: parsed.data.estimatedDeliveryAt,
     });
 
@@ -796,7 +796,7 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       particularTokenId: parsed.data.particularTokenId ?? null,
       createdByAdminId: admin.id,
       createdByClinicUserId: null,
-      receptionAt: parsed.data.receptionAt,
+      receptionAt: parsed.data.labReceivedAt,
       estimatedDeliveryAt: delivery.estimatedDeliveryAt,
       estimatedDeliveryAutoCalculatedAt:
         delivery.estimatedDeliveryAutoCalculatedAt,
@@ -864,6 +864,7 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
         specialStainRequired: finalCase.specialStainRequired,
         specialStainNotifiedAt: finalCase.specialStainNotifiedAt ?? null,
         estimatedDeliveryAt: finalCase.estimatedDeliveryAt,
+        labReceivedAt: finalCase.receptionAt,
         estimatedDeliveryWasManuallyAdjusted:
           finalCase.estimatedDeliveryWasManuallyAdjusted,
         createdVia: "admin",
@@ -1068,14 +1069,14 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       }
     }
 
-    const nextReceptionAt = parsed.data.receptionAt ?? current.receptionAt;
+    const nextLabReceivedAt = parsed.data.labReceivedAt ?? current.receptionAt;
     const deliveryRecalculationNeeded =
-      parsed.data.receptionAt instanceof Date ||
+      parsed.data.labReceivedAt instanceof Date ||
       parsed.data.estimatedDeliveryAt instanceof Date;
 
     const delivery = deliveryRecalculationNeeded
       ? applyEstimatedDeliveryRules({
-          receptionAt: nextReceptionAt,
+          labReceivedAt: nextLabReceivedAt,
           manualEstimatedDeliveryAt:
             parsed.data.estimatedDeliveryAt instanceof Date
               ? parsed.data.estimatedDeliveryAt
@@ -1118,7 +1119,7 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
         typeof parsed.data.particularTokenId === "undefined"
           ? undefined
           : parsed.data.particularTokenId,
-      receptionAt: parsed.data.receptionAt,
+      receptionAt: parsed.data.labReceivedAt,
       estimatedDeliveryAt: delivery?.estimatedDeliveryAt,
       estimatedDeliveryAutoCalculatedAt:
         delivery?.estimatedDeliveryAutoCalculatedAt,
@@ -1237,6 +1238,7 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
         toStage: finalCase.currentStage,
         specialStainRequired: finalCase.specialStainRequired,
         specialStainNotifiedAt: finalCase.specialStainNotifiedAt ?? null,
+        labReceivedAt: finalCase.receptionAt,
         updatedVia: "admin",
       },
     });

--- a/test/admin-study-tracking.fastify.test.ts
+++ b/test/admin-study-tracking.fastify.test.ts
@@ -315,7 +315,7 @@ test("adminStudyTrackingNativeRoutes crea POST / con admin, vínculos y notifica
         clinicId: 3,
         reportId: 55,
         particularTokenId: 7,
-        receptionAt: "2026-04-20T00:00:00.000Z",
+        labReceivedAt: "2026-04-22T00:00:00.000Z",
         currentStage: "evaluation",
         specialStainRequired: true,
         paymentUrl: "https://pay.example/study-11",
@@ -336,6 +336,18 @@ test("adminStudyTrackingNativeRoutes crea POST / con admin, vínculos y notifica
     assert.equal(createCalls[0].particularTokenId, 7);
     assert.equal(createCalls[0].createdByAdminId, 1);
     assert.equal(createCalls[0].createdByClinicUserId, null);
+    assert.equal(
+      (createCalls[0].receptionAt as Date).toISOString(),
+      "2026-04-22T00:00:00.000Z",
+    );
+    assert.notEqual(
+      (createCalls[0].receptionAt as Date).toISOString(),
+      "2026-04-19T00:00:00.000Z",
+    );
+    assert.equal(
+      (createCalls[0].estimatedDeliveryAt as Date).toISOString(),
+      "2026-05-13T00:00:00.000Z",
+    );
     assert.equal(createCalls[0].specialStainRequired, true);
     assert.ok(createCalls[0].estimatedDeliveryAt instanceof Date);
     assert.deepEqual(updateTokenCalls, [{ particularTokenId: 7, reportId: 55 }]);
@@ -454,6 +466,70 @@ test("adminStudyTrackingNativeRoutes expone GET /:trackingCaseId con detalle glo
     assert.equal(body.success, true);
     assert.equal(body.trackingCase.id, 11);
     assert.equal(body.trackingCase.clinicId, 3);
+  } finally {
+    await app.close();
+  }
+});
+
+test("adminStudyTrackingNativeRoutes recalcula estimación al modificar labReceivedAt", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const current = createTrackingCaseFixture({
+    receptionAt: new Date("2026-04-20T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-11T00:00:00.000Z"),
+  });
+  const updated = createTrackingCaseFixture({
+    receptionAt: new Date("2026-04-22T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-13T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-13T00:00:00.000Z"),
+  });
+
+  const app = await createTestApp({
+    getClinicScopedStudyTrackingCase: async () => current,
+    updateStudyTrackingCase: async (
+      trackingCaseId: number,
+      input: Record<string, unknown>,
+    ) => {
+      assert.equal(trackingCaseId, 11);
+      updateCalls.push(input);
+      return updated;
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/admin/study-tracking/11",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        clinicId: 3,
+        labReceivedAt: "2026-04-22T00:00:00.000Z",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(updateCalls.length, 1);
+    assert.equal(
+      (updateCalls[0].receptionAt as Date).toISOString(),
+      "2026-04-22T00:00:00.000Z",
+    );
+    assert.equal(
+      (updateCalls[0].estimatedDeliveryAt as Date).toISOString(),
+      "2026-05-13T00:00:00.000Z",
+    );
+    assert.equal(
+      (updateCalls[0].estimatedDeliveryAutoCalculatedAt as Date).toISOString(),
+      "2026-05-13T00:00:00.000Z",
+    );
+    assert.equal(updateCalls[0].estimatedDeliveryWasManuallyAdjusted, false);
+
+    const body = JSON.parse(response.body);
+    assert.equal(body.trackingCase.labReceivedAt, "2026-04-22T00:00:00.000Z");
+    assert.equal(body.trackingCase.estimatedDeliveryAt, "2026-05-13T00:00:00.000Z");
   } finally {
     await app.close();
   }

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -434,6 +434,11 @@ test("admin token card consume seguimiento por token desde study-tracking", () =
   assert.ok(card.includes("getAdminStudyTrackingCases"));
   assert.ok(card.includes("trackingCasesByTokenId"));
   assert.ok(card.includes("Seguimiento"));
+  assert.ok(card.includes("labReceivedAt"));
+  assert.ok(card.includes("Entrega en laboratorio"));
+  assert.ok(card.includes("Impacta la estimación del informe."));
+  assert.ok(card.includes("handleLabReceivedAtUpdate("));
+  assert.ok(card.includes("Actualizar entrega"));
   assert.ok(card.includes("getTrackingStageLabel("));
   assert.ok(card.includes("Alerta: Solicitud de tinción especial"));
   assert.ok(card.includes("Solicitar tinción especial"));

--- a/test/logger-and-email.test.ts
+++ b/test/logger-and-email.test.ts
@@ -318,7 +318,7 @@ test("templates de email no tienen mojibake visible", () => {
   for (const expected of [
     "clínica",
     "tinción",
-    "Recepción",
+    "Entrega en laboratorio",
     "Teléfono",
     "Ingresá",
     "gestión",

--- a/test/particular-study-tracking.fastify.test.ts
+++ b/test/particular-study-tracking.fastify.test.ts
@@ -135,6 +135,29 @@ test("particularStudyTrackingNativeRoutes expone GET /me con seguimiento del tok
   }
 });
 
+test("particularStudyTrackingNativeRoutes no permite modificar labReceivedAt", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/me",
+      headers: {
+        origin: "http://localhost:3000",
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+        "content-type": "application/json",
+      },
+      payload: {
+        labReceivedAt: "2026-04-25T00:00:00.000Z",
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+  } finally {
+    await app.close();
+  }
+});
+
 test("particularStudyTrackingNativeRoutes devuelve 404 cuando no existe seguimiento para el token", async () => {
   const app = await createTestApp({
     getParticularStudyTrackingCase: async () => null,

--- a/test/study-tracking-clinic-schema.test.ts
+++ b/test/study-tracking-clinic-schema.test.ts
@@ -33,6 +33,7 @@ test("clinicCreateStudyTrackingSchema omite clinicId y estimatedDeliveryAt del p
     clinicId: 999,
     reportId: "12",
     particularTokenId: "34",
+    labReceivedAt: "2026-04-30T10:00:00.000Z",
     receptionAt: "2026-04-21T10:00:00.000Z",
     estimatedDeliveryAt: "2026-04-25T10:00:00.000Z",
     currentStage: "processing",
@@ -50,6 +51,7 @@ test("clinicCreateStudyTrackingSchema omite clinicId y estimatedDeliveryAt del p
   }
 
   assert.equal("clinicId" in parsed.data, false);
+  assert.equal("labReceivedAt" in parsed.data, false);
   assert.equal("estimatedDeliveryAt" in parsed.data, false);
 
   assert.equal(parsed.data.reportId, 12);

--- a/test/study-tracking-edge.test.ts
+++ b/test/study-tracking-edge.test.ts
@@ -8,28 +8,28 @@ import {
   updateStudyTrackingSchema,
 } from "../server/lib/study-tracking.ts";
 
-test("calculateEstimatedDeliveryAt rechaza receptionAt invalido", () => {
+test("calculateEstimatedDeliveryAt rechaza labReceivedAt invalido", () => {
   assert.throws(
     () => calculateEstimatedDeliveryAt(new Date("invalido"), 15),
-    /receptionAt inválido|receptionAt invÃ¡lido/,
+    /labReceivedAt inválido|labReceivedAt invÃ¡lido/,
   );
 });
 
-test("calculateEstimatedDeliveryAt devuelve el mismo dia cuando requiredBusinessDays ya se consume en receptionAt", () => {
+test("calculateEstimatedDeliveryAt empieza a contar desde el día siguiente", () => {
   const result = calculateEstimatedDeliveryAt(
     new Date("2026-01-05T00:00:00.000Z"),
     1,
   );
 
-  assert.equal(result.toISOString(), "2026-01-05T00:00:00.000Z");
+  assert.equal(result.toISOString(), "2026-01-06T00:00:00.000Z");
 });
 
 test("applyEstimatedDeliveryRules no marca ajuste manual cuando la fecha manual coincide con la automatica", () => {
-  const receptionAt = new Date("2026-01-02T00:00:00.000Z");
-  const autoCalculated = calculateEstimatedDeliveryAt(receptionAt, 15);
+  const labReceivedAt = new Date("2026-01-02T00:00:00.000Z");
+  const autoCalculated = calculateEstimatedDeliveryAt(labReceivedAt, 15);
 
   const result = applyEstimatedDeliveryRules({
-    receptionAt,
+    labReceivedAt,
     manualEstimatedDeliveryAt: autoCalculated,
   });
 

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -28,8 +28,8 @@ function createTrackingCaseFixture(overrides: Record<string, unknown> = {}) {
     createdByAdminId: null,
     createdByClinicUserId: 9,
     receptionAt: new Date("2026-04-20T00:00:00.000Z"),
-    estimatedDeliveryAt: new Date("2026-05-08T00:00:00.000Z"),
-    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-08T00:00:00.000Z"),
+    estimatedDeliveryAt: new Date("2026-05-11T00:00:00.000Z"),
+    estimatedDeliveryAutoCalculatedAt: new Date("2026-05-11T00:00:00.000Z"),
     estimatedDeliveryWasManuallyAdjusted: false,
     currentStage: "reception",
     processingAt: null,
@@ -160,30 +160,32 @@ async function createTestApp(overrides: Record<string, unknown> = {}) {
   return app;
 }
 
-test("study tracking calcula entrega con feriados nacionales argentinos perpetuos", () => {
+test("study tracking calcula entrega con feriados argentinos configurados", () => {
+  const independenceDay2026 = new Date("2026-07-09T00:00:00.000Z");
+  const bridgeHoliday2026 = new Date("2026-07-10T00:00:00.000Z");
   const futureIndependenceDay = new Date("2040-07-09T00:00:00.000Z");
-  const futureChristmas = new Date("2099-12-25T00:00:00.000Z");
 
-  assert.equal(isArgentinaNationalHoliday(futureIndependenceDay), true);
-  assert.equal(getBusinessDayWeight(futureIndependenceDay), 0);
-  assert.equal(isArgentinaNationalHoliday(futureChristmas), true);
-  assert.equal(getBusinessDayWeight(futureChristmas), 0);
+  assert.equal(isArgentinaNationalHoliday(independenceDay2026), true);
+  assert.equal(getBusinessDayWeight(independenceDay2026), 0);
+  assert.equal(isArgentinaNationalHoliday(bridgeHoliday2026), true);
+  assert.equal(getBusinessDayWeight(bridgeHoliday2026), 0);
+  assert.equal(isArgentinaNationalHoliday(futureIndependenceDay), false);
 
   const oneBusinessDayAcrossHoliday = calculateEstimatedDeliveryAt(
-    new Date("2040-07-08T00:00:00.000Z"),
+    new Date("2026-07-08T00:00:00.000Z"),
     1,
   );
 
   assert.equal(
     oneBusinessDayAcrossHoliday.toISOString(),
-    "2040-07-10T00:00:00.000Z",
+    "2026-07-13T00:00:00.000Z",
   );
 
   const fifteenBusinessDays = calculateEstimatedDeliveryAt(
     new Date("2026-04-20T00:00:00.000Z"),
   );
 
-  assert.equal(fifteenBusinessDays.toISOString(), "2026-05-08T00:00:00.000Z");
+  assert.equal(fifteenBusinessDays.toISOString(), "2026-05-11T00:00:00.000Z");
 });
 
 test("studyTrackingNativeRoutes expone GET /notifications clinic-scoped", async () => {
@@ -421,6 +423,7 @@ test("studyTrackingNativeRoutes bloquea POST / porque el workflow es admin-only"
       payload: {
         reportId: 55,
         particularTokenId: 7,
+        labReceivedAt: "2026-04-25T00:00:00.000Z",
         receptionAt: "2026-04-20T00:00:00.000Z",
         currentStage: "reception",
         specialStainRequired: true,

--- a/test/study-tracking.test.ts
+++ b/test/study-tracking.test.ts
@@ -2,13 +2,18 @@
 import assert from "node:assert/strict";
 import {
   adminCreateStudyTrackingSchema,
+  addBusinessDaysFromLabReceivedDate,
   applyEstimatedDeliveryRules,
   applyStageTimestampDefaults,
   buildValidationError,
   calculateEstimatedDeliveryAt,
+  getArgentinaNonWorkingDates,
   getArgentinaNationalHolidayKeys,
   getBusinessDayWeight,
+  getWorkingDayWeight,
   isArgentinaNationalHoliday,
+  isSaturday,
+  isSunday,
   parseBooleanQuery,
   parseEntityId,
   parseOffset,
@@ -24,7 +29,7 @@ test("adminCreateStudyTrackingSchema normaliza booleanos, textos y fechas", () =
     clinicId: "4",
     reportId: "12",
     particularTokenId: null,
-    receptionAt: "2026-04-20T10:00:00.000Z",
+    labReceivedAt: "2026-04-20T10:00:00.000Z",
     estimatedDeliveryAt: "2026-05-12T10:00:00.000Z",
     currentStage: "processing",
     specialStainRequired: "si",
@@ -48,13 +53,16 @@ test("adminCreateStudyTrackingSchema normaliza booleanos, textos y fechas", () =
   assert.equal(parsed.data.adminContactEmail, "lab@example.com");
   assert.equal(parsed.data.adminContactPhone, "3511234567");
   assert.equal(parsed.data.notes, "Caso prioritario");
+  assert.ok(parsed.data.labReceivedAt instanceof Date);
   assert.ok(parsed.data.receptionAt instanceof Date);
+  assert.equal(parsed.data.labReceivedAt.toISOString(), parsed.data.receptionAt.toISOString());
 });
 
 test("updateStudyTrackingSchema permite limpiar campos opcionales con null", () => {
   const parsed = updateStudyTrackingSchema.safeParse({
     reportId: null,
     particularTokenId: "18",
+    labReceivedAt: "2026-05-04T00:00:00.000Z",
     estimatedDeliveryAt: null,
     processingAt: null,
     evaluationAt: undefined,
@@ -76,6 +84,8 @@ test("updateStudyTrackingSchema permite limpiar campos opcionales con null", () 
   assert.equal(parsed.data.reportId, null);
   assert.equal(parsed.data.particularTokenId, 18);
   assert.equal(parsed.data.estimatedDeliveryAt, null);
+  assert.equal(parsed.data.labReceivedAt?.toISOString(), "2026-05-04T00:00:00.000Z");
+  assert.equal(parsed.data.receptionAt?.toISOString(), "2026-05-04T00:00:00.000Z");
   assert.equal(parsed.data.processingAt, null);
   assert.equal(parsed.data.reportDevelopmentAt, null);
   assert.equal(parsed.data.deliveredAt, null);
@@ -117,17 +127,25 @@ test("buildValidationError devuelve el primer error de study-tracking", () => {
   assert.equal(buildValidationError(parsed.error), "clinicId es obligatorio");
 });
 
-test("feriados nacionales y pesos de días hábiles se calculan correctamente", () => {
+test("feriados configurados 2026 y pesos de días hábiles se calculan correctamente", () => {
   const holidays2026 = getArgentinaNationalHolidayKeys(2026);
+  const nonWorking2026 = getArgentinaNonWorkingDates(2026);
 
   assert.equal(holidays2026.has("2026-01-01"), true);
   assert.equal(holidays2026.has("2026-02-16"), true);
   assert.equal(holidays2026.has("2026-02-17"), true);
+  assert.equal(holidays2026.has("2026-03-23"), true);
   assert.equal(holidays2026.has("2026-04-03"), true);
+  assert.equal(holidays2026.has("2026-07-10"), true);
+  assert.equal(nonWorking2026.has("2026-12-25"), true);
 
+  assert.equal(isSunday("2026-05-24"), true);
+  assert.equal(isSaturday("2026-05-23"), true);
   assert.equal(isArgentinaNationalHoliday(new Date("2026-05-25T00:00:00.000Z")), true);
   assert.equal(getBusinessDayWeight(new Date("2026-05-25T00:00:00.000Z")), 0);
-  assert.equal(getBusinessDayWeight(new Date("2026-05-23T00:00:00.000Z")), 0.5);
+  assert.equal(getWorkingDayWeight("2026-05-23"), 0.5);
+  assert.equal(getWorkingDayWeight("2026-05-24"), 0);
+  assert.equal(getWorkingDayWeight("2026-07-10"), 0);
   assert.equal(getBusinessDayWeight(new Date("2026-05-26T00:00:00.000Z")), 1);
 });
 
@@ -137,23 +155,30 @@ test("calculateEstimatedDeliveryAt contempla sábado como medio día hábil", ()
     2,
   );
 
-  assert.equal(deliveryAt.toISOString(), "2026-01-05T00:00:00.000Z");
+  assert.equal(deliveryAt.toISOString(), "2026-01-06T00:00:00.000Z");
+});
+
+test("addBusinessDaysFromLabReceivedDate atraviesa sábado, domingo y feriado", () => {
+  assert.equal(addBusinessDaysFromLabReceivedDate("2026-01-02", 0.5), "2026-01-03");
+  assert.equal(addBusinessDaysFromLabReceivedDate("2026-01-02", 1), "2026-01-05");
+  assert.equal(addBusinessDaysFromLabReceivedDate("2026-07-08", 0.5), "2026-07-11");
+  assert.equal(addBusinessDaysFromLabReceivedDate("2026-07-08", 1), "2026-07-13");
 });
 
 test("applyEstimatedDeliveryRules diferencia ajuste manual y cálculo automático", () => {
-  const receptionAt = new Date("2026-01-02T00:00:00.000Z");
+  const labReceivedAt = new Date("2026-01-02T00:00:00.000Z");
   const manualEstimatedDeliveryAt = new Date("2026-01-06T00:00:00.000Z");
 
-  const automatic = applyEstimatedDeliveryRules({ receptionAt });
+  const automatic = applyEstimatedDeliveryRules({ labReceivedAt });
   const manual = applyEstimatedDeliveryRules({
-    receptionAt,
+    labReceivedAt,
     manualEstimatedDeliveryAt,
   });
 
-  assert.equal(automatic.estimatedDeliveryAt.toISOString(), "2026-01-21T00:00:00.000Z");
+  assert.equal(automatic.estimatedDeliveryAt.toISOString(), "2026-01-22T00:00:00.000Z");
   assert.equal(automatic.estimatedDeliveryWasManuallyAdjusted, false);
   assert.equal(manual.estimatedDeliveryAt.toISOString(), "2026-01-06T00:00:00.000Z");
-  assert.equal(manual.estimatedDeliveryAutoCalculatedAt.toISOString(), "2026-01-21T00:00:00.000Z");
+  assert.equal(manual.estimatedDeliveryAutoCalculatedAt.toISOString(), "2026-01-22T00:00:00.000Z");
   assert.equal(manual.estimatedDeliveryWasManuallyAdjusted, true);
 });
 
@@ -270,9 +295,27 @@ test("serializers de study-tracking mantienen la forma pública esperada", () =>
   const serializedCase = serializeStudyTrackingCase(trackingCase as any);
   const serializedNotification = serializeStudyTrackingNotification(notification as any);
 
+  assert.equal(serializedCase.labReceivedAt.toISOString(), "2026-04-20T00:00:00.000Z");
+  assert.equal(serializedCase.receptionAt.toISOString(), "2026-04-20T00:00:00.000Z");
   assert.equal(serializedCase.estimatedDeliveryWasManuallyAdjusted, true);
   assert.equal(serializedCase.currentStage, "processing");
   assert.equal(serializedCase.paymentUrl, "https://example.com/pay/123");
   assert.equal(serializedNotification.type, "special_stain_required");
   assert.equal(serializedNotification.isRead, false);
+
+  const serializedText = JSON.stringify(serializedCase);
+  for (const forbiddenKey of [
+    "storagePath",
+    "signedUrl",
+    "rawToken",
+    "cookie",
+    "session",
+    "secret",
+    "service_role",
+    "stack",
+    "cause",
+    "details",
+  ]) {
+    assert.equal(serializedText.includes(forbiddenKey), false, forbiddenKey);
+  }
 });

--- a/test/token-study-tracking.test.ts
+++ b/test/token-study-tracking.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { StudyTrackingCase } from "../drizzle/schema.ts";
+import { calculateEstimatedDeliveryAt } from "../server/lib/study-tracking.ts";
+import { ensureStudyTrackingCaseForToken } from "../server/lib/token-study-tracking.ts";
+
+function createStudyTrackingCaseFixture(
+  input: Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">,
+): StudyTrackingCase {
+  return {
+    id: 11,
+    createdAt: new Date("2026-01-05T12:00:00.000Z"),
+    updatedAt: new Date("2026-01-05T12:00:00.000Z"),
+    ...input,
+  } as StudyTrackingCase;
+}
+
+test("ensureStudyTrackingCaseForToken no usa Fecha de envío como base SLA", async () => {
+  const now = new Date("2026-01-05T00:00:00.000Z");
+  const createCalls: Array<
+    Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">
+  > = [];
+
+  const token = {
+    id: 7,
+    clinicId: 3,
+    reportId: null,
+    shippingDate: new Date("2026-01-02T00:00:00.000Z"),
+    extractionDate: new Date("2026-01-01T00:00:00.000Z"),
+    detailsLesion: "Lesión nodular pequeña",
+    createdByAdminId: 1,
+    createdByClinicUserId: null,
+  };
+
+  const created = await ensureStudyTrackingCaseForToken(
+    {
+      getParticularStudyTrackingCase: async () => null,
+      getStudyTrackingCaseByReportId: async () => null,
+      createStudyTrackingCase: async (input) => {
+        createCalls.push(input);
+        return createStudyTrackingCaseFixture(input);
+      },
+      updateStudyTrackingCase: async () => null,
+    },
+    {
+      token,
+      now,
+    },
+  );
+
+  assert.equal(createCalls.length, 1);
+  assert.equal(createCalls[0].receptionAt.toISOString(), now.toISOString());
+  assert.notEqual(
+    createCalls[0].receptionAt.toISOString(),
+    token.shippingDate.toISOString(),
+  );
+  assert.equal(
+    createCalls[0].estimatedDeliveryAt.toISOString(),
+    calculateEstimatedDeliveryAt(now).toISOString(),
+  );
+  assert.equal(created.receptionAt.toISOString(), now.toISOString());
+});


### PR DESCRIPTION
## Summary
- Treat study tracking receptionAt as the lab receipt date / Entrega en laboratorio
- Base automatic delivery estimates on lab receipt date instead of token shipping/extraction dates
- Start deterministic delivery counting from the next calendar day
- Preserve Saturday as half working day and exclude Sundays plus configured Argentina non-working dates
- Add 2026 Argentina non-working date coverage and future-year maintenance documentation
- Keep lab receipt editing restricted to admin surfaces
- Preserve token/public safety and avoid sensitive leakage

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build