### PR TITLE
fix(particulares): show lab delivery and report estimate

### DIFF
--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -773,6 +773,12 @@ export function ParticularesContent() {
                         <p className="text-xs text-muted-foreground">
                           Actualizado: {formatDate(trackingCase.updatedAt)}
                         </p>
+                        <p className="text-xs text-muted-foreground">
+                          Entrega en laboratorio: {formatDate(trackingCase.receptionAt)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Estimación informe: {formatDate(trackingCase.estimatedDeliveryAt)}
+                        </p>
                         {trackingCase.specialStainRequired ? (
                           <div className="space-y-3">
                             <div className="clinical-alert-warning p-3 text-sm">
@@ -826,6 +832,12 @@ export function ParticularesContent() {
                         </p>
                         <p className="text-xs text-muted-foreground">
                           Actualizado: {formatDate(trackingCase.updatedAt)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Entrega en laboratorio: {formatDate(trackingCase.receptionAt)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Estimación informe: {formatDate(trackingCase.estimatedDeliveryAt)}
                         </p>
                         {trackingCase.specialStainRequired ? (
                           <div className="space-y-3">

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -252,6 +252,27 @@ test("particulares content arma mensajes de tincion especial con contexto dinami
   assert.ok(emailBlock.includes("encodeURIComponent(message)"));
 });
 
+test("particulares content muestra receptionAt y estimatedDeliveryAt en seguimiento", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("Entrega en laboratorio:"),
+    "tracking section must show 'Entrega en laboratorio:'",
+  );
+  assert.ok(
+    source.includes("trackingCase.receptionAt"),
+    "tracking section must use trackingCase.receptionAt",
+  );
+  assert.ok(
+    source.includes("Estimación informe:"),
+    "tracking section must show 'Estimación informe:'",
+  );
+  assert.ok(
+    source.includes("trackingCase.estimatedDeliveryAt"),
+    "tracking section must use trackingCase.estimatedDeliveryAt",
+  );
+});
+
 test("particulares content omite datos ausentes y sensibles en mensaje de tincion especial", () => {
   const source = read(PARTICULARES_CONTENT_PATH);
   const valueBlock = extractFunctionBlock(

--- a/test/particular-study-tracking.fastify.test.ts
+++ b/test/particular-study-tracking.fastify.test.ts
@@ -130,6 +130,16 @@ test("particularStudyTrackingNativeRoutes expone GET /me con seguimiento del tok
     assert.equal(body.trackingCase.id, 11);
     assert.equal(body.trackingCase.particularTokenId, 7);
     assert.equal(body.trackingCase.specialStainRequired, true);
+    assert.equal(
+      body.trackingCase.receptionAt,
+      "2026-04-20T00:00:00.000Z",
+      "receptionAt debe exponerse al particular autenticado",
+    );
+    assert.equal(
+      body.trackingCase.estimatedDeliveryAt,
+      "2026-05-11T00:00:00.000Z",
+      "estimatedDeliveryAt debe exponerse al particular autenticado",
+    );
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Summary
- Show lab delivery date in the authenticated particular dashboard when available
- Show report estimate in the authenticated particular dashboard when available
- Preserve existing backend public payload shape and confirm receptionAt / estimatedDeliveryAt are already serialized safely
- Add regression coverage for frontend rendering and particular tracking payload

## Validation
- focused study tracking tests: 64/64 passing
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- post-commit frontend build leaves git status clean