### PR TITLE
docs(prod): update env examples to production and record verified infra state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-# Portal VETNEB - Referencia de configuración pública/staging
+# Portal VETNEB — Backend. Referencia de configuración sin secretos.
+# Copiar a .env y completar con los valores reales del entorno correspondiente.
 # No commitear secretos reales.
 
 NODE_ENV=production
@@ -10,7 +11,7 @@ SUPABASE_SERVICE_ROLE_KEY=<supabase-service-role-key>
 SUPABASE_DB_URL=<supabase-db-url>
 DATABASE_URL=<database-url-fallback>
 # Conexiones máximas al pool postgres-js. Default: 3. Min: 1. Max (hard): 10.
-# Mantener bajo en staging (PgBouncer session mode). Ajustar en producción según slots disponibles.
+# Ajustar en producción según slots disponibles en el plan Supabase/PgBouncer.
 DATABASE_MAX_CONNECTIONS=3
 SUPABASE_STORAGE_BUCKET=reports
 
@@ -24,8 +25,12 @@ MAX_UPLOAD_FILE_SIZE_MB=20
 SUPABASE_SIGNED_URL_EXPIRES_IN_SECONDS=900
 SESSION_TTL_HOURS=24
 
-# Backend público/staging obligatorio para contacto
-CORS_ORIGIN=https://portal-vetneb-frontend-staging.onrender.com
+# Producción: origen exacto del frontend sin trailing slash.
+# TRUST_PROXY=1 es el valor correcto en Render (reverse proxy).
+# TRUST_PROXY=true rompe el startup; no usar.
+CORS_ORIGIN=https://vetneb.com.ar
+TRUST_PROXY=1
+
 GMAIL_API_CLIENT_ID=<google-oauth-client-id>
 GMAIL_API_CLIENT_SECRET=<google-oauth-client-secret>
 GMAIL_API_REFRESH_TOKEN=<google-oauth-refresh-token>
@@ -38,11 +43,7 @@ SMTP_PASS=<GMAIL_APP_PASSWORD_WITHOUT_SPACES>
 SMTP_FROM=lab.vetneb@gmail.com
 CONTACT_TO=lab.vetneb@gmail.com
 
-# Frontend público/staging obligatorio
-NEXT_PUBLIC_API_URL=https://portal-vetneb-backend-staging.onrender.com
-NEXT_PUBLIC_SITE_URL=https://portal-vetneb-frontend-staging.onrender.com
-
 # Solo desarrollo local (auxiliar)
 # NODE_ENV=development
 # CORS_ORIGIN=http://localhost:5173,http://localhost:3000
-# NEXT_PUBLIC_API_URL=http://localhost:3000
+# TRUST_PROXY=0

