### PR TITLE
fix(dashboard): stabilize admin workspace sync and reports filters

### DIFF
--- a/docs/pr0-dashboard-admin-sync-reports-filters.md
+++ b/docs/pr0-dashboard-admin-sync-reports-filters.md
@@ -1,0 +1,116 @@
+# PR-0: fix(dashboard): stabilize admin workspace sync and reports filters
+
+## Problema
+
+Tres bugs de estabilidad independientes detectados en la auditoría premium:
+
+1. **Admin workspace no sincroniza con URL**: `AdminDashboardWorkspaceController` usaba `useState(initialModule)` sin `useSearchParams` ni `useEffect`. Al usar back/forward del navegador la URL cambiaba pero el estado React no. Deep links como `/dashboard/admin?module=admin-clinics` no abrían el workspace directamente tras hidratación.
+
+2. **`studyType` se perdía al hacer submit del FilterDrawer**: El form GET de `/dashboard/informes` tenía campos `query` y `status`, pero no `studyType`. Al filtrar, la URL perdía ese parámetro aunque existía en `buildActiveFilters` y se pasaba a `searchReportsPaginated`.
+
+3. **`reportId` inválido seleccionaba silenciosamente `reports[0]`**: El patrón `reports.find(...) ?? reports[0] ?? null` hacía que un `?reportId=999` no encontrado en la página abriera el primer informe sin ninguna indicación visual.
+
+## Causa raíz
+
+1. Falta del patrón de sync URL ya implementado en `ClinicDashboardWorkspaceController` (useSearchParams + useEffect). La versión admin nunca se portó.
+2. Input `studyType` ausente del form, aunque el parámetro existe en la URL y se procesa en el servidor.
+3. Lógica de fallback excesivamente permisiva: no distingue "sin reportId" (default al primero) de "reportId no encontrado" (ninguno seleccionado).
+
+## Solución
+
+### 1. Admin workspace sync
+
+- Agregado `ADMIN_MODULE_VALUES` (`as const`) y `parseModuleFromUrl(value: string | null): AdminModule | null` en `AdminDashboardWorkspaceController.tsx`.
+- Importado `useSearchParams` de `next/navigation` y `useEffect` de `react`.
+- `useState` sigue arrancando con `initialModule` (SSR correcto).
+- `useEffect` sincroniza `activeModule` con `searchParams.get("module")` en cada cambio, habilitando back/forward.
+- `admin/page.tsx` envuelve el controller en `<Suspense>` (obligatorio al usar `useSearchParams` en componente hijo).
+
+### 2. studyType en filtros
+
+- Agregado `<label>` con `<Input name="studyType" defaultValue={studyType} ...>` en el FilterDrawer de `/dashboard/informes`.
+- Al hacer submit del form GET, `studyType` se incluye en la URL y no se pierde.
+- Links de paginación y selección ya preservaban `studyType` via `buildInformesHref`.
+
+### 3. reportId inválido
+
+- Cambiada la lógica de `selectedReport`:
+  - **Antes**: `reports.find(...) ?? reports[0] ?? null` (siempre abre el primero si no hay match)
+  - **Después**: `selectedReportId === null ? (reports[0] ?? null) : (reports.find(...) ?? null)`
+  - Sin `reportId` → primer informe como default (comportamiento esperado).
+  - Con `reportId` no encontrado → `null`, se muestra el estado vacío del detalle en vez de abrir silenciosamente otro informe.
+
+## Archivos tocados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx` | Agrega useSearchParams, useEffect, ADMIN_MODULE_VALUES, parseModuleFromUrl |
+| `frontend/src/app/dashboard/admin/page.tsx` | Agrega Suspense import + wrapper |
+| `frontend/src/app/dashboard/informes/page.tsx` | Agrega studyType input, corrige selectedReport logic |
+| `test/frontend-dashboard-admin.test.ts` | Agrega tests de URL sync y Suspense |
+| `test/frontend-dashboard-informes.test.ts` | Agrega test de studyType en form |
+| `test/frontend-dashboard-reports-master-detail.test.ts` | Actualiza assertion selectedReport + test nuevo |
+| `frontend/e2e/dashboard-card-navigation-shell.spec.ts` | Agrega deep link, back/forward, invalid module tests |
+
+## Tests agregados/actualizados
+
+### Unitarios (test/)
+
+- `AdminDashboardWorkspaceController syncs module from URL with useSearchParams and useEffect` — verifica presencia de useSearchParams, useEffect, ADMIN_MODULE_VALUES, parseModuleFromUrl, [searchParams] dependency.
+- `admin page wraps AdminDashboardWorkspaceController in Suspense for useSearchParams` — verifica Suspense en page.tsx.
+- `dashboard informes filter form includes studyType input to preserve it on submit` — verifica name="studyType", defaultValue={studyType}, aria-label.
+- `dashboard informes reportId null selects first report by default without silent fallback` — verifica nuevo patrón `selectedReportId === null`.
+- Actualizado: `dashboard informes composes master-detail...` — assertions ajustadas al nuevo patrón.
+
+### E2E (frontend/e2e/)
+
+- `/dashboard?module=operaciones` abre workspace directamente.
+- `Volver a módulos` desde clinic deep link limpia query y vuelve al hub.
+- Invalid clinic module query param → hub.
+- `/dashboard/admin?module=admin-clinics` abre Clínicas workspace directamente.
+- `/dashboard/admin?module=audit-log` abre Auditoría workspace directamente.
+- `Volver a módulos` desde admin deep link limpia query y vuelve al hub admin.
+- Invalid admin module query param → hub admin.
+- Browser back desde admin workspace → hub.
+- Browser forward después de back → workspace restaurado.
+
+## Comandos ejecutados
+
+```
+pnpm --dir frontend lint          # PASS
+pnpm --dir frontend typecheck     # PASS
+pnpm --dir frontend build         # PASS — 25 rutas, sin errores
+pnpm validate:local               # PASS — 2471 tests, 0 fail
+pnpm security:public-surface      # PASS — sin findings de exposición pública
+git diff --check                  # CLEAN
+git restore frontend/next-env.d.ts frontend/tsconfig.json
+```
+
+## Riesgos
+
+- **Suspense en admin/page.tsx**: Minimal. Es el patrón estándar de Next.js para componentes que usan `useSearchParams`. La carga de la ruta no cambia; el spinner solo aplica si el componente no se puede renderizar en el servidor.
+- **selectedReport null para reportId no encontrado**: La UI ya tiene un `EmptyState` para `selectedReport === null` en el detalle. El cambio solo expone ese estado que antes quedaba oculto.
+- **StudyType input visible**: Sin riesgo. No cambia contratos API. El campo ya existía como parámetro URL; solo se agrega el input para que el form GET lo preserve.
+
+## Evidencia: AdminSectionTabs.tsx — no eliminado
+
+`AdminSectionTabs.tsx` no tiene referencias como import React en ningún componente activo. Solo aparece mencionado en un comentario en `PublicRouteControl.tsx`. Sin embargo, el test suite `test/frontend-dashboard-admin-section-tabs.test.ts` verifica activamente la existencia del archivo y su contrato de componente (PR-7 scope test). Eliminarlo haría fallar esos tests.
+
+**Decisión**: preservado. No es navegación principal (no se usa en `admin/page.tsx` ni en `AdminDashboardWorkspaceController`). Candidato a eliminación en un PR dedicado que actualice también los tests de PR-7.
+
+## Evidencia: AdminSectionTabs NO es navegación principal
+
+- `admin/page.tsx` no importa ni renderiza `AdminSectionTabs`.
+- `AdminDashboardWorkspaceController.tsx` no importa ni renderiza `AdminSectionTabs`.
+- La navegación admin es exclusivamente `DashboardModuleHub` → click card → `DashboardModuleWorkspace` con `onBack`.
+
+## Evidencia: no se reintroduce scroll global
+
+- `admin/page.tsx` mantiene `<main className="dashboard-main">` sin cambios en la clase.
+- El contenedor `overflow-hidden` del shell no se toca.
+- Tests E2E de `dashboard shell — no global scroll` y `admin shell — no global scroll` permanecen sin cambios y verifican el invariante.
+
+## Evidencia: deep links cubiertos
+
+- `/dashboard?module=operaciones` — test E2E nuevo: `"/dashboard?module=operaciones opens Centro de operaciones workspace directly"`.
+- `/dashboard/admin?module=admin-clinics` — test E2E nuevo: `"/dashboard/admin?module=admin-clinics opens Clínicas workspace directly"`.

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -496,6 +496,154 @@ test.describe("admin shell — no global scroll", () => {
   });
 });
 
