### PR TITLE
feat(dashboard): mobile polish and bottom actions

### DIFF
--- a/docs/pr-9-dashboard-mobile-polish-bottom-actions.md
+++ b/docs/pr-9-dashboard-mobile-polish-bottom-actions.md
@@ -1,0 +1,55 @@
+# PR-9 - Dashboard mobile polish and bottom action bar
+
+## Resumen
+
+Se pulió la experiencia móvil/tablet de dashboards privados reforzando el comportamiento inferior de `StickyActionBar`, el safe-area, el scroll interno de filtros/tabs/drawers y el resguardo inferior de contenido donde hay acciones fixed en mobile.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/page.tsx`
+- `frontend/src/app/dashboard/admin/AdminSectionTabs.tsx`
+- `frontend/src/components/dashboard/FilterDrawer.tsx`
+- `frontend/src/components/dashboard/MasterDetailWorkspace.tsx`
+- `frontend/src/components/dashboard/StickyActionBar.tsx`
+- `frontend/src/components/dashboard/StickyFilterBar.tsx`
+- `test/frontend-dashboard-mobile-polish-bottom-actions.test.ts`
+- `docs/pr-9-dashboard-mobile-polish-bottom-actions.md`
+
+## Mejoras mobile/safe-area por componente
+
+- `StickyActionBar`: conserva mobile fixed bottom y desktop sticky, suma padding inferior con `env(safe-area-inset-bottom)`, pointer-events controlado, botones más altos y legibles, grid mobile de una columna con paso a dos columnas desde 420px.
+- `StickyFilterBar`: mantiene sticky, acota ancho máximo, evita overflow de página y mueve los chips a scroll horizontal interno con `overscroll-x-contain`.
+- `FilterDrawer`: panel acotado a `h-dvh`/`max-h-dvh`, overlay sin overflow de página, scroll interno con overscroll contenido y footer/header sin colapsar; footer respeta safe-area.
+- `MasterDetailWorkspace`: refuerza `max-w-full`, `overflow-x-hidden` y `scroll-mt` móvil para navegación hacia detalle sin quedar bajo barras sticky.
+- `AdminSectionTabs`: tablist con scroll horizontal interno, contenedor sin overflow-x de página y tabs `whitespace-nowrap`.
+- `/dashboard`: agrega spacer móvil inferior como las otras páginas privadas con `StickyActionBar`.
+
+## Decisiones técnicas
+
+- No se creó `BottomActionBar`: `StickyActionBar` ya centralizaba el comportamiento bottom/sticky y era más seguro reforzarlo allí.
+- Los cambios son de clases/resguardos responsivos y no alteran datos, fetches, handlers, rutas ni layout macro.
+- Desktop queda con el patrón existente `md:sticky`.
+
+## Validaciones ejecutadas
+
+- `git diff --check`: OK, sin errores de whitespace. Git emitio avisos esperados de normalizacion LF/CRLF en archivos frontend tocados.
+- `pnpm test`: OK, 2396 tests passed.
+- `pnpm build`: OK.
+- `pnpm security:public-surface`: OK, sin public devtools exposure findings. La auditoria solo reporto marcadores server-only existentes en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint`: OK.
+- `pnpm --dir frontend typecheck`: OK.
+- `pnpm --dir frontend build`: OK. Next genero cambios automaticos en `frontend/next-env.d.ts` y `frontend/tsconfig.json`; se restauraron ambos para mantener el scope de PR-9.
+
+## Riesgos residuales
+
+- El safe-area depende del soporte del navegador para `env(safe-area-inset-bottom)`; en navegadores sin notch se resuelve como padding base por el `calc`.
+- Los chips de filtros ahora priorizan no generar scroll de página y pueden requerir scroll horizontal interno cuando hay valores largos.
+
+## Confirmación de scope
+
+- Sin cambios en backend.
+- Sin cambios en API routes.
+- Sin cambios en auth.
+- Sin cambios en middleware.
+- Sin cambios en SEO ni rutas públicas.
+- Sin cambios en dependencias, `package.json`, `pnpm-lock.yaml`, `next-env.d.ts` o `tsconfig.json`.

