### PR TITLE
chore(ops): add public production smoke script

### DIFF
--- a/docs/smoke-prod-public.md
+++ b/docs/smoke-prod-public.md
@@ -1,0 +1,34 @@
+# Smoke produccion publico
+
+Valida que los endpoints publicos de produccion responden correctamente sin requerir credenciales.
+No reemplaza el smoke autenticado (`pnpm smoke:staging`) ni el smoke local (`pnpm smoke:test`).
+
+## Endpoints validados
+
+- `GET https://api.vetneb.com.ar/health` — HTTP 200, `success=true`, `database=up`, `storage=up`
+- `GET https://vetneb.com.ar/` — HTTP 200
+- `GET https://vetneb.com.ar/robots.txt` — HTTP 200
+- `GET https://vetneb.com.ar/sitemap.xml` — HTTP 200, contiene `https://vetneb.com.ar`
+
+## Ejecucion
+
+Terminal 1:
+
+```powershell
+pnpm smoke:prod:public
+```
+
+Override de URLs (opcional, sin trailing slash):
+
+```powershell
+$env:PROD_FRONTEND_URL = "https://vetneb.com.ar"
+$env:PROD_API_URL = "https://api.vetneb.com.ar"
+pnpm smoke:prod:public
+```
+
+## Notas
+
+- No requiere credenciales ni secretos.
+- Sale con exit code 1 ante cualquier falla.
+- Timeout de 15 segundos por request.
+- Registrar evidencia sanitizada del resultado en `docs/production-readiness-evidence.md` (P0-022).

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "auth:reset-login-rate-limit": "tsx scripts/dev/reset-login-rate-limit.ts",
     "smoke:test": "node scripts/smoke/smoke-test.mjs",
     "smoke:upload": "node scripts/smoke/smoke-upload.mjs",
+    "smoke:prod:public": "node scripts/smoke/smoke-prod-public.mjs",
     "smoke:staging": "powershell -ExecutionPolicy Bypass -File scripts/dev/smoke-staging.ps1",
     "test": "node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts",
     "security:public-surface": "node scripts/security/audit-public-devtools-surface.mjs",

--- a/scripts/smoke/smoke-prod-public.mjs
+++ b/scripts/smoke/smoke-prod-public.mjs
@@ -1,0 +1,87 @@
+const FRONTEND_URL = (process.env.PROD_FRONTEND_URL ?? "https://vetneb.com.ar").replace(/\/+$/, "");
+const API_URL = (process.env.PROD_API_URL ?? "https://api.vetneb.com.ar").replace(/\/+$/, "");
+
+const TIMEOUT_MS = 15_000;
+
+function fail(message, error) {
+  console.error("SMOKE PROD PUBLIC FALLO");
+  console.error(message);
+  if (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+  process.exit(1);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function readJson(response) {
+  const text = await response.text();
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { raw: text };
+  }
+}
+
+async function fetchWithTimeout(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      fail(`TIMEOUT (>${TIMEOUT_MS}ms): ${url}`);
+    }
+    fail(`ERROR DE RED: ${url}`, error);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function run() {
+  console.log("INICIANDO SMOKE PROD PUBLIC");
+  console.log(`FRONTEND : ${FRONTEND_URL}`);
+  console.log(`API      : ${API_URL}`);
+  console.log("");
+
+  // GET /health
+  const healthRes = await fetchWithTimeout(`${API_URL}/health`);
+  const healthJson = await readJson(healthRes);
+
+  assert(healthRes.ok, `HEALTH HTTP ${healthRes.status}`);
+  assert(healthJson?.success === true, `HEALTH success=${healthJson?.success} (esperado true)`);
+  if (healthJson?.status !== undefined) {
+    assert(healthJson.status === "ok", `HEALTH status=${healthJson.status} (esperado ok)`);
+  }
+  assert(healthJson?.checks?.database === "up", `HEALTH checks.database=${healthJson?.checks?.database} (esperado up)`);
+  assert(healthJson?.checks?.storage === "up", `HEALTH checks.storage=${healthJson?.checks?.storage} (esperado up)`);
+  console.log("OK /health");
+
+  // GET frontend /
+  const frontendRes = await fetchWithTimeout(`${FRONTEND_URL}/`);
+  assert(frontendRes.ok, `FRONTEND HTTP ${frontendRes.status}`);
+  console.log(`OK ${FRONTEND_URL}/`);
+
+  // GET /robots.txt
+  const robotsRes = await fetchWithTimeout(`${FRONTEND_URL}/robots.txt`);
+  assert(robotsRes.ok, `ROBOTS.TXT HTTP ${robotsRes.status}`);
+  console.log("OK /robots.txt");
+
+  // GET /sitemap.xml
+  const sitemapRes = await fetchWithTimeout(`${FRONTEND_URL}/sitemap.xml`);
+  assert(sitemapRes.ok, `SITEMAP.XML HTTP ${sitemapRes.status}`);
+  const sitemapText = await sitemapRes.text();
+  assert(sitemapText.includes(FRONTEND_URL), `SITEMAP no contiene ${FRONTEND_URL}`);
+  console.log("OK /sitemap.xml");
+
+  console.log("");
+  console.log("SMOKE PROD PUBLIC COMPLETO OK");
+}
+
+run().catch((error) => {
+  fail("ERROR INESPERADO EN SMOKE PROD PUBLIC", error);
+});


### PR DESCRIPTION
## Summary
- Add public production smoke script without credentials
- Validate production API health, database and storage checks
- Validate frontend, robots.txt and sitemap.xml availability
- Add pnpm smoke:prod:public command
- Document smoke execution and public URL overrides

## Validation
- git diff --check
- pnpm smoke:prod:public
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build