### PR TITLE
fix(login): hide rate limit details and keep frontend build clean

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -40,7 +40,7 @@ function formatSurface(value: AdminFailedLoginAlertSurface) {
 function formatReason(value: AdminFailedLoginAlertReason) {
   if (value === "missing_credentials") return "Credenciales faltantes";
   if (value === "invalid_credentials") return "Credenciales inválidas";
-  return "Rate limit";
+  return "Bloqueo temporal";
 }
 
 function getSurfaceVariant(
@@ -208,7 +208,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
               <option value="all">Todos</option>
               <option value="missing_credentials">Credenciales faltantes</option>
               <option value="invalid_credentials">Credenciales inválidas</option>
-              <option value="rate_limited">Rate limit</option>
+              <option value="rate_limited">Bloqueo temporal</option>
             </select>
           </label>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,7 +59,7 @@ export const BACKEND_OPERATION_ERROR_MESSAGE =
 export const ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE =
   "Sesión admin no autenticada o inválida. Iniciá sesión nuevamente.";
 export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE =
-  "Demasiados intentos de inicio de sesión. Intentá nuevamente más tarde.";
+  "Acceso temporalmente restringido. Intentá nuevamente más tarde.";
 
 function isLocalOrLanHostname(hostname: string): boolean {
   const normalizedHost = hostname.trim().toLowerCase();
@@ -194,10 +194,9 @@ function readRetryAfterSeconds(
 }
 
 function buildRateLimitErrorMessage(
-  backendMessage: string | null,
   retryAfterSeconds: number | null,
 ): string {
-  const baseMessage = backendMessage ?? LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE;
+  const baseMessage = LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE;
 
   if (retryAfterSeconds === null || retryAfterSeconds === 0) {
     return baseMessage;
@@ -273,7 +272,7 @@ async function apiFetch<T>(
       const retryAfterSeconds = readRetryAfterSeconds(res.headers, body);
 
       throw new RateLimitError(
-        buildRateLimitErrorMessage(backendMessage, retryAfterSeconds),
+        buildRateLimitErrorMessage(retryAfterSeconds),
         retryAfterSeconds,
       );
     }

--- a/test/frontend-admin-failed-login-alerts-card.test.ts
+++ b/test/frontend-admin-failed-login-alerts-card.test.ts
@@ -45,7 +45,7 @@ test("admin failed login alerts card keeps surface reason and nullable formatter
   assert.ok(source.includes("function formatReason(value: AdminFailedLoginAlertReason)"));
   assert.ok(source.includes('if (value === "missing_credentials") return "Credenciales faltantes";'));
   assert.ok(source.includes('if (value === "invalid_credentials") return "Credenciales inválidas";'));
-  assert.ok(source.includes('return "Rate limit";'));
+  assert.ok(source.includes('return "Bloqueo temporal";'));
   assert.ok(source.includes("function formatNullable(value: string | null)"));
   assert.ok(source.includes('return value && value.trim() ? value : "—";'));
 });

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -84,7 +84,8 @@ test("frontend API client surfaces backend errors safely", () => {
   assert.ok(source.includes("retryAfterSeconds?: unknown;"));
   assert.ok(source.includes("const backendMessage ="));
   assert.ok(source.includes("if (res.status === 429) {"));
-  assert.ok(source.includes("buildRateLimitErrorMessage(backendMessage, retryAfterSeconds)"));
+  assert.ok(source.includes("buildRateLimitErrorMessage(retryAfterSeconds)"));
+  assert.equal(source.includes("buildRateLimitErrorMessage(backendMessage,"), false);
   assert.ok(source.includes("if (backendMessage) {"));
   assert.ok(source.includes("throw new Error(backendMessage);"));
   assert.ok(source.includes("if (res.status >= 500) {"));
@@ -96,7 +97,8 @@ test("frontend API client formats 429 rate-limit guidance from headers or JSON m
   const source = read(API_CLIENT_PATH);
 
   assert.ok(source.includes("export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE ="));
-  assert.ok(source.includes("Demasiados intentos de inicio de sesión. Intentá nuevamente más tarde."));
+  assert.ok(source.includes("Acceso temporalmente restringido. Intent"));
+  assert.equal(source.includes("Demasiados intentos"), false);
   assert.equal(source.includes("LOGIN_RATE_LIMIT_HEADERS_MISSING_MESSAGE"), false);
   assert.equal(source.includes("El backend no informó cuándo reintentar"), false);
   assert.equal(source.includes("const LOGIN_RATE_LIMIT_REQUIRED_HEADERS ="), false);

--- a/test/login-rate-limit-ux-safety.test.ts
+++ b/test/login-rate-limit-ux-safety.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+const LOGIN_CONTENT_PATH = "frontend/src/components/public/LoginContent.tsx";
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+const NEXT_ENV_PATH = "frontend/next-env.d.ts";
+const FRONTEND_SRC_PATH = "frontend/src";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function listFrontendSourceFiles(relativeDir: string): string[] {
+  const absoluteDir = resolve(process.cwd(), relativeDir);
+  const entries = readdirSync(absoluteDir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const relativePath = join(relativeDir, entry.name).replace(/\\/g, "/");
+
+    if (entry.isDirectory()) {
+      if (entry.name === ".next" || entry.name === "node_modules") {
+        continue;
+      }
+
+      files.push(...listFrontendSourceFiles(relativePath));
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (!/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      continue;
+    }
+
+    files.push(relativePath);
+  }
+
+  return files;
+}
+
+// Strings forbidden from appearing in login UI source and client-side error messages.
+// Tests may contain them as regression sentinels; frontend/src must not expose them as visible copy.
+const FORBIDDEN_LOGIN_UX_STRINGS = [
+  "Too Many Requests",
+  "Rate limit",
+  "rate limit",
+  "rate-limit",
+  "Demasiados intentos",
+] as const;
+
+const FORBIDDEN_VISIBLE_FRONTEND_STRINGS = [
+  '"429"',
+  "Too Many Requests",
+  "Rate limit",
+  "rate limit",
+  "rate-limit",
+  "Demasiados intentos de inicio de sesión",
+  "Demasiados intentos",
+] as const;
+
+test("login rate limit client message uses safe non-technical wording", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes("Acceso temporalmente restringido"),
+    "LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE must use safe non-technical wording",
+  );
+
+  const msgStart = source.indexOf("LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE =");
+  const msgEnd = source.indexOf(";", msgStart);
+  const msgSection = source.slice(msgStart, msgEnd);
+
+  for (const forbidden of FORBIDDEN_LOGIN_UX_STRINGS) {
+    assert.equal(
+      msgSection.includes(forbidden),
+      false,
+      `LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE must not contain: ${forbidden}`,
+    );
+  }
+
+  assert.equal(
+    msgSection.includes("Demasiados intentos"),
+    false,
+    "LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE must not contain Demasiados intentos",
+  );
+});
+
+test("buildRateLimitErrorMessage accepts only retryAfterSeconds and never passes backend message to user", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes("function buildRateLimitErrorMessage(\n  retryAfterSeconds: number | null,"),
+    "buildRateLimitErrorMessage must accept only retryAfterSeconds",
+  );
+  assert.equal(
+    source.includes("function buildRateLimitErrorMessage(\n  backendMessage"),
+    false,
+    "buildRateLimitErrorMessage must not accept backendMessage parameter",
+  );
+
+  assert.ok(
+    source.includes("buildRateLimitErrorMessage(retryAfterSeconds)"),
+    "buildRateLimitErrorMessage call site must pass only retryAfterSeconds",
+  );
+  assert.equal(
+    source.includes("buildRateLimitErrorMessage(backendMessage,"),
+    false,
+    "buildRateLimitErrorMessage call site must not pass backendMessage",
+  );
+
+  assert.equal(
+    source.includes("backendMessage ?? LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE"),
+    false,
+    "buildRateLimitErrorMessage must not fall back to backendMessage as base",
+  );
+});
+
+test("LoginContent does not hardcode any forbidden rate limit or technical strings", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  for (const forbidden of FORBIDDEN_LOGIN_UX_STRINGS) {
+    assert.equal(
+      source.includes(forbidden),
+      false,
+      `LoginContent.tsx must not contain: ${forbidden}`,
+    );
+  }
+
+  assert.equal(
+    source.includes("429"),
+    false,
+    "LoginContent.tsx must not contain the HTTP status 429 as a literal string",
+  );
+
+  assert.equal(
+    source.includes("Demasiados intentos"),
+    false,
+    "LoginContent.tsx must not contain Demasiados intentos",
+  );
+});
+
+test("frontend source does not expose forbidden visible rate limit string literals", () => {
+  const findings: string[] = [];
+
+  for (const filePath of listFrontendSourceFiles(FRONTEND_SRC_PATH)) {
+    const source = read(filePath);
+
+    for (const forbidden of FORBIDDEN_VISIBLE_FRONTEND_STRINGS) {
+      if (source.includes(forbidden)) {
+        findings.push(`${filePath}: contains ${forbidden}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    findings,
+    [],
+    "frontend/src must not expose forbidden visible rate-limit strings",
+  );
+});
+
+test("frontend next-env.d.ts references production build path not dev path", () => {
+  const source = read(NEXT_ENV_PATH);
+
+  assert.ok(
+    source.includes('.next/types/routes.d.ts'),
+    "next-env.d.ts must reference .next/types/routes.d.ts (production build path, not dev path)",
+  );
+  assert.equal(
+    source.includes('.next/dev/types/routes.d.ts'),
+    false,
+    "next-env.d.ts must not reference .next/dev/types/routes.d.ts — dev path causes dirty working tree after pnpm --dir frontend build",
+  );
+});


### PR DESCRIPTION
## Summary
- Hide backend rate-limit details from the login client UX
- Replace explicit login rate-limit copy with safe non-technical wording
- Prevent backendMessage from being used to construct visible rate-limit errors
- Replace visible admin failed-login rate-limit copy with neutral wording
- Stabilize frontend/next-env.d.ts on the production build route types path
- Add regression contracts for login rate-limit UX safety and next-env build stability

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- post-commit frontend build leaves git status clean