### PR TITLE
feat(dashboard): admin command center and sticky actions

### DIFF
--- a/docs/pr-2-dashboard-admin-command-center.md
+++ b/docs/pr-2-dashboard-admin-command-center.md
@@ -1,0 +1,58 @@
+# PR-2 - Admin Command Center + Sticky Action Bar
+
+## Resumen
+
+Se reorganizo `/dashboard/admin` como un command center privado y conservador. La pantalla ahora prioriza acciones operativas arriba del fold, resumen/KPIs con datos ya disponibles, alertas criticas cerca del top y agrupacion posterior por sistema, gestion, configuracion secundaria y auditoria.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `test/frontend-dashboard-admin.test.ts`
+- `test/frontend-visual-consistency.test.ts`
+
+## Componentes creados
+
+- `frontend/src/components/dashboard/StickyActionBar.tsx`
+- `frontend/src/app/dashboard/admin/AdminCommandCenter.tsx`
+- `test/frontend-dashboard-admin-command-center.test.ts`
+
+## Decisiones tecnicas
+
+- `StickyActionBar` es un componente client reusable, sin logica de negocio, con acciones de texto visible, soporte `href`/`onClick`, `visible=false`, foco visible y comportamiento fixed bottom en mobile/sticky en desktop.
+- La navegacion por `href` usa boton y `window.location.assign` para respetar el contrato existente del repo que evita `next/link`, `<Link>` y tags `<a>` en `frontend/src`.
+- `AdminCommandCenter` vive junto a las cards admin porque consume labels y composicion propios de esa superficie privada.
+- Los KPIs usan solo datos existentes en la pagina: cantidad de eventos de auditoria, cantidad de tipos de evento y status real del sistema.
+- `AdminFailedLoginAlertsReadOnlyCard` quedo antes de sistema/gestion/configuracion para que alertas criticas no queden enterradas en una pagina larga.
+
+## Logica existente preservada
+
+- No se cambiaron fetches, endpoints, auth, middleware, backend, SEO, rutas publicas ni calculos de fechas.
+- Se mantuvieron las cards existentes: clinicas, alertas de login fallido, schema health, maintenance dry-run, tokens particulares, pricing, sesiones y roles.
+- Se conservaron los ids usados por sidebar/anclas (`admin-report-upload`, `admin-health`, `admin-clinics`, `admin-particular-tokens`, `admin-pricing`, `admin-sessions`, `admin-users-roles`, `admin-maintenance`, `audit-log`).
+- La carga de informes sigue delegada al flujo real desde tokens administrados.
+
+## Validaciones ejecutadas
+
+- `git diff --check`: PASS, sin errores de whitespace. Git aviso que `frontend/src/app/dashboard/admin/page.tsx` sera normalizado CRLF cuando Git lo toque.
+- `pnpm test`: PASS, 2314 tests pass, 1 skipped.
+- `pnpm build`: PASS, backend bundle generado correctamente.
+- `pnpm security:public-surface`: PASS, sin findings publicos. Se mantuvieron solo notas server-only existentes en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend build`: PASS, Next build completo.
+
+## Riesgos residuales
+
+- La barra sticky usa `window.location.assign` para hashes/paths porque el contrato global bloquea anchors y `next/link`; esto evita ampliar superficie publica, aunque no usa navegacion SPA.
+- La validacion visual fue de contrato/build, no de screenshot interactivo.
+
+## Confirmacion de scope
+
+- Sin cambios en backend/server.
+- Sin cambios en API routes.
+- Sin cambios en auth.
+- Sin cambios en middleware.
+- Sin cambios en SEO, sitemap o robots.
+- Sin cambios en rutas publicas.
+- Sin cambios en `package.json`, `pnpm-lock.yaml`, `next-env.d.ts` ni dependencias.
+- No se implemento MasterDetailWorkspace, StudyTimeline, FilterDrawer, clinic command center, logistica hub ni tabs admin.

--- a/frontend/src/app/dashboard/admin/AdminCommandCenter.tsx
+++ b/frontend/src/app/dashboard/admin/AdminCommandCenter.tsx
@@ -1,0 +1,135 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
+
+type AdminCommandCenterProps = {
+  auditEntriesCount: number;
+  eventTypesCount: number;
+  systemStatusLabel: string;
+  systemStatusVariant: BadgeVariant;
+  systemStatusIndicatorClass: string;
+  systemStatusDetail: string;
+  hasSystemHealthFetchError: boolean;
+};
+
+export function AdminCommandCenter({
+  auditEntriesCount,
+  eventTypesCount,
+  systemStatusLabel,
+  systemStatusVariant,
+  systemStatusIndicatorClass,
+  systemStatusDetail,
+  hasSystemHealthFetchError,
+}: AdminCommandCenterProps) {
+  return (
+    <section
+      className="space-y-5"
+      aria-labelledby="admin-command-center-heading"
+    >
+      <div>
+        <h2
+          id="admin-command-center-heading"
+          className="dashboard-section-heading"
+        >
+          Resumen operativo
+        </h2>
+        <p className="dashboard-section-description">
+          Lectura inmediata de auditoría, variedad de eventos y salud del sistema.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Card className="dashboard-surface h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Eventos de auditoría
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold text-vetneb-ink">
+              {auditEntriesCount}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Registros totales
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="dashboard-surface h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Tipos de evento
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold text-vetneb-ink">
+              {eventTypesCount}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Categorías distintas
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="dashboard-surface h-full">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Estado del sistema
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-2">
+              <span
+                className={cn("h-2.5 w-2.5 rounded-full", systemStatusIndicatorClass)}
+                aria-hidden="true"
+              />
+              <Badge variant={systemStatusVariant}>
+                {systemStatusLabel}
+              </Badge>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {hasSystemHealthFetchError
+                ? "No se pudo consultar el estado del sistema."
+                : systemStatusDetail}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="dashboard-surface">
+        <CardHeader>
+          <CardTitle className="text-base">Alertas</CardTitle>
+          <CardDescription>
+            Seguridad y salud operativa quedan priorizadas antes de las secciones secundarias.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div className="surface-soft">
+            <p className="text-sm font-semibold text-vetneb-ink">
+              Intentos fallidos de login
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Revisar actividad de acceso antes de cambios administrativos.
+            </p>
+          </div>
+          <div className="surface-soft">
+            <p className="text-sm font-semibold text-vetneb-ink">
+              Sistema
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Consultar salud, esquema y mantenimiento agrupados.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -1,6 +1,18 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
+import {
+  Activity,
+  Building2,
+  FileUp,
+  ShieldAlert,
+  TicketCheck,
+} from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
+import {
+  StickyActionBar,
+  type StickyActionBarAction,
+} from "@/components/dashboard/StickyActionBar";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -18,6 +30,7 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
+import { AdminCommandCenter } from "./AdminCommandCenter";
 import { AdminClinicsManagementCard } from "./AdminClinicsManagementCard";
 import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
@@ -384,6 +397,33 @@ export default async function AdminPage({
   const selectedActorTypeLabel = selectedActorType
     ? ACTOR_LABELS[selectedActorType] ?? selectedActorType
     : "Todos";
+  const adminQuickActions = [
+    {
+      label: "Subir informe",
+      href: "#admin-report-upload",
+      variant: "default",
+      icon: <FileUp className="h-4 w-4" aria-hidden="true" />,
+      "aria-label": "Ir a carga de informes",
+    },
+    {
+      label: "Gestionar clínicas",
+      href: "#admin-clinics",
+      variant: "outline",
+      icon: <Building2 className="h-4 w-4" aria-hidden="true" />,
+    },
+    {
+      label: "Revisar tokens",
+      href: "#admin-particular-tokens",
+      variant: "outline",
+      icon: <TicketCheck className="h-4 w-4" aria-hidden="true" />,
+    },
+    {
+      label: "Ver sistema",
+      href: "#admin-health",
+      variant: "outline",
+      icon: <Activity className="h-4 w-4" aria-hidden="true" />,
+    },
+  ] satisfies StickyActionBarAction[];
 
   return (
     <>
@@ -393,438 +433,496 @@ export default async function AdminPage({
         notifications="admin"
       />
       <main className="dashboard-main">
-        <section
-          id="admin-report-upload"
-          className="dashboard-surface overflow-hidden p-0"
-        >
-          <div className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between">
-            <div className="min-w-0">
-              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-vetneb-navy">
-                Panel administrador
-              </p>
-              <h2 className="mt-2 text-xl font-semibold text-vetneb-ink">
-                Carga de informes
-              </h2>
-              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-                La carga de informes se realiza desde cada token administrado
-                en &quot;Últimos tokens administrados&quot;, para vincular clínica y token
-                sin búsqueda manual.
-              </p>
-            </div>
-          </div>
-        </section>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <Card className="dashboard-surface h-full">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                Eventos de auditoría
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
-                {auditEntries.length}
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">Registros totales</p>
-            </CardContent>
-          </Card>
-          <Card className="dashboard-surface h-full">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                Tipos de evento
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
-                {Object.keys(eventCounts).length}
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">Categorías distintas</p>
-            </CardContent>
-          </Card>
-          <Card className="dashboard-surface h-full">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                Estado del sistema
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center gap-2">
-                <span
-                  className={`h-2.5 w-2.5 rounded-full ${getSystemStatusIndicatorClass(
-                    systemStatus,
-                  )}`}
-                />
-                <Badge variant={getSystemStatusVariant(systemStatus)}>
-                  {formatSystemStatus(systemStatus)}
-                </Badge>
-              </div>
-              <p className="mt-2 text-xs text-muted-foreground">
-                {hasSystemHealthFetchError
-                  ? "No se pudo consultar el estado del sistema."
-                  : formatSystemStatusDetail(serviceChecks)}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-        <Card id="admin-health" className="dashboard-surface">
-          <CardHeader>
-            <CardTitle className="text-base">Estado y mantenimiento</CardTitle>
-            <CardDescription>
-              Estado de servicios, versión y consumo runtime del backend en producción
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {hasSystemHealthFetchError ? (
-              <div
-                role="alert"
-                className="mb-4 clinical-alert-warning"
+        <DashboardPageHeader
+          title="Administración"
+          description="Command center privado para priorizar acciones, auditoría y salud operativa sin cambiar la lógica existente."
+          badge={
+            <Badge variant={getSystemStatusVariant(systemStatus)}>
+              {formatSystemStatus(systemStatus)}
+            </Badge>
+          }
+          actions={
+            <div className="flex flex-wrap items-center gap-2">
+              <PublicRouteControl
+                href="/dashboard/admin#failed-login-alerts"
+                variant="bare"
+                prefetch={false}
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
               >
-                No se pudo consultar el estado del sistema. Los valores de salud
-                operacional se muestran como desconocidos hasta recuperar la lectura.
-              </div>
-            ) : null}
-            <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
-              <div className="surface-soft">
-                <p className="mb-2 text-xs text-muted-foreground">Base de datos</p>
-                <Badge variant={getServiceVariant(serviceChecks.database)}>
-                  {formatServiceStatus(serviceChecks.database)}
-                </Badge>
-              </div>
-              <div className="surface-soft">
-                <p className="mb-2 text-xs text-muted-foreground">Almacenamiento</p>
-                <Badge variant={getServiceVariant(serviceChecks.storage)}>
-                  {formatServiceStatus(serviceChecks.storage)}
-                </Badge>
-              </div>
-              <div className="surface-soft">
-                <p className="mb-2 text-xs text-muted-foreground">
-                  Transporte de correo
-                </p>
-                <Badge
-                  variant={getEmailTransportBadgeVariant(
-                    serviceChecks.email_transport,
-                  )}
-                >
-                  {formatEmailTransport(serviceChecks.email_transport)}
-                </Badge>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Gmail API: {formatServiceStatus(serviceChecks.gmail_api)}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  SMTP: {formatServiceStatus(serviceChecks.smtp)}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="mb-2 text-xs text-muted-foreground">Contacto email</p>
-                <Badge variant={getServiceVariant(serviceChecks.contact_email)}>
-                  {formatServiceStatus(serviceChecks.contact_email)}
-                </Badge>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {contactRecipients.length > 0
-                    ? `Destino: ${contactRecipients.join(", ")}`
-                    : "Sin destinatarios configurados"}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  CONTACT_TO: {formatConfigurationFlag(serviceChecks.contact_to_configured)}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  SMTP_FROM: {formatConfigurationFlag(serviceChecks.smtp_from_configured)}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="mb-2 text-xs text-muted-foreground">CORS público</p>
-                <Badge variant={getServiceVariant(serviceChecks.cors)}>
-                  {formatServiceStatus(serviceChecks.cors)}
-                </Badge>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {corsOrigins.length > 0
-                    ? `${corsOrigins.length} origen(es) activo(s)`
-                    : "Sin orígenes configurados"}
-                </p>
-                {corsOrigins.length > 0 ? (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {corsOrigins.join(", ")}
-                  </p>
-                ) : null}
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Orígenes locales/LAN:{" "}
-                  {serviceChecks.cors_has_local_or_lan_origins === true ? "Presentes" : "No"}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Entorno</p>
-                <p className="mt-1 text-lg font-semibold text-vetneb-ink">
-                  {nodeEnv}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">nodeEnv activo</p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Backend</p>
-                <p className="mt-1 text-lg font-semibold text-vetneb-ink">
-                  {systemHealth?.version ?? "—"}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">Versión activa</p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Tiempo activo</p>
-                <p className="mt-1 text-lg font-semibold text-vetneb-ink">
-                  {formatUptime(systemHealth?.runtime.uptimeSeconds)}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Control: {formatHealthTimestamp(systemHealth?.health?.timestamp)}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Memoria runtime</p>
-                <p className="mt-1 text-lg font-semibold text-vetneb-ink">
-                  {systemHealth?.runtime.memory.rssMb ?? "—"} MB
-                </p>
-                <div className="mt-2 space-y-1 text-xs text-muted-foreground">
-                  <p>RSS: {systemHealth?.runtime.memory.rssMb ?? "—"} MB</p>
-                  <p>
-                    Heap usado: {systemHealth?.runtime.memory.heapUsedMb ?? "—"} MB
-                  </p>
-                  <p>
-                    Heap total: {systemHealth?.runtime.memory.heapTotalMb ?? "—"} MB
-                  </p>
-                  <p>
-                    Memoria externa: {systemHealth?.runtime.memory.externalMb ?? "—"} MB
-                  </p>
-                  <p>
-                    Buffers:{" "}
-                    {systemHealth?.runtime.memory.arrayBuffersMb ?? "—"} MB
-                  </p>
-                </div>
-              </div>
+                <ShieldAlert className="h-4 w-4" aria-hidden="true" />
+                Ver alertas
+              </PublicRouteControl>
+              <PublicRouteControl
+                href="/dashboard/admin#audit-log"
+                variant="bare"
+                prefetch={false}
+                className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-colors hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+              >
+                Ver auditoría
+              </PublicRouteControl>
             </div>
-          </CardContent>
-        </Card>
-        <section id="admin-schema-health">
-          <AdminSchemaHealthStatusCard />
-        </section>
-        <section id="admin-maintenance">
-          <AdminMaintenanceDryRunCard />
-        </section>
-        <AdminClinicsManagementCard />
-        <section id="admin-particular-tokens">
-          <AdminParticularTokensCard />
-        </section>
-        <section id="admin-pricing">
-          <AdminPricingEditorCard />
-        </section>
-        <section id="admin-sessions">
-          <AdminSessionsReadOnlyCard />
-        </section>
-        <AdminFailedLoginAlertsReadOnlyCard />
-        <section id="admin-users-roles">
-          <AdminUsersRolesReadOnlyCard />
-        </section>
-        <Card id="admin-notifications" className="dashboard-surface">
-          <CardHeader>
-            <CardTitle className="text-base">Notificaciones</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Registradas</p>
-                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
-                  {notificationAuditEntries.length}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Última notificación</p>
-                <p className="mt-1 text-sm font-semibold text-vetneb-ink">
-                  {lastNotificationAuditEntry
-                    ? formatDateTime(lastNotificationAuditEntry.createdAt)
-                    : "—"}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Auditoría</p>
-                <PublicRouteControl
-                  href={buildAdminAuditFilterHref({
-                    event: "study_tracking.notification.created",
-                  })}
-                  variant="textLink"
-                  className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                >
-                  Ver notificaciones
-                </PublicRouteControl>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card id="audit-role-changes" className="dashboard-surface">
-          <CardHeader>
-            <CardTitle className="text-base">
-              Auditoría de cambios de rol clínica
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Cambios registrados</p>
-                <p className="mt-1 text-2xl font-bold text-vetneb-ink">
-                  {roleChangeAuditEntries.length}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Último cambio</p>
-                <p className="mt-1 text-sm font-semibold text-vetneb-ink">
-                  {lastRoleChangeAuditEntry
-                    ? formatDateTime(lastRoleChangeAuditEntry.createdAt)
-                    : "—"}
-                </p>
-              </div>
-              <div className="surface-soft">
-                <p className="text-xs text-muted-foreground">Filtro audit</p>
-                <PublicRouteControl
-                  href={buildAdminAuditFilterHref({
-                    event: "clinic_user.role.changed",
-                  })}
-                  variant="textLink"
-                  className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                >
-                  Ver cambios de rol
-                </PublicRouteControl>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+          }
+        />
 
+        <StickyActionBar
+          context="Acciones rápidas"
+          actions={adminQuickActions}
+        />
 
-        <Card id="admin-event-summary" className="dashboard-surface">
-          <CardHeader>
-            <CardTitle className="text-base">Resumen por tipo de evento</CardTitle>
-            <CardDescription>
-              Distribución de eventos registrados en el log de auditoría
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {Object.entries(eventCounts).map(([event, count]) => (
+        <AdminCommandCenter
+          auditEntriesCount={auditEntries.length}
+          eventTypesCount={Object.keys(eventCounts).length}
+          systemStatusLabel={formatSystemStatus(systemStatus)}
+          systemStatusVariant={getSystemStatusVariant(systemStatus)}
+          systemStatusIndicatorClass={getSystemStatusIndicatorClass(systemStatus)}
+          systemStatusDetail={formatSystemStatusDetail(serviceChecks)}
+          hasSystemHealthFetchError={hasSystemHealthFetchError}
+        />
+
+        <section className="space-y-4" aria-labelledby="admin-alertas-heading">
+          <div>
+            <h2 id="admin-alertas-heading" className="dashboard-section-heading">
+              Alertas críticas
+            </h2>
+            <p className="dashboard-section-description">
+              Intentos fallidos y señales de acceso se revisan antes de las tareas secundarias.
+            </p>
+          </div>
+          <AdminFailedLoginAlertsReadOnlyCard />
+        </section>
+
+        <section className="space-y-4" aria-labelledby="admin-sistema-heading">
+          <div>
+            <h2 id="admin-sistema-heading" className="dashboard-section-heading">
+              Sistema
+            </h2>
+            <p className="dashboard-section-description">
+              Salud, esquema y mantenimiento quedan agrupados para lectura operativa.
+            </p>
+          </div>
+
+          <Card id="admin-health" className="dashboard-surface">
+            <CardHeader>
+              <CardTitle className="text-base">Estado y mantenimiento</CardTitle>
+              <CardDescription>
+                Estado de servicios, versión y consumo runtime del backend en producción
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {hasSystemHealthFetchError ? (
                 <div
-                  key={event}
-                  className="clinical-muted-band flex items-center gap-2 rounded-lg px-3 py-2"
+                  role="alert"
+                  className="mb-4 clinical-alert-warning"
                 >
-                  <Badge variant={getEventVariant(event)} className="text-xs">
-                    {EVENT_LABELS[event] ?? event}
-                  </Badge>
-                  <span className="clinical-pill px-2.5 py-0.5 text-xs tracking-normal">
-                    {count}
-                  </span>
+                  No se pudo consultar el estado del sistema. Los valores de salud
+                  operacional se muestran como desconocidos hasta recuperar la lectura.
                 </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card id="audit-log" className="dashboard-surface">
-          <CardHeader>
-            <CardTitle className="text-base">
-              Log de auditoría ({filteredAuditEntries.length}/{auditEntries.length})
-            </CardTitle>
-            <CardDescription>
-              Filtros activos: evento <strong>{selectedAuditEventLabel}</strong>
-              {" · "}actor <strong>{selectedActorTypeLabel}</strong>
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4 p-0">
-            {hasActiveAuditFilters ? (
-              <div className="clinical-muted-band mx-6 mt-4 flex flex-col gap-2 rounded-lg px-4 py-3 text-sm text-vetneb-navy md:flex-row md:items-center md:justify-between">
-                <span>
-                  Mostrando {filteredAuditEntries.length} de {auditEntries.length} eventos.
-                </span>
-                <PublicRouteControl
-                  href="/dashboard/admin#audit-log"
-                  replace
-                  variant="textLink"
-                  className="font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                >
-                  Limpiar filtros
-                </PublicRouteControl>
+              ) : null}
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                <div className="surface-soft">
+                  <p className="mb-2 text-xs text-muted-foreground">Base de datos</p>
+                  <Badge variant={getServiceVariant(serviceChecks.database)}>
+                    {formatServiceStatus(serviceChecks.database)}
+                  </Badge>
+                </div>
+                <div className="surface-soft">
+                  <p className="mb-2 text-xs text-muted-foreground">Almacenamiento</p>
+                  <Badge variant={getServiceVariant(serviceChecks.storage)}>
+                    {formatServiceStatus(serviceChecks.storage)}
+                  </Badge>
+                </div>
+                <div className="surface-soft">
+                  <p className="mb-2 text-xs text-muted-foreground">
+                    Transporte de correo
+                  </p>
+                  <Badge
+                    variant={getEmailTransportBadgeVariant(
+                      serviceChecks.email_transport,
+                    )}
+                  >
+                    {formatEmailTransport(serviceChecks.email_transport)}
+                  </Badge>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Gmail API: {formatServiceStatus(serviceChecks.gmail_api)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    SMTP: {formatServiceStatus(serviceChecks.smtp)}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="mb-2 text-xs text-muted-foreground">Contacto email</p>
+                  <Badge variant={getServiceVariant(serviceChecks.contact_email)}>
+                    {formatServiceStatus(serviceChecks.contact_email)}
+                  </Badge>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {contactRecipients.length > 0
+                      ? `Destino: ${contactRecipients.join(", ")}`
+                      : "Sin destinatarios configurados"}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    CONTACT_TO: {formatConfigurationFlag(serviceChecks.contact_to_configured)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    SMTP_FROM: {formatConfigurationFlag(serviceChecks.smtp_from_configured)}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="mb-2 text-xs text-muted-foreground">CORS público</p>
+                  <Badge variant={getServiceVariant(serviceChecks.cors)}>
+                    {formatServiceStatus(serviceChecks.cors)}
+                  </Badge>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {corsOrigins.length > 0
+                      ? `${corsOrigins.length} origen(es) activo(s)`
+                      : "Sin orígenes configurados"}
+                  </p>
+                  {corsOrigins.length > 0 ? (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {corsOrigins.join(", ")}
+                    </p>
+                  ) : null}
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Orígenes locales/LAN:{" "}
+                    {serviceChecks.cors_has_local_or_lan_origins === true ? "Presentes" : "No"}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Entorno</p>
+                  <p className="mt-1 text-lg font-semibold text-vetneb-ink">
+                    {nodeEnv}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">nodeEnv activo</p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Backend</p>
+                  <p className="mt-1 text-lg font-semibold text-vetneb-ink">
+                    {systemHealth?.version ?? "—"}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">Versión activa</p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Tiempo activo</p>
+                  <p className="mt-1 text-lg font-semibold text-vetneb-ink">
+                    {formatUptime(systemHealth?.runtime.uptimeSeconds)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Control: {formatHealthTimestamp(systemHealth?.health?.timestamp)}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Memoria runtime</p>
+                  <p className="mt-1 text-lg font-semibold text-vetneb-ink">
+                    {systemHealth?.runtime.memory.rssMb ?? "—"} MB
+                  </p>
+                  <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                    <p>RSS: {systemHealth?.runtime.memory.rssMb ?? "—"} MB</p>
+                    <p>
+                      Heap usado: {systemHealth?.runtime.memory.heapUsedMb ?? "—"} MB
+                    </p>
+                    <p>
+                      Heap total: {systemHealth?.runtime.memory.heapTotalMb ?? "—"} MB
+                    </p>
+                    <p>
+                      Memoria externa: {systemHealth?.runtime.memory.externalMb ?? "—"} MB
+                    </p>
+                    <p>
+                      Buffers:{" "}
+                      {systemHealth?.runtime.memory.arrayBuffersMb ?? "—"} MB
+                    </p>
+                  </div>
+                </div>
               </div>
-            ) : null}
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>ID</TableHead>
-                  <TableHead>Evento</TableHead>
-                  <TableHead>Actor</TableHead>
-                  <TableHead>Tipo actor</TableHead>
-                  <TableHead>Objetivo</TableHead>
-                  <TableHead>Detalle</TableHead>
-                  <TableHead>Fecha</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {auditEntriesLoadError ? (
+            </CardContent>
+          </Card>
+
+          <AdminSchemaHealthStatusCard />
+
+          <section id="admin-maintenance">
+            <AdminMaintenanceDryRunCard />
+          </section>
+        </section>
+
+        <section className="space-y-4" aria-labelledby="admin-gestion-heading">
+          <div>
+            <h2 id="admin-gestion-heading" className="dashboard-section-heading">
+              Gestión
+            </h2>
+            <p className="dashboard-section-description">
+              Operación administrativa sobre informes, clínicas, tokens y roles.
+            </p>
+          </div>
+
+          <section
+            id="admin-report-upload"
+            className="dashboard-surface overflow-hidden p-0"
+          >
+            <div className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between">
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-[0.1em] text-vetneb-navy">
+                  Panel administrador
+                </p>
+                <h2 className="mt-2 text-xl font-semibold text-vetneb-ink">
+                  Carga de informes
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                  La carga de informes se realiza desde cada token administrado
+                  en &quot;Últimos tokens administrados&quot;, para vincular clínica y token
+                  sin búsqueda manual.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <AdminClinicsManagementCard />
+
+          <section id="admin-particular-tokens">
+            <AdminParticularTokensCard />
+          </section>
+
+          <section id="admin-sessions">
+            <AdminSessionsReadOnlyCard />
+          </section>
+
+          <section id="admin-users-roles">
+            <AdminUsersRolesReadOnlyCard />
+          </section>
+        </section>
+
+        <section className="space-y-4" aria-labelledby="admin-configuracion-heading">
+          <div>
+            <h2 id="admin-configuracion-heading" className="dashboard-section-heading">
+              Configuración secundaria
+            </h2>
+            <p className="dashboard-section-description">
+              Ajustes y lecturas no urgentes quedan después de alertas, sistema y gestión.
+            </p>
+          </div>
+
+          <section id="admin-pricing">
+            <AdminPricingEditorCard />
+          </section>
+
+          <Card id="admin-notifications" className="dashboard-surface">
+            <CardHeader>
+              <CardTitle className="text-base">Notificaciones</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Registradas</p>
+                  <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                    {notificationAuditEntries.length}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Última notificación</p>
+                  <p className="mt-1 text-sm font-semibold text-vetneb-ink">
+                    {lastNotificationAuditEntry
+                      ? formatDateTime(lastNotificationAuditEntry.createdAt)
+                      : "—"}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Auditoría</p>
+                  <PublicRouteControl
+                    href={buildAdminAuditFilterHref({
+                      event: "study_tracking.notification.created",
+                    })}
+                    variant="textLink"
+                    className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                  >
+                    Ver notificaciones
+                  </PublicRouteControl>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="space-y-4" aria-labelledby="admin-auditoria-heading">
+          <div>
+            <h2 id="admin-auditoria-heading" className="dashboard-section-heading">
+              Auditoría
+            </h2>
+            <p className="dashboard-section-description">
+              Eventos, cambios de rol y log operativo con filtros actuales.
+            </p>
+          </div>
+
+          <Card id="audit-role-changes" className="dashboard-surface">
+            <CardHeader>
+              <CardTitle className="text-base">
+                Auditoría de cambios de rol clínica
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Cambios registrados</p>
+                  <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+                    {roleChangeAuditEntries.length}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Último cambio</p>
+                  <p className="mt-1 text-sm font-semibold text-vetneb-ink">
+                    {lastRoleChangeAuditEntry
+                      ? formatDateTime(lastRoleChangeAuditEntry.createdAt)
+                      : "—"}
+                  </p>
+                </div>
+                <div className="surface-soft">
+                  <p className="text-xs text-muted-foreground">Filtro audit</p>
+                  <PublicRouteControl
+                    href={buildAdminAuditFilterHref({
+                      event: "clinic_user.role.changed",
+                    })}
+                    variant="textLink"
+                    className="mt-1 inline-flex text-sm font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                  >
+                    Ver cambios de rol
+                  </PublicRouteControl>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card id="admin-event-summary" className="dashboard-surface">
+            <CardHeader>
+              <CardTitle className="text-base">Resumen por tipo de evento</CardTitle>
+              <CardDescription>
+                Distribución de eventos registrados en el log de auditoría
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(eventCounts).map(([event, count]) => (
+                  <div
+                    key={event}
+                    className="clinical-muted-band flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Badge variant={getEventVariant(event)} className="text-xs">
+                      {EVENT_LABELS[event] ?? event}
+                    </Badge>
+                    <span className="clinical-pill px-2.5 py-0.5 text-xs tracking-normal">
+                      {count}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card id="audit-log" className="dashboard-surface">
+            <CardHeader>
+              <CardTitle className="text-base">
+                Log de auditoría ({filteredAuditEntries.length}/{auditEntries.length})
+              </CardTitle>
+              <CardDescription>
+                Filtros activos: evento <strong>{selectedAuditEventLabel}</strong>
+                {" · "}actor <strong>{selectedActorTypeLabel}</strong>
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 p-0">
+              {hasActiveAuditFilters ? (
+                <div className="clinical-muted-band mx-6 mt-4 flex flex-col gap-2 rounded-lg px-4 py-3 text-sm text-vetneb-navy md:flex-row md:items-center md:justify-between">
+                  <span>
+                    Mostrando {filteredAuditEntries.length} de {auditEntries.length} eventos.
+                  </span>
+                  <PublicRouteControl
+                    href="/dashboard/admin#audit-log"
+                    replace
+                    variant="textLink"
+                    className="font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                  >
+                    Limpiar filtros
+                  </PublicRouteControl>
+                </div>
+              ) : null}
+              <Table>
+                <TableHeader>
                   <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      role="alert"
-                      className="clinical-table-state clinical-alert-warning"
-                    >
-                      No se pudieron cargar los eventos de auditoría. Intente nuevamente.
-                    </TableCell>
+                    <TableHead>ID</TableHead>
+                    <TableHead>Evento</TableHead>
+                    <TableHead>Actor</TableHead>
+                    <TableHead>Tipo actor</TableHead>
+                    <TableHead>Objetivo</TableHead>
+                    <TableHead>Detalle</TableHead>
+                    <TableHead>Fecha</TableHead>
                   </TableRow>
-                ) : filteredAuditEntries.length ? (
-                  filteredAuditEntries.map((entry) => (
-                    <TableRow key={entry.id}>
-                      <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-                        #{entry.id}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={getEventVariant(entry.event)}>
-                          {EVENT_LABELS[entry.event] ?? entry.event}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm text-vetneb-ink/88">
-                        {entry.actorId ? `#${entry.actorId}` : "—"}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {ACTOR_LABELS[entry.actorType] ?? entry.actorType}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {entry.targetType && entry.targetId
-                          ? `${entry.targetType} #${entry.targetId}`
-                          : "—"}
-                      </TableCell>
-                      <TableCell className="max-w-md whitespace-normal break-words text-xs text-muted-foreground">
-                        {getAuditMetadataSummary(entry)}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {formatDateTime(entry.createdAt)}
+                </TableHeader>
+                <TableBody>
+                  {auditEntriesLoadError ? (
+                    <TableRow>
+                      <TableCell
+                        colSpan={7}
+                        role="alert"
+                        className="clinical-table-state clinical-alert-warning"
+                      >
+                        No se pudieron cargar los eventos de auditoría. Intente nuevamente.
                       </TableCell>
                     </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      className="clinical-table-state"
-                    >
-                      {hasActiveAuditFilters
-                        ? "No hay eventos para los filtros seleccionados."
-                        : "No hay eventos de auditoría disponibles."}
-                      {hasActiveAuditFilters ? (
-                        <div className="mt-2">
-                          <PublicRouteControl
-                            href="/dashboard/admin#audit-log"
-                            replace
-                            variant="textLink"
-                            className="font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                          >
-                            Limpiar filtros
-                          </PublicRouteControl>
-                        </div>
-                      ) : null}
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
+                  ) : filteredAuditEntries.length ? (
+                    filteredAuditEntries.map((entry) => (
+                      <TableRow key={entry.id}>
+                        <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                          #{entry.id}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={getEventVariant(entry.event)}>
+                            {EVENT_LABELS[entry.event] ?? entry.event}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-sm text-vetneb-ink/88">
+                          {entry.actorId ? `#${entry.actorId}` : "—"}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {ACTOR_LABELS[entry.actorType] ?? entry.actorType}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {entry.targetType && entry.targetId
+                            ? `${entry.targetType} #${entry.targetId}`
+                            : "—"}
+                        </TableCell>
+                        <TableCell className="max-w-md whitespace-normal break-words text-xs text-muted-foreground">
+                          {getAuditMetadataSummary(entry)}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {formatDateTime(entry.createdAt)}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell
+                        colSpan={7}
+                        className="clinical-table-state"
+                      >
+                        {hasActiveAuditFilters
+                          ? "No hay eventos para los filtros seleccionados."
+                          : "No hay eventos de auditoría disponibles."}
+                        {hasActiveAuditFilters ? (
+                          <div className="mt-2">
+                            <PublicRouteControl
+                              href="/dashboard/admin#audit-log"
+                              replace
+                              variant="textLink"
+                              className="font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                            >
+                              Limpiar filtros
+                            </PublicRouteControl>
+                          </div>
+                        ) : null}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </section>
+
+        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/frontend/src/components/dashboard/StickyActionBar.tsx
+++ b/frontend/src/components/dashboard/StickyActionBar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type StickyActionBarAction = {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  variant?: ButtonProps["variant"];
+  disabled?: boolean;
+  icon?: ReactNode;
+  "aria-label"?: string;
+};
+
+export type StickyActionBarProps = {
+  context?: string;
+  actions: StickyActionBarAction[];
+  visible?: boolean;
+  className?: string;
+};
+
+export function StickyActionBar({
+  context,
+  actions,
+  visible = true,
+  className,
+}: StickyActionBarProps) {
+  if (visible === false) {
+    return null;
+  }
+
+  const navigateToHref = (href: string) => {
+    window.location.assign(href);
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 border-t border-vetneb-line/80 bg-card/95 px-3 py-3 shadow-md backdrop-blur md:sticky md:top-[4.75rem] md:bottom-auto md:rounded-lg md:border md:px-4 md:shadow-sm",
+        className,
+      )}
+      data-sticky-action-bar="true"
+    >
+      <div className="mx-auto flex max-w-6xl flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        {context ? (
+          <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+            {context}
+          </p>
+        ) : null}
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-end">
+          {actions.map((action, index) => {
+            const ariaLabel = action["aria-label"] ?? action.label;
+            const content = (
+              <>
+                {action.icon ? (
+                  <span className="shrink-0" aria-hidden="true">
+                    {action.icon}
+                  </span>
+                ) : null}
+                <span>{action.label}</span>
+              </>
+            );
+
+            return (
+              <Button
+                key={`${action.label}-${index}`}
+                type="button"
+                variant={action.variant ?? "outline"}
+                size="sm"
+                disabled={action.disabled}
+                onClick={() => {
+                  action.onClick?.();
+
+                  if (action.href) {
+                    navigateToHref(action.href);
+                  }
+                }}
+                aria-label={ariaLabel}
+                className="w-full focus-visible:ring-2 focus-visible:ring-ring/85 sm:w-auto"
+              >
+                {content}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/test/frontend-dashboard-admin-command-center.test.ts
+++ b/test/frontend-dashboard-admin-command-center.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const ADMIN_COMMAND_CENTER_PATH =
+  "frontend/src/app/dashboard/admin/AdminCommandCenter.tsx";
+const STICKY_ACTION_BAR_PATH =
+  "frontend/src/components/dashboard/StickyActionBar.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertNoForbiddenSurfaceImports(source: string, context: string): void {
+  const importLines = source
+    .split("\n")
+    .filter((line) => line.trim().startsWith("import "));
+  const forbiddenPatterns = [
+    /@\/app\/api/,
+    /@\/middleware/,
+    /@\/lib\/auth/,
+    /@\/components\/public/,
+    /\.\.\/.*\/auth/,
+    /\.\.\/.*\/middleware/,
+    /\.\.\/.*\/public/,
+  ];
+
+  for (const line of importLines) {
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(
+        pattern.test(line),
+        false,
+        `${context} must not import forbidden surface via: ${line}`,
+      );
+    }
+  }
+}
+
+test("StickyActionBar keeps reusable fixed and sticky action contracts", () => {
+  const source = read(STICKY_ACTION_BAR_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("export type StickyActionBarAction = {"));
+  assert.ok(source.includes("label: string;"));
+  assert.ok(source.includes("href?: string;"));
+  assert.ok(source.includes("onClick?: () => void;"));
+  assert.ok(source.includes('variant?: ButtonProps["variant"];'));
+  assert.ok(source.includes('"aria-label"?: string;'));
+  assert.ok(source.includes("context?: string;"));
+  assert.ok(source.includes("visible?: boolean;"));
+  assert.ok(source.includes("if (visible === false) {"));
+  assert.ok(source.includes("return null;"));
+  assert.ok(source.includes("const navigateToHref = (href: string) => {"));
+  assert.ok(source.includes("window.location.assign(href);"));
+  assert.ok(source.includes("if (action.href) {"));
+  assert.ok(source.includes("navigateToHref(action.href);"));
+  assert.ok(source.includes("action.onClick?.();"));
+  assert.ok(source.includes("<span>{action.label}</span>"));
+  assert.ok(source.includes("fixed inset-x-0 bottom-0 z-50"));
+  assert.ok(source.includes("md:sticky md:top-[4.75rem]"));
+  assert.ok(source.includes("focus-visible:ring-2 focus-visible:ring-ring/85"));
+  assert.equal(source.includes("Dropdown"), false);
+  assert.equal(source.includes('from "next/link"'), false);
+  assert.equal(source.includes("<Link"), false);
+  assert.equal(source.includes("<a"), false);
+  assert.equal(source.includes("fetch("), false);
+});
+
+test("AdminCommandCenter keeps real KPI summary and alert shortcuts", () => {
+  const source = read(ADMIN_COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("type AdminCommandCenterProps = {"));
+  assert.ok(source.includes("auditEntriesCount: number;"));
+  assert.ok(source.includes("eventTypesCount: number;"));
+  assert.ok(source.includes("systemStatusLabel: string;"));
+  assert.ok(source.includes("hasSystemHealthFetchError: boolean;"));
+  assert.ok(source.includes('aria-labelledby="admin-command-center-heading"'));
+  assert.ok(source.includes("Resumen operativo"));
+  assert.ok(source.includes("Eventos de auditoría"));
+  assert.ok(source.includes("Tipos de evento"));
+  assert.ok(source.includes("Estado del sistema"));
+  assert.ok(source.includes("Registros totales"));
+  assert.ok(source.includes("Categorías distintas"));
+  assert.ok(source.includes("No se pudo consultar el estado del sistema."));
+  assert.ok(source.includes("Alertas"));
+  assert.ok(source.includes("Intentos fallidos de login"));
+  assert.ok(source.includes("Consultar salud, esquema y mantenimiento agrupados."));
+  assert.ok(source.includes('className="surface-soft"'));
+  assert.equal(source.includes("<a"), false);
+  assert.equal(source.includes("fetch("), false);
+});
+
+test("dashboard admin composes command center, sticky actions, and existing cards", () => {
+  const source = read(ADMIN_PAGE_PATH);
+  const mainSource = source.slice(source.indexOf('<main className="dashboard-main">'));
+
+  assert.ok(source.includes("<DashboardPageHeader"));
+  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<AdminCommandCenter"));
+  assert.ok(source.includes("const adminQuickActions = ["));
+  assert.ok(source.includes('label: "Subir informe"'));
+  assert.ok(source.includes('href: "#admin-report-upload"'));
+  assert.ok(source.includes('label: "Gestionar clínicas"'));
+  assert.ok(source.includes('href: "#admin-clinics"'));
+  assert.ok(source.includes('label: "Revisar tokens"'));
+  assert.ok(source.includes('href: "#admin-particular-tokens"'));
+  assert.ok(source.includes('label: "Ver sistema"'));
+  assert.ok(source.includes('href: "#admin-health"'));
+  assert.ok(source.includes("<AdminFailedLoginAlertsReadOnlyCard />"));
+  assert.ok(source.includes("<AdminSchemaHealthStatusCard />"));
+  assert.ok(source.includes("<AdminMaintenanceDryRunCard />"));
+  assert.ok(source.includes("<AdminClinicsManagementCard />"));
+  assert.ok(source.includes("<AdminParticularTokensCard />"));
+  assert.ok(source.includes("<AdminPricingEditorCard />"));
+  assert.ok(source.includes("<AdminSessionsReadOnlyCard />"));
+  assert.ok(source.includes("<AdminUsersRolesReadOnlyCard />"));
+  assert.ok(source.includes('className="h-24 md:hidden" aria-hidden="true"'));
+
+  const order = [
+    "<DashboardPageHeader",
+    "<StickyActionBar",
+    "<AdminCommandCenter",
+    "Alertas críticas",
+    "<AdminFailedLoginAlertsReadOnlyCard />",
+    "Sistema",
+    "Gestión",
+    "Configuración secundaria",
+    "Auditoría",
+  ].map((marker) => mainSource.indexOf(marker));
+
+  for (const index of order) {
+    assert.ok(index >= 0, `admin main source must contain ordered marker ${index}`);
+  }
+
+  assert.deepEqual(
+    order,
+    [...order].sort((a, b) => a - b),
+    "admin command center order must prioritize actions, alerts, system, management, and audit",
+  );
+});
+
+test("dashboard admin command center changes stay inside frontend scope", () => {
+  const stickyActionBarSource = read(STICKY_ACTION_BAR_PATH);
+  const commandCenterSource = read(ADMIN_COMMAND_CENTER_PATH);
+  const packageDiff = execFileSync(
+    "git",
+    ["diff", "--name-only", "--", "package.json", "pnpm-lock.yaml"],
+    { encoding: "utf8" },
+  ).trim();
+
+  assertNoForbiddenSurfaceImports(stickyActionBarSource, "StickyActionBar");
+  assertNoForbiddenSurfaceImports(commandCenterSource, "AdminCommandCenter");
+  assert.equal(stickyActionBarSource.includes("app/api"), false);
+  assert.equal(commandCenterSource.includes("app/api"), false);
+  assert.equal(stickyActionBarSource.toLowerCase().includes("middleware"), false);
+  assert.equal(commandCenterSource.toLowerCase().includes("middleware"), false);
+  assert.equal(packageDiff, "");
+});

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const ADMIN_COMMAND_CENTER_PATH =
+  "frontend/src/app/dashboard/admin/AdminCommandCenter.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -21,6 +23,9 @@ test("dashboard admin defines non-indexable metadata and admin dependencies", ()
   assert.ok(source.includes('title: "Administración — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
+  assert.ok(source.includes('import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";'));
+  assert.ok(source.includes('} from "@/components/dashboard/StickyActionBar";'));
+  assert.ok(source.includes('import { AdminCommandCenter } from "./AdminCommandCenter";'));
   assert.ok(source.includes('import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";'));
   assert.ok(source.includes('import { formatDateTime } from "@/lib/utils";'));
 });
@@ -134,12 +139,17 @@ test("dashboard admin keeps audit filters and filter href builder", () => {
 
 test("dashboard admin renders topbar, health, and summary cards", () => {
   const source = read(ADMIN_PAGE_PATH);
+  const commandCenterSource = read(ADMIN_COMMAND_CENTER_PATH);
+  const combinedSource = `${source}\n${commandCenterSource}`;
 
   assert.ok(source.includes('title="Administración"'));
   assert.ok(source.includes('subtitle="Auditoría, reportes y estado operacional"'));
-  assert.ok(source.includes("Eventos de auditoría"));
-  assert.ok(source.includes("Tipos de evento"));
-  assert.ok(source.includes("Estado del sistema"));
+  assert.ok(source.includes("<DashboardPageHeader"));
+  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<AdminCommandCenter"));
+  assert.ok(combinedSource.includes("Eventos de auditoría"));
+  assert.ok(combinedSource.includes("Tipos de evento"));
+  assert.ok(combinedSource.includes("Estado del sistema"));
   assert.ok(source.includes('id="admin-report-upload"'));
   assert.ok(source.includes("Panel administrador"));
   assert.ok(source.includes("cada token administrado"));
@@ -172,45 +182,27 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);
 });
 
-test("dashboard admin removes horizontal quick actions and preserves admin sections", () => {
+test("dashboard admin keeps sticky quick actions and preserves admin sections", () => {
   const source = read(ADMIN_PAGE_PATH);
-  const quickActionsTitle = ["Accesos", "rápidos"].join(" ");
-  const quickActionsDescription = [
-    "Atajos operativos",
-    "para navegar las superficies administrativas clave.",
-  ].join(" ");
-  const removedSnippets = [
-    quickActionsTitle,
-    quickActionsDescription,
-    'label: "Subir informe"',
-    'label: "Estado"',
-    'label: "Clínicas"',
-    'label: "Tokens particulares"',
-    'label: "Sesiones"',
-    'label: "Roles clínica"',
-    'label: "Auditoría"',
-    'label: "Mantenimiento"',
-    'href: "#admin-report-upload"',
-    'href: "#admin-health"',
-    'href: "#admin-clinics"',
-    'href: "#admin-particular-tokens"',
-    'href: "#admin-sessions"',
-    'href: "#admin-users-roles"',
-    'href: "#audit-log"',
-    'href: "#admin-maintenance"',
-    `xl:grid-cols-${7}`,
-  ];
 
-  for (const snippet of removedSnippets) {
-    assert.equal(source.includes(snippet), false);
-  }
-
+  assert.ok(source.includes("const adminQuickActions = ["));
+  assert.ok(source.includes('label: "Subir informe"'));
+  assert.ok(source.includes('href: "#admin-report-upload"'));
+  assert.ok(source.includes('label: "Gestionar clínicas"'));
+  assert.ok(source.includes('href: "#admin-clinics"'));
+  assert.ok(source.includes('label: "Revisar tokens"'));
+  assert.ok(source.includes('href: "#admin-particular-tokens"'));
+  assert.ok(source.includes('label: "Ver sistema"'));
+  assert.ok(source.includes('href: "#admin-health"'));
+  assert.ok(source.includes('context="Acciones rápidas"'));
   assert.ok(source.includes('id="admin-report-upload"'));
   assert.ok(source.includes("Carga de informes"));
   assert.ok(source.includes("cada token administrado"));
-  assert.ok(source.includes("Eventos de auditoría"));
-  assert.ok(source.includes("Tipos de evento"));
-  assert.ok(source.includes("Estado del sistema"));
+  assert.ok(source.includes("Alertas críticas"));
+  assert.ok(source.includes("Sistema"));
+  assert.ok(source.includes("Gestión"));
+  assert.ok(source.includes("Configuración secundaria"));
+  assert.ok(source.includes("Auditoría"));
   assert.ok(source.includes('id="admin-health"'));
   assert.ok(source.includes("<AdminClinicsManagementCard />"));
   assert.ok(source.includes('id="admin-maintenance"'));
@@ -221,19 +213,24 @@ test("dashboard admin removes horizontal quick actions and preserves admin secti
   assert.ok(source.includes('id="audit-log"'));
 
   const mainIndex = source.indexOf('<main className="dashboard-main">');
+  const stickyActionBarIndex = source.indexOf("<StickyActionBar", mainIndex);
+  const commandCenterIndex = source.indexOf("<AdminCommandCenter", mainIndex);
+  const alertsCardIndex = source.indexOf("<AdminFailedLoginAlertsReadOnlyCard />", mainIndex);
+  const systemSectionIndex = source.indexOf("admin-sistema-heading", mainIndex);
   const reportUploadTitleIndex = source.indexOf("Carga de informes");
 
   assert.ok(mainIndex >= 0);
+  assert.ok(stickyActionBarIndex >= 0);
+  assert.ok(commandCenterIndex >= 0);
+  assert.ok(alertsCardIndex >= 0);
+  assert.ok(systemSectionIndex >= 0);
   assert.ok(reportUploadTitleIndex >= 0);
-  assert.ok(mainIndex < reportUploadTitleIndex);
-  assert.equal(
-    source.slice(mainIndex, reportUploadTitleIndex).includes(quickActionsTitle),
-    false,
-  );
-  assert.equal(
-    source.slice(mainIndex, reportUploadTitleIndex).includes("dashboard-surface"),
-    true,
-  );
+  assert.ok(mainIndex < stickyActionBarIndex);
+  assert.ok(stickyActionBarIndex < commandCenterIndex);
+  assert.ok(commandCenterIndex < alertsCardIndex);
+  assert.ok(alertsCardIndex < systemSectionIndex);
+  assert.ok(systemSectionIndex < reportUploadTitleIndex);
+  assert.equal(source.includes(`xl:grid-cols-${7}`), false);
 });
 
 test("dashboard admin surfaces system health fetch failures", () => {

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -18,6 +18,8 @@ const ADMIN_DASHBOARD_SIDEBAR_PATH =
 const DASHBOARD_TOPBAR_PATH = "frontend/src/components/dashboard/DashboardTopbar.tsx";
 const DASHBOARD_HOME_PATH = "frontend/src/app/dashboard/page.tsx";
 const DASHBOARD_ADMIN_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const DASHBOARD_ADMIN_COMMAND_CENTER_PATH =
+  "frontend/src/app/dashboard/admin/AdminCommandCenter.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -426,15 +428,24 @@ test("dashboard home keeps visual dashboard states and card spacing conventions"
 
 test("dashboard admin keeps dense professional layout and visual state surfaces", () => {
   const source = read(DASHBOARD_ADMIN_PATH);
+  const commandCenterSource = read(DASHBOARD_ADMIN_COMMAND_CENTER_PATH);
+  const combinedSource = `${source}\n${commandCenterSource}`;
 
   assertContainsAll(
     source,
     [
       '<main className="dashboard-main">',
+      "<DashboardPageHeader",
+      "<StickyActionBar",
+      "<AdminCommandCenter",
       "<AdminMaintenanceDryRunCard />",
       "<AdminSessionsReadOnlyCard />",
       "<AdminFailedLoginAlertsReadOnlyCard />",
       "<AdminUsersRolesReadOnlyCard />",
+      "Alertas críticas",
+      "Gestión",
+      "Sistema",
+      "Configuración secundaria",
       'id="audit-log"',
       'id="audit-role-changes"',
       "getSystemStatusIndicatorClass(",
@@ -443,7 +454,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   );
 
   assertMatchesAll(
-    source,
+    combinedSource,
     [
       /className="grid grid-cols-1 gap-4 md:grid-cols-3"/,
       /className="dashboard-surface h-full"/,


### PR DESCRIPTION
## Summary
- Add reusable StickyActionBar for private dashboard contextual actions
- Add AdminCommandCenter with real admin summary data and visible operational actions
- Reorganize /dashboard/admin to prioritize header, sticky actions, command center, alerts, system, management, secondary configuration and audit
- Preserve existing admin cards, data fetching and business logic
- Add native contract tests and PR implementation documentation

## Scope
- No backend changes
- No API route changes
- No auth/session changes
- No middleware changes
- No SEO/public route changes
- No dependency changes
- No package.json or pnpm-lock.yaml changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build