### PR TITLE
feat(seo): strengthen public metadata and structured data

### DIFF
--- a/docs/implementation/seo-public-surface-extreme.md
+++ b/docs/implementation/seo-public-surface-extreme.md
@@ -1,0 +1,145 @@
+# SEO Extremo — Superficie Pública VETNEB
+
+**Rama:** `seo/extreme-public-surface-optimization`
+**Fecha:** 2026-06-04
+**Alcance:** Toda la superficie pública de `frontend/src/app/` (Next.js App Router).
+
+---
+
+## Páginas cubiertas
+
+| Ruta | Indexable | JSON-LD | Canonical | Robots metadata |
+|------|-----------|---------|-----------|-----------------|
+| `/` | ✓ | Organization + WebSite (layout) | ✓ | index/follow |
+| `/servicios` | ✓ | Service + BreadcrumbList | ✓ | index/follow |
+| `/citologia-veterinaria` | ✓ | Service + BreadcrumbList | ✓ | index/follow |
+| `/histopatologia-veterinaria` | ✓ | Service + BreadcrumbList | ✓ | index/follow |
+| `/informes-veterinarios` | ✓ | Service + BreadcrumbList | ✓ | index/follow |
+| `/laboratorio-patologico-veterinario` | ✓ | Service + BreadcrumbList | ✓ | index/follow |
+| `/clinicas` | ✓ | WebPage + BreadcrumbList **(nuevo)** | ✓ | index/follow |
+| `/precios` | ✓ | WebPage + BreadcrumbList **(nuevo)** | ✓ | index/follow |
+| `/contacto` | ✓ | ContactPage + BreadcrumbList **(nuevo)** | ✓ | index/follow |
+| `/profesionales` | ✓ | SearchResultsPage + BreadcrumbList + SearchAction | ✓ | index/follow |
+| `/profesionales/[clinicId]` | ✓ | — (client-rendered) | ✓ | index/follow |
+| `/login` | ✗ | — | — | noindex/nofollow |
+| `/particulares` | ✗ | — | — | noindex/nofollow |
+| `/offline` | ✗ | — | — | noindex/nofollow **(corregido)** |
+
+---
+
+## Decisiones de index/noindex
+
+- **`/login`**: noindex. Es acceso autenticado, no aporta valor de búsqueda.
+- **`/particulares`**: noindex. Es portal de acceso por token privado.
+- **`/offline`**: noindex **(gap corregido)**. Era una página de fallback PWA sin metadata robots. Agregado `robots: { index: false, follow: false }`.
+- **`/dashboard/*`**: bloqueado en robots.txt y sin metadata pública.
+
+---
+
+## Cambios implementados
+
+### `frontend/src/lib/seo.ts`
+- **Agregado `getContactPageJsonLd()`**: emite `ContactPage` + `BreadcrumbList` para `/contacto`. Tipo ContactPage (WebPage subtype) con referencias `@id` al Organization y WebSite del graph global.
+- **Agregado `getClinicasPageJsonLd()`**: emite `WebPage` + `BreadcrumbList` para `/clinicas`. Consistente con el patrón de otros helpers.
+- **Agregado `getPreciosPageJsonLd()`**: emite `WebPage` + `BreadcrumbList` para `/precios`.
+
+### `frontend/src/app/robots.ts`
+- **Agregado `/offline` y `/particulares` a `disallow`**. Antes solo bloqueaban `/dashboard` y `/api`. Las páginas noindex que no aportan crawl budget útil deben bloquearse también en robots.txt como segunda capa.
+
+### `frontend/src/app/offline/page.tsx`
+- **Agregado `robots: { index: false, follow: false }`**. Era la única página noindex no declarada explícitamente en metadata.
+
+### `frontend/src/app/page.tsx` (home)
+- **Corregido título duplicado de marca.** El título anterior `"Portal VETNEB — Laboratorio Patológico Veterinario"` con el template `%s | Portal VETNEB` renderizaba como `"Portal VETNEB — Laboratorio Patológico Veterinario | Portal VETNEB"` — doble marca, mala señal de calidad para Google. Cambiado a `"Laboratorio Patológico Veterinario — Histopatología, Citología y Hematología"` → renderiza como `"Laboratorio Patológico Veterinario — Histopatología, Citología y Hematología | Portal VETNEB"`.
+
+### `frontend/src/app/precios/page.tsx`
+- **Mejorado título**: de `"Lista de precios"` (genérico) a `"Precios de Estudios Patológicos Veterinarios"` (descriptivo, keyword-rich).
+- **Agregado JSON-LD**: `getPreciosPageJsonLd()`.
+
+### `frontend/src/app/contacto/page.tsx`
+- **Agregado JSON-LD**: `getContactPageJsonLd()`. Emitido desde el server component page, antes de que `ContactoContent` (client component) renderice.
+
+### `frontend/src/app/clinicas/page.tsx`
+- **Agregado JSON-LD**: `getClinicasPageJsonLd()`.
+
+---
+
+## Structured data implementada / preexistente
+
+| Tipo | Páginas | Función helper |
+|------|---------|----------------|
+| `Organization` + `WebSite` | Todas (layout global) | `getOrganizationJsonLd()` |
+| `Service` + `BreadcrumbList` | `/servicios`, `/citologia-veterinaria`, `/histopatologia-veterinaria`, `/informes-veterinarios`, `/laboratorio-patologico-veterinario` | `getServicesJsonLd()`, `getDiagnosticServiceJsonLd()` |
+| `ContactPage` + `BreadcrumbList` | `/contacto` | `getContactPageJsonLd()` |
+| `WebPage` + `BreadcrumbList` | `/clinicas`, `/precios` | `getClinicasPageJsonLd()`, `getPreciosPageJsonLd()` |
+| `SearchResultsPage` + `SearchAction` + `BreadcrumbList` | `/profesionales` | `getProfessionalsPageJsonLd()` |
+
+### Tipos deliberadamente NO implementados
+- `LocalBusiness` / `VeterinaryCare`: no se cuenta con dirección física verificable (solo ciudad).
+- `AggregateRating` / `Review`: sin datos de reseñas reales.
+- `FAQPage`: no hay sección FAQ visible en ninguna página pública.
+- `MedicalClaim`: sin claims clínicos verificables.
+- `openingHours`, `GeoCoordinates`, `PostalAddress`: sin datos de calle verificables.
+
+---
+
+## Contratos de regresión agregados
+
+**Archivo:** `test/frontend-seo-public-surface-extreme.test.ts`
+
+| Test | Contrato |
+|------|----------|
+| `robots.ts disallows dashboard, api, offline and particulares` | Verifica presencia de los 4 paths en disallow |
+| `robots.ts does not allow dashboard or api routes explicitly` | La sección allow no contiene /dashboard ni /api |
+| `offline page declares robots noindex` | `robots: { index: false, follow: false }` en offline/page.tsx |
+| `login and particulares pages declare robots noindex` | Ambas páginas tienen noindex |
+| `home page title does not start with brand name` | El título de home no empieza con "Portal VETNEB —" para evitar duplicación |
+| `sitemap includes all public indexable service pages` | 9 URLs de servicios y páginas institucionales presentes |
+| `sitemap excludes private, noindex and tokenized routes` | /dashboard, /api, /offline, /particulares, /login ausentes |
+| `service pages emit getDiagnosticServiceJsonLd structured data` | 5 páginas de servicio tienen script JSON-LD con JSON.stringify |
+| `contacto page emits ContactPage JSON-LD` | getContactPageJsonLd en seo.ts y contacto/page.tsx |
+| `clinicas page emits WebPage JSON-LD with breadcrumb` | getClinicasPageJsonLd en seo.ts y clinicas/page.tsx |
+| `precios page emits WebPage JSON-LD with breadcrumb` | getPreciosPageJsonLd en seo.ts y precios/page.tsx |
+| `profesionales page emits SearchResultsPage JSON-LD` | getProfessionalsPageJsonLd en profesionales/page.tsx |
+| `seo.ts JSON-LD helpers do not include unverifiable schema types` | Sin AggregateRating, Review, FAQPage, openingHours, GeoCoordinates, PostalAddress, priceRange, MedicalClaim |
+| `JSON-LD across all public pages uses JSON.stringify` | Sin interpolación manual de strings peligrosos |
+| `seo.ts does not contain placeholder, localhost or internal domain references` | Sin localhost, example.com, TODO, FIXME |
+| `seo.ts canonical URL defaults to production domain` | URL de producción hardcodeada como fallback |
+| `all helpers emit BreadcrumbList` | 5 helpers tienen BreadcrumbList |
+| `all public indexable pages declare canonical` | 10 páginas usan createPageMetadata o generateMetadata |
+| `dashboard routes never in sitemap` | 4 rutas de dashboard ausentes del sitemap |
+| `precios page title is descriptive` | No usa el genérico "Lista de precios", incluye keyword veterinario |
+| `contacto page title does not contain brand name` | El title no contiene "Portal VETNEB" para evitar `"Contacto — Portal VETNEB \| Portal VETNEB"` |
+
+---
+
+## Validaciones ejecutadas
+
+- `pnpm test` (backend + tests de frontend estáticos)
+- `pnpm build` (backend)
+- `pnpm security:public-surface`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+
+---
+
+## Corrección post-implementación: título de `/contacto`
+
+El riesgo residual de duplicación en `/contacto` fue corregido. El title `"Contacto — Portal VETNEB"` fue reemplazado por `"Contacto — Laboratorio Patológico Veterinario"`, resultando en el title final:
+
+```
+Contacto — Laboratorio Patológico Veterinario | Portal VETNEB
+```
+
+61 caracteres, sin duplicación de marca, con keyword value. Se agregó el contrato de regresión `contacto page title does not contain brand name`.
+
+---
+
+## Riesgos residuales
+
+1. **`/profesionales/[clinicId]`**: El contenido del perfil se carga client-side. Googlebot ejecuta JS pero el tiempo de renderizado puede limitar la indexación completa. No se agregó JSON-LD porque los datos del perfil no están disponibles en server-side (se cargan desde la API). Riesgo: bajo — las páginas de perfil son de búsqueda interna, no SEO primario.
+
+2. **JSON-LD `dangerouslySetInnerHTML` + `JSON.stringify`**: Técnicamente seguro porque todos los datos son constantes de tiempo de build, pero `JSON.stringify` no escapa `</script>` en valores de string. En este proyecto todos los valores son literales inofensivos, por lo que el riesgo es nulo en la práctica. Si en el futuro se agregan datos dinámicos de usuario, se debe usar un sanitizador que escape `</script>`.
+
+3. **`lastModified` en sitemap**: Se usa `new Date()` que cambia en cada build. Esto genera un sitemap diferente en cada deployment, lo que puede causar reindexaciones innecesarias. Riesgo: bajo — es el patrón existente del proyecto y aceptado.

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -21,7 +21,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { createPageMetadata } from "@/lib/seo";
+import { createPageMetadata, getClinicasPageJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
@@ -103,8 +103,14 @@ const steps = [
 ];
 
 export default function ClinicasPage() {
+  const jsonLd = getClinicasPageJsonLd();
+
   return (
     <PublicLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <section
         className="public-secondary-hero-surface py-16 text-white md:py-20"
         aria-labelledby="clinicas-page-title"

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -1,13 +1,23 @@
 import type { Metadata } from "next";
-import { createPageMetadata } from "@/lib/seo";
+import { createPageMetadata, getContactPageJsonLd } from "@/lib/seo";
 import { ContactoContent } from "@/components/public/ContactoContent";
 
 export const metadata: Metadata = createPageMetadata(
-  "Contacto — Portal VETNEB",
+  "Contacto — Laboratorio Patológico Veterinario",
   "Contacte con el equipo de Portal VETNEB. Solicite acceso para su clínica o consulte sobre los servicios del laboratorio veterinario.",
   "/contacto",
 );
 
 export default function ContactoPage() {
-  return <ContactoContent />;
+  const jsonLd = getContactPageJsonLd();
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ContactoContent />
+    </>
+  );
 }

--- a/frontend/src/app/offline/page.tsx
+++ b/frontend/src/app/offline/page.tsx
@@ -6,11 +6,14 @@ import { OfflineActions } from "@/components/pwa/OfflineActions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { createPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = createPageMetadata(
-  "Sin conexión — Portal VETNEB",
-  "Página offline de Portal VETNEB. Permite mantener una experiencia segura cuando la conexión de red no está disponible.",
-  "/offline",
-);
+export const metadata: Metadata = {
+  ...createPageMetadata(
+    "Sin conexión — Portal VETNEB",
+    "Página offline de Portal VETNEB. Permite mantener una experiencia segura cuando la conexión de red no está disponible.",
+    "/offline",
+  ),
+  robots: { index: false, follow: false },
+};
 
 const offlineGuidance = [
   {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -22,7 +22,7 @@ import { createPageMetadata } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
 export const metadata: Metadata = createPageMetadata(
-  "Portal VETNEB — Laboratorio Patológico Veterinario",
+  "Laboratorio Patológico Veterinario — Histopatología, Citología y Hematología",
   "La anatomía patológica veterinaria estudia los motivos, el desarrollo y las consecuencias de distintas enfermedades mediante el análisis de tejidos, órganos y muestras celulares. VETNEB integra histopatología, citología, citopatología, hematología, diagnóstico hematológico y hemoparásitos.",
   "/",
 );

--- a/frontend/src/app/precios/page.tsx
+++ b/frontend/src/app/precios/page.tsx
@@ -1,14 +1,24 @@
 import type { Metadata } from "next";
 
 import { PreciosContent } from "@/components/public/PreciosContent";
-import { createPageMetadata } from "@/lib/seo";
+import { createPageMetadata, getPreciosPageJsonLd } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata(
-  "Lista de precios",
+  "Precios de Estudios Patológicos Veterinarios",
   "Listado público de estudios de citologías e histopatologías con sus valores de referencia y estado vigente.",
   "/precios",
 );
 
 export default function PreciosPage() {
-  return <PreciosContent />;
+  const jsonLd = getPreciosPageJsonLd();
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <PreciosContent />
+    </>
+  );
 }

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -14,7 +14,12 @@ export default function robots(): MetadataRoute.Robots {
           "/contacto",
           "/precios",
         ],
-        disallow: ["/dashboard", "/api"],
+        disallow: [
+          "/dashboard",
+          "/api",
+          "/offline",
+          "/particulares",
+        ],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -333,6 +333,162 @@ export function getDiagnosticServiceJsonLd({
   };
 }
 
+// ─── JSON-LD para página de contacto ────────────────────────────────────────
+
+export function getContactPageJsonLd() {
+  const pageUrl = buildCanonicalUrl("/contacto");
+  const organizationId = `${SITE_URL}/#organization`;
+  const websiteId = `${SITE_URL}/#website`;
+  const breadcrumbId = `${pageUrl}#breadcrumb`;
+  const webpageId = `${pageUrl}#webpage`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Inicio",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Contacto",
+            item: pageUrl,
+          },
+        ],
+      },
+      {
+        "@type": "ContactPage",
+        "@id": webpageId,
+        url: pageUrl,
+        name: "Contacto — Portal VETNEB",
+        description:
+          "Contacte con el equipo de Portal VETNEB para registrar su clínica, coordinar envío de muestras o consultar sobre los servicios del laboratorio patológico veterinario.",
+        inLanguage: "es-AR",
+        isPartOf: {
+          "@id": websiteId,
+        },
+        publisher: {
+          "@id": organizationId,
+        },
+        breadcrumb: {
+          "@id": breadcrumbId,
+        },
+      },
+    ],
+  };
+}
+
+// ─── JSON-LD para página de clínicas ─────────────────────────────────────────
+
+export function getClinicasPageJsonLd() {
+  const pageUrl = buildCanonicalUrl("/clinicas");
+  const organizationId = `${SITE_URL}/#organization`;
+  const websiteId = `${SITE_URL}/#website`;
+  const breadcrumbId = `${pageUrl}#breadcrumb`;
+  const webpageId = `${pageUrl}#webpage`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Inicio",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Clínicas",
+            item: pageUrl,
+          },
+        ],
+      },
+      {
+        "@type": "WebPage",
+        "@id": webpageId,
+        url: pageUrl,
+        name: "Portal para Clínicas Veterinarias — VETNEB",
+        description:
+          "Portal de gestión para clínicas veterinarias. Acceso a informes, seguimiento de estudios, logística y auditoría desde un único lugar.",
+        inLanguage: "es-AR",
+        isPartOf: {
+          "@id": websiteId,
+        },
+        publisher: {
+          "@id": organizationId,
+        },
+        breadcrumb: {
+          "@id": breadcrumbId,
+        },
+      },
+    ],
+  };
+}
+
+// ─── JSON-LD para página de precios ──────────────────────────────────────────
+
+export function getPreciosPageJsonLd() {
+  const pageUrl = buildCanonicalUrl("/precios");
+  const organizationId = `${SITE_URL}/#organization`;
+  const websiteId = `${SITE_URL}/#website`;
+  const breadcrumbId = `${pageUrl}#breadcrumb`;
+  const webpageId = `${pageUrl}#webpage`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Inicio",
+            item: SITE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Precios",
+            item: pageUrl,
+          },
+        ],
+      },
+      {
+        "@type": "WebPage",
+        "@id": webpageId,
+        url: pageUrl,
+        name: "Precios de Estudios Patológicos Veterinarios — VETNEB",
+        description:
+          "Listado público de estudios de citologías e histopatologías con sus valores de referencia y estado vigente.",
+        inLanguage: "es-AR",
+        isPartOf: {
+          "@id": websiteId,
+        },
+        publisher: {
+          "@id": organizationId,
+        },
+        breadcrumb: {
+          "@id": breadcrumbId,
+        },
+      },
+    ],
+  };
+}
+
 // ─── JSON-LD para página pública de profesionales ────────────────────────────
 
 export function getProfessionalsPageJsonLd() {

--- a/test/frontend-clinicas-page-content.test.ts
+++ b/test/frontend-clinicas-page-content.test.ts
@@ -18,7 +18,7 @@ test("clinicas page defines metadata and public layout wiring", () => {
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { PublicLayout } from "@/components/layout/PublicLayout";'));
-  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes('import { createPageMetadata, getClinicasPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
   assert.ok(source.includes('"Portal para Clínicas Veterinarias"'));

--- a/test/frontend-contacto-page.test.ts
+++ b/test/frontend-contacto-page.test.ts
@@ -17,9 +17,9 @@ test("contacto public page defines metadata through SEO helper", () => {
   const source = read(CONTACTO_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes('import { createPageMetadata, getContactPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Contacto — Portal VETNEB"'));
+  assert.ok(source.includes('"Contacto — Laboratorio Patológico Veterinario"'));
   assert.ok(source.includes('"Contacte con el equipo de Portal VETNEB.'));
   assert.ok(source.includes('"/contacto"'));
 });
@@ -29,7 +29,7 @@ test("contacto public page delegates rendering to ContactoContent", () => {
 
   assert.ok(source.includes('import { ContactoContent } from "@/components/public/ContactoContent";'));
   assert.ok(source.includes("export default function ContactoPage()"));
-  assert.ok(source.includes("return <ContactoContent />;"));
+  assert.ok(source.includes("<ContactoContent />"));
 });
 
 test("contacto content keeps public layout and contact form landmarks", () => {

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -33,7 +33,7 @@ test("home page defines public metadata — organization JSON-LD is emitted by r
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(source.includes('"Portal VETNEB — Laboratorio Patológico Veterinario"'));
+  assert.ok(source.includes('"Laboratorio Patológico Veterinario — Histopatología, Citología y Hematología"'));
   assert.ok(source.includes('"/"'));
   // Organization JSON-LD is injected by layout.tsx to avoid duplication on the home page
   assert.equal(source.includes("getOrganizationJsonLd"), false);

--- a/test/frontend-precios-page-content.test.ts
+++ b/test/frontend-precios-page-content.test.ts
@@ -20,9 +20,9 @@ test("precios page defines public metadata and layout", () => {
 
   assert.ok(pageSource.includes('import type { Metadata } from "next";'));
   assert.ok(pageSource.includes('import { PreciosContent } from "@/components/public/PreciosContent";'));
-  assert.ok(pageSource.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(pageSource.includes('import { createPageMetadata, getPreciosPageJsonLd } from "@/lib/seo";'));
   assert.ok(pageSource.includes("export const metadata: Metadata = createPageMetadata("));
-  assert.ok(pageSource.includes('"Lista de precios"'));
+  assert.ok(pageSource.includes('"Precios de Estudios Patológicos Veterinarios"'));
   assert.ok(pageSource.includes('"/precios"'));
   assert.ok(pageSource.includes("<PreciosContent />"));
   assert.ok(contentSource.includes('"use client";'));

--- a/test/frontend-public-page-metadata.test.ts
+++ b/test/frontend-public-page-metadata.test.ts
@@ -42,7 +42,7 @@ test("clinicas public page defines SEO metadata", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
-  assert.ok(source.includes('import { createPageMetadata } from "@/lib/seo";'));
+  assert.ok(source.includes('import { createPageMetadata, getClinicasPageJsonLd } from "@/lib/seo";'));
   assert.ok(source.includes("export const metadata: Metadata = createPageMetadata("));
   assert.ok(source.includes('"Portal para Clínicas Veterinarias"'));
   assert.ok(source.includes('"Acceso al portal de gestión para clínicas veterinarias.'));

--- a/test/frontend-public-seo-contract.test.ts
+++ b/test/frontend-public-seo-contract.test.ts
@@ -56,7 +56,8 @@ test("root layout embeds institutional JSON-LD script", () => {
 test("robots policy blocks dashboard and api while exposing sitemap", () => {
   const source = read(ROBOTS_PATH);
 
-  assert.ok(source.includes('disallow: ["/dashboard", "/api"]'));
+  assert.ok(source.includes('"/dashboard"'));
+  assert.ok(source.includes('"/api"'));
   assert.ok(source.includes("sitemap: `${SITE_URL}/sitemap.xml`,"));
 });
 

--- a/test/frontend-seo-metadata.test.ts
+++ b/test/frontend-seo-metadata.test.ts
@@ -98,7 +98,10 @@ test("frontend robots allows public institutional pages and blocks private/API s
   assert.ok(source.includes('"/profesionales"'));
   assert.ok(source.includes('"/contacto"'));
   assert.ok(source.includes('"/precios"'));
-  assert.ok(source.includes('disallow: ["/dashboard", "/api"]'));
+  assert.ok(source.includes('"/dashboard"'));
+  assert.ok(source.includes('"/api"'));
+  assert.ok(source.includes('"/offline"'));
+  assert.ok(source.includes('"/particulares"'));
   assert.ok(source.includes("sitemap: `${SITE_URL}/sitemap.xml`,"));
 });
 

--- a/test/frontend-seo-public-surface-extreme.test.ts
+++ b/test/frontend-seo-public-surface-extreme.test.ts
@@ -1,0 +1,449 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const SEO_PATH = "frontend/src/lib/seo.ts";
+const ROBOTS_PATH = "frontend/src/app/robots.ts";
+const SITEMAP_PATH = "frontend/src/app/sitemap.ts";
+const HOME_PATH = "frontend/src/app/page.tsx";
+const SERVICIOS_PATH = "frontend/src/app/servicios/page.tsx";
+const CITOLOGIA_PATH = "frontend/src/app/citologia-veterinaria/page.tsx";
+const HISTOPAT_PATH = "frontend/src/app/histopatologia-veterinaria/page.tsx";
+const INFORMES_PATH = "frontend/src/app/informes-veterinarios/page.tsx";
+const LABORATORIO_PATH = "frontend/src/app/laboratorio-patologico-veterinario/page.tsx";
+const CLINICAS_PATH = "frontend/src/app/clinicas/page.tsx";
+const PRECIOS_PATH = "frontend/src/app/precios/page.tsx";
+const CONTACTO_PATH = "frontend/src/app/contacto/page.tsx";
+const PROFESIONALES_PATH = "frontend/src/app/profesionales/page.tsx";
+const OFFLINE_PATH = "frontend/src/app/offline/page.tsx";
+const LOGIN_PATH = "frontend/src/app/login/page.tsx";
+const PARTICULARES_PATH = "frontend/src/app/particulares/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ─── robots.ts contracts ──────────────────────────────────────────────────────
+
+test("robots.ts disallows dashboard, api, offline and particulares", () => {
+  const source = read(ROBOTS_PATH);
+
+  assert.ok(source.includes('"/dashboard"'), "robots must disallow /dashboard");
+  assert.ok(source.includes('"/api"'), "robots must disallow /api");
+  assert.ok(source.includes('"/offline"'), "robots must disallow /offline");
+  assert.ok(source.includes('"/particulares"'), "robots must disallow /particulares");
+});
+
+test("robots.ts does not allow dashboard or api routes explicitly", () => {
+  const source = read(ROBOTS_PATH);
+
+  const allowSection = source.slice(source.indexOf("allow:"), source.indexOf("disallow:"));
+
+  assert.equal(
+    allowSection.includes("/dashboard"),
+    false,
+    "allow list must not include /dashboard",
+  );
+  assert.equal(
+    allowSection.includes("/api"),
+    false,
+    "allow list must not include /api",
+  );
+});
+
+// ─── Offline page noindex contract ───────────────────────────────────────────
+
+test("offline page declares robots noindex", () => {
+  const source = read(OFFLINE_PATH);
+
+  assert.ok(
+    source.includes("robots: { index: false, follow: false }"),
+    "offline page must have robots noindex/nofollow",
+  );
+});
+
+// ─── Login y particulares noindex contract ────────────────────────────────────
+
+test("login and particulares pages declare robots noindex", () => {
+  const loginSource = read(LOGIN_PATH);
+  const particularesSource = read(PARTICULARES_PATH);
+
+  assert.ok(
+    loginSource.includes("robots: { index: false, follow: false }"),
+    "login page must have robots noindex",
+  );
+  assert.ok(
+    particularesSource.includes("index: false,"),
+    "particulares page must have robots index: false",
+  );
+  assert.ok(
+    particularesSource.includes("follow: false,"),
+    "particulares page must have robots follow: false",
+  );
+});
+
+// ─── Titles sin doble marca (home y contacto) ────────────────────────────────
+
+test("contacto page title does not contain brand name to avoid template duplication", () => {
+  const source = read(CONTACTO_PATH);
+
+  assert.equal(
+    source.includes('"Contacto — Portal VETNEB"'),
+    false,
+    "contacto title must not contain 'Portal VETNEB' — the template appends '| Portal VETNEB', causing 'Contacto — Portal VETNEB | Portal VETNEB'",
+  );
+  assert.ok(
+    source.includes('"Contacto — Laboratorio Patológico Veterinario"'),
+    "contacto title must be 'Contacto — Laboratorio Patológico Veterinario' for keyword value without brand duplication",
+  );
+});
+
+test("home page title does not start with brand name to avoid template duplication", () => {
+  const source = read(HOME_PATH);
+
+  assert.equal(
+    source.includes('"Portal VETNEB — Laboratorio Patológico Veterinario"'),
+    false,
+    "home title must not start with 'Portal VETNEB' since the template appends '| Portal VETNEB' — this would duplicate the brand",
+  );
+  assert.ok(
+    source.includes("createPageMetadata("),
+    "home page must use createPageMetadata helper",
+  );
+  assert.ok(
+    source.includes('"/",'),
+    "home page must pass canonical root path",
+  );
+});
+
+// ─── Sitemap incluye todas las páginas públicas indexables ───────────────────
+
+test("sitemap includes all public indexable service pages", () => {
+  const source = read(SITEMAP_PATH);
+
+  const requiredUrls = [
+    "${SITE_URL}/servicios",
+    "${SITE_URL}/citologia-veterinaria",
+    "${SITE_URL}/histopatologia-veterinaria",
+    "${SITE_URL}/informes-veterinarios",
+    "${SITE_URL}/laboratorio-patologico-veterinario",
+    "${SITE_URL}/clinicas",
+    "${SITE_URL}/profesionales",
+    "${SITE_URL}/contacto",
+    "${SITE_URL}/precios",
+  ];
+
+  for (const url of requiredUrls) {
+    assert.ok(
+      source.includes(url),
+      `sitemap must include URL: ${url}`,
+    );
+  }
+});
+
+test("sitemap excludes private, noindex and tokenized routes", () => {
+  const source = read(SITEMAP_PATH);
+
+  const forbiddenPaths = [
+    "/dashboard",
+    "/api",
+    "/offline",
+    "/particulares",
+    "/login",
+  ];
+
+  for (const path of forbiddenPaths) {
+    assert.equal(
+      source.includes(path),
+      false,
+      `sitemap must not include path: ${path}`,
+    );
+  }
+});
+
+// ─── JSON-LD en páginas de servicios ─────────────────────────────────────────
+
+test("service pages emit getDiagnosticServiceJsonLd structured data", () => {
+  const pages = [
+    { path: SERVICIOS_PATH, name: "servicios" },
+    { path: CITOLOGIA_PATH, name: "citologia-veterinaria" },
+    { path: HISTOPAT_PATH, name: "histopatologia-veterinaria" },
+    { path: INFORMES_PATH, name: "informes-veterinarios" },
+    { path: LABORATORIO_PATH, name: "laboratorio-patologico-veterinario" },
+  ];
+
+  for (const page of pages) {
+    const source = read(page.path);
+
+    assert.ok(
+      source.includes('type="application/ld+json"'),
+      `${page.name} must emit application/ld+json script`,
+    );
+    assert.ok(
+      source.includes("JSON.stringify("),
+      `${page.name} JSON-LD must use JSON.stringify`,
+    );
+    assert.ok(
+      source.includes("dangerouslySetInnerHTML="),
+      `${page.name} JSON-LD must use dangerouslySetInnerHTML`,
+    );
+  }
+});
+
+test("contacto page emits ContactPage JSON-LD", () => {
+  const pageSource = read(CONTACTO_PATH);
+  const seoSource = read(SEO_PATH);
+
+  assert.ok(
+    seoSource.includes("export function getContactPageJsonLd()"),
+    "seo.ts must export getContactPageJsonLd",
+  );
+  assert.ok(
+    seoSource.includes('"@type": "ContactPage"'),
+    "getContactPageJsonLd must emit ContactPage type",
+  );
+  assert.ok(
+    pageSource.includes("getContactPageJsonLd"),
+    "contacto page must use getContactPageJsonLd",
+  );
+  assert.ok(
+    pageSource.includes('type="application/ld+json"'),
+    "contacto page must emit application/ld+json",
+  );
+  assert.ok(
+    pageSource.includes("JSON.stringify("),
+    "contacto page JSON-LD must use JSON.stringify",
+  );
+});
+
+test("clinicas page emits WebPage JSON-LD with breadcrumb", () => {
+  const pageSource = read(CLINICAS_PATH);
+  const seoSource = read(SEO_PATH);
+
+  assert.ok(
+    seoSource.includes("export function getClinicasPageJsonLd()"),
+    "seo.ts must export getClinicasPageJsonLd",
+  );
+  assert.ok(
+    pageSource.includes("getClinicasPageJsonLd"),
+    "clinicas page must use getClinicasPageJsonLd",
+  );
+  assert.ok(
+    pageSource.includes('type="application/ld+json"'),
+    "clinicas page must emit application/ld+json",
+  );
+});
+
+test("precios page emits WebPage JSON-LD with breadcrumb", () => {
+  const pageSource = read(PRECIOS_PATH);
+  const seoSource = read(SEO_PATH);
+
+  assert.ok(
+    seoSource.includes("export function getPreciosPageJsonLd()"),
+    "seo.ts must export getPreciosPageJsonLd",
+  );
+  assert.ok(
+    pageSource.includes("getPreciosPageJsonLd"),
+    "precios page must use getPreciosPageJsonLd",
+  );
+  assert.ok(
+    pageSource.includes('type="application/ld+json"'),
+    "precios page must emit application/ld+json",
+  );
+});
+
+test("profesionales page emits SearchResultsPage JSON-LD", () => {
+  const source = read(PROFESIONALES_PATH);
+
+  assert.ok(
+    source.includes("getProfessionalsPageJsonLd"),
+    "profesionales page must use getProfessionalsPageJsonLd",
+  );
+  assert.ok(
+    source.includes('type="application/ld+json"'),
+    "profesionales page must emit application/ld+json",
+  );
+});
+
+// ─── JSON-LD no contiene datos prohibidos ni tipos riesgosos ─────────────────
+
+test("seo.ts JSON-LD helpers do not include unverifiable schema types", () => {
+  const source = read(SEO_PATH);
+
+  assert.equal(source.includes("AggregateRating"), false, "seo.ts must not contain AggregateRating");
+  assert.equal(source.includes('"@type": "Review"'), false, "seo.ts must not contain Review type");
+  assert.equal(source.includes('"@type": "FAQPage"'), false, "seo.ts must not contain FAQPage type");
+  assert.equal(source.includes("openingHours"), false, "seo.ts must not contain openingHours (not verified)");
+  assert.equal(source.includes("GeoCoordinates"), false, "seo.ts must not contain GeoCoordinates (no verified address)");
+  assert.equal(source.includes("PostalAddress"), false, "seo.ts must not contain PostalAddress (no verified street address)");
+  assert.equal(source.includes("priceRange"), false, "seo.ts must not contain priceRange (not verified)");
+  assert.equal(source.includes("MedicalClaim"), false, "seo.ts must not contain MedicalClaim");
+});
+
+test("JSON-LD across all public pages uses JSON.stringify and not manual interpolation", () => {
+  const pagePaths = [
+    SERVICIOS_PATH,
+    CITOLOGIA_PATH,
+    HISTOPAT_PATH,
+    INFORMES_PATH,
+    LABORATORIO_PATH,
+    CLINICAS_PATH,
+    PRECIOS_PATH,
+    CONTACTO_PATH,
+    PROFESIONALES_PATH,
+  ];
+
+  for (const pagePath of pagePaths) {
+    const source = read(pagePath);
+
+    if (!source.includes('type="application/ld+json"')) {
+      continue;
+    }
+
+    assert.ok(
+      source.includes("JSON.stringify("),
+      `${pagePath}: JSON-LD script must use JSON.stringify for safe serialization`,
+    );
+    assert.equal(
+      source.includes("__html: `{"),
+      false,
+      `${pagePath}: JSON-LD must not use template literal string interpolation`,
+    );
+  }
+});
+
+// ─── Sin datos inventados ni placeholders en seo.ts ──────────────────────────
+
+test("seo.ts does not contain placeholder, localhost or internal domain references", () => {
+  const source = read(SEO_PATH);
+
+  const forbidden = [
+    "localhost",
+    "example.com",
+    "TODO",
+    "FIXME",
+    "placeholder",
+    "your-domain",
+    "yoursite",
+  ];
+
+  for (const term of forbidden) {
+    assert.equal(
+      source.toLowerCase().includes(term.toLowerCase()),
+      false,
+      `seo.ts must not contain: ${term}`,
+    );
+  }
+});
+
+test("seo.ts canonical URL defaults to production domain, not localhost", () => {
+  const source = read(SEO_PATH);
+
+  assert.ok(
+    source.includes('"https://portal.vetneb.com"'),
+    "seo.ts must default to production canonical URL",
+  );
+  assert.equal(
+    source.includes("localhost"),
+    false,
+    "seo.ts must not contain localhost as canonical URL",
+  );
+});
+
+// ─── BreadcrumbList en helpers de servicios y nuevas páginas ─────────────────
+
+test("seo.ts JSON-LD helpers emit BreadcrumbList for service and informational pages", () => {
+  const source = read(SEO_PATH);
+
+  const helpersWithBreadcrumb = [
+    "getDiagnosticServiceJsonLd",
+    "getProfessionalsPageJsonLd",
+    "getContactPageJsonLd",
+    "getClinicasPageJsonLd",
+    "getPreciosPageJsonLd",
+  ];
+
+  for (const helper of helpersWithBreadcrumb) {
+    const helperStart = source.indexOf(`export function ${helper}`);
+    const helperEnd = source.indexOf("\nexport function", helperStart + 1);
+    const helperBody = helperEnd > -1
+      ? source.slice(helperStart, helperEnd)
+      : source.slice(helperStart);
+
+    assert.ok(
+      helperBody.includes('"@type": "BreadcrumbList"'),
+      `${helper} must emit BreadcrumbList`,
+    );
+  }
+});
+
+// ─── Canonical URL en todas las páginas públicas indexables ──────────────────
+
+test("all public indexable pages declare canonical via createPageMetadata or generateMetadata", () => {
+  const indexablePages = [
+    { path: HOME_PATH, name: "home" },
+    { path: SERVICIOS_PATH, name: "servicios" },
+    { path: CITOLOGIA_PATH, name: "citologia" },
+    { path: HISTOPAT_PATH, name: "histopatologia" },
+    { path: INFORMES_PATH, name: "informes" },
+    { path: LABORATORIO_PATH, name: "laboratorio" },
+    { path: CLINICAS_PATH, name: "clinicas" },
+    { path: PRECIOS_PATH, name: "precios" },
+    { path: CONTACTO_PATH, name: "contacto" },
+    { path: PROFESIONALES_PATH, name: "profesionales" },
+  ];
+
+  for (const page of indexablePages) {
+    const source = read(page.path);
+
+    const hasMetadataHelper =
+      source.includes("createPageMetadata(") ||
+      source.includes("generateMetadata(");
+
+    assert.ok(
+      hasMetadataHelper,
+      `${page.name} page must use createPageMetadata or generateMetadata for canonical URL`,
+    );
+  }
+});
+
+// ─── Páginas privadas no aparecen en sitemap ──────────────────────────────────
+
+test("dashboard routes are never referenced in sitemap", () => {
+  const source = read(SITEMAP_PATH);
+
+  const dashboardPaths = [
+    "/dashboard",
+    "/dashboard/informes",
+    "/dashboard/logistica",
+    "/dashboard/admin",
+  ];
+
+  for (const path of dashboardPaths) {
+    assert.equal(
+      source.includes(path),
+      false,
+      `sitemap must not include dashboard path: ${path}`,
+    );
+  }
+});
+
+// ─── Descripción de precios mejorada ─────────────────────────────────────────
+
+test("precios page title is descriptive and keyword-rich", () => {
+  const source = read(PRECIOS_PATH);
+
+  assert.equal(
+    source.includes('"Lista de precios"'),
+    false,
+    "precios title must not be the generic 'Lista de precios' — use a descriptive keyword-rich title",
+  );
+  assert.ok(
+    source.includes("Veterinario") || source.includes("Veterinaria") || source.includes("Patológico"),
+    "precios title must include veterinary/pathology keyword",
+  );
+});


### PR DESCRIPTION
## Summary
- Strengthen public page metadata, canonical coverage, Open Graph, robots and sitemap behavior
- Add structured data for ContactPage, WebPage and BreadcrumbList where public content supports it
- Improve public SEO titles, including home/contact/precios cases without duplicated brand titles
- Add explicit noindex handling for offline and crawl-budget protections for non-SEO public fallback routes
- Add regression contracts for public SEO metadata, JSON-LD safety, sitemap/robots constraints and title duplication

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- post-amend frontend build leaves git status clean
- SEO focal tests: 42 pass / 0 fail