### PR TITLE
feat(public): add subtle depth to flat public sections

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -215,7 +215,7 @@ export default function HomePage() {
 
       <div className="public-soft-canvas">
         <section
-          className="border-b border-vetneb-line/80 bg-white py-12 md:py-16"
+          className="border-b border-vetneb-line/80 bg-gradient-to-b from-white via-white to-vetneb-surface/40 py-12 md:py-16"
           aria-labelledby="clinical-trust-heading"
         >
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -508,11 +508,12 @@ export default function HomePage() {
 
         {/* CTA final */}
         <section
-          className="bg-vetneb-navy py-16 text-primary-foreground md:py-20"
+          className="relative isolate overflow-hidden bg-vetneb-navy py-16 text-primary-foreground md:py-20"
           aria-labelledby="cta-heading"
         >
+          <div className="diagnostic-field" data-tone="dark" aria-hidden="true" />
           <PublicScrollReveal>
-            <div className="container mx-auto px-4 text-center sm:px-6 lg:px-8">
+            <div className="container relative z-10 mx-auto px-4 text-center sm:px-6 lg:px-8">
               <h2
                 id="cta-heading"
                 className="mx-auto max-w-3xl text-3xl font-bold leading-tight md:text-4xl"

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -60,7 +60,7 @@ const mapsEmbedUrl =
 
 export function FooterFaq() {
   return (
-    <section className="relative overflow-hidden py-12" aria-labelledby="footer-faq-heading">
+    <section className="relative overflow-hidden bg-vetneb-surface-muted/40 py-12" aria-labelledby="footer-faq-heading">
       <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
         <h2 id="footer-faq-heading" className="mb-8 text-lg font-bold text-foreground">
           Preguntas frecuentes:

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -313,7 +313,7 @@ test("home page exposes final conversion CTA without private route metadata", ()
   const routesSource = read("frontend/src/lib/routes.ts");
   const finalCtaSection = extractBetween(
     source,
-    'className="bg-vetneb-navy py-16 text-primary-foreground md:py-20"',
+    'className="relative isolate overflow-hidden bg-vetneb-navy py-16 text-primary-foreground md:py-20"',
     "</section>",
   );
   const forbiddenWords = [


### PR DESCRIPTION
﻿## Summary
- Add subtle gradient depth to the home clinical trust section
- Add existing diagnostic-field texture to the final home CTA surface
- Add subtle surface-muted separation to the public footer FAQ section
- Update home visual contract marker for the final CTA section

## Scope
- Visual surface-only change
- No text/copy changes
- No SEO, metadata or JSON-LD changes
- No navigation, routes, backend or dashboard changes
- No padding, grid, gap, breakpoint or section-order changes

## Validation
- git diff --check: OK
- pnpm --dir frontend lint: OK
- pnpm --dir frontend typecheck: OK
- pnpm --dir frontend build: OK
- pnpm build: OK
- pnpm test: blocked locally by 3 pre-existing/scope-guard failures sensitive to uncommitted page.tsx changes; related visual contract passes. Expected to pass in CI after commit.

## Manual QA recommended
- Home trust section at 375px, 768px, 1280px, 1440px
- Home final CTA at 375px, 768px, 1280px, 1440px
- Verify diagnostic-field overlay does not cover or block CTA buttons
- Footer FAQ on desktop and mobile

## Risk
Low. The PR only adds subtle visual surface depth using existing classes and updates the matching visual contract marker.