--- a/frontend/src/app/dashboard/admin/AdminSectionTabs.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSectionTabs.tsx
@@ -117,14 +117,16 @@ export function AdminSectionTabs({
 
   return (
     <section
-      className={["space-y-4", className].filter(Boolean).join(" ")}
+      className={["max-w-full min-w-0 space-y-4 overflow-x-hidden", className]
+        .filter(Boolean)
+        .join(" ")}
       aria-label="Secciones administrativas"
     >
       <div
         role="tablist"
         aria-label="Secciones de administración"
         aria-orientation="horizontal"
-        className="flex max-w-full gap-1 overflow-x-auto rounded-md border border-vetneb-line/80 bg-card/80 p-1"
+        className="flex max-w-full gap-1 overflow-x-auto overscroll-x-contain rounded-md border border-vetneb-line/80 bg-card/80 p-1"
       >
         {availableTabs.map((tab, index) => {
           const isActive = tab.id === activeTabId;
@@ -141,7 +143,7 @@ export function AdminSectionTabs({
               onClick={() => setActiveTabId(tab.id)}
               onKeyDown={(event) => handleTabKeyDown(event, index)}
               className={[
-                "inline-flex min-h-10 shrink-0 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+                "inline-flex min-h-10 shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
                 isActive
                   ? "bg-vetneb-navy text-primary-foreground"
                   : "text-foreground/78 hover:bg-accent/70 hover:text-accent-foreground",

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -113,6 +113,7 @@ export default async function DashboardPage() {
         />
         <ClinicPublicProfileCard />
         <ClinicParticularTokensCard />
+        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/frontend/src/components/dashboard/FilterDrawer.tsx
+++ b/frontend/src/components/dashboard/FilterDrawer.tsx
@@ -81,7 +81,10 @@ export function FilterDrawer({
       </Button>
 
       {open ? (
-        <div className="fixed inset-0 z-[70]" data-filter-drawer-open="true">
+        <div
+          className="fixed inset-0 z-[70] overflow-hidden"
+          data-filter-drawer-open="true"
+        >
           <div
             className="absolute inset-0 bg-vetneb-ink/30 backdrop-blur-[2px]"
             aria-hidden="true"
@@ -94,9 +97,9 @@ export function FilterDrawer({
             aria-labelledby={titleId}
             aria-describedby={description ? descriptionId : undefined}
             tabIndex={-1}
-            className="absolute right-0 top-0 flex h-dvh w-full max-w-md flex-col overflow-hidden border-l border-vetneb-line/80 bg-card shadow-lg"
+            className="absolute inset-y-0 right-0 flex h-dvh w-full max-w-md max-h-dvh flex-col overflow-hidden border-l border-vetneb-line/80 bg-card pb-[env(safe-area-inset-bottom)] shadow-lg"
           >
-            <div className="flex items-start justify-between gap-4 border-b border-vetneb-line/80 px-4 py-4">
+            <div className="shrink-0 flex items-start justify-between gap-4 border-b border-vetneb-line/80 px-4 py-4">
               <div className="min-w-0">
                 <h2 id={titleId} className="text-base font-semibold text-vetneb-ink">
                   {title}
@@ -120,12 +123,12 @@ export function FilterDrawer({
               </Button>
             </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+            <div className="min-h-0 flex-1 overscroll-contain overflow-y-auto px-4 py-4">
               {children}
             </div>
 
             {footer ? (
-              <div className="border-t border-vetneb-line/80 px-4 py-4">
+              <div className="shrink-0 border-t border-vetneb-line/80 px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-4">
                 {footer}
               </div>
             ) : null}

--- a/frontend/src/components/dashboard/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/dashboard/MasterDetailWorkspace.tsx
@@ -35,9 +35,9 @@ export function MasterDetailWorkspace({
     >
       <div
         aria-label={masterLabel}
-        className="min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm"
+        className="max-w-full min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm"
       >
-        <div className="max-h-none min-w-0 overflow-x-hidden overflow-y-visible xl:max-h-[calc(100vh-13rem)] xl:overflow-y-auto">
+        <div className="max-h-none max-w-full min-w-0 overflow-x-hidden overflow-y-visible xl:max-h-[calc(100vh-13rem)] xl:overflow-y-auto">
           {master}
         </div>
       </div>
@@ -45,7 +45,7 @@ export function MasterDetailWorkspace({
       <div
         aria-label={detailLabel}
         data-detail-state={hasSelection ? "selected" : "empty"}
-        className="min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm"
+        className="max-w-full min-w-0 scroll-mt-28 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm md:scroll-mt-24"
       >
         <p className="sr-only" aria-live="polite">
           {hasSelection

--- a/frontend/src/components/dashboard/StickyActionBar.tsx
+++ b/frontend/src/components/dashboard/StickyActionBar.tsx
@@ -41,12 +41,12 @@ export function StickyActionBar({
     <section
       aria-label={context ? `${context} del dashboard` : "Acciones del dashboard"}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 border-t border-vetneb-line/80 bg-card/95 px-3 py-3 shadow-md backdrop-blur md:sticky md:top-[4.75rem] md:bottom-auto md:rounded-lg md:border md:px-4 md:shadow-sm",
+        "pointer-events-none fixed inset-x-0 bottom-0 z-50 border-t border-vetneb-line/80 bg-card/95 px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-3 shadow-md backdrop-blur md:pointer-events-auto md:sticky md:top-[4.75rem] md:bottom-auto md:rounded-lg md:border md:px-4 md:py-3 md:shadow-sm",
         className,
       )}
       data-sticky-action-bar="true"
     >
-      <div className="mx-auto flex max-w-6xl flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div className="pointer-events-auto mx-auto flex max-w-6xl min-w-0 flex-col gap-2 md:flex-row md:items-center md:justify-between">
         {context ? (
           <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
             {context}
@@ -55,13 +55,13 @@ export function StickyActionBar({
         <div
           role="group"
           aria-label={context ? `Acciones: ${context}` : "Acciones rápidas"}
-          className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-end"
+          className="grid min-w-0 grid-cols-1 gap-2 min-[420px]:grid-cols-2 sm:flex sm:flex-wrap sm:items-center sm:justify-end"
         >
           {children ? (
             <div
               role="group"
               aria-label="Acciones contextuales"
-              className="col-span-2 flex justify-start sm:justify-end"
+              className="col-span-full flex min-w-0 justify-start sm:justify-end"
             >
               {children}
             </div>
@@ -94,7 +94,7 @@ export function StickyActionBar({
                   }
                 }}
                 aria-label={ariaLabel}
-                className="w-full focus-visible:ring-2 focus-visible:ring-ring/85 sm:w-auto"
+                className="min-h-10 w-full whitespace-normal focus-visible:ring-2 focus-visible:ring-ring/85 sm:w-auto sm:whitespace-nowrap"
               >
                 {content}
               </Button>

--- a/frontend/src/components/dashboard/StickyFilterBar.tsx
+++ b/frontend/src/components/dashboard/StickyFilterBar.tsx
@@ -29,7 +29,7 @@ export function StickyFilterBar({
       aria-label={ariaLabel ?? "Filtros del dashboard"}
       data-sticky-filter-bar="true"
       className={cn(
-        "sticky top-3 z-40 min-w-0 rounded-lg border border-vetneb-line/80 bg-card/95 px-3 py-3 shadow-sm backdrop-blur md:top-[8.75rem] md:px-4",
+        "sticky top-3 z-40 max-w-full min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 px-3 py-3 shadow-sm backdrop-blur md:top-[8.75rem] md:px-4",
         className,
       )}
     >
@@ -41,7 +41,7 @@ export function StickyFilterBar({
             </p>
           ) : null}
           <ul
-            className="flex min-w-0 flex-wrap items-center gap-2"
+            className="flex max-w-full min-w-0 items-center gap-2 overflow-x-auto overscroll-x-contain pb-1"
             aria-live="polite"
             aria-label="Filtros activos"
           >
@@ -49,14 +49,14 @@ export function StickyFilterBar({
               activeFilters.map((filter) => (
                 <li
                   key={`${filter.label}-${filter.value}`}
-                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-vetneb-line/80 bg-vetneb-surface-muted/80 px-2.5 py-1 text-xs font-semibold text-vetneb-ink"
+                  className="inline-flex max-w-[min(16rem,calc(100vw-4rem))] shrink-0 items-center gap-1 rounded-md border border-vetneb-line/80 bg-vetneb-surface-muted/80 px-2.5 py-1 text-xs font-semibold text-vetneb-ink"
                 >
                   <span className="text-muted-foreground">{filter.label}</span>
                   <span className="min-w-0 truncate">{filter.value}</span>
                 </li>
               ))
             ) : (
-              <li className="inline-flex rounded-md border border-vetneb-line/80 bg-vetneb-surface-muted/80 px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+              <li className="inline-flex shrink-0 rounded-md border border-vetneb-line/80 bg-vetneb-surface-muted/80 px-2.5 py-1 text-xs font-semibold text-muted-foreground">
                 Sin filtros activos
               </li>
             )}
@@ -67,7 +67,7 @@ export function StickyFilterBar({
           <div
             role="group"
             aria-label="Acciones de filtros"
-            className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end [&_button]:focus-visible:ring-2 [&_button]:focus-visible:ring-ring/85"
+            className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-end [&_button]:focus-visible:ring-2 [&_button]:focus-visible:ring-ring/85"
           >
             {drawer}
             {actions}

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const DASHBOARD_HOME_PATH = "frontend/src/app/dashboard/page.tsx";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const LOGISTICA_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
+const STICKY_ACTION_BAR_PATH =
+  "frontend/src/components/dashboard/StickyActionBar.tsx";
+const STICKY_FILTER_BAR_PATH =
+  "frontend/src/components/dashboard/StickyFilterBar.tsx";
+const FILTER_DRAWER_PATH = "frontend/src/components/dashboard/FilterDrawer.tsx";
+const MASTER_DETAIL_WORKSPACE_PATH =
+  "frontend/src/components/dashboard/MasterDetailWorkspace.tsx";
+const ADMIN_SECTION_TABS_PATH =
+  "frontend/src/app/dashboard/admin/AdminSectionTabs.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function assertNoForbiddenSurfaceImports(source: string, context: string): void {
+  const importLines = source
+    .split("\n")
+    .filter((line) => line.trim().startsWith("import "));
+  const forbiddenPatterns = [
+    /next\/link/,
+    /@\/app\/api/,
+    /@\/middleware/,
+    /@\/lib\/auth/,
+    /\.\.\/.*\/auth/,
+    /\.\.\/.*\/middleware/,
+  ];
+
+  for (const line of importLines) {
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(
+        pattern.test(line),
+        false,
+        `${context} must not import forbidden surface via: ${line}`,
+      );
+    }
+  }
+}
+
+test("PR-9 StickyActionBar keeps mobile bottom safe-area action contract", () => {
+  const source = read(STICKY_ACTION_BAR_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("fixed inset-x-0 bottom-0 z-50"));
+  assert.ok(source.includes("pb-[calc(0.75rem+env(safe-area-inset-bottom))]"));
+  assert.ok(source.includes("md:sticky md:top-[4.75rem]"));
+  assert.ok(source.includes("pointer-events-none"));
+  assert.ok(source.includes("pointer-events-auto"));
+  assert.ok(source.includes("grid min-w-0 grid-cols-1 gap-2 min-[420px]:grid-cols-2"));
+  assert.ok(source.includes("min-h-10 w-full whitespace-normal"));
+  assert.ok(source.includes('type="button"'));
+  assert.ok(source.includes("<span>{action.label}</span>"));
+  assert.ok(source.includes("focus-visible:ring-2"));
+  assertNoForbiddenSurfaceImports(source, "StickyActionBar");
+  assert.equal(source.includes('from "next/link"'), false);
+  assert.equal(source.includes("<Link"), false);
+  assert.equal(source.includes("<a"), false);
+});
+
+test("PR-9 StickyFilterBar keeps sticky behavior and internal chip scrolling", () => {
+  const source = read(STICKY_FILTER_BAR_PATH);
+
+  assert.ok(source.includes("sticky top-3 z-40"));
+  assert.ok(source.includes("max-w-full min-w-0 overflow-hidden"));
+  assert.ok(source.includes("overflow-x-auto"));
+  assert.ok(source.includes("overscroll-x-contain"));
+  assert.ok(source.includes("max-w-[min(16rem,calc(100vw-4rem))]"));
+  assert.ok(source.includes("shrink-0"));
+  assert.ok(source.includes("Sin filtros activos"));
+  assert.equal(source.includes("w-screen"), false);
+  assertNoForbiddenSurfaceImports(source, "StickyFilterBar");
+});
+
+test("PR-9 FilterDrawer fits mobile viewport and keeps scrollable content", () => {
+  const source = read(FILTER_DRAWER_PATH);
+
+  assert.ok(source.includes("fixed inset-0 z-[70] overflow-hidden"));
+  assert.ok(source.includes("h-dvh w-full max-w-md max-h-dvh"));
+  assert.ok(source.includes("pb-[env(safe-area-inset-bottom)]"));
+  assert.ok(source.includes("min-h-0 flex-1 overscroll-contain overflow-y-auto"));
+  assert.ok(source.includes("pb-[calc(1rem+env(safe-area-inset-bottom))]"));
+  assert.ok(source.includes("focus-visible:ring-2"));
+  assert.ok(source.includes('aria-expanded={open}'));
+  assert.ok(source.includes('role="dialog"'));
+  assertNoForbiddenSurfaceImports(source, "FilterDrawer");
+});
+
+test("PR-9 MasterDetailWorkspace and AdminSectionTabs avoid horizontal page overflow", () => {
+  const workspaceSource = read(MASTER_DETAIL_WORKSPACE_PATH);
+  const tabsSource = read(ADMIN_SECTION_TABS_PATH);
+
+  assert.ok(workspaceSource.includes("grid min-w-0 grid-cols-1"));
+  assert.ok(workspaceSource.includes("overflow-x-hidden"));
+  assert.ok(workspaceSource.includes("max-w-full min-w-0"));
+  assert.ok(workspaceSource.includes("scroll-mt-28"));
+  assert.ok(tabsSource.includes("max-w-full min-w-0 space-y-4 overflow-x-hidden"));
+  assert.ok(tabsSource.includes("overflow-x-auto overscroll-x-contain"));
+  assert.ok(tabsSource.includes("whitespace-nowrap"));
+  assert.ok(tabsSource.includes('role="tablist"'));
+  assert.ok(tabsSource.includes("focus-visible:ring-2"));
+  assertNoForbiddenSurfaceImports(workspaceSource, "MasterDetailWorkspace");
+  assertNoForbiddenSurfaceImports(tabsSource, "AdminSectionTabs");
+});
+
+test("PR-9 private dashboard pages leave bottom space for mobile fixed actions", () => {
+  const dashboardSource = read(DASHBOARD_HOME_PATH);
+  const adminSource = read(ADMIN_PAGE_PATH);
+  const informesSource = read(INFORMES_PAGE_PATH);
+  const logisticaSource = read(LOGISTICA_PAGE_PATH);
+
+  for (const [context, source] of [
+    ["dashboard", dashboardSource],
+    ["admin", adminSource],
+    ["informes", informesSource],
+    ["logistica", logisticaSource],
+  ] as const) {
+    assert.ok(source.includes("<StickyActionBar"), `${context} uses StickyActionBar`);
+    assert.ok(
+      source.includes('className="h-24 md:hidden" aria-hidden="true"'),
+      `${context} keeps mobile bottom spacer`,
+    );
+  }
+});
+
+test("PR-9 mobile polish scope avoids forbidden surfaces and dependencies", () => {
+  const changedFiles = execFileSync("git", ["diff", "--name-only"], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const blockedPrefixes = [
+    "server/",
+    "drizzle/",
+    "shared/",
+    "frontend/src/app/api/",
+    "frontend/src/middleware",
+    "frontend/src/app/servicios/",
+    "frontend/src/app/histopatologia-veterinaria/",
+  ];
+  const blockedFiles = [
+    "package.json",
+    "pnpm-lock.yaml",
+    "frontend/package.json",
+    "frontend/pnpm-lock.yaml",
+    "frontend/next-env.d.ts",
+    "frontend/tsconfig.json",
+    "frontend/src/app/layout.tsx",
+    "frontend/src/lib/auth.ts",
+    "frontend/src/lib/seo.ts",
+  ];
+
+  for (const file of changedFiles) {
+    assert.equal(
+      blockedPrefixes.some((prefix) => file.startsWith(prefix)),
+      false,
+      `${file} is outside PR-9 private dashboard mobile scope`,
+    );
+    assert.equal(
+      blockedFiles.includes(file),
+      false,
+      `${file} must not be modified by PR-9`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Improve private dashboard mobile/tablet behavior for sticky and bottom action patterns
- Strengthen StickyActionBar mobile safe-area handling while preserving desktop sticky behavior
- Improve internal overflow handling for filters, drawer, master-detail workspace and admin tabs
- Add bottom content spacing for the clinic dashboard so mobile actions do not cover content
- Add native mobile polish contract tests and PR implementation documentation

## Scope
- No backend changes
- No API route changes
- No auth/session changes
- No middleware changes
- No SEO/public route changes
- No dependency changes
- No package.json, pnpm-lock.yaml, next-env.d.ts or tsconfig.json changes
- No route or endpoint changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build