### PR TITLE
feat(dashboard): polish loading empty and error states

### DIFF
--- a/docs/pr-10-dashboard-state-polish.md
+++ b/docs/pr-10-dashboard-state-polish.md
@@ -1,0 +1,156 @@
+# PR-10 — feat(dashboard): polish loading, empty and error states
+
+## Resumen
+
+Cierre del roadmap base de dashboards privados con polish premium y consistente de estados. Se mejoran los tres componentes de estado compartidos (`LoadingState`, `EmptyState`, `ErrorState`) con atributos de accesibilidad completos, props opcionales no-breaking y mejoras visuales sobrias. Las integraciones existentes en dashboards privados (informes, logística, principal) ya usan estos componentes correctamente desde PRs anteriores.
+
+---
+
+## Archivos modificados
+
+| Archivo | Tipo | Cambio |
+|---|---|---|
+| `frontend/src/components/dashboard/LoadingState.tsx` | componente | mejoras accesibilidad + props opcionales |
+| `frontend/src/components/dashboard/EmptyState.tsx` | componente | props opcionales contextualización |
+| `frontend/src/components/dashboard/ErrorState.tsx` | componente | tone/supportText + focus-visible |
+| `test/frontend-dashboard-state-polish.test.ts` | test | contrato completo PR-10 |
+| `docs/pr-10-dashboard-state-polish.md` | docs | este documento |
+
+---
+
+## Mejoras por componente
+
+### LoadingState
+
+**Props nuevas (no-breaking):**
+- `label?: string` — texto accesible personalizable (default: `"Cargando..."`)
+- `compact?: boolean` — layout compacto para paneles pequeños (default: `false`)
+
+**Accesibilidad:**
+- `role="status"` en todos los variants (live region implícita)
+- `aria-live="polite"` explícito en todos los variants
+- `aria-busy="true"` mantenido (ya existía)
+- `<span className="sr-only">{loadingLabel}</span>` en todos los variants
+
+**Visual:**
+- Sin cambios de layout relevantes; el `compact` solo reduce padding y `min-h`
+- Sin spinner fullscreen ni `animate-spin`
+- Skeletons estables vía `Skeleton` de shadcn/ui
+
+**API pública mantenida:** `variant`, `rows`, `className` — sin cambios de firma.
+
+---
+
+### EmptyState
+
+**Props nuevas (no-breaking):**
+- `eyebrow?: string` — etiqueta contextual sobre el título (uppercase tracking)
+- `secondaryAction?: ReactNode` — acción secundaria debajo de la primaria
+
+**Accesibilidad:**
+- `aria-hidden="true"` en el contenedor del ícono y en el `<Icon>` mantenidos
+- Ícono decorativo no aporta semántica al lector de pantalla
+
+**Visual:**
+- Jerarquía: eyebrow → ícono → título → descripción → action → secondaryAction
+- Sin gradientes decorativos fuertes ni `shadow-xl`
+- Borde dashed existente mantenido
+
+**API pública mantenida:** `title`, `description`, `action`, `icon`, `className` — sin cambios de firma.
+
+---
+
+### ErrorState
+
+**Props nuevas (no-breaking):**
+- `supportText?: string` — texto de soporte secundario bajo el mensaje principal
+- `tone?: "warning" | "critical"` — severidad visual (default: `"critical"` = comportamiento anterior)
+
+**Accesibilidad:**
+- `role="alert"` mantenido
+- `type="button"` en botón retry mantenido
+- `focus-visible:ring-2` explícito en el botón retry
+
+**Seguridad:**
+- Sin stack traces ni detalles internos expuestos
+- Título default: `"No se pudo completar la acción"` (sin "Error desconocido")
+- El `message` es responsabilidad del llamador; el componente no procesa ni expone datos sensibles
+
+**Visual:**
+- `tone="warning"`: colores amber/amarillo (amber-500/700)
+- `tone="critical"`: colores destructive existentes (sin cambio visual para llamadores sin `tone`)
+- Ícono cambia a `AlertTriangle` para tone warning, `AlertCircle` para critical
+
+**API pública mantenida:** `title`, `message`, `onRetry`, `className` — sin cambios de firma.
+
+---
+
+## Integraciones realizadas
+
+Las integraciones ya estaban implementadas en PRs anteriores:
+
+| Dashboard | EmptyState | ErrorState | LoadingState |
+|---|---|---|---|
+| `/dashboard` (principal) | ✓ vía ClinicCommandCenter | ✓ role="alert" inline | ✓ StatsCards propio |
+| `/dashboard/informes` | ✓ tabla + detail | ✓ tabla | — |
+| `/dashboard/logistica` | ✓ LogisticsCommandCenter | ✓ LogisticsCommandCenter | — |
+| `/dashboard/logistica/visitas` | ✓ tabla | ✓ tabla | — |
+| `/dashboard/logistica/rutas` | ✓ tabla | — | — |
+| `/dashboard/logistica/metricas` | ✓ tarjetas | ✓ tarjetas | — |
+
+No se realizaron cambios en páginas de dashboard. Las mejoras de los componentes se propagan automáticamente.
+
+---
+
+## Decisiones técnicas
+
+- **`role="status"` vs `aria-live`**: Se añaden ambos. `role="status"` crea live region implícita con `aria-live="polite"`, se añade `aria-live` explícito para compatibilidad máxima con lectores de pantalla legacy.
+- **sr-only en LoadingState**: El texto `Cargando...` es `sr-only` para no romper layouts visuales. Puede personalizarse via prop `label`.
+- **tone en ErrorState**: `"critical"` replica exactamente el comportamiento anterior (destructive colors). `"warning"` usa amber sin tocar variables CSS del proyecto para no requerir cambios en globals.css.
+- **eyebrow en EmptyState**: Texto uppercase tracking, muted, para contexto de panel sin ser visual dominante.
+- **No se tocan páginas de dashboard**: Las integraciones existentes ya son correctas. Añadir `eyebrow` a instancias existentes sería un cambio de contenido, no de lógica, y no aporta valor suficiente para justificarlo.
+- **No se crearon endpoints, rutas, ni componentes nuevos**: Scope estrictamente cumplido.
+
+---
+
+## Validaciones ejecutadas
+
+```
+pnpm test                          — suite completa de tests
+pnpm build                         — build raíz
+pnpm security:public-surface       — superficie pública
+pnpm --dir frontend lint           — ESLint frontend
+pnpm --dir frontend typecheck      — TypeScript frontend
+pnpm --dir frontend build          — build Next.js
+```
+
+Ver resultados en sección siguiente.
+
+---
+
+## Riesgos residuales
+
+| Riesgo | Severidad | Mitigación |
+|---|---|---|
+| `tone="warning"` usa `amber-*` directos no en design tokens | Baja | Solo afecta instancias que pasen `tone="warning"` explícitamente; comportamiento default no cambia |
+| `compact` en LoadingState reduce `min-h` | Baja | Solo activo cuando se pasa `compact={true}` explícitamente; default `false` mantiene layout anterior |
+| `eyebrow` en EmptyState añade un `<p>` nuevo | Baja | Solo renderizado si `eyebrow` prop es truthy; todos los usos existentes sin prop no se ven afectados |
+
+---
+
+## Confirmación de no-changes en áreas protegidas
+
+- ✅ Sin cambios en backend
+- ✅ Sin cambios en API routes
+- ✅ Sin cambios en auth / middleware
+- ✅ Sin cambios en SEO / metadata
+- ✅ Sin cambios en rutas públicas
+- ✅ Sin cambios en lógica de negocio
+- ✅ Sin cambios en cálculo de fechas
+- ✅ Sin cambios en `package.json`
+- ✅ Sin cambios en `pnpm-lock.yaml`
+- ✅ Sin cambios en `next-env.d.ts`
+- ✅ Sin cambios en `tsconfig.json`
+- ✅ Sin instalación de dependencias
+- ✅ Sin nuevos endpoints
+- ✅ Sin nuevas rutas

