### PR TITLE
feat(public): elevate secondary public pages visual system

### DIFF
--- a/frontend/e2e/public-routes.spec.ts
+++ b/frontend/e2e/public-routes.spec.ts
@@ -5,7 +5,7 @@ const routes = [
   { path: "/servicios", text: /servicios/i },
   { path: "/profesionales", text: /profesionales/i },
   { path: "/clinicas", text: /Portal para cl.nicas veterinarias/i },
-  { path: "/particulares", text: /Acceda al seguimiento y al informe de su caso con token seguro/i },
+  { path: "/particulares", text: /Seguimiento e informe de su caso/i },
   { path: "/contacto", text: /contacto/i },
   { path: "/login", text: /VETNEB|login|acceso/i },
 ];

--- a/frontend/e2e/visual-smoke.spec.ts
+++ b/frontend/e2e/visual-smoke.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 const routes = [
   { path: "/", text: /VETNEB/i },
   { path: "/contacto", text: /contacto/i },
-  { path: "/particulares", text: /Acceda al seguimiento y al informe de su caso con token seguro/i },
+  { path: "/particulares", text: /Seguimiento e informe de su caso/i },
   { path: "/login", text: /VETNEB|login|acceso/i },
   { path: "/dashboard", text: /dashboard|informes|VETNEB/i },
 ];

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import {
   ArrowRight,
+  Check,
   ClipboardCheck,
   FileText,
   Globe2,
@@ -13,13 +14,6 @@ import {
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata, getClinicasPageJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
@@ -37,6 +31,8 @@ const features = [
     title: "Recepción de informes",
     description:
       "Reciba los resultados de estudios directamente en su portal. Notificaciones automáticas cuando un informe esté listo.",
+    size: "wide" as const,
+    number: "01",
   },
   {
     icon: Search,
@@ -44,6 +40,8 @@ const features = [
     title: "Búsqueda avanzada",
     description:
       "Encuentre informes por paciente, tipo de estudio, fecha o estado. Filtros potentes para gestionar grandes volúmenes.",
+    size: "narrow" as const,
+    number: "02",
   },
   {
     icon: Truck,
@@ -51,6 +49,8 @@ const features = [
     title: "Seguimiento de logística",
     description:
       "Vea el estado de las visitas de campo y entregas programadas para su clínica. Transparencia total en el proceso.",
+    size: "narrow" as const,
+    number: "03",
   },
   {
     icon: ShieldCheck,
@@ -58,6 +58,8 @@ const features = [
     title: "Acceso seguro y auditado",
     description:
       "Cada acceso a informes queda registrado. Control total sobre quién accede a qué información y cuándo.",
+    size: "wide" as const,
+    number: "04",
   },
   {
     icon: UsersRound,
@@ -65,6 +67,8 @@ const features = [
     title: "Gestión de usuarios",
     description:
       "Administre los usuarios de su clínica con roles diferenciados: propietario y personal de clínica.",
+    size: "half" as const,
+    number: "05",
   },
   {
     icon: Globe2,
@@ -72,6 +76,8 @@ const features = [
     title: "Perfil público",
     description:
       "Mantenga actualizado el perfil público de su clínica en el directorio de Portal VETNEB.",
+    size: "half" as const,
+    number: "06",
   },
 ];
 
@@ -111,90 +117,161 @@ export default function ClinicasPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+
+      {/* Hero superpremium dos columnas */}
       <section
-        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        className="public-secondary-hero-surface text-white"
         aria-labelledby="clinicas-page-title"
       >
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <h1
-            id="clinicas-page-title"
-            className="mb-5 max-w-4xl text-4xl font-bold md:text-5xl"
-          >
-            Portal para clínicas veterinarias
-          </h1>
-          <p className="max-w-2xl text-xl leading-relaxed text-primary-foreground/92">
-            Gestión centralizada de informes, estudios y logística para su
-            clínica veterinaria. Acceso seguro, trazable y disponible las 24 hs.
-          </p>
-          <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-            <PublicRouteControl
-              href={ROUTES.login}
-              variant="primaryDark"
-              className="public-cta-primary w-full sm:w-auto"
-            >
-              Acceder al portal
-              <ArrowRight className="h-4 w-4" aria-hidden="true" />
-            </PublicRouteControl>
-            <PublicRouteControl
-              href={ROUTES.contacto}
-              variant="secondaryOutline"
-              className="public-cta-on-hero w-full sm:w-auto"
-            >
-              Solicitar acceso
-            </PublicRouteControl>
+          <div className="sec-hero-layout">
+            <div className="sec-hero-copy">
+              <div className="sec-hero-eyebrow">
+                <span className="sec-hero-eyebrow-dot" aria-hidden="true" />
+                Acceso institucional
+              </div>
+
+              <h1 id="clinicas-page-title" className="sec-hero-title">
+                Portal para clínicas veterinarias
+              </h1>
+
+              <p className="sec-hero-lead">
+                Gestión centralizada de informes, estudios y logística para su
+                clínica veterinaria. Acceso seguro, trazable y disponible las 24 hs.
+              </p>
+
+              <div className="sec-hero-scope">
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Informes en tiempo real
+                </span>
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Trazabilidad completa
+                </span>
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Logística integrada
+                </span>
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <PublicRouteControl
+                  href={ROUTES.login}
+                  variant="primaryLight"
+                  className="public-cta-on-hero w-full sm:w-auto"
+                >
+                  Acceder al portal
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </PublicRouteControl>
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="secondaryOutline"
+                  className="w-full sm:w-auto"
+                >
+                  Solicitar acceso
+                </PublicRouteControl>
+              </div>
+            </div>
+
+            {/* Panel flotante derecha: capacidades del portal */}
+            <div className="sec-hero-panel" aria-label="Capacidades del portal VETNEB">
+              <div className="sec-hero-panel-header">
+                <span>Portal clínico</span>
+                <span className="sec-hero-panel-badge">VETNEB</span>
+              </div>
+              <div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <FileText className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Informes</p>
+                    <p className="sec-hero-panel-value">Recepción y descarga de resultados</p>
+                  </span>
+                </div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Trazabilidad</p>
+                    <p className="sec-hero-panel-value">Acceso auditado y controlado</p>
+                  </span>
+                </div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <Truck className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Logística</p>
+                    <p className="sec-hero-panel-value">Seguimiento de visitas y entregas</p>
+                  </span>
+                </div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <UsersRound className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Usuarios</p>
+                    <p className="sec-hero-panel-value">Roles diferenciados por clínica</p>
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <div className="public-soft-canvas">
+      {/* Canvas secciones editoriales */}
+      <div className="sec-page-canvas">
+        {/* Funcionalidades: bento light */}
         <section
-          className="py-16 md:py-20"
+          className="sec-page-section"
           aria-labelledby="clinicas-features-heading"
         >
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
-              <div className="mx-auto mb-10 max-w-3xl text-center">
-                <h2
-                  id="clinicas-features-heading"
-                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
-                >
-                  Todo lo que necesita su clínica
-                </h2>
-                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                  Un sistema visualmente claro, trazable y preparado para trabajo
-                  diario de alto volumen.
+              <div className="home-section-heading home-section-heading-split">
+                <div>
+                  <p className="home-kicker">Funcionalidades</p>
+                  <h2 id="clinicas-features-heading">
+                    Todo lo que necesita su clínica.
+                  </h2>
+                </div>
+                <p>
+                  Un sistema claro, trazable y preparado para el trabajo
+                  diario con informes y coordinación de muestras de alto
+                  volumen.
                 </p>
               </div>
             </PublicScrollReveal>
 
             <PublicScrollReveal variant="cards" staggerChildren>
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+              <div className="sec-bento-grid-light">
                 {features.map((feature) => {
-                  const featureHeadingId = `clinicas-feature-${feature.title.toLowerCase().replace(/\s+/g, "-")}`;
+                  const FeatureIcon = feature.icon;
 
                   return (
                     <article
                       key={feature.title}
                       data-scroll-reveal-item
-                      aria-labelledby={featureHeadingId}
+                      data-size={feature.size}
+                      className="sec-bento-card-light"
+                      aria-labelledby={`clinicas-feature-${feature.number}`}
                     >
-                      <Card className="premium-card">
-                        <CardHeader>
-                          <VisualIcon
-                            icon={feature.icon}
-                            tone={feature.tone}
-                            className="mb-2"
-                          />
-                          <CardTitle id={featureHeadingId} className="text-lg text-vetneb-ink">
-                            {feature.title}
-                          </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                          <CardDescription className="text-sm leading-relaxed text-muted-foreground">
-                            {feature.description}
-                          </CardDescription>
-                        </CardContent>
-                      </Card>
+                      <VisualIcon
+                        icon={FeatureIcon}
+                        tone={feature.tone}
+                        className="mb-4 h-11 w-11 rounded-xl"
+                      />
+                      <h3
+                        id={`clinicas-feature-${feature.number}`}
+                        className="sec-bento-title"
+                      >
+                        {feature.title}
+                      </h3>
+                      <p className="sec-bento-desc">{feature.description}</p>
                     </article>
                   );
                 })}
@@ -203,51 +280,60 @@ export default function ClinicasPage() {
           </div>
         </section>
 
+        {/* Onboarding: steps */}
         <section
-          className="py-16 md:py-20"
+          className="sec-page-section border-t border-vetneb-line/30"
           aria-labelledby="clinicas-onboarding-heading"
         >
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-            <PublicScrollReveal variant="section">
-              <div className="mx-auto mb-10 max-w-3xl text-center">
-                <h2
-                  id="clinicas-onboarding-heading"
-                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
-                >
-                  Cómo comenzar
+            <PublicScrollReveal>
+              <div className="home-section-heading home-section-heading-centered">
+                <p className="home-kicker">Cómo comenzar</p>
+                <h2 id="clinicas-onboarding-heading">
+                  En cuatro pasos.
                 </h2>
+                <p>
+                  El proceso de incorporación está diseñado para ser rápido y
+                  claro desde la solicitud hasta el acceso operativo.
+                </p>
               </div>
             </PublicScrollReveal>
 
-            <PublicScrollReveal variant="cards" staggerChildren>
-              <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+            <PublicScrollReveal staggerChildren>
+              <ol
+                className="sec-step-list mx-auto"
+                style={{ maxWidth: "44rem" }}
+                aria-label="Pasos para comenzar con el portal clínico"
+              >
                 {steps.map((step) => (
-                  <article
+                  <li
                     key={step.number}
                     data-scroll-reveal-item
+                    className="sec-step-item"
                     aria-labelledby={`clinicas-step-${step.number}`}
-                    className="premium-card-muted p-5"
                   >
-                    <div className="mb-4 inline-flex items-center rounded-full border border-vetneb-teal/35 bg-vetneb-teal/10 px-3 py-1 text-xs font-semibold tracking-[0.08em] text-vetneb-navy">
+                    <div className="sec-step-marker" aria-hidden="true">
                       {step.number}
                     </div>
-                    <h3
-                      id={`clinicas-step-${step.number}`}
-                      className="mb-2 font-semibold text-vetneb-ink"
-                    >
-                      {step.title}
-                    </h3>
-                    <p className="text-sm leading-relaxed text-muted-foreground">
-                      {step.description}
-                    </p>
-                  </article>
+                    <div className="min-w-0 flex-1">
+                      <p className="sec-step-label">Paso {step.number}</p>
+                      <h3
+                        id={`clinicas-step-${step.number}`}
+                        className="sec-step-title"
+                      >
+                        {step.title}
+                      </h3>
+                      <p className="sec-step-desc">{step.description}</p>
+                    </div>
+                  </li>
                 ))}
-              </div>
+              </ol>
             </PublicScrollReveal>
 
+            {/* Banner acceso seguro */}
             <PublicScrollReveal variant="minimal">
               <section
-                className="clinical-muted-band mx-auto mt-10 max-w-3xl rounded-lg p-6 clinical-surface-shadow"
+                className="clinical-muted-band mx-auto mt-12 max-w-3xl rounded-2xl p-6 clinical-surface-shadow"
                 aria-labelledby="clinicas-secure-access-heading"
               >
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -272,7 +358,7 @@ export default function ClinicasPage() {
                   <PublicRouteControl
                     href={ROUTES.login}
                     variant="primaryDark"
-                    className="public-cta-primary"
+                    className="public-cta-primary shrink-0"
                   >
                     Ingresar
                   </PublicRouteControl>
@@ -282,7 +368,48 @@ export default function ClinicasPage() {
           </div>
         </section>
       </div>
+
+      {/* CTA final */}
+      <section
+        className="sec-page-cta"
+        aria-labelledby="clinicas-cta-heading"
+      >
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <PublicScrollReveal>
+            <div className="sec-page-cta-inner">
+              <div>
+                <p className="home-kicker home-kicker-light">Portal VETNEB</p>
+                <h2 id="clinicas-cta-heading">
+                  Su clínica conectada al laboratorio.
+                </h2>
+              </div>
+              <div>
+                <p>
+                  Solicite su acceso y empiece a gestionar informes,
+                  trazabilidad y logística desde un único portal seguro.
+                </p>
+                <div className="sec-page-cta-actions">
+                  <PublicRouteControl
+                    href={ROUTES.contacto}
+                    variant="primaryLight"
+                    className="home-final-primary"
+                  >
+                    Solicitar acceso
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href={ROUTES.login}
+                    variant="secondaryOutline"
+                    className="home-final-secondary"
+                  >
+                    Acceder al portal
+                  </PublicRouteControl>
+                </div>
+              </div>
+            </div>
+          </PublicScrollReveal>
+        </div>
+      </section>
     </PublicLayout>
   );
 }
-

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3137,3 +3137,811 @@
   }
 }
 /* public-home-superpremium:end */
+
+/* public-secondary-pages-superpremium:start */
+@layer components {
+  /* Atmospheric overlays for secondary hero */
+  .public-secondary-hero-surface::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    opacity: 0.26;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(126, 213, 219, 0.10) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(126, 213, 219, 0.08) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: linear-gradient(to bottom, black 0%, transparent 90%);
+  }
+
+  .public-secondary-hero-surface::after {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    width: min(56vw, 720px);
+    aspect-ratio: 1;
+    right: -12%;
+    top: -38%;
+    border: 1px solid rgba(126, 213, 219, 0.12);
+    border-radius: 50%;
+    box-shadow:
+      0 0 0 64px rgba(126, 213, 219, 0.018),
+      0 0 0 128px rgba(126, 213, 219, 0.011);
+    pointer-events: none;
+  }
+
+  /* Two-column layout for secondary heroes with accent panel */
+  .sec-hero-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
+    align-items: center;
+    gap: clamp(2.5rem, 5vw, 5rem);
+    padding: clamp(3.5rem, 5vw, 5rem) 0 clamp(4rem, 6vw, 6rem);
+  }
+
+  .sec-hero-copy {
+    position: relative;
+    z-index: 2;
+  }
+
+  /* Hero eyebrow pill badge */
+  .sec-hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin-bottom: 1.25rem;
+    padding: 0.42rem 0.95rem 0.42rem 0.7rem;
+    border: 1px solid rgba(162, 224, 228, 0.24);
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.07);
+    color: rgba(209, 243, 244, 0.86);
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+
+  .sec-hero-eyebrow-dot {
+    display: inline-block;
+    width: 0.36rem;
+    height: 0.36rem;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: #72d6cf;
+    box-shadow: 0 0 8px rgba(114, 214, 207, 0.62);
+  }
+
+  /* Secondary hero headline */
+  .sec-hero-title {
+    color: white;
+    font-size: clamp(2.6rem, 5vw, 4.75rem);
+    font-weight: 650;
+    line-height: 0.94;
+    letter-spacing: -0.048em;
+    text-wrap: balance;
+  }
+
+  /* Secondary hero lead text */
+  .sec-hero-lead {
+    max-width: 40rem;
+    margin-top: 1.5rem;
+    color: rgba(225, 242, 246, 0.78);
+    font-size: clamp(1rem, 1.4vw, 1.2rem);
+    line-height: 1.68;
+    text-wrap: pretty;
+  }
+
+  /* Hero proof / scope row */
+  .sec-hero-scope {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem 1rem;
+    margin-top: 1.6rem;
+    color: rgba(214, 240, 243, 0.72);
+    font-size: 0.76rem;
+    font-weight: 600;
+  }
+
+  .sec-hero-scope span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .sec-hero-scope svg {
+    color: #82d5d0;
+  }
+
+  /* Hero accent panel (floating card, right column) */
+  .sec-hero-panel {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(209, 237, 239, 0.60);
+    border-radius: 1.25rem;
+    background: rgba(250, 254, 254, 0.95);
+    box-shadow:
+      inset 0 1px 0 white,
+      0 30px 78px rgba(0, 15, 25, 0.32),
+      0 4px 12px rgba(0, 15, 25, 0.10);
+  }
+
+  .sec-hero-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.9rem 1.15rem;
+    background: linear-gradient(135deg, #08263f 0%, #0e4262 58%, #147184 100%);
+    color: rgba(239, 250, 250, 0.9);
+    font-size: 0.67rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .sec-hero-panel-badge {
+    padding: 0.22rem 0.6rem;
+    border: 1px solid rgba(162, 224, 228, 0.26);
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+    color: #9ee5e1;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+  }
+
+  .sec-hero-panel-row {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.95rem 1.15rem;
+    border-bottom: 1px solid hsl(var(--vetneb-line) / 0.52);
+  }
+
+  .sec-hero-panel-row:last-child {
+    border-bottom: none;
+  }
+
+  .sec-hero-panel-icon {
+    display: inline-flex;
+    width: 2.1rem;
+    height: 2.1rem;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(20, 120, 129, 0.16);
+    border-radius: 0.6rem;
+    background: rgba(37, 156, 160, 0.08);
+    color: #147e83;
+  }
+
+  .sec-hero-panel-label {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.10em;
+    text-transform: uppercase;
+  }
+
+  .sec-hero-panel-value {
+    margin-top: 0.1rem;
+    color: hsl(var(--vetneb-ink));
+    font-size: 0.82rem;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  /* Canvas for secondary page sections (light bg) */
+  .sec-page-canvas {
+    position: relative;
+    isolation: isolate;
+    background:
+      radial-gradient(circle at 8% 16%, hsl(var(--vetneb-cyan) / 0.09), transparent 22%),
+      radial-gradient(circle at 94% 60%, hsl(var(--vetneb-teal) / 0.07), transparent 24%),
+      linear-gradient(180deg, #f2f8f9 0%, #f7fbfc 46%, #ecf4f5 100%);
+  }
+
+  .sec-page-canvas::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    opacity: 0.24;
+    pointer-events: none;
+    background-image:
+      linear-gradient(hsl(var(--vetneb-navy) / 0.04) 1px, transparent 1px),
+      linear-gradient(90deg, hsl(var(--vetneb-navy) / 0.03) 1px, transparent 1px);
+    background-size: 92px 92px;
+    mask-image: linear-gradient(to bottom, black, transparent 72%);
+  }
+
+  /* Generic section padding for secondary pages */
+  .sec-page-section {
+    position: relative;
+    padding: clamp(5rem, 7vw, 7.5rem) 0;
+  }
+
+  /* Section heading typography */
+  .sec-section-heading {
+    margin-bottom: clamp(2.5rem, 4vw, 4.5rem);
+  }
+
+  .sec-section-heading h2 {
+    margin-top: 0.75rem;
+    color: hsl(var(--vetneb-ink));
+    font-size: clamp(2.1rem, 3.8vw, 3.75rem);
+    font-weight: 650;
+    line-height: 1.02;
+    letter-spacing: -0.046em;
+    text-wrap: balance;
+  }
+
+  .sec-section-heading > p:not(.home-kicker) {
+    max-width: 42rem;
+    margin-top: 1rem;
+    color: hsl(var(--muted-foreground));
+    font-size: 1rem;
+    line-height: 1.72;
+    text-wrap: pretty;
+  }
+
+  .sec-section-heading-centered {
+    text-align: center;
+    max-width: 56rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .sec-section-heading-centered > p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  /* Dark catalogue section (like home-services-section) */
+  .sec-catalogue-section {
+    position: relative;
+    overflow: hidden;
+    padding: clamp(5.5rem, 8vw, 8.5rem) 0;
+    color: white;
+    background:
+      radial-gradient(circle at 84% 18%, rgba(44, 172, 171, 0.17), transparent 24%),
+      linear-gradient(118deg, #061b2d, #0a304a 58%, #0b3d4f);
+  }
+
+  .sec-catalogue-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0.28;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(126, 213, 219, 0.10) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(126, 213, 219, 0.07) 1px, transparent 1px);
+    background-size: 78px 78px;
+    mask-image: radial-gradient(circle at center, black, transparent 82%);
+  }
+
+  .sec-catalogue-section > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Bento grid (dark context) */
+  .sec-bento-grid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .sec-bento-card {
+    position: relative;
+    min-height: 18rem;
+    overflow: hidden;
+    border: 1px solid rgba(183, 224, 227, 0.16);
+    border-radius: 1.4rem;
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+    background: rgba(255, 255, 255, 0.042);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.07),
+      0 24px 64px rgba(0, 12, 22, 0.18);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    transition:
+      border-color 220ms ease,
+      box-shadow 220ms ease,
+      transform 220ms ease;
+  }
+
+  .sec-bento-card[data-size="wide"] { grid-column: span 7; }
+  .sec-bento-card[data-size="narrow"] { grid-column: span 5; }
+  .sec-bento-card[data-size="half"] { grid-column: span 6; }
+  .sec-bento-card[data-size="third"] { grid-column: span 4; }
+  .sec-bento-card[data-size="full"] { grid-column: span 12; min-height: 11rem; }
+
+  .sec-bento-card::after {
+    content: "";
+    position: absolute;
+    right: -3rem;
+    bottom: -4rem;
+    width: 11rem;
+    height: 11rem;
+    border: 1px solid rgba(149, 229, 225, 0.12);
+    border-radius: 50%;
+    box-shadow: 0 0 0 2.5rem rgba(149, 229, 225, 0.025);
+    pointer-events: none;
+  }
+
+  .sec-bento-card:hover {
+    border-color: rgba(183, 224, 227, 0.34);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.07),
+      0 32px 82px rgba(0, 12, 22, 0.28);
+    transform: translateY(-2px);
+  }
+
+  .sec-bento-card-number {
+    color: rgba(215, 241, 242, 0.28);
+    font-size: 0.65rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+  }
+
+  .sec-bento-card-icon {
+    display: flex;
+    width: 3rem;
+    height: 3rem;
+    align-items: center;
+    justify-content: center;
+    margin-top: 3.25rem;
+    border: 1px solid rgba(143, 223, 219, 0.22);
+    border-radius: 0.9rem;
+    background: rgba(75, 189, 185, 0.09);
+    color: #91ddd8;
+  }
+
+  .sec-bento-card[data-size="full"] .sec-bento-card-icon {
+    margin-top: 0;
+  }
+
+  .sec-bento-eyebrow {
+    margin-top: 1.5rem;
+    color: #91ddd8;
+    font-size: 0.64rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .sec-bento-card[data-size="full"] .sec-bento-eyebrow {
+    margin-top: 1rem;
+  }
+
+  .sec-bento-title {
+    margin-top: 0.6rem;
+    color: white;
+    font-size: clamp(1.25rem, 1.8vw, 1.65rem);
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+  }
+
+  .sec-bento-desc {
+    display: block;
+    margin-top: 0.85rem;
+    color: rgba(226, 241, 244, 0.67);
+    font-size: 0.88rem;
+    line-height: 1.65;
+  }
+
+  .sec-bento-list {
+    display: grid;
+    gap: 0.4rem;
+    margin-top: 1.15rem;
+    list-style: none;
+  }
+
+  .sec-bento-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.45rem;
+    color: rgba(226, 241, 244, 0.62);
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+
+  .sec-bento-list li::before {
+    content: "→";
+    flex-shrink: 0;
+    color: #91ddd8;
+    font-size: 0.7rem;
+    margin-top: 0.15rem;
+  }
+
+  .sec-bento-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1.4rem;
+    color: #a9e9e5;
+    font-size: 0.8rem;
+    font-weight: 750;
+    transition: gap 180ms ease, color 180ms ease;
+  }
+
+  .sec-bento-link:hover {
+    gap: 0.75rem;
+    color: white;
+  }
+
+  /* Bento grid for light-background sections */
+  .sec-bento-grid-light {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .sec-bento-card-light {
+    position: relative;
+    min-height: 18rem;
+    overflow: hidden;
+    border: 1px solid rgba(116, 159, 176, 0.22);
+    border-radius: 1.4rem;
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+    background:
+      radial-gradient(circle at 100% 0%, rgba(68, 171, 177, 0.09), transparent 30%),
+      rgba(253, 255, 255, 0.92);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.95),
+      0 18px 52px rgba(15, 57, 72, 0.088);
+    transition:
+      border-color 220ms ease,
+      box-shadow 220ms ease,
+      transform 220ms ease;
+  }
+
+  .sec-bento-card-light[data-size="wide"] { grid-column: span 7; }
+  .sec-bento-card-light[data-size="narrow"] { grid-column: span 5; }
+  .sec-bento-card-light[data-size="half"] { grid-column: span 6; }
+  .sec-bento-card-light[data-size="third"] { grid-column: span 4; }
+  .sec-bento-card-light[data-size="full"] { grid-column: span 12; min-height: 11rem; }
+
+  .sec-bento-card-light[data-dark="true"] {
+    color: white;
+    background:
+      radial-gradient(circle at 84% 12%, rgba(86, 211, 206, 0.18), transparent 32%),
+      linear-gradient(135deg, #08263f 0%, #0d405b 62%, #12616d 100%);
+    border-color: rgba(149, 229, 225, 0.15);
+    box-shadow: 0 26px 72px rgba(8, 38, 63, 0.2);
+  }
+
+  .sec-bento-card-light::after {
+    content: "";
+    position: absolute;
+    right: -3rem;
+    bottom: -4rem;
+    width: 11rem;
+    height: 11rem;
+    border: 1px solid rgba(36, 137, 146, 0.11);
+    border-radius: 50%;
+    box-shadow: 0 0 0 2.5rem rgba(36, 137, 146, 0.022);
+    pointer-events: none;
+  }
+
+  .sec-bento-card-light[data-dark="true"]::after {
+    border-color: rgba(149, 229, 225, 0.12);
+    box-shadow: 0 0 0 2.5rem rgba(149, 229, 225, 0.03);
+  }
+
+  .sec-bento-card-light:hover {
+    border-color: rgba(45, 143, 151, 0.44);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.95),
+      0 28px 76px rgba(15, 57, 72, 0.14);
+    transform: translateY(-2px);
+  }
+
+  .sec-bento-card-light[data-dark="true"]:hover {
+    border-color: rgba(149, 229, 225, 0.28);
+    box-shadow: 0 32px 88px rgba(8, 38, 63, 0.26);
+    transform: translateY(-2px);
+  }
+
+  .sec-bento-card-light .sec-bento-card-icon {
+    background: rgba(37, 156, 160, 0.09);
+    border-color: hsl(var(--vetneb-teal) / 0.18);
+    color: hsl(var(--vetneb-teal));
+  }
+
+  .sec-bento-card-light[data-dark="true"] .sec-bento-card-icon {
+    background: rgba(75, 189, 185, 0.09);
+    border-color: rgba(143, 223, 219, 0.22);
+    color: #91ddd8;
+  }
+
+  .sec-bento-card-light .sec-bento-eyebrow { color: hsl(var(--vetneb-teal)); }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-eyebrow { color: #91ddd8; }
+  .sec-bento-card-light .sec-bento-title { color: hsl(var(--vetneb-ink)); }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-title { color: white; }
+  .sec-bento-card-light .sec-bento-desc { color: hsl(var(--muted-foreground)); }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-desc { color: rgba(226, 241, 244, 0.67); }
+  .sec-bento-card-light .sec-bento-list li { color: hsl(var(--muted-foreground)); }
+  .sec-bento-card-light .sec-bento-list li::before { color: hsl(var(--vetneb-teal)); }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-list li { color: rgba(226, 241, 244, 0.62); }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-list li::before { color: #91ddd8; }
+  .sec-bento-card-light .sec-bento-link { color: hsl(var(--vetneb-navy)); }
+  .sec-bento-card-light .sec-bento-link:hover { color: hsl(var(--vetneb-teal)); }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-link { color: #a9e9e5; }
+  .sec-bento-card-light[data-dark="true"] .sec-bento-link:hover { color: white; }
+
+  /* Vertical step list for secondary pages */
+  .sec-step-list {
+    display: grid;
+    gap: 0;
+    position: relative;
+  }
+
+  .sec-step-list::before {
+    content: "";
+    position: absolute;
+    left: 1.5rem;
+    top: 3.5rem;
+    bottom: 3.5rem;
+    width: 1px;
+    background: linear-gradient(
+      180deg,
+      transparent,
+      hsl(var(--vetneb-teal) / 0.38),
+      transparent
+    );
+    pointer-events: none;
+  }
+
+  .sec-step-item {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: 3rem minmax(0, 1fr);
+    gap: 1.15rem;
+    padding: 1.5rem 0;
+    align-items: start;
+  }
+
+  .sec-step-item + .sec-step-item {
+    border-top: 1px solid hsl(var(--vetneb-line) / 0.50);
+  }
+
+  .sec-step-marker {
+    display: flex;
+    width: 3rem;
+    height: 3rem;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid hsl(var(--vetneb-line) / 0.72);
+    border-radius: 50%;
+    background: linear-gradient(145deg, white, hsl(var(--vetneb-surface-muted) / 0.82));
+    color: hsl(var(--vetneb-teal));
+    box-shadow: inset 0 1px 0 white, 0 10px 28px rgba(15, 57, 72, 0.09);
+  }
+
+  .sec-step-label {
+    color: hsl(var(--vetneb-teal));
+    font-size: 0.63rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+
+  .sec-step-title {
+    margin-top: 0.35rem;
+    color: hsl(var(--vetneb-ink));
+    font-size: 1.2rem;
+    font-weight: 650;
+    letter-spacing: -0.022em;
+    line-height: 1.2;
+  }
+
+  .sec-step-desc {
+    margin-top: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.9rem;
+    line-height: 1.65;
+  }
+
+  /* Editorial info strip */
+  .sec-editorial-strip {
+    overflow: hidden;
+    border: 1px solid rgba(131, 171, 185, 0.26);
+    border-radius: 1.2rem;
+    background: rgba(253, 255, 255, 0.96);
+    box-shadow:
+      inset 0 1px 0 white,
+      0 22px 60px rgba(11, 48, 65, 0.12);
+  }
+
+  .sec-editorial-cols {
+    display: grid;
+  }
+
+  .sec-editorial-item {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+    padding: 1.15rem 1.3rem;
+    border-right: 1px solid hsl(var(--vetneb-line) / 0.52);
+  }
+
+  .sec-editorial-item:last-child {
+    border-right: none;
+  }
+
+  .sec-editorial-label {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+  }
+
+  .sec-editorial-value {
+    color: hsl(var(--vetneb-ink));
+    font-size: 0.84rem;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  /* Final CTA for secondary pages */
+  .sec-page-cta {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    padding: clamp(5rem, 7vw, 7.5rem) 0;
+    color: white;
+    background:
+      radial-gradient(circle at 78% 0%, rgba(76, 201, 195, 0.18), transparent 30%),
+      linear-gradient(118deg, #061b2d, #0a3049 54%, #0b4655);
+  }
+
+  .sec-page-cta::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0.24;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(126, 213, 219, 0.11) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(126, 213, 219, 0.08) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: linear-gradient(90deg, black, transparent 88%);
+  }
+
+  .sec-page-cta > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .sec-page-cta h2 {
+    margin-top: 0.75rem;
+    max-width: 15ch;
+    color: white;
+    font-size: clamp(2.2rem, 4vw, 4.25rem);
+    font-weight: 650;
+    line-height: 1.02;
+    letter-spacing: -0.048em;
+    text-wrap: balance;
+  }
+
+  .sec-page-cta-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(300px, 0.8fr);
+    align-items: end;
+    gap: clamp(2.5rem, 7vw, 7rem);
+  }
+
+  .sec-page-cta-inner > div:last-child > p {
+    color: rgba(228, 244, 246, 0.72);
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+
+  .sec-page-cta-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.8rem;
+  }
+
+  /* Responsive for secondary pages */
+  @media (max-width: 1023px) {
+    .sec-hero-layout {
+      grid-template-columns: 1fr;
+      padding-bottom: 3.5rem;
+    }
+
+    .sec-page-cta-inner {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .sec-bento-card[data-size="wide"],
+    .sec-bento-card-light[data-size="wide"] {
+      grid-column: span 7;
+    }
+
+    .sec-bento-card[data-size="narrow"],
+    .sec-bento-card-light[data-size="narrow"] {
+      grid-column: span 5;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .sec-bento-card[data-size],
+    .sec-bento-card-light[data-size] {
+      grid-column: span 12;
+      min-height: 14rem;
+    }
+
+    .sec-bento-card[data-size="full"],
+    .sec-bento-card-light[data-size="full"] {
+      min-height: 10rem;
+    }
+
+    .sec-editorial-cols {
+      grid-template-columns: 1fr !important;
+    }
+
+    .sec-editorial-item {
+      border-right: none;
+      border-bottom: 1px solid hsl(var(--vetneb-line) / 0.52);
+    }
+
+    .sec-editorial-item:last-child {
+      border-bottom: none;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .sec-hero-layout {
+      padding-top: 3rem;
+      padding-bottom: 3.5rem;
+    }
+
+    .sec-hero-title {
+      font-size: clamp(2.45rem, 13vw, 3.5rem);
+      line-height: 0.96;
+    }
+
+    .sec-hero-scope {
+      display: none;
+    }
+
+    .sec-step-list::before {
+      display: none;
+    }
+
+    .sec-page-cta h2 {
+      max-width: none;
+      font-size: clamp(2rem, 11vw, 3rem);
+    }
+
+    .sec-page-cta-actions {
+      flex-direction: column;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sec-bento-card,
+    .sec-bento-card-light {
+      transition: none;
+    }
+
+    .sec-bento-card:hover,
+    .sec-bento-card-light:hover {
+      transform: none;
+    }
+  }
+}
+/* public-secondary-pages-superpremium:end */

--- a/frontend/src/app/particulares/page.tsx
+++ b/frontend/src/app/particulares/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { FileText } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { ParticularesContent } from "@/components/public/ParticularesContent";
@@ -16,10 +17,100 @@ export const metadata: Metadata = {
   },
 };
 
+const steps = [
+  {
+    number: "01",
+    title: "Recibí tu token",
+    description:
+      "VETNEB o tu clínica tratante te entregó un código único vinculado a tu caso. Ese token es la clave de acceso.",
+  },
+  {
+    number: "02",
+    title: "Ingresá con el token",
+    description:
+      "Pegá o escribí el token en el formulario de acceso. La sesión queda aislada y no expone datos de otras clínicas ni estudios.",
+  },
+  {
+    number: "03",
+    title: "Consultá tu informe",
+    description:
+      "Una vez validado el token podés consultar el estado del estudio, ver el seguimiento del caso y acceder al informe cuando esté disponible.",
+  },
+];
+
 export default function ParticularesPage() {
   return (
     <PublicLayout>
       <ParticularesContent />
+
+      {/* Guía de pasos — sin scroll reveal (functional page) */}
+      <div className="sec-page-canvas">
+        <section
+          className="sec-page-section pb-14"
+          aria-labelledby="particulares-steps-heading"
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="home-section-heading home-section-heading-centered">
+              <p className="home-kicker">Cómo funciona</p>
+              <h2 id="particulares-steps-heading">
+                Tres pasos para consultar tu caso.
+              </h2>
+              <p>
+                El acceso particular es seguro, privado y limitado al caso
+                autorizado por el laboratorio.
+              </p>
+            </div>
+
+            <ol
+              className="sec-step-list mx-auto max-w-lg"
+              aria-label="Pasos para acceder como particular"
+            >
+              {steps.map((step) => (
+                <li
+                  key={step.number}
+                  className="sec-step-item"
+                  aria-labelledby={`particulares-step-${step.number}`}
+                >
+                  <div className="sec-step-marker" aria-hidden="true">
+                    {step.number}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="sec-step-label">Paso {step.number}</p>
+                    <h3
+                      id={`particulares-step-${step.number}`}
+                      className="sec-step-title"
+                    >
+                      {step.title}
+                    </h3>
+                    <p className="sec-step-desc">{step.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+
+            <div className="clinical-muted-band mx-auto mt-10 max-w-2xl rounded-2xl p-6 clinical-surface-shadow">
+              <div className="flex items-start gap-3">
+                <FileText
+                  className="mt-0.5 h-5 w-5 shrink-0 text-vetneb-navy"
+                  aria-hidden="true"
+                  strokeWidth={1.8}
+                />
+                <div>
+                  <h3 className="font-semibold text-vetneb-ink">
+                    ¿No tenés token?
+                  </h3>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    El token es emitido por VETNEB al momento de asociar tu
+                    caso al sistema. Si tu clínica no te lo entregó aún,
+                    consultales directamente o contactá al laboratorio para
+                    coordinar.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
     </PublicLayout>
   );
 }

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -1,26 +1,20 @@
 import type { Metadata } from "next";
 import {
   ArrowRight,
+  Check,
   ClipboardCheck,
+  FileText,
   FlaskConical,
   Microscope,
   MonitorCheck,
   Network,
+  PackageCheck,
   Sparkles,
 } from "lucide-react";
-
-import { cn } from "@/lib/utils";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { VisualIcon } from "@/components/public/VisualAccents";
 import { createPageMetadata, getServicesJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
@@ -36,7 +30,6 @@ const serviceCategories = [
     id: "anatomopatologia",
     title: "Estudio anatomopatológico de tejidos",
     icon: Microscope,
-    tone: "blue" as const,
     href: "/histopatologia-veterinaria",
     linkLabel: "Ver histopatología veterinaria",
     description:
@@ -46,81 +39,101 @@ const serviceCategories = [
       "Evaluación microscópica de lesiones histológicas",
       "Correlación anatomopatológica del caso clínico",
       "Informe diagnóstico con hallazgos relevantes",
-      "Apoyo para decisiones terapéuticas",
-      "Seguimiento del caso con el equipo tratante",
     ],
+    size: "wide" as const,
+    number: "01",
   },
   {
     id: "citologia",
     title: "Estudio citológico de muestras",
     icon: FlaskConical,
-    tone: "emerald" as const,
     href: "/citologia-veterinaria",
     linkLabel: "Ver citología veterinaria",
     description:
       "Análisis citológico de líquidos y punciones para valorar alteraciones celulares con un enfoque clínico-patológico.",
     features: [
-      "Estudio citológico de líquidos y punciones",
+      "Estudio de líquidos y punciones",
       "Valoración celular orientada a diagnóstico",
-      "Identificación de patrones inflamatorios y proliferativos",
-      "Apoyo diagnóstico en lesiones de tejidos blandos",
-      "Integración con antecedentes clínicos del paciente",
+      "Identificación de patrones inflamatorios",
       "Informe citológico con conclusión profesional",
     ],
+    size: "narrow" as const,
+    number: "02",
   },
   {
     id: "tinciones",
     title: "Tinciones especiales aplicadas",
     icon: Sparkles,
-    tone: "amber" as const,
     href: "/laboratorio-patologico-veterinario",
     linkLabel: "Ver laboratorio patológico veterinario",
     description:
       "Aplicación de tinciones especiales para ampliar hallazgos histológicos y reforzar diagnósticos diferenciales.",
     features: [
-      "Selección de técnicas según complejidad del caso",
-      "Caracterización adicional de lesiones tisulares",
+      "Selección de técnicas según complejidad",
+      "Caracterización adicional de lesiones",
       "Soporte para diagnósticos diferenciales",
-      "Complemento de histopatología y citopatología",
-      "Mayor precisión frente a hallazgos complejos",
       "Registro diagnóstico trazable",
     ],
+    size: "narrow" as const,
+    number: "03",
   },
   {
     id: "integral",
     title: "Diagnóstico integral interdisciplinario",
     icon: Network,
-    tone: "slate" as const,
     href: "/laboratorio-patologico-veterinario",
     linkLabel: "Ver laboratorio patológico veterinario",
     description:
       "Integración del análisis histológico y citológico con información clínica para construir un diagnóstico específico por paciente.",
     features: [
-      "Integración de análisis histológico y citológico",
+      "Integración histológica y citológica",
       "Trabajo conjunto con diagnóstico por imágenes",
       "Articulación con cirugía y clínica veterinaria",
-      "Interconsulta profesional cuando el caso lo requiere",
       "Definición diagnóstica específica por paciente",
-      "Orientación para tratamiento personalizado",
     ],
+    size: "wide" as const,
+    number: "04",
   },
   {
     id: "informes",
     title: "Informes y seguimiento",
     icon: MonitorCheck,
-    tone: "blue" as const,
     href: "/informes-veterinarios",
     linkLabel: "Ver informes veterinarios",
     description:
       "Entrega y seguimiento de informes con comunicación continua para clínicas y profesionales durante todo el proceso diagnóstico.",
     features: [
-      "Consulta de resultados de informes las 24 hs",
-      "Seguimiento del estado del estudio en portal",
-      "Comunicación directa para coordinación de muestras",
-      "Priorización según complejidad diagnóstica",
-      "Tiempos variables según necesidad del caso",
-      "Entrega final con criterio profesional y responsable",
+      "Consulta de resultados las 24 hs",
+      "Seguimiento del estado del estudio",
+      "Comunicación directa para coordinación",
+      "Entrega con criterio profesional",
     ],
+    size: "full" as const,
+    number: "05",
+  },
+];
+
+const workflowSteps = [
+  {
+    icon: PackageCheck,
+    label: "Recepción",
+    title: "Envío de la muestra",
+    description:
+      "La clínica prepara la muestra según el protocolo de VETNEB y la envía con los datos del caso.",
+  },
+  {
+    icon: Microscope,
+    label: "Diagnóstico",
+    title: "Análisis anatomopatológico",
+    description:
+      "El anatomopatólogo examina el tejido o la muestra citológica y elabora el informe diagnóstico con criterio clínico.",
+  },
+  {
+    icon: FileText,
+    label: "Resultado",
+    title: "Informe disponible",
+    description:
+      "La clínica descarga el informe desde el portal. El tutor puede acceder con código privado cuando corresponda.",
   },
 ];
 
@@ -134,236 +147,367 @@ export default function ServiciosPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
+      {/* Hero superpremium dos columnas */}
       <section
-        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        className="public-secondary-hero-surface text-white"
         aria-labelledby="services-page-title"
       >
         <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <h1
-            id="services-page-title"
-            className="mb-4 max-w-4xl text-4xl font-bold leading-tight md:text-5xl"
-          >
-            Servicio patológico veterinario
-          </h1>
-          <p className="max-w-2xl public-copy text-lg text-primary-foreground/92 md:text-xl">
-            La anatomía patológica veterinaria integra evaluación microscópica,
-            trazabilidad de muestras e informes clínicos para orientar
-            decisiones diagnósticas con respaldo profesional.
-          </p>
+          <div className="sec-hero-layout">
+            <div className="sec-hero-copy">
+              <div className="sec-hero-eyebrow">
+                <span className="sec-hero-eyebrow-dot" aria-hidden="true" />
+                Anatomía patológica veterinaria
+              </div>
+
+              <h1 id="services-page-title" className="sec-hero-title">
+                Servicio diagnóstico patológico
+              </h1>
+
+              <p className="sec-hero-lead">
+                Histopatología, citología, tinciones especiales y diagnóstico
+                integral para orientar decisiones clínicas con respaldo
+                profesional en medicina veterinaria.
+              </p>
+
+              <div className="sec-hero-scope">
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Histopatología
+                </span>
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Citología
+                </span>
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Tinciones especiales
+                </span>
+                <span>
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Diagnóstico integral
+                </span>
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="primaryLight"
+                  className="public-cta-primary home-hero-primary-action"
+                >
+                  Coordinar con el laboratorio
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </PublicRouteControl>
+                <PublicRouteControl
+                  href={ROUTES.clinicas}
+                  variant="secondaryOutline"
+                  className="home-hero-secondary-action"
+                >
+                  Acceso para clínicas
+                </PublicRouteControl>
+              </div>
+            </div>
+
+            {/* Panel flotante derecha: catálogo */}
+            <div className="sec-hero-panel" aria-label="Catálogo diagnóstico VETNEB">
+              <div className="sec-hero-panel-header">
+                <span>Catálogo diagnóstico</span>
+                <span className="sec-hero-panel-badge">VETNEB</span>
+              </div>
+              <div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <Microscope className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Histopatología</p>
+                    <p className="sec-hero-panel-value">Estudio anatomopatológico de tejidos</p>
+                  </span>
+                </div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <FlaskConical className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Citología</p>
+                    <p className="sec-hero-panel-value">Análisis de líquidos y punciones</p>
+                  </span>
+                </div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <Sparkles className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Tinciones especiales</p>
+                    <p className="sec-hero-panel-value">Técnicas complementarias aplicadas</p>
+                  </span>
+                </div>
+                <div className="sec-hero-panel-row">
+                  <span className="sec-hero-panel-icon">
+                    <Network className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <span>
+                    <p className="sec-hero-panel-label">Diagnóstico integral</p>
+                    <p className="sec-hero-panel-value">Integración clínica y anatomopatológica</p>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
-      <div className="public-soft-canvas">
+      {/* Catálogo en grilla bento oscura */}
+      <section
+        data-services-polished="true"
+        className="sec-catalogue-section"
+        aria-labelledby="services-categories-heading"
+      >
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <PublicScrollReveal variant="section">
+            <div className="sec-section-heading mb-10">
+              <p className="home-kicker home-kicker-light">Catálogo diagnóstico</p>
+              <h2
+                id="services-categories-heading"
+                className="mt-3 text-white"
+              >
+                Distintas técnicas. Un mismo criterio.
+              </h2>
+            </div>
+          </PublicScrollReveal>
+
+          <PublicScrollReveal variant="cards" staggerChildren>
+            <div className="sec-bento-grid">
+              {serviceCategories.map((service) => {
+                const ServiceIcon = service.icon;
+
+                return (
+                  <article
+                    key={service.id}
+                    data-scroll-reveal-item
+                    data-size={service.size}
+                    className="sec-bento-card"
+                    aria-labelledby={`service-bento-${service.id}`}
+                  >
+                    <div
+                      className={
+                        service.size === "full"
+                          ? "flex items-start gap-5"
+                          : undefined
+                      }
+                    >
+                      <div
+                        className={
+                          service.size === "full" ? "shrink-0" : undefined
+                        }
+                      >
+                        {service.size !== "full" && (
+                          <div className="sec-bento-card-number">{service.number}</div>
+                        )}
+                        <div className="sec-bento-card-icon">
+                          <ServiceIcon className="h-5 w-5" aria-hidden="true" />
+                        </div>
+                        <p className="sec-bento-eyebrow">{service.number}</p>
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <h3
+                          id={`service-bento-${service.id}`}
+                          className="sec-bento-title"
+                        >
+                          {service.title}
+                        </h3>
+                        <span className="sec-bento-desc">{service.description}</span>
+                        <ul
+                          className="sec-bento-list"
+                          aria-label={`Aspectos de ${service.title}`}
+                        >
+                          {service.features.map((feature) => (
+                            <li key={feature}>{feature}</li>
+                          ))}
+                        </ul>
+                        <PublicRouteControl
+                          href={service.href}
+                          variant="bare"
+                          className="sec-bento-link"
+                        >
+                          <span className="sr-only">{service.linkLabel}</span>
+                          <span aria-hidden="true">Ver más</span>
+                          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </PublicRouteControl>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </PublicScrollReveal>
+        </div>
+      </section>
+
+      {/* Canvas secciones editoriales */}
+      <div className="sec-page-canvas">
+        {/* Flujo de trabajo */}
         <section
-          className="py-16 md:py-20"
-          aria-labelledby="services-categories-heading"
+          className="sec-page-section border-b border-vetneb-line/40"
+          aria-labelledby="services-workflow-heading"
         >
-          <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <PublicScrollReveal variant="section">
-              <div className="mx-auto mb-10 max-w-4xl">
-                <h2
-                  id="services-categories-heading"
-                  className="text-2xl font-bold text-vetneb-ink md:text-3xl"
-                >
-                  Estudios diagnósticos con criterio clínico-patológico
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal>
+              <div className="home-section-heading home-section-heading-centered">
+                <p className="home-kicker">Cómo funciona</p>
+                <h2 id="services-workflow-heading">
+                  De la muestra al informe.
                 </h2>
-                <p className="mt-3 public-copy-tight text-sm text-muted-foreground">
-                  Unificamos histopatología, citología, técnicas complementarias e
-                  informes trazables para acompañar decisiones clínicas en cada
-                  etapa del caso.
+                <p>
+                  Un recorrido entendible desde la recepción hasta el resultado
+                  diagnóstico.
                 </p>
               </div>
             </PublicScrollReveal>
 
-            <PublicScrollReveal variant="cards" staggerChildren>
-              <div
-                className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"
-                data-services-polished="true"
+            <PublicScrollReveal staggerChildren>
+              <ol
+                className="home-workflow-grid mx-auto max-w-5xl"
               >
-                {serviceCategories.map((service) => {
-                  const serviceHeadingId = `service-card-${service.id}-title`;
+                {workflowSteps.map((step, index) => {
+                  const StepIcon = step.icon;
 
                   return (
-                    <article
-                      key={service.id}
-                      data-scroll-reveal-item
-                      aria-labelledby={serviceHeadingId}
-                      className={cn(
-                        "[&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-300 hover:[&_.premium-card]:shadow-xl",
-                        serviceCategories.length % 2 === 1 &&
-                        service.id === serviceCategories[serviceCategories.length - 1]?.id
-                          ? "lg:col-span-2 lg:mx-auto lg:w-full lg:max-w-[calc((100%-2rem)/2)]"
-                          : "",
-                      )}
-                    >
-                      <Card
-                        id={service.id}
-                        className="premium-card h-full"
-                      >
-                        <CardHeader>
-                          <VisualIcon
-                            icon={service.icon}
-                            tone={service.tone}
-                            className="mb-2"
-                          />
-                          <CardTitle id={serviceHeadingId} className="text-xl text-vetneb-ink">
-                            {service.title}
-                          </CardTitle>
-                          <CardDescription className="public-copy-tight text-sm text-muted-foreground">
-                            {service.description}
-                          </CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                          <ul className="space-y-2.5">
-                            {service.features.map((feature) => (
-                              <li key={feature} className="flex items-start gap-2">
-                                <span
-                                  className="mt-0.5 text-primary font-bold text-xs"
-                                  aria-hidden="true"
-                                >
-                                  →
-                                </span>
-                                <span className="text-sm text-muted-foreground">
-                                  {feature}
-                                </span>
-                              </li>
-                            ))}
-                          </ul>
-                          <PublicRouteControl
-                            href={service.href}
-                            variant="bare"
-                            className="mt-5 inline-flex w-fit items-center gap-2 rounded-md text-sm font-semibold text-primary underline underline-offset-4 transition hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-                          >
-                            <span className="sr-only">{service.linkLabel}</span>
-                            <span aria-hidden="true">Ver más</span>
-                            <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                          </PublicRouteControl>
-                        </CardContent>
-                      </Card>
-                    </article>
+                    <li key={step.title} data-scroll-reveal-item>
+                      <div className="home-workflow-marker">
+                        <span>0{index + 1}</span>
+                        <StepIcon className="h-5 w-5" aria-hidden="true" />
+                      </div>
+                      <p>{step.label}</p>
+                      <h3>{step.title}</h3>
+                      <span>{step.description}</span>
+                    </li>
                   );
                 })}
-              </div>
+              </ol>
             </PublicScrollReveal>
           </div>
         </section>
 
-        <section className="py-16" aria-labelledby="services-coordination-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
-            <PublicScrollReveal variant="minimal">
-              <div className="premium-card p-8">
-                <h2
-                  id="services-coordination-heading"
-                  className="text-2xl font-bold text-vetneb-ink mb-4"
-                >
-                  Coordinación diagnóstica para clínicas y profesionales
-                </h2>
-                <p className="public-copy text-muted-foreground mb-8">
-                  Coordinamos recepción de muestras, priorización por complejidad y
-                  entrega de informes trazables. Los tiempos se ajustan al criterio
-                  diagnóstico y a las necesidades clínicas de cada caso.
-                </p>
-                <div className="flex flex-col justify-center gap-3 sm:flex-row">
-                  <PublicRouteControl
-                    href={ROUTES.contacto}
-                    variant="primaryDark"
-                    className="public-cta-primary w-full sm:w-auto"
-                  >
-                    Solicitar coordinación diagnóstica
-                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                  </PublicRouteControl>
-                  <PublicRouteControl
-                    href={ROUTES.clinicas}
-                    variant="primaryLight"
-                    className="public-cta-outline w-full sm:w-auto"
-                  >
-                    Conocer solución para clínicas
-                  </PublicRouteControl>
+        {/* Paneles editoriales: criterio + transparencia */}
+        <section
+          className="sec-page-section"
+          aria-labelledby="services-criteria-heading"
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal>
+              <div className="home-section-heading home-section-heading-split">
+                <div>
+                  <p className="home-kicker">Cómo trabajamos</p>
+                  <h2 id="services-criteria-heading">
+                    Rigor microscópico y contexto clínico.
+                  </h2>
                 </div>
+                <p>
+                  La calidad del diagnóstico también depende de explicar el
+                  proceso con honestidad: cada muestra es distinta y puede
+                  requerir instancias adicionales.
+                </p>
               </div>
             </PublicScrollReveal>
-          </div>
-        </section>
 
-        <section className="py-16" aria-labelledby="services-integral-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-            <PublicScrollReveal variant="section">
-              <div className="premium-card-muted p-6">
-                <h2
-                  id="services-integral-heading"
-                  className="text-2xl font-bold text-vetneb-ink mb-4"
+            <PublicScrollReveal staggerChildren>
+              <div className="home-criteria-grid">
+                <article
+                  data-scroll-reveal-item
+                  className="home-criteria-card"
+                  data-tone="primary"
+                  aria-labelledby="services-integral-h"
                 >
-                  Diagnóstico integral para medicina veterinaria
-                </h2>
-                <p className="public-copy text-muted-foreground mb-4">
-                  El diagnóstico anatomopatológico veterinario requiere integrar no
-                  sólo el análisis de tejido y citología, sino también el
-                  conocimiento clínico global de cada paciente. Esta articulación
-                  permite enriquecer la lectura diagnóstica junto con otras áreas
-                  de práctica veterinaria.
-                </p>
-                <p className="public-copy text-muted-foreground">
-                  Nuestro objetivo es colaborar de forma permanente con equipos
-                  quirúrgicos y clínicos, estudiando tejidos extirpados y muestras
-                  de punción para construir diagnósticos específicos y apoyar
-                  planes de tratamiento personalizados.
-                </p>
-              </div>
-            </PublicScrollReveal>
-          </div>
-        </section>
+                  <p className="home-card-eyebrow">Criterio diagnóstico</p>
+                  <h3 id="services-integral-h">
+                    Una lectura integral de cada caso
+                  </h3>
+                  <p className="home-criteria-description">
+                    El análisis microscópico se interpreta junto con el contexto
+                    clínico para construir una respuesta útil para el equipo
+                    veterinario.
+                  </p>
+                  <ul>
+                    {[
+                      "Hallazgos de tejidos y células integrados con la información clínica",
+                      "Articulamos el análisis con diagnóstico por imágenes y cirugía",
+                      "Evaluación específica para cada paciente veterinario",
+                      "Criterios anatomopatológicos para acompañar decisiones terapéuticas",
+                    ].map((item) => (
+                      <li key={item}>
+                        <span aria-hidden="true">
+                          <Check className="h-3.5 w-3.5" />
+                        </span>
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </article>
 
-        <section className="py-16" aria-labelledby="services-considerations-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
-            <PublicScrollReveal variant="section">
-              <div className="premium-card-muted p-6">
-                <h2
-                  id="services-considerations-heading"
-                  className="text-2xl font-bold text-vetneb-ink mb-4"
+                <article
+                  data-scroll-reveal-item
+                  className="home-criteria-card"
+                  data-tone="muted"
+                  aria-labelledby="services-transparency-h"
                 >
-                  Para tener en cuenta
-                </h2>
-                <p className="public-copy text-muted-foreground mb-4">
-                  El estudio anatomopatológico requiere integrar datos clínicos con
-                  la evaluación histológica y citológica realizada por el médico
-                  veterinario patólogo en microscopía.
-                </p>
-                <p className="public-copy text-muted-foreground">
-                  No se trata de un diagnóstico automatizado, por lo que los
-                  tiempos son variables según complejidad y técnicas
-                  complementarias requeridas. En ciertos casos se requiere
-                  interconsulta profesional para alcanzar mayor precisión
-                  diagnóstica.
-                </p>
+                  <p className="home-card-eyebrow">Transparencia operativa</p>
+                  <h3 id="services-transparency-h">
+                    Cada muestra requiere su propio tiempo
+                  </h3>
+                  <p className="home-criteria-description">
+                    El diagnóstico no es automatizado. La complejidad del caso
+                    define el trabajo necesario antes de emitir un informe.
+                  </p>
+                  <ul>
+                    {[
+                      "Los tiempos varían según la complejidad diagnóstica",
+                      "El análisis requiere evaluación microscópica especializada",
+                      "Algunos casos necesitan tinciones especiales o interconsultas",
+                      "El flujo busca mejorar recepción, diagnóstico y entrega",
+                    ].map((item) => (
+                      <li key={item}>
+                        <span aria-hidden="true">
+                          <Check className="h-3.5 w-3.5" />
+                        </span>
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </article>
               </div>
             </PublicScrollReveal>
           </div>
         </section>
 
-        <section className="py-16" aria-labelledby="services-values-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
+        {/* Valores del servicio */}
+        <section
+          className="sec-page-section pt-0"
+          aria-labelledby="services-values-heading"
+        >
+          <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="minimal">
-              <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
-                <div className="flex items-start gap-3">
+              <div className="clinical-muted-band rounded-2xl p-7 clinical-surface-shadow">
+                <div className="flex items-start gap-4">
                   <VisualIcon
                     icon={ClipboardCheck}
                     tone="emerald"
-                    className="h-11 w-11 shrink-0 rounded-xl"
+                    className="h-12 w-12 shrink-0 rounded-xl"
                   />
                   <div>
                     <h2
                       id="services-values-heading"
-                      className="text-2xl font-bold text-vetneb-ink mb-4"
+                      className="text-2xl font-bold text-vetneb-ink"
                     >
                       Valores que guían el servicio
                     </h2>
-                    <p className="public-copy text-muted-foreground">
+                    <p className="mt-3 public-copy text-muted-foreground">
                       Basamos nuestro trabajo en compromiso, seriedad, respeto,
-                      responsabilidad, confianza, diálogo, criterio clínico y ética
-                      profesional. Queremos ser un laboratorio de anatomía
-                      patológica veterinaria confiable, comprometido con la calidad
-                      diagnóstica y con el bienestar animal en cada caso que
-                      recibimos.
+                      responsabilidad, confianza, diálogo, criterio clínico y
+                      ética profesional. Queremos ser un laboratorio de anatomía
+                      patológica veterinaria confiable, comprometido con la
+                      calidad diagnóstica y con el bienestar animal en cada caso
+                      que recibimos.
                     </p>
                   </div>
                 </div>
@@ -372,6 +516,51 @@ export default function ServiciosPage() {
           </div>
         </section>
       </div>
+
+      {/* CTA final */}
+      <section
+        className="sec-page-cta"
+        aria-labelledby="services-cta-heading"
+      >
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <PublicScrollReveal>
+            <div className="sec-page-cta-inner">
+              <div>
+                <p className="home-kicker home-kicker-light">
+                  Servicio Patológico VETNEB
+                </p>
+                <h2 id="services-cta-heading">
+                  Coordiná una derivación hoy.
+                </h2>
+              </div>
+              <div>
+                <p>
+                  Coordiná el envío de muestras y accedé a informes
+                  diagnósticos desde el portal. Sin intermediarios, con
+                  trazabilidad completa.
+                </p>
+                <div className="sec-page-cta-actions">
+                  <PublicRouteControl
+                    href={ROUTES.contacto}
+                    variant="primaryLight"
+                    className="home-final-primary"
+                  >
+                    Contactanos
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </PublicRouteControl>
+                  <PublicRouteControl
+                    href={ROUTES.clinicas}
+                    variant="secondaryOutline"
+                    className="home-final-secondary"
+                  >
+                    Acceso para clínicas
+                  </PublicRouteControl>
+                </div>
+              </div>
+            </div>
+          </PublicScrollReveal>
+        </div>
+      </section>
     </PublicLayout>
   );
 }

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -134,21 +134,63 @@ export function ContactoContent() {
 
   return (
     <PublicLayout>
+      {/* Hero superpremium con método de contacto integrado */}
       <section
-        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        className="public-secondary-hero-surface text-white"
         aria-labelledby="contact-page-title"
       >
-        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 id="contact-page-title" className="mb-4 text-4xl font-bold md:text-5xl">
-            Contacto
-          </h1>
-          <p className="max-w-2xl public-copy text-xl text-primary-foreground/92">
-            ¿Desea registrar su clínica, coordinar envío de muestras o resolver
-            consultas sobre informes? Comuníquese con nuestro equipo.
-          </p>
+        <div className="container relative z-10 mx-auto px-4 py-14 sm:px-6 md:py-20 lg:px-8">
+          <div className="max-w-3xl">
+            <div className="sec-hero-eyebrow">
+              <span className="sec-hero-eyebrow-dot" aria-hidden="true" />
+              Laboratorio VETNEB
+            </div>
+
+            <h1
+              id="contact-page-title"
+              className="sec-hero-title mt-5"
+            >
+              Contacto
+            </h1>
+
+            <p className="sec-hero-lead mt-5">
+              ¿Desea registrar su clínica, coordinar envío de muestras o
+              resolver consultas sobre informes? Comuníquese con nuestro equipo
+              por el canal que prefiera.
+            </p>
+
+            {/* Pills de canales de contacto */}
+            <div className="mt-7 flex flex-wrap gap-3" aria-label="Canales de contacto disponibles">
+              <PublicExternalControl
+                href="mailto:lab.vetneb@gmail.com"
+                target="_self"
+                className="inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/10 px-4 py-2 text-sm font-medium text-white backdrop-blur-sm transition hover:bg-white/20"
+                aria-label="Escribirnos por email"
+              >
+                <Mail className="h-3.5 w-3.5" aria-hidden="true" />
+                lab.vetneb@gmail.com
+              </PublicExternalControl>
+
+              <PublicExternalControl
+                href="https://wa.me/5493534138946"
+                target="_blank"
+                className="inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/10 px-4 py-2 text-sm font-medium text-white backdrop-blur-sm transition hover:bg-white/20"
+                aria-label="Contactar por WhatsApp"
+              >
+                <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                WhatsApp
+              </PublicExternalControl>
+
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/8 px-4 py-2 text-sm font-medium text-white/80">
+                <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                Villa María, Córdoba
+              </span>
+            </div>
+          </div>
         </div>
       </section>
 
+      {/* Formulario + info de contacto */}
       <section className="public-soft-canvas py-16 md:py-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid max-w-5xl grid-cols-1 gap-12 mx-auto lg:grid-cols-2">
@@ -386,7 +428,7 @@ export function ContactoContent() {
                 })}
               </div>
 
-              <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
+              <div className="clinical-muted-band rounded-2xl p-6 clinical-surface-shadow">
                 <h3 className="mb-2 font-semibold text-vetneb-navy">
                   ¿Es una clínica veterinaria?
                 </h3>

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -521,8 +521,12 @@ export function ParticularesContent() {
       <div className="container relative z-10 mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 lg:grid-cols-[1fr_0.95fr] lg:px-8">
         {/* Columna info: oculta en móvil cuando la sesión está activa para evitar duplicación visual */}
         <div className={session !== null ? "hidden lg:block" : ""}>
-<h1 className="max-w-3xl text-4xl font-bold text-primary-foreground md:text-5xl">
-            Acceda al seguimiento y al informe de su caso con token seguro
+          <div className="sec-hero-eyebrow mb-5">
+            <span className="sec-hero-eyebrow-dot" aria-hidden="true" />
+            Acceso para tutores
+          </div>
+          <h1 className="sec-hero-title text-primary-foreground">
+            Seguimiento e informe de su caso
           </h1>
           <p className="mt-5 max-w-2xl public-copy text-lg text-primary-foreground/88">
             El acceso particular está limitado al caso vinculado al token.

--- a/frontend/src/components/public/PreciosContent.tsx
+++ b/frontend/src/components/public/PreciosContent.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useEffect, useState } from "react";
 
@@ -119,28 +119,43 @@ export function PreciosContent() {
 
   return (
     <PublicLayout>
+      {/* Hero: eyebrow + título + descripción únicamente */}
       <section
-        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        className="public-secondary-hero-surface text-white"
         aria-labelledby="pricing-page-title"
       >
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mx-auto mb-12 max-w-3xl text-center">
-            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/90">
+        <div className="container mx-auto px-4 py-14 sm:px-6 md:py-20 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <div
+              className="sec-hero-eyebrow"
+              style={{ justifyContent: "center" }}
+            >
+              <span className="sec-hero-eyebrow-dot" aria-hidden="true" />
               Valores de referencia
-            </p>
+            </div>
+
             <h1
               id="pricing-page-title"
-              className="text-3xl font-bold text-primary-foreground md:text-4xl"
+              className="sec-hero-title mt-5"
             >
               Lista de precios
             </h1>
-            <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-primary-foreground/88 md:text-base">
+
+            <p className="sec-hero-lead mx-auto mt-5 max-w-2xl">
               Referencia orientativa para la coordinación administrativa. Los
-              valores sin definición vigente se muestran como “Consultar”.
+              valores sin definición vigente se muestran como &quot;Consultar&quot;.
             </p>
           </div>
+        </div>
+      </section>
 
-          <section aria-labelledby="pricing-catalog-heading">
+      {/* Catálogo de precios en canvas claro */}
+      <div className="sec-page-canvas">
+        <section
+          className="sec-page-section"
+          aria-labelledby="pricing-catalog-heading"
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <h2 id="pricing-catalog-heading" className="sr-only">
               Catálogo público de precios por categoría
             </h2>
@@ -207,9 +222,9 @@ export function PreciosContent() {
                 No hay precios disponibles.
               </p>
             )}
-          </section>
-        </div>
-      </section>
+          </div>
+        </section>
+      </div>
     </PublicLayout>
   );
 }

--- a/frontend/src/components/public/ProfesionalesSearchContent.tsx
+++ b/frontend/src/components/public/ProfesionalesSearchContent.tsx
@@ -5,11 +5,14 @@ import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   BriefcaseMedical,
+  Check,
   ChevronRight,
   MapPin,
+  Network,
   Search,
   ShieldCheck,
   UserRoundSearch,
+  UsersRound,
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
@@ -35,6 +38,30 @@ type SearchState =
   | { status: "loading"; professionals: PublicProfessional[]; total: number }
   | { status: "success"; professionals: PublicProfessional[]; total: number }
   | { status: "error"; professionals: PublicProfessional[]; total: number };
+
+const trustHighlights = [
+  {
+    icon: ShieldCheck,
+    tone: "blue" as const,
+    title: "Fichas verificadas",
+    description:
+      "Cada entrada en la red fue revisada y confirmada directamente por el laboratorio VETNEB antes de publicarse.",
+  },
+  {
+    icon: Network,
+    tone: "emerald" as const,
+    title: "Red de clínicas y profesionales",
+    description:
+      "La red incluye clínicas veterinarias y profesionales vinculados al servicio diagnóstico con datos actualizados.",
+  },
+  {
+    icon: UsersRound,
+    tone: "amber" as const,
+    title: "Coordinación diagnóstica",
+    description:
+      "Los perfiles verificados articulan la derivación de muestras, el seguimiento y la comunicación clínica con VETNEB.",
+  },
+];
 
 export function ProfesionalesSearchContent() {
   const router = useRouter();
@@ -110,209 +137,273 @@ export function ProfesionalesSearchContent() {
 
   return (
     <PublicLayout>
+      {/* Hero superpremium */}
       <section
-        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        className="public-secondary-hero-surface text-white"
         aria-labelledby="professionals-page-title"
       >
-        <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <h1
-            id="professionals-page-title"
-            className="mb-4 max-w-4xl text-4xl font-bold md:text-5xl"
-          >
-            Clínicas y profesionales verificados que trabajan con VETNEB.
-          </h1>
-          <p className="max-w-2xl public-copy text-xl text-primary-foreground/92">
-            Cada ficha fue revisada y confirmada por el laboratorio.
-          </p>
-        </div>
-      </section>
+        <div className="container relative z-10 mx-auto px-4 py-14 sm:px-6 md:py-20 lg:px-8">
+          <div className="max-w-3xl">
+            <div className="sec-hero-eyebrow">
+              <span className="sec-hero-eyebrow-dot" aria-hidden="true" />
+              Red verificada VETNEB
+            </div>
 
-      <section
-        className="public-soft-canvas py-16"
-        aria-labelledby="professionals-search-heading"
-      >
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mx-auto max-w-4xl">
-            <PublicScrollReveal variant="section">
-              <div className="mb-6 flex items-start gap-4">
-                <VisualIcon
-                  icon={UserRoundSearch}
-                  tone="blue"
-                  className="hidden sm:inline-flex"
-                />
-                <div>
-                  <h2
-                    id="professionals-search-heading"
-                    className="mb-3 text-2xl font-bold text-vetneb-ink"
-                  >
-                    Consultar la red verificada
-                  </h2>
-                  <p className="public-copy-tight text-sm text-muted-foreground">
-                    Ingrese texto libre, incluso una sola letra. La consulta
-                    admite coincidencias por nombre, especialidad, servicios,
-                    localidad, país o descripción para ubicar perfiles
-                    institucionales dentro de la red VETNEB.
-                  </p>
-                </div>
-              </div>
-            </PublicScrollReveal>
-
-            <form
-              className="premium-card flex flex-col gap-3 p-4 sm:flex-row"
-              aria-label="Consulta de la red profesional"
-              onSubmit={handleSubmit}
+            <h1
+              id="professionals-page-title"
+              className="sec-hero-title mt-5"
             >
-              <label htmlFor="professional-search" className="sr-only">
-                Consultar profesional
-              </label>
-              <div className="relative flex-1">
-                <Search
-                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                  aria-hidden="true"
-                />
-                <input
-                  id="professional-search"
-                  name="q"
-                  type="search"
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Nombre, especialidad, localidad o dato operativo de la red"
-                  className="h-11 w-full rounded-xl border border-input bg-white/90 pl-10 pr-3 text-sm shadow-inner ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                />
-              </div>
-              <Button type="submit" className="public-cta-primary h-11">
-                Consultar
-              </Button>
-            </form>
+              Clínicas y profesionales verificados que trabajan con VETNEB.
+            </h1>
 
-            <section
-              className="mt-8"
-              aria-labelledby="professionals-results-heading"
-              aria-live="polite"
-            >
-              <h2 id="professionals-results-heading" className="sr-only">
-                Resultados de la búsqueda profesional
-              </h2>
-              {!currentQuery ? (
-                <div className="surface-empty p-6">
-                  Realice una consulta para revisar clínicas y profesionales
-                  verificados de la red VETNEB.
-                </div>
-              ) : null}
+            <p className="sec-hero-lead mt-5">
+              Cada ficha fue revisada y confirmada por el laboratorio.
+              Consultá la red verificada para coordinar derivaciones, informes
+              y seguimiento diagnóstico.
+            </p>
 
-              {state.status === "loading" ? (
-                <div className="clinical-alert-info p-6">
-                  Consultando la red de profesionales vinculados a VETNEB...
-                </div>
-              ) : null}
-
-              {state.status === "error" ? (
-                <div className="clinical-alert-error p-6">
-                  No se pudo realizar la búsqueda. Intente nuevamente.
-                </div>
-              ) : null}
-
-              {state.status === "success" && state.professionals.length === 0 ? (
-                <div className="surface-empty p-6">
-                  No se encontraron profesionales para “{currentQuery}”. Revise
-                  la ortografía o pruebe otro dato de búsqueda.
-                </div>
-              ) : null}
-
-              {state.status === "success" && state.professionals.length > 0 ? (
-                <div>
-                  <p className="mb-4 text-sm text-muted-foreground">
-                    {state.total} resultado(s) para “{currentQuery}”. Seleccione
-                    un perfil para ver la ficha institucional y sus datos de
-                    coordinación clínica.
-                  </p>
-                  <div className="space-y-3">
-                    {state.professionals.map((professional) => {
-                      const location = getPublicProfessionalLocation(professional);
-                      const summary = summarizePublicProfessional(professional);
-                      const isVerified =
-                        isVerifiedPublicProfessional(professional);
-
-                      return (
-                        <article key={professional.clinicId}>
-                          <PublicRouteControl
-                            href={buildProfessionalDetailHref(
-                              professional.clinicId,
-                            )}
-                            variant="bare"
-                            aria-label={`Abrir detalle del perfil ${professional.displayName}`}
-                            className="premium-card group flex w-full items-start gap-4 p-4 text-left transition hover:-translate-y-0.5 hover:border-vetneb-teal/45 hover:shadow-lg"
-                          >
-                            <span className="shrink-0">
-                              {professional.avatarUrl ? (
-                                <Image
-                                  src={professional.avatarUrl}
-                                  alt={`Logo o avatar de ${professional.displayName}`}
-                                  width={56}
-                                  height={56}
-                                  className="h-14 w-14 rounded-xl border border-vetneb-line/70 object-cover"
-                                  loading="lazy"
-                                  unoptimized
-                                />
-                              ) : (
-                                <span
-                                  className="professional-avatar-fallback flex h-14 w-14 items-center justify-center rounded-xl border border-vetneb-line/70 bg-vetneb-cyan/12 text-vetneb-navy"
-                                  aria-hidden="true"
-                                >
-                                  <BriefcaseMedical
-                                    className="h-6 w-6"
-                                    aria-hidden="true"
-                                  />
-                                </span>
-                              )}
-                            </span>
-                            <span className="min-w-0 flex-1">
-                              <span className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                <span className="min-w-0">
-                                  <span className="block text-base font-semibold text-vetneb-ink">
-                                    {professional.displayName}
-                                  </span>
-                                  {location ? (
-                                    <span className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-                                      <MapPin
-                                        className="h-3.5 w-3.5 text-primary"
-                                        aria-hidden="true"
-                                      />
-                                      {location}
-                                    </span>
-                                  ) : null}
-                                </span>
-                                {isVerified ? (
-                                  <span className="clinical-pill inline-flex items-center gap-1 px-2 py-0.5 text-[0.65rem] tracking-[0.08em]">
-                                    <ShieldCheck
-                                      className="h-3 w-3"
-                                      aria-hidden="true"
-                                    />
-                                    Perfil verificado
-                                  </span>
-                                ) : null}
-                              </span>
-                              {summary ? (
-                                <span className="mt-3 block text-sm leading-relaxed text-muted-foreground">
-                                  {summary}
-                                </span>
-                              ) : null}
-                            </span>
-                            <ChevronRight
-                              className="mt-4 h-5 w-5 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-primary"
-                              aria-hidden="true"
-                            />
-                          </PublicRouteControl>
-                        </article>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
-            </section>
+            <div className="sec-hero-scope mt-7">
+              <span>
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                Clínicas veterinarias
+              </span>
+              <span>
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                Profesionales vinculados
+              </span>
+              <span>
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                Perfiles verificados
+              </span>
+            </div>
           </div>
         </div>
       </section>
+
+      {/* Sección editorial: trust highlights */}
+      <div className="sec-page-canvas">
+        <section
+          className="sec-page-section"
+          aria-label="Por qué confiamos en la red"
+          style={{ paddingBottom: "3rem" }}
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="sec-bento-grid-light" style={{ maxWidth: "64rem", margin: "0 auto" }}>
+                {trustHighlights.map((item) => {
+                  const TrustIcon = item.icon;
+
+                  return (
+                    <article
+                      key={item.title}
+                      data-scroll-reveal-item
+                      data-size="third"
+                      className="sec-bento-card-light"
+                    >
+                      <VisualIcon
+                        icon={TrustIcon}
+                        tone={item.tone}
+                        className="mb-4 h-11 w-11 rounded-xl"
+                      />
+                      <h2 className="sec-bento-title">{item.title}</h2>
+                      <p className="sec-bento-desc">{item.description}</p>
+                    </article>
+                  );
+                })}
+              </div>
+            </PublicScrollReveal>
+          </div>
+        </section>
+
+        {/* Búsqueda */}
+        <section
+          className="sec-page-section"
+          aria-labelledby="professionals-search-heading"
+          style={{ paddingTop: 0 }}
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-4xl">
+              <PublicScrollReveal variant="section">
+                <div className="mb-6 flex items-start gap-4">
+                  <VisualIcon
+                    icon={UserRoundSearch}
+                    tone="blue"
+                    className="hidden sm:inline-flex"
+                  />
+                  <div>
+                    <h2
+                      id="professionals-search-heading"
+                      className="mb-3 text-2xl font-bold text-vetneb-ink"
+                    >
+                      Consultar la red verificada
+                    </h2>
+                    <p className="public-copy-tight text-sm text-muted-foreground">
+                      Ingrese texto libre, incluso una sola letra. La consulta
+                      admite coincidencias por nombre, especialidad, servicios,
+                      localidad, país o descripción para ubicar perfiles
+                      institucionales dentro de la red VETNEB.
+                    </p>
+                  </div>
+                </div>
+              </PublicScrollReveal>
+
+              <form
+                className="premium-card flex flex-col gap-3 p-4 sm:flex-row"
+                aria-label="Consulta de la red profesional"
+                onSubmit={handleSubmit}
+              >
+                <label htmlFor="professional-search" className="sr-only">
+                  Consultar profesional
+                </label>
+                <div className="relative flex-1">
+                  <Search
+                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <input
+                    id="professional-search"
+                    name="q"
+                    type="search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Nombre, especialidad, localidad o dato operativo de la red"
+                    className="h-11 w-full rounded-xl border border-input bg-white/90 pl-10 pr-3 text-sm shadow-inner ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  />
+                </div>
+                <Button type="submit" className="public-cta-primary h-11">
+                  Consultar
+                </Button>
+              </form>
+
+              <section
+                className="mt-8"
+                aria-labelledby="professionals-results-heading"
+                aria-live="polite"
+              >
+                <h2 id="professionals-results-heading" className="sr-only">
+                  Resultados de la búsqueda profesional
+                </h2>
+                {!currentQuery ? (
+                  <div className="surface-empty p-6">
+                    Realice una consulta para revisar clínicas y profesionales
+                    verificados de la red VETNEB.
+                  </div>
+                ) : null}
+
+                {state.status === "loading" ? (
+                  <div className="clinical-alert-info p-6">
+                    Consultando la red de profesionales vinculados a VETNEB...
+                  </div>
+                ) : null}
+
+                {state.status === "error" ? (
+                  <div className="clinical-alert-error p-6">
+                    No se pudo realizar la búsqueda. Intente nuevamente.
+                  </div>
+                ) : null}
+
+                {state.status === "success" && state.professionals.length === 0 ? (
+                  <div className="surface-empty p-6">
+                    No se encontraron profesionales para &quot;{currentQuery}&quot;. Revise
+                    la ortografía o pruebe otro dato de búsqueda.
+                  </div>
+                ) : null}
+
+                {state.status === "success" && state.professionals.length > 0 ? (
+                  <div>
+                    <p className="mb-4 text-sm text-muted-foreground">
+                      {state.total} resultado(s) para &quot;{currentQuery}&quot;. Seleccione
+                      un perfil para ver la ficha institucional y sus datos de
+                      coordinación clínica.
+                    </p>
+                    <div className="space-y-3">
+                      {state.professionals.map((professional) => {
+                        const location = getPublicProfessionalLocation(professional);
+                        const summary = summarizePublicProfessional(professional);
+                        const isVerified =
+                          isVerifiedPublicProfessional(professional);
+
+                        return (
+                          <article key={professional.clinicId}>
+                            <PublicRouteControl
+                              href={buildProfessionalDetailHref(
+                                professional.clinicId,
+                              )}
+                              variant="bare"
+                              aria-label={`Abrir detalle del perfil ${professional.displayName}`}
+                              className="premium-card group flex w-full items-start gap-4 p-4 text-left transition hover:-translate-y-0.5 hover:border-vetneb-teal/45 hover:shadow-lg"
+                            >
+                              <span className="shrink-0">
+                                {professional.avatarUrl ? (
+                                  <Image
+                                    src={professional.avatarUrl}
+                                    alt={`Logo o avatar de ${professional.displayName}`}
+                                    width={56}
+                                    height={56}
+                                    className="h-14 w-14 rounded-xl border border-vetneb-line/70 object-cover"
+                                    loading="lazy"
+                                    unoptimized
+                                  />
+                                ) : (
+                                  <span
+                                    className="professional-avatar-fallback flex h-14 w-14 items-center justify-center rounded-xl border border-vetneb-line/70 bg-vetneb-cyan/12 text-vetneb-navy"
+                                    aria-hidden="true"
+                                  >
+                                    <BriefcaseMedical
+                                      className="h-6 w-6"
+                                      aria-hidden="true"
+                                    />
+                                  </span>
+                                )}
+                              </span>
+                              <span className="min-w-0 flex-1">
+                                <span className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                  <span className="min-w-0">
+                                    <span className="block text-base font-semibold text-vetneb-ink">
+                                      {professional.displayName}
+                                    </span>
+                                    {location ? (
+                                      <span className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                                        <MapPin
+                                          className="h-3.5 w-3.5 text-primary"
+                                          aria-hidden="true"
+                                        />
+                                        {location}
+                                      </span>
+                                    ) : null}
+                                  </span>
+                                  {isVerified ? (
+                                    <span className="clinical-pill inline-flex items-center gap-1 px-2 py-0.5 text-[0.65rem] tracking-[0.08em]">
+                                      <ShieldCheck
+                                        className="h-3 w-3"
+                                        aria-hidden="true"
+                                      />
+                                      Perfil verificado
+                                    </span>
+                                  ) : null}
+                                </span>
+                                {summary ? (
+                                  <span className="mt-3 block text-sm leading-relaxed text-muted-foreground">
+                                    {summary}
+                                  </span>
+                                ) : null}
+                              </span>
+                              <ChevronRight
+                                className="mt-4 h-5 w-5 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-primary"
+                                aria-hidden="true"
+                              />
+                            </PublicRouteControl>
+                          </article>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+              </section>
+            </div>
+          </div>
+        </section>
+      </div>
     </PublicLayout>
   );
 }

--- a/test/frontend-clinicas-page-content.test.ts
+++ b/test/frontend-clinicas-page-content.test.ts
@@ -40,7 +40,6 @@ test("clinicas page exposes hero content and primary CTAs", () => {
 test("clinicas page keeps hero CTAs visible on blue hero background", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
-  assert.ok(source.includes("public-cta-primary"));
   assert.ok(source.includes("public-cta-on-hero"));
   assert.ok(source.includes("w-full sm:w-auto"));
   assert.ok(source.includes('variant="secondaryOutline"'));
@@ -81,8 +80,8 @@ test("clinicas page remains public and avoids direct backend/API calls", () => {
 test("clinicas page keeps one continuous soft canvas below hero", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
-  assert.ok(source.includes('className="public-soft-canvas"'));
-  assert.ok(source.includes('className="py-16 md:py-20"'));
+  assert.ok(source.includes('className="sec-page-canvas"'));
+  assert.ok(source.includes('className="sec-page-section'));
   assert.equal(source.includes('className="bg-white py-16 md:py-20"'), false);
   assert.equal(source.includes('className="public-soft-canvas py-16 md:py-20"'), false);
 });

--- a/test/frontend-public-page-ctas.test.ts
+++ b/test/frontend-public-page-ctas.test.ts
@@ -34,9 +34,8 @@ test("servicios public page exposes conversion CTAs", () => {
 
   assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes"'));
-  assert.ok(source.includes("Coordinación diagnóstica para clínicas y profesionales"));
-  assert.ok(source.includes("Solicitar coordinación diagnóstica"));
-  assert.ok(source.includes("Conocer solución para clínicas"));
+  assert.ok(source.includes("Coordinar con el laboratorio"));
+  assert.ok(source.includes("Acceso para clínicas"));
   assert.ok(source.includes("href={ROUTES.contacto}"));
   assert.ok(source.includes("href={ROUTES.clinicas}"));
 });

--- a/test/frontend-public-page-semantics.test.ts
+++ b/test/frontend-public-page-semantics.test.ts
@@ -65,7 +65,6 @@ test("servicios page keeps semantic headings, sections and reveal policy", () =>
 
   assert.ok(source.includes("<h1"));
   assert.ok(source.includes("<h2"));
-  assert.ok(source.includes("CardTitle"));
   assert.ok(source.includes("<section"));
   assert.ok(source.includes("<article"));
   assert.ok(source.includes("PublicScrollReveal"));

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -31,9 +31,9 @@ test("servicios page defines metadata JSON-LD and public layout wiring", () => {
 test("servicios page exposes hero content", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Servicio patológico veterinario"));
-  assert.ok(source.includes("La anatomía patológica veterinaria integra evaluación microscópica"));
-  assert.ok(source.includes("trazabilidad de muestras e informes clínicos"));
+  assert.ok(source.includes("Servicio diagnóstico patológico"));
+  assert.ok(source.includes("Histopatología, citología, tinciones especiales"));
+  assert.ok(source.includes("Anatomía patológica veterinaria"));
 });
 
 test("servicios page lists laboratory service categories", () => {
@@ -52,23 +52,20 @@ test("servicios page keeps detailed service feature bullets", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes("Recepción y procesamiento de muestras de tejidos"));
-  assert.ok(source.includes("Estudio citológico de líquidos y punciones"));
-  assert.ok(source.includes("Complemento de histopatología y citopatología"));
-  assert.ok(source.includes("Interconsulta profesional cuando el caso lo requiere"));
-  assert.ok(source.includes("Consulta de resultados de informes las 24 hs"));
-  assert.ok(source.includes("Priorización según complejidad diagnóstica"));
+  assert.ok(source.includes("Estudio de líquidos y punciones"));
+  assert.ok(source.includes("Caracterización adicional de lesiones"));
+  assert.ok(source.includes("Informe citológico con conclusión profesional"));
+  assert.ok(source.includes("Consulta de resultados las 24 hs"));
+  assert.ok(source.includes("Definición diagnóstica específica por paciente"));
 });
 
 test("servicios page exposes conversion CTAs and SEO copy", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Coordinación diagnóstica para clínicas y profesionales"));
   assert.ok(source.includes('href={ROUTES.contacto}'));
-  assert.ok(source.includes("Solicitar coordinación diagnóstica"));
+  assert.ok(source.includes("Coordinar con el laboratorio"));
   assert.ok(source.includes('href={ROUTES.clinicas}'));
-  assert.ok(source.includes("Conocer solución para clínicas"));
-  assert.ok(source.includes("Diagnóstico integral para medicina veterinaria"));
-  assert.ok(source.includes("Para tener en cuenta"));
+  assert.ok(source.includes("Acceso para clínicas"));
   assert.ok(source.includes("Valores que guían el servicio"));
   assert.ok(source.includes("veterinaria confiable"));
 });
@@ -81,12 +78,12 @@ test("servicios page remains public and avoids direct backend/API calls", () => 
   assert.equal(source.includes("fetch("), false);
 });
 
-test("servicios page keeps one continuous soft canvas through middle sections", () => {
+test("servicios page keeps superpremium canvas structure", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes('className="public-soft-canvas"'));
-  assert.ok(source.includes('className="py-16 md:py-20"'));
-  assert.ok(source.includes('className="py-16"'));
+  assert.ok(source.includes('className="sec-page-canvas"'));
+  assert.ok(source.includes('className="sec-catalogue-section"'));
+  assert.ok(source.includes('data-services-polished="true"'));
   assert.equal(source.includes('className="bg-white py-16"'), false);
   assert.equal(source.includes('className="bg-blue-50 py-16"'), false);
   assert.equal(source.includes('className="bg-gray-50 py-16"'), false);
@@ -103,9 +100,7 @@ test("servicios page hides service link typography while keeping link semantics"
   assert.ok(source.includes('className="sr-only"'));
   assert.ok(source.includes("<span"));
   assert.ok(source.includes("{service.linkLabel}"));
-  assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
-  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-300"));
-  assert.ok(source.includes("hover:[&_.premium-card]:shadow-xl"));
+  assert.ok(source.includes("sec-bento-link"));
   assert.equal(source.includes("group-hover:text-vetneb-teal"), false);
 });
 
@@ -115,9 +110,7 @@ test("servicios page shows unified card CTA while preserving hidden SEO labels",
   assert.ok(source.includes("<span aria-hidden=\"true\">Ver más</span>"));
   assert.ok(source.includes("{service.linkLabel}"));
   assert.ok(source.includes('className="sr-only"'));
-  assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
-  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-300"));
-  assert.ok(source.includes("hover:[&_.premium-card]:shadow-xl"));
+  assert.ok(source.includes("sec-bento-link"));
   assert.equal(source.includes("Ver laboratorio patológico veterinario</div>"), false);
   assert.equal(source.includes("Ver histopatología veterinaria</div>"), false);
   assert.equal(source.includes("Ver citología veterinaria</div>"), false);
@@ -133,6 +126,6 @@ test("servicios page card links are constrained to explicit CTAs not full card w
   // No absolute overlay link trick
   assert.equal(source.includes("absolute inset-0"), false);
   // Explicit constrained CTA exists inside card
-  assert.ok(source.includes("inline-flex w-fit"));
+  assert.ok(source.includes("sec-bento-link"));
   assert.ok(source.includes("href={service.href}"));
 });

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -235,7 +235,7 @@ test("servicios page keeps professional section/card structure and responsive la
       "const serviceCategories = [",
       "serviceCategories.map((service) =>",
       "service.features.map((feature) =>",
-      "data-services-polished=\"true\"",
+      'data-services-polished="true"',
     ],
     "servicios visual structure",
   );
@@ -243,12 +243,12 @@ test("servicios page keeps professional section/card structure and responsive la
   assertMatchesAll(
     source,
     [
-      /className="public-secondary-hero-surface py-16 text-white md:py-20"/,
-      /className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"/,
-      /className="premium-card h-full"/,
-      /className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center"/,
-      /className="flex flex-col justify-center gap-3 sm:flex-row"/,
-      /className="py-16"/,
+      /className="public-secondary-hero-surface text-white"/,
+      /className="sec-catalogue-section"/,
+      /className="sec-bento-grid"/,
+      /className="sec-bento-card"/,
+      /className="sec-page-canvas"/,
+      /className="sec-page-cta"/,
     ],
     "servicios class contracts",
   );


### PR DESCRIPTION
## Summary

- Adds `sec-*` CSS system to `globals.css`: hero layout (two-column), bento grid dark/light, step list, catalogue section, page CTA, and all companion tokens
- Upgrades all 6 secondary public pages (`/servicios`, `/profesionales`, `/clinicas`, `/particulares`, `/contacto`, `/precios`) to match the superpremium visual level of the home page
- Preserves all functional code (search, forms, pricing fetch, token auth) unchanged — only visual structure and copy framing updated
- Tests updated to reflect intentional visual contract changes (new class names, new CTA copy)

## Per-route changes

- **`/servicios`**: two-column hero with diagnostic panel, bento catalogue dark, workflow steps, criteria/values section
- **`/profesionales`**: hero eyebrow + scope tags, editorial trust highlights with verified-network framing; search and results untouched
- **`/clinicas`**: two-column hero with capability panel, bento features light, four-step onboarding, secure-access banner
- **`/particulares`**: hero eyebrow in `ParticularesContent`, three-step guide below functional content (no ScrollReveal — FUNCTIONAL boundary respected)
- **`/contacto`**: editorial hero with contact-method pills (email, WhatsApp, location); form and info grid preserved
- **`/precios`**: isolated superpremium hero section; all pricing logic/state unchanged

## Test plan

- [x] `git diff --name-only` guard: no server/, dashboard, package.json, pnpm-lock.yaml, next.config touched
- [x] `pnpm security:public-surface` — PASS
- [x] `pnpm test` — all tests pass (zero failures post-commit)
- [x] `pnpm --dir frontend typecheck` — no errors
- [x] `pnpm --dir frontend lint` — no errors
- [x] `pnpm --dir frontend build` — all public routes build as static

🤖 Generated with [Claude Code](https://claude.com/claude-code)