### PR TITLE
fix(security): enforce CSP report byte limit

### DIFF
--- a/frontend/src/app/api/security/csp-report/route.ts
+++ b/frontend/src/app/api/security/csp-report/route.ts
@@ -156,7 +156,7 @@ export async function POST(req: Request): Promise<Response> {
     return new Response(null, { status: 204 });
   }
 
-  if (raw.length > MAX_BODY_BYTES) {
+  if (Buffer.byteLength(raw, "utf8") > MAX_BODY_BYTES) {
     return new Response(null, { status: 413 });
   }
 

--- a/test/frontend-csp-report-endpoint-contract.test.ts
+++ b/test/frontend-csp-report-endpoint-contract.test.ts
@@ -185,6 +185,15 @@ test("POST returns 413 when actual body length > 16 KB", async () => {
   assert.equal(res.status, 413);
 });
 
+test("POST measures the actual body limit in UTF-8 bytes", async () => {
+  const big = JSON.stringify({ "csp-report": { x: "á".repeat(9 * 1024) } });
+  assert.ok(big.length < 16 * 1024);
+  assert.ok(Buffer.byteLength(big, "utf8") > 16 * 1024);
+
+  const res = await POST(makeRequest(big));
+  assert.equal(res.status, 413);
+});
+
 test("POST returns 204 silently on invalid JSON", async () => {
   const res = await POST(makeRequest("not json at all"));
   assert.equal(res.status, 204);


### PR DESCRIPTION
## Summary
- Enforce the CSP report body limit using UTF-8 byte length instead of UTF-16 string length
- Add multibyte payload coverage for the CSP report endpoint contract
- Confirm the existing Next.js /api/security/csp-report route remains local and is not intercepted by API rewrites

## Scope
- Frontend CSP report handler only
- No Fastify/backend route added
- No auth/CORS/rate-limit/API client/health changes
- No dependency changes
- No package lock changes

## Validation
- CSP contract tests: 69 passed
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm typecheck:test
- pnpm --dir frontend build

## Note
A pre-existing runtime smoke issue was observed: next dev/start cannot resolve the extensionless import ./src/lib/security/csp-policy from next.config.ts in that smoke path. This PR does not modify it because it is independent from the CSP report byte-limit fix.