### PR TITLE
feat(public): refine scroll reveal and process step depth

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -402,7 +402,7 @@ export default function HomePage() {
                     >
                       <div className="flex items-center gap-4">
                         <span
-                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground"
+                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)] ring-2 ring-primary/20"
                           aria-hidden="true"
                         >
                           {index + 1}

--- a/frontend/src/components/public/PublicScrollReveal.tsx
+++ b/frontend/src/components/public/PublicScrollReveal.tsx
@@ -29,14 +29,14 @@ const PUBLIC_MOTION_POLICY_PRESETS: Record<
   PublicScrollRevealPreset
 > = {
   section: {
-    fromOpacity: 0.96,
+    fromOpacity: 0.88,
     fromY: 14,
     duration: 0.75,
     ease: "power2.out",
     start: "top 86%",
   },
   cards: {
-    fromOpacity: 0.96,
+    fromOpacity: 0.88,
     fromY: 16,
     duration: 0.72,
     ease: "power2.out",
@@ -44,7 +44,7 @@ const PUBLIC_MOTION_POLICY_PRESETS: Record<
     stagger: 0.07,
   },
   minimal: {
-    fromOpacity: 0.98,
+    fromOpacity: 0.92,
     fromY: 8,
     duration: 0.55,
     ease: "power2.out",

--- a/test/frontend-public-scroll-reveal-contract.test.ts
+++ b/test/frontend-public-scroll-reveal-contract.test.ts
@@ -92,8 +92,8 @@ test("public scroll reveal infrastructure is client-only and uses safe gsap prim
   assert.ok(source.includes("section: {"));
   assert.ok(source.includes("cards: {"));
   assert.ok(source.includes("minimal: {"));
-  assert.ok(source.includes("fromOpacity: 0.98"));
-  assert.ok(source.includes("fromOpacity: 0.96"));
+  assert.ok(source.includes("fromOpacity: 0.92"));
+  assert.ok(source.includes("fromOpacity: 0.88"));
   assert.ok(source.includes("fromY: 14"));
   assert.ok(source.includes("fromY: 16"));
   assert.ok(source.includes("fromY: 8"));


### PR DESCRIPTION
﻿## Summary
- Make public scroll reveal slightly more perceptible by lowering initial fromOpacity values
- Add subtle shadow and ring depth to home process step circles
- Update PublicScrollReveal visual contract assertions for the approved fromOpacity values

## Scope
- Visual motion/depth-only change
- No text/copy changes
- No SEO, metadata or JSON-LD changes
- No navigation, routes, backend or dashboard changes
- No padding, grid, gap, breakpoint or section-order changes
- No changes to prefers-reduced-motion or GSAP lazy-load behavior

## Validation
- git diff --check: OK
- pnpm --dir frontend lint: OK
- pnpm --dir frontend typecheck: OK
- pnpm --dir frontend build: OK
- pnpm build: OK
- pnpm test: blocked locally by 3 scope guards sensitive to uncommitted page.tsx changes; related PublicScrollReveal contract passes. Expected to pass in CI after commit.

## Manual QA recommended
- Scroll reveal on home, /servicios and /contacto
- Verify prefers-reduced-motion disables reveal motion
- Check the home 'Cómo funciona' step circles at 375px, 768px, 1280px and 1440px
- Confirm the step circles gain depth without reading as clickable buttons

## Risk
Low. The PR changes only reveal start opacity values and decorative depth on static step circles.
