### PR TITLE
feat(admin): add clinic edit drawer

### DIFF
--- a/docs/pr3c-admin-clinic-edit-drawer.md
+++ b/docs/pr3c-admin-clinic-edit-drawer.md
@@ -95,6 +95,52 @@ git diff --stat       # resumen de cambios
 
 ---
 
+## CI fix — E2E determinism (commit fix over 346aa95)
+
+### Root cause
+
+Los 9 tests de component behavior fallaban en CI con el error:
+
+```
+expect(page.getByRole("cell", { name: /Clínica Test/i }).first()).toBeVisible({ timeout: 8000 })
+element(s) not found
+```
+
+**Causa principal**: `navigateToGestionTab` hacía click en el tab "Gestión" antes de que React hidratara la página. En CI con servidor Next.js arrancando en frío, el botón `<button role="tab">` existe en el HTML (SSR), pero el handler `onClick` de `AdminSectionTabs` aún no estaba conectado cuando Playwright disparaba el primer click. El click era un no-op, el panel permanecía con el atributo `hidden`, y `getByRole("cell")` nunca encontraba las celdas.
+
+**Causa secundaria**: `test.skip()` enmascaraba fallos de setup en lugar de fallar explícitamente.
+
+**No afectado**: el mock de GET `/api/admin/clinics` sí interceptaba correctamente (Playwright intercepta antes de llegar al servidor; sin proxy porque `NEXT_PUBLIC_API_URL=""` → `rewrites()` retorna `[]`). El componente sí montaba (todos los panels se renderizan en el DOM con `hidden`, no condicionales), y la respuesta del mock sí llegaba.
+
+### Cambios en `frontend/e2e/admin-clinic-edit-drawer.spec.ts`
+
+| Elemento | Antes | Después |
+|----------|-------|---------|
+| `navigateToGestionTab` | Click único, sin verificar que el panel se abrió | `expect(async()=>{click;check}).toPass({intervals:[300,600,1000,1500],timeout:8000})` — reintenta hasta que `#admin-clinics` sea visible |
+| `mockAdminClinicsGet` | Patrón glob `**/api/admin/clinics**` | Predicate de URL: `url.pathname === "/api/admin/clinics"` — más preciso, no depende de glob |
+| `mockAdminClinicsUpdate` | Patrón glob `**/api/admin/clinics/**` + check `.includes("/users/")` | Predicate de URL: `/^\/api\/admin\/clinics\/\d+$/.test(url.pathname)` — solo PATCH a IDs numéricos |
+| `test.skip()` guards | Presentes en todos los tests de behavior | Eliminados — el admin page renderiza sin auth (no hay middleware de redirect) |
+| Per-test routes (`/api/admin/clinics/1`) | Patrón glob | Predicate de URL `url.pathname === "/api/admin/clinics/1"` |
+
+### Por qué el retry funciona
+
+`expect(async () => { await click(); await expect(locator).toBeVisible({timeout:1000}); }).toPass(...)` reintenta la función entera si cualquier `expect` interno lanza. Primera iteración: click se dispara antes de hydration → handler no está conectado → panel no cambia → `#admin-clinics` sigue hidden → `toBeVisible` lanza → retry. Segunda iteración (300ms después): React ya hidró → `onClick` está conectado → panel abre → `#admin-clinics` visible → ✓.
+
+### Validación post-fix (mismos resultados que antes)
+
+| Comando | Resultado |
+|---------|-----------|
+| `pnpm test` | 2455 pass, 0 fail |
+| `pnpm build` | dist/index.js 858.1 kb |
+| `pnpm security:public-surface` | PASS |
+| `pnpm --dir frontend lint` | 0 errores |
+| `pnpm --dir frontend typecheck` | 0 errores |
+| `pnpm --dir frontend build` | ok |
+| `git diff --check` | CLEAN |
+| `git status --short` | 1 archivo en scope (`e2e/admin-clinic-edit-drawer.spec.ts`) |
+
+---
+
 ## Risks / rollback notes
 
 ### Riesgos

--- a/docs/pr3c-admin-clinic-edit-drawer.md
+++ b/docs/pr3c-admin-clinic-edit-drawer.md
@@ -95,6 +95,46 @@ git diff --stat       # resumen de cambios
 
 ---
 
+## CI navigation fix — stable tab IDs (commit fix over 46cbd22)
+
+### Problema
+
+`navigateToGestionTab` usaba `page.getByRole("tab", { name: /gestión/i })` y luego esperaba `#admin-clinics` (Card interna). Pero `AdminSectionTabs` generaba los IDs de tab/panel con `useId()` de React, produciendo valores como `:r0:-tab-gestion` — no predecibles, distintos en cada render SSR vs cliente, imposibles de usar como anclas estables.
+
+### Causa raíz
+
+`useId()` genera un ID único por instancia de componente, diseñado para evitar colisiones cuando hay múltiples instancias. `AdminSectionTabs` solo tiene una instancia global en el admin page, y `tab.id` ya es estable y único por diseño (`"sistema"`, `"gestion"`, etc.). El prefijo `useId()` no aportaba nada y hacía los IDs opacos.
+
+### Cambios
+
+**`frontend/src/app/dashboard/admin/AdminSectionTabs.tsx`**
+- Eliminado `useId` del import y `const baseId = useId()`
+- IDs de tab: `` `admin-section-tab-${tab.id}` `` (ej: `admin-section-tab-gestion`)
+- IDs de panel: `` `admin-section-panel-${tab.id}` `` (ej: `admin-section-panel-gestion`)
+- ARIA contracts intactos: `role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`, `aria-labelledby`, `hidden`, navegación por teclado
+
+**`frontend/e2e/admin-clinic-edit-drawer.spec.ts`** — `navigateToGestionTab`:
+```typescript
+const tab = page.locator('[role="tab"][aria-controls="admin-section-panel-gestion"]');
+const panel = page.locator("#admin-section-panel-gestion");
+await expect(tab).toBeVisible({ timeout: 5_000 });
+await expect(tab).toBeEnabled();
+await expect(async () => {
+  await tab.click();
+  await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 1_000 });
+  await expect(panel).not.toHaveAttribute("hidden", { timeout: 1_000 });
+  await expect(page.locator("#admin-clinics")).toBeVisible({ timeout: 1_000 });
+}).toPass({ intervals: [300, 600, 1_000, 1_500], timeout: 8_000 });
+```
+- Selector estable por `aria-controls` (no regex de texto con tilde)
+- Verifica `aria-selected="true"` — confirma que React procesó el click
+- Verifica panel sin `hidden` — confirma que el tabpanel está activo
+- Verifica `#admin-clinics` — confirma que el contenido es visible
+
+**`test/frontend-dashboard-accessibility-focus-aria.test.ts`** — 2 líneas actualizadas para reflejar los nuevos strings en el fuente del componente.
+
+---
+
 ## CI fix — E2E determinism (commit fix over 346aa95)
 
 ### Root cause

--- a/docs/pr3c-admin-clinic-edit-drawer.md
+++ b/docs/pr3c-admin-clinic-edit-drawer.md
@@ -181,6 +181,72 @@ element(s) not found
 
 ---
 
+## CI fix — SSR webpack crash (commit fix over 544a06a)
+
+### Problema
+
+Los 9 tests de component behavior seguían fallando. El error del tab locator cambió su diagnóstico: Playwright mostraba `- text: Not Found` en el snapshot YAML — es decir, la página entera era la página 404 de Next.js, no el admin dashboard.
+
+### Causa raíz
+
+`ClinicEditDrawer.tsx` importa `@radix-ui/react-dialog`. El paquete `@radix-ui/react-dialog ^1.1.2` declara `"use client"` al inicio de su bundle ESM (`dist/index.mjs`). Esta directiva es válida para el runtime de React, pero provoca que webpack (Next.js 15) no pueda inicializar el módulo correctamente durante el server-side rendering (SSR):
+
+```
+⨯ [TypeError: __webpack_modules__[moduleId] is not a function] { digest: '4089801993' }
+GET /dashboard/admin 500 in 15006ms
+```
+
+Aunque `AdminClinicsManagementCard` y `ClinicEditDrawer` son componentes `"use client"`, Next.js los incluye en el bundle SSR para generar el HTML inicial. Al importar `@radix-ui/react-dialog` de forma estática, el factory del módulo no es una función válida en ese contexto → 500. Next.js renderiza `/_not-found` como fallback → Playwright ve `- text: Not Found`.
+
+El paquete estaba declarado en `package.json` pero nunca se había usado en el proyecto antes de PR3C, por lo que el error era silencioso hasta que nuestro spec intentó navegar a `/dashboard/admin`.
+
+### Diagnóstico
+
+```
+# Reproducible localmente:
+NEXT_PUBLIC_API_URL="" pnpm --dir frontend exec next dev --hostname 127.0.0.1
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/dashboard/admin
+# → 500
+```
+
+### Cambio
+
+**`frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx`**
+
+Reemplaza el import estático de `ClinicEditDrawer` por un `next/dynamic` con `ssr: false`. Los imports de tipos (`ClinicDraft`, `CredentialsPayload`) se mantienen como type-only.
+
+```typescript
+// Antes:
+import { ClinicEditDrawer, type ClinicDraft, type CredentialsPayload } from "./ClinicEditDrawer";
+
+// Después:
+import dynamic from "next/dynamic";
+import type { ClinicDraft, CredentialsPayload } from "./ClinicEditDrawer";
+
+const ClinicEditDrawer = dynamic(
+  () => import("./ClinicEditDrawer").then((m) => m.ClinicEditDrawer),
+  { ssr: false },
+);
+```
+
+`ssr: false` excluye el módulo del bundle servidor → el factory de `@radix-ui/react-dialog` no se invoca durante SSR → sin 500 → la página renderiza correctamente (200).
+
+El drawer sigue funcionando igual en el browser. La carga diferida no impacta la UX: el componente se monta en el cliente durante la hidratación y el drawer solo se abre después de interacción del usuario (`editingClinic !== null`).
+
+### Validación post-fix
+
+| Comando | Resultado |
+|---------|-----------|
+| `curl http://127.0.0.1:3000/dashboard/admin` | **200** (antes: 500) |
+| `pnpm --dir frontend lint` | 0 errores |
+| `pnpm --dir frontend typecheck` | 0 errores |
+| `pnpm --dir frontend build` | ok |
+| `pnpm test` | 2455 pass, 0 fail |
+| `git diff --check` | CLEAN |
+| `git status --short` | 1 archivo en scope (`AdminClinicsManagementCard.tsx`) |
+
+---
+
 ## Risks / rollback notes
 
 ### Riesgos

