### PR TITLE
chore(shared): wire low-risk audit constants guardrails

### DIFF
--- a/shared/const.ts
+++ b/shared/const.ts
@@ -1,5 +1,8 @@
 export const COOKIE_NAME = "app_session_id";
 export const ONE_YEAR_MS = 1000 * 60 * 60 * 24 * 365;
-export const AXIOS_TIMEOUT_MS = 30_000;
+export const FETCH_TIMEOUT_MS = 30_000;
+
+/** @deprecated Use FETCH_TIMEOUT_MS. */
+export const AXIOS_TIMEOUT_MS = FETCH_TIMEOUT_MS;
 export const UNAUTHED_ERR_MSG = "Inicia sesion (10001)";
 export const NOT_ADMIN_ERR_MSG = "No tienes el permiso requerido (10002)";

--- a/test/shared-const-and-errors.test.ts
+++ b/test/shared-const-and-errors.test.ts
@@ -1,7 +1,10 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   AXIOS_TIMEOUT_MS,
+  FETCH_TIMEOUT_MS,
   COOKIE_NAME,
   NOT_ADMIN_ERR_MSG,
   ONE_YEAR_MS,
@@ -18,9 +21,27 @@ import {
 test("shared const mantiene valores públicos esperados", () => {
   assert.equal(COOKIE_NAME, "app_session_id");
   assert.equal(ONE_YEAR_MS, 1000 * 60 * 60 * 24 * 365);
-  assert.equal(AXIOS_TIMEOUT_MS, 30_000);
+  assert.equal(FETCH_TIMEOUT_MS, 30_000);
+  assert.equal(AXIOS_TIMEOUT_MS, FETCH_TIMEOUT_MS);
   assert.equal(UNAUTHED_ERR_MSG, "Inicia sesion (10001)");
   assert.equal(NOT_ADMIN_ERR_MSG, "No tienes el permiso requerido (10002)");
+});
+
+test("AXIOS_TIMEOUT_MS es alias backward-compat de FETCH_TIMEOUT_MS", () => {
+  assert.equal(AXIOS_TIMEOUT_MS, FETCH_TIMEOUT_MS);
+  assert.equal(FETCH_TIMEOUT_MS, 30_000);
+});
+
+test("cookie parity: COOKIE_NAME coincide con el literal de sesión en frontend/src/proxy.ts", () => {
+  const source = readFileSync(
+    resolve(process.cwd(), "frontend/src/proxy.ts"),
+    "utf8",
+  );
+
+  assert.ok(
+    source.includes(`"${COOKIE_NAME}"`),
+    `proxy.ts debe contener "${COOKIE_NAME}" (valor de COOKIE_NAME en shared/const)`,
+  );
 });
 
 test("HttpError conserva statusCode, message y name", () => {


### PR DESCRIPTION
## Summary
- Add canonical `FETCH_TIMEOUT_MS` while preserving `AXIOS_TIMEOUT_MS` as `@deprecated` backward-compat alias (no axios in the project)
- Add guardrail test: `AXIOS_TIMEOUT_MS === FETCH_TIMEOUT_MS` (alias contract)
- Add cookie-parity contract: verifies `COOKIE_NAME` from `shared/const` matches the literal used in `frontend/src/proxy.ts`

## Scope
- Non-critical audit follow-up only
- No auth/security/rate-limit/API client/dashboard changes
- No dependency changes — no package.json or lock file touched
- `frontend/src/proxy.ts` intentionally NOT changed: 10 test files enforce its literal cookie constants as a source-level security contract; cross-workspace import would break those guardrails

## Why proxy.ts was not wired
`ADMIN_SESSION_COOKIE_NAME` has no counterpart in `shared/const`. Multiple test files (`frontend-middleware.test.ts`, `auth-session-boundaries.test.ts`, `global-auth-boundary-contract.test.ts`) verify the exact literal `const CLINIC_SESSION_COOKIE_NAME = "app_session_id"` — these ARE the parity guardrails. The new cookie-parity test in `shared-const-and-errors.test.ts` adds a complementary cross-reference from the shared side.

## Validation
- `pnpm test` — 2415/2416 pass, 0 fail
- `pnpm build` — OK
- `pnpm security:public-surface` — PASS
- `pnpm --dir frontend typecheck` — no errors
- `pnpm --dir frontend lint` — no errors
- `pnpm --dir frontend build` — OK