### PR TITLE
feat(dashboard): logistics hub operational

### DIFF
--- a/docs/pr-5-dashboard-logistics-hub.md
+++ b/docs/pr-5-dashboard-logistics-hub.md
@@ -1,0 +1,88 @@
+# PR-5 — feat(dashboard): logistics hub operational
+
+## Objetivo
+
+Rediseño conservador de `/dashboard/logistica` como hub operativo premium. La página mantiene toda la lógica de fetch, auth y rutas existentes, y añade `DashboardPageHeader`, `StickyActionBar` y `LogisticsCommandCenter` siguiendo el patrón establecido en PR-4 (ClinicCommandCenter) y PR-3 (AdminCommandCenter).
+
+## Archivos modificados
+
+| Archivo | Acción |
+|---|---|
+| `frontend/src/app/dashboard/logistica/page.tsx` | Rediseñado: añade DashboardPageHeader, StickyActionBar, LogisticsCommandCenter |
+| `frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx` | Nuevo componente presentacional |
+| `test/frontend-dashboard-logistica.test.ts` | Actualizado para reflejar nueva arquitectura |
+| `test/frontend-dashboard-logistics-hub.test.ts` | Tests de contrato nuevos para el hub |
+| `docs/pr-5-dashboard-logistics-hub.md` | Este documento |
+
+## Decisiones de diseño
+
+### LogisticsCommandCenter — presentacional puro
+
+El componente no hace fetch. Recibe `fieldVisits`, `routePlans`, `fieldVisitsLoadError`, `routePlansLoadError` como props. La lógica de fetching permanece en `page.tsx` (Server Component), que es el único lugar con acceso a cookies y caché.
+
+### KPIs derivados, no inventados
+
+- **Visitas activas**: `fieldVisits.filter(v => v.status === "in_progress" || v.status === "scheduled").length`
+- **Planes activos**: `routePlans.filter(p => p.status === "in_progress" || p.status === "released").length`
+- **Total visitas**: `fieldVisits.length`
+
+Todos se derivan directamente de los arrays ya cargados. Ningún dato es inventado.
+
+### StickyActionBar — navegación real
+
+Las tres acciones usan rutas existentes del registro `ROUTES`:
+- **Ver visitas** → `ROUTES.dashboardLogisticaVisitas`
+- **Ver rutas** → `ROUTES.dashboardLogisticaRutas`
+- **Ver métricas** → `ROUTES.dashboardLogisticaMetricas`
+
+No se usa `next/link` ni `<a>` directamente. La navegación usa `window.location.assign` vía `StickyActionBar`.
+
+### Listas limitadas a 5 items
+
+`fieldVisits.slice(0, 5)` y `routePlans.slice(0, 5)` — evita scroll vertical excesivo en el hub. Las páginas de detalle (`/visitas`, `/rutas`) mantienen la vista completa.
+
+### StatusBadge para visitas de campo
+
+Los estados de visita (`scheduled`, `in_progress`, `done`, `canceled`, `no_show`, `pending`) están mapeados en `StatusBadge`. Para planes de ruta se usa `Badge + getRoutePlanStatusVariant/Label` de `@/lib/utils` para mostrar correctamente `draft`, `released`, `planned`, `completed`.
+
+### Sin gradientes decorativos ni shadow-xl
+
+Se usan únicamente clases utilitarias del design system existente: `dashboard-surface`, `dashboard-list-row`, `dashboard-kpi-pill`, `surface-note-info`, `dashboard-section-heading`.
+
+## Scope estricto
+
+**No tocado:**
+- Backend, API routes, auth, middleware
+- SEO / rutas públicas
+- `package.json`, `pnpm-lock.yaml`, `next-env.d.ts`
+- Sub-páginas `/visitas`, `/rutas`, `/metricas`
+- Páginas del resto del dashboard
+
+## Tests
+
+### Tests actualizados
+- `test/frontend-dashboard-logistica.test.ts` — refleja la nueva estructura (DashboardPageHeader + StickyActionBar + LogisticsCommandCenter)
+
+### Tests nuevos
+- `test/frontend-dashboard-logistics-hub.test.ts` — cubre:
+  - Existencia y scope de LogisticsCommandCenter
+  - Props contract tipado
+  - Banner operativo con KPI pills
+  - Listas con StatusBadge / Badge
+  - EmptyState cuando no hay datos
+  - Errores con `role="alert"`
+  - Layout responsive (1 col mobile, 2 col desktop)
+  - Sin next/link ni `<a>`
+  - Sin imports prohibidos (API/auth/public/middleware)
+  - Scope: sin cambios en package.json, pnpm-lock.yaml, backend
+
+## Validaciones
+
+```
+pnpm test                          ✓
+pnpm build                         ✓
+pnpm security:public-surface       ✓
+pnpm --dir frontend lint           ✓
+pnpm --dir frontend typecheck      ✓
+pnpm --dir frontend build          ✓
+```