--- a/frontend/src/components/dashboard/EmptyState.tsx
+++ b/frontend/src/components/dashboard/EmptyState.tsx
@@ -7,6 +7,8 @@ export type EmptyStateProps = {
   description?: string;
   action?: ReactNode;
   icon?: LucideIcon;
+  eyebrow?: string;
+  secondaryAction?: ReactNode;
   className?: string;
 };
 
@@ -15,6 +17,8 @@ export function EmptyState({
   description,
   action,
   icon: Icon = Inbox,
+  eyebrow,
+  secondaryAction,
   className,
 }: EmptyStateProps) {
   return (
@@ -30,6 +34,11 @@ export function EmptyState({
       >
         <Icon className="h-5 w-5" aria-hidden="true" />
       </div>
+      {eyebrow ? (
+        <p className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          {eyebrow}
+        </p>
+      ) : null}
       <h2 className="text-base font-semibold text-vetneb-ink">{title}</h2>
       {description ? (
         <p className="mt-1 max-w-md text-sm text-muted-foreground">
@@ -37,7 +46,9 @@ export function EmptyState({
         </p>
       ) : null}
       {action ? <div className="mt-4 flex justify-center">{action}</div> : null}
+      {secondaryAction ? (
+        <div className="mt-2 flex justify-center">{secondaryAction}</div>
+      ) : null}
     </div>
   );
 }
-

--- a/frontend/src/components/dashboard/ErrorState.tsx
+++ b/frontend/src/components/dashboard/ErrorState.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle, RefreshCw } from "lucide-react";
+import { AlertCircle, AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -8,6 +8,8 @@ export type ErrorStateProps = {
   title?: string;
   message: string;
   onRetry?: () => void;
+  supportText?: string;
+  tone?: "warning" | "critical";
   className?: string;
 };
 
@@ -15,21 +17,46 @@ export function ErrorState({
   title = "No se pudo completar la acción",
   message,
   onRetry,
+  supportText,
+  tone = "critical",
   className,
 }: ErrorStateProps) {
+  const isWarning = tone === "warning";
+  const Icon = isWarning ? AlertTriangle : AlertCircle;
+
   return (
     <div
       role="alert"
       className={cn(
-        "flex flex-col gap-3 rounded-lg border border-destructive/25 bg-destructive/8 px-4 py-4 text-destructive sm:flex-row sm:items-start sm:justify-between",
+        "flex flex-col gap-3 rounded-lg border px-4 py-4 sm:flex-row sm:items-start sm:justify-between",
+        isWarning
+          ? "border-amber-500/25 bg-amber-500/8 text-amber-700"
+          : "border-destructive/25 bg-destructive/8 text-destructive",
         className,
       )}
     >
       <div className="flex gap-3">
-        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
         <div>
           {title ? <h2 className="text-sm font-semibold">{title}</h2> : null}
-          <p className="text-sm text-destructive/88">{message}</p>
+          <p
+            className={cn(
+              "text-sm",
+              isWarning ? "text-amber-700/88" : "text-destructive/88",
+            )}
+          >
+            {message}
+          </p>
+          {supportText ? (
+            <p
+              className={cn(
+                "mt-1 text-xs",
+                isWarning ? "text-amber-600/75" : "text-destructive/65",
+              )}
+            >
+              {supportText}
+            </p>
+          ) : null}
         </div>
       </div>
       {onRetry ? (
@@ -38,7 +65,12 @@ export function ErrorState({
           variant="outline"
           size="sm"
           onClick={onRetry}
-          className="shrink-0 border-destructive/30 text-destructive hover:border-destructive/45 hover:bg-destructive/10 hover:text-destructive"
+          className={cn(
+            "shrink-0 focus-visible:ring-2",
+            isWarning
+              ? "border-amber-500/30 text-amber-700 hover:border-amber-500/45 hover:bg-amber-500/10 hover:text-amber-700"
+              : "border-destructive/30 text-destructive hover:border-destructive/45 hover:bg-destructive/10 hover:text-destructive",
+          )}
         >
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
           Reintentar
@@ -47,4 +79,3 @@ export function ErrorState({
     </div>
   );
 }
-

--- a/frontend/src/components/dashboard/LoadingState.tsx
+++ b/frontend/src/components/dashboard/LoadingState.tsx
@@ -4,6 +4,8 @@ import { cn } from "@/lib/utils";
 export type LoadingStateProps = {
   variant?: "table" | "cards" | "detail" | "timeline";
   rows?: number;
+  label?: string;
+  compact?: boolean;
   className?: string;
 };
 
@@ -16,19 +18,26 @@ function getRows(rows: number) {
 export function LoadingState({
   variant = "cards",
   rows = 3,
+  label,
+  compact = false,
   className,
 }: LoadingStateProps) {
   const items = getRows(rows);
+  const loadingLabel = label ?? "Cargando...";
 
   if (variant === "table") {
     return (
       <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
         className={cn(
-          "rounded-lg border border-vetneb-line/75 bg-card/92 p-4",
+          "rounded-lg border border-vetneb-line/75 bg-card/92",
+          compact ? "p-3" : "p-4",
           className,
         )}
-        aria-busy="true"
       >
+        <span className="sr-only">{loadingLabel}</span>
         <div className="grid grid-cols-4 gap-3 border-b border-vetneb-line/60 pb-3">
           {Array.from({ length: 4 }).map((_, index) => (
             <Skeleton key={index} className="h-4 w-full" />
@@ -50,12 +59,16 @@ export function LoadingState({
   if (variant === "detail") {
     return (
       <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
         className={cn(
-          "rounded-lg border border-vetneb-line/75 bg-card/92 p-5",
+          "rounded-lg border border-vetneb-line/75 bg-card/92",
+          compact ? "p-4" : "p-5",
           className,
         )}
-        aria-busy="true"
       >
+        <span className="sr-only">{loadingLabel}</span>
         <Skeleton className="h-5 w-40" />
         <Skeleton className="mt-3 h-4 w-3/4" />
         <Skeleton className="mt-2 h-4 w-1/2" />
@@ -71,9 +84,16 @@ export function LoadingState({
   if (variant === "timeline") {
     return (
       <div
-        className={cn("space-y-4 rounded-lg border border-vetneb-line/75 bg-card/92 p-5", className)}
+        role="status"
+        aria-live="polite"
         aria-busy="true"
+        className={cn(
+          "space-y-4 rounded-lg border border-vetneb-line/75 bg-card/92",
+          compact ? "p-4" : "p-5",
+          className,
+        )}
       >
+        <span className="sr-only">{loadingLabel}</span>
         {items.map((_, index) => (
           <div key={index} className="flex min-h-14 gap-3">
             <Skeleton className="h-9 w-9 rounded-full" />
@@ -89,13 +109,23 @@ export function LoadingState({
 
   return (
     <div
-      className={cn("grid gap-4 sm:grid-cols-2 lg:grid-cols-3", className)}
+      role="status"
+      aria-live="polite"
       aria-busy="true"
+      className={cn(
+        "grid sm:grid-cols-2 lg:grid-cols-3",
+        compact ? "gap-3" : "gap-4",
+        className,
+      )}
     >
+      <span className="sr-only">{loadingLabel}</span>
       {items.map((_, index) => (
         <div
           key={index}
-          className="min-h-32 rounded-lg border border-vetneb-line/75 bg-card/92 p-4"
+          className={cn(
+            "rounded-lg border border-vetneb-line/75 bg-card/92 p-4",
+            compact ? "min-h-24" : "min-h-32",
+          )}
         >
           <Skeleton className="h-4 w-28" />
           <Skeleton className="mt-4 h-8 w-16" />
@@ -106,4 +136,3 @@ export function LoadingState({
     </div>
   );
 }
-

--- a/test/frontend-dashboard-state-polish.test.ts
+++ b/test/frontend-dashboard-state-polish.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const LOADING_STATE_PATH = "frontend/src/components/dashboard/LoadingState.tsx";
+const EMPTY_STATE_PATH = "frontend/src/components/dashboard/EmptyState.tsx";
+const ERROR_STATE_PATH = "frontend/src/components/dashboard/ErrorState.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ── LoadingState ────────────────────────────────────────────────────────────
+
+test("loading state has role=status and aria-live=polite for accessible announcement", () => {
+  const source = read(LOADING_STATE_PATH);
+
+  assert.ok(source.includes('role="status"'));
+  assert.ok(source.includes('aria-live="polite"'));
+});
+
+test("loading state has sr-only accessible loading text", () => {
+  const source = read(LOADING_STATE_PATH);
+
+  assert.ok(source.includes('className="sr-only"'));
+  assert.ok(source.includes("Cargando..."));
+});
+
+test("loading state maintains all four variants and skeleton usage", () => {
+  const source = read(LOADING_STATE_PATH);
+
+  assert.ok(source.includes('variant?: "table" | "cards" | "detail" | "timeline";'));
+  assert.ok(source.includes('if (variant === "table")'));
+  assert.ok(source.includes('if (variant === "detail")'));
+  assert.ok(source.includes('if (variant === "timeline")'));
+  assert.ok(source.includes('import { Skeleton } from "@/components/ui/skeleton";'));
+  assert.ok(source.includes('aria-busy="true"'));
+  assert.ok(source.includes("getRows(rows)"));
+});
+
+test("loading state supports optional label and compact props without breaking existing api", () => {
+  const source = read(LOADING_STATE_PATH);
+
+  assert.ok(source.includes("label?: string;"));
+  assert.ok(source.includes("compact?: boolean;"));
+  assert.ok(source.includes('variant = "cards"'));
+  assert.ok(source.includes("rows?: number;"));
+  assert.ok(source.includes("className?: string;"));
+});
+
+test("loading state does not render a fullscreen spinner", () => {
+  const source = read(LOADING_STATE_PATH);
+
+  assert.equal(
+    source.includes("fixed inset-0"),
+    false,
+    "loading state must not use fullscreen overlay",
+  );
+  assert.equal(
+    source.includes("animate-spin"),
+    false,
+    "loading state must not use spinner animation",
+  );
+});
+
+// ── EmptyState ──────────────────────────────────────────────────────────────
+
+test("empty state retains full existing api surface", () => {
+  const source = read(EMPTY_STATE_PATH);
+
+  assert.ok(source.includes('import { Inbox, type LucideIcon } from "lucide-react";'));
+  assert.ok(source.includes("title: string;"));
+  assert.ok(source.includes("description?: string;"));
+  assert.ok(source.includes("action?: ReactNode;"));
+  assert.ok(source.includes("icon?: LucideIcon;"));
+  assert.ok(source.includes("icon: Icon = Inbox"));
+  assert.ok(source.includes("{title}"));
+  assert.ok(source.includes("{description}"));
+  assert.ok(source.includes("{action}"));
+  assert.ok(source.includes('aria-hidden="true"'));
+});
+
+test("empty state supports optional eyebrow prop for contextual labeling", () => {
+  const source = read(EMPTY_STATE_PATH);
+
+  assert.ok(source.includes("eyebrow?: string;"));
+  assert.ok(source.includes("{eyebrow}"));
+});
+
+test("empty state supports optional secondaryAction prop for dual call-to-action", () => {
+  const source = read(EMPTY_STATE_PATH);
+
+  assert.ok(source.includes("secondaryAction?: ReactNode;"));
+  assert.ok(source.includes("{secondaryAction}"));
+});
+
+test("empty state icon wrapper and icon element are both aria-hidden", () => {
+  const source = read(EMPTY_STATE_PATH);
+
+  const hiddenCount = (source.match(/aria-hidden="true"/g) ?? []).length;
+
+  assert.ok(
+    hiddenCount >= 2,
+    `empty state must have aria-hidden on both icon container and icon element, found ${hiddenCount}`,
+  );
+});
+
+// ── ErrorState ──────────────────────────────────────────────────────────────
+
+test("error state retains full existing api and role=alert", () => {
+  const source = read(ERROR_STATE_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("message: string;"));
+  assert.ok(source.includes("onRetry?: () => void;"));
+  assert.ok(source.includes('role="alert"'));
+  assert.ok(source.includes("{message}"));
+  assert.ok(source.includes("onRetry ? ("));
+  assert.ok(source.includes("onClick={onRetry}"));
+  assert.ok(source.includes("Reintentar"));
+  assert.equal(source.includes("Error desconocido"), false);
+});
+
+test("error state retry button has type=button attribute", () => {
+  const source = read(ERROR_STATE_PATH);
+
+  assert.ok(source.includes('type="button"'));
+});
+
+test("error state supports optional tone prop for warning and critical severity", () => {
+  const source = read(ERROR_STATE_PATH);
+
+  assert.ok(source.includes('tone?: "warning" | "critical";'));
+  assert.ok(source.includes('tone = "critical"'));
+  assert.ok(source.includes("isWarning"));
+});
+
+test("error state supports optional supportText prop for contextual guidance", () => {
+  const source = read(ERROR_STATE_PATH);
+
+  assert.ok(source.includes("supportText?: string;"));
+  assert.ok(source.includes("{supportText}"));
+});
+
+test("error state retry button has explicit focus-visible ring", () => {
+  const source = read(ERROR_STATE_PATH);
+
+  assert.ok(source.includes("focus-visible:ring-2"));
+});
+
+test("error state does not expose stack traces or internal error details", () => {
+  const source = read(ERROR_STATE_PATH);
+
+  assert.equal(source.includes(".stack"), false, "error state must not expose .stack");
+  assert.equal(source.includes("Error desconocido"), false);
+});
+
+// ── Scope contracts ─────────────────────────────────────────────────────────
+
+test("state components do not import api auth or backend modules", () => {
+  const paths = [LOADING_STATE_PATH, EMPTY_STATE_PATH, ERROR_STATE_PATH];
+
+  for (const path of paths) {
+    const source = read(path);
+
+    assert.equal(
+      source.includes('from "@/lib/api"'),
+      false,
+      `${path} must not import api module`,
+    );
+    assert.equal(
+      source.includes('from "@/lib/auth"'),
+      false,
+      `${path} must not import auth module`,
+    );
+    assert.equal(
+      source.includes("cookies("),
+      false,
+      `${path} must not use cookies()`,
+    );
+    assert.equal(
+      source.includes('"/api'),
+      false,
+      `${path} must not embed /api literals`,
+    );
+  }
+});
+
+test("state components do not use next/link or anchor tags for navigation", () => {
+  const paths = [LOADING_STATE_PATH, EMPTY_STATE_PATH, ERROR_STATE_PATH];
+
+  for (const path of paths) {
+    const source = read(path);
+
+    assert.equal(
+      source.includes('from "next/link"'),
+      false,
+      `${path} must not import next/link`,
+    );
+  }
+});
+
+test("loading state empty state and error state do not touch package deps or tsconfig", () => {
+  const paths = [LOADING_STATE_PATH, EMPTY_STATE_PATH, ERROR_STATE_PATH];
+
+  for (const path of paths) {
+    const source = read(path);
+
+    assert.equal(source.includes("package.json"), false);
+    assert.equal(source.includes("tsconfig"), false);
+    assert.equal(source.includes("next-env"), false);
+  }
+});


### PR DESCRIPTION
## Summary
- Polish LoadingState with accessible status semantics, labels and compact support
- Polish EmptyState with contextual eyebrow and secondary actions while preserving the existing API
- Polish ErrorState with warning/critical tones, support text and safer retry focus treatment
- Add native dashboard state polish tests and PR implementation documentation

## Scope
- No backend changes
- No API route changes
- No auth/session changes
- No middleware changes
- No SEO/public route changes
- No dependency changes
- No package.json, pnpm-lock.yaml, next-env.d.ts or tsconfig.json changes
- No route or endpoint changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build