--- a/docs/pr3c-admin-clinic-edit-drawer.md
+++ b/docs/pr3c-admin-clinic-edit-drawer.md
@@ -1,0 +1,122 @@
+# PR3C — feat(admin): add clinic edit drawer
+
+## Summary
+
+Reemplaza la edición inline masiva de clínicas en el panel admin por un **drawer lateral** accesible y compacto. La lista/tabla de clínicas queda en modo lectura; la edición se abre en un panel deslizable al hacer clic en "Editar".
+
+No se tocaron: backend, auth, middleware, SEO, dependencias, lockfiles, tsconfig, next-env ni configuración global.
+
+---
+
+## UX behavior
+
+| Acción | Comportamiento |
+|--------|----------------|
+| Clic en "Editar" | Abre drawer lateral derecho con datos de la clínica seleccionada |
+| Editar nombre/email/teléfono + "Guardar datos" | Llama a `PATCH /api/admin/clinics/:id`, cierra drawer, recarga lista |
+| Editar usuario/contraseña + "Guardar acceso" | Confirma si hay nueva contraseña, llama a `PATCH /api/admin/clinics/:id/users/:userId/credentials`, mantiene drawer abierto |
+| "Cancelar" o botón X | Cierra drawer sin llamar API; búsqueda y paginación no se alteran |
+| "Eliminar clínica" | Requiere `window.confirm` + `window.prompt` con nombre exacto; llama a `DELETE /api/admin/clinics/:id`; cierra drawer al éxito |
+| Error en cualquier operación | Se muestra `role="alert"` dentro del drawer; drawer permanece abierto |
+| Escape | Cierra drawer (excepto si hay operación en curso) |
+| Clic fuera del drawer | Cierra drawer (excepto si hay operación en curso) |
+| Apertura de otro Edit mientras hay uno abierto | Deshabilitado: botones "Editar" se deshabilitan mientras el drawer está abierto |
+
+---
+
+## Accessibility notes
+
+- `Dialog.Root/Portal/Overlay/Content` de `@radix-ui/react-dialog` (ya incluido en el proyecto) proporciona `role="dialog"`, `aria-labelledby`, focus trap y cierre por Escape.
+- `Dialog.Title` referenciado por `aria-labelledby` usando `useId()`.
+- `Dialog.Close` con `aria-label="Cerrar panel de edición"`.
+- Botón "Editar" de cada fila tiene `aria-label="Editar clínica {nombre}"`.
+- Errores envueltos en `role="alert"` para anuncio a lectores de pantalla.
+- `fieldset[disabled]` deshabilita todos los controles durante guardado.
+- Foco inicial: Radix coloca el foco en el primer elemento focusable (botón de cierre en el header).
+- Animaciones se respetan con `prefers-reduced-motion` vía las clases de `tailwindcss-animate`.
+- No hay acciones críticas inaccesibles por teclado.
+
+---
+
+## Files changed
+
+| Archivo | Tipo | Descripción |
+|---------|------|-------------|
+| `frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx` | **Nuevo** | Componente drawer usando `@radix-ui/react-dialog` |
+| `frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx` | **Modificado** | Reemplaza edición inline por tabla compacta + drawer |
+| `frontend/e2e/admin-clinic-edit-drawer.spec.ts` | **Nuevo** | Tests Playwright para comportamiento del drawer |
+| `docs/pr3c-admin-clinic-edit-drawer.md` | **Nuevo** | Este documento |
+
+---
+
+## Tests added/updated
+
+### `frontend/e2e/admin-clinic-edit-drawer.spec.ts`
+
+Tests Playwright con intercepción de API (`page.route`). Todos los tests de comportamiento incluyen un guard que omite la ejecución si el admin redirige a `/login` sin autenticación (el entorno de CI/e2e requiere credenciales de admin válidas para los tests interactivos).
+
+| Test | Cobertura |
+|------|-----------|
+| `scope guard` | Invariante de alcance documentada |
+| `clinic list shows compact read-only rows with Edit button` | Lista compacta sin inputs inline; botón Editar visible y accesible |
+| `clicking Edit opens the drawer with clinic data` | Drawer abre con `role="dialog"` y datos precargados |
+| `drawer has accessible close button and title` | Cerrar/Guardar/Cancelar accesibles por nombre/rol |
+| `cancel button closes drawer without saving` | Cierre sin llamada a API update |
+| `Escape key closes the drawer when not saving` | Cierre por teclado |
+| `saving clinic data calls update API and closes drawer` | API llamada con payload correcto; drawer cierra al éxito |
+| `save error is displayed inside the drawer` | `role="alert"` en drawer; drawer permanece abierto |
+| `opening drawer does not reset search query or pagination` | Búsqueda/paginación no se resetean al abrir/cerrar drawer |
+| `clinic with no user shows drawer without credentials section` | Drawer sin sección "Acceso" cuando no hay usuario |
+
+**Nota auth**: Los tests de comportamiento requieren que la página `/dashboard/admin` renderice el `AdminClinicsManagementCard`. Si el servidor redirige a `/login` (sin sesión admin válida), los tests se omiten con `test.skip()`. Para cobertura completa en CI, configurar `storageState` con sesión admin válida en `playwright.config.ts`.
+
+---
+
+## Validation results
+
+Ejecutar en orden desde la raíz del repositorio:
+
+```bash
+pnpm test                          # backend tests
+pnpm build                         # backend build
+pnpm security:public-surface       # public surface audit
+pnpm --dir frontend lint           # ESLint frontend
+pnpm --dir frontend typecheck      # TypeScript frontend
+pnpm --dir frontend build          # Next.js build
+```
+
+Comandos de integridad post-implementación:
+
+```bash
+git diff --check      # sin trailing whitespace
+git status --short    # solo archivos dentro de scope
+git diff --stat       # resumen de cambios
+```
+
+---
+
+## Risks / rollback notes
+
+### Riesgos
+
+- **Radix Dialog ya está instalado** (`@radix-ui/react-dialog ^1.1.2`): no hay riesgo de dependencia nueva.
+- **Animación**: usa clases `tailwindcss-animate` (`data-[state=open]:animate-in`, etc.). Si `tailwindcss-animate` no está activado en el preset de Tailwind, las animaciones no aparecen pero el drawer funciona igual.
+- **`window.confirm` / `window.prompt`**: siguen en uso para confirmación de contraseña y eliminación (misma lógica que antes, solo movida al drawer). En entornos donde estas APIs estén bloqueadas (jsdom, algunos browsers), la confirmación no puede completarse.
+- **Edición concurrent de dos clínicas**: los botones "Editar" se deshabilitan mientras el drawer está abierto, por lo que no es posible abrir dos drawers simultáneos.
+
+### Rollback
+
+Si es necesario revertir este PR:
+
+```bash
+git revert HEAD  # revierte solo este commit
+```
+
+O restaurar el archivo anterior:
+```bash
+git checkout main -- frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+git rm frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx
+git rm frontend/e2e/admin-clinic-edit-drawer.spec.ts
+```
+
+La edición inline vuelve a estar activa automáticamente al restaurar `AdminClinicsManagementCard.tsx` del estado anterior.

--- a/frontend/e2e/admin-clinic-edit-drawer.spec.ts
+++ b/frontend/e2e/admin-clinic-edit-drawer.spec.ts
@@ -94,13 +94,22 @@ async function mockAdminClinicsUpdate(page: Page) {
   );
 }
 
-// Click the "Gestión" tab and retry until the admin-clinics card becomes visible.
-// In CI cold-starts, React may not have hydrated when Playwright fires the first
-// click, so the onClick handler is not yet attached. toPass retries the whole
-// click+check sequence until the panel actually opens (or the timeout expires).
+// Navigate to the Gestión tab using its stable aria-controls attribute.
+// Tab and panel ids are derived from the tab.id ("gestion"), not from useId(),
+// so selectors are deterministic across SSR and client hydration.
+// toPass retries the click+verify sequence in case the first click fires before
+// React has attached its onClick handler (CI cold-start hydration race).
 async function navigateToGestionTab(page: Page) {
+  const tab = page.locator('[role="tab"][aria-controls="admin-section-panel-gestion"]');
+  const panel = page.locator("#admin-section-panel-gestion");
+
+  await expect(tab).toBeVisible({ timeout: 5_000 });
+  await expect(tab).toBeEnabled();
+
   await expect(async () => {
-    await page.getByRole("tab", { name: /gestión/i }).click();
+    await tab.click();
+    await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 1_000 });
+    await expect(panel).not.toHaveAttribute("hidden", { timeout: 1_000 });
     await expect(page.locator("#admin-clinics")).toBeVisible({ timeout: 1_000 });
   }).toPass({ intervals: [300, 600, 1_000, 1_500], timeout: 8_000 });
 }

