### PR TITLE
feat(dashboard): filter drawer and sticky filters

### DIFF
--- a/docs/pr-6-dashboard-filter-drawer-sticky-filters.md
+++ b/docs/pr-6-dashboard-filter-drawer-sticky-filters.md
@@ -1,0 +1,95 @@
+# PR-6 - feat(dashboard): filter drawer and sticky filters
+
+## Resumen
+
+PR-6 crea una foundation reusable para filtros premium en dashboards privados y la integra de forma conservadora en `/dashboard/informes`.
+
+La pagina mantiene los fetches existentes, cookies, `searchParams`, query params, seleccion de informe, `MasterDetailWorkspace`, `StudyTimeline`, `StickyActionBar` y acciones reales de archivo. El formulario GET de filtros se reubica en un drawer accionado desde una barra sticky con resumen de filtros activos.
+
+## Archivos modificados
+
+| Archivo | Accion |
+|---|---|
+| `frontend/src/components/dashboard/FilterDrawer.tsx` | Nuevo componente reusable de drawer de filtros |
+| `frontend/src/components/dashboard/StickyFilterBar.tsx` | Nuevo componente reusable sticky para resumen de filtros |
+| `frontend/src/app/dashboard/informes/page.tsx` | Integra filtros existentes dentro de `FilterDrawer` y `StickyFilterBar` |
+| `test/frontend-dashboard-filter-drawer-sticky-filters.test.ts` | Tests de contrato de PR-6 |
+| `docs/pr-6-dashboard-filter-drawer-sticky-filters.md` | Documento de entrega |
+
+## Componentes creados
+
+### FilterDrawer
+
+- Client component aislado solo para abrir/cerrar el drawer.
+- Presentacional: no hace fetch, no importa API/auth/middleware/public components y no contiene logica de negocio.
+- Expone `title`, `description`, `triggerLabel`, `activeCount`, `children`, `footer` y `className`.
+- Usa `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`, trigger con `aria-haspopup`, `aria-expanded` y estilos `focus-visible`.
+- Renderiza texto visible en trigger y cierre.
+
+### StickyFilterBar
+
+- Server-compatible y presentacional.
+- Expone `ActiveFilter`, `activeFilters`, `actions`, `drawer`, `title` y `className`.
+- Muestra chips de filtros activos o `Sin filtros activos`.
+- Incluye slot de `drawer` y slot de `actions`.
+- Usa layout sticky responsive sin fetch, sin dependencias nuevas y sin `next/link` ni tags `<a>`.
+
+## Decisiones tecnicas
+
+- El drawer es el unico componente con `"use client"` porque la interaccion local se limita a abrir/cerrar.
+- `StickyFilterBar` queda sin estado ni fetch para poder reutilizarla en otros dashboards privados.
+- Los filtros se colocan antes de `MasterDetailWorkspace` para que la lista y el detalle no compitan por espacio con el formulario.
+- No se agregaron librerias UI, animacion ni headless components.
+- No se uso `next/link`, `<a>` ni `Button asChild`.
+- No se usaron gradientes decorativos ni `shadow-xl`.
+
+## Filtros y query params
+
+- Se conservaron los query params existentes: `query`, `status`, `studyType` y `reportId`.
+- El formulario sigue usando `method="get"`.
+- Los campos accionables siguen siendo los existentes: busqueda (`query`) y estado (`status`).
+- `studyType` se conserva como parametro reconocido y se muestra en el resumen si viene activo, sin inventar un control nuevo.
+- `reportId` sigue siendo seleccion de detalle, no filtro visual.
+- `buildInformesHref` conserva `query`, `status`, `studyType` y `reportId` al seleccionar informes, igual que antes.
+- `searchReports` y `getReports` se mantienen con los mismos parametros y `requestOptions`.
+
+## Validaciones
+
+Resultados de validacion ejecutados durante PR-6:
+
+```
+git diff --stat                         PASS
+git diff --check                        PASS
+pnpm test                               PASS
+pnpm build                              PASS
+pnpm security:public-surface            PASS
+pnpm --dir frontend lint                PASS
+pnpm --dir frontend typecheck           PASS
+pnpm --dir frontend build               PASS
+git status --short                      PASS
+git diff --name-only                    PASS
+git ls-files --others --exclude-standard PASS
+```
+
+Notas:
+
+- `pnpm test`: 2379 tests, 2378 pass, 1 skipped, 0 fail.
+- `pnpm build`: backend bundle generado correctamente en `dist/index.js`.
+- `pnpm security:public-surface`: PASS; mantiene dos findings informativos `server-only` ya clasificados para `frontend/src/proxy.ts`.
+- `pnpm --dir frontend build`: Next.js 16.2.7 compilo y genero rutas correctamente.
+
+## Riesgos residuales
+
+- El drawer no bloquea scroll de fondo ni aplica focus trap, para evitar nuevas dependencias y mantener el cambio minimo.
+- `studyType` puede aparecer como chip si llega por URL, pero no se agrego un nuevo campo porque no existia como control visual previo.
+
+## Confirmacion de scope
+
+- No se tocaron backend, API routes, auth, middleware ni SEO.
+- No se tocaron rutas publicas.
+- No se tocaron endpoints ni logica de negocio.
+- No se tocaron calculos de fechas.
+- No se modificaron `package.json`, `pnpm-lock.yaml` ni `next-env.d.ts`.
+- No se instalaron dependencias.
+- No se redisenaron admin, logistica ni clinica.
+- No se hizo commit, push ni PR.

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -5,11 +5,16 @@ import { FileText, ListChecks } from "lucide-react";
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ErrorState } from "@/components/dashboard/ErrorState";
+import { FilterDrawer } from "@/components/dashboard/FilterDrawer";
 import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import {
+  StickyFilterBar,
+  type ActiveFilter,
+} from "@/components/dashboard/StickyFilterBar";
 import {
   StickyActionBar,
   type StickyActionBarAction,
@@ -77,6 +82,35 @@ function normalizeReportIdFilter(value: string) {
   const reportId = Number(value);
 
   return Number.isInteger(reportId) && reportId > 0 ? reportId : null;
+}
+
+function getStatusFilterLabel(value: string) {
+  return statusOptions.find((option) => option.value === value)?.label ?? value;
+}
+
+function buildActiveFilters(input: {
+  query: string;
+  status: string;
+  studyType: string;
+}): ActiveFilter[] {
+  const activeFilters: ActiveFilter[] = [];
+
+  if (input.query) {
+    activeFilters.push({ label: "Búsqueda", value: input.query });
+  }
+
+  if (input.status) {
+    activeFilters.push({
+      label: "Estado",
+      value: getStatusFilterLabel(input.status),
+    });
+  }
+
+  if (input.studyType) {
+    activeFilters.push({ label: "Tipo de estudio", value: input.studyType });
+  }
+
+  return activeFilters;
 }
 
 function buildInformesHref(input: {
@@ -229,6 +263,7 @@ export default async function InformesPage({
   const selectedReportTimelineSteps = selectedReport
     ? buildStudyTimelineSteps(selectedReport)
     : [];
+  const activeFilters = buildActiveFilters({ query, status, studyType });
   const stickyActions = [
     {
       label: "Lista",
@@ -284,6 +319,66 @@ export default async function InformesPage({
           ) : null}
         </StickyActionBar>
 
+        <StickyFilterBar
+          title="Filtros"
+          activeFilters={activeFilters}
+          drawer={
+            <FilterDrawer
+              title="Filtros de informes"
+              description="Búsqueda por paciente o tipo de estudio, y estado operativo."
+              triggerLabel="Filtrar informes"
+              activeCount={activeFilters.length}
+            >
+              <form method="get" className="space-y-4">
+                <label className="block">
+                  <span className="text-sm font-semibold text-vetneb-ink">
+                    Buscar
+                  </span>
+                  <Input
+                    name="query"
+                    defaultValue={query}
+                    placeholder="Buscar por paciente o tipo de estudio..."
+                    className="mt-1 min-w-0"
+                    aria-label="Buscar informes"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-semibold text-vetneb-ink">
+                    Estado
+                  </span>
+                  <select
+                    name="status"
+                    defaultValue={status}
+                    className="field-select mt-1"
+                    aria-label="Filtrar por estado"
+                  >
+                    {statusOptions.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
+                  <PublicRouteControl
+                    href="/dashboard/informes"
+                    replace
+                    variant="bare"
+                    className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+                  >
+                    Limpiar
+                  </PublicRouteControl>
+                  <Button type="submit" size="sm">
+                    Filtrar
+                  </Button>
+                </div>
+              </form>
+            </FilterDrawer>
+          }
+        />
+
         <MasterDetailWorkspace
           selectedId={selectedReportIdValue}
           master={
@@ -293,46 +388,9 @@ export default async function InformesPage({
                   Informes ({reports.length})
                 </h2>
                 <p className="dashboard-section-description">
-                  Lista clinic-scoped con filtros existentes y selección de detalle.
+                  Lista clinic-scoped con selección de detalle.
                 </p>
               </div>
-
-              <form method="get" className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_14rem] lg:grid-cols-1">
-                  <Input
-                    name="query"
-                    defaultValue={query}
-                    placeholder="Buscar por paciente o tipo de estudio..."
-                    className="min-w-0"
-                    aria-label="Buscar informes"
-                  />
-                  <select
-                    name="status"
-                    defaultValue={status}
-                    className="field-select"
-                    aria-label="Filtrar por estado"
-                  >
-                    {statusOptions.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button type="submit" size="sm">
-                    Filtrar
-                  </Button>
-                  <PublicRouteControl
-                    href="/dashboard/informes"
-                    replace
-                    variant="bare"
-                    className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
-                  >
-                    Limpiar
-                  </PublicRouteControl>
-                </div>
-              </form>
 
               <div className="min-w-0 overflow-x-auto rounded-lg border border-vetneb-line/70">
                 <Table>

--- a/frontend/src/components/dashboard/FilterDrawer.tsx
+++ b/frontend/src/components/dashboard/FilterDrawer.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { SlidersHorizontal, X } from "lucide-react";
+import { useId, useState, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type FilterDrawerProps = {
+  title: string;
+  description?: string;
+  triggerLabel?: string;
+  activeCount?: number;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+};
+
+export function FilterDrawer({
+  title,
+  description,
+  triggerLabel = "Filtros",
+  activeCount = 0,
+  children,
+  footer,
+  className,
+}: FilterDrawerProps) {
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+  const descriptionId = useId();
+  const panelId = useId();
+
+  return (
+    <div className={cn("min-w-0", className)}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen(true)}
+        className="w-full focus-visible:ring-2 focus-visible:ring-ring/85 sm:w-auto"
+      >
+        <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+        <span>{triggerLabel}</span>
+        {activeCount > 0 ? (
+          <span className="ml-1 inline-flex min-w-5 items-center justify-center rounded-md border border-vetneb-teal/30 bg-vetneb-teal/12 px-1.5 text-xs font-semibold text-vetneb-teal">
+            {activeCount}
+          </span>
+        ) : null}
+      </Button>
+
+      {open ? (
+        <div className="fixed inset-0 z-[70]" data-filter-drawer-open="true">
+          <div
+            className="absolute inset-0 bg-vetneb-ink/30 backdrop-blur-[2px]"
+            aria-hidden="true"
+          />
+          <div
+            id={panelId}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={description ? descriptionId : undefined}
+            className="absolute right-0 top-0 flex h-dvh w-full max-w-md flex-col overflow-hidden border-l border-vetneb-line/80 bg-card shadow-lg"
+          >
+            <div className="flex items-start justify-between gap-4 border-b border-vetneb-line/80 px-4 py-4">
+              <div className="min-w-0">
+                <h2 id={titleId} className="text-base font-semibold text-vetneb-ink">
+                  {title}
+                </h2>
+                {description ? (
+                  <p id={descriptionId} className="mt-1 text-sm text-muted-foreground">
+                    {description}
+                  </p>
+                ) : null}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setOpen(false)}
+                className="shrink-0 focus-visible:ring-2 focus-visible:ring-ring/85"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+                <span>Cerrar</span>
+              </Button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+              {children}
+            </div>
+
+            {footer ? (
+              <div className="border-t border-vetneb-line/80 px-4 py-4">
+                {footer}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/StickyFilterBar.tsx
+++ b/frontend/src/components/dashboard/StickyFilterBar.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type ActiveFilter = {
+  label: string;
+  value: string;
+};
+
+export type StickyFilterBarProps = {
+  title?: string;
+  activeFilters?: ActiveFilter[];
+  actions?: ReactNode;
+  drawer?: ReactNode;
+  className?: string;
+};
+
+export function StickyFilterBar({
+  title = "Filtros",
+  activeFilters = [],
+  actions,
+  drawer,
+  className,
+}: StickyFilterBarProps) {
+  return (
+    <section
+      aria-label="Filtros del dashboard"
+      data-sticky-filter-bar="true"
+      className={cn(
+        "sticky top-3 z-40 min-w-0 rounded-lg border border-vetneb-line/80 bg-card/95 px-3 py-3 shadow-sm backdrop-blur md:top-[8.75rem] md:px-4",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 space-y-2">
+          {title ? (
+            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+              {title}
+            </p>
+          ) : null}
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            {activeFilters.length ? (
+              activeFilters.map((filter) => (
+                <span
+                  key={`${filter.label}-${filter.value}`}
+                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-vetneb-line/80 bg-vetneb-surface-muted/80 px-2.5 py-1 text-xs font-semibold text-vetneb-ink"
+                >
+                  <span className="text-muted-foreground">{filter.label}</span>
+                  <span className="min-w-0 truncate">{filter.value}</span>
+                </span>
+              ))
+            ) : (
+              <span className="inline-flex rounded-md border border-vetneb-line/80 bg-vetneb-surface-muted/80 px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+                Sin filtros activos
+              </span>
+            )}
+          </div>
+        </div>
+
+        {drawer || actions ? (
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end [&_button]:focus-visible:ring-2 [&_button]:focus-visible:ring-ring/85">
+            {drawer}
+            {actions}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
+++ b/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const FILTER_DRAWER_PATH = "frontend/src/components/dashboard/FilterDrawer.tsx";
+const STICKY_FILTER_BAR_PATH =
+  "frontend/src/components/dashboard/StickyFilterBar.tsx";
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const DOC_PATH = "docs/pr-6-dashboard-filter-drawer-sticky-filters.md";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertNoForbiddenSurfaceImports(source: string, context: string): void {
+  const importLines = source
+    .split("\n")
+    .filter((line) => line.trim().startsWith("import "));
+  const forbiddenPatterns = [
+    /@\/app\/api/,
+    /@\/middleware/,
+    /@\/lib\/auth/,
+    /@\/components\/public/,
+    /\.\.\/.*\/auth/,
+    /\.\.\/.*\/middleware/,
+    /\.\.\/.*\/public/,
+  ];
+
+  for (const line of importLines) {
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(
+        pattern.test(line),
+        false,
+        `${context} must not import forbidden surface via: ${line}`,
+      );
+    }
+  }
+}
+
+test("FilterDrawer exposes reusable client drawer contract without forbidden surfaces", () => {
+  const source = read(FILTER_DRAWER_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("export type FilterDrawerProps = {"));
+  assert.ok(source.includes("title: string;"));
+  assert.ok(source.includes("description?: string;"));
+  assert.ok(source.includes("triggerLabel?: string;"));
+  assert.ok(source.includes("activeCount?: number;"));
+  assert.ok(source.includes("children: ReactNode;"));
+  assert.ok(source.includes("footer?: ReactNode;"));
+  assert.ok(source.includes("className?: string;"));
+  assert.ok(source.includes('aria-haspopup="dialog"'));
+  assert.ok(source.includes("aria-expanded={open}"));
+  assert.ok(source.includes('role="dialog"'));
+  assert.ok(source.includes('aria-modal="true"'));
+  assert.ok(source.includes("aria-labelledby={titleId}"));
+  assert.ok(source.includes("activeCount > 0"));
+  assert.ok(source.includes("<span>{triggerLabel}</span>"));
+  assert.ok(source.includes("<span>Cerrar</span>"));
+  assert.ok(source.includes("footer ?"));
+  assert.ok(source.includes("focus-visible:ring-2"));
+  assert.ok(source.includes("h-dvh w-full max-w-md"));
+  assertNoForbiddenSurfaceImports(source, "FilterDrawer");
+  assert.equal(source.includes('from "next/link"'), false);
+  assert.equal(source.includes("<Link"), false);
+  assert.equal(source.includes("<a"), false);
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("shadow-xl"), false);
+});
+
+test("StickyFilterBar renders sticky active-filter summary and action slots", () => {
+  const source = read(STICKY_FILTER_BAR_PATH);
+
+  assert.ok(source.includes("export type ActiveFilter = {"));
+  assert.ok(source.includes("label: string;"));
+  assert.ok(source.includes("value: string;"));
+  assert.ok(source.includes("export type StickyFilterBarProps = {"));
+  assert.ok(source.includes("activeFilters?: ActiveFilter[];"));
+  assert.ok(source.includes("actions?: ReactNode;"));
+  assert.ok(source.includes("drawer?: ReactNode;"));
+  assert.ok(source.includes("activeFilters = [],"));
+  assert.ok(source.includes('aria-label="Filtros del dashboard"'));
+  assert.ok(source.includes('data-sticky-filter-bar="true"'));
+  assert.ok(source.includes("sticky top-3"));
+  assert.ok(source.includes("md:top-[8.75rem]"));
+  assert.ok(source.includes("activeFilters.length ?"));
+  assert.ok(source.includes("activeFilters.map((filter) =>"));
+  assert.ok(source.includes("Sin filtros activos"));
+  assert.ok(source.includes("{drawer}"));
+  assert.ok(source.includes("{actions}"));
+  assert.ok(source.includes("focus-visible:ring-2"));
+  assertNoForbiddenSurfaceImports(source, "StickyFilterBar");
+  assert.equal(source.includes('"use client"'), false);
+  assert.equal(source.includes('from "next/link"'), false);
+  assert.equal(source.includes("<Link"), false);
+  assert.equal(source.includes("<a"), false);
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("shadow-xl"), false);
+});
+
+test("dashboard informes integrates drawer and sticky filter bar without changing reports behavior", () => {
+  const source = read(INFORMES_PAGE_PATH);
+  const mainSource = source.slice(source.indexOf('<main className="dashboard-main">'));
+
+  assert.ok(source.includes('import { FilterDrawer } from "@/components/dashboard/FilterDrawer";'));
+  assert.ok(source.includes('} from "@/components/dashboard/StickyFilterBar";'));
+  assert.ok(source.includes("type ActiveFilter,"));
+  assert.ok(source.includes("function buildActiveFilters(input: {"));
+  assert.ok(source.includes("query: string;"));
+  assert.ok(source.includes("status: string;"));
+  assert.ok(source.includes("studyType: string;"));
+  assert.ok(source.includes('activeFilters.push({ label: "Búsqueda", value: input.query });'));
+  assert.ok(source.includes('label: "Estado"'));
+  assert.ok(source.includes('label: "Tipo de estudio"'));
+  assert.ok(source.includes("const activeFilters = buildActiveFilters({ query, status, studyType });"));
+  assert.ok(source.includes("<StickyFilterBar"));
+  assert.ok(source.includes("activeFilters={activeFilters}"));
+  assert.ok(source.includes("<FilterDrawer"));
+  assert.ok(source.includes('triggerLabel="Filtrar informes"'));
+  assert.ok(source.includes("activeCount={activeFilters.length}"));
+  assert.ok(source.includes('<form method="get"'));
+  assert.ok(source.includes('name="query"'));
+  assert.ok(source.includes("defaultValue={query}"));
+  assert.ok(source.includes('name="status"'));
+  assert.ok(source.includes("defaultValue={status}"));
+  assert.ok(source.includes("<Button type=\"submit\" size=\"sm\">"));
+  assert.ok(source.includes("Filtrar"));
+  assert.ok(source.includes('href="/dashboard/informes"'));
+  assert.ok(source.includes("Limpiar"));
+  assert.ok(source.includes("reports = query"));
+  assert.ok(source.includes("? await searchReports("));
+  assert.ok(source.includes("query,"));
+  assert.ok(source.includes("status: status || undefined,"));
+  assert.ok(source.includes("studyType: studyType || undefined,"));
+  assert.ok(source.includes(": await getReports("));
+  assert.ok(source.includes("requestOptions,"));
+  assert.ok(source.includes("<MasterDetailWorkspace"));
+  assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
+  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<ReportFileActions"));
+  assert.equal(source.includes('from "next/link"'), false);
+  assert.equal(source.includes("<Link"), false);
+  assert.equal(source.includes("<a"), false);
+
+  const stickyActionIndex = mainSource.indexOf("<StickyActionBar");
+  const stickyFilterIndex = mainSource.indexOf("<StickyFilterBar");
+  const workspaceIndex = mainSource.indexOf("<MasterDetailWorkspace");
+
+  assert.ok(stickyActionIndex >= 0);
+  assert.ok(stickyFilterIndex > stickyActionIndex);
+  assert.ok(workspaceIndex > stickyFilterIndex);
+});
+
+test("PR-6 scope leaves backend auth API middleware SEO and dependencies untouched", () => {
+  const changedFiles = execFileSync("git", ["diff", "--name-only"], {
+    encoding: "utf8",
+  })
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const blockedPrefixes = [
+    "server/",
+    "drizzle/",
+    "frontend/src/app/api/",
+    "frontend/src/middleware",
+    "frontend/middleware",
+  ];
+  const blockedFiles = [
+    "package.json",
+    "pnpm-lock.yaml",
+    "frontend/next-env.d.ts",
+    "frontend/src/app/layout.tsx",
+    "frontend/src/app/page.tsx",
+    "frontend/src/lib/auth.ts",
+    "frontend/src/lib/seo.ts",
+  ];
+
+  for (const file of changedFiles) {
+    assert.equal(
+      blockedPrefixes.some((prefix) => file.startsWith(prefix)),
+      false,
+      `${file} is outside PR-6 frontend dashboard scope`,
+    );
+    assert.equal(
+      blockedFiles.includes(file),
+      false,
+      `${file} must not be modified by PR-6`,
+    );
+  }
+});
+
+test("PR-6 documentation records decisions validations and residual risk", () => {
+  const source = read(DOC_PATH);
+
+  assert.ok(source.includes("# PR-6"));
+  assert.ok(source.includes("## Resumen"));
+  assert.ok(source.includes("## Archivos modificados"));
+  assert.ok(source.includes("## Componentes creados"));
+  assert.ok(source.includes("## Decisiones tecnicas"));
+  assert.ok(source.includes("## Filtros y query params"));
+  assert.ok(source.includes("## Validaciones"));
+  assert.ok(source.includes("## Riesgos residuales"));
+  assert.ok(source.includes("## Confirmacion de scope"));
+  assert.ok(source.includes("FilterDrawer"));
+  assert.ok(source.includes("StickyFilterBar"));
+  assert.ok(source.includes("/dashboard/informes"));
+});


### PR DESCRIPTION
## Summary
- Add reusable FilterDrawer for private dashboard filter controls
- Add reusable StickyFilterBar for active filter summaries and filter actions
- Integrate existing /dashboard/informes filters into the new filter foundation
- Preserve existing searchParams, query params, fetches, report actions, MasterDetailWorkspace, StudyTimeline and StickyActionBar behavior
- Add native contract tests and PR implementation documentation

## Scope
- No backend changes
- No API route changes
- No auth/session changes
- No middleware changes
- No SEO/public route changes
- No dependency changes
- No package.json or pnpm-lock.yaml changes
- No next-env.d.ts changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build