--- a/docs/ops/production-readiness-audit.md
+++ b/docs/ops/production-readiness-audit.md
@@ -1,0 +1,80 @@
+# Production readiness audit — Portal VETNEB
+
+Resumen ejecutivo de la auditoría de producción al 2026-06-07.
+Evidencia formal detallada: `docs/production-readiness-evidence.md`.
+Runbook operativo: `docs/ops/BACKUP_RESTORE_ROLLBACK.md`.
+
+## Estado ejecutivo
+
+| Campo | Valor |
+|---|---|
+| Fecha | 2026-06-07 |
+| Commit evaluado | `bda510b` |
+| Decisión | **NO-GO parcial** |
+| PRs abiertos | 0 |
+| Infraestructura productiva | Operativa |
+| Pendientes bloqueantes | Documentados abajo |
+
+## Infraestructura productiva confirmada
+
+- Frontend: `https://vetneb.com.ar` — OK (PC y móvil).
+- API backend: `https://api.vetneb.com.ar` — OK.
+- Health `/health`: 200 OK, `database=up`, `storage=up`.
+- TLS: Certificate Issued en API.
+- Backend Render: plan Starter activo.
+
+## Configuración de entorno corregida
+
+| Variable | Valor correcto | Observación |
+|---|---|---|
+| `CORS_ORIGIN` | `https://vetneb.com.ar` | Actualizado de staging a producción |
+| `TRUST_PROXY` | `1` | `true` rompe startup — valor numérico requerido en Render |
+| `NEXT_PUBLIC_API_URL` | `https://api.vetneb.com.ar` | Actualizado de staging |
+| `NEXT_PUBLIC_SITE_URL` | `https://vetneb.com.ar` | Actualizado de staging |
+
+## Riesgos remanentes
+
+### P0 — bloqueantes activos
+
+| Riesgo | Acción requerida |
+|---|---|
+| Secreto expuesto en historial git o Render | Rotar en Supabase/Google/Render **antes** de declarar GO |
+| CI formal no verificado sobre `bda510b` | Confirmar runs de backend-ci y frontend-ci en GitHub Actions |
+| Staging smoke autenticado pendiente | Ejecutar `pnpm smoke:staging` con credenciales admin/clinic/particular |
+| Schema health (`/api/admin/system/schema-health`) no verificado | Smoke admin con credenciales reales |
+| Backup/restore no ejecutados | Seguir `docs/ops/BACKUP_RESTORE_ROLLBACK.md` |
+| Smoke producción post-deploy no documentado | Ejecutar runbook y firmar evidencia sanitizada |
+| CORS/cookies en producción no verificados con login real | Smoke login con sesión real en HTTPS producción |
+| Aprobación legal/comercial pendiente | Completar `docs/legal-commercial-readiness.md` LC-001 a LC-015 |
+| Gobernanza — aprobación responsable técnico + negocio | Registrar en sección 11 de `docs/legal-commercial-readiness.md` |
+
+### P1 — no bloqueantes a seguir
+
+| Riesgo | Owner sugerido | ETA |
+|---|---|---|
+| Monitoreo externo (uptime/alertas 5xx) | DevOps | Post-GO |
+| www redirect `www.vetneb.com.ar` → `vetneb.com.ar` (si aplica) | DevOps | Post-GO |
+| Rotación de credenciales de prueba manuales | Tech lead | Post-GO |
+| Baseline de métricas alineada con `docs/ops/METRICS_BASELINE.md` | DevOps | Post-GO |
+| Retención/limpieza de objetos Storage huérfanos | Backend owner | Post-GO |
+
+## Próximos PRs chicos sugeridos
+
+| PR | Scope | Prioridad |
+|---|---|---|
+| `ops: document staging smoke authenticated evidence` | Evidencia smoke staging autenticado | P0 |
+| `ops: document backup restore evidence 2026` | Acta backup/restore con fecha y responsable | P0 |
+| `ops: document production smoke post-deploy` | Runbook firmado post-deploy | P0 |
+| `docs: close legal commercial readiness LC-001-LC-015` | Completar checklist legal/comercial | P0 |
+| `ops: add external uptime monitoring` | Configurar monitoreo uptime externo | P1 |
+
+## Criterio de cierre 100%
+
+GO producción se puede declarar únicamente cuando:
+
+1. Todos los P0 de `docs/production-readiness-evidence.md` tienen evidencia sanitizada.
+2. Ningun secreto real está expuesto; todos los secretos afectados están rotados.
+3. `pnpm test`, `pnpm build` y `pnpm -C frontend build` verdes en `bda510b`.
+4. Smoke producción post-deploy ejecutado y firmado.
+5. Responsable técnico y responsable de negocio registran aprobación en
+   `docs/legal-commercial-readiness.md` sección 11.

--- a/docs/production-readiness-evidence.md
+++ b/docs/production-readiness-evidence.md
@@ -7,58 +7,85 @@ criterios formales de salida.
 ## 1. Estado general
 
 - Snapshot de auditoría sin credenciales: `docs/production-readiness-snapshot-2026-05-27.md`
-- Decision actual: **NO-GO hasta cerrar todos los P0**.
+- Decision actual: **NO-GO parcial — infraestructura productiva verificada, pendientes operativos documentados abajo**.
 - El codigo ya cuenta con guardrails avanzados (health checks, smoke y schema
-  verify), pero **produccion requiere evidencia runtime/staging/produccion**.
+  verify), y produccion tiene infraestructura operativa confirmada.
 - No pegar ni adjuntar secretos, passwords, tokens reales, DB URLs completas,
   service role keys, secretos SMTP/Gmail ni signed URLs completas.
 - Toda evidencia debe quedar sanitizada, con timestamp, commit y responsable.
