### PR TITLE
fix(dashboard): sync workspace routing and reports back navigation

### DIFF
--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -44,6 +44,7 @@ import {
   getReportStatusVariant,
   formatDate,
 } from "@/lib/utils";
+import { ROUTES } from "@/lib/routes";
 import type { Report, ReportStatus } from "@/types";
 
 export const metadata: Metadata = {
@@ -339,6 +340,16 @@ export default async function InformesPage({
                 size="sm"
               />
             ) : null
+          }
+          actions={
+            <PublicRouteControl
+              href={ROUTES.dashboard}
+              variant="bare"
+              aria-label="Volver al dashboard"
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+            >
+              <span>Volver a m&oacute;dulos</span>
+            </PublicRouteControl>
           }
         />
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
@@ -109,37 +110,39 @@ export default async function DashboardPage({
           title="Dashboard Clínica"
           description="Seleccione un módulo para acceder a sus funciones."
         />
-        <ClinicDashboardWorkspaceController
-          initialModule={initialModule}
-          pendingReports={pendingReports}
-          activeVisits={activeVisits}
-          workspaces={{
-            operaciones: (
-              <ClinicCommandCenter
-                stats={stats}
-                statsLoadError={statsLoadError}
-                recentReports={recentReports}
-                recentVisits={recentVisits}
-                reportsLoadError={reportsLoadError}
-                visitsLoadError={visitsLoadError}
-              />
-            ),
-            informes: (
-              <ClinicInformesWorkspaceSummary
-                recentReports={recentReports}
-                reportsLoadError={reportsLoadError}
-              />
-            ),
-            logistica: (
-              <ClinicLogisticaWorkspaceSummary
-                recentVisits={recentVisits}
-                visitsLoadError={visitsLoadError}
-              />
-            ),
-            perfil: <ClinicPublicProfileCard />,
-            tokens: <ClinicParticularTokensCard />,
-          }}
-        />
+        <Suspense>
+          <ClinicDashboardWorkspaceController
+            initialModule={initialModule}
+            pendingReports={pendingReports}
+            activeVisits={activeVisits}
+            workspaces={{
+              operaciones: (
+                <ClinicCommandCenter
+                  stats={stats}
+                  statsLoadError={statsLoadError}
+                  recentReports={recentReports}
+                  recentVisits={recentVisits}
+                  reportsLoadError={reportsLoadError}
+                  visitsLoadError={visitsLoadError}
+                />
+              ),
+              informes: (
+                <ClinicInformesWorkspaceSummary
+                  recentReports={recentReports}
+                  reportsLoadError={reportsLoadError}
+                />
+              ),
+              logistica: (
+                <ClinicLogisticaWorkspaceSummary
+                  recentVisits={recentVisits}
+                  visitsLoadError={visitsLoadError}
+                />
+              ),
+              perfil: <ClinicPublicProfileCard />,
+              tokens: <ClinicParticularTokensCard />,
+            }}
+          />
+        </Suspense>
         <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>

--- a/frontend/src/components/dashboard/ClinicDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/ClinicDashboardSidebar.tsx
@@ -35,12 +35,12 @@ const clinicNavItems: DashboardNavItem[] = [
   },
   {
     label: "Perfil público",
-    href: `${ROUTES.dashboard}#clinic-public-profile`,
+    href: `${ROUTES.dashboard}?module=perfil`,
     icon: Building2,
   },
   {
     label: "Tokens particulares",
-    href: `${ROUTES.dashboard}#clinic-particular-tokens`,
+    href: `${ROUTES.dashboard}?module=tokens`,
     icon: KeyRound,
   },
 ];

--- a/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
+++ b/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback, type ReactNode } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useCallback, useEffect, type ReactNode } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Building2,
   FileText,