--- a/frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx
+++ b/frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx
@@ -1,0 +1,195 @@
+import type { FieldVisit, RoutePlan } from "@/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import { EmptyState } from "@/components/dashboard/EmptyState";
+import { Truck, Route } from "lucide-react";
+import {
+  getRoutePlanStatusLabel,
+  getRoutePlanStatusVariant,
+  formatDate,
+} from "@/lib/utils";
+
+export type LogisticsCommandCenterProps = {
+  fieldVisits: FieldVisit[];
+  routePlans: RoutePlan[];
+  fieldVisitsLoadError: boolean;
+  routePlansLoadError: boolean;
+};
+
+export function LogisticsCommandCenter({
+  fieldVisits,
+  routePlans,
+  fieldVisitsLoadError,
+  routePlansLoadError,
+}: LogisticsCommandCenterProps) {
+  const activeVisits = fieldVisits.filter(
+    (v) => v.status === "in_progress" || v.status === "scheduled",
+  );
+  const activePlans = routePlans.filter(
+    (p) => p.status === "in_progress" || p.status === "released",
+  );
+  const recentVisits = fieldVisits.slice(0, 5);
+  const recentPlans = routePlans.slice(0, 5);
+
+  return (
+    <section
+      className="space-y-5"
+      aria-labelledby="logistics-command-center-heading"
+    >
+      <section
+        className="surface-note-info"
+        aria-labelledby="logistics-operational-priority"
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-vetneb-navy/80">
+              Estado operativo logística
+            </p>
+            <p
+              id="logistics-operational-priority"
+              className="mt-1 text-sm font-medium text-vetneb-navy"
+            >
+              Priorice visitas activas y planes en curso para sostener continuidad operativa.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 sm:min-w-[24rem]">
+            <div className="dashboard-kpi-pill" data-tone="focus">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                Visitas activas
+              </p>
+              <p className="mt-1 text-lg font-bold leading-none">
+                {activeVisits.length}
+              </p>
+            </div>
+            <div className="dashboard-kpi-pill" data-tone="critical">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                Planes activos
+              </p>
+              <p className="mt-1 text-lg font-bold leading-none">
+                {activePlans.length}
+              </p>
+            </div>
+            <div className="dashboard-kpi-pill">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                Total visitas
+              </p>
+              <p className="mt-1 text-lg font-bold leading-none">
+                {fieldVisits.length}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div>
+        <h2
+          id="logistics-command-center-heading"
+          className="dashboard-section-heading"
+        >
+          Centro de logística
+        </h2>
+        <p className="dashboard-section-description">
+          Visitas de campo activas y planes de ruta en tiempo real.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card className="dashboard-surface">
+          <CardHeader className="flex flex-row items-start justify-between pb-3">
+            <div>
+              <CardTitle className="text-base">Visitas de campo</CardTitle>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Programadas y en curso.
+              </p>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1.5">
+            {fieldVisitsLoadError ? (
+              <p role="alert" className="clinical-alert-warning">
+                No se pudieron cargar las visitas de campo. Intente nuevamente.
+              </p>
+            ) : recentVisits.length ? (
+              recentVisits.map((visit) => (
+                <div key={visit.id} className="dashboard-list-row">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-vetneb-ink">
+                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {visit.address ?? "Sin dirección"} ·{" "}
+                      {formatDate(visit.scheduledAt)}
+                    </p>
+                  </div>
+                  <StatusBadge
+                    status={visit.status}
+                    size="sm"
+                    className="ml-2 shrink-0"
+                  />
+                </div>
+              ))
+            ) : (
+              <EmptyState
+                title="Sin visitas activas"
+                description="No hay visitas de campo disponibles."
+                icon={Truck}
+              />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="dashboard-surface">
+          <CardHeader className="flex flex-row items-start justify-between pb-3">
+            <div>
+              <CardTitle className="text-base">Planes de ruta</CardTitle>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Liberados y en ejecución.
+              </p>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1.5">
+            {routePlansLoadError ? (
+              <p role="alert" className="clinical-alert-warning">
+                No se pudieron cargar los planes de ruta. Intente nuevamente.
+              </p>
+            ) : recentPlans.length ? (
+              recentPlans.map((plan) => {
+                const progress =
+                  plan.totalStops > 0
+                    ? Math.round(
+                        (plan.completedStops / plan.totalStops) * 100,
+                      )
+                    : 0;
+                return (
+                  <div key={plan.id} className="dashboard-list-row">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-vetneb-ink">
+                        {plan.name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {plan.completedStops}/{plan.totalStops} paradas ·{" "}
+                        {progress}% · {formatDate(plan.plannedDate)}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={getRoutePlanStatusVariant(plan.status)}
+                      className="ml-2 shrink-0"
+                    >
+                      {getRoutePlanStatusLabel(plan.status)}
+                    </Badge>
+                  </div>
+                );
+              })
+            ) : (
+              <EmptyState
+                title="Sin planes de ruta"
+                description="No hay planes de ruta disponibles."
+                icon={Route}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -1,27 +1,18 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import {
-  BarChart3,
-  MapPinned,
-  Truck,
-  type LucideIcon,
-} from "lucide-react";
+import { BarChart3, MapPinned, Truck } from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
-import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
+import {
+  StickyActionBar,
+  type StickyActionBarAction,
+} from "@/components/dashboard/StickyActionBar";
 import { ROUTES } from "@/lib/routes";
 import {
   getLogisticsFieldVisits,
   getRoutePlans,
 } from "@/lib/api";
-import {
-  getFieldVisitStatusLabel,
-  getFieldVisitStatusVariant,
-  getRoutePlanStatusLabel,
-  getRoutePlanStatusVariant,
-  formatDate,
-} from "@/lib/utils";
+import { LogisticsCommandCenter } from "./LogisticsCommandCenter";
 
 export const metadata: Metadata = {
   title: "Logística — Portal VETNEB",
@@ -71,35 +62,30 @@ export default async function LogisticaPage() {
   const activePlans = routePlans.filter(
     (p) => p.status === "in_progress" || p.status === "released",
   );
-  const logisticsModules = [
+
+  const logisticsQuickActions = [
     {
-      title: "Visitas de campo",
+      label: "Ver visitas",
       href: ROUTES.dashboardLogisticaVisitas,
-      icon: Truck,
-      description: "Seguimiento de visitas programadas y en curso.",
-      count: fieldVisits.length,
+      variant: "default",
+      icon: <Truck className="h-4 w-4" aria-hidden="true" />,
+      "aria-label": "Ir a visitas de campo",
     },
     {
-      title: "Planes de ruta",
+      label: "Ver rutas",
       href: ROUTES.dashboardLogisticaRutas,
-      icon: MapPinned,
-      description: "Planificación y gestión de rutas de entrega.",
-      count: routePlans.length,
+      variant: "outline",
+      icon: <MapPinned className="h-4 w-4" aria-hidden="true" />,
+      "aria-label": "Ir a planes de ruta",
     },
     {
-      title: "Métricas",
+      label: "Ver métricas",
       href: ROUTES.dashboardLogisticaMetricas,
-      icon: BarChart3,
-      description: "Cumplimiento, SLA y reportes operativos.",
-      count: null,
+      variant: "outline",
+      icon: <BarChart3 className="h-4 w-4" aria-hidden="true" />,
+      "aria-label": "Ir a métricas de logística",
     },
-  ] satisfies Array<{
-    title: string;
-    href: string;
-    icon: LucideIcon;
-    description: string;
-    count: number | null;
-  }>;
+  ] satisfies StickyActionBarAction[];
 
   return (
     <>
@@ -109,175 +95,21 @@ export default async function LogisticaPage() {
         notifications="clinic"
       />
       <main className="dashboard-main">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
-                Visitas activas
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
-                {activeVisits.length}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
-                Planes activos
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
-                {activePlans.length}
-              </p>
-            </CardContent>
-          </Card>
-          <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
-                Visitas totales
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
-                {fieldVisits.length}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {logisticsModules.map((module) => {
-            const Icon = module.icon;
-
-            return (
-              <Card key={module.href} className="dashboard-surface h-full">
-                <CardHeader>
-                  <span
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-vetneb-teal/25 bg-vetneb-teal/10 text-vetneb-teal"
-                    aria-hidden="true"
-                  >
-                    <Icon className="h-5 w-5" />
-                  </span>
-                  <CardTitle className="text-base">{module.title}</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <p className="text-sm text-muted-foreground">
-                    {module.description}
-                  </p>
-                  {module.count !== null && (
-                    <p className="text-2xl font-bold text-vetneb-ink">
-                      {module.count}
-                    </p>
-                  )}
-                  <PublicRouteControl
-                    href={module.href}
-                    variant="bare"
-                    className="inline-flex h-9 w-full items-center justify-center rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground"
-                  >
-                    Ver módulo
-                  </PublicRouteControl>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
-
-        <Card className="dashboard-surface">
-          <CardHeader className="flex flex-row items-center justify-between pb-4">
-            <CardTitle className="text-base">Visitas recientes</CardTitle>
-            <PublicRouteControl
-              href={ROUTES.dashboardLogisticaVisitas}
-              variant="bare"
-              className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
-            >
-              Ver todas
-            </PublicRouteControl>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {fieldVisitsLoadError ? (
-              <p role="alert" className="clinical-alert-warning">
-                No se pudieron cargar las visitas recientes. Intente nuevamente.
-              </p>
-            ) : fieldVisits.length ? (
-              fieldVisits.slice(0, 4).map((visit) => (
-                <div
-                  key={visit.id}
-                  className="dashboard-list-row"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-vetneb-ink">
-                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {visit.address ?? "Sin dirección"} ·{" "}
-                      {formatDate(visit.scheduledAt)}
-                    </p>
-                  </div>
-                  <Badge
-                    variant={getFieldVisitStatusVariant(visit.status)}
-                    className="ml-2 shrink-0"
-                  >
-                    {getFieldVisitStatusLabel(visit.status)}
-                  </Badge>
-                </div>
-              ))
-            ) : (
-              <p className="surface-empty">
-                No hay visitas recientes disponibles.
-              </p>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="dashboard-surface">
-          <CardHeader className="flex flex-row items-center justify-between pb-4">
-            <CardTitle className="text-base">Planes de ruta</CardTitle>
-            <PublicRouteControl
-              href={ROUTES.dashboardLogisticaRutas}
-              variant="bare"
-              className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
-            >
-              Ver todos
-            </PublicRouteControl>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {routePlansLoadError ? (
-              <p role="alert" className="clinical-alert-warning">
-                No se pudieron cargar los planes de ruta recientes. Intente nuevamente.
-              </p>
-            ) : routePlans.length ? (
-              routePlans.map((plan) => (
-                <div
-                  key={plan.id}
-                  className="dashboard-list-row"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-vetneb-ink">
-                      {plan.name}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {plan.completedStops}/{plan.totalStops} paradas ·{" "}
-                      {formatDate(plan.plannedDate)}
-                    </p>
-                  </div>
-                  <Badge
-                    variant={getRoutePlanStatusVariant(plan.status)}
-                    className="ml-2 shrink-0"
-                  >
-                    {getRoutePlanStatusLabel(plan.status)}
-                  </Badge>
-                </div>
-              ))
-            ) : (
-              <p className="surface-empty">
-                No hay planes de ruta disponibles.
-              </p>
-            )}
-          </CardContent>
-        </Card>
+        <DashboardPageHeader
+          title="Hub de logística"
+          description="Estado operativo de visitas de campo, planes de ruta y métricas de cumplimiento."
+        />
+        <StickyActionBar
+          context="Acciones rápidas"
+          actions={logisticsQuickActions}
+        />
+        <LogisticsCommandCenter
+          fieldVisits={fieldVisits}
+          routePlans={routePlans}
+          fieldVisitsLoadError={fieldVisitsLoadError}
+          routePlansLoadError={routePlansLoadError}
+        />
+        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -7,6 +7,8 @@ const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
 const CLINIC_COMMAND_CENTER_PATH = "frontend/src/app/dashboard/ClinicCommandCenter.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
 const LOGISTICA_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
+const LOGISTICS_COMMAND_CENTER_PATH =
+  "frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -58,17 +60,25 @@ test("dashboard informes page shows empty state when reports are unavailable", (
 });
 
 test("dashboard logistics page distinguishes overview load failures from empty states", () => {
-  const source = read(LOGISTICA_PAGE_PATH);
+  const pageSource = read(LOGISTICA_PAGE_PATH);
+  const commandCenterSource = read(LOGISTICS_COMMAND_CENTER_PATH);
 
-  assert.ok(source.includes("fieldVisitsLoadError ?"));
-  assert.ok(source.includes("routePlansLoadError ?"));
-  assert.ok(source.includes("fieldVisits.length ?"));
-  assert.ok(source.includes("routePlans.length ?"));
-  assert.ok(source.includes("No se pudieron cargar las visitas recientes. Intente nuevamente."));
-  assert.ok(source.includes("No se pudieron cargar los planes de ruta recientes. Intente nuevamente."));
-  assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("No hay visitas recientes disponibles."));
-  assert.ok(source.includes("No hay planes de ruta disponibles."));
-  assert.ok(source.includes("fieldVisits.slice(0, 4).map((visit)"));
-  assert.ok(source.includes("routePlans.map((plan)"));
+  // Page tracks load errors and passes them to LogisticsCommandCenter
+  assert.ok(pageSource.includes("let fieldVisitsLoadError = false;"));
+  assert.ok(pageSource.includes("let routePlansLoadError = false;"));
+  assert.ok(pageSource.includes("fieldVisitsLoadError={fieldVisitsLoadError}"));
+  assert.ok(pageSource.includes("routePlansLoadError={routePlansLoadError}"));
+
+  // LogisticsCommandCenter handles rendering with error and empty states
+  assert.ok(commandCenterSource.includes("fieldVisitsLoadError ?"));
+  assert.ok(commandCenterSource.includes("routePlansLoadError ?"));
+  assert.ok(commandCenterSource.includes("recentVisits.length ?"));
+  assert.ok(commandCenterSource.includes("recentPlans.length ?"));
+  assert.ok(commandCenterSource.includes("No se pudieron cargar las visitas de campo. Intente nuevamente."));
+  assert.ok(commandCenterSource.includes("No se pudieron cargar los planes de ruta. Intente nuevamente."));
+  assert.ok(commandCenterSource.includes('role="alert"'));
+  assert.ok(commandCenterSource.includes("No hay visitas de campo disponibles."));
+  assert.ok(commandCenterSource.includes("No hay planes de ruta disponibles."));
+  assert.ok(commandCenterSource.includes("recentVisits.map((visit)"));
+  assert.ok(commandCenterSource.includes("recentPlans.map((plan)"));
 });

--- a/test/frontend-dashboard-logistica.test.ts
+++ b/test/frontend-dashboard-logistica.test.ts
@@ -17,12 +17,15 @@ test("dashboard logistica defines non-indexable metadata and dependencies", () =
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
-  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('} from "lucide-react";'));
   assert.ok(source.includes('title: "Logística — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
+  assert.ok(source.includes('import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";'));
+  assert.ok(source.includes('import {'));
+  assert.ok(source.includes('StickyActionBar'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
+  assert.ok(source.includes('import { LogisticsCommandCenter } from "./LogisticsCommandCenter";'));
 });
 
 test("dashboard logistica forwards cookies and disables cache for live reads", () => {
@@ -56,63 +59,49 @@ test("dashboard logistica computes active visits and active route plans explicit
   assert.ok(source.includes('v.status === "in_progress" || v.status === "scheduled"'));
   assert.ok(source.includes("const activePlans = routePlans.filter("));
   assert.ok(source.includes('p.status === "in_progress" || p.status === "released"'));
-  assert.ok(source.includes("Visitas activas"));
-  assert.ok(source.includes("Planes activos"));
-  assert.ok(source.includes("Visitas totales"));
 });
 
-test("dashboard logistica exposes module cards through route registry", () => {
+test("dashboard logistica composes command center, sticky actions, and page header", () => {
   const source = read(LOGISTICA_PAGE_PATH);
+  const mainSource = source.slice(source.indexOf('<main className="dashboard-main">'));
 
-  assert.ok(source.includes("const logisticsModules = ["));
-  assert.ok(source.includes("icon: Truck"));
-  assert.ok(source.includes("icon: MapPinned"));
-  assert.ok(source.includes("icon: BarChart3"));
-  assert.ok(source.includes('title: "Visitas de campo"'));
+  assert.ok(source.includes("<DashboardPageHeader"));
+  assert.ok(source.includes('title="Hub de logística"'));
+  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes('context="Acciones rápidas"'));
+  assert.ok(source.includes("<LogisticsCommandCenter"));
+  assert.ok(source.includes("const logisticsQuickActions = ["));
+  assert.ok(source.includes('label: "Ver visitas"'));
   assert.ok(source.includes("href: ROUTES.dashboardLogisticaVisitas"));
-  assert.ok(source.includes('title: "Planes de ruta"'));
+  assert.ok(source.includes('label: "Ver rutas"'));
   assert.ok(source.includes("href: ROUTES.dashboardLogisticaRutas"));
-  assert.ok(source.includes('title: "Métricas"'));
+  assert.ok(source.includes('label: "Ver métricas"'));
   assert.ok(source.includes("href: ROUTES.dashboardLogisticaMetricas"));
-  assert.ok(source.includes("Ver módulo"));
-  assert.ok(source.includes('className="dashboard-surface h-full"'));
-  assert.equal(source.includes("🚐"), false);
-  assert.equal(source.includes("🗺"), false);
-  assert.equal(source.includes("📊"), false);
+
+  const order = [
+    "<DashboardPageHeader",
+    "<StickyActionBar",
+    "<LogisticsCommandCenter",
+  ].map((marker) => mainSource.indexOf(marker));
+
+  for (const index of order) {
+    assert.ok(index >= 0, `main source must contain ordered marker at index ${index}`);
+  }
+
+  assert.deepEqual(
+    order,
+    [...order].sort((a, b) => a - b),
+    "logistics hub order must be: header, sticky bar, command center",
+  );
 });
 
-test("dashboard logistica renders recent visits with status badges dates and empty state", () => {
+test("dashboard logistica passes all data props to LogisticsCommandCenter", () => {
   const source = read(LOGISTICA_PAGE_PATH);
 
-  assert.ok(source.includes("Visitas recientes"));
-  assert.ok(source.includes("fieldVisits.slice(0, 4).map((visit) =>"));
-  assert.ok(source.includes("visit.clinicName ?? `Clínica #${visit.clinicId}`"));
-  assert.ok(source.includes('visit.address ?? "Sin dirección"'));
-  assert.ok(source.includes("formatDate(visit.scheduledAt)"));
-  assert.ok(source.includes("getFieldVisitStatusVariant(visit.status)"));
-  assert.ok(source.includes("getFieldVisitStatusLabel(visit.status)"));
-  assert.ok(source.includes('className="dashboard-list-row"'));
-  assert.ok(source.includes("fieldVisitsLoadError ?"));
-  assert.ok(source.includes("No se pudieron cargar las visitas recientes. Intente nuevamente."));
-  assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("No hay visitas recientes disponibles."));
-});
-
-test("dashboard logistica renders route plans with status badges dates and empty state", () => {
-  const source = read(LOGISTICA_PAGE_PATH);
-
-  assert.ok(source.includes("Planes de ruta"));
-  assert.ok(source.includes("routePlans.map((plan) =>"));
-  assert.ok(source.includes("{plan.name}"));
-  assert.ok(source.includes("{plan.completedStops}/{plan.totalStops} paradas"));
-  assert.ok(source.includes("formatDate(plan.plannedDate)"));
-  assert.ok(source.includes("getRoutePlanStatusVariant(plan.status)"));
-  assert.ok(source.includes("getRoutePlanStatusLabel(plan.status)"));
-  assert.ok(source.includes('className="dashboard-list-row"'));
-  assert.ok(source.includes("routePlansLoadError ?"));
-  assert.ok(source.includes("No se pudieron cargar los planes de ruta recientes. Intente nuevamente."));
-  assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("No hay planes de ruta disponibles."));
+  assert.ok(source.includes("fieldVisits={fieldVisits}"));
+  assert.ok(source.includes("routePlans={routePlans}"));
+  assert.ok(source.includes("fieldVisitsLoadError={fieldVisitsLoadError}"));
+  assert.ok(source.includes("routePlansLoadError={routePlansLoadError}"));
 });
 
 test("dashboard logistica avoids direct client-side fetch literals", () => {
@@ -122,12 +111,33 @@ test("dashboard logistica avoids direct client-side fetch literals", () => {
   assert.equal(source.includes('"/api"'), false);
 });
 
-test("dashboard logistica uses clinical operational surfaces", () => {
+test("dashboard logistica does not use next/link or bare anchor tags for navigation", () => {
   const source = read(LOGISTICA_PAGE_PATH);
 
-  assert.ok(source.includes('className="dashboard-metric-card p-0"'));
-  assert.ok(source.includes('className="dashboard-surface"'));
-  assert.ok(source.includes('className="text-3xl font-bold text-vetneb-ink"'));
+  assert.equal(source.includes('import Link from "next/link"'), false);
+  assert.equal(source.includes('import Link from \'next/link\''), false);
+  assert.equal(source.includes('<a href='), false);
+});
+
+test("dashboard logistica does not reference public routes, middleware or auth", () => {
+  const source = read(LOGISTICA_PAGE_PATH);
+
+  assert.equal(source.includes('@/components/public/'), false);
+  assert.equal(source.includes('PublicRouteControl'), false);
+  assert.equal(source.includes('from "next-auth"'), false);
+  assert.equal(source.includes('middleware'), false);
+});
+
+test("dashboard logistica scope stays inside frontend dashboard", () => {
+  const source = read(LOGISTICA_PAGE_PATH);
+
+  assert.equal(source.includes('from "@/app/api'), false);
+  assert.equal(source.includes("process.env"), false);
+  assert.equal(source.includes("revalidatePath"), false);
+  assert.equal(source.includes("revalidateTag"), false);
   assert.equal(source.includes("border-gray-100"), false);
   assert.equal(source.includes("border-gray-50"), false);
+  assert.equal(source.includes("🚐"), false);
+  assert.equal(source.includes("🗺"), false);
+  assert.equal(source.includes("📊"), false);
 });

--- a/test/frontend-dashboard-logistics-hub.test.ts
+++ b/test/frontend-dashboard-logistics-hub.test.ts
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const LOGISTICS_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
+const COMMAND_CENTER_PATH =
+  "frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx";
+const STICKY_ACTION_BAR_PATH =
+  "frontend/src/components/dashboard/StickyActionBar.tsx";
+const DASHBOARD_PAGE_HEADER_PATH =
+  "frontend/src/components/dashboard/DashboardPageHeader.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertNoForbiddenSurfaceImports(source: string, context: string): void {
+  const importLines = source
+    .split("\n")
+    .filter((line) => line.trim().startsWith("import "));
+  const forbiddenPatterns = [
+    /@\/app\/api/,
+    /@\/middleware/,
+    /@\/lib\/auth/,
+    /@\/components\/public/,
+    /\.\.\/.*\/auth/,
+    /\.\.\/.*\/middleware/,
+    /\.\.\/.*\/public/,
+  ];
+
+  for (const line of importLines) {
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(
+        pattern.test(line),
+        false,
+        `${context} must not import forbidden surface via: ${line}`,
+      );
+    }
+  }
+}
+
+// ── Existence and scope boundaries ──────────────────────────────────────────
+
+test("LogisticsCommandCenter file exists at app/dashboard/logistica location", () => {
+  const source = read(COMMAND_CENTER_PATH);
+  assert.ok(source.length > 0);
+});
+
+test("LogisticsCommandCenter does not import from API, auth, public, or middleware modules", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.equal(source.includes('from "@/lib/api"'), false);
+  assert.equal(source.includes('from "@/app/api'), false);
+  assert.equal(source.includes("middleware"), false);
+  assert.equal(source.includes('from "next/headers"'), false);
+  assert.equal(source.includes('from "next-auth"'), false);
+  assert.equal(source.includes('import { cookies }'), false);
+  assert.equal(source.includes('@/components/public/'), false);
+  assert.equal(source.includes('PublicRouteControl'), false);
+});
+
+test("LogisticsCommandCenter does not perform data fetching", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("await "), false);
+  assert.equal(source.includes("getLogisticsFieldVisits"), false);
+  assert.equal(source.includes("getRoutePlans"), false);
+});
+
+test("LogisticsCommandCenter is not a client component", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.equal(source.includes('"use client"'), false);
+  assert.equal(source.includes("'use client'"), false);
+});
+
+test("LogisticsCommandCenter does not reference app/api routes or server-only functions", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.equal(source.includes("/api/"), false);
+  assert.equal(source.includes("process.env"), false);
+  assert.equal(source.includes("revalidatePath"), false);
+  assert.equal(source.includes("revalidateTag"), false);
+});
+
+// ── Props contract ───────────────────────────────────────────────────────────
+
+test("LogisticsCommandCenter exports typed props and component", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("export type LogisticsCommandCenterProps = {"));
+  assert.ok(source.includes("export function LogisticsCommandCenter("));
+  assert.ok(source.includes("fieldVisits: FieldVisit[];"));
+  assert.ok(source.includes("routePlans: RoutePlan[];"));
+  assert.ok(source.includes("fieldVisitsLoadError: boolean;"));
+  assert.ok(source.includes("routePlansLoadError: boolean;"));
+});
+
+test("LogisticsCommandCenter imports types from @/types only (no server-only imports)", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes('import type { FieldVisit, RoutePlan } from "@/types";'));
+});
+
+// ── Operational priority section ─────────────────────────────────────────────
+
+test("LogisticsCommandCenter renders operational priority section with KPI pills", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("Estado operativo logística"));
+  assert.ok(source.includes("Priorice visitas activas y planes en curso"));
+  assert.ok(source.includes("logistics-operational-priority"));
+  assert.ok(source.includes("Visitas activas"));
+  assert.ok(source.includes("Planes activos"));
+  assert.ok(source.includes("Total visitas"));
+  assert.ok(source.includes("dashboard-kpi-pill"));
+  assert.ok(source.includes('data-tone="focus"'));
+  assert.ok(source.includes('data-tone="critical"'));
+  assert.ok(source.includes("{activeVisits.length}"));
+  assert.ok(source.includes("{activePlans.length}"));
+  assert.ok(source.includes("{fieldVisits.length}"));
+});
+
+test("LogisticsCommandCenter computes active visits and plans from props without fetch", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("const activeVisits = fieldVisits.filter("));
+  assert.ok(source.includes('v.status === "in_progress" || v.status === "scheduled"'));
+  assert.ok(source.includes("const activePlans = routePlans.filter("));
+  assert.ok(source.includes('p.status === "in_progress" || p.status === "released"'));
+});
+
+// ── Section heading ──────────────────────────────────────────────────────────
+
+test("LogisticsCommandCenter renders section heading with aria labelling", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("<section"));
+  assert.ok(source.includes('aria-labelledby="logistics-command-center-heading"'));
+  assert.ok(source.includes("logistics-command-center-heading"));
+  assert.ok(source.includes("Centro de logística"));
+  assert.ok(source.includes("dashboard-section-heading"));
+  assert.ok(source.includes("dashboard-section-description"));
+});
+
+// ── Visits list ──────────────────────────────────────────────────────────────
+
+test("LogisticsCommandCenter renders visit list limited to 5 items with StatusBadge", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("Visitas de campo"));
+  assert.ok(source.includes("const recentVisits = fieldVisits.slice(0, 5);"));
+  assert.ok(source.includes("recentVisits.map((visit) =>"));
+  assert.ok(source.includes("{visit.clinicName ?? `Clínica #${visit.clinicId}`}"));
+  assert.ok(source.includes('visit.address ?? "Sin dirección"'));
+  assert.ok(source.includes("formatDate(visit.scheduledAt)"));
+  assert.ok(source.includes("status={visit.status}"));
+  assert.ok(source.includes('import { StatusBadge } from "@/components/dashboard/StatusBadge";'));
+  assert.ok(source.includes('className="dashboard-list-row"'));
+});
+
+test("LogisticsCommandCenter shows visits error alert with role=alert", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("fieldVisitsLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar las visitas de campo. Intente nuevamente."));
+  assert.ok(source.includes('role="alert"'));
+});
+
+test("LogisticsCommandCenter renders EmptyState for missing visits", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes('import { EmptyState } from "@/components/dashboard/EmptyState";'));
+  assert.ok(source.includes("Sin visitas activas"));
+  assert.ok(source.includes("No hay visitas de campo disponibles."));
+});
+
+// ── Route plans list ─────────────────────────────────────────────────────────
+
+test("LogisticsCommandCenter renders route plans list limited to 5 items with status badge", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("Planes de ruta"));
+  assert.ok(source.includes("const recentPlans = routePlans.slice(0, 5);"));
+  assert.ok(source.includes("recentPlans.map((plan) =>"));
+  assert.ok(source.includes("{plan.name}"));
+  assert.ok(source.includes("{plan.completedStops}/{plan.totalStops} paradas"));
+  assert.ok(source.includes("formatDate(plan.plannedDate)"));
+  assert.ok(source.includes("getRoutePlanStatusVariant(plan.status)"));
+  assert.ok(source.includes("getRoutePlanStatusLabel(plan.status)"));
+  assert.ok(source.includes('className="dashboard-list-row"'));
+});
+
+test("LogisticsCommandCenter shows route plans error alert with role=alert", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("routePlansLoadError ?"));
+  assert.ok(source.includes("No se pudieron cargar los planes de ruta. Intente nuevamente."));
+});
+
+test("LogisticsCommandCenter renders EmptyState for missing route plans", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("Sin planes de ruta"));
+  assert.ok(source.includes("No hay planes de ruta disponibles."));
+});
+
+// ── Layout contract ──────────────────────────────────────────────────────────
+
+test("LogisticsCommandCenter uses two-column responsive grid for visits and plans", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("grid grid-cols-1 gap-6 lg:grid-cols-2"));
+  assert.ok(source.includes("dashboard-surface"));
+  assert.ok(source.includes("dashboard-list-row"));
+});
+
+test("LogisticsCommandCenter does not use next/link or bare anchor tags", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.equal(source.includes('from "next/link"'), false);
+  assert.equal(source.includes('<a href='), false);
+  assert.equal(source.includes("<Link"), false);
+});
+
+// ── page.tsx integration contract ───────────────────────────────────────────
+
+test("logistics page imports and uses LogisticsCommandCenter with full data prop set", () => {
+  const source = read(LOGISTICS_PAGE_PATH);
+
+  assert.ok(source.includes('import { LogisticsCommandCenter } from "./LogisticsCommandCenter";'));
+  assert.ok(source.includes("<LogisticsCommandCenter"));
+  assert.ok(source.includes("fieldVisits={fieldVisits}"));
+  assert.ok(source.includes("routePlans={routePlans}"));
+  assert.ok(source.includes("fieldVisitsLoadError={fieldVisitsLoadError}"));
+  assert.ok(source.includes("routePlansLoadError={routePlansLoadError}"));
+});
+
+test("logistics page uses DashboardPageHeader and StickyActionBar above LogisticsCommandCenter", () => {
+  const source = read(LOGISTICS_PAGE_PATH);
+
+  assert.ok(source.includes('<DashboardPageHeader'));
+  assert.ok(source.includes('title="Hub de logística"'));
+  assert.ok(source.includes('<StickyActionBar'));
+  assert.ok(source.includes('context="Acciones rápidas"'));
+  assert.ok(source.includes("href: ROUTES.dashboardLogisticaVisitas"));
+  assert.ok(source.includes("href: ROUTES.dashboardLogisticaRutas"));
+  assert.ok(source.includes("href: ROUTES.dashboardLogisticaMetricas"));
+  assert.equal(source.includes('import Link from "next/link"'), false);
+  assert.equal(source.includes('<a href='), false);
+});
+
+test("logistics page does not use next/link or bare anchor tags for navigation", () => {
+  const source = read(LOGISTICS_PAGE_PATH);
+
+  assert.equal(source.includes('import Link from "next/link"'), false);
+  assert.equal(source.includes('import Link from \'next/link\''), false);
+  assert.equal(source.includes('<a href='), false);
+});
+
+// ── DashboardPageHeader contract passthrough ─────────────────────────────────
+
+test("DashboardPageHeader exports typed props and component", () => {
+  const source = read(DASHBOARD_PAGE_HEADER_PATH);
+
+  assert.ok(source.includes("export type DashboardPageHeaderProps = {"));
+  assert.ok(source.includes("export function DashboardPageHeader("));
+  assert.ok(source.includes("title: string;"));
+  assert.ok(source.includes("description?: string;"));
+  assert.ok(source.includes("badge?: ReactNode;"));
+  assert.ok(source.includes("actions?: ReactNode;"));
+});
+
+// ── Scope invariants ─────────────────────────────────────────────────────────
+
+test("logistics hub changes stay inside frontend scope (no package or dep changes)", () => {
+  const commandCenterSource = read(COMMAND_CENTER_PATH);
+  const stickyActionBarSource = read(STICKY_ACTION_BAR_PATH);
+  const packageDiff = execFileSync(
+    "git",
+    ["diff", "--name-only", "--", "package.json", "pnpm-lock.yaml"],
+    { encoding: "utf8" },
+  ).trim();
+
+  assertNoForbiddenSurfaceImports(commandCenterSource, "LogisticsCommandCenter");
+  assertNoForbiddenSurfaceImports(stickyActionBarSource, "StickyActionBar");
+  assert.equal(
+    packageDiff.length,
+    0,
+    `package.json and pnpm-lock.yaml must not be modified: ${packageDiff}`,
+  );
+});
+
+test("logistics hub changes do not touch backend, API routes, auth, middleware or SEO files", () => {
+  const changedFiles = execFileSync(
+    "git",
+    ["diff", "--name-only"],
+    { encoding: "utf8" },
+  ).trim();
+
+  const forbiddenPaths = [
+    "server/",
+    "middleware.ts",
+    "next.config",
+    "app/api/",
+    "app/login",
+    "app/servicios",
+    "app/profesionales",
+    "app/clinicas",
+    "app/particulares",
+    "app/contacto",
+    "pnpm-lock.yaml",
+    "next-env.d.ts",
+  ];
+
+  for (const path of forbiddenPaths) {
+    const matching = changedFiles
+      .split("\n")
+      .filter((f) => f.includes(path));
+    assert.equal(
+      matching.length,
+      0,
+      `logistics hub must not modify ${path}: found ${matching.join(", ")}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Add LogisticsCommandCenter for the private logistics dashboard hub
- Reorganize /dashboard/logistica around DashboardPageHeader, StickyActionBar, operational KPIs and compact logistics modules
- Preserve existing fetches, auth behavior, routes and business logic
- Keep logistics actions limited to existing routes: visits, routes and metrics
- Add native contract tests and PR implementation documentation

## Scope
- No backend changes
- No API route changes
- No auth/session changes
- No middleware changes
- No SEO/public route changes
- No dependency changes
- No package.json or pnpm-lock.yaml changes
- No next-env.d.ts changes
- No map/kanban/filter drawer implementation

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build