### PR TITLE
feat(ui): add dashboard interaction foundation

### DIFF
--- a/docs/pr1-dashboard-interaction-foundation.md
+++ b/docs/pr1-dashboard-interaction-foundation.md
@@ -1,0 +1,240 @@
+# PR-1: Dashboard Interaction Foundation
+
+- **Fecha:** 2026-06-10
+- **Rama:** `feat/ui-dashboard-interaction-foundation`
+- **Base:** `main` — HEAD `1868a1e fix(dashboard): stabilize admin workspace sync and reports filters (#924)`
+- **Tipo:** feat(ui)
+
+---
+
+## Problema
+
+El dashboard clínica/admin tenía interacciones planas:
+
+- Las cards del hub usaban `duration-200` hardcodeado sin tokens reutilizables.
+- El botón "Volver a módulos" usaba `transition-colors` sin duración explícita.
+- No existían tokens CSS de motion ni clases de interacción reutilizables.
+- Sin estado `active:/press` en cards ni botones de workspace.
+- Las clases de reducción de movimiento no cubrían explícitamente los nuevos patrones.
+
+---
+
+## Objetivo visual
+
+Establecer una foundation reutilizable de motion tokens e interaction classes que todo futuro PR del roadmap premium pueda consumir sin reintroducir duraciones hardcodeadas ni violaciones de `prefers-reduced-motion`.
+
+---
+
+## Solución aplicada
+
+### 1. Motion tokens en `globals.css` (`:root`)
+
+```css
+--motion-fast: 120ms;
+--motion-base: 180ms;
+--motion-slow: 280ms;
+--ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+--ease-in-out-soft: cubic-bezier(0.4, 0, 0.2, 1);
+```
+
+### 2. Clases interaction foundation (`globals.css`, sección `dashboard-interaction-foundation`)
+
+| Clase | Uso | Transitions | Active state |
+|---|---|---|---|
+| `.dashboard-card-interactive` | Cards del hub | `border-color, box-shadow, transform` / `--motion-base` / `--ease-out-soft` | `scale(0.99)` |
+| `.dashboard-btn-interactive` | Botones de workspace (Volver, etc.) | `background-color, border-color, box-shadow, color, transform` / `--motion-fast` / `--ease-out-soft` | `scale(0.98)` |
+| `.dashboard-row-interactive` | Filas de lista (ready for PR-3) | `background-color, border-color` / `--motion-fast` / `--ease-out-soft` | — |
+| `.dashboard-disabled-state` | Estado disabled claro | `opacity: 0.45; cursor: not-allowed; pointer-events: none` | — |
+
+### 3. Reduced motion override explícito
+
+Dentro de la sección `@layer components` de interaction-foundation:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-card-interactive,
+  .dashboard-btn-interactive,
+  .dashboard-row-interactive {
+    transition: none;
+  }
+  .dashboard-card-interactive:active,
+  .dashboard-btn-interactive:active {
+    transform: none;
+  }
+}
+```
+
+Complementa el bloque global preexistente (`globals.css:927-945`) que ya aplica `transition-duration: 0.01ms !important` a todos los elementos.
+
+### 4. Aplicación en componentes
+
+**`DashboardModuleHub.tsx`:**
+- `"transition-[border-color,box-shadow] duration-200"` → `"dashboard-card-interactive"`
+- Se mantienen: hover states Tailwind, `focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2`, `data-dashboard-module-card`, `data-dashboard-module-hub`
+
+**`DashboardModuleWorkspace.tsx`:**
+- `transition-colors` (sin duración) → `dashboard-btn-interactive`
+- Se mantienen: hover states, focus ring, `data-dashboard-module-workspace`, "Volver a módulos" aria-label
+
+---
+
+## Tokens / clases agregadas
+
+```
+:root {
+  --motion-fast: 120ms
+  --motion-base: 180ms
+  --motion-slow: 280ms
+  --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1)
+  --ease-in-out-soft: cubic-bezier(0.4, 0, 0.2, 1)
+}
+
+@layer components {
+  .dashboard-card-interactive
+  .dashboard-card-interactive:active
+  .dashboard-btn-interactive
+  .dashboard-btn-interactive:active
+  .dashboard-row-interactive
+  .dashboard-disabled-state
+  @media (prefers-reduced-motion: reduce) { ... }
+}
+```
+
+---
+
+## Archivos tocados
+
+| Archivo | Tipo de cambio |
+|---|---|
+| `frontend/src/app/globals.css` | +53 líneas: motion tokens en `:root` + sección `dashboard-interaction-foundation` |
+| `frontend/src/components/dashboard/DashboardModuleHub.tsx` | -1/+1: `duration-200` → `dashboard-card-interactive` |
+| `frontend/src/components/dashboard/DashboardModuleWorkspace.tsx` | -1/+1: `transition-colors` → `dashboard-btn-interactive` |
+| `test/frontend-dashboard-interaction-foundation.test.ts` | nuevo: 24 tests nativos |
+| `frontend/e2e/dashboard-interaction-foundation.spec.ts` | nuevo: 6 smoke E2E |
+| `docs/pr1-dashboard-interaction-foundation.md` | nuevo: este documento |
+
+---
+
+## Tests agregados / actualizados
+
+### Nuevos: `test/frontend-dashboard-interaction-foundation.test.ts` (24 tests)
+
+- Presencia de los 5 tokens CSS en `:root`
+- Definición de `.dashboard-card-interactive` con `--motion-base` y `--ease-out-soft`
+- Estado `:active { transform: scale(0.99) }` en card interactive
+- Definición de `.dashboard-btn-interactive` con `--motion-fast`
+- Estado `:active { transform: scale(0.98) }` en btn interactive
+- Definición de `.dashboard-row-interactive` y `.dashboard-disabled-state`
+- Bloque `@media (prefers-reduced-motion: reduce)` cubre los 3 nuevos patrones
+- Reduced-motion elimina `transform` en estados active
+- Sección delimitada por comentarios `start/end`
+- `DashboardModuleHub` usa `dashboard-card-interactive`
+- `DashboardModuleHub` no tiene `duration-200` hardcodeado
+- `DashboardModuleHub` mantiene atributos `data-` para E2E
+- `DashboardModuleHub` mantiene `focus-visible:ring-2`
+- `DashboardModuleWorkspace` usa `dashboard-btn-interactive` en Volver
+- `DashboardModuleWorkspace` mantiene focus ring y atributo `data-`
+- `DashboardShellRouter` mantiene `h-dvh overflow-hidden` (no scroll global)
+- Shell no importa `AdminSectionTabs` como navegación
+- Scope guard: sin dependencias nuevas
+- Scope guard: archivos prohibidos no tocados
+
+### Nuevos: `frontend/e2e/dashboard-interaction-foundation.spec.ts` (6 tests smoke)
+
+- `/dashboard` carga hub clínica
+- `/dashboard/admin` carga hub admin
+- `/dashboard?module=operaciones` renderiza workspace
+- `/dashboard/admin?module=admin-clinics` renderiza workspace
+- Hub cards tienen `.dashboard-card-interactive` en DOM
+- Volver button tiene `.dashboard-btn-interactive` en DOM
+- Reduced motion: hub visible con `prefers-reduced-motion: reduce`
+
+---
+
+## Comandos ejecutados
+
+**Terminal 1:**
+
+```powershell
+git branch --show-current            # feat/ui-dashboard-interaction-foundation
+git status --short                   # limpio al inicio
+git log -1 --oneline                 # 1868a1e fix(dashboard): stabilize admin...
+git diff --check                     # sin errores whitespace
+git diff --stat                      # 3 archivos: globals.css (+53), Hub (-1/+1), Workspace (-1/+1)
+pnpm --dir frontend lint             # OK
+pnpm --dir frontend typecheck        # OK
+pnpm --dir frontend build            # OK (Next.js 16.2.7 Turbopack, 25 páginas)
+git status --short                   # next-env.d.ts y tsconfig.json intactos
+node --test test/frontend-dashboard-interaction-foundation.test.ts  # 24/24
+node --test test/frontend-dashboard-shell.test.ts                   # 6/6
+node --test test/frontend-dashboard-accessibility-focus-aria.test.ts # 6/6
+node --test test/frontend-dashboard-admin-section-tabs.test.ts       # 5/5
+node --test test/frontend-dashboard-shared-components.test.ts ...    # 43/43
+pnpm validate:local                  # 2495/2495
+pnpm security:public-surface         # PASS
+```
+
+---
+
+## Riesgos
+
+| Riesgo | Valoración | Mitigación aplicada |
+|---|---|---|
+| CSS specificity: tokens vs Tailwind `duration-*` | Bajo | Se elimina `duration-200` del componente; el token del CSS class es la única fuente de verdad |
+| Regresión de `data-dashboard-module-*` atributos (usados en E2E) | Bajo | Atributos no tocados; verificados por tests nativos |
+| `will-change: transform` creando stacking contexts inesperados | Eliminado | No se usa `will-change` en las nuevas clases |
+| scale(0.99) recortando contenido en tarjetas con overflow | Muy bajo | Hub cards no tienen `overflow: hidden` en el wrapper; scale es sutil |
+| Hydration mismatch: active state con transform | Ninguno | El `:active` es CSS puro, no condicionado a estado cliente de React |
+| Break de E2E existentes por cambio de clases | Ninguno | E2E usan `data-*` atributos, no class names |
+
+---
+
+## Evidencia de reduced motion
+
+**Cobertura doble:**
+
+1. **Global preexistente** (`globals.css:927-945`): aplica `transition-duration: 0.01ms !important` a `*` + `transition: none; animation: none` a `.render-card`, `.premium-card`, `[data-services-polished="true"] > [id]`, `.clinical-skeleton`.
+
+2. **Nueva sección explícita** (`dashboard-interaction-foundation`): `transition: none` y `transform: none` específicamente en `.dashboard-card-interactive`, `.dashboard-btn-interactive`, `.dashboard-row-interactive` con sus estados `:active`.
+
+**Test:** "PR-1 globals.css reduced-motion overrides dashboard-card-interactive transition" → verde.
+
+---
+
+## Evidencia de no dependencias nuevas
+
+```powershell
+git diff --stat
+# 3 files changed, 55 insertions(+), 2 deletions(-)
+# No package.json, no pnpm-lock.yaml
+```
+
+`pnpm validate:local` pasa sin instalar nada nuevo. `pnpm security:public-surface` PASS.
+
+---
+
+## Evidencia de no scroll global
+
+`DashboardShellRouter.tsx` mantiene `h-dvh overflow-hidden` en el contenedor raíz (verificado por test "PR-1 DashboardShellRouter keeps h-dvh overflow-hidden preventing global scroll").
+
+---
+
+## Evidencia de no AdminSectionTabs como navegación principal
+
+`DashboardShellRouter.tsx` no importa `AdminSectionTabs` (verificado por test "PR-1 dashboard shell router does not use AdminSectionTabs as navigation"). El componente existe en disco como código muerto (no modificado ni usado en páginas — igual que antes de este PR).
+
+---
+
+## No-alcance explícito
+
+- **No command palette**: no implementado; pertenece a PR-8.
+- **No data visualization**: no implementado; pertenece a PR-7.
+- **No AI / copilot**: no implementado; pertenece a PR-10.
+- **No rediseño total**: estructura de hub → workspace sin cambios.
+- **No transición hub↔workspace**: animación de entrada/salida pertenece a PR-2.
+- **No tooltip component**: reemplazo de `title=` en sidebar pertenece a PR-1b o PR-2.
+- **No backend**: cero archivos en `server/`, `drizzle/`, `shared/`.
+- **No auth / middleware**: no tocados.
+- **No PWA / service worker**: no tocados.
+- **No deps nuevas**: `frontend/package.json` sin cambios.
+- **No `next-env.d.ts` / `tsconfig.json`**: intactos post-build.

--- a/frontend/e2e/dashboard-interaction-foundation.spec.ts
+++ b/frontend/e2e/dashboard-interaction-foundation.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+
+type Page = import("@playwright/test").Page;
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+test.describe("dashboard interaction foundation — smoke (PR-1)", () => {
+  test("clinic /dashboard loads module hub", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("admin /dashboard/admin loads module hub", async ({ page }) => {
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("clinic /dashboard?module=operaciones renders workspace", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("admin /dashboard/admin?module=admin-clinics renders workspace", async ({
+    page,
+  }) => {
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin?module=admin-clinics");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("hub cards have dashboard-card-interactive class applied (PR-1 contract)", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    await expect(hub).toBeVisible({ timeout: 8_000 });
+
+    const interactiveCards = hub.locator(".dashboard-card-interactive");
+    await expect(interactiveCards.first()).toBeVisible();
+  });
+
+  test("workspace Volver button has dashboard-btn-interactive class applied (PR-1 contract)", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="operaciones"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 8_000 });
+
+    const volverBtn = workspace.locator(
+      'button[aria-label="Volver a módulos"]',
+    );
+    await expect(volverBtn).toBeVisible();
+    await expect(volverBtn).toHaveClass(/dashboard-btn-interactive/);
+  });
+
+  test("reduced-motion: hub still visible with prefers-reduced-motion: reduce", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -48,6 +48,11 @@
     --font-heading: var(--font-inter);
     --font-body: var(--font-source-sans-3);
     --font-ui: var(--font-inter);
+    --motion-fast: 120ms;
+    --motion-base: 180ms;
+    --motion-slow: 280ms;
+    --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-in-out-soft: cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .dark {
@@ -1036,6 +1041,54 @@
 
 }
 /* dashboard-auth-visual-system:end */
+/* dashboard-interaction-foundation:start */
+@layer components {
+  .dashboard-card-interactive {
+    transition-property: border-color, box-shadow, transform;
+    transition-duration: var(--motion-base);
+    transition-timing-function: var(--ease-out-soft);
+  }
+
+  .dashboard-card-interactive:active {
+    transform: scale(0.99);
+  }
+
+  .dashboard-btn-interactive {
+    transition-property: background-color, border-color, box-shadow, color, transform;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: var(--ease-out-soft);
+  }
+
+  .dashboard-btn-interactive:active {
+    transform: scale(0.98);
+  }
+
+  .dashboard-row-interactive {
+    transition-property: background-color, border-color;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: var(--ease-out-soft);
+  }
+
+  .dashboard-disabled-state {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dashboard-card-interactive,
+    .dashboard-btn-interactive,
+    .dashboard-row-interactive {
+      transition: none;
+    }
+
+    .dashboard-card-interactive:active,
+    .dashboard-btn-interactive:active {
+      transform: none;
+    }
+  }
+}
+/* dashboard-interaction-foundation:end */
 
 
 

--- a/frontend/src/components/dashboard/DashboardModuleHub.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleHub.tsx
@@ -73,7 +73,7 @@ export function DashboardModuleHub({
           const sharedClassName = cn(
             "group flex w-full flex-col rounded-xl border border-vetneb-line/80 bg-card/95",
             "shadow-[0_12px_34px_rgba(15,45,62,0.08)] ring-1 ring-white/55",
-            "transition-[border-color,box-shadow] duration-200",
+            "dashboard-card-interactive",
             "hover:border-vetneb-teal/42 hover:shadow-[0_20px_50px_rgba(15,45,62,0.13)] hover:ring-vetneb-teal/10",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
           );

--- a/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
@@ -30,7 +30,7 @@ export function DashboardModuleWorkspace({
             type="button"
             onClick={onBack}
             aria-label="Volver a módulos"
-            className="inline-flex h-9 items-center gap-2 rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 shrink-0"
+            className="inline-flex h-9 items-center gap-2 rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm dashboard-btn-interactive hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 shrink-0"
           >
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
             <span>Volver a módulos</span>

--- a/test/frontend-dashboard-interaction-foundation.test.ts
+++ b/test/frontend-dashboard-interaction-foundation.test.ts
@@ -1,0 +1,337 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+const DASHBOARD_MODULE_HUB_PATH =
+  "frontend/src/components/dashboard/DashboardModuleHub.tsx";
+const DASHBOARD_MODULE_WORKSPACE_PATH =
+  "frontend/src/components/dashboard/DashboardModuleWorkspace.tsx";
+const DASHBOARD_SHELL_ROUTER_PATH =
+  "frontend/src/components/dashboard/DashboardShellRouter.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ── Motion tokens in globals.css ────────────────────────────────────────────
+
+test("PR-1 globals.css defines --motion-fast token", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("--motion-fast: 120ms;"),
+    "globals.css must define --motion-fast: 120ms",
+  );
+});
+
+test("PR-1 globals.css defines --motion-base token", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("--motion-base: 180ms;"),
+    "globals.css must define --motion-base: 180ms",
+  );
+});
+
+test("PR-1 globals.css defines --motion-slow token", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("--motion-slow: 280ms;"),
+    "globals.css must define --motion-slow: 280ms",
+  );
+});
+
+test("PR-1 globals.css defines --ease-out-soft token", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("--ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);"),
+    "globals.css must define --ease-out-soft easing",
+  );
+});
+
+// ── Interaction utility classes in globals.css ───────────────────────────────
+
+test("PR-1 globals.css defines .dashboard-card-interactive with motion tokens", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-card-interactive {"),
+    "globals.css must define .dashboard-card-interactive",
+  );
+  assert.ok(
+    source.includes("transition-duration: var(--motion-base);"),
+    ".dashboard-card-interactive must use --motion-base token",
+  );
+  assert.ok(
+    source.includes("transition-timing-function: var(--ease-out-soft);"),
+    ".dashboard-card-interactive must use --ease-out-soft token",
+  );
+});
+
+test("PR-1 globals.css defines .dashboard-card-interactive active press state", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-card-interactive:active {"),
+    ".dashboard-card-interactive must define :active state",
+  );
+  assert.ok(
+    source.includes("transform: scale(0.99);"),
+    ".dashboard-card-interactive:active must use scale(0.99) press state",
+  );
+});
+
+test("PR-1 globals.css defines .dashboard-btn-interactive with motion tokens", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-btn-interactive {"),
+    "globals.css must define .dashboard-btn-interactive",
+  );
+  assert.ok(
+    source.includes("transition-duration: var(--motion-fast);"),
+    ".dashboard-btn-interactive must use --motion-fast token",
+  );
+});
+
+test("PR-1 globals.css defines .dashboard-btn-interactive active press state", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-btn-interactive:active {"),
+    ".dashboard-btn-interactive must define :active state",
+  );
+  assert.ok(
+    source.includes("transform: scale(0.98);"),
+    ".dashboard-btn-interactive:active must use scale(0.98) press state",
+  );
+});
+
+test("PR-1 globals.css defines .dashboard-row-interactive for future list rows", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-row-interactive {"),
+    "globals.css must define .dashboard-row-interactive",
+  );
+});
+
+test("PR-1 globals.css defines .dashboard-disabled-state", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-disabled-state {"),
+    "globals.css must define .dashboard-disabled-state",
+  );
+  assert.ok(
+    source.includes("cursor: not-allowed;"),
+    ".dashboard-disabled-state must set cursor: not-allowed",
+  );
+});
+
+// ── Reduced-motion override for interaction classes ──────────────────────────
+
+test("PR-1 globals.css reduced-motion overrides dashboard-card-interactive transition", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const rmIndex = source.lastIndexOf("@media (prefers-reduced-motion: reduce)");
+  assert.ok(rmIndex >= 0, "globals.css must have at least one prefers-reduced-motion block");
+
+  const rmSection = source.slice(rmIndex);
+  assert.ok(
+    rmSection.includes(".dashboard-card-interactive,"),
+    "reduced-motion block must include .dashboard-card-interactive",
+  );
+  assert.ok(
+    rmSection.includes(".dashboard-btn-interactive,"),
+    "reduced-motion block must include .dashboard-btn-interactive",
+  );
+  assert.ok(
+    rmSection.includes(".dashboard-row-interactive {"),
+    "reduced-motion block must include .dashboard-row-interactive",
+  );
+});
+
+test("PR-1 globals.css reduced-motion removes active transform from interaction classes", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const rmIndex = source.lastIndexOf("@media (prefers-reduced-motion: reduce)");
+  const rmSection = source.slice(rmIndex);
+  assert.ok(
+    rmSection.includes(".dashboard-card-interactive:active,"),
+    "reduced-motion must override .dashboard-card-interactive:active transform",
+  );
+  assert.ok(
+    rmSection.includes(".dashboard-btn-interactive:active {"),
+    "reduced-motion must override .dashboard-btn-interactive:active transform",
+  );
+  assert.ok(
+    rmSection.includes("transform: none;"),
+    "reduced-motion active states must set transform: none",
+  );
+});
+
+test("PR-1 globals.css interaction-foundation section is delimited by comments", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("/* dashboard-interaction-foundation:start */"),
+    "globals.css must have dashboard-interaction-foundation:start comment",
+  );
+  assert.ok(
+    source.includes("/* dashboard-interaction-foundation:end */"),
+    "globals.css must have dashboard-interaction-foundation:end comment",
+  );
+});
+
+// ── Component application ────────────────────────────────────────────────────
+
+test("PR-1 DashboardModuleHub applies dashboard-card-interactive to hub cards", () => {
+  const source = read(DASHBOARD_MODULE_HUB_PATH);
+  assert.ok(
+    source.includes("dashboard-card-interactive"),
+    "DashboardModuleHub must use dashboard-card-interactive class on module cards",
+  );
+});
+
+test("PR-1 DashboardModuleHub does not use hardcoded duration-200 on hub cards", () => {
+  const source = read(DASHBOARD_MODULE_HUB_PATH);
+  assert.equal(
+    source.includes('"transition-[border-color,box-shadow] duration-200"'),
+    false,
+    "DashboardModuleHub must not use hardcoded duration-200; use dashboard-card-interactive instead",
+  );
+});
+
+test("PR-1 DashboardModuleHub keeps data-dashboard-module-hub and data-dashboard-module-card attributes", () => {
+  const source = read(DASHBOARD_MODULE_HUB_PATH);
+  assert.ok(
+    source.includes('data-dashboard-module-hub="true"'),
+    "DashboardModuleHub must keep data-dashboard-module-hub attribute",
+  );
+  assert.ok(
+    source.includes("data-dashboard-module-card={card.moduleId}"),
+    "DashboardModuleHub must keep data-dashboard-module-card attribute",
+  );
+});
+
+test("PR-1 DashboardModuleHub keeps focus-visible ring for keyboard navigation", () => {
+  const source = read(DASHBOARD_MODULE_HUB_PATH);
+  assert.ok(
+    source.includes("focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"),
+    "DashboardModuleHub must keep explicit focus-visible ring classes",
+  );
+});
+
+test("PR-1 DashboardModuleWorkspace Volver button applies dashboard-btn-interactive", () => {
+  const source = read(DASHBOARD_MODULE_WORKSPACE_PATH);
+  assert.ok(
+    source.includes("dashboard-btn-interactive"),
+    "DashboardModuleWorkspace Volver button must use dashboard-btn-interactive class",
+  );
+});
+
+test("PR-1 DashboardModuleWorkspace keeps focus-visible ring on Volver button", () => {
+  const source = read(DASHBOARD_MODULE_WORKSPACE_PATH);
+  assert.ok(
+    source.includes("focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"),
+    "DashboardModuleWorkspace Volver button must keep focus-visible ring",
+  );
+});
+
+test("PR-1 DashboardModuleWorkspace keeps data-dashboard-module-workspace attribute", () => {
+  const source = read(DASHBOARD_MODULE_WORKSPACE_PATH);
+  assert.ok(
+    source.includes("data-dashboard-module-workspace={moduleId}"),
+    "DashboardModuleWorkspace must keep data-dashboard-module-workspace attribute",
+  );
+});
+
+// ── No global scroll introduced ──────────────────────────────────────────────
+
+test("PR-1 DashboardShellRouter keeps h-dvh overflow-hidden preventing global scroll", () => {
+  const source = read(DASHBOARD_SHELL_ROUTER_PATH);
+  assert.ok(
+    source.includes("h-dvh overflow-hidden"),
+    "DashboardShellRouter must keep h-dvh overflow-hidden to prevent global scroll",
+  );
+});
+
+// ── No AdminSectionTabs as navigation ───────────────────────────────────────
+
+test("PR-1 dashboard shell router does not use AdminSectionTabs as navigation", () => {
+  const source = read(DASHBOARD_SHELL_ROUTER_PATH);
+  assert.equal(
+    source.includes('import { AdminSectionTabs }'),
+    false,
+    "DashboardShellRouter must not import AdminSectionTabs as navigation",
+  );
+});
+
+// ── No new dependencies ──────────────────────────────────────────────────────
+
+test("PR-1 interaction foundation does not add new dependencies to package.json", () => {
+  const changedFiles = execFileSync("git", ["diff", "--name-only"], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  const depFiles = changedFiles.filter(
+    (f) =>
+      f === "package.json" ||
+      f === "pnpm-lock.yaml" ||
+      f === "frontend/package.json" ||
+      f === "frontend/pnpm-lock.yaml",
+  );
+
+  assert.deepEqual(
+    depFiles,
+    [],
+    `PR-1 must not add new dependencies; modified dep files: ${depFiles.join(", ")}`,
+  );
+});
+
+// ── Scope guard ──────────────────────────────────────────────────────────────
+
+test("PR-1 interaction foundation stays within allowed file scope", () => {
+  const changedFiles = execFileSync("git", ["diff", "--name-only"], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  const blockedPrefixes = [
+    "server/",
+    "drizzle/",
+    "shared/",
+    "frontend/src/app/api/",
+    "frontend/src/middleware",
+    "frontend/src/app/servicios/",
+    "frontend/src/app/histopatologia-veterinaria/",
+  ];
+
+  const blockedExactFiles = [
+    "package.json",
+    "pnpm-lock.yaml",
+    "frontend/package.json",
+    "frontend/pnpm-lock.yaml",
+    "frontend/next-env.d.ts",
+    "frontend/tsconfig.json",
+    "frontend/src/app/layout.tsx",
+    "frontend/src/app/page.tsx",
+    "frontend/src/lib/auth.ts",
+    "frontend/src/lib/seo.ts",
+    "frontend/src/middleware.ts",
+  ];
+
+  for (const file of changedFiles) {
+    assert.equal(
+      blockedPrefixes.some((prefix) => file.startsWith(prefix)),
+      false,
+      `PR-1 must not touch blocked prefix: ${file}`,
+    );
+    assert.equal(
+      blockedExactFiles.includes(file),
+      false,
+      `PR-1 must not modify blocked file: ${file}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Add dashboard motion tokens and reusable interaction classes
- Add reduced-motion-safe card/button/row interaction utilities
- Apply foundation to dashboard module cards and workspace back actions
- Add source-contract and E2E smoke coverage for the interaction foundation
- Document PR-1 implementation and constraints

## Validation
- pnpm validate:local
- pnpm --dir frontend build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck

## Notes
- No backend changes
- No dependency changes
- No PWA/auth/middleware/SEO changes
- Does not reintroduce AdminSectionTabs as primary navigation
- Does not reintroduce global dashboard scroll
- Supports prefers-reduced-motion