@@ -12,6 +12,21 @@ import {
 import { DashboardModuleHub } from "./DashboardModuleHub";
 import { DashboardModuleWorkspace } from "./DashboardModuleWorkspace";
 import { ROUTES } from "@/lib/routes";
+
+const CLINIC_MODULE_VALUES = [
+  "operaciones",
+  "informes",
+  "logistica",
+  "perfil",
+  "tokens",
+] as const;
+
+function parseModuleFromUrl(value: string | null): ClinicModule | null {
+  if (!value) return null;
+  return (CLINIC_MODULE_VALUES as readonly string[]).includes(value)
+    ? (value as ClinicModule)
+    : null;
+}
 
 export type ClinicModule =
   | "operaciones"
@@ -68,9 +83,14 @@ export function ClinicDashboardWorkspaceController({
   workspaces,
 }: ClinicDashboardWorkspaceControllerProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [activeModule, setActiveModule] = useState<ClinicModule | null>(
     initialModule ?? null,
   );
+
+  useEffect(() => {
+    setActiveModule(parseModuleFromUrl(searchParams.get("module")));
+  }, [searchParams]);
 
   const activateModule = useCallback(
     (moduleId: ClinicModule) => {

--- a/test/frontend-clinic-public-profile.test.ts
+++ b/test/frontend-clinic-public-profile.test.ts
@@ -94,5 +94,5 @@ test("clinic dashboard renders public profile before token generation and keeps 
       source.indexOf("<ClinicParticularTokensCard />"),
   );
   assert.ok(sidebarSource.includes('label: "Perfil público"'));
-  assert.ok(sidebarSource.includes('`${ROUTES.dashboard}#clinic-public-profile`'));
+  assert.ok(sidebarSource.includes('`${ROUTES.dashboard}?module=perfil`'));
 });

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -50,7 +50,7 @@ test("clinic dashboard exists as a clinic-only dashboard and keeps admin out", (
   assert.ok(source.includes('import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";'));
   assert.ok(source.includes("<ClinicParticularTokensCard />"));
   assert.ok(sidebarSource.includes('label: "Tokens particulares"'));
-  assert.ok(sidebarSource.includes('`${ROUTES.dashboard}#clinic-particular-tokens`'));
+  assert.ok(sidebarSource.includes('`${ROUTES.dashboard}?module=tokens`'));
   assert.equal(source.includes(removedSessionScopeCopy), false);
   assert.equal(source.includes('label: "Admin"'), false);
   assert.equal(source.includes("ROUTES.dashboardAdmin"), false);

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -162,6 +162,17 @@ test("dashboard informes separates fetch failures from real empty report lists",
   assert.ok(source.includes("No hay informes disponibles."));
 });
 
+test("dashboard informes page includes back navigation to modules hub", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("href={ROUTES.dashboard}"));
+  assert.ok(source.includes("Volver a m&oacute;dulos"));
+  assert.ok(!source.includes("module=informes"));
+  assert.ok(source.includes("Volver"));
+  assert.ok(source.includes('aria-label="Volver al dashboard"'));
+  assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
+});
+
 test("api client supports reports status filter without bypassing wrappers", () => {
   const source = read(API_CLIENT_PATH);
 

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -90,8 +90,8 @@ test("clinic dashboard sidebar keeps clinic operations and excludes admin naviga
   assert.ok(source.includes('label: "Tokens particulares"'));
   assert.ok(source.includes("ROUTES.dashboardInformes"));
   assert.ok(source.includes("ROUTES.dashboardLogistica"));
-  assert.ok(source.includes('`${ROUTES.dashboard}#clinic-public-profile`'));
-  assert.ok(source.includes('`${ROUTES.dashboard}#clinic-particular-tokens`'));
+  assert.ok(source.includes('`${ROUTES.dashboard}?module=perfil`'));
+  assert.ok(source.includes('`${ROUTES.dashboard}?module=tokens`'));
   assert.equal(source.includes("ROUTES.dashboardAdmin"), false);
 });
 


### PR DESCRIPTION
## Summary
- Sync clinic dashboard workspace state with URL search params for deterministic direct loads and browser back/forward navigation
- Replace obsolete clinic sidebar hash links with module query links
- Add reports back navigation to the modules hub
- Preserve reports filters, pagination and master-detail source contracts
- Restore UTF-8-safe reports source contracts after encoding corruption during local repair

## Validation
- pnpm validate:local
- pnpm --dir frontend build

## Notes
- Preserves dashboard hub/workspace architecture
- Does not reintroduce AdminSectionTabs as primary navigation
- Does not reintroduce global long dashboard scroll
- Does not touch backend or data models
- Does not commit generated Next files