### PR TITLE
test(smoke): validate favicon ico in prod public smoke

### DIFF
--- a/docs/smoke-prod-public.md
+++ b/docs/smoke-prod-public.md
@@ -9,6 +9,7 @@ No reemplaza el smoke autenticado (`pnpm smoke:staging`) ni el smoke local (`pnp
 - `GET https://vetneb.com.ar/` — HTTP 200
 - `GET https://vetneb.com.ar/robots.txt` — HTTP 200
 - `GET https://vetneb.com.ar/sitemap.xml` — HTTP 200, contiene `https://vetneb.com.ar`
+- `GET https://vetneb.com.ar/favicon.ico` — HTTP 200, body no vacío, magic bytes ICO `00 00 01 00`
 
 ## Ejecucion
 

--- a/scripts/smoke/smoke-prod-public.mjs
+++ b/scripts/smoke/smoke-prod-public.mjs
@@ -78,6 +78,22 @@ async function run() {
   assert(sitemapText.includes(FRONTEND_URL), `SITEMAP no contiene ${FRONTEND_URL}`);
   console.log("OK /sitemap.xml");
 
+  // GET /favicon.ico
+  const faviconRes = await fetchWithTimeout(`${FRONTEND_URL}/favicon.ico`);
+  assert(faviconRes.ok, `FAVICON.ICO HTTP ${faviconRes.status}`);
+  const faviconBytes = new Uint8Array(await faviconRes.arrayBuffer());
+  assert(faviconBytes.byteLength > 0, "FAVICON.ICO body vacío");
+  assert(
+    faviconBytes[0] === 0x00 &&
+      faviconBytes[1] === 0x00 &&
+      faviconBytes[2] === 0x01 &&
+      faviconBytes[3] === 0x00,
+    `FAVICON.ICO magic bytes inválidos: ${Array.from(faviconBytes.slice(0, 4))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join(" ")}`
+  );
+  console.log("OK /favicon.ico");
+
   console.log("");
   console.log("SMOKE PROD PUBLIC COMPLETO OK");
 }


### PR DESCRIPTION
## Summary
- Extend public production smoke to validate /favicon.ico
- Require favicon HTTP 200, non-empty body, and ICO magic bytes
- Document favicon validation in the public production smoke runbook
- Keep smoke credential-free and avoid printing binary content

## Validation
- git diff --check
- pnpm smoke:prod:public
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Notes
- No secrets added
- No backend changes
- No visible UI changes
- No dependencies added
- No assets modified