### PR TITLE
chore(admin): use canonical Tailwind min-width class

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -487,7 +487,7 @@ export function AdminClinicsManagementCard() {
                     <TableRow
                       key={`${clinic.clinicId}-${user?.userId ?? "empty"}`}
                     >
-                      <TableCell className="min-w-[220px] align-top">
+                      <TableCell className="min-w-55 align-top">
                         <div className="space-y-2">
                           <Input
                             value={clinicDraft.clinicName}
@@ -509,7 +509,7 @@ export function AdminClinicsManagementCard() {
                         </div>
                       </TableCell>
 
-                      <TableCell className="min-w-[220px] align-top">
+                      <TableCell className="min-w-55 align-top">
                         <div className="space-y-2">
                           <Input
                             type="email"
@@ -544,7 +544,7 @@ export function AdminClinicsManagementCard() {
                         </div>
                       </TableCell>
 
-                      <TableCell className="min-w-[220px] align-top">
+                      <TableCell className="min-w-55 align-top">
                         {user && userDraft ? (
                           <div className="space-y-2">
                             <Input


### PR DESCRIPTION
## Summary
- Replace arbitrary min-w-[220px] classes with canonical Tailwind min-w-55 in admin clinic management table cells
- Keep visual sizing equivalent while removing editor/lint canonical class warnings

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build