### PR TITLE
fix(public): correct secondary hero gradient and service card hover palette

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1268,7 +1268,7 @@
     isolation: isolate;
     overflow: hidden;
     color: hsl(var(--primary-foreground));
-    background: linear-gradient(90deg, #103C60 0%, #2B5B88 52%, #BFD6E0 100%);
+    background: linear-gradient(90deg, #103C60 0%, #2B5B88 52%, #2C5278 100%);
   }
 }
 /* public-secondary-hero-surface:end */

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -189,7 +189,7 @@ export default function ServiciosPage() {
                       data-scroll-reveal-item
                       aria-labelledby={serviceHeadingId}
                       className={cn(
-                        "[&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-sky-50 hover:[&_.premium-card]:border-sky-300 hover:[&_.premium-card]:shadow-xl",
+                        "[&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-vetneb-surface-muted/40 hover:[&_.premium-card]:border-vetneb-teal/48 hover:[&_.premium-card]:shadow-[0_22px_66px_rgba(15,45,62,0.145)]",
                         serviceCategories.length % 2 === 1 &&
                         service.id === serviceCategories[serviceCategories.length - 1]?.id
                           ? "lg:col-span-2 lg:mx-auto lg:w-full lg:max-w-[calc((100%-2rem)/2)]"

--- a/test/frontend-public-secondary-hero-surface.test.ts
+++ b/test/frontend-public-secondary-hero-surface.test.ts
@@ -41,7 +41,7 @@ test("public secondary hero surface defines the shared visual surface", () => {
   assert.ok(block.includes(".public-secondary-hero-surface"));
   assert.ok(
     block.includes(
-      "linear-gradient(90deg, #103C60 0%, #2B5B88 52%, #BFD6E0 100%)",
+      "linear-gradient(90deg, #103C60 0%, #2B5B88 52%, #2C5278 100%)",
     ),
   );
   assert.ok(!block.includes(".public-secondary-hero-surface::before"));

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -103,9 +103,9 @@ test("servicios page hides service link typography while keeping link semantics"
   assert.ok(source.includes('className="sr-only"'));
   assert.ok(source.includes("<span"));
   assert.ok(source.includes("{service.linkLabel}"));
-  assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
-  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-300"));
-  assert.ok(source.includes("hover:[&_.premium-card]:shadow-xl"));
+  assert.ok(source.includes("hover:[&_.premium-card]:bg-vetneb-surface-muted/40"));
+  assert.ok(source.includes("hover:[&_.premium-card]:border-vetneb-teal/48"));
+  assert.ok(source.includes("hover:[&_.premium-card]:shadow-[0_22px_66px_rgba(15,45,62,0.145)]"));
   assert.equal(source.includes("group-hover:text-vetneb-teal"), false);
 });
 
@@ -115,9 +115,9 @@ test("servicios page shows unified card CTA while preserving hidden SEO labels",
   assert.ok(source.includes("<span aria-hidden=\"true\">Ver más</span>"));
   assert.ok(source.includes("{service.linkLabel}"));
   assert.ok(source.includes('className="sr-only"'));
-  assert.ok(source.includes("hover:[&_.premium-card]:bg-sky-50"));
-  assert.ok(source.includes("hover:[&_.premium-card]:border-sky-300"));
-  assert.ok(source.includes("hover:[&_.premium-card]:shadow-xl"));
+  assert.ok(source.includes("hover:[&_.premium-card]:bg-vetneb-surface-muted/40"));
+  assert.ok(source.includes("hover:[&_.premium-card]:border-vetneb-teal/48"));
+  assert.ok(source.includes("hover:[&_.premium-card]:shadow-[0_22px_66px_rgba(15,45,62,0.145)]"));
   assert.equal(source.includes("Ver laboratorio patológico veterinario</div>"), false);
   assert.equal(source.includes("Ver histopatología veterinaria</div>"), false);
   assert.equal(source.includes("Ver citología veterinaria</div>"), false);


### PR DESCRIPTION
## Summary
- Correct secondary public hero gradient final color from #BFD6E0 to #2C5278 for stronger contrast
- Replace /servicios service card hover palette from Tailwind sky colors to VETNEB surface/teal tokens
- Update visual contract tests to pin the approved gradient and hover classes

## Scope
- Visual surface-only change
- No text/copy changes
- No SEO, metadata or JSON-LD changes
- No layout, navigation, routes, backend or dashboard changes

## Validation
- git diff --check: OK
- pnpm --dir frontend lint: OK
- pnpm --dir frontend typecheck: OK
- pnpm --dir frontend build: OK
- pnpm build: OK
- pnpm test: blocked by 5 pre-existing failures in main; confirmed with git stash && pnpm test. Tests touched by this PR pass.

## Manual QA recommended
- /servicios at 375px, 768px, 1280px, 1440px
- /contacto at 375px, 768px, 1280px, 1440px
- Desktop hover on service cards

## Risk
Low. The PR only changes visual color tokens and updates matching visual contracts.