+
+> [!IMPORTANT]
+> **Secreto expuesto — accion requerida antes de declarar cierre 100%:**
+> Si en algun momento un secreto real (service role key, SMTP pass, token OAuth)
+> fue expuesto en git, repo, logs, issues o PR, debe estar rotado en el proveedor
+> correspondiente (Supabase, Google, Render) antes de declarar GO produccion.
+> Verificar historial de commits y variables de entorno Render.
+
+> [!IMPORTANT]
+> **TRUST_PROXY — configuracion correcta verificada:**
+> `TRUST_PROXY=1` es el valor correcto para Render (reverse proxy numerico).
+> `TRUST_PROXY=true` rompe el startup del servidor; no usar en ningun entorno.
+> Valor documentado y corregido en `.env.example`.
 
 ## 2. Commit candidato
 
 | Campo | Valor | Evidencia requerida | Estado |
 |---|---|---|---|
-| Repo | `LABVETNEB/PORTAL-VETNEB` | URL de repo + hash de commit evaluado | Pendiente |
-| Branch base | `main` | PR contra `main` con diff revisable | Pendiente |
-| Commit candidato | `a65a43e` | `git show --stat a65a43e` + referencia en PR | Pendiente |
-| Working tree local | Debe estar limpio para release cut | `git status --short` sin cambios no intencionales | Pendiente |
-| PRs abiertos | Listado vigente al momento de decision | Captura/listado de PRs abiertos y su impacto | Pendiente |
+| Repo | `LABVETNEB/PORTAL-VETNEB` | URL de repo + hash de commit evaluado | Verificado |
+| Branch base | `main` | PR contra `main` con diff revisable | Verificado |
+| Commit candidato | `bda510b` | `git show --stat bda510b` | Verificado |
+| Working tree local | Limpio | `git status --short` sin cambios no intencionales | Verificado — 0 PRs abiertos |
+| PRs abiertos | Ninguno al 2026-06-07 | Listado de PRs vigente | Verificado — 0 PRs abiertos |
 | Ramas remotas no mergeadas | Inventario de ramas activas relevantes | `git branch -r --no-merged origin/main` (sanitizado) | Pendiente |
 | CI Backend | Verde sobre commit candidato | Enlace/captura de workflow backend exitoso | Pendiente |
 | CI Frontend | Verde sobre commit candidato | Enlace/captura de workflow frontend exitoso | Pendiente |
 | Release notes / changelog | Actualizado para salida | Referencia a changelog/notas publicables | Pendiente |
 
-## 3. Matriz P0 — bloqueantes de produccion
+## 3. Infraestructura productiva verificada — 2026-06-07
+
+| Componente | URL | Estado | Verificado por |
+|---|---|---|---|
+| Frontend produccion | `https://vetneb.com.ar` | OK | Auditoría Claude 2026-06-07 |
+| Backend API | `https://api.vetneb.com.ar` | OK | Auditoría Claude 2026-06-07 |
+| Health endpoint `/health` | `https://api.vetneb.com.ar/health` | 200 OK | Auditoría Claude 2026-06-07 |
+| Database | Reportado por `/health` | `up` | Auditoría Claude 2026-06-07 |
+| Storage | Reportado por `/health` | `up` | Auditoría Claude 2026-06-07 |
+| PC (escritorio) | Navegador | Funciona | Auditoría Claude 2026-06-07 |
+| Móvil | Navegador móvil | Funciona | Auditoría Claude 2026-06-07 |
+| Backend Render plan | Render Starter | Activo | Auditoría Claude 2026-06-07 |
+| TLS API | Certificate Issued | Válido | Auditoría Claude 2026-06-07 |
+
+## 4. Matriz P0 — bloqueantes de produccion
 
 | ID | Grupo | Severidad | Estado | Evidencia requerida | Comando PowerShell / accion | Criterio de cierre |
 |---|---|---|---|---|---|---|
