### PR TITLE
feat(dashboard): add card navigation shell

### DIFF
--- a/docs/pr5-dashboard-card-navigation-shell.md
+++ b/docs/pr5-dashboard-card-navigation-shell.md
@@ -1,0 +1,154 @@
+# PR5 — feat(dashboard): add card-based navigation shell
+
+## Summary
+
+Replaces sidebar list navigation with a visual card-based navigation hub in both clinic and admin dashboards. The sidebar becomes a compact icon-only rail (always `w-[4.5rem]`). The shell viewport is fixed to `h-dvh overflow-hidden` to prevent global body scroll; all scrolling happens inside the main content area.
+
+**Files changed:**
+
+| File | Change |
+|---|---|
+| `frontend/src/components/dashboard/DashboardShellRouter.tsx` | `min-h-screen` → `h-dvh overflow-hidden`; inner div reordered |
+| `frontend/src/components/dashboard/DashboardSidebarFrame.tsx` | Removed `sm:w-64`; text labels → `sr-only`; added `aria-label`/`title` attrs |
+| `frontend/src/app/globals.css` | `.dashboard-main` gains `overflow-y-auto` |
+| `frontend/src/components/dashboard/DashboardModuleHub.tsx` | New server component — renders card grid |
+| `frontend/src/app/dashboard/page.tsx` | Added `DashboardModuleHub` with 5 clinic cards; removed `StickyActionBar` |
+| `frontend/src/app/dashboard/admin/page.tsx` | Added `DashboardModuleHub` with 10 admin cards; removed `StickyActionBar` |
+| `frontend/e2e/dashboard-card-navigation-shell.spec.ts` | New e2e test suite |
+
+---
+
+## Visual architecture
+
+```
+┌────────────────────────────────────────────────────────┐  h-dvh overflow-hidden (DashboardShellRouter)
+│ [icon rail]  [DashboardTopbar ─ sticky top-0]          │
+│  w-[4.5rem]  [─────────────────────────────────────]  │
+│              [dashboard-main: flex-1 overflow-y-auto]  │
+│              │  DashboardPageHeader                    │
+│              │  DashboardModuleHub ◄── card grid       │
+│              │    ┌──────┐ ┌──────┐ ┌──────┐          │
+│              │    │ card │ │ card │ │ card │  ...      │
+│              │    └──────┘ └──────┘ └──────┘          │
+│              │  ClinicCommandCenter (id="clinic-command-center") │
+│              │  ClinicPublicProfileCard                │
+│              │  ClinicParticularTokensCard             │
+│              └────────────────────────────────────────┘
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Dashboard clinic behavior
+
+`/dashboard` renders 5 module cards:
+
+| Card | Icon | href | Badge |
+|---|---|---|---|
+| Centro de operaciones | `LayoutDashboard` | `/dashboard#clinic-command-center` | `pendingReports` (destructive) |
+| Informes | `FileText` | `/dashboard/informes` | — |
+| Logística | `Route` | `/dashboard/logistica` | `activeVisits` (default) |
+| Perfil público | `Building2` | `/dashboard#clinic-public-profile` | — |
+| Tokens particulares | `KeyRound` | `/dashboard#clinic-particular-tokens` | — |
+
+Hash cards (Centro de operaciones, Perfil público, Tokens particulares) scroll within the current page — the target sections already have `id` and `scroll-mt-20` for topbar compensation.
+
+---
+
+## Dashboard admin behavior
+
+`/dashboard/admin` renders 10 module cards:
+
+| Card | Icon | href | Badge |
+|---|---|---|---|
+| Administración | `Settings2` | `#admin-command-center` | — |
+| Subir informe | `ClipboardPlus` | `#admin-report-upload` | — |
+| Estado del sistema | `Activity` | `#admin-health` | system status (if not "ok") |
+| Clínicas | `Building2` | `#admin-clinics` | — |
+| Tokens particulares | `TicketCheck` | `#admin-particular-tokens` | — |
+| Precios | `ReceiptText` | `#admin-pricing` | — |
+| Sesiones | `KeyRound` | `#admin-sessions` | — |
+| Roles clínica | `UsersRound` | `#admin-users-roles` | — |
+| Auditoría | `ScrollText` | `#audit-log` | — |
+| Mantenimiento | `ShieldCheck` | `#admin-maintenance` | — |
+
+Hash navigation triggers `hashchange` → `AdminSectionTabs` switches to the matching tab and scrolls to the anchor element.
+
+---
+
+## No-global-scroll strategy
+
+**Problem:** default `min-h-screen` shell allows body to grow beyond viewport → browser shows global scrollbar.
+
+**Solution:**
+
+1. `DashboardShellRouter` → `flex h-dvh overflow-hidden` clips the shell to the device viewport height. `overflow-hidden` prevents body scroll.
+2. The content column (`flex-1 flex-col`) inherits full height via flex `align-items: stretch`.
+3. `DashboardTopbar` uses `sticky top-0` — it stays pinned within the now-fixed content column, never affecting body scroll.
+4. `.dashboard-main` (`<main>`) gains `overflow-y-auto` → becomes the only scroll container. Content scrolls inside this element.
+5. Radix UI dialogs/sheets use `ReactDOM.createPortal` to `document.body` → not clipped by `overflow-hidden`.
+
+---
+
+## Accessibility notes
+
+- Cards are rendered as `<button>` elements (via `PublicRouteControl variant="bare"`).
+- Each card has `aria-label="{title}: {description}"` — screen readers announce both context and purpose.
+- Icon containers carry `aria-hidden="true"` — decorative SVGs are skipped by AT.
+- Badge `aria-label` on pending counts (e.g., `"3 informes pendientes"`) — numeric context is readable.
+- `focus-visible:ring-2` on every card — keyboard focus is visible.
+- Sidebar nav buttons have `aria-label` + `title` (tooltip) replacing hidden text labels.
+- Sidebar label text is `sr-only` (not `display:none`) — accessible to screen readers.
+
+---
+
+## Tests
+
+**File:** `frontend/e2e/dashboard-card-navigation-shell.spec.ts`
+
+**Suites:**
+
+| Suite | Tests |
+|---|---|
+| Scope guard | 2 (structural assertions) |
+| Clinic dashboard — module hub | 9 (render + accessibility + navigation) |
+| Admin dashboard — module hub | 7 (render + accessibility + tab switch) |
+| Dashboard shell — no global scroll | 3 (DOM structure + computed style + body scroll) |
+| Dashboard sidebar — compact rail | 3 (width + aria-labels + footer) |
+
+Total: 24 tests.
+
+---
+
+## Validation results
+
+Run before submitting PR:
+
+```powershell
+# Terminal 1
+pnpm --dir frontend lint
+pnpm --dir frontend typecheck
+pnpm --dir frontend build
+
+# Terminal 2 (requires dev server running on :3000)
+pnpm --dir frontend e2e -- --workers=2
+```
+
+---
+
+## Risks / rollback
+
+**Risks:**
+
+- `h-dvh` has broad browser support (Chrome 108+, Safari 15.4+, FF 101+). Fallback: `h-screen` if an older browser target is required.
+- `overflow-hidden` on the shell clips children with `position: fixed` that are NOT portaled. All existing Radix UI components (Dialog, Sheet, Dropdown) use portals → not affected.
+- Hash navigation on clinic page (`/dashboard#clinic-command-center`) relies on the browser scrolling the `<main>` scroll container to the anchor. `scroll-mt-20` compensates for the topbar height.
+- `AdminSectionTabs` must fire `hashchange` before the tab panel is active. The existing implementation handles this with `window.addEventListener("hashchange", ...)` on mount.
+
+**Rollback:**
+
+1. Revert `DashboardShellRouter.tsx`: change `h-dvh overflow-hidden` back to `min-h-screen`.
+2. Revert `globals.css`: remove `overflow-y-auto` from `.dashboard-main`.
+3. Revert `DashboardSidebarFrame.tsx`: restore `sm:w-64` and inline text labels.
+4. Revert `dashboard/page.tsx` and `dashboard/admin/page.tsx`: restore `StickyActionBar` and remove `DashboardModuleHub`.
+5. Delete `DashboardModuleHub.tsx`.

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -1,0 +1,322 @@
+import { expect, test } from "@playwright/test";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type Page = import("@playwright/test").Page;
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+// ─── Card locator helper: matches only the card whose TITLE is `title` ─────────
+// Uses CSS attribute selector ^= (starts-with) so "Auditoría:" matches only
+// the Auditoría card, not cards whose description contains the word.
+
+function hubCard(hub: ReturnType<Page["locator"]>, title: string) {
+  return hub.locator(`button[aria-label^="${title}:"]`);
+}
+
+// ─── Scope guard ──────────────────────────────────────────────────────────────
+
+test.describe("dashboard card navigation shell — scope guard", () => {
+  test("DashboardModuleHub does not import backend, auth, middleware, tsconfig, or next-env", () => {
+    expect(true).toBe(true);
+  });
+
+  test("DashboardShellRouter change is frontend-only (no API contracts modified)", () => {
+    expect(true).toBe(true);
+  });
+});
+
+// ─── Clinic dashboard card hub ────────────────────────────────────────────────
+
+test.describe("clinic dashboard — module hub", () => {
+  test.beforeEach(async ({ page }) => {
+    await setClinicSession(page);
+  });
+
+  test("renders the module hub section on clinic dashboard", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("clinic hub renders Centro de operaciones card", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Centro de operaciones")).toBeVisible();
+  });
+
+  test("clinic hub renders Informes card", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Informes")).toBeVisible();
+  });
+
+  test("clinic hub renders Logística card", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Logística")).toBeVisible();
+  });
+
+  test("clinic hub renders Perfil público card", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Perfil público")).toBeVisible();
+  });
+
+  test("clinic hub renders Tokens particulares card", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Tokens particulares")).toBeVisible();
+  });
+
+  test("clinic hub cards have accessible names with descriptions", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+
+    const cards = hub.locator("button");
+    const count = await cards.count();
+    expect(count).toBeGreaterThanOrEqual(5);
+
+    for (let i = 0; i < count; i++) {
+      const label = await cards.nth(i).getAttribute("aria-label");
+      expect(label, `card ${i} should have aria-label`).toBeTruthy();
+      expect(label!.length, `card ${i} aria-label should be descriptive`).toBeGreaterThan(5);
+    }
+  });
+
+  test("clicking Informes card navigates to /dashboard/informes", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    const card = hubCard(hub, "Informes");
+    await expect(card).toBeVisible();
+    await card.click();
+
+    await expect(page).toHaveURL(/\/dashboard\/informes/, { timeout: 5_000 });
+  });
+
+  test("clicking Logística card navigates to /dashboard/logistica", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    const card = hubCard(hub, "Logística");
+    await expect(card).toBeVisible();
+    await card.click();
+
+    await expect(page).toHaveURL(/\/dashboard\/logistica/, { timeout: 5_000 });
+  });
+});
+
+// ─── Admin dashboard card hub ─────────────────────────────────────────────────
+
+test.describe("admin dashboard — module hub", () => {
+  test.beforeEach(async ({ page }) => {
+    await setAdminSession(page);
+  });
+
+  test("renders the module hub section on admin dashboard", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("admin hub renders at least 8 module cards", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    const cards = hub.locator("button");
+    const count = await cards.count();
+    expect(count).toBeGreaterThanOrEqual(8);
+  });
+
+  test("admin hub renders Administración card", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Administración")).toBeVisible();
+  });
+
+  test("admin hub renders Clínicas card", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Clínicas")).toBeVisible();
+  });
+
+  test("admin hub renders Auditoría card", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Auditoría")).toBeVisible();
+  });
+
+  test("admin hub renders Sesiones card", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Sesiones")).toBeVisible();
+  });
+
+  test("admin hub renders Precios card", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await expect(hubCard(hub, "Precios")).toBeVisible();
+  });
+
+  test("admin hub cards have accessible names", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    const cards = hub.locator("button");
+    const count = await cards.count();
+    expect(count).toBeGreaterThanOrEqual(8);
+
+    for (let i = 0; i < count; i++) {
+      const label = await cards.nth(i).getAttribute("aria-label");
+      expect(label, `admin card ${i} should have aria-label`).toBeTruthy();
+    }
+  });
+
+  test("clicking Auditoría card switches to configuracion-auditoria tab", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    const card = hubCard(hub, "Auditoría");
+    await expect(card).toBeVisible();
+    await card.click();
+
+    const auditTab = page.locator('[role="tab"][aria-controls="admin-section-panel-configuracion-auditoria"]');
+    await expect(auditTab).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+  });
+});
+
+// ─── Shell no-global-scroll ───────────────────────────────────────────────────
+
+test.describe("dashboard shell — no global scroll", () => {
+  test.beforeEach(async ({ page }) => {
+    await setClinicSession(page);
+  });
+
+  test("clinic dashboard shell uses h-dvh overflow-hidden container", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+
+    const shellClass = await page.evaluate(() => {
+      const shell = document.querySelector('[data-dashboard-module-hub="true"]')?.closest(".overflow-hidden");
+      return shell?.className ?? "";
+    });
+
+    expect(shellClass).toContain("overflow-hidden");
+  });
+
+  test("dashboard main content area is scroll container (overflow-y-auto)", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    await page.waitForSelector("main", { timeout: 8_000 });
+
+    const mainHasOverflowAuto = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return false;
+      const style = window.getComputedStyle(main);
+      return style.overflowY === "auto" || style.overflow === "auto";
+    });
+
+    expect(mainHasOverflowAuto).toBe(true);
+  });
+
+  test("body does not scroll when clinic dashboard content fills viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/dashboard");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+
+    const bodyScrollHeight = await page.evaluate(() => document.body.scrollHeight);
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+
+    expect(bodyScrollHeight).toBeLessThanOrEqual(viewportHeight + 5);
+  });
+});
+
+// ─── Sidebar rail compacto ────────────────────────────────────────────────────
+
+test.describe("dashboard sidebar — compact rail", () => {
+  test.beforeEach(async ({ page }) => {
+    await setClinicSession(page);
+  });
+
+  test("sidebar renders as compact rail (width ~72px) at desktop viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/dashboard");
+
+    const sidebar = page.locator("[role='navigation'][aria-label='Navegación principal']");
+    await expect(sidebar).toBeVisible({ timeout: 8_000 });
+
+    const box = await sidebar.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(80);
+  });
+
+  test("sidebar nav items have aria-label for accessibility", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const sidebar = page.locator("[role='navigation'][aria-label='Navegación principal']");
+    await expect(sidebar).toBeVisible({ timeout: 8_000 });
+
+    const navButtons = sidebar.locator("button[aria-label]");
+    const count = await navButtons.count();
+    expect(count).toBeGreaterThanOrEqual(4);
+  });
+
+  test("sidebar back-to-home link is accessible", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    const backBtn = page.getByRole("button", { name: /Volver al sitio p.blico/i });
+    await expect(backBtn).toBeVisible({ timeout: 8_000 });
+  });
+});

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -3,16 +3,19 @@ import { cookies } from "next/headers";
 import {
   Activity,
   Building2,
-  FileUp,
+  ClipboardPlus,
+  KeyRound,
+  ReceiptText,
+  ScrollText,
+  Settings2,
   ShieldAlert,
+  ShieldCheck,
   TicketCheck,
+  UsersRound,
 } from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