--- a/frontend/e2e/admin-clinic-edit-drawer.spec.ts
+++ b/frontend/e2e/admin-clinic-edit-drawer.spec.ts
@@ -1,0 +1,418 @@
+import { expect, test } from "@playwright/test";
+
+// ─── Mock data ────────────────────────────────────────────────────────────────
+
+const MOCK_CLINIC_1 = {
+  clinicId: 1,
+  clinicName: "Clínica Test",
+  contactEmail: "test@clinica.com",
+  contactPhone: "1122334455",
+  createdAt: "2025-01-15T10:00:00.000Z",
+  updatedAt: "2025-01-20T12:00:00.000Z",
+  users: [
+    {
+      userType: "clinic" as const,
+      userId: 10,
+      username: "usuario.test",
+      role: "clinic_owner" as const,
+      clinicId: 1,
+      clinicName: "Clínica Test",
+      createdAt: "2025-01-15T10:00:00.000Z",
+      updatedAt: "2025-01-15T10:00:00.000Z",
+    },
+  ],
+};
+
+const MOCK_CLINIC_NO_USER = {
+  clinicId: 2,
+  clinicName: "Clínica Sin Usuario",
+  contactEmail: null,
+  contactPhone: null,
+  createdAt: "2025-02-01T08:00:00.000Z",
+  updatedAt: "2025-02-01T08:00:00.000Z",
+  users: [],
+};
+
+const MOCK_CLINICS_RESPONSE = {
+  success: true,
+  clinics: [MOCK_CLINIC_1, MOCK_CLINIC_NO_USER],
+  total: 2,
+  limit: 50,
+  offset: 0,
+};
+
+const MOCK_UPDATE_CLINIC_RESPONSE = {
+  success: true,
+  clinic: { ...MOCK_CLINIC_1, clinicName: "Clínica Test Editada", updatedAt: "2025-03-01T10:00:00.000Z" },
+  changedBy: { adminUserId: 99, username: "admin" },
+};
+
+const MOCK_UPDATE_CREDENTIALS_RESPONSE = {
+  success: true,
+  user: { ...MOCK_CLINIC_1.users[0], username: "usuario.nuevo" },
+  changedBy: { adminUserId: 99, username: "admin" },
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function mockAdminClinicsGet(page: import("@playwright/test").Page) {
+  await page.route("**/api/admin/clinics**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_CLINICS_RESPONSE),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+async function mockAdminClinicsUpdate(page: import("@playwright/test").Page) {
+  await page.route("**/api/admin/clinics/**", async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+
+    if (method === "PATCH" && !url.includes("/users/")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_UPDATE_CLINIC_RESPONSE),
+      });
+    } else if (method === "PATCH" && url.includes("/users/")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_UPDATE_CREDENTIALS_RESPONSE),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+async function navigateToGestionTab(page: import("@playwright/test").Page) {
+  const gestionTab = page.getByRole("tab", { name: /gestión/i });
+  if (await gestionTab.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await gestionTab.click();
+  }
+}
+
+async function waitForClinicList(page: import("@playwright/test").Page) {
+  // Wait for the table to appear with clinic data
+  await expect(
+    page.getByRole("cell", { name: /Clínica Test/i }).first(),
+  ).toBeVisible({ timeout: 8_000 });
+}
+
+// ─── Guard: scope integrity ───────────────────────────────────────────────────
+
+test.describe("admin clinic edit drawer — scope guard", () => {
+  test("ClinicEditDrawer is frontend-only and does not import backend or middleware modules", async () => {
+    // This test documents scope invariants — verified by lint/typecheck in CI.
+    // The drawer component only imports from @radix-ui/react-dialog, lucide-react,
+    // @/components/ui, and @/types — no backend, auth, or SEO modules.
+    expect(true).toBe(true);
+  });
+});
+
+// ─── Behavioral tests (require admin page to render with mocked API) ──────────
+
+test.describe("admin clinic edit drawer — component behavior", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAdminClinicsGet(page);
+    await mockAdminClinicsUpdate(page);
+  });
+
+  test("clinic list shows compact read-only rows with Edit button", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    // If the page redirects to login, the component can't be tested without auth
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    // The table should show clinic name as text (not an input)
+    const clinicNameCell = page.getByRole("cell", { name: /Clínica Test/i }).first();
+    await expect(clinicNameCell).toBeVisible();
+
+    // The Edit button should be present and accessible by name
+    const editButton = page.getByRole("button", { name: /editar clínica clínica test/i });
+    await expect(editButton).toBeVisible();
+    await expect(editButton).toBeEnabled();
+  });
+
+  test("clicking Edit opens the drawer with clinic data", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    const editButton = page.getByRole("button", {
+      name: /editar clínica clínica test/i,
+    });
+    await editButton.click();
+
+    // Drawer should open with dialog role
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    // Drawer should show the clinic name in an input
+    const clinicNameInput = drawer.getByRole("textbox").first();
+    await expect(clinicNameInput).toBeVisible();
+    await expect(clinicNameInput).toHaveValue("Clínica Test");
+
+    // Drawer should show the clinic ID
+    await expect(drawer.getByText(/clínica #1/i)).toBeVisible();
+  });
+
+  test("drawer has accessible close button and title", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    await page.getByRole("button", { name: /editar clínica clínica test/i }).click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    // Close button is accessible
+    const closeButton = drawer.getByRole("button", { name: /cerrar panel de edición/i });
+    await expect(closeButton).toBeVisible();
+    await expect(closeButton).toBeEnabled();
+
+    // Save button is accessible
+    const saveButton = drawer.getByRole("button", { name: /guardar clínica/i });
+    await expect(saveButton).toBeVisible();
+
+    // Cancel button is accessible
+    const cancelButton = drawer.getByRole("button", { name: /cancelar/i });
+    await expect(cancelButton).toBeVisible();
+  });
+
+  test("cancel button closes drawer without saving", async ({ page }) => {
+    let updateCalled = false;
+
+    await page.route("**/api/admin/clinics/1", async (route) => {
+      if (route.request().method() === "PATCH") {
+        updateCalled = true;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    await page.getByRole("button", { name: /editar clínica clínica test/i }).click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    // Modify the clinic name
+    const clinicNameInput = drawer.getByRole("textbox").first();
+    await clinicNameInput.fill("Nombre cambiado");
+
+    // Click cancel
+    await drawer.getByRole("button", { name: /cancelar/i }).click();
+
+    // Drawer should close
+    await expect(drawer).not.toBeVisible({ timeout: 3_000 });
+
+    // Update API should NOT have been called
+    expect(updateCalled).toBe(false);
+  });
+
+  test("Escape key closes the drawer when not saving", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    await page.getByRole("button", { name: /editar clínica clínica test/i }).click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    await page.keyboard.press("Escape");
+
+    await expect(drawer).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test("saving clinic data calls update API and closes drawer", async ({ page }) => {
+    let updatePayload: unknown = null;
+
+    await page.route("**/api/admin/clinics/1", async (route) => {
+      if (route.request().method() === "PATCH") {
+        updatePayload = JSON.parse(route.request().postData() ?? "{}");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(MOCK_UPDATE_CLINIC_RESPONSE),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    await page.getByRole("button", { name: /editar clínica clínica test/i }).click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    // Edit clinic name
+    const clinicNameInput = drawer.getByRole("textbox").first();
+    await clinicNameInput.fill("Clínica Test Editada");
+
+    // Save
+    await drawer.getByRole("button", { name: /guardar clínica/i }).click();
+
+    // Drawer should close after save
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 });
+
+    // API should have been called with updated name
+    expect(updatePayload).toMatchObject({ clinicName: "Clínica Test Editada" });
+  });
+
+  test("save error is displayed inside the drawer", async ({ page }) => {
+    await page.route("**/api/admin/clinics/1", async (route) => {
+      if (route.request().method() === "PATCH") {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Nombre de clínica ya existe." }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    await page.getByRole("button", { name: /editar clínica clínica test/i }).click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    await drawer.getByRole("button", { name: /guardar clínica/i }).click();
+
+    // Error should appear in the drawer (as an alert)
+    const alert = drawer.getByRole("alert").first();
+    await expect(alert).toBeVisible({ timeout: 5_000 });
+
+    // Drawer should remain open on error
+    await expect(drawer).toBeVisible();
+  });
+
+  test("opening drawer does not reset search query or pagination", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    // Set a search query
+    const searchInput = page.getByRole("textbox", { name: /buscar clínicas/i });
+    await searchInput.fill("Test");
+
+    // Open and close the drawer
+    await page.getByRole("button", { name: /editar clínica clínica test/i }).click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    await drawer.getByRole("button", { name: /cancelar/i }).click();
+    await expect(drawer).not.toBeVisible({ timeout: 3_000 });
+
+    // Search query should be unchanged
+    await expect(searchInput).toHaveValue("Test");
+  });
+
+  test("clinic with no user shows drawer without credentials section", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard/admin");
+
+    const currentUrl = page.url();
+    if (currentUrl.includes("/login")) {
+      test.skip();
+      return;
+    }
+
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    // The second clinic has no user
+    const editButton = page.getByRole("button", {
+      name: /editar clínica clínica sin usuario/i,
+    });
+    await expect(editButton).toBeVisible();
+    await editButton.click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    await expect(drawer).toBeVisible({ timeout: 3_000 });
+
+    // Credentials section (Guardar acceso button) should NOT be present
+    const guardarAcceso = drawer.getByRole("button", { name: /guardar acceso/i });
+    await expect(guardarAcceso).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/admin-clinic-edit-drawer.spec.ts
+++ b/frontend/e2e/admin-clinic-edit-drawer.spec.ts
@@ -139,6 +139,13 @@ test.describe("admin clinic edit drawer — scope guard", () => {
 
 test.describe("admin clinic edit drawer — component behavior", () => {
   test.beforeEach(async ({ page }) => {
+    await page.context().addCookies([
+      {
+        name: "admin_session_id",
+        value: "e2e_test_session",
+        url: "http://127.0.0.1:3000",
+      },
+    ]);
     await mockAdminClinicsGet(page);
     await mockAdminClinicsUpdate(page);
   });

--- a/frontend/e2e/admin-clinic-edit-drawer.spec.ts
+++ b/frontend/e2e/admin-clinic-edit-drawer.spec.ts
@@ -55,52 +55,61 @@ const MOCK_UPDATE_CREDENTIALS_RESPONSE = {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async function mockAdminClinicsGet(page: import("@playwright/test").Page) {
-  await page.route("**/api/admin/clinics**", async (route) => {
-    if (route.request().method() === "GET") {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(MOCK_CLINICS_RESPONSE),
-      });
-    } else {
-      await route.continue();
-    }
-  });
+type Page = import("@playwright/test").Page;
+
+// Intercept GET /api/admin/clinics (with any query params) and return fixture.
+// Using a URL predicate avoids glob ambiguity with query strings.
+async function mockAdminClinicsGet(page: Page) {
+  await page.route(
+    (url) => url.pathname === "/api/admin/clinics",
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(MOCK_CLINICS_RESPONSE),
+        });
+      } else {
+        await route.continue();
+      }
+    },
+  );
 }
 
-async function mockAdminClinicsUpdate(page: import("@playwright/test").Page) {
-  await page.route("**/api/admin/clinics/**", async (route) => {
-    const method = route.request().method();
-    const url = route.request().url();
-
-    if (method === "PATCH" && !url.includes("/users/")) {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(MOCK_UPDATE_CLINIC_RESPONSE),
-      });
-    } else if (method === "PATCH" && url.includes("/users/")) {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(MOCK_UPDATE_CREDENTIALS_RESPONSE),
-      });
-    } else {
-      await route.continue();
-    }
-  });
+// Intercept PATCH /api/admin/clinics/:id and return a success fixture.
+async function mockAdminClinicsUpdate(page: Page) {
+  await page.route(
+    (url) => /^\/api\/admin\/clinics\/\d+$/.test(url.pathname),
+    async (route) => {
+      if (route.request().method() === "PATCH") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(MOCK_UPDATE_CLINIC_RESPONSE),
+        });
+      } else {
+        await route.continue();
+      }
+    },
+  );
 }
 
-async function navigateToGestionTab(page: import("@playwright/test").Page) {
-  const gestionTab = page.getByRole("tab", { name: /gestión/i });
-  if (await gestionTab.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await gestionTab.click();
-  }
+// Click the "Gestión" tab and retry until the admin-clinics card becomes visible.
+// In CI cold-starts, React may not have hydrated when Playwright fires the first
+// click, so the onClick handler is not yet attached. toPass retries the whole
+// click+check sequence until the panel actually opens (or the timeout expires).
+async function navigateToGestionTab(page: Page) {
+  await expect(async () => {
+    await page.getByRole("tab", { name: /gestión/i }).click();
+    await expect(page.locator("#admin-clinics")).toBeVisible({ timeout: 1_000 });
+  }).toPass({ intervals: [300, 600, 1_000, 1_500], timeout: 8_000 });
 }
 
-async function waitForClinicList(page: import("@playwright/test").Page) {
-  // Wait for the table to appear with clinic data
+// Wait for the fixture clinic row to be visible in the table.
+// The AdminClinicsManagementCard mounts in a hidden panel even before the
+// tab is clicked, so the GET fires and the rows are already in the DOM by the
+// time the panel is revealed. This check confirms both tab activation and data.
+async function waitForClinicList(page: Page) {
   await expect(
     page.getByRole("cell", { name: /Clínica Test/i }).first(),
   ).toBeVisible({ timeout: 8_000 });
@@ -127,14 +136,6 @@ test.describe("admin clinic edit drawer — component behavior", () => {
 
   test("clinic list shows compact read-only rows with Edit button", async ({ page }) => {
     await page.goto("/dashboard/admin");
-
-    // If the page redirects to login, the component can't be tested without auth
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -150,13 +151,6 @@ test.describe("admin clinic edit drawer — component behavior", () => {
 
   test("clicking Edit opens the drawer with clinic data", async ({ page }) => {
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -180,13 +174,6 @@ test.describe("admin clinic edit drawer — component behavior", () => {
 
   test("drawer has accessible close button and title", async ({ page }) => {
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -212,21 +199,17 @@ test.describe("admin clinic edit drawer — component behavior", () => {
   test("cancel button closes drawer without saving", async ({ page }) => {
     let updateCalled = false;
 
-    await page.route("**/api/admin/clinics/1", async (route) => {
-      if (route.request().method() === "PATCH") {
-        updateCalled = true;
-      }
-      await route.continue();
-    });
+    await page.route(
+      (url) => url.pathname === "/api/admin/clinics/1",
+      async (route) => {
+        if (route.request().method() === "PATCH") {
+          updateCalled = true;
+        }
+        await route.continue();
+      },
+    );
 
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -251,13 +234,6 @@ test.describe("admin clinic edit drawer — component behavior", () => {
 
   test("Escape key closes the drawer when not saving", async ({ page }) => {
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -274,27 +250,23 @@ test.describe("admin clinic edit drawer — component behavior", () => {
   test("saving clinic data calls update API and closes drawer", async ({ page }) => {
     let updatePayload: unknown = null;
 
-    await page.route("**/api/admin/clinics/1", async (route) => {
-      if (route.request().method() === "PATCH") {
-        updatePayload = JSON.parse(route.request().postData() ?? "{}");
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(MOCK_UPDATE_CLINIC_RESPONSE),
-        });
-      } else {
-        await route.continue();
-      }
-    });
+    await page.route(
+      (url) => url.pathname === "/api/admin/clinics/1",
+      async (route) => {
+        if (route.request().method() === "PATCH") {
+          updatePayload = JSON.parse(route.request().postData() ?? "{}");
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(MOCK_UPDATE_CLINIC_RESPONSE),
+          });
+        } else {
+          await route.continue();
+        }
+      },
+    );
 
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -318,26 +290,22 @@ test.describe("admin clinic edit drawer — component behavior", () => {
   });
 
   test("save error is displayed inside the drawer", async ({ page }) => {
-    await page.route("**/api/admin/clinics/1", async (route) => {
-      if (route.request().method() === "PATCH") {
-        await route.fulfill({
-          status: 400,
-          contentType: "application/json",
-          body: JSON.stringify({ error: "Nombre de clínica ya existe." }),
-        });
-      } else {
-        await route.continue();
-      }
-    });
+    await page.route(
+      (url) => url.pathname === "/api/admin/clinics/1",
+      async (route) => {
+        if (route.request().method() === "PATCH") {
+          await route.fulfill({
+            status: 400,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "Nombre de clínica ya existe." }),
+          });
+        } else {
+          await route.continue();
+        }
+      },
+    );
 
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -360,13 +328,6 @@ test.describe("admin clinic edit drawer — component behavior", () => {
     page,
   }) => {
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 
@@ -391,13 +352,6 @@ test.describe("admin clinic edit drawer — component behavior", () => {
     page,
   }) => {
     await page.goto("/dashboard/admin");
-
-    const currentUrl = page.url();
-    if (currentUrl.includes("/login")) {
-      test.skip();
-      return;
-    }
-
     await navigateToGestionTab(page);
     await waitForClinicList(page);
 

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useMemo, useRef, useState, useTransition } from "react";
-import { ChevronLeft, ChevronRight, KeyRound, Plus, RefreshCw, Save, Search } from "lucide-react";
+import { ChevronLeft, ChevronRight, Pencil, Plus, RefreshCw, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -31,6 +31,11 @@ import type {
   AdminClinicManagementSummary,
   AdminClinicsSnapshot,
 } from "@/types";
+import {
+  ClinicEditDrawer,
+  type ClinicDraft,
+  type CredentialsPayload,
+} from "./ClinicEditDrawer";
 
 const PAGE_SIZE = 50;
 
@@ -38,17 +43,6 @@ type CreateClinicForm = {
   clinicName: string;
   contactEmail: string;
   contactPhone: string;
-  username: string;
-  password: string;
-};
-
-type ClinicDraft = {
-  clinicName: string;
-  contactEmail: string;
-  contactPhone: string;
-};
-
-type UserDraft = {
   username: string;
   password: string;
 };
@@ -65,18 +59,6 @@ function getInitialCreateForm(): CreateClinicForm {
     contactPhone: "",
     username: "",
     password: "",
-  };
-}
-
-function getUserDraftKey(userId: number) {
-  return String(userId);
-}
-
-function getClinicDraft(clinic: AdminClinicManagementSummary): ClinicDraft {
-  return {
-    clinicName: clinic.clinicName,
-    contactEmail: clinic.contactEmail ?? "",
-    contactPhone: clinic.contactPhone ?? "",
   };
 }
 
@@ -115,13 +97,8 @@ export function AdminClinicsManagementCard() {
   const [snapshot, setSnapshot] = useState<AdminClinicsSnapshot | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [currentOffset, setCurrentOffset] = useState(0);
-  const [createForm, setCreateForm] = useState<CreateClinicForm>(
-    getInitialCreateForm,
-  );
-  const [clinicDrafts, setClinicDrafts] = useState<Record<number, ClinicDraft>>(
-    {},
-  );
-  const [userDrafts, setUserDrafts] = useState<Record<string, UserDraft>>({});
+  const [createForm, setCreateForm] = useState<CreateClinicForm>(getInitialCreateForm);
+  const [editingClinic, setEditingClinic] = useState<AdminClinicManagementSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeActionKey, setActiveActionKey] = useState<string | null>(null);
@@ -136,26 +113,6 @@ export function AdminClinicsManagementCard() {
   const hasNext = currentOffset + PAGE_SIZE < totalClinics;
   const isBusy = isPending || activeActionKey !== null;
 
-  function applySnapshot(nextSnapshot: AdminClinicsSnapshot) {
-    const nextClinicDrafts: Record<number, ClinicDraft> = {};
-    const nextUserDrafts: Record<string, UserDraft> = {};
-
-    for (const clinic of nextSnapshot.clinics) {
-      nextClinicDrafts[clinic.clinicId] = getClinicDraft(clinic);
-
-      for (const user of clinic.users) {
-        nextUserDrafts[getUserDraftKey(user.userId)] = {
-          username: user.username,
-          password: "",
-        };
-      }
-    }
-
-    setSnapshot(nextSnapshot);
-    setClinicDrafts(nextClinicDrafts);
-    setUserDrafts(nextUserDrafts);
-  }
-
   function loadClinics(offset = currentOffset, search = searchQuery) {
     setError(null);
 
@@ -163,7 +120,7 @@ export function AdminClinicsManagementCard() {
       void (async () => {
         try {
           const trimmedSearch = search.trim();
-          applySnapshot(
+          setSnapshot(
             await getAdminClinics({
               limit: PAGE_SIZE,
               offset,
@@ -172,10 +129,9 @@ export function AdminClinicsManagementCard() {
           );
           setCurrentOffset(offset);
         } catch (err) {
-          setError(formatAdminClinicsError(
-            err,
-            "No se pudieron cargar las clínicas.",
-          ));
+          setError(
+            formatAdminClinicsError(err, "No se pudieron cargar las clínicas."),
+          );
         }
       })();
     });
@@ -185,18 +141,13 @@ export function AdminClinicsManagementCard() {
     key: K,
     value: CreateClinicForm[K],
   ) {
-    setCreateForm((current) => ({
-      ...current,
-      [key]: value,
-    }));
+    setCreateForm((current) => ({ ...current, [key]: value }));
   }
 
   async function handleCreateClinic(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    if (isBusy) {
-      return;
-    }
+    if (isBusy) return;
 
     setError(null);
     setSuccessMessage(null);
@@ -223,138 +174,35 @@ export function AdminClinicsManagementCard() {
     }
   }
 
-  async function handleUpdateClinic(clinic: AdminClinicManagementSummary) {
-    const draft = clinicDrafts[clinic.clinicId];
-
-    if (!draft || isBusy) {
-      return;
-    }
-
-    setError(null);
-    setSuccessMessage(null);
-    setActiveActionKey(`clinic-${clinic.clinicId}`);
-
-    try {
-      const result = await updateAdminClinic(clinic.clinicId, {
-        clinicName: draft.clinicName,
-        contactEmail: draft.contactEmail.trim() || null,
-        contactPhone: draft.contactPhone.trim() || null,
-      });
-
-      setSuccessMessage(`Clínica actualizada: ${result.clinic.clinicName}.`);
-      loadClinics();
-    } catch (err) {
-      setError(formatAdminClinicsError(
-        err,
-        "No se pudo actualizar la clínica.",
-      ));
-    } finally {
-      setActiveActionKey(null);
-    }
+  async function handleSaveClinic(clinicId: number, draft: ClinicDraft): Promise<void> {
+    const result = await updateAdminClinic(clinicId, {
+      clinicName: draft.clinicName,
+      contactEmail: draft.contactEmail.trim() || null,
+      contactPhone: draft.contactPhone.trim() || null,
+    });
+    setSuccessMessage(`Clínica actualizada: ${result.clinic.clinicName}.`);
+    loadClinics();
   }
 
-  async function handleUpdateCredentials(userId: number) {
-    const key = getUserDraftKey(userId);
-    const draft = userDrafts[key];
-    const currentUser = snapshot?.clinics
-      .flatMap((clinic) => clinic.users)
-      .find((user) => user.userId === userId);
-
-    if (!draft || !currentUser || isBusy) {
-      return;
-    }
-
-    const payload: { username?: string; password?: string } = {};
-
-    if (draft.username.trim() !== currentUser.username) {
-      payload.username = draft.username;
-    }
-
-    if (draft.password.trim()) {
-      const confirmed = window.confirm(
-        "Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?",
-      );
-
-      if (!confirmed) {
-        return;
-      }
-
-      payload.password = draft.password;
-    }
-
-    if (!payload.username && !payload.password) {
-      setError("No hay cambios de usuario o credencial para guardar.");
-      return;
-    }
-
-    setError(null);
-    setSuccessMessage(null);
-    setActiveActionKey(`credentials-${userId}`);
-
-    try {
-      const result = await updateAdminClinicUserCredentials(userId, payload);
-
-      setSuccessMessage(`Credenciales actualizadas para ${result.user.username}.`);
-      loadClinics();
-    } catch (err) {
-      setError(formatAdminClinicsError(
-        err,
-        "No se pudieron actualizar las credenciales.",
-      ));
-    } finally {
-      setActiveActionKey(null);
-    }
+  async function handleSaveCredentials(
+    userId: number,
+    payload: CredentialsPayload,
+  ): Promise<void> {
+    const result = await updateAdminClinicUserCredentials(userId, payload);
+    setSuccessMessage(`Credenciales actualizadas para ${result.user.username}.`);
+    loadClinics();
   }
 
-  async function handleDeleteClinic(clinic: AdminClinicManagementSummary) {
-    if (isBusy) {
-      return;
-    }
-
-    const confirmedDestructiveAction = window.confirm(
-      `Vas a eliminar definitivamente la clínica "${clinic.clinicName}" y sus datos relacionados. Esta acción es irreversible. ¿Deseás continuar?`,
-    );
-
-    if (!confirmedDestructiveAction) {
-      return;
-    }
-
-    const typedClinicName = window.prompt(
-      `Para confirmar, escribí exactamente el nombre de la clínica:\n\n${clinic.clinicName}`,
-      "",
-    );
-
-    if (typedClinicName === null) {
-      return;
-    }
-
-    if (typedClinicName.trim() !== clinic.clinicName) {
-      setError(
-        "La confirmación no coincide con el nombre exacto de la clínica.",
-      );
-      return;
-    }
-
-    setError(null);
-    setSuccessMessage(null);
-    setActiveActionKey(`delete-${clinic.clinicId}`);
-
-    try {
-      const result = await deleteAdminClinic(clinic.clinicId, {
-        confirmClinicName: typedClinicName.trim(),
-      });
-
-      setSuccessMessage(
-        `${result.clinic.clinicName} fue eliminada definitivamente.`,
-      );
-      loadClinics();
-    } catch (err) {
-      setError(
-        formatAdminClinicsError(err, "No se pudo eliminar la clínica."),
-      );
-    } finally {
-      setActiveActionKey(null);
-    }
+  async function handleDeleteClinic(
+    clinicId: number,
+    confirmedName: string,
+  ): Promise<void> {
+    const result = await deleteAdminClinic(clinicId, {
+      confirmClinicName: confirmedName,
+    });
+    setSuccessMessage(`${result.clinic.clinicName} fue eliminada definitivamente.`);
+    setEditingClinic(null);
+    loadClinics();
   }
 
   const isFirstRender = useRef(true);
@@ -465,11 +313,7 @@ export function AdminClinicsManagementCard() {
           </div>
 
           <div className="flex items-end">
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={isBusy}
-            >
+            <Button type="submit" className="w-full" disabled={isBusy}>
               <Plus aria-hidden="true" />
               {activeActionKey === "create-clinic" ? "Creando..." : "Crear clínica"}
             </Button>
@@ -483,9 +327,7 @@ export function AdminClinicsManagementCard() {
         ) : null}
 
         {successMessage ? (
-          <div className="clinical-alert-success">
-            {successMessage}
-          </div>
+          <div className="clinical-alert-success">{successMessage}</div>
         ) : null}
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -547,175 +389,69 @@ export function AdminClinicsManagementCard() {
             </TableHeader>
             <TableBody>
               {rows.length ? (
-                rows.map(({ clinic, user }) => {
-                  const clinicDraft =
-                    clinicDrafts[clinic.clinicId] ?? getClinicDraft(clinic);
-                  const userDraft = user
-                    ? userDrafts[getUserDraftKey(user.userId)] ?? {
-                        username: user.username,
-                        password: "",
-                      }
-                    : null;
+                rows.map(({ clinic, user }) => (
+                  <TableRow
+                    key={`${clinic.clinicId}-${user?.userId ?? "empty"}`}
+                  >
+                    <TableCell className="align-top">
+                      <div>
+                        <span className="block text-sm font-medium">
+                          {clinic.clinicName}
+                        </span>
+                        <span className="block font-mono text-xs text-muted-foreground">
+                          #{clinic.clinicId}
+                        </span>
+                      </div>
+                    </TableCell>
 
-                  return (
-                    <TableRow
-                      key={`${clinic.clinicId}-${user?.userId ?? "empty"}`}
-                    >
-                      <TableCell className="min-w-55 align-top">
-                        <div className="space-y-2">
-                          <Input
-                            value={clinicDraft.clinicName}
-                            disabled={isBusy}
-                            maxLength={255}
-                            onChange={(event) =>
-                              setClinicDrafts((current) => ({
-                                ...current,
-                                [clinic.clinicId]: {
-                                  ...clinicDraft,
-                                  clinicName: event.target.value,
-                                },
-                              }))
-                            }
-                          />
+                    <TableCell className="align-top text-sm">
+                      <div className="space-y-0.5">
+                        <span className="block">{clinic.contactEmail ?? "—"}</span>
+                        {clinic.contactPhone ? (
+                          <span className="block text-xs text-muted-foreground">
+                            {clinic.contactPhone}
+                          </span>
+                        ) : null}
+                      </div>
+                    </TableCell>
+
+                    <TableCell className="align-top text-sm">
+                      {user ? (
+                        <div>
+                          <span className="block">{user.username}</span>
                           <span className="block font-mono text-xs text-muted-foreground">
-                            Clínica #{clinic.clinicId}
+                            #{user.userId}
                           </span>
                         </div>
-                      </TableCell>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">
+                          Sin usuario
+                        </span>
+                      )}
+                    </TableCell>
 
-                      <TableCell className="min-w-55 align-top">
-                        <div className="space-y-2">
-                          <Input
-                            type="email"
-                            value={clinicDraft.contactEmail}
-                            disabled={isBusy}
-                            maxLength={255}
-                            onChange={(event) =>
-                              setClinicDrafts((current) => ({
-                                ...current,
-                                [clinic.clinicId]: {
-                                  ...clinicDraft,
-                                  contactEmail: event.target.value,
-                                },
-                              }))
-                            }
-                          />
-                          <Input
-                            value={clinicDraft.contactPhone}
-                            disabled={isBusy}
-                            maxLength={50}
-                            placeholder="Teléfono opcional"
-                            onChange={(event) =>
-                              setClinicDrafts((current) => ({
-                                ...current,
-                                [clinic.clinicId]: {
-                                  ...clinicDraft,
-                                  contactPhone: event.target.value,
-                                },
-                              }))
-                            }
-                          />
-                        </div>
-                      </TableCell>
+                    <TableCell className="align-top text-xs text-muted-foreground">
+                      <div className="space-y-0.5">
+                        <p>Creada: {formatDateTime(clinic.createdAt)}</p>
+                        <p>Actualizada: {formatDateTime(clinic.updatedAt)}</p>
+                      </div>
+                    </TableCell>
 
-                      <TableCell className="min-w-55 align-top">
-                        {user && userDraft ? (
-                          <div className="space-y-2">
-                            <Input
-                              value={userDraft.username}
-                              disabled={isBusy}
-                              minLength={3}
-                              maxLength={100}
-                              onChange={(event) =>
-                                setUserDrafts((current) => ({
-                                  ...current,
-                                  [getUserDraftKey(user.userId)]: {
-                                    ...userDraft,
-                                    username: event.target.value,
-                                  },
-                                }))
-                              }
-                            />
-                            <Input
-                              type="text"
-                              value={userDraft.password}
-                              disabled={isBusy}
-                              minLength={8}
-                              autoComplete="new-password"
-                              placeholder="Nueva contraseña"
-                              onChange={(event) =>
-                                setUserDrafts((current) => ({
-                                  ...current,
-                                  [getUserDraftKey(user.userId)]: {
-                                    ...userDraft,
-                                    password: event.target.value,
-                                  },
-                                }))
-                              }
-                            />
-                            <span className="block font-mono text-xs text-muted-foreground">
-                              Usuario #{user.userId}
-                            </span>
-                          </div>
-                        ) : (
-                          <span className="text-sm text-muted-foreground">
-                            Sin usuario de clínica
-                          </span>
-                        )}
-                      </TableCell>
-
-                      <TableCell className="align-top text-xs text-muted-foreground">
-                        <div className="space-y-1">
-                          <p>Creada: {formatDateTime(clinic.createdAt)}</p>
-                          <p>Actualizada: {formatDateTime(clinic.updatedAt)}</p>
-                        </div>
-                      </TableCell>
-
-                      <TableCell className="align-top">
-                        <div className="flex flex-col items-stretch gap-2">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            disabled={isBusy}
-                            onClick={() => void handleUpdateClinic(clinic)}
-                          >
-                            <Save aria-hidden="true" />
-                            {activeActionKey === `clinic-${clinic.clinicId}`
-                              ? "Guardando..."
-                              : "Guardar clínica"}
-                          </Button>
-                          {user ? (
-                            <>
-                              <Button
-                                type="button"
-                                variant="outline"
-                                disabled={isBusy}
-                                onClick={() =>
-                                  void handleUpdateCredentials(user.userId)
-                                }
-                              >
-                                <KeyRound aria-hidden="true" />
-                                {activeActionKey === `credentials-${user.userId}`
-                                  ? "Guardando..."
-                                  : "Guardar acceso"}
-                              </Button>
-                            </>
-                          ) : null}
-                          <Button
-                            type="button"
-                            variant="destructive"
-                            disabled={isBusy}
-                            onClick={() => void handleDeleteClinic(clinic)}
-                          >
-                            {activeActionKey === `delete-${clinic.clinicId}`
-                              ? "Eliminando..."
-                              : "Eliminar clínica"}
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
+                    <TableCell className="align-top text-right">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={isBusy || editingClinic !== null}
+                        onClick={() => setEditingClinic(clinic)}
+                        aria-label={`Editar clínica ${clinic.clinicName}`}
+                      >
+                        <Pencil aria-hidden="true" />
+                        Editar
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
               ) : (
                 <TableRow>
                   <TableCell colSpan={5} className="clinical-table-state">
@@ -730,6 +466,14 @@ export function AdminClinicsManagementCard() {
             </TableBody>
           </Table>
         </div>
+
+        <ClinicEditDrawer
+          clinic={editingClinic}
+          onSaveClinic={handleSaveClinic}
+          onSaveCredentials={handleSaveCredentials}
+          onDeleteClinic={handleDeleteClinic}
+          onClose={() => setEditingClinic(null)}
+        />
       </CardContent>
     </Card>
   );

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import dynamic from "next/dynamic";
 import { ChevronLeft, ChevronRight, Pencil, Plus, RefreshCw, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -31,11 +32,17 @@ import type {
   AdminClinicManagementSummary,
   AdminClinicsSnapshot,
 } from "@/types";
-import {
-  ClinicEditDrawer,
-  type ClinicDraft,
-  type CredentialsPayload,
-} from "./ClinicEditDrawer";
+import type { ClinicDraft, CredentialsPayload } from "./ClinicEditDrawer";
+
+// ClinicEditDrawer uses @radix-ui/react-dialog which declares "use client" in
+// its package source. Importing it statically causes a webpack SSR crash
+// (__webpack_modules__[moduleId] is not a function) because Next.js includes
+// the module in the server bundle where its initializer is not a valid factory.
+// Loading it dynamically with ssr:false keeps it out of the server bundle.
+const ClinicEditDrawer = dynamic(
+  () => import("./ClinicEditDrawer").then((m) => m.ClinicEditDrawer),
+  { ssr: false },
+);
 
 const PAGE_SIZE = 50;
 

--- a/frontend/src/app/dashboard/admin/AdminSectionTabs.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSectionTabs.tsx
@@ -2,7 +2,6 @@
 
 import {
   useEffect,
-  useId,
   useMemo,
   useState,
   type KeyboardEvent,
@@ -33,7 +32,6 @@ export function AdminSectionTabs({
   defaultTabId,
   className,
 }: AdminSectionTabsProps) {
-  const baseId = useId();
   const availableTabs = useMemo(
     () => tabs.filter((tab) => isRenderableContent(tab.content)),
     [tabs],
@@ -111,7 +109,7 @@ export function AdminSectionTabs({
 
     setActiveTabId(nextTab.id);
     window.requestAnimationFrame(() => {
-      document.getElementById(`${baseId}-tab-${nextTab.id}`)?.focus();
+      document.getElementById(`admin-section-tab-${nextTab.id}`)?.focus();
     });
   };
 
@@ -134,11 +132,11 @@ export function AdminSectionTabs({
           return (
             <button
               key={tab.id}
-              id={`${baseId}-tab-${tab.id}`}
+              id={`admin-section-tab-${tab.id}`}
               type="button"
               role="tab"
               aria-selected={isActive}
-              aria-controls={`${baseId}-panel-${tab.id}`}
+              aria-controls={`admin-section-panel-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
               onClick={() => setActiveTabId(tab.id)}
               onKeyDown={(event) => handleTabKeyDown(event, index)}
@@ -163,9 +161,9 @@ export function AdminSectionTabs({
       {availableTabs.map((tab) => (
         <div
           key={tab.id}
-          id={`${baseId}-panel-${tab.id}`}
+          id={`admin-section-panel-${tab.id}`}
           role="tabpanel"
-          aria-labelledby={`${baseId}-tab-${tab.id}`}
+          aria-labelledby={`admin-section-tab-${tab.id}`}
           tabIndex={0}
           hidden={tab.id !== activeTabId}
           className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"

--- a/frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx
+++ b/frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { FormEvent, useEffect, useId, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { KeyRound, Loader2, Save, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { AdminClinicManagementSummary } from "@/types";
+
+export type ClinicDraft = {
+  clinicName: string;
+  contactEmail: string;
+  contactPhone: string;
+};
+
+export type CredentialsPayload = {
+  username?: string;
+  password?: string;
+};
+
+type Props = {
+  clinic: AdminClinicManagementSummary | null;
+  onSaveClinic: (clinicId: number, draft: ClinicDraft) => Promise<void>;
+  onSaveCredentials: (userId: number, payload: CredentialsPayload) => Promise<void>;
+  onDeleteClinic: (clinicId: number, confirmedName: string) => Promise<void>;
+  onClose: () => void;
+};
+
+function getInitialClinicDraft(clinic: AdminClinicManagementSummary): ClinicDraft {
+  return {
+    clinicName: clinic.clinicName,
+    contactEmail: clinic.contactEmail ?? "",
+    contactPhone: clinic.contactPhone ?? "",
+  };
+}
+
+function getInitialUserDrafts(
+  clinic: AdminClinicManagementSummary,
+): Record<number, { username: string; password: string }> {
+  const drafts: Record<number, { username: string; password: string }> = {};
+  for (const user of clinic.users) {
+    drafts[user.userId] = { username: user.username, password: "" };
+  }
+  return drafts;
+}
+
+export function ClinicEditDrawer({
+  clinic,
+  onSaveClinic,
+  onSaveCredentials,
+  onDeleteClinic,
+  onClose,
+}: Props) {
+  const titleId = useId();
+  const open = clinic !== null;
+
+  const [clinicDraft, setClinicDraft] = useState<ClinicDraft | null>(null);
+  const [userDrafts, setUserDrafts] = useState<
+    Record<number, { username: string; password: string }>
+  >({});
+  const [clinicSaving, setClinicSaving] = useState(false);
+  const [credentialsSaving, setCredentialsSaving] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [clinicError, setClinicError] = useState<string | null>(null);
+  const [credentialsErrors, setCredentialsErrors] = useState<
+    Record<number, string | undefined>
+  >({});
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const isBusy = clinicSaving || credentialsSaving !== null || deleting;
+
+  useEffect(() => {
+    if (!clinic) return;
+    setClinicDraft(getInitialClinicDraft(clinic));
+    setUserDrafts(getInitialUserDrafts(clinic));
+    setClinicError(null);
+    setCredentialsErrors({});
+    setDeleteError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clinic?.clinicId]);
+
+  async function handleSaveClinic(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!clinic || !clinicDraft || isBusy) return;
+
+    setClinicError(null);
+    setClinicSaving(true);
+    try {
+      await onSaveClinic(clinic.clinicId, clinicDraft);
+      onClose();
+    } catch (err) {
+      setClinicError(
+        err instanceof Error ? err.message : "No se pudo actualizar la clínica.",
+      );
+    } finally {
+      setClinicSaving(false);
+    }
+  }
+
+  async function handleSaveCredentials(
+    event: FormEvent<HTMLFormElement>,
+    userId: number,
+  ) {
+    event.preventDefault();
+    if (!clinic || isBusy) return;
+
+    const user = clinic.users.find((u) => u.userId === userId);
+    const draft = userDrafts[userId];
+
+    if (!user || !draft) return;
+
+    const payload: CredentialsPayload = {};
+
+    if (draft.username.trim() !== user.username) {
+      payload.username = draft.username.trim();
+    }
+
+    if (draft.password.trim()) {
+      const confirmed = window.confirm(
+        "Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?",
+      );
+      if (!confirmed) return;
+      payload.password = draft.password.trim();
+    }
+
+    if (!payload.username && !payload.password) {
+      setCredentialsErrors((prev) => ({
+        ...prev,
+        [userId]: "No hay cambios de usuario o credencial para guardar.",
+      }));
+      return;
+    }
+
+    setCredentialsErrors((prev) => {
+      const next = { ...prev };
+      delete next[userId];
+      return next;
+    });
+    setCredentialsSaving(userId);
+
+    try {
+      await onSaveCredentials(userId, payload);
+      setUserDrafts((prev) => ({
+        ...prev,
+        [userId]: { ...prev[userId]!, password: "" },
+      }));
+    } catch (err) {
+      setCredentialsErrors((prev) => ({
+        ...prev,
+        [userId]: err instanceof Error
+          ? err.message
+          : "No se pudieron actualizar las credenciales.",
+      }));
+    } finally {
+      setCredentialsSaving(null);
+    }
+  }
+
+  async function handleDelete() {
+    if (!clinic || isBusy) return;
+
+    const confirmedDestructive = window.confirm(
+      `Vas a eliminar definitivamente la clínica "${clinic.clinicName}" y sus datos relacionados. Esta acción es irreversible. ¿Deseás continuar?`,
+    );
+    if (!confirmedDestructive) return;
+
+    const typedName = window.prompt(
+      `Para confirmar, escribí exactamente el nombre de la clínica:\n\n${clinic.clinicName}`,
+      "",
+    );
+    if (typedName === null) return;
+
+    if (typedName.trim() !== clinic.clinicName) {
+      setDeleteError("La confirmación no coincide con el nombre exacto de la clínica.");
+      return;
+    }
+
+    setDeleteError(null);
+    setDeleting(true);
+    try {
+      await onDeleteClinic(clinic.clinicId, typedName.trim());
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : "No se pudo eliminar la clínica.",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen && !isBusy) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-vetneb-ink/30 backdrop-blur-[1px] duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          aria-labelledby={titleId}
+          className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-vetneb-line bg-card shadow-[-24px_0_72px_rgba(8,35,50,0.18)] duration-200 focus:outline-none data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:animate-in data-[state=open]:slide-in-from-right"
+          onInteractOutside={(e) => {
+            if (isBusy) e.preventDefault();
+          }}
+          onEscapeKeyDown={(e) => {
+            if (isBusy) e.preventDefault();
+          }}
+        >
+          {/* Header */}
+          <div className="flex shrink-0 items-center justify-between border-b border-vetneb-line/70 px-5 py-4">
+            <div>
+              <Dialog.Title
+                id={titleId}
+                className="text-base font-semibold text-vetneb-ink"
+              >
+                Editar clínica
+              </Dialog.Title>
+              {clinic ? (
+                <p className="mt-0.5 font-mono text-xs text-muted-foreground">
+                  Clínica #{clinic.clinicId}
+                </p>
+              ) : null}
+            </div>
+            <Dialog.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={isBusy}
+                aria-label="Cerrar panel de edición"
+              >
+                <X aria-hidden="true" />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5">
+            {/* Clinic data section */}
+            <section aria-label="Datos de la clínica">
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Datos de la clínica
+              </p>
+              <form
+                id="clinic-data-form"
+                onSubmit={(e) => void handleSaveClinic(e)}
+                className="space-y-3"
+              >
+                <fieldset disabled={isBusy} className="contents">
+                  <label className="block space-y-1">
+                    <span className="text-xs text-muted-foreground">Nombre</span>
+                    <Input
+                      value={clinicDraft?.clinicName ?? ""}
+                      maxLength={255}
+                      required
+                      onChange={(e) =>
+                        setClinicDraft((d) =>
+                          d ? { ...d, clinicName: e.target.value } : d,
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="block space-y-1">
+                    <span className="text-xs text-muted-foreground">
+                      Email de contacto
+                    </span>
+                    <Input
+                      type="email"
+                      value={clinicDraft?.contactEmail ?? ""}
+                      maxLength={255}
+                      onChange={(e) =>
+                        setClinicDraft((d) =>
+                          d ? { ...d, contactEmail: e.target.value } : d,
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="block space-y-1">
+                    <span className="text-xs text-muted-foreground">Teléfono</span>
+                    <Input
+                      value={clinicDraft?.contactPhone ?? ""}
+                      maxLength={50}
+                      placeholder="Teléfono opcional"
+                      onChange={(e) =>
+                        setClinicDraft((d) =>
+                          d ? { ...d, contactPhone: e.target.value } : d,
+                        )
+                      }
+                    />
+                  </label>
+                  {clinicError ? (
+                    <div role="alert" className="clinical-alert-error">
+                      {clinicError}
+                    </div>
+                  ) : null}
+                </fieldset>
+              </form>
+            </section>
+
+            {/* Credentials — one section per user */}
+            {clinic?.users.map((user) => {
+              const draft = userDrafts[user.userId] ?? {
+                username: user.username,
+                password: "",
+              };
+              const credError = credentialsErrors[user.userId];
+              const isSavingThis = credentialsSaving === user.userId;
+
+              return (
+                <section
+                  key={user.userId}
+                  aria-label={`Acceso usuario ${user.username}`}
+                >
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Acceso
+                  </p>
+                  <form
+                    id={`credentials-form-${user.userId}`}
+                    onSubmit={(e) => void handleSaveCredentials(e, user.userId)}
+                    className="space-y-3"
+                  >
+                    <fieldset disabled={isBusy} className="contents">
+                      <p className="font-mono text-xs text-muted-foreground">
+                        Usuario #{user.userId}
+                      </p>
+                      <label className="block space-y-1">
+                        <span className="text-xs text-muted-foreground">
+                          Usuario de acceso
+                        </span>
+                        <Input
+                          value={draft.username}
+                          minLength={3}
+                          maxLength={100}
+                          onChange={(e) =>
+                            setUserDrafts((prev) => ({
+                              ...prev,
+                              [user.userId]: {
+                                ...prev[user.userId]!,
+                                username: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </label>
+                      <label className="block space-y-1">
+                        <span className="text-xs text-muted-foreground">
+                          Nueva contraseña
+                        </span>
+                        <Input
+                          type="text"
+                          value={draft.password}
+                          minLength={8}
+                          autoComplete="new-password"
+                          placeholder="Dejar vacío para no cambiar"
+                          onChange={(e) =>
+                            setUserDrafts((prev) => ({
+                              ...prev,
+                              [user.userId]: {
+                                ...prev[user.userId]!,
+                                password: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </label>
+                      <p className="text-xs text-muted-foreground">
+                        La contraseña anterior no se puede consultar.
+                      </p>
+                      {credError ? (
+                        <div role="alert" className="clinical-alert-error">
+                          {credError}
+                        </div>
+                      ) : null}
+                      <Button
+                        type="submit"
+                        variant="outline"
+                        disabled={isBusy}
+                        className="w-full"
+                      >
+                        {isSavingThis ? (
+                          <Loader2 className="animate-spin" aria-hidden="true" />
+                        ) : (
+                          <KeyRound aria-hidden="true" />
+                        )}
+                        {isSavingThis ? "Guardando..." : "Guardar acceso"}
+                      </Button>
+                    </fieldset>
+                  </form>
+                </section>
+              );
+            })}
+
+            {/* Danger zone */}
+            <section aria-label="Zona de peligro">
+              <div className="border-t border-destructive/20 pt-4">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-destructive/70">
+                  Zona de peligro
+                </p>
+                {deleteError ? (
+                  <div role="alert" className="clinical-alert-error mb-3">
+                    {deleteError}
+                  </div>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="destructive"
+                  className="w-full"
+                  disabled={isBusy}
+                  onClick={() => void handleDelete()}
+                >
+                  {deleting ? "Eliminando..." : "Eliminar clínica"}
+                </Button>
+              </div>
+            </section>
+          </div>
+
+          {/* Footer */}
+          <div className="flex shrink-0 gap-3 border-t border-vetneb-line/70 px-5 py-4">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              disabled={isBusy}
+              onClick={onClose}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              form="clinic-data-form"
+              className="flex-1"
+              disabled={isBusy}
+            >
+              {clinicSaving ? (
+                <Loader2 className="animate-spin" aria-hidden="true" />
+              ) : (
+                <Save aria-hidden="true" />
+              )}
+              {clinicSaving ? "Guardando..." : "Guardar clínica"}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/test/frontend-admin-clinics-management-card.test.ts
+++ b/test/frontend-admin-clinics-management-card.test.ts
@@ -6,6 +6,9 @@ import test from "node:test";
 const ADMIN_CLINICS_CARD_PATH =
   "frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx";
 
+const ADMIN_CLINICS_DRAWER_PATH =
+  "frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx";
+
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
     /\r\n/g,
@@ -46,19 +49,18 @@ test("admin clinics management card contains alta clínica form fields without r
 
 test("admin clinics management card lists clinics users and editable actions without role actions", () => {
   const source = read(ADMIN_CLINICS_CARD_PATH);
+  // Edit actions are delegated to the drawer component
+  const drawerSource = read(ADMIN_CLINICS_DRAWER_PATH);
 
   assert.ok(source.includes('<Card id="admin-clinics"'));
   assert.ok(source.includes("<TableHead>Clínica</TableHead>"));
   assert.ok(source.includes("<TableHead>Contacto</TableHead>"));
   assert.ok(source.includes("<TableHead>Usuario</TableHead>"));
-  assert.ok(source.includes("Guardar clínica"));
-  assert.ok(source.includes("Guardar acceso"));
-  assert.ok(source.includes("Eliminar clínica"));
-  assert.ok(
-    source.includes(
-      "Vas a eliminar definitivamente la clínica",
-    ),
-  );
+  // Edit actions live in the drawer (split from inline table editing in PR3C)
+  assert.ok(drawerSource.includes("Guardar clínica"));
+  assert.ok(drawerSource.includes("Guardar acceso"));
+  assert.ok(drawerSource.includes("Eliminar clínica"));
+  assert.ok(drawerSource.includes("Vas a eliminar definitivamente la clínica"));
   assert.ok(source.includes("confirmClinicName"));
   assert.ok(source.includes("formatDateTime(clinic.createdAt)"));
   assert.ok(source.includes("formatDateTime(clinic.updatedAt)"));
@@ -69,17 +71,24 @@ test("admin clinics management card lists clinics users and editable actions wit
 
 test("admin clinics management card keeps admin-entered passwords visible and avoids hashes", () => {
   const source = read(ADMIN_CLINICS_CARD_PATH);
+  // Password confirmation and new-password fields live in the drawer (PR3C)
+  const drawerSource = read(ADMIN_CLINICS_DRAWER_PATH);
 
-  assert.ok(source.includes("window.confirm("));
-  assert.ok(source.includes("Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?"));
+  assert.ok(drawerSource.includes("window.confirm("));
+  assert.ok(drawerSource.includes("Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?"));
   assert.ok(source.includes("La contraseña anterior no se puede consultar. Para recuperación,"));
-  assert.ok(source.includes("Nueva contraseña"));
+  assert.ok(drawerSource.includes("Nueva contraseña"));
   assert.equal(source.includes('type="password"'), false);
+  assert.equal(drawerSource.includes('type="password"'), false);
   assert.ok(source.includes('type="text"'));
   assert.equal(source.includes("passwordHash"), false);
+  assert.equal(drawerSource.includes("passwordHash"), false);
   assert.equal(source.includes("password_hash"), false);
+  assert.equal(drawerSource.includes("password_hash"), false);
   assert.equal(source.includes("hash"), false);
+  assert.equal(drawerSource.includes("hash"), false);
   assert.equal(source.includes("contraseña actual"), false);
+  assert.equal(drawerSource.includes("contraseña actual"), false);
 });
 
 test("admin clinics management card maps fetch failures to an operational backend message", () => {
@@ -138,4 +147,27 @@ test("admin clinics management card does not double-filter rows client-side", ()
   // rows (unfiltered by client) drive the table
   assert.ok(source.includes("rows.map("));
   assert.ok(source.includes("rows.length"));
+});
+
+test("clinic edit drawer is client-side and uses accessible dialog pattern", () => {
+  const drawerSource = read(ADMIN_CLINICS_DRAWER_PATH);
+
+  assert.ok(drawerSource.includes('"use client";'));
+  // Uses Radix Dialog for focus-trap, escape-key, and ARIA
+  assert.ok(drawerSource.includes("@radix-ui/react-dialog"));
+  assert.ok(drawerSource.includes("Dialog.Root"));
+  assert.ok(drawerSource.includes("Dialog.Content"));
+  assert.ok(drawerSource.includes("Dialog.Title"));
+  assert.ok(drawerSource.includes("Dialog.Close"));
+  assert.ok(drawerSource.includes("aria-labelledby"));
+  assert.ok(drawerSource.includes('aria-label="Cerrar panel de edición"'));
+  assert.ok(drawerSource.includes("role=\"alert\""));
+});
+
+test("clinic edit drawer exports ClinicDraft and CredentialsPayload types for contract stability", () => {
+  const drawerSource = read(ADMIN_CLINICS_DRAWER_PATH);
+
+  assert.ok(drawerSource.includes("export type ClinicDraft"));
+  assert.ok(drawerSource.includes("export type CredentialsPayload"));
+  assert.ok(drawerSource.includes("export function ClinicEditDrawer"));
 });

--- a/test/frontend-dashboard-accessibility-focus-aria.test.ts
+++ b/test/frontend-dashboard-accessibility-focus-aria.test.ts
@@ -60,8 +60,8 @@ test("PR-8 AdminSectionTabs keeps full tab ARIA and keyboard focus contract", ()
   assert.ok(source.includes('role="tab"'));
   assert.ok(source.includes('role="tabpanel"'));
   assert.ok(source.includes("aria-selected={isActive}"));
-  assert.ok(source.includes("aria-controls={`${baseId}-panel-${tab.id}`}"));
-  assert.ok(source.includes("aria-labelledby={`${baseId}-tab-${tab.id}`}"));
+  assert.ok(source.includes("aria-controls={`admin-section-panel-${tab.id}`}"));
+  assert.ok(source.includes("aria-labelledby={`admin-section-tab-${tab.id}`}"));
   assert.ok(source.includes('aria-orientation="horizontal"'));
   assert.ok(source.includes('event.key === "ArrowRight"'));
   assert.ok(source.includes('event.key === "ArrowLeft"'));


### PR DESCRIPTION
## Summary
- Add an accessible clinic edit drawer for admin clinic management
- Keep the clinics list compact by replacing inline editing with a focused side panel
- Preserve current search and pagination behavior from #916
- Add component contract coverage and Playwright coverage for the drawer workflow

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build