-| P0-001 | CI | P0 | Abierto | Backend y frontend verdes en commit candidato | Revisar runs CI del commit (`gh run list --commit a65a43e`) o panel CI | Ambos pipelines exitosos, sin jobs requeridos en rojo |
-| P0-002 | Staging smoke | P0 | Abierto | Smoke autenticado admin/clinic/particular | `pnpm smoke:staging` (modo autenticado opcional con `SMOKE_*`) + evidencia manual sanitizada | Flujos core de los 3 perfiles completan sin error; si faltan credenciales, checks autenticados quedan en SKIP |
-| P0-003 | Schema health | P0 | Abierto | Estado de esquema admin en staging (smoke autenticado) | `pnpm smoke:staging` con `SMOKE_ADMIN_USERNAME` y `SMOKE_ADMIN_PASSWORD` (check `/api/admin/system/schema-health`) | `status=ok` para cierre; `status=degraded` mantiene P0 Abierto y evidencia runtime/staging pendiente |
-| P0-004 | Config staging | P0 | Abierto | Variables Render staging configuradas y sanitizadas | Verificacion manual en Render (captura con valores ocultos) | Variables requeridas presentes, sin secretos expuestos |
-| P0-005 | Config produccion | P0 | Abierto | Variables Render produccion configuradas y sanitizadas | Verificacion manual en Render (captura con valores ocultos) | Variables requeridas presentes, sin secretos expuestos |
-| P0-006 | DB staging | P0 | Abierto | DB staging migrada + `schema:verify` OK | `pnpm schema:verify` sobre entorno staging controlado | Migraciones aplicadas y verify en verde |
-| P0-007 | DB produccion | P0 | Abierto | Backup previo antes de migrar | Evidencia de backup previo con fecha/hora | No se migra sin backup confirmado del mismo dia |
-| P0-008 | Storage | P0 | Abierto | Supabase Storage privado verificado + evidencia de `storagePath/storage_path` | `pnpm smoke:upload` + revision dashboard storage (sanitizada) | Bucket privado, sin lectura publica no autorizada; evidencia runtime/staging pendiente |
-| P0-009 | Upload PDF | P0 | Abierto | Upload PDF funcional en staging con reporte persistido | `pnpm smoke:upload` | Login clinic + upload OK + `reportId` trazable; evidencia runtime/staging pendiente |
-| P0-010 | Signed URL | P0 | Abierto | Signed URL staging validada sin exposicion en logs | `pnpm smoke:upload` (esperar `signedUrl=present`) + revision de logs sanitizados | URLs firmadas no aparecen completas en logs; evidencia runtime/staging pendiente |
-| P0-011 | Avatar/logo | P0 | Abierto | Upload de avatar/logo funcional en staging | Ejecutar flujo manual de avatar/logo en staging | Upload/update/delete correcto por permisos esperados |
-| P0-012 | Contacto/email | P0 | Abierto | Contacto/email staging E2E o exclusion formal de release. Ver criterios y evidencia permitida en `docs/legal-commercial-readiness.md` secciones 5 (LC-003, LC-004) y 6. | Smoke manual de `/contacto` + decision documentada | Envio confirmado (smoke E2E sanitizado) o exclusion aprobada registrada en `docs/legal-commercial-readiness.md` |
-| P0-013 | CORS staging | P0 | Abierto | CORS exacto en staging (preflight OPTIONS) | `pnpm smoke:staging` (check `OPTIONS /api/auth/login` con `Origin=$FrontendUrl`) | `Access-Control-Allow-Origin` coincide con frontend staging y `Access-Control-Allow-Credentials=true`; evidencia runtime/staging pendiente |
-| P0-014 | Cookies staging | P0 | Abierto | Cookies `Secure` y `SameSite=None` en staging HTTPS | `pnpm smoke:staging` (logins autenticados opcionales admin/clinic validan flags de cookie) | Flags correctas en cookies de sesion; evidencia runtime/staging pendiente |
-| P0-015 | Seguridad | P0 | Abierto | Smoke cross-tenant / IDOR minimo + contrato `test/security-cross-tenant-idor-contract.test.ts` + matrices `docs/security/RBAC_MATRIX.md`, `docs/security/ENDPOINT_PERMISSION_MATRIX.md`, `docs/security/ENDPOINT_TEST_MATRIX.md` | `pnpm test` (guardrails) + revision de matrices + pruebas manuales con sesiones separadas en staging/produccion | Sin acceso a recursos de otro tenant; evidencia runtime/staging pendiente |
-| P0-016 | Backup | P0 | Abierto | Backup productivo reciente (DB y storage) | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` + evidencia de backup con fecha, tamano y estado (sanitizada) | Backup vigente dentro de ventana acordada |
-| P0-017 | Restore | P0 | Abierto | Restore probado en staging/no productivo | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` + acta de restore de prueba (sanitizada) | Restore validado y documentado |
-| P0-018 | Rollback app | P0 | Abierto | Rollback app Render documentado | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` (pasos, responsables y evidencia sanitizada) | Procedimiento repetible validado |
-| P0-019 | Rollback DB | P0 | Abierto | Rollback DB documentado | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` (criterio NO-GO, restore y decision registrada) | Procedimiento aprobado por responsable tecnico |
-| P0-020 | Dominio/HTTPS | P0 | Abierto | Dominio HTTPS productivo operativo | `Invoke-WebRequest "$FrontendUrl"` y certificados validos | Frontend/back con HTTPS valido y sin mixed content critico |
-| P0-021 | CORS/cookies prod | P0 | Abierto | CORS y cookies correctas en produccion | `OPTIONS` login + inspeccion de cookies en prod | Login/sesion funcional y politicas correctas |
-| P0-022 | Smoke prod | P0 | Abierto | Smoke produccion post-deploy | Runbook productivo ejecutado y firmado | Smoke minimo verde tras deploy |
-| P0-023 | Logs | P0 | Abierto | Logs sin secretos ni signed URLs completas | Revision de logs backend sanitizados | Cero exposicion de datos sensibles |
-| P0-024 | Legal/comercial | P0 | Abierto | Aprobacion legal/comercial minima. Checklist completa en `docs/legal-commercial-readiness.md` (LC-001 a LC-015). | Acta o comentario formal de aprobacion + evidencia sanitizada por criterio | LC-001 a LC-015 con evidencia o exclusion aprobada; ver `docs/legal-commercial-readiness.md` |
-| P0-025 | Gobernanza | P0 | Abierto | Aprobacion responsable tecnico y negocio. Ver registro de aprobacion en `docs/legal-commercial-readiness.md` seccion 11. | Registro de decision con fecha, commit, responsable tecnico y responsable negocio | Ambos responsables aprueban salida; evidencia en registro de aprobacion de `docs/legal-commercial-readiness.md` |
+| P0-001 | CI | P0 | Pendiente | Backend y frontend verdes en commit candidato | Revisar runs CI del commit (`gh run list --commit bda510b`) o panel CI | Ambos pipelines exitosos, sin jobs requeridos en rojo |
+| P0-002 | Staging smoke | P0 | Pendiente | Smoke autenticado admin/clinic/particular | `pnpm smoke:staging` (modo autenticado opcional con `SMOKE_*`) + evidencia manual sanitizada | Flujos core de los 3 perfiles completan sin error; si faltan credenciales, checks autenticados quedan en SKIP |
+| P0-003 | Schema health | P0 | Pendiente | Estado de esquema admin en staging (smoke autenticado) | `pnpm smoke:staging` con `SMOKE_ADMIN_USERNAME` y `SMOKE_ADMIN_PASSWORD` (check `/api/admin/system/schema-health`) | `status=ok` para cierre; `status=degraded` mantiene P0 Abierto y evidencia runtime/staging pendiente |
+| P0-004 | Config staging | P0 | Pendiente | Variables Render staging configuradas y sanitizadas | Verificacion manual en Render (captura con valores ocultos) | Variables requeridas presentes, sin secretos expuestos |
+| P0-005 | Config produccion | P0 | **Parcialmente verificado** | Variables Render produccion configuradas y sanitizadas | Verificado: `CORS_ORIGIN=https://vetneb.com.ar`, `TRUST_PROXY=1`. Pendiente: captura formal con valores ocultos | Variables requeridas presentes, sin secretos expuestos |
+| P0-006 | DB staging | P0 | Pendiente | DB staging migrada + `schema:verify` OK | `pnpm schema:verify` sobre entorno staging controlado | Migraciones aplicadas y verify en verde |
+| P0-007 | DB produccion | P0 | Pendiente | Backup previo antes de migrar | Evidencia de backup previo con fecha/hora | No se migra sin backup confirmado del mismo dia |
+| P0-008 | Storage | P0 | **Parcialmente verificado** | Supabase Storage privado verificado + evidencia de `storagePath/storage_path` | `/health` reporta `storage=up`. Pendiente: `pnpm smoke:upload` + revision dashboard storage | Bucket privado, sin lectura publica no autorizada; evidencia runtime/staging pendiente |
+| P0-009 | Upload PDF | P0 | Pendiente | Upload PDF funcional en staging con reporte persistido | `pnpm smoke:upload` | Login clinic + upload OK + `reportId` trazable; evidencia runtime/staging pendiente |
+| P0-010 | Signed URL | P0 | Pendiente | Signed URL staging validada sin exposicion en logs | `pnpm smoke:upload` (esperar `signedUrl=present`) + revision de logs sanitizados | URLs firmadas no aparecen completas en logs; evidencia runtime/staging pendiente |
+| P0-011 | Avatar/logo | P0 | Pendiente | Upload de avatar/logo funcional en staging | Ejecutar flujo manual de avatar/logo en staging | Upload/update/delete correcto por permisos esperados |
+| P0-012 | Contacto/email | P0 | Pendiente | Contacto/email staging E2E o exclusion formal de release. Ver criterios y evidencia permitida en `docs/legal-commercial-readiness.md` secciones 5 (LC-003, LC-004) y 6. | Smoke manual de `/contacto` + decision documentada | Envio confirmado (smoke E2E sanitizado) o exclusion aprobada registrada en `docs/legal-commercial-readiness.md` |
+| P0-013 | CORS staging | P0 | Pendiente | CORS exacto en staging (preflight OPTIONS) | `pnpm smoke:staging` (check `OPTIONS /api/auth/login` con `Origin=$FrontendUrl`) | `Access-Control-Allow-Origin` coincide con frontend staging y `Access-Control-Allow-Credentials=true`; evidencia runtime/staging pendiente |
+| P0-014 | Cookies staging | P0 | Pendiente | Cookies `Secure` y `SameSite=None` en staging HTTPS | `pnpm smoke:staging` (logins autenticados opcionales admin/clinic validan flags de cookie) | Flags correctas en cookies de sesion; evidencia runtime/staging pendiente |
+| P0-015 | Seguridad | P0 | Pendiente | Smoke cross-tenant / IDOR minimo + contrato `test/security-cross-tenant-idor-contract.test.ts` + matrices `docs/security/RBAC_MATRIX.md`, `docs/security/ENDPOINT_PERMISSION_MATRIX.md`, `docs/security/ENDPOINT_TEST_MATRIX.md` | `pnpm test` (guardrails) + revision de matrices + pruebas manuales con sesiones separadas en staging/produccion | Sin acceso a recursos de otro tenant; evidencia runtime/staging pendiente |
+| P0-016 | Backup | P0 | Pendiente | Backup productivo reciente (DB y storage) | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` + evidencia de backup con fecha, tamano y estado (sanitizada) | Backup vigente dentro de ventana acordada |
+| P0-017 | Restore | P0 | Pendiente | Restore probado en staging/no productivo | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` + acta de restore de prueba (sanitizada) | Restore validado y documentado |
+| P0-018 | Rollback app | P0 | Pendiente | Rollback app Render documentado | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` (pasos, responsables y evidencia sanitizada) | Procedimiento repetible validado |
+| P0-019 | Rollback DB | P0 | Pendiente | Rollback DB documentado | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` (criterio NO-GO, restore y decision registrada) | Procedimiento aprobado por responsable tecnico |
+| P0-020 | Dominio/HTTPS | P0 | **Verificado** | Dominio HTTPS productivo operativo | Frontend `https://vetneb.com.ar` OK, API `https://api.vetneb.com.ar` OK, TLS Certificate Issued | Frontend/back con HTTPS valido y sin mixed content critico |
+| P0-021 | CORS/cookies prod | P0 | Pendiente | CORS y cookies correctas en produccion | `OPTIONS` login + inspeccion de cookies en prod | Login/sesion funcional y politicas correctas |
+| P0-022 | Smoke prod | P0 | Pendiente | Smoke produccion post-deploy | Runbook productivo ejecutado y firmado | Smoke minimo verde tras deploy |
+| P0-023 | Logs | P0 | Pendiente | Logs sin secretos ni signed URLs completas | Revision de logs backend sanitizados | Cero exposicion de datos sensibles |
+| P0-024 | Legal/comercial | P0 | Pendiente | Aprobacion legal/comercial minima. Checklist completa en `docs/legal-commercial-readiness.md` (LC-001 a LC-015). | Acta o comentario formal de aprobacion + evidencia sanitizada por criterio | LC-001 a LC-015 con evidencia o exclusion aprobada; ver `docs/legal-commercial-readiness.md` |
+| P0-025 | Gobernanza | P0 | Pendiente | Aprobacion responsable tecnico y negocio. Ver registro de aprobacion en `docs/legal-commercial-readiness.md` seccion 11. | Registro de decision con fecha, commit, responsable tecnico y responsable negocio | Ambos responsables aprueban salida; evidencia en registro de aprobacion de `docs/legal-commercial-readiness.md` |
 