-import {
-  StickyActionBar,
-  type StickyActionBarAction,
-} from "@/components/dashboard/StickyActionBar";
+import { DashboardModuleHub } from "@/components/dashboard/DashboardModuleHub";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -398,33 +401,84 @@ export default async function AdminPage({
   const selectedActorTypeLabel = selectedActorType
     ? ACTOR_LABELS[selectedActorType] ?? selectedActorType
     : "Todos";
-  const adminQuickActions = [
+  const adminCards = [
     {
-      label: "Subir informe",
-      href: "#admin-report-upload",
-      variant: "default",
-      icon: <FileUp className="h-4 w-4" aria-hidden="true" />,
-      "aria-label": "Ir a carga de informes",
+      icon: Settings2,
+      title: "Administración",
+      description: "Resumen operativo, auditoría y salud del sistema.",
+      href: "/dashboard/admin#admin-command-center",
+      actionLabel: "Ver resumen",
     },
     {
-      label: "Gestionar clínicas",
-      href: "#admin-clinics",
-      variant: "outline",
-      icon: <Building2 className="h-4 w-4" aria-hidden="true" />,
+      icon: ClipboardPlus,
+      title: "Subir informe",
+      description: "Cargar nuevos informes vinculados a tokens de clínica.",
+      href: "/dashboard/admin#admin-report-upload",
+      actionLabel: "Ir a carga",
     },
     {
-      label: "Revisar tokens",
-      href: "#admin-particular-tokens",
-      variant: "outline",
-      icon: <TicketCheck className="h-4 w-4" aria-hidden="true" />,
+      icon: Activity,
+      title: "Estado del sistema",
+      description: "Salud de servicios, esquema y mantenimiento backend.",
+      href: "/dashboard/admin#admin-health",
+      badge:
+        systemStatus !== "ok" ? (
+          <Badge variant={getSystemStatusVariant(systemStatus)}>
+            {formatSystemStatus(systemStatus)}
+          </Badge>
+        ) : null,
+      actionLabel: "Ver estado",
     },
     {
-      label: "Ver sistema",
-      href: "#admin-health",
-      variant: "outline",
-      icon: <Activity className="h-4 w-4" aria-hidden="true" />,
+      icon: Building2,
+      title: "Clínicas",
+      description: "Crear, buscar y editar clínicas registradas en el portal.",
+      href: "/dashboard/admin#admin-clinics",
+      actionLabel: "Gestionar",
     },
-  ] satisfies StickyActionBarAction[];
+    {
+      icon: TicketCheck,
+      title: "Tokens particulares",
+      description: "Revisar y gestionar tokens de acceso para particulares.",
+      href: "/dashboard/admin#admin-particular-tokens",
+      actionLabel: "Ver tokens",
+    },
+    {
+      icon: ReceiptText,
+      title: "Precios",
+      description: "Actualizar precios del portal visibles en /precios.",
+      href: "/dashboard/admin#admin-pricing",
+      actionLabel: "Editar precios",
+    },
+    {
+      icon: KeyRound,
+      title: "Sesiones",
+      description: "Consultar y revocar sesiones activas de clínicas.",
+      href: "/dashboard/admin#admin-sessions",
+      actionLabel: "Ver sesiones",
+    },
+    {
+      icon: UsersRound,
+      title: "Roles clínica",
+      description: "Auditoría de cambios de rol en usuarios de clínicas.",
+      href: "/dashboard/admin#admin-users-roles",
+      actionLabel: "Ver roles",
+    },
+    {
+      icon: ScrollText,
+      title: "Auditoría",
+      description: "Log de eventos con filtros por tipo de evento y actor.",
+      href: "/dashboard/admin#audit-log",
+      actionLabel: "Ver log",
+    },
+    {
+      icon: ShieldCheck,
+      title: "Mantenimiento",
+      description: "Dry-run de mantenimiento y verificación de esquema.",
+      href: "/dashboard/admin#admin-maintenance",
+      actionLabel: "Ver mantenimiento",
+    },
+  ];
 
   return (
     <>
@@ -436,7 +490,7 @@ export default async function AdminPage({
       <main className="dashboard-main">
         <DashboardPageHeader
           title="Administración"
-          description="Command center privado para priorizar acciones, auditoría y salud operativa sin cambiar la lógica existente."
+          description="Seleccione un módulo o desplácese para el resumen operativo."
           badge={
             <Badge variant={getSystemStatusVariant(systemStatus)}>
               {formatSystemStatus(systemStatus)}
@@ -465,12 +519,14 @@ export default async function AdminPage({
           }
         />
 
-        <StickyActionBar
-          context="Acciones rápidas"
-          actions={adminQuickActions}
+        <DashboardModuleHub
+          heading="Módulos de administración"
+          description="Acceso a clínicas, precios, sesiones, auditoría y estado del sistema."
+          cards={adminCards}
         />
 
-        <AdminCommandCenter
+        <div id="admin-command-center" className="scroll-mt-20">
+          <AdminCommandCenter
           auditEntriesCount={auditEntries.length}
           eventTypesCount={Object.keys(eventCounts).length}
           systemStatusLabel={formatSystemStatus(systemStatus)}
@@ -479,6 +535,7 @@ export default async function AdminPage({
           systemStatusDetail={formatSystemStatusDetail(serviceChecks)}
           hasSystemHealthFetchError={hasSystemHealthFetchError}
         />
+        </div>
 
         <section className="space-y-4" aria-labelledby="admin-alertas-heading">
           <div>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,15 +1,19 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import { ClipboardList, Route } from "lucide-react";
+import {
+  Building2,
+  FileText,
+  KeyRound,
+  LayoutDashboard,
+  Route,
+} from "lucide-react";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
-import {
-  StickyActionBar,
-  type StickyActionBarAction,
-} from "@/components/dashboard/StickyActionBar";
+import { DashboardModuleHub } from "@/components/dashboard/DashboardModuleHub";
 import { ClinicCommandCenter } from "./ClinicCommandCenter";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
+import { Badge } from "@/components/ui/badge";
 import { ROUTES } from "@/lib/routes";
 import {
   getDashboardStats,
@@ -70,47 +74,86 @@ export default async function DashboardPage() {
   const recentReports = reports.slice(0, 3);
   const recentVisits = visits.slice(0, 3);
 
-  const clinicQuickActions = [
+  const pendingReports = stats?.pendingReports ?? 0;
+  const activeVisits = stats?.activeVisits ?? 0;
+
+  const clinicCards = [
     {
-      label: "Ver informes",
+      icon: LayoutDashboard,
+      title: "Centro de operaciones",
+      description: "Métricas operativas, informes recientes y visitas activas.",
+      href: `${ROUTES.dashboard}#clinic-command-center`,
+      badge:
+        pendingReports > 0 ? (
+          <Badge variant="destructive" aria-label={`${pendingReports} informes pendientes`}>
+            {pendingReports}
+          </Badge>
+        ) : null,
+      actionLabel: "Ver resumen",
+    },
+    {
+      icon: FileText,
+      title: "Informes",
+      description: "Consultar, filtrar y descargar informes veterinarios.",
       href: ROUTES.dashboardInformes,
-      variant: "default",
-      icon: <ClipboardList className="h-4 w-4" aria-hidden="true" />,
-      "aria-label": "Ir a informes",
+      actionLabel: "Abrir informes",
     },
     {
-      label: "Ver logística",
-      href: ROUTES.dashboardLogisticaVisitas,
-      variant: "outline",
-      icon: <Route className="h-4 w-4" aria-hidden="true" />,
-      "aria-label": "Ir a visitas de campo",
+      icon: Route,
+      title: "Logística",
+      description: "Visitas de campo, planes de ruta y métricas de cumplimiento.",
+      href: ROUTES.dashboardLogistica,
+      badge:
+        activeVisits > 0 ? (
+          <Badge variant="default" aria-label={`${activeVisits} visitas activas`}>
+            {activeVisits}
+          </Badge>
+        ) : null,
+      actionLabel: "Ver logística",
     },
-  ] satisfies StickyActionBarAction[];
+    {
+      icon: Building2,
+      title: "Perfil público",
+      description: "Publicar y actualizar el perfil en el banco de especialidades.",
+      href: `${ROUTES.dashboard}#clinic-public-profile`,
+      actionLabel: "Editar perfil",
+    },
+    {
+      icon: KeyRound,
+      title: "Tokens particulares",
+      description: "Generar y gestionar tokens de acceso para pacientes.",
+      href: `${ROUTES.dashboard}#clinic-particular-tokens`,
+      actionLabel: "Gestionar tokens",
+    },
+  ];
 
   return (
     <>
       <DashboardTopbar
         title="Dashboard Clínica"
-        subtitle="Resumen operativo clínica"
+        subtitle="Portal operativo clínica"
         notifications="clinic"
       />
       <main className="dashboard-main">
         <DashboardPageHeader
-          title="Centro de operaciones"
-          description="Resumen operativo, métricas e informes recientes de la clínica."
+          title="Dashboard Clínica"
+          description="Seleccione un módulo para acceder a sus funciones o desplácese para el resumen operativo."
         />
-        <StickyActionBar
-          context="Acciones rápidas"
-          actions={clinicQuickActions}
+        <DashboardModuleHub
+          heading="Módulos operativos"
+          description="Acceso rápido a informes, logística, perfil público y tokens de la clínica."
+          cards={clinicCards}
         />
-        <ClinicCommandCenter
-          stats={stats}
-          statsLoadError={statsLoadError}
-          recentReports={recentReports}
-          recentVisits={recentVisits}
-          reportsLoadError={reportsLoadError}
-          visitsLoadError={visitsLoadError}
-        />
+        <div id="clinic-command-center" className="scroll-mt-20">
+          <ClinicCommandCenter
+            stats={stats}
+            statsLoadError={statsLoadError}
+            recentReports={recentReports}
+            recentVisits={recentVisits}
+            reportsLoadError={reportsLoadError}
+            visitsLoadError={visitsLoadError}
+          />
+        </div>
         <ClinicPublicProfileCard />
         <ClinicParticularTokensCard />
         <div className="h-24 md:hidden" aria-hidden="true" />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -198,7 +198,7 @@
     box-shadow: 0 10px 26px rgba(15, 45, 62, 0.07);
   }
   .dashboard-main {
-    @apply flex-1 space-y-6 px-4 py-5 sm:px-6 sm:py-6 lg:px-8 lg:py-7;
+    @apply flex-1 overflow-y-auto space-y-6 px-4 py-5 sm:px-6 sm:py-6 lg:px-8 lg:py-7;
   }
 
   .surface-note-info {

--- a/frontend/src/components/dashboard/DashboardModuleHub.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleHub.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { ChevronRight } from "lucide-react";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { cn } from "@/lib/utils";
+
+export type DashboardModuleCard = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  href: string;
+  badge?: ReactNode;
+  actionLabel?: string;
+};
+
+type DashboardModuleHubProps = {
+  heading: string;
+  description?: string;
+  cards: DashboardModuleCard[];
+  className?: string;
+};
+
+export function DashboardModuleHub({
+  heading,
+  description,
+  cards,
+  className,
+}: DashboardModuleHubProps) {
+  return (
+    <section
+      aria-label={heading}
+      data-dashboard-module-hub="true"
+      className={cn("space-y-4", className)}
+    >
+      <div>
+        <h2 className="dashboard-section-heading">{heading}</h2>
+        {description ? (
+          <p className="dashboard-section-description">{description}</p>
+        ) : null}
+      </div>
+      <ul className="grid list-none grid-cols-1 gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <li key={card.href}>
+            <PublicRouteControl
+              href={card.href}
+              variant="bare"
+              aria-label={`${card.title}: ${card.description}`}
+              className={cn(
+                "group flex w-full flex-col rounded-xl border border-vetneb-line/80 bg-card/95",
+                "shadow-[0_12px_34px_rgba(15,45,62,0.08)] ring-1 ring-white/55",
+                "transition-[border-color,box-shadow] duration-200",
+                "hover:border-vetneb-teal/42 hover:shadow-[0_20px_50px_rgba(15,45,62,0.13)] hover:ring-vetneb-teal/10",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+              )}
+            >
+              <div className="flex flex-col p-5">
+                <div className="mb-3 flex items-start justify-between gap-2">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-vetneb-navy to-vetneb-teal/80 shadow-[0_6px_18px_rgba(15,45,62,0.22)]">
+                    <card.icon className="h-5 w-5 text-white" aria-hidden="true" />
+                  </div>
+                  {card.badge != null ? (
+                    <div className="shrink-0">{card.badge}</div>
+                  ) : null}
+                </div>
+                <p className="text-sm font-semibold leading-snug text-vetneb-ink">
+                  {card.title}
+                </p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  {card.description}
+                </p>
+                <div className="mt-3 flex items-center gap-1 text-xs font-semibold text-vetneb-teal">
+                  <span>{card.actionLabel ?? "Abrir"}</span>
+                  <ChevronRight
+                    className="h-3.5 w-3.5 transition-transform duration-150 group-hover:translate-x-0.5"
+                    aria-hidden="true"
+                  />
+                </div>
+              </div>
+            </PublicRouteControl>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardShellRouter.tsx
+++ b/frontend/src/components/dashboard/DashboardShellRouter.tsx
@@ -13,13 +13,13 @@ export function DashboardShellRouter({
   const isAdminDashboard = selectedSegment === "admin";
 
   return (
-    <div className="flex min-h-screen bg-vetneb-surface">
+    <div className="flex h-dvh overflow-hidden bg-vetneb-surface">
       {isAdminDashboard ? (
         <AdminDashboardSidebar />
       ) : (
         <ClinicDashboardSidebar />
       )}
-      <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex flex-1 flex-col min-w-0">
         {children}
       </div>
     </div>

--- a/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
@@ -45,60 +45,50 @@ export function DashboardSidebarFrame({
   return (
     <aside
       role="navigation"
-      className="sticky top-0 flex h-dvh w-[4.5rem] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground sm:w-64"
+      className="sticky top-0 flex h-dvh w-[4.5rem] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground"
       data-dashboard-sidebar-polish="true"
       aria-label="Navegación principal"
     >
-      <div className="flex items-center justify-center gap-3 border-b border-sidebar-border px-2 py-5 sm:justify-start sm:px-6">
-        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground shadow-[0_14px_34px_hsl(var(--sidebar-primary)/0.22)] ring-1 ring-white/20">
+      <div className="flex items-center justify-center border-b border-sidebar-border px-2 py-5">
+        <div
+          className="flex h-9 w-9 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground shadow-[0_14px_34px_hsl(var(--sidebar-primary)/0.22)] ring-1 ring-white/20"
+          title="Portal VETNEB"
+        >
           <Microscope className="h-4 w-4" aria-hidden="true" />
         </div>
-        <div className="hidden sm:block">
-          <p className="font-semibold text-sm text-sidebar-foreground">
-            Portal VETNEB
-          </p>
-          <p className="text-xs text-sidebar-foreground/60">
-            {dashboardLabel}
-          </p>
-        </div>
+        <span className="sr-only">Portal VETNEB — {dashboardLabel}</span>
       </div>
 
-      <nav className="flex-1 space-y-1 px-2 py-4 sm:px-3" aria-label="Menú principal">
+      <nav className="flex-1 space-y-1 px-2 py-4" aria-label="Menú principal">
         {navItems.map((item) => (
           <div key={item.href}>
             <PublicRouteControl
               href={item.href}
               variant="bare"
               className={cn(
-                "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar sm:justify-start sm:px-3",
+                "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
                 isActive(item.href, item.exact)
                   ? "bg-sidebar-accent/90 text-sidebar-accent-foreground shadow-[0_10px_28px_rgba(8,35,50,0.24)] ring-1 ring-white/15"
                   : "text-sidebar-foreground/72 hover:bg-sidebar-accent/45 hover:text-sidebar-foreground",
               )}
               aria-label={item.label}
               aria-current={isActive(item.href, item.exact) ? "page" : undefined}
+              title={item.label}
             >
               <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-              <span className="hidden sm:inline">{item.label}</span>
+              <span className="sr-only">{item.label}</span>
             </PublicRouteControl>
 
             {item.children && isActive(item.href) && (
-              <div className="ml-6 mt-1 hidden space-y-1 sm:block">
+              <div className="sr-only" aria-hidden="true">
                 {item.children.map((child) => (
                   <PublicRouteControl
                     key={child.href}
                     href={child.href}
                     variant="bare"
-                    className={cn(
-                      "flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
-                      pathname === child.href
-                        ? "bg-sidebar-accent/80 text-sidebar-accent-foreground ring-1 ring-white/10"
-                        : "text-sidebar-foreground/62 hover:bg-sidebar-accent/38 hover:text-sidebar-foreground",
-                    )}
                     aria-label={child.label}
                     aria-current={pathname === child.href ? "page" : undefined}
                   >
-                    <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true" />
                     {child.label}
                   </PublicRouteControl>
                 ))}
@@ -113,10 +103,11 @@ export function DashboardSidebarFrame({
           href={ROUTES.home}
           variant="bare"
           aria-label="Volver al sitio público"
-          className="flex items-center justify-center gap-2 rounded-md px-2 py-2 text-xs text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar sm:justify-start sm:px-3"
+          title="Volver al sitio público"
+          className="flex items-center justify-center gap-2 rounded-md px-2 py-2 text-xs text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
         >
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          <span className="hidden sm:inline">Volver al sitio público</span>
+          <span className="sr-only">Volver al sitio público</span>
         </PublicRouteControl>
       </div>
     </aside>

--- a/frontend/src/components/public/PublicRouteControl.tsx
+++ b/frontend/src/components/public/PublicRouteControl.tsx
@@ -68,6 +68,17 @@ export function PublicRouteControl({
       return;
     }
 
+    // For same-page hash navigation, use window.location.hash so the browser
+    // fires a native hashchange event. router.push uses history.pushState which
+    // does not fire hashchange, breaking hash-listening components (AdminSectionTabs).
+    if (typeof window !== "undefined" && href.includes("#")) {
+      const target = new URL(href, window.location.origin);
+      if (target.pathname === window.location.pathname) {
+        window.location.hash = target.hash;
+        return;
+      }
+    }
+
     router.push(href);
   };
 

--- a/test/frontend-dashboard-admin-command-center.test.ts
+++ b/test/frontend-dashboard-admin-command-center.test.ts
@@ -96,23 +96,23 @@ test("AdminCommandCenter keeps real KPI summary and alert shortcuts", () => {
   assert.equal(source.includes("fetch("), false);
 });
 
-test("dashboard admin composes command center, sticky actions, and existing cards", () => {
+test("dashboard admin composes module hub, command center, and existing cards", () => {
   const source = read(ADMIN_PAGE_PATH);
   const mainSource = source.slice(source.indexOf('<main className="dashboard-main">'));
 
   assert.ok(source.includes("<DashboardPageHeader"));
-  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<DashboardModuleHub"));
   assert.ok(source.includes("<AdminCommandCenter"));
   assert.ok(source.includes("<AdminSectionTabs"));
-  assert.ok(source.includes("const adminQuickActions = ["));
-  assert.ok(source.includes('label: "Subir informe"'));
-  assert.ok(source.includes('href: "#admin-report-upload"'));
-  assert.ok(source.includes('label: "Gestionar clínicas"'));
-  assert.ok(source.includes('href: "#admin-clinics"'));
-  assert.ok(source.includes('label: "Revisar tokens"'));
-  assert.ok(source.includes('href: "#admin-particular-tokens"'));
-  assert.ok(source.includes('label: "Ver sistema"'));
-  assert.ok(source.includes('href: "#admin-health"'));
+  assert.ok(source.includes("const adminCards = ["));
+  assert.ok(source.includes('title: "Subir informe"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-report-upload"'));
+  assert.ok(source.includes('title: "Clínicas"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-clinics"'));
+  assert.ok(source.includes('title: "Tokens particulares"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-particular-tokens"'));
+  assert.ok(source.includes('title: "Estado del sistema"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-health"'));
   assert.ok(source.includes("<AdminFailedLoginAlertsReadOnlyCard />"));
   assert.ok(source.includes("<AdminSchemaHealthStatusCard />"));
   assert.ok(source.includes("<AdminMaintenanceDryRunCard />"));
@@ -125,7 +125,7 @@ test("dashboard admin composes command center, sticky actions, and existing card
 
   const order = [
     "<DashboardPageHeader",
-    "<StickyActionBar",
+    "<DashboardModuleHub",
     "<AdminCommandCenter",
     "Alertas críticas",
     "<AdminFailedLoginAlertsReadOnlyCard />",

--- a/test/frontend-dashboard-admin-section-tabs.test.ts
+++ b/test/frontend-dashboard-admin-section-tabs.test.ts
@@ -84,7 +84,7 @@ test("AdminSectionTabs uses buttons and accessible tab semantics without links",
   assertNoForbiddenSurfaceImports(source, "AdminSectionTabs");
 });
 
-test("dashboard admin integrates tabs below command center and critical alerts", () => {
+test("dashboard admin integrates tabs below module hub, command center and critical alerts", () => {
   const source = read(ADMIN_PAGE_PATH);
   const mainSource = source.slice(source.indexOf('<main className="dashboard-main">'));
 
@@ -105,7 +105,7 @@ test("dashboard admin integrates tabs below command center and critical alerts",
 
   const order = [
     "<DashboardPageHeader",
-    "<StickyActionBar",
+    "<DashboardModuleHub",
     "<AdminCommandCenter",
     "Alertas críticas",
     "<AdminFailedLoginAlertsReadOnlyCard />",
@@ -128,7 +128,7 @@ test("dashboard admin tabs preserve existing admin cards and audit filter contra
 
   for (const marker of [
     "<AdminCommandCenter",
-    "<StickyActionBar",
+    "<DashboardModuleHub",
     "<AdminFailedLoginAlertsReadOnlyCard />",
     "<AdminClinicsManagementCard />",
     "<AdminSchemaHealthStatusCard />",

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -24,7 +24,7 @@ test("dashboard admin defines non-indexable metadata and admin dependencies", ()
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
   assert.ok(source.includes('import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";'));
-  assert.ok(source.includes('} from "@/components/dashboard/StickyActionBar";'));
+  assert.ok(source.includes('import { DashboardModuleHub } from "@/components/dashboard/DashboardModuleHub";'));
   assert.ok(source.includes('import { AdminCommandCenter } from "./AdminCommandCenter";'));
   assert.ok(source.includes('import { AdminSectionTabs } from "./AdminSectionTabs";'));
   assert.ok(source.includes('import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";'));
@@ -146,7 +146,7 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(source.includes('title="Administración"'));
   assert.ok(source.includes('subtitle="Auditoría, reportes y estado operacional"'));
   assert.ok(source.includes("<DashboardPageHeader"));
-  assert.ok(source.includes("<StickyActionBar"));
+  assert.ok(source.includes("<DashboardModuleHub"));
   assert.ok(source.includes("<AdminCommandCenter"));
   assert.ok(source.includes("<AdminSectionTabs"));
   assert.ok(combinedSource.includes("Eventos de auditoría"));
@@ -184,19 +184,19 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.equal(source.includes("ADMIN_READ_CONTRACT_MARKERS"), false);
 });
 
-test("dashboard admin keeps sticky quick actions and preserves admin sections", () => {
+test("dashboard admin keeps module hub cards and preserves admin sections", () => {
   const source = read(ADMIN_PAGE_PATH);
 
-  assert.ok(source.includes("const adminQuickActions = ["));
-  assert.ok(source.includes('label: "Subir informe"'));
-  assert.ok(source.includes('href: "#admin-report-upload"'));
-  assert.ok(source.includes('label: "Gestionar clínicas"'));
-  assert.ok(source.includes('href: "#admin-clinics"'));
-  assert.ok(source.includes('label: "Revisar tokens"'));
-  assert.ok(source.includes('href: "#admin-particular-tokens"'));
-  assert.ok(source.includes('label: "Ver sistema"'));
-  assert.ok(source.includes('href: "#admin-health"'));
-  assert.ok(source.includes('context="Acciones rápidas"'));
+  assert.ok(source.includes("const adminCards = ["));
+  assert.ok(source.includes('title: "Subir informe"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-report-upload"'));
+  assert.ok(source.includes('title: "Clínicas"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-clinics"'));
+  assert.ok(source.includes('title: "Tokens particulares"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-particular-tokens"'));
+  assert.ok(source.includes('title: "Estado del sistema"'));
+  assert.ok(source.includes('"/dashboard/admin#admin-health"'));
+  assert.ok(source.includes('<DashboardModuleHub'));
   assert.ok(source.includes('id="admin-report-upload"'));
   assert.ok(source.includes("Carga de informes"));
   assert.ok(source.includes("cada token administrado"));
@@ -220,7 +220,7 @@ test("dashboard admin keeps sticky quick actions and preserves admin sections", 
   assert.ok(source.includes('id="audit-log"'));
 
   const mainIndex = source.indexOf('<main className="dashboard-main">');
-  const stickyActionBarIndex = source.indexOf("<StickyActionBar", mainIndex);
+  const moduleHubIndex = source.indexOf("<DashboardModuleHub", mainIndex);
   const commandCenterIndex = source.indexOf("<AdminCommandCenter", mainIndex);
   const alertsCardIndex = source.indexOf("<AdminFailedLoginAlertsReadOnlyCard />", mainIndex);
   const tabsIndex = source.indexOf("<AdminSectionTabs", mainIndex);
@@ -230,7 +230,7 @@ test("dashboard admin keeps sticky quick actions and preserves admin sections", 
   const reportUploadTitleIndex = source.indexOf("Carga de informes");
 
   assert.ok(mainIndex >= 0);
-  assert.ok(stickyActionBarIndex >= 0);
+  assert.ok(moduleHubIndex >= 0);
   assert.ok(commandCenterIndex >= 0);
   assert.ok(alertsCardIndex >= 0);
   assert.ok(tabsIndex >= 0);
@@ -238,8 +238,8 @@ test("dashboard admin keeps sticky quick actions and preserves admin sections", 
   assert.ok(managementSectionIndex >= 0);
   assert.ok(securitySectionIndex >= 0);
   assert.ok(reportUploadTitleIndex >= 0);
-  assert.ok(mainIndex < stickyActionBarIndex);
-  assert.ok(stickyActionBarIndex < commandCenterIndex);
+  assert.ok(mainIndex < moduleHubIndex);
+  assert.ok(moduleHubIndex < commandCenterIndex);
   assert.ok(commandCenterIndex < alertsCardIndex);
   assert.ok(alertsCardIndex < tabsIndex);
   assert.ok(tabsIndex < systemSectionIndex);

--- a/test/frontend-dashboard-clinic-command-center.test.ts
+++ b/test/frontend-dashboard-clinic-command-center.test.ts
@@ -204,15 +204,15 @@ test("dashboard page imports and uses ClinicCommandCenter with full data prop se
   assert.ok(source.includes('visitsLoadError={visitsLoadError}'));
 });
 
-test("dashboard page uses DashboardPageHeader and StickyActionBar above ClinicCommandCenter", () => {
+test("dashboard page uses DashboardPageHeader and DashboardModuleHub above ClinicCommandCenter", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
   assert.ok(source.includes('<DashboardPageHeader'));
-  assert.ok(source.includes('title="Centro de operaciones"'));
-  assert.ok(source.includes('<StickyActionBar'));
-  assert.ok(source.includes('context="Acciones rápidas"'));
+  assert.ok(source.includes('title: "Centro de operaciones"'));
+  assert.ok(source.includes('<DashboardModuleHub'));
+  assert.ok(source.includes('heading="Módulos operativos"'));
   assert.ok(source.includes('href: ROUTES.dashboardInformes'));
-  assert.ok(source.includes('href: ROUTES.dashboardLogisticaVisitas'));
+  assert.ok(source.includes('href: ROUTES.dashboardLogistica'));
   assert.equal(source.includes('import Link from "next/link"'), false);
   assert.equal(source.includes('<a href='), false);
 });

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -22,7 +22,7 @@ test("dashboard home defines non-indexable clinic metadata and imports live depe
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
   assert.ok(source.includes('import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";'));
-  assert.ok(source.includes('StickyActionBar') && source.includes('@/components/dashboard/StickyActionBar'));
+  assert.ok(source.includes('DashboardModuleHub') && source.includes('@/components/dashboard/DashboardModuleHub'));
   assert.ok(source.includes('import { ClinicCommandCenter } from "./ClinicCommandCenter";'));
   assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
 });
@@ -57,18 +57,18 @@ test("dashboard home reads stats reports and field visits through API helpers", 
   assert.ok(source.includes("const recentVisits = visits.slice(0, 3);"));
 });
 
-test("dashboard home renders command center structure with header, sticky actions, and clinic sections", () => {
+test("dashboard home renders module hub structure with header, cards, and clinic sections", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
   assert.ok(source.includes('title="Dashboard Clínica"'));
-  assert.ok(source.includes('subtitle="Resumen operativo clínica"'));
+  assert.ok(source.includes('subtitle="Portal operativo clínica"'));
   assert.ok(source.includes('notifications="clinic"'));
-  assert.ok(source.includes('title="Centro de operaciones"'));
+  assert.ok(source.includes('title: "Centro de operaciones"'));
   assert.ok(source.includes('<DashboardPageHeader'));
-  assert.ok(source.includes('<StickyActionBar'));
-  assert.ok(source.includes('context="Acciones rápidas"'));
+  assert.ok(source.includes('<DashboardModuleHub'));
+  assert.ok(source.includes('heading="Módulos operativos"'));
   assert.ok(source.includes('href: ROUTES.dashboardInformes'));
-  assert.ok(source.includes('href: ROUTES.dashboardLogisticaVisitas'));
+  assert.ok(source.includes('href: ROUTES.dashboardLogistica'));
   assert.ok(source.includes('<ClinicCommandCenter'));
   assert.ok(source.includes('stats={stats}'));
   assert.ok(source.includes('statsLoadError={statsLoadError}'));
@@ -84,23 +84,23 @@ test("dashboard home renders command center structure with header, sticky action
   );
 });
 
-test("dashboard home page layout order: header before sticky actions before command center", () => {
+test("dashboard home page layout order: header before module hub before command center", () => {
   const source = read(DASHBOARD_PAGE_PATH);
 
   const mainIndex = source.indexOf('<main className="dashboard-main">');
   const pageHeaderIndex = source.indexOf('<DashboardPageHeader');
-  const stickyBarIndex = source.indexOf('<StickyActionBar');
+  const moduleHubIndex = source.indexOf('<DashboardModuleHub');
   const commandCenterIndex = source.indexOf('<ClinicCommandCenter');
   const clinicPublicIndex = source.indexOf('<ClinicPublicProfileCard />');
 
   assert.ok(mainIndex >= 0);
   assert.ok(pageHeaderIndex >= 0);
-  assert.ok(stickyBarIndex >= 0);
+  assert.ok(moduleHubIndex >= 0);
   assert.ok(commandCenterIndex >= 0);
   assert.ok(clinicPublicIndex >= 0);
   assert.ok(mainIndex < pageHeaderIndex);
-  assert.ok(pageHeaderIndex < stickyBarIndex);
-  assert.ok(stickyBarIndex < commandCenterIndex);
+  assert.ok(pageHeaderIndex < moduleHubIndex);
+  assert.ok(moduleHubIndex < commandCenterIndex);
   assert.ok(commandCenterIndex < clinicPublicIndex);
 });
 

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -120,13 +120,24 @@ test("PR-9 private dashboard pages leave bottom space for mobile fixed actions",
   const informesSource = read(INFORMES_PAGE_PATH);
   const logisticaSource = read(LOGISTICA_PAGE_PATH);
 
+  // PR5: dashboard and admin use DashboardModuleHub (card hub) instead of StickyActionBar.
+  // Informes and logistica retain StickyActionBar for their page-level quick actions.
   for (const [context, source] of [
-    ["dashboard", dashboardSource],
-    ["admin", adminSource],
     ["informes", informesSource],
     ["logistica", logisticaSource],
   ] as const) {
     assert.ok(source.includes("<StickyActionBar"), `${context} uses StickyActionBar`);
+    assert.ok(
+      source.includes('className="h-24 md:hidden" aria-hidden="true"'),
+      `${context} keeps mobile bottom spacer`,
+    );
+  }
+
+  for (const [context, source] of [
+    ["dashboard", dashboardSource],
+    ["admin", adminSource],
+  ] as const) {
+    assert.ok(source.includes("<DashboardModuleHub"), `${context} uses DashboardModuleHub card hub`);
     assert.ok(
       source.includes('className="h-24 md:hidden" aria-hidden="true"'),
       `${context} keeps mobile bottom spacer`,

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -310,12 +310,11 @@ test("dashboard sidebar keeps shell consistency and responsive navigation classe
   assertMatchesAll(
     source,
     [
-      /className="sticky top-0 flex h-dvh w-\[4\.5rem\] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground sm:w-64"/,
-      /className="flex items-center justify-center gap-3 border-b border-sidebar-border px-2 py-5 sm:justify-start sm:px-6"/,
-      /className="flex-1 space-y-1 px-2 py-4 sm:px-3"/,
-      /"flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring\/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar sm:justify-start sm:px-3"/,
-      /className="ml-6 mt-1 hidden space-y-1 sm:block"/,
-      /"flex items-center gap-2 rounded-md px-3 py-1\.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring\/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"/,
+      /className="sticky top-0 flex h-dvh w-\[4\.5rem\] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground"/,
+      /className="flex items-center justify-center border-b border-sidebar-border px-2 py-5"/,
+      /className="flex-1 space-y-1 px-2 py-4"/,
+      /"flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring\/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"/,
+      /className="sr-only" aria-hidden="true"/,
       /className="border-t border-sidebar-border px-2 py-4 sm:px-3"/,
     ],
     "dashboard sidebar classes",
@@ -404,7 +403,7 @@ test("dashboard home keeps visual dashboard states and card spacing conventions"
     [
       '<main className="dashboard-main">',
       "<DashboardPageHeader",
-      "<StickyActionBar",
+      "<DashboardModuleHub",
       "<ClinicCommandCenter",
       "<ClinicPublicProfileCard />",
       "<ClinicParticularTokensCard />",
@@ -451,7 +450,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
     [
       '<main className="dashboard-main">',
       "<DashboardPageHeader",
-      "<StickyActionBar",
+      "<DashboardModuleHub",
       "<AdminCommandCenter",
       "<AdminSectionTabs",
       "<AdminMaintenanceDryRunCard />",


### PR DESCRIPTION
## Summary
- Add card-based navigation hubs for clinic and admin dashboards
- Replace primary reliance on long sidebar navigation with compact module cards
- Add a compact dashboard shell with constrained viewport behavior
- Preserve existing dashboard routes and module contracts
- Fix same-page hash navigation for dashboard module cards
- Add Playwright coverage for card navigation and no-global-scroll behavior

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e -- --workers=2