+// ─── Clinic dashboard — deep link direct navigation ──────────────────────────
+
+test.describe("clinic dashboard — deep link direct navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await setClinicSession(page);
+  });
+
+  test("/dashboard?module=operaciones opens Centro de operaciones workspace directly", async ({ page }) => {
+    await page.goto("/dashboard?module=operaciones");
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).not.toBeVisible();
+  });
+
+  test("Volver a módulos from clinic deep link clears query and returns to hub", async ({ page }) => {
+    await page.goto("/dashboard?module=operaciones");
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    await page.getByRole("button", { name: "Volver a módulos" }).click();
+
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.url()).not.toContain("module=");
+  });
+
+  test("invalid module query param falls back to clinic hub", async ({ page }) => {
+    await page.goto("/dashboard?module=modulo-invalido-xyz");
+
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.locator('[data-dashboard-module-workspace]'),
+    ).not.toBeVisible();
+  });
+});
+
+// ─── Admin dashboard — deep link direct navigation ────────────────────────────
+
+test.describe("admin dashboard — deep link direct navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await setAdminSession(page);
+  });
+
+  test("/dashboard/admin?module=admin-clinics opens Clínicas workspace directly", async ({ page }) => {
+    await page.goto("/dashboard/admin?module=admin-clinics");
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).not.toBeVisible();
+  });
+
+  test("/dashboard/admin?module=audit-log opens Auditoría workspace directly", async ({ page }) => {
+    await page.goto("/dashboard/admin?module=audit-log");
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="audit-log"]'),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).not.toBeVisible();
+  });
+
+  test("Volver a módulos from admin deep link clears query and returns to admin hub", async ({ page }) => {
+    await page.goto("/dashboard/admin?module=admin-clinics");
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    await page.getByRole("button", { name: "Volver a módulos" }).click();
+
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.url()).not.toContain("module=");
+  });
+
+  test("invalid admin module query param falls back to admin hub", async ({ page }) => {
+    await page.goto("/dashboard/admin?module=modulo-invalido-xyz");
+
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.locator('[data-dashboard-module-workspace]'),
+    ).not.toBeVisible();
+  });
+});
+
+// ─── Admin dashboard — browser back/forward sync ─────────────────────────────
+
+test.describe("admin dashboard — browser back/forward sync", () => {
+  test.beforeEach(async ({ page }) => {
+    await setAdminSession(page);
+  });
+
+  test("browser back from admin workspace returns to admin hub", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await hubCard(hub, "Clínicas").click();
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 5_000 });
+
+    await page.goBack();
+
+    await expect(hub).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).not.toBeVisible();
+  });
+
+  test("browser forward after back restores admin workspace", async ({ page }) => {
+    await page.goto("/dashboard/admin");
+
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+    await hubCard(hub, "Clínicas").click();
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 5_000 });
+
+    await page.goBack();
+    await expect(hub).toBeVisible({ timeout: 5_000 });
+
+    await page.goForward();
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});
+
 // ─── Sidebar rail compacto ────────────────────────────────────────────────────
 
 test.describe("dashboard sidebar — compact rail", () => {

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -526,7 +526,7 @@ test.describe("clinic dashboard — deep link direct navigation", () => {
     await expect(
       page.locator('[data-dashboard-module-hub="true"]'),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.url()).not.toContain("module=");
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 5_000 });
   });
 
   test("invalid module query param falls back to clinic hub", async ({ page }) => {
@@ -582,7 +582,7 @@ test.describe("admin dashboard — deep link direct navigation", () => {
     await expect(
       page.locator('[data-dashboard-module-hub="true"]'),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.url()).not.toContain("module=");
+    await expect(page).toHaveURL(/\/dashboard\/admin$/, { timeout: 5_000 });
   });
 
   test("invalid admin module query param falls back to admin hub", async ({ page }) => {
@@ -614,9 +614,11 @@ test.describe("admin dashboard — browser back/forward sync", () => {
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
     ).toBeVisible({ timeout: 5_000 });
+    await expect(page).toHaveURL(/module=admin-clinics/, { timeout: 5_000 });
 
     await page.goBack();
 
+    await expect(page).toHaveURL(/\/dashboard\/admin$/, { timeout: 5_000 });
     await expect(hub).toBeVisible({ timeout: 5_000 });
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
@@ -633,11 +635,14 @@ test.describe("admin dashboard — browser back/forward sync", () => {
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
     ).toBeVisible({ timeout: 5_000 });
+    await expect(page).toHaveURL(/module=admin-clinics/, { timeout: 5_000 });
 
     await page.goBack();
+    await expect(page).toHaveURL(/\/dashboard\/admin$/, { timeout: 5_000 });
     await expect(hub).toBeVisible({ timeout: 5_000 });
 
     await page.goForward();
+    await expect(page).toHaveURL(/module=admin-clinics/, { timeout: 5_000 });
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
     ).toBeVisible({ timeout: 5_000 });

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -134,7 +134,7 @@ export function AdminDashboardWorkspaceController({
   const activateModule = useCallback(
     (moduleId: AdminModule) => {
       setActiveModule(moduleId);
-      router.replace(`/dashboard/admin?module=${moduleId}`, { scroll: false });
+      router.push(`/dashboard/admin?module=${moduleId}`, { scroll: false });
     },
     [router],
   );

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback, type ReactNode } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useCallback, useEffect, type ReactNode } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Activity,
   Building2,
@@ -29,6 +29,26 @@ export type AdminModule =
   | "admin-users-roles"
   | "audit-log"
   | "admin-maintenance";
+
+const ADMIN_MODULE_VALUES = [
+  "admin",
+  "admin-report-upload",
+  "admin-health",
+  "admin-clinics",
+  "admin-particular-tokens",
+  "admin-pricing",
+  "admin-sessions",
+  "admin-users-roles",
+  "audit-log",
+  "admin-maintenance",
+] as const;
+
+function parseModuleFromUrl(value: string | null): AdminModule | null {
+  if (!value) return null;
+  return (ADMIN_MODULE_VALUES as readonly string[]).includes(value)
+    ? (value as AdminModule)
+    : null;
+}
 
 type AdminWorkspaceSlots = {
   admin: ReactNode;
@@ -102,9 +122,14 @@ export function AdminDashboardWorkspaceController({
   systemStatusVariant,
 }: AdminDashboardWorkspaceControllerProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [activeModule, setActiveModule] = useState<AdminModule | null>(
     initialModule ?? null,
   );
+
+  useEffect(() => {
+    setActiveModule(parseModuleFromUrl(searchParams.get("module")));
+  }, [searchParams]);
 
   const activateModule = useCallback(
     (moduleId: AdminModule) => {

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { cookies } from "next/headers";
 import {
   Table,
@@ -847,24 +848,26 @@ export default async function AdminPage({
             </Badge>
           }
         />
-        <AdminDashboardWorkspaceController
-          initialModule={initialModule}
-          workspaces={{
-            admin: adminWorkspaceSlot,
-            "admin-report-upload": reportUploadWorkspaceSlot,
-            "admin-health": healthWorkspaceSlot,
-            "admin-clinics": clinicsWorkspaceSlot,
-            "admin-particular-tokens": tokensWorkspaceSlot,
-            "admin-pricing": pricingWorkspaceSlot,
-            "admin-sessions": sessionsWorkspaceSlot,
-            "admin-users-roles": usersRolesWorkspaceSlot,
-            "audit-log": auditLogWorkspaceSlot,
-            "admin-maintenance": maintenanceWorkspaceSlot,
-          }}
-          systemStatus={systemStatus}
-          systemStatusLabel={formatSystemStatus(systemStatus)}
-          systemStatusVariant={getSystemStatusVariant(systemStatus)}
-        />
+        <Suspense>
+          <AdminDashboardWorkspaceController
+            initialModule={initialModule}
+            workspaces={{
+              admin: adminWorkspaceSlot,
+              "admin-report-upload": reportUploadWorkspaceSlot,
+              "admin-health": healthWorkspaceSlot,
+              "admin-clinics": clinicsWorkspaceSlot,
+              "admin-particular-tokens": tokensWorkspaceSlot,
+              "admin-pricing": pricingWorkspaceSlot,
+              "admin-sessions": sessionsWorkspaceSlot,
+              "admin-users-roles": usersRolesWorkspaceSlot,
+              "audit-log": auditLogWorkspaceSlot,
+              "admin-maintenance": maintenanceWorkspaceSlot,
+            }}
+            systemStatus={systemStatus}
+            systemStatusLabel={formatSystemStatus(systemStatus)}
+            systemStatusVariant={getSystemStatusVariant(systemStatus)}
+          />
+        </Suspense>
         <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -295,7 +295,9 @@ export default async function InformesPage({
   const pageEnd = Math.min(offset + reports.length, reportsTotal);
 
   const selectedReport =
-    reports.find((report) => report.id === selectedReportId) ?? reports[0] ?? null;
+    selectedReportId === null
+      ? (reports[0] ?? null)
+      : (reports.find((report) => report.id === selectedReportId) ?? null);
   const selectedReportIdValue = selectedReport ? String(selectedReport.id) : null;
   const selectedReportTimelineSteps = selectedReport
     ? buildStudyTimelineSteps(selectedReport)
@@ -406,6 +408,19 @@ export default async function InformesPage({
                       </option>
                     ))}
                   </select>
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-semibold text-vetneb-ink">
+                    Tipo de estudio
+                  </span>
+                  <Input
+                    name="studyType"
+                    defaultValue={studyType}
+                    placeholder="Filtrar por tipo de estudio..."
+                    className="mt-1 min-w-0"
+                    aria-label="Filtrar por tipo de estudio"
+                  />
                 </label>
 
                 <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">

--- a/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
+++ b/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
@@ -95,7 +95,7 @@ export function ClinicDashboardWorkspaceController({
   const activateModule = useCallback(
     (moduleId: ClinicModule) => {
       setActiveModule(moduleId);
-      router.replace(`${ROUTES.dashboard}?module=${moduleId}`, { scroll: false });
+      router.push(`${ROUTES.dashboard}?module=${moduleId}`, { scroll: false });
     },
     [router],
   );

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -292,6 +292,31 @@ test("dashboard admin distinguishes audit log load failures from empty states", 
   assert.equal(source.includes("fetch("), false);
 });
 
+test("AdminDashboardWorkspaceController syncs module from URL with useSearchParams and useEffect", () => {
+  const source = readFileSync(
+    resolve(process.cwd(), "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+  assert.ok(source.includes('useSearchParams'));
+  assert.ok(source.includes('useEffect'));
+  assert.ok(source.includes('const ADMIN_MODULE_VALUES = ['));
+  assert.ok(source.includes('function parseModuleFromUrl(value: string | null): AdminModule | null'));
+  assert.ok(source.includes('searchParams.get("module")'));
+  assert.ok(source.includes('setActiveModule(parseModuleFromUrl(searchParams.get("module")));'));
+  assert.ok(source.includes('[searchParams]'));
+  assert.ok(source.includes('from "next/navigation"'));
+  assert.ok(source.includes('useRouter, useSearchParams'));
+});
+
+test("admin page wraps AdminDashboardWorkspaceController in Suspense for useSearchParams", () => {
+  const source = read(ADMIN_PAGE_PATH);
+
+  assert.ok(source.includes('<Suspense>'));
+  assert.ok(source.includes('</Suspense>'));
+  assert.ok(source.includes('import { Suspense } from "react";'));
+});
+
 test("dashboard admin avoids duplicate section ids in navigation anchors", () => {
   const source = read(ADMIN_PAGE_PATH);
   const adminHealthIdMatches = source.match(/id="admin-health"/g) ?? [];

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -173,6 +173,15 @@ test("dashboard informes page includes back navigation to modules hub", () => {
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
 });
 
+test("dashboard informes filter form includes studyType input to preserve it on submit", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes('name="studyType"'));
+  assert.ok(source.includes("defaultValue={studyType}"));
+  assert.ok(source.includes('aria-label="Filtrar por tipo de estudio"'));
+  assert.ok(source.includes('placeholder="Filtrar por tipo de estudio..."'));
+});
+
 test("api client supports reports status filter without bypassing wrappers", () => {
   const source = read(API_CLIENT_PATH);
 

--- a/test/frontend-dashboard-reports-master-detail.test.ts
+++ b/test/frontend-dashboard-reports-master-detail.test.ts
@@ -117,7 +117,9 @@ test("dashboard informes composes master-detail, selected report detail, timelin
   assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
   assert.ok(source.includes("buildStudyTimelineSteps(selectedReport)"));
   assert.ok(source.includes("const selectedReport ="));
-  assert.ok(source.includes("reports.find((report) => report.id === selectedReportId) ?? reports[0] ?? null"));
+  assert.ok(source.includes("selectedReportId === null"));
+  assert.ok(source.includes("? (reports[0] ?? null)"));
+  assert.ok(source.includes(": (reports.find((report) => report.id === selectedReportId) ?? null)"));
   assert.ok(source.includes("const stickyActions = ["));
   assert.ok(source.includes('label: "Lista"'));
   assert.ok(source.includes('href: "#reports-master-list"'));
@@ -176,6 +178,15 @@ test("dashboard informes pagination does not use client-side filter", () => {
   assert.ok(source.includes("const offset = (page - 1) * REPORTS_PAGE_SIZE"));
   assert.equal(source.includes("reports.slice("), false);
   assert.equal(source.includes("reports.filter("), false);
+});
+
+test("dashboard informes reportId null selects first report by default without silent fallback", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(source.includes("selectedReportId === null"));
+  assert.ok(source.includes("? (reports[0] ?? null)"));
+  assert.ok(source.includes(": (reports.find((report) => report.id === selectedReportId) ?? null)"));
+  assert.equal(source.includes("?? reports[0] ?? null"), false);
 });
 
 test("dashboard informes master-detail scope avoids forbidden navigation and dependency changes", () => {


### PR DESCRIPTION
## Summary
- Sync admin dashboard workspace state with URL search params for deterministic direct loads and browser back/forward navigation
- Preserve reports studyType filters through the reports filter drawer
- Avoid silently falling back to another report when reportId is invalid or not visible
- Add E2E coverage for clinic/admin dashboard module deep links and back navigation
- Document implementation and validation notes

## Validation
- pnpm validate:local
- pnpm --dir frontend build
- pnpm security:public-surface

## Notes
- Preserves dashboard hub/workspace architecture
- Does not reintroduce AdminSectionTabs as primary navigation
- Does not reintroduce global long dashboard scroll
- Does not touch backend or data models
- Does not commit generated Next files