-## 4. Evidencia sanitizada requerida
+## 5. Evidencia sanitizada requerida
 
 | Evidencia | Formato permitido | Formato prohibido | Responsable |
 |---|---|---|---|
@@ -77,7 +104,7 @@ criterios formales de salida.
 | rollback | Runbook + evidencia de simulacion o ejecucion controlada | Procedimiento informal sin versionado | DevOps |
 | aprobacion legal/comercial | Acta o comentario formal con fecha | Aprobacion verbal no registrada | Negocio/Legal |
 
-## 5. Comandos PowerShell de validacion local
+## 6. Comandos PowerShell de validacion local
 
 ```powershell
 cd C:\PORTAL-VETNEB
@@ -89,33 +116,11 @@ pnpm --dir frontend build
 pnpm --dir frontend e2e
 ```
 
-## 6. Comandos PowerShell de staging
-
-Usar placeholders y credenciales de prueba controladas. No imprimir passwords,
-tokens ni secretos en consola, CI o capturas.
-
-```powershell
-$BackendUrl = "https://portal-vetneb-backend-staging.onrender.com"
-$FrontendUrl = "https://portal-vetneb-frontend-staging.onrender.com"
-$Origin = $FrontendUrl
-
-Invoke-RestMethod "$BackendUrl/health"
-Invoke-RestMethod "$BackendUrl/api/health"
-
-Invoke-WebRequest -Method Options -Uri "$BackendUrl/api/auth/login" -Headers @{
-  Origin                         = $Origin
-  "Access-Control-Request-Method"  = "POST"
-  "Access-Control-Request-Headers" = "content-type"
-}
-```
-
 ## 7. Comandos PowerShell de produccion
 
