### PR TITLE
feat(dashboard): reports master detail and study timeline

### DIFF
--- a/docs/pr-3-dashboard-reports-master-detail.md
+++ b/docs/pr-3-dashboard-reports-master-detail.md
@@ -1,0 +1,72 @@
+# PR-3 - Reports Master-Detail + Study Timeline
+
+## Resumen
+
+Se transformo `/dashboard/informes` en un workspace operativo privado con layout master-detail. La lista de informes queda como panel maestro, el detalle del informe seleccionado queda como panel principal, y el proceso del estudio se muestra con `StudyTimeline`. Las acciones reales de visualizacion/descarga siguen usando `ReportFileActions` y ahora tambien quedan visibles en `StickyActionBar`.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/informes/page.tsx`
+- `frontend/src/components/dashboard/StickyActionBar.tsx`
+- `test/frontend-dashboard-informes.test.ts`
+
+## Componentes creados
+
+- `frontend/src/components/dashboard/MasterDetailWorkspace.tsx`
+- `frontend/src/components/dashboard/StudyTimeline.tsx`
+- `test/frontend-dashboard-reports-master-detail.test.ts`
+
+## Decisiones tecnicas
+
+- `MasterDetailWorkspace` es puro layout: recibe `master`, `detail`, `emptyDetail`, `selectedId` y `className`; no importa datos, API, auth, middleware ni componentes publicos.
+- `StudyTimeline` recibe pasos ya formados. No calcula fechas ni negocio; solo renderiza estado visual con icono, texto y fecha/placeholder.
+- `/dashboard/informes` sigue siendo server component y conserva los fetches existentes con cookies forwardeadas y `cache: "no-store"`.
+- La seleccion se maneja con `reportId` en query param y `PublicRouteControl`, evitando `next/link` y tags `<a>` por el contrato global del repo.
+- `StickyActionBar` recibio un ajuste no breaking: `children?: ReactNode`, usado para alojar `ReportFileActions` sin duplicar logica de descarga/preview.
+
+## Logica existente preservada
+
+- Se mantienen `getReports`, `searchReports`, `getReportsRequestOptions`, filtros por `query/status/studyType`, manejo de error y empty state.
+- Se mantienen `ReportFileActions` y sus endpoints existentes para preview/download.
+- No se cambian endpoints, autenticacion, middleware, backend, rutas publicas, SEO, dependencias ni calculos de fechas.
+- No se implementa `FilterDrawer`, clinic command center, logistica hub, admin tabs ni rutas nuevas.
+
+## Timeline sin cambiar negocio
+
+Los steps se derivan solo de campos ya presentes en `Report`:
+
+- `uploaded`: usa `uploadDate` o `createdAt`.
+- `processing`: usa el `status/currentStatus` existente y muestra `updatedAt` solo cuando el estado actual es `processing`.
+- `ready`: usa `updatedAt` cuando el informe esta `ready` o `delivered`.
+- `delivered`: usa `updatedAt` solo cuando el informe esta `delivered`.
+
+No se agrega `estimatedDeliveryAt`, no se usa `new Date()` y no se recalculan fechas.
+
+## Validaciones ejecutadas
+
+- `git diff --stat`: PASS. Tracked diff: `456 insertions(+), 116 deletions(-)` en 3 archivos modificados; los nuevos archivos quedan untracked hasta staging manual.
+- `git diff --check`: PASS. Git aviso normal de CRLF en `frontend/src/app/dashboard/informes/page.tsx` y `frontend/src/components/dashboard/StickyActionBar.tsx`.
+- `pnpm test`: PASS, 2319 tests pass, 1 skipped.
+- `pnpm build`: PASS.
+- `pnpm security:public-surface`: PASS, sin findings publicos. Solo notas server-only existentes en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend build`: PASS.
+- Browser local: `/dashboard/informes` responde como ruta privada y redirige a `/login?next=%2Fdashboard%2Finformes` sin error de render inmediato.
+
+## Riesgos residuales
+
+- La seleccion por `reportId` recarga server-side en lugar de ser client-side instantanea. Se eligio para conservar fetch/auth/server rendering sin introducir logica nueva.
+- La timeline usa `updatedAt` como fecha disponible del estado alcanzado cuando no hay fechas de workflow mas granulares en el payload clinic actual.
+- La verificacion visual autenticada del workspace completo queda pendiente de una sesion clinic valida.
+
+## Confirmacion de scope
+
+- Sin cambios en backend/server.
+- Sin cambios en API routes.
+- Sin cambios en auth.
+- Sin cambios en middleware.
+- Sin cambios en SEO, sitemap o robots.
+- Sin cambios en rutas publicas.
+- Sin cambios en `package.json`, `pnpm-lock.yaml`, `next-env.d.ts`, `next.config.ts` ni dependencias.
+- Sin `next/link`, `<Link>` ni `<a>` en los archivos nuevos o modificados de esta PR.

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -1,9 +1,23 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
+import { FileText, ListChecks } from "lucide-react";
 
+import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
+import { EmptyState } from "@/components/dashboard/EmptyState";
+import { ErrorState } from "@/components/dashboard/ErrorState";
+import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import {
+  StickyActionBar,
+  type StickyActionBarAction,
+} from "@/components/dashboard/StickyActionBar";
+import {
+  StudyTimeline,
+  type StudyTimelineStep,
+} from "@/components/dashboard/StudyTimeline";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,13 +29,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getReports, searchReports } from "@/lib/api";
 import {
   getReportStatusLabel,
   getReportStatusVariant,
   formatDate,
 } from "@/lib/utils";
+import type { Report, ReportStatus } from "@/types";
 
 export const metadata: Metadata = {
   title: "Informes — Portal VETNEB",
@@ -40,6 +54,7 @@ type InformesPageSearchParams = {
   query?: string | string[];
   status?: string | string[];
   studyType?: string | string[];
+  reportId?: string | string[];
 };
 
 function normalizeSearchParamValue(value: string | string[] | undefined) {
@@ -56,6 +71,107 @@ function normalizeStatusFilter(value: string) {
   }
 
   return "";
+}
+
+function normalizeReportIdFilter(value: string) {
+  const reportId = Number(value);
+
+  return Number.isInteger(reportId) && reportId > 0 ? reportId : null;
+}
+
+function buildInformesHref(input: {
+  query?: string;
+  status?: string;
+  studyType?: string;
+  reportId?: number | null;
+  hash?: string;
+}) {
+  const params = new URLSearchParams();
+
+  if (input.query) {
+    params.set("query", input.query);
+  }
+
+  if (input.status) {
+    params.set("status", input.status);
+  }
+
+  if (input.studyType) {
+    params.set("studyType", input.studyType);
+  }
+
+  if (input.reportId) {
+    params.set("reportId", String(input.reportId));
+  }
+
+  const qs = params.toString();
+  const hash = input.hash ? `#${input.hash}` : "";
+
+  return `/dashboard/informes${qs ? `?${qs}` : ""}${hash}`;
+}
+
+function getReportTitle(report: Report) {
+  return report.patientName ? `${report.patientName} · Informe #${report.id}` : `Informe #${report.id}`;
+}
+
+const REPORT_STATUS_ORDER = {
+  uploaded: 0,
+  processing: 1,
+  ready: 2,
+  delivered: 3,
+} satisfies Record<ReportStatus, number>;
+
+function getTimelineStepStatus(
+  currentStatus: ReportStatus,
+  stepStatus: ReportStatus,
+): StudyTimelineStep["status"] {
+  if (currentStatus === stepStatus) {
+    return stepStatus === "delivered" ? "completed" : "current";
+  }
+
+  return REPORT_STATUS_ORDER[currentStatus] > REPORT_STATUS_ORDER[stepStatus]
+    ? "completed"
+    : "pending";
+}
+
+function buildStudyTimelineSteps(report: Report): StudyTimelineStep[] {
+  const currentStatus = report.currentStatus ?? report.status;
+  const uploadedDate = report.uploadDate ?? report.createdAt;
+  const updatedDate = report.updatedAt;
+
+  return [
+    {
+      id: "uploaded",
+      label: "Carga recibida",
+      date: uploadedDate ? formatDate(uploadedDate) : null,
+      description: "Fecha registrada para el informe en el portal.",
+      status: "completed",
+    },
+    {
+      id: "processing",
+      label: "Procesamiento",
+      date: currentStatus === "processing" ? formatDate(updatedDate) : null,
+      description: "Estado operativo informado por el registro del informe.",
+      status: getTimelineStepStatus(currentStatus, "processing"),
+    },
+    {
+      id: "ready",
+      label: "Informe disponible",
+      date:
+        currentStatus === "ready" || currentStatus === "delivered"
+          ? formatDate(updatedDate)
+          : null,
+      description: "El archivo queda disponible cuando el estado real lo indique.",
+      status: getTimelineStepStatus(currentStatus, "ready"),
+    },
+    {
+      id: "delivered",
+      label: "Entrega",
+      date: currentStatus === "delivered" ? formatDate(updatedDate) : null,
+      description: "Cierre del circuito visible para la clínica.",
+      status: getTimelineStepStatus(currentStatus, "delivered"),
+    },
+  ];
 }
 
 async function getReportsRequestOptions(): Promise<RequestInit> {
@@ -78,6 +194,9 @@ export default async function InformesPage({
     normalizeSearchParamValue(resolvedSearchParams.status),
   );
   const studyType = normalizeSearchParamValue(resolvedSearchParams.studyType).trim();
+  const selectedReportId = normalizeReportIdFilter(
+    normalizeSearchParamValue(resolvedSearchParams.reportId),
+  );
   const requestOptions = await getReportsRequestOptions();
   let reports: Awaited<ReturnType<typeof getReports>> = [];
   let reportsLoadError = false;
@@ -104,6 +223,32 @@ export default async function InformesPage({
     reportsLoadError = true;
   }
 
+  const selectedReport =
+    reports.find((report) => report.id === selectedReportId) ?? reports[0] ?? null;
+  const selectedReportIdValue = selectedReport ? String(selectedReport.id) : null;
+  const selectedReportTimelineSteps = selectedReport
+    ? buildStudyTimelineSteps(selectedReport)
+    : [];
+  const stickyActions = [
+    {
+      label: "Lista",
+      href: "#reports-master-list",
+      variant: "outline",
+      icon: <ListChecks className="h-4 w-4" aria-hidden="true" />,
+      "aria-label": "Ir a lista de informes",
+    },
+    {
+      label: "Detalle",
+      href: "#report-detail",
+      variant: "default",
+      disabled: !selectedReport,
+      icon: <FileText className="h-4 w-4" aria-hidden="true" />,
+      "aria-label": selectedReport
+        ? `Ir al detalle del informe ${selectedReport.id}`
+        : "Detalle de informe no disponible",
+    },
+  ] satisfies StickyActionBarAction[];
+
   return (
     <>
       <DashboardTopbar
@@ -112,125 +257,296 @@ export default async function InformesPage({
         notifications="clinic"
       />
       <main className="dashboard-main">
-        <Card className="dashboard-surface">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Filtros
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form method="get" className="flex flex-col gap-3 sm:flex-row">
-              <Input
-                name="query"
-                defaultValue={query}
-                placeholder="Buscar por paciente o tipo de estudio..."
-                className="sm:max-w-sm"
-                aria-label="Buscar informes"
+        <DashboardPageHeader
+          title="Informes"
+          description="Workspace operativo para revisar informes clinic-scoped, abrir detalle y consultar el avance del estudio sin salir de la lista."
+          badge={
+            selectedReport ? (
+              <StatusBadge
+                status={selectedReport.status}
+                label={getReportStatusLabel(selectedReport.status)}
+                size="sm"
               />
-              <select
-                name="status"
-                defaultValue={status}
-                className="field-select sm:w-56"
-                aria-label="Filtrar por estado"
-              >
-                {statusOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-              <div className="flex items-center gap-2">
-                <Button type="submit" size="sm">
-                  Filtrar
-                </Button>
-                <PublicRouteControl
-                  href="/dashboard/informes"
-                  replace
-                  variant="bare"
-                  className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
-                >
-                  Limpiar
-                </PublicRouteControl>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
+            ) : null
+          }
+        />
 
-        <Card className="dashboard-surface">
-          <CardHeader>
-            <CardTitle className="text-base">
-              Informes ({reports.length})
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>ID</TableHead>
-                  <TableHead>Paciente</TableHead>
-                  <TableHead>Tipo de estudio</TableHead>
-                  <TableHead>Clínica</TableHead>
-                  <TableHead>Fecha</TableHead>
-                  <TableHead>Estado</TableHead>
-                  <TableHead className="text-right">Acciones</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {reportsLoadError ? (
-                  <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      role="alert"
-                      className="clinical-table-state clinical-alert-warning"
-                    >
-                      No se pudieron cargar los informes. Intente nuevamente.
-                    </TableCell>
-                  </TableRow>
-                ) : reports.length ? (
-                  reports.map((report) => (
-                    <TableRow key={report.id} id={`report-${report.id}`}>
-                      <TableCell className="font-mono text-xs text-muted-foreground">
-                        #{report.id}
-                      </TableCell>
-                      <TableCell className="font-medium">
-                        {report.patientName ?? "—"}
-                      </TableCell>
-                      <TableCell className="text-vetneb-ink/75">
-                        {report.studyType ?? "—"}
-                      </TableCell>
-                      <TableCell className="text-sm text-vetneb-ink/75">
-                        {report.clinicName ?? `Clínica #${report.clinicId}`}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {formatDate(report.uploadDate)}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={getReportStatusVariant(report.status)}>
-                          {getReportStatusLabel(report.status)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <ReportFileActions
-                          reportId={report.id}
-                          hasFile={report.hasFile}
-                        />
-                      </TableCell>
+        <StickyActionBar
+          context={selectedReport ? `Informe #${selectedReport.id}` : "Informes"}
+          actions={stickyActions}
+        >
+          {selectedReport ? (
+            <ReportFileActions
+              reportId={selectedReport.id}
+              hasFile={selectedReport.hasFile}
+              align="start"
+            />
+          ) : null}
+        </StickyActionBar>
+
+        <MasterDetailWorkspace
+          selectedId={selectedReportIdValue}
+          master={
+            <div id="reports-master-list" className="space-y-4 p-4">
+              <div>
+                <h2 className="dashboard-section-heading">
+                  Informes ({reports.length})
+                </h2>
+                <p className="dashboard-section-description">
+                  Lista clinic-scoped con filtros existentes y selección de detalle.
+                </p>
+              </div>
+
+              <form method="get" className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_14rem] lg:grid-cols-1">
+                  <Input
+                    name="query"
+                    defaultValue={query}
+                    placeholder="Buscar por paciente o tipo de estudio..."
+                    className="min-w-0"
+                    aria-label="Buscar informes"
+                  />
+                  <select
+                    name="status"
+                    defaultValue={status}
+                    className="field-select"
+                    aria-label="Filtrar por estado"
+                  >
+                    {statusOptions.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button type="submit" size="sm">
+                    Filtrar
+                  </Button>
+                  <PublicRouteControl
+                    href="/dashboard/informes"
+                    replace
+                    variant="bare"
+                    className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+                  >
+                    Limpiar
+                  </PublicRouteControl>
+                </div>
+              </form>
+
+              <div className="min-w-0 overflow-x-auto rounded-lg border border-vetneb-line/70">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>ID</TableHead>
+                      <TableHead>Paciente</TableHead>
+                      <TableHead>Tipo de estudio</TableHead>
+                      <TableHead>Clínica</TableHead>
+                      <TableHead>Fecha</TableHead>
+                      <TableHead>Estado</TableHead>
+                      <TableHead className="text-right">Acciones</TableHead>
                     </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      className="clinical-table-state"
+                  </TableHeader>
+                  <TableBody>
+                    {reportsLoadError ? (
+                      <TableRow>
+                        <TableCell
+                          colSpan={7}
+                          role="alert"
+                          className="clinical-table-state"
+                        >
+                          <ErrorState
+                            title="No se pudieron cargar los informes"
+                            message="No se pudieron cargar los informes. Intente nuevamente."
+                            className="text-left"
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ) : reports.length ? (
+                      reports.map((report) => {
+                        const isSelected = selectedReport?.id === report.id;
+
+                        return (
+                          <TableRow
+                            key={report.id}
+                            id={`report-${report.id}`}
+                            className={isSelected ? "bg-vetneb-cyan/10" : undefined}
+                          >
+                            <TableCell className="font-mono text-xs text-muted-foreground">
+                              #{report.id}
+                            </TableCell>
+                            <TableCell className="font-medium">
+                              {report.patientName ?? "—"}
+                            </TableCell>
+                            <TableCell className="text-vetneb-ink/75">
+                              {report.studyType ?? "—"}
+                            </TableCell>
+                            <TableCell className="text-sm text-vetneb-ink/75">
+                              {report.clinicName ?? `Clínica #${report.clinicId}`}
+                            </TableCell>
+                            <TableCell className="text-sm text-muted-foreground">
+                              {formatDate(report.uploadDate)}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={getReportStatusVariant(report.status)}>
+                                {getReportStatusLabel(report.status)}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex flex-col items-end gap-2">
+                                <PublicRouteControl
+                                  href={buildInformesHref({
+                                    query,
+                                    status,
+                                    studyType,
+                                    reportId: report.id,
+                                    hash: "report-detail",
+                                  })}
+                                  replace
+                                  prefetch={false}
+                                  variant="bare"
+                                  aria-current={isSelected ? "true" : undefined}
+                                  className="inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-2 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70"
+                                >
+                                  {isSelected ? "Seleccionado" : "Seleccionar"}
+                                </PublicRouteControl>
+                                <ReportFileActions
+                                  reportId={report.id}
+                                  hasFile={report.hasFile}
+                                />
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                    ) : (
+                      <TableRow>
+                        <TableCell
+                          colSpan={7}
+                          className="clinical-table-state"
+                        >
+                          <EmptyState
+                            title="No hay informes disponibles."
+                            description="Cuando haya informes para los filtros actuales, aparecerán en este panel."
+                            className="border-0 bg-transparent"
+                          />
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          }
+          detail={
+            selectedReport ? (
+              <div id="report-detail" className="space-y-6 p-5">
+                <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 md:flex-row md:items-start md:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                      Detalle del informe
+                    </p>
+                    <h2 className="mt-1 text-xl font-semibold text-vetneb-ink">
+                      {getReportTitle(selectedReport)}
+                    </h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Clínica {selectedReport.clinicName ?? `#${selectedReport.clinicId}`}
+                    </p>
+                  </div>
+                  <StatusBadge
+                    status={selectedReport.status}
+                    label={getReportStatusLabel(selectedReport.status)}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  <div className="surface-soft">
+                    <p className="text-xs text-muted-foreground">Paciente</p>
+                    <p className="mt-1 font-semibold text-vetneb-ink">
+                      {selectedReport.patientName ?? "—"}
+                    </p>
+                  </div>
+                  <div className="surface-soft">
+                    <p className="text-xs text-muted-foreground">Tipo de estudio</p>
+                    <p className="mt-1 font-semibold text-vetneb-ink">
+                      {selectedReport.studyType ?? "—"}
+                    </p>
+                  </div>
+                  <div className="surface-soft">
+                    <p className="text-xs text-muted-foreground">Fecha</p>
+                    <p className="mt-1 font-semibold text-vetneb-ink">
+                      {formatDate(selectedReport.uploadDate)}
+                    </p>
+                  </div>
+                  <div className="surface-soft">
+                    <p className="text-xs text-muted-foreground">Creado</p>
+                    <p className="mt-1 font-semibold text-vetneb-ink">
+                      {formatDate(selectedReport.createdAt)}
+                    </p>
+                  </div>
+                  <div className="surface-soft">
+                    <p className="text-xs text-muted-foreground">Actualizado</p>
+                    <p className="mt-1 font-semibold text-vetneb-ink">
+                      {formatDate(selectedReport.updatedAt)}
+                    </p>
+                  </div>
+                  <div className="surface-soft">
+                    <p className="text-xs text-muted-foreground">Archivo</p>
+                    <p className="mt-1 font-semibold text-vetneb-ink">
+                      {selectedReport.fileName ?? (selectedReport.hasFile ? "Disponible" : "—")}
+                    </p>
+                  </div>
+                </div>
+
+                <section id="report-actions" className="space-y-3">
+                  <div>
+                    <h3 className="text-base font-semibold text-vetneb-ink">
+                      Acciones
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Acciones reales existentes para visualizar o descargar el archivo.
+                    </p>
+                  </div>
+                  <ReportFileActions
+                    reportId={selectedReport.id}
+                    hasFile={selectedReport.hasFile}
+                    align="start"
+                  />
+                </section>
+
+                <section className="space-y-3" aria-labelledby="study-timeline-heading">
+                  <div>
+                    <h3
+                      id="study-timeline-heading"
+                      className="text-base font-semibold text-vetneb-ink"
                     >
-                      No hay informes disponibles.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
+                      Línea de tiempo del estudio
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Pasos derivados del estado y fechas ya disponibles del informe.
+                    </p>
+                  </div>
+                  <StudyTimeline steps={selectedReportTimelineSteps} />
+                </section>
+              </div>
+            ) : (
+              <EmptyState
+                title="No hay informe seleccionado"
+                description="Seleccione un informe de la lista para ver el detalle operativo."
+                className="m-5"
+              />
+            )
+          }
+          emptyDetail={
+            <EmptyState
+              title="No hay informe seleccionado"
+              description="Seleccione un informe de la lista para ver el detalle operativo."
+              className="m-5"
+            />
+          }
+        />
+
+        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/frontend/src/components/dashboard/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/dashboard/MasterDetailWorkspace.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type MasterDetailWorkspaceProps = {
+  master: ReactNode;
+  detail: ReactNode;
+  emptyDetail?: ReactNode;
+  selectedId?: string | null;
+  className?: string;
+};
+
+export function MasterDetailWorkspace({
+  master,
+  detail,
+  emptyDetail,
+  selectedId,
+  className,
+}: MasterDetailWorkspaceProps) {
+  const hasSelection = Boolean(selectedId);
+
+  return (
+    <section
+      className={cn(
+        "grid min-w-0 grid-cols-1 gap-4 overflow-x-hidden xl:grid-cols-[minmax(18rem,24rem)_minmax(0,1fr)]",
+        className,
+      )}
+      data-selected-id={selectedId ?? undefined}
+    >
+      <div
+        aria-label="Panel maestro"
+        className="min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm"
+      >
+        <div className="max-h-none min-w-0 overflow-x-hidden overflow-y-visible xl:max-h-[calc(100vh-13rem)] xl:overflow-y-auto">
+          {master}
+        </div>
+      </div>
+
+      <div
+        aria-label="Panel de detalle"
+        className="min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm"
+      >
+        {hasSelection ? detail : emptyDetail ?? detail}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/StickyActionBar.tsx
+++ b/frontend/src/components/dashboard/StickyActionBar.tsx
@@ -17,6 +17,7 @@ export type StickyActionBarAction = {
 export type StickyActionBarProps = {
   context?: string;
   actions: StickyActionBarAction[];
+  children?: ReactNode;
   visible?: boolean;
   className?: string;
 };
@@ -24,6 +25,7 @@ export type StickyActionBarProps = {
 export function StickyActionBar({
   context,
   actions,
+  children,
   visible = true,
   className,
 }: StickyActionBarProps) {
@@ -50,6 +52,11 @@ export function StickyActionBar({
           </p>
         ) : null}
         <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-end">
+          {children ? (
+            <div className="col-span-2 flex justify-start sm:justify-end">
+              {children}
+            </div>
+          ) : null}
           {actions.map((action, index) => {
             const ariaLabel = action["aria-label"] ?? action.label;
             const content = (

--- a/frontend/src/components/dashboard/StudyTimeline.tsx
+++ b/frontend/src/components/dashboard/StudyTimeline.tsx
@@ -1,0 +1,140 @@
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  LoaderCircle,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type StudyTimelineStepStatus =
+  | "completed"
+  | "current"
+  | "pending"
+  | "warning"
+  | "error";
+
+export type StudyTimelineStep = {
+  id: string;
+  label: string;
+  date?: string | null;
+  description?: string;
+  status: StudyTimelineStepStatus;
+};
+
+export type StudyTimelineProps = {
+  steps: StudyTimelineStep[];
+  compact?: boolean;
+  className?: string;
+};
+
+type TimelineStatusConfig = {
+  label: string;
+  icon: LucideIcon;
+  markerClassName: string;
+  labelClassName: string;
+};
+
+const TIMELINE_STATUS_CONFIG = {
+  completed: {
+    label: "Completado",
+    icon: CheckCircle2,
+    markerClassName: "border-vetneb-teal/35 bg-vetneb-teal/12 text-vetneb-teal",
+    labelClassName: "text-vetneb-teal",
+  },
+  current: {
+    label: "Actual",
+    icon: LoaderCircle,
+    markerClassName: "border-vetneb-cyan/35 bg-vetneb-cyan/14 text-vetneb-navy",
+    labelClassName: "text-vetneb-navy",
+  },
+  pending: {
+    label: "Pendiente",
+    icon: Clock3,
+    markerClassName: "border-vetneb-line bg-vetneb-surface-muted/80 text-vetneb-ink/70",
+    labelClassName: "text-muted-foreground",
+  },
+  warning: {
+    label: "Atención",
+    icon: AlertTriangle,
+    markerClassName: "border-vetneb-cyan/35 bg-vetneb-cyan/10 text-vetneb-navy",
+    labelClassName: "text-vetneb-navy",
+  },
+  error: {
+    label: "Error",
+    icon: XCircle,
+    markerClassName: "border-destructive/35 bg-destructive/10 text-destructive",
+    labelClassName: "text-destructive",
+  },
+} satisfies Record<StudyTimelineStepStatus, TimelineStatusConfig>;
+
+export function StudyTimeline({
+  steps,
+  compact = false,
+  className,
+}: StudyTimelineProps) {
+  return (
+    <ol
+      className={cn(
+        "space-y-3",
+        compact ? "text-sm" : "text-base",
+        className,
+      )}
+      aria-label="Línea de tiempo del estudio"
+    >
+      {steps.map((step, index) => {
+        const config = TIMELINE_STATUS_CONFIG[step.status];
+        const Icon = config.icon;
+        const isLastStep = index === steps.length - 1;
+
+        return (
+          <li
+            key={step.id}
+            className="grid grid-cols-[auto_minmax(0,1fr)] gap-3"
+            data-timeline-status={step.status}
+          >
+            <div className="flex flex-col items-center">
+              <span
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-full border",
+                  config.markerClassName,
+                )}
+                aria-hidden="true"
+              >
+                <Icon className="h-4 w-4" aria-hidden="true" />
+              </span>
+              {!isLastStep ? (
+                <span
+                  className="mt-2 h-full min-h-5 w-px bg-vetneb-line"
+                  aria-hidden="true"
+                />
+              ) : null}
+            </div>
+            <div className={cn("min-w-0 pb-4", isLastStep ? "pb-0" : null)}>
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <p className="font-semibold text-vetneb-ink">{step.label}</p>
+                <span
+                  className={cn(
+                    "inline-flex w-fit items-center rounded-md px-2 py-0.5 text-xs font-semibold",
+                    config.markerClassName,
+                  )}
+                >
+                  {config.label}
+                </span>
+              </div>
+              <p className={cn("mt-1 text-sm font-medium", config.labelClassName)}>
+                {step.date ?? "Pendiente"}
+              </p>
+              {step.description ? (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {step.description}
+                </p>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -22,6 +22,11 @@ test("dashboard informes defines non-indexable metadata and clinic read dependen
   assert.ok(source.includes('title: "Informes — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
+  assert.ok(source.includes('import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";'));
+  assert.ok(source.includes('import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";'));
+  assert.ok(source.includes('import { StatusBadge } from "@/components/dashboard/StatusBadge";'));
+  assert.ok(source.includes('} from "@/components/dashboard/StickyActionBar";'));
+  assert.ok(source.includes('} from "@/components/dashboard/StudyTimeline";'));
   assert.ok(source.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
   assert.equal(source.includes("UploadReportModal"), false);
 });
@@ -32,10 +37,12 @@ test("dashboard informes reads filters from searchParams and uses live search en
   assert.ok(source.includes("type InformesPageSearchParams = {"));
   assert.ok(source.includes("query?: string | string[];"));
   assert.ok(source.includes("status?: string | string[];"));
+  assert.ok(source.includes("reportId?: string | string[];"));
   assert.ok(source.includes("searchParams?: Promise<InformesPageSearchParams>;"));
   assert.ok(source.includes("const resolvedSearchParams = (await searchParams) ?? {};"));
   assert.ok(source.includes("const query = normalizeSearchParamValue(resolvedSearchParams.query).trim();"));
   assert.ok(source.includes("const status = normalizeStatusFilter("));
+  assert.ok(source.includes("const selectedReportId = normalizeReportIdFilter("));
   assert.ok(source.includes("reports = query"));
   assert.ok(source.includes("? await searchReports("));
   assert.ok(source.includes("query,"));
@@ -74,6 +81,10 @@ test("dashboard informes renders clinic reports surface without technical source
   assert.ok(source.includes('title="Informes"'));
   assert.ok(source.includes('subtitle="Consulta de informes médicos veterinarios"'));
   assert.ok(source.includes('notifications="clinic"'));
+  assert.ok(source.includes("<DashboardPageHeader"));
+  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<MasterDetailWorkspace"));
+  assert.ok(source.includes("<StudyTimeline"));
   assert.equal(source.includes("<UploadReportModal />"), false);
   assert.equal(source.includes("/api/admin"), false);
   assert.equal(source.includes(removedSourceCopy), false);
@@ -95,6 +106,8 @@ test("dashboard informes renders filters and reports table columns", () => {
   assert.ok(source.includes("Filtrar"));
   assert.ok(source.includes('href="/dashboard/informes"'));
   assert.ok(source.includes("Limpiar"));
+  assert.ok(source.includes('id="reports-master-list"'));
+  assert.ok(source.includes('id="report-detail"'));
   assert.ok(source.includes("<TableHead>ID</TableHead>"));
   assert.ok(source.includes("<TableHead>Paciente</TableHead>"));
   assert.ok(source.includes("<TableHead>Tipo de estudio</TableHead>"));
@@ -108,6 +121,7 @@ test("dashboard informes keeps row rendering badges dates and report actions", (
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("reports.map((report) =>"));
+  assert.ok(source.includes("const isSelected = selectedReport?.id === report.id;"));
   assert.ok(source.includes('report.patientName ?? "—"'));
   assert.ok(source.includes('report.studyType ?? "—"'));
   assert.ok(source.includes("report.clinicName ?? `Clínica #${report.clinicId}`"));
@@ -117,6 +131,8 @@ test("dashboard informes keeps row rendering badges dates and report actions", (
   assert.ok(source.includes("<ReportFileActions"));
   assert.ok(source.includes("reportId={report.id}"));
   assert.ok(source.includes("hasFile={report.hasFile}"));
+  assert.ok(source.includes("reportId={selectedReport.id}"));
+  assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
   assert.equal(source.includes("storagePath"), false);
 });
 
@@ -124,6 +140,7 @@ test("dashboard informes keeps empty state and avoids client-side fetch literals
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("No hay informes disponibles."));
+  assert.ok(source.includes("<EmptyState"));
   assert.ok(source.includes("colSpan={7}"));
   assert.equal(source.includes("fetch("), false);
   assert.equal(source.includes("mock"), false);

--- a/test/frontend-dashboard-reports-master-detail.test.ts
+++ b/test/frontend-dashboard-reports-master-detail.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const MASTER_DETAIL_WORKSPACE_PATH =
+  "frontend/src/components/dashboard/MasterDetailWorkspace.tsx";
+const STUDY_TIMELINE_PATH =
+  "frontend/src/components/dashboard/StudyTimeline.tsx";
+const STICKY_ACTION_BAR_PATH =
+  "frontend/src/components/dashboard/StickyActionBar.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertNoForbiddenSurfaceImports(source: string, context: string): void {
+  const importLines = source
+    .split("\n")
+    .filter((line) => line.trim().startsWith("import "));
+  const forbiddenPatterns = [
+    /@\/app\/api/,
+    /@\/middleware/,
+    /@\/lib\/auth/,
+    /@\/components\/public/,
+    /\.\.\/.*\/auth/,
+    /\.\.\/.*\/middleware/,
+    /\.\.\/.*\/public/,
+  ];
+
+  for (const line of importLines) {
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(
+        pattern.test(line),
+        false,
+        `${context} must not import forbidden surface via: ${line}`,
+      );
+    }
+  }
+}
+
+test("MasterDetailWorkspace keeps reusable two-panel layout contract", () => {
+  const source = read(MASTER_DETAIL_WORKSPACE_PATH);
+
+  assert.ok(source.includes("export type MasterDetailWorkspaceProps = {"));
+  assert.ok(source.includes("master: ReactNode;"));
+  assert.ok(source.includes("detail: ReactNode;"));
+  assert.ok(source.includes("emptyDetail?: ReactNode;"));
+  assert.ok(source.includes("selectedId?: string | null;"));
+  assert.ok(source.includes("className?: string;"));
+  assert.ok(source.includes('aria-label="Panel maestro"'));
+  assert.ok(source.includes('aria-label="Panel de detalle"'));
+  assert.ok(source.includes("xl:grid-cols-[minmax(18rem,24rem)_minmax(0,1fr)]"));
+  assert.ok(source.includes("overflow-x-hidden"));
+  assert.ok(source.includes("xl:max-h-[calc(100vh-13rem)]"));
+  assert.ok(source.includes("xl:overflow-y-auto"));
+  assert.ok(source.includes("data-selected-id={selectedId ?? undefined}"));
+  assert.equal(source.includes("fetch("), false);
+});
+
+test("StudyTimeline supports ordered visual states without business calculations", () => {
+  const source = read(STUDY_TIMELINE_PATH);
+
+  assert.ok(source.includes("export type StudyTimelineStep = {"));
+  assert.ok(source.includes("steps: StudyTimelineStep[];"));
+  assert.ok(source.includes('"completed"'));
+  assert.ok(source.includes('"current"'));
+  assert.ok(source.includes('"pending"'));
+  assert.ok(source.includes('"warning"'));
+  assert.ok(source.includes('"error"'));
+  assert.ok(source.includes("const TIMELINE_STATUS_CONFIG = {"));
+  assert.ok(source.includes("completed: {"));
+  assert.ok(source.includes("current: {"));
+  assert.ok(source.includes("pending: {"));
+  assert.ok(source.includes("warning: {"));
+  assert.ok(source.includes("error: {"));
+  assert.ok(source.includes("icon: CheckCircle2"));
+  assert.ok(source.includes("icon: LoaderCircle"));
+  assert.ok(source.includes("icon: Clock3"));
+  assert.ok(source.includes("icon: AlertTriangle"));
+  assert.ok(source.includes("icon: XCircle"));
+  assert.ok(source.includes("{config.label}"));
+  assert.ok(source.includes('{step.date ?? "Pendiente"}'));
+  assert.ok(source.includes("steps.map((step, index) =>"));
+  assert.ok(source.includes("data-timeline-status={step.status}"));
+  assert.equal(source.includes("formatDate("), false);
+  assert.equal(source.includes("getReports"), false);
+  assert.equal(source.includes("fetch("), false);
+});
+
+test("dashboard informes composes master-detail, selected report detail, timeline, and sticky actions", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("<DashboardPageHeader"));
+  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<MasterDetailWorkspace"));
+  assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
+  assert.ok(source.includes("buildStudyTimelineSteps(selectedReport)"));
+  assert.ok(source.includes("const selectedReport ="));
+  assert.ok(source.includes("reports.find((report) => report.id === selectedReportId) ?? reports[0] ?? null"));
+  assert.ok(source.includes("const stickyActions = ["));
+  assert.ok(source.includes('label: "Lista"'));
+  assert.ok(source.includes('href: "#reports-master-list"'));
+  assert.ok(source.includes('label: "Detalle"'));
+  assert.ok(source.includes('href: "#report-detail"'));
+  assert.ok(source.includes('id="reports-master-list"'));
+  assert.ok(source.includes('id="report-detail"'));
+  assert.ok(source.includes('id="report-actions"'));
+  assert.ok(source.includes("Línea de tiempo del estudio"));
+  assert.ok(source.includes("Pasos derivados del estado y fechas ya disponibles del informe."));
+  assert.ok(source.includes("reportId={selectedReport.id}"));
+  assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
+  assert.ok(source.includes("reportId={report.id}"));
+  assert.ok(source.includes("hasFile={report.hasFile}"));
+});
+
+test("dashboard informes derives timeline steps from existing report fields only", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("function buildStudyTimelineSteps(report: Report): StudyTimelineStep[]"));
+  assert.ok(source.includes("const currentStatus = report.currentStatus ?? report.status;"));
+  assert.ok(source.includes("const uploadedDate = report.uploadDate ?? report.createdAt;"));
+  assert.ok(source.includes("const updatedDate = report.updatedAt;"));
+  assert.ok(source.includes('id: "uploaded"'));
+  assert.ok(source.includes('id: "processing"'));
+  assert.ok(source.includes('id: "ready"'));
+  assert.ok(source.includes('id: "delivered"'));
+  assert.ok(source.includes("formatDate(uploadedDate)"));
+  assert.ok(source.includes("formatDate(updatedDate)"));
+  assert.equal(source.includes("estimatedDeliveryAt"), false);
+  assert.equal(source.includes("new Date("), false);
+});
+
+test("dashboard informes master-detail scope avoids forbidden navigation and dependency changes", () => {
+  const informesSource = read(INFORMES_PAGE_PATH);
+  const masterDetailSource = read(MASTER_DETAIL_WORKSPACE_PATH);
+  const timelineSource = read(STUDY_TIMELINE_PATH);
+  const stickyActionBarSource = read(STICKY_ACTION_BAR_PATH);
+  const packageDiff = execFileSync(
+    "git",
+    ["diff", "--name-only", "--", "package.json", "pnpm-lock.yaml"],
+    { encoding: "utf8" },
+  ).trim();
+
+  assertNoForbiddenSurfaceImports(masterDetailSource, "MasterDetailWorkspace");
+  assertNoForbiddenSurfaceImports(timelineSource, "StudyTimeline");
+  assertNoForbiddenSurfaceImports(stickyActionBarSource, "StickyActionBar");
+  assert.equal(informesSource.includes('from "next/link"'), false);
+  assert.equal(masterDetailSource.includes('from "next/link"'), false);
+  assert.equal(timelineSource.includes('from "next/link"'), false);
+  assert.equal(stickyActionBarSource.includes('from "next/link"'), false);
+  assert.equal(informesSource.includes("<a"), false);
+  assert.equal(masterDetailSource.includes("<a"), false);
+  assert.equal(timelineSource.includes("<a"), false);
+  assert.equal(stickyActionBarSource.includes("<a"), false);
+  assert.equal(packageDiff, "");
+});


### PR DESCRIPTION
## Summary
- Add reusable MasterDetailWorkspace for private dashboard two-panel workflows
- Add StudyTimeline for visual study/report process tracking without changing business date logic
- Rework /dashboard/informes into a master-detail reports workspace with selected report detail, timeline and sticky report actions
- Preserve existing fetches, filters, report file actions, auth behavior and route contracts
- Add native contract tests and PR implementation documentation

## Scope
- No backend changes
- No API route changes
- No auth/session changes
- No middleware changes
- No SEO/public route changes
- No dependency changes
- No package.json or pnpm-lock.yaml changes
- No next-env.d.ts changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build