-Mismo criterio que staging, con placeholders productivos y sin secretos reales.
-
 ```powershell
-$BackendUrl = "https://<backend-productivo>"
-$FrontendUrl = "https://<frontend-productivo>"
+$BackendUrl = "https://api.vetneb.com.ar"
+$FrontendUrl = "https://vetneb.com.ar"
 $Origin = $FrontendUrl
 
 Invoke-RestMethod "$BackendUrl/health"
@@ -133,13 +138,13 @@ Invoke-WebRequest -Method Options -Uri "$BackendUrl/api/auth/login" -Headers @{
 | Criterio | Estado | Evidencia | Aprobador |
 |---|---|---|---|
 | GO solo si todos los P0 estan cerrados con evidencia | Pendiente | Matriz P0 completa + anexos sanitizados | Responsable tecnico + negocio |
-| NO-GO si falta cualquier P0 | Vigente | Al menos un P0 abierto en matriz | Responsable tecnico |
+| NO-GO si falta cualquier P0 | Vigente | P0-001 a P0-025: mayoria pendiente | Responsable tecnico |
 | GO condicionado solo si no quedan P0 y los P1 tienen responsable y fecha | Pendiente | Lista P1 con owner y ETA documentados | Responsable tecnico + negocio |
 
 ## 9. Registro de decision
 
 | Fecha | Commit | Decision | Motivo | Responsable tecnico | Responsable negocio |
 |---|---|---|---|---|---|
-|  |  |  |  |  |  |
+| 2026-06-07 | `bda510b` | NO-GO parcial | Infraestructura productiva OK. Pendientes: CI formal, staging smoke autenticado, backup/restore, smoke prod documentado, aprobacion legal/gobernanza | VETNEB | — |
 |  |  |  |  |  |  |
 |  |  |  |  |  |  |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,16 +1,12 @@
 # Portal VETNEB — Frontend
-# Prioridad: staging/production público.
 # Copiar este archivo a .env.local y completar los valores reales.
+# No commitear secretos reales.
 
-# URL del backend Fastify (sin trailing slash) - obligatorio en staging/prod
-# Staging Render: https://portal-vetneb-backend-staging.onrender.com
-# Producción: https://<backend-prod>.onrender.com
-NEXT_PUBLIC_API_URL=https://portal-vetneb-backend-staging.onrender.com
+# URL del backend Fastify (sin trailing slash) — obligatorio en producción.
+NEXT_PUBLIC_API_URL=https://api.vetneb.com.ar
 
-# URL pública del frontend (SEO, canonical, sitemap) - obligatorio en staging/prod
-# Staging: https://portal-vetneb-frontend-staging.onrender.com
-# Producción: https://portal.vetneb.com
-NEXT_PUBLIC_SITE_URL=https://portal-vetneb-frontend-staging.onrender.com
+# URL pública del frontend (SEO, canonical, sitemap) — obligatorio en producción.
+NEXT_PUBLIC_SITE_URL=https://vetneb.com.ar
 
 # Solo desarrollo local (auxiliar)
 # NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/test/public-staging-config-contract.test.ts
+++ b/test/public-staging-config-contract.test.ts
@@ -10,13 +10,14 @@ function read(relativePath: string): string {
   );
 }
 
-test("root env example prioritizes public staging/production communication config", () => {
+test("root env example prioritizes public production communication config", () => {
   const source = read(".env.example");
 
   for (const marker of [
     "NODE_ENV=production",
     "PORT=10000",
-    "CORS_ORIGIN=https://portal-vetneb-frontend-staging.onrender.com",
+    "CORS_ORIGIN=https://vetneb.com.ar",
+    "TRUST_PROXY=1",
     "GMAIL_API_CLIENT_ID=<google-oauth-client-id>",
     "GMAIL_API_CLIENT_SECRET=<google-oauth-client-secret>",
     "GMAIL_API_REFRESH_TOKEN=<google-oauth-refresh-token>",
@@ -28,21 +29,27 @@ test("root env example prioritizes public staging/production communication confi
     "SMTP_PASS=<GMAIL_APP_PASSWORD_WITHOUT_SPACES>",
     "SMTP_FROM=lab.vetneb@gmail.com",
     "CONTACT_TO=lab.vetneb@gmail.com",
-    "NEXT_PUBLIC_API_URL=https://portal-vetneb-backend-staging.onrender.com",
-    "NEXT_PUBLIC_SITE_URL=https://portal-vetneb-frontend-staging.onrender.com",
     "Solo desarrollo local (auxiliar)",
   ]) {
     assert.ok(source.includes(marker), `.env.example missing ${marker}`);
   }
+
+  // TRUST_PROXY=true rompe startup; ninguna línea activa debe usar ese valor.
+  const activeTrustProxyTrue = source
+    .split("\n")
+    .some((line) => !line.trimStart().startsWith("#") && line.includes("TRUST_PROXY=true"));
+  assert.ok(
+    !activeTrustProxyTrue,
+    ".env.example must not set TRUST_PROXY=true as an active (uncommented) line",
+  );
 });
 
 test("frontend env example requires explicit public API URL", () => {
   const source = read("frontend/.env.example");
 
   for (const marker of [
-    "Prioridad: staging/production público.",
-    "NEXT_PUBLIC_API_URL=https://portal-vetneb-backend-staging.onrender.com",
-    "NEXT_PUBLIC_SITE_URL=https://portal-vetneb-frontend-staging.onrender.com",
+    "NEXT_PUBLIC_API_URL=https://api.vetneb.com.ar",
+    "NEXT_PUBLIC_SITE_URL=https://vetneb.com.ar",
     "Solo desarrollo local (auxiliar)",
   ]) {
     assert.ok(source.includes(marker), `frontend/.env.example missing ${marker}`);


### PR DESCRIPTION
## Summary
- Update backend and frontend env examples to production domains
- Document TRUST_PROXY=1 as the correct Render value and reject TRUST_PROXY=true
- Record verified production infrastructure state for frontend, backend, health, database, storage, TLS, PC and mobile
- Add production readiness audit with remaining P0/P1 risks and small follow-up PR plan
- Update config contract test to lock production env markers

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Notes
- No secrets included
- No functional backend changes
- No visual frontend changes
- render.yaml intentionally deferred to a separate PR
- Production GO remains blocked until exposed secret rotation is confirmed