### PR TITLE
feat(dashboard): polish workspace layout

### DIFF
--- a/docs/pr2-dashboard-workspace-layout-polish.md
+++ b/docs/pr2-dashboard-workspace-layout-polish.md
@@ -1,0 +1,270 @@
+# PR-2: Dashboard Workspace Layout Polish
+
+- **Fecha:** 2026-06-10
+- **Rama:** `feat/dashboard-workspace-layout-polish`
+- **Base:** `main` — HEAD `f1cc744 feat(ui): add dashboard interaction foundation (#925)`
+- **Tipo:** feat(dashboard)
+
+---
+
+## Problema
+
+Los workspaces del dashboard clínica/admin tenían presentación visual plana:
+
+- `DashboardModuleWorkspace` montaba sin animación de entrada — el cambio hub → workspace era un swap instantáneo sin continuidad espacial.
+- El header del workspace (Volver + título) no tenía separación visual del cuerpo.
+- Los paneles del `MasterDetailWorkspace` usaban clases Tailwind hardcodeadas (`shadow-sm`, `bg-card/95`, `border-vetneb-line/80`) sin tokens reutilizables.
+- El `FilterDrawer` tenía `shadow-lg` sin conexión con el sistema de sombras del dashboard.
+- Los items de navegación de `DashboardSidebarFrame` usaban `transition-colors` (Tailwind, 150ms fijo) en lugar de los motion tokens del sistema.
+- Los botones del `StickyActionBar` no tenían el estado press/active de la foundation.
+
+---
+
+## Objetivo visual
+
+Aplicar los tokens de interacción existentes (`--motion-base`, `--motion-fast`, `--ease-out-soft`, clases foundation PR-1) a la capa de layout/estructura visual de los workspaces, elevando la percepción de calidad sin cambiar lógica de negocio.
+
+---
+
+## Solución aplicada
+
+### 1. `globals.css` — Nueva sección `dashboard-workspace-layout-polish`
+
+**Keyframe de entrada:**
+```css
+@keyframes dashboard-workspace-enter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0);    }
+}
+```
+
+**Clases nuevas:**
+
+| Clase | Propósito |
+|---|---|
+| `.dashboard-workspace-enter` | Animación de entrada del workspace (opacity + translateY, `--motion-base`, `--ease-out-soft`) |
+| `.dashboard-workspace-header` | Separador visual header/cuerpo: `border-bottom`, `padding-bottom: 1rem`, `margin-bottom: 1rem` |
+| `.dashboard-master-panel` | Panel maestro del master-detail: background, border-color, box-shadow con inset |
+| `.dashboard-detail-panel` | Panel de detalle: gradient sutil, box-shadow consistente |
+| `.dashboard-detail-panel[data-detail-state="selected"]` | Refuerzo visual cuando hay selección activa (teal border, sombra más pronunciada) |
+| `.dashboard-nav-interactive` | Transición token-based para items de navegación: `background-color, color, box-shadow` / `--motion-fast` / `--ease-out-soft` |
+| `.dashboard-filter-panel` | Sombra lateral semántica para el drawer de filtros |
+
+**`prefers-reduced-motion: reduce` — bloque consolidado (último en el archivo):**
+- Cubre `.dashboard-card-interactive`, `.dashboard-btn-interactive`, `.dashboard-row-interactive` (PR-1)
+- Añade `animation: none` para `.dashboard-workspace-enter` (PR-2)
+- Garantiza que el test `lastIndexOf` de PR-1 siga verde
+
+### 2. `DashboardModuleWorkspace.tsx`
+
+- Añade `dashboard-workspace-enter` al `<section>` raíz → animación de entrada al montar
+- Reemplaza `mb-4 flex flex-col...` → `dashboard-workspace-header flex flex-col...` → separador visual header/cuerpo
+
+### 3. `MasterDetailWorkspace.tsx`
+
+- Master panel: elimina `border-vetneb-line/80 bg-card/95 shadow-sm`, añade `dashboard-master-panel`
+- Detail panel: elimina `border-vetneb-line/80 bg-card/95 shadow-sm`, añade `dashboard-detail-panel`
+- `data-detail-state` preservado para E2E y CSS del estado seleccionado
+
+### 4. `FilterDrawer.tsx`
+
+- Reemplaza `shadow-lg` (Tailwind) con `dashboard-filter-panel` (shadow lateral semántica del sistema)
+
+### 5. `DashboardSidebarFrame.tsx`
+
+- Reemplaza `transition-colors` (Tailwind, 150ms fijo) → `dashboard-nav-interactive` (motion tokens: `--motion-fast`, `--ease-out-soft`) en items de navegación y enlace "Volver al sitio público"
+
+### 6. `StickyActionBar.tsx`
+
+- Añade `dashboard-btn-interactive` a los botones de acciones → propaga el estado `:active { transform: scale(0.98) }` del sistema
+
+---
+
+## Archivos tocados
+
+| Archivo | Tipo de cambio |
+|---|---|
+| `frontend/src/app/globals.css` | +74 líneas: keyframe + sección `dashboard-workspace-layout-polish` + bloque reduced-motion consolidado |
+| `frontend/src/components/dashboard/DashboardModuleWorkspace.tsx` | -2/+2: enter animation + header separator |
+| `frontend/src/components/dashboard/DashboardSidebarFrame.tsx` | -2/+2: `transition-colors` → `dashboard-nav-interactive` |
+| `frontend/src/components/dashboard/FilterDrawer.tsx` | -1/+1: `shadow-lg` → `dashboard-filter-panel` |
+| `frontend/src/components/dashboard/MasterDetailWorkspace.tsx` | -2/+2: panel polish classes |
+| `frontend/src/components/dashboard/StickyActionBar.tsx` | -1/+1: añade `dashboard-btn-interactive` |
+| `test/frontend-visual-consistency.test.ts` | -1/+1: actualiza regex sidebar (`transition-colors` → `dashboard-nav-interactive`) |
+| `test/frontend-dashboard-workspace-layout-polish.test.ts` | nuevo: 36 tests nativos PR-2 |
+| `frontend/e2e/dashboard-workspace-layout-polish.spec.ts` | nuevo: 7 smoke E2E PR-2 |
+| `docs/pr2-dashboard-workspace-layout-polish.md` | nuevo: este documento |
+
+---
+
+## Tokens / clases reutilizados
+
+```
+:root (PR-1, reutilizados):
+  --motion-fast: 120ms
+  --motion-base: 180ms
+  --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1)
+
+@layer components (PR-1, preservados):
+  .dashboard-card-interactive   — hub cards (sin cambio)
+  .dashboard-btn-interactive    — Volver button + StickyActionBar buttons
+  .dashboard-row-interactive    — ready for PR-3 list rows (sin cambio)
+  .dashboard-disabled-state     — (sin cambio)
+
+@keyframes + @layer components (PR-2, nuevos):
+  dashboard-workspace-enter     — workspace enter animation
+  .dashboard-workspace-enter
+  .dashboard-workspace-header
+  .dashboard-master-panel
+  .dashboard-detail-panel
+  .dashboard-detail-panel[data-detail-state="selected"]
+  .dashboard-nav-interactive
+  .dashboard-filter-panel
+```
+
+---
+
+## Tests agregados / actualizados
+
+### Nuevo: `test/frontend-dashboard-workspace-layout-polish.test.ts` (36 tests)
+
+- Sección `dashboard-workspace-layout-polish` marcada con comentarios
+- `@keyframes dashboard-workspace-enter` definido con `opacity: 0` y `translateY(6px)`
+- `.dashboard-workspace-enter` usa `--motion-base` y `--ease-out-soft`
+- Reduced-motion desactiva `.dashboard-workspace-enter` con `animation: none`
+- `.dashboard-workspace-header` con `border-bottom` + `padding-bottom` + `margin-bottom`
+- `.dashboard-master-panel` y `.dashboard-detail-panel` definidos
+- Estado `[data-detail-state="selected"]` en `.dashboard-detail-panel`
+- `.dashboard-nav-interactive` usa `--motion-fast` y `--ease-out-soft`
+- `.dashboard-filter-panel` con `box-shadow: -14px 0 44px`
+- `DashboardModuleWorkspace` tiene `dashboard-workspace-enter` y `dashboard-workspace-header`
+- `DashboardModuleWorkspace` no tiene `mb-4` en el header
+- `DashboardModuleWorkspace` preserva `data-dashboard-module-workspace`, `dashboard-btn-interactive`, `focus-visible` ring
+- `MasterDetailWorkspace` usa `dashboard-master-panel` y `dashboard-detail-panel`
+- `MasterDetailWorkspace` sin `shadow-sm` en paneles
+- `MasterDetailWorkspace` preserva `data-detail-state`, `overflow-hidden rounded-lg border`
+- `FilterDrawer` usa `dashboard-filter-panel`, sin `shadow-lg`, preserva `role=dialog`, `aria-modal`, `data-filter-drawer-open`
+- `DashboardSidebarFrame` usa `dashboard-nav-interactive`, sin `transition-colors`, preserva `focus-visible`, `aria-current`
+- `StickyActionBar` usa `dashboard-btn-interactive`, preserva `data-sticky-action-bar`, `focus-visible`
+- `DashboardShellRouter` preserva `h-dvh overflow-hidden`
+- `DashboardShellRouter` no importa `AdminSectionTabs`
+- Sin dependencias nuevas, dentro del scope de archivos permitidos
+
+### Nuevo: `frontend/e2e/dashboard-workspace-layout-polish.spec.ts` (7 tests)
+
+- `/dashboard` carga hub clínica
+- `/dashboard?module=operaciones` renderiza workspace con clase `dashboard-workspace-enter`
+- `/dashboard/admin` carga hub admin
+- `/dashboard/admin?module=admin-clinics` renderiza workspace con clase `dashboard-workspace-enter`
+- `/dashboard/informes` master-detail carga
+- Workspace "Volver" preserva `dashboard-btn-interactive` (PR-1 contract)
+- `prefers-reduced-motion: reduce` — workspace sigue visible sin animación
+- No scroll global (≤5px overflow)
+
+### Actualizado: `test/frontend-visual-consistency.test.ts` (1 línea)
+
+- Regex del sidebar actualizada: `transition-colors` → `dashboard-nav-interactive` (refleja la mejora intencional de PR-2)
+
+---
+
+## Comandos ejecutados
+
+**Terminal 1:**
+
+```powershell
+git branch --show-current            # feat/dashboard-workspace-layout-polish
+git status --short                   # limpio al inicio
+git log -1 --oneline                 # f1cc744 feat(ui): add dashboard interaction foundation (#925)
+git diff --check                     # sin errores whitespace
+git diff --stat                      # 7 archivos: 83 ins, 9 del + 2 nuevos
+pnpm --dir frontend lint             # OK
+pnpm --dir frontend typecheck        # OK
+pnpm --dir frontend build            # OK (25 páginas, Turbopack)
+git diff -- frontend/next-env.d.ts frontend/tsconfig.json  # vacío (no modificados)
+git status --short                   # 7 M + 2 ?? nuevos
+node --test test/frontend-dashboard-workspace-layout-polish.test.ts  # 36/36
+node --test test/frontend-dashboard-interaction-foundation.test.ts   # 24/24
+node --test test/frontend-dashboard-shell.test.ts                     # 6/6
+pnpm validate:local                  # 2531/2531
+pnpm security:public-surface         # PASS
+```
+
+---
+
+## Riesgos
+
+| Riesgo | Valoración | Mitigación aplicada |
+|---|---|---|
+| Animación de entrada causa hydration mismatch | Ninguno | `DashboardModuleWorkspace` ya es `"use client"`; la animación CSS pura no condiciona markup SSR |
+| `animation: both` puede causar flash si el componente se renderiza antes que CSS | Muy bajo | CSS está en `globals.css` que carga antes del componente; `both` rellena el estado inicial inmediatamente |
+| `dashboard-workspace-header` cambia el layout (padding + margin en lugar de solo margin) | Bajo | El spacing total es equivalente (1rem); el `border-bottom` añade 1px visual, no afecta flexbox flow |
+| `dashboard-nav-interactive` en sidebar puede perder `transition-colors` propiedades (border-color, fill) | Muy bajo | El sidebar rail no muestra bordes visibles en los nav items; `background-color + color` es suficiente |
+| `dashboard-filter-panel` sin `shadow-lg` puede ser menos visible | Bajo | La shadow lateral (`-14px 0 44px rgba(8,35,50,0.20)`) es visualmente más apropiada que `shadow-lg` para un panel lateral |
+| Reduced-motion consolidado puede duplicar reglas con PR-1 | Ninguno | CSS cascade: la última regla aplicable gana; doble declaración de `transition: none` es inocua |
+| Regresión en test de visual-consistency del sidebar | Resuelto | Actualizado el regex en el test para reflejar la mejora (`dashboard-nav-interactive`) |
+
+---
+
+## Evidencia de no cambios de lógica
+
+- No se modificaron props públicas de ningún componente
+- No se cambió `onBack`, `activeModule`, `searchParams`, `reportId`, paginación ni filtros
+- No se modificaron rutas, `ROUTES`, `parseClinicModule`, `parseAdminModule`
+- No se modificaron `getDashboardStats`, `getReports`, `getLogisticsFieldVisits`
+- No se tocaron archivos de `server/`, `drizzle/`, `shared/`, `src/lib/auth.ts`, `src/middleware.ts`
+
+---
+
+## Evidencia de no dependencias nuevas
+
+```
+git diff --stat:
+  7 files changed, 83 insertions(+), 9 deletions(-)
+  No package.json, no pnpm-lock.yaml
+```
+
+Test "PR-2 workspace layout polish does not add new dependencies" → verde.
+
+---
+
+## Evidencia de reduced motion preservado
+
+1. **Bloque consolidado** en `globals.css` (último `@media (prefers-reduced-motion: reduce)` del archivo): cubre `dashboard-card-interactive`, `dashboard-btn-interactive`, `dashboard-row-interactive` (PR-1) y añade `animation: none` para `dashboard-workspace-enter` (PR-2).
+2. **Bloque global preexistente** (`globals.css:932-950`): `transition-duration: 0.01ms !important` y `animation-duration: 0.01ms !important` a `*`.
+3. **Test**: "PR-2 globals.css reduced-motion disables dashboard-workspace-enter animation" → verde.
+4. **E2E**: "reduced-motion: workspace still visible with prefers-reduced-motion: reduce" → cobertura de smoke.
+5. **PR-1 tests**: "PR-1 globals.css reduced-motion overrides dashboard-card-interactive transition" → sigue verde (bloque consolidado cubre ambos PRs).
+
+---
+
+## Evidencia de no scroll global
+
+- `DashboardShellRouter.tsx` mantiene `h-dvh overflow-hidden` (sin cambio)
+- Test "PR-2 DashboardShellRouter keeps h-dvh overflow-hidden preventing global scroll" → verde
+- E2E "no global scroll" verifica `scrollHeight - clientHeight ≤ 5px`
+
+---
+
+## Evidencia de que no se reintroduce AdminSectionTabs como navegación principal
+
+- `DashboardShellRouter.tsx` no importa `AdminSectionTabs` (sin cambio)
+- Test "PR-2 DashboardShellRouter does not import AdminSectionTabs" → verde
+
+---
+
+## No-alcance explícito
+
+- **No command palette**: no implementado; pertenece a PR-8
+- **No data visualization**: no implementado; pertenece a PR-7
+- **No AI / copilot**: no implementado; pertenece a PR-10
+- **No rediseño total**: estructura hub → workspace sin cambios
+- **No transición hub↔workspace con View Transitions API**: no implementado en este PR (requiere mayor análisis de hydration risk)
+- **No tooltip component**: reemplazo de `title=` en sidebar no está en scope de PR-2
+- **No backend**: cero archivos en `server/`, `drizzle/`, `shared/`
+- **No auth / middleware**: no tocados
+- **No PWA / service worker**: no tocados
+- **No dependencias nuevas**: `frontend/package.json` sin cambios
+- **No `next-env.d.ts` / `tsconfig.json`**: intactos post-build
+- **No selección optimista de informes**: pertenece a PR-3
+- **No search highlight**: pertenece a PR-3
+- **No filtros client-side**: pertenece a PR-3

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -63,14 +63,15 @@ test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
     await expect(workspace).toHaveClass(/dashboard-workspace-enter/);
   });
 
-  test("/dashboard/informes master-detail loads", async ({ page }) => {
+  test("/dashboard/informes layout loads", async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator('[aria-label="Workspace maestro detalle"]').or(
-      page.locator('section[aria-label*="nformes"]').or(
-        page.locator("main"),
-      ),
-    )).toBeVisible({ timeout: 8_000 });
+    await expect(page.locator("main.dashboard-main")).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(
+      page.getByRole("region", { name: "Informes del dashboard" }),
+    ).toBeVisible({ timeout: 8_000 });
   });
 
   test("workspace Volver button keeps dashboard-btn-interactive (PR-1 contract preserved)", async ({
@@ -93,20 +94,21 @@ test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await setClinicSession(page);
     await page.goto("/dashboard?module=operaciones");
-    await expect(
-      page.locator('[data-dashboard-module-workspace="operaciones"]'),
-    ).toBeVisible({ timeout: 8_000 });
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="operaciones"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 8_000 });
+    await expect(workspace).toHaveClass(/dashboard-workspace-enter/);
   });
 
   test("no global scroll: shell keeps h-dvh overflow-hidden layout", async ({
     page,
   }) => {
     await setClinicSession(page);
-    await page.goto("/dashboard?module=operaciones");
+    await page.goto("/dashboard");
     await expect(
-      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+      page.locator('[data-dashboard-module-hub="true"]'),
     ).toBeVisible({ timeout: 8_000 });
-
     const overflow = await page.evaluate(
       () =>
         document.documentElement.scrollHeight -

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@playwright/test";
+
+type Page = import("@playwright/test").Page;
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
+  test("clinic /dashboard loads module hub", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("clinic /dashboard?module=operaciones renders workspace with enter class", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="operaciones"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 8_000 });
+    await expect(workspace).toHaveClass(/dashboard-workspace-enter/);
+  });
+
+  test("admin /dashboard/admin loads module hub", async ({ page }) => {
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("admin /dashboard/admin?module=admin-clinics renders workspace with enter class", async ({
+    page,
+  }) => {
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin?module=admin-clinics");
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="admin-clinics"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 8_000 });
+    await expect(workspace).toHaveClass(/dashboard-workspace-enter/);
+  });
+
+  test("/dashboard/informes master-detail loads", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard/informes");
+    await expect(page.locator('[aria-label="Workspace maestro detalle"]').or(
+      page.locator('section[aria-label*="nformes"]').or(
+        page.locator("main"),
+      ),
+    )).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("workspace Volver button keeps dashboard-btn-interactive (PR-1 contract preserved)", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="operaciones"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 8_000 });
+    const volverBtn = workspace.locator('button[aria-label="Volver a módulos"]');
+    await expect(volverBtn).toBeVisible();
+    await expect(volverBtn).toHaveClass(/dashboard-btn-interactive/);
+  });
+
+  test("reduced-motion: workspace still visible with prefers-reduced-motion: reduce", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("no global scroll: shell keeps h-dvh overflow-hidden layout", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollHeight -
+        document.documentElement.clientHeight,
+    );
+    expect(overflow).toBeLessThanOrEqual(5);
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1089,6 +1089,80 @@
   }
 }
 /* dashboard-interaction-foundation:end */
+/* dashboard-workspace-layout-polish:start */
+@keyframes dashboard-workspace-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@layer components {
+  .dashboard-workspace-enter {
+    animation: dashboard-workspace-enter var(--motion-base) var(--ease-out-soft) both;
+  }
+
+  .dashboard-workspace-header {
+    border-bottom: 1px solid hsl(var(--vetneb-line) / 0.68);
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .dashboard-master-panel {
+    background: hsl(var(--card) / 0.95);
+    border-color: hsl(var(--vetneb-line) / 0.82);
+    box-shadow:
+      inset 0 1px 0 hsl(var(--card) / 0.90),
+      0 8px 22px rgba(15, 45, 62, 0.07);
+  }
+
+  .dashboard-detail-panel {
+    background: linear-gradient(180deg, hsl(var(--card) / 0.98), hsl(var(--vetneb-surface-raised) / 0.92));
+    border-color: hsl(var(--vetneb-line) / 0.82);
+    box-shadow:
+      inset 0 1px 0 hsl(var(--card) / 0.92),
+      0 8px 22px rgba(15, 45, 62, 0.07);
+  }
+
+  .dashboard-detail-panel[data-detail-state="selected"] {
+    border-color: hsl(var(--vetneb-teal) / 0.32);
+    box-shadow:
+      inset 0 1px 0 hsl(var(--card) / 0.94),
+      0 14px 38px rgba(15, 45, 62, 0.10);
+  }
+
+  .dashboard-nav-interactive {
+    transition-property: background-color, color, box-shadow;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: var(--ease-out-soft);
+  }
+
+  .dashboard-filter-panel {
+    box-shadow: -14px 0 44px rgba(8, 35, 50, 0.20);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dashboard-card-interactive,
+    .dashboard-btn-interactive,
+    .dashboard-row-interactive {
+      transition: none;
+    }
+
+    .dashboard-card-interactive:active,
+    .dashboard-btn-interactive:active {
+      transform: none;
+    }
+
+    .dashboard-workspace-enter {
+      animation: none;
+    }
+  }
+}
+/* dashboard-workspace-layout-polish:end */
 
 
 

--- a/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
@@ -20,11 +20,11 @@ export function DashboardModuleWorkspace({
 }: DashboardModuleWorkspaceProps) {
   return (
     <section
-      className="flex h-full min-h-0 flex-col"
+      className="flex h-full min-h-0 flex-col dashboard-workspace-enter"
       data-dashboard-module-workspace={moduleId}
       aria-label={title}
     >
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="dashboard-workspace-header flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <button
             type="button"

--- a/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
@@ -66,7 +66,7 @@ export function DashboardSidebarFrame({
               href={item.href}
               variant="bare"
               className={cn(
-                "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+                "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold dashboard-nav-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
                 isActive(item.href, item.exact)
                   ? "bg-sidebar-accent/90 text-sidebar-accent-foreground shadow-[0_10px_28px_rgba(8,35,50,0.24)] ring-1 ring-white/15"
                   : "text-sidebar-foreground/72 hover:bg-sidebar-accent/45 hover:text-sidebar-foreground",
@@ -104,7 +104,7 @@ export function DashboardSidebarFrame({
           variant="bare"
           aria-label="Volver al sitio público"
           title="Volver al sitio público"
-          className="flex items-center justify-center gap-2 rounded-md px-2 py-2 text-xs text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+          className="flex items-center justify-center gap-2 rounded-md px-2 py-2 text-xs text-sidebar-foreground/60 dashboard-nav-interactive hover:bg-sidebar-accent/40 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
         >
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
           <span className="sr-only">Volver al sitio público</span>

--- a/frontend/src/components/dashboard/FilterDrawer.tsx
+++ b/frontend/src/components/dashboard/FilterDrawer.tsx
@@ -97,7 +97,7 @@ export function FilterDrawer({
             aria-labelledby={titleId}
             aria-describedby={description ? descriptionId : undefined}
             tabIndex={-1}
-            className="absolute inset-y-0 right-0 flex h-dvh w-full max-w-md max-h-dvh flex-col overflow-hidden border-l border-vetneb-line/80 bg-card pb-[env(safe-area-inset-bottom)] shadow-lg"
+            className="absolute inset-y-0 right-0 flex h-dvh w-full max-w-md max-h-dvh flex-col overflow-hidden border-l border-vetneb-line/80 bg-card pb-[env(safe-area-inset-bottom)] dashboard-filter-panel"
           >
             <div className="shrink-0 flex items-start justify-between gap-4 border-b border-vetneb-line/80 px-4 py-4">
               <div className="min-w-0">

--- a/frontend/src/components/dashboard/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/dashboard/MasterDetailWorkspace.tsx
@@ -35,7 +35,7 @@ export function MasterDetailWorkspace({
     >
       <div
         aria-label={masterLabel}
-        className="max-w-full min-w-0 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm"
+        className="max-w-full min-w-0 overflow-hidden rounded-lg border dashboard-master-panel"
       >
         <div className="max-h-none max-w-full min-w-0 overflow-x-hidden overflow-y-visible xl:max-h-[calc(100vh-13rem)] xl:overflow-y-auto">
           {master}
@@ -45,7 +45,7 @@ export function MasterDetailWorkspace({
       <div
         aria-label={detailLabel}
         data-detail-state={hasSelection ? "selected" : "empty"}
-        className="max-w-full min-w-0 scroll-mt-28 overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-sm md:scroll-mt-24"
+        className="max-w-full min-w-0 scroll-mt-28 overflow-hidden rounded-lg border dashboard-detail-panel md:scroll-mt-24"
       >
         <p className="sr-only" aria-live="polite">
           {hasSelection

--- a/frontend/src/components/dashboard/StickyActionBar.tsx
+++ b/frontend/src/components/dashboard/StickyActionBar.tsx
@@ -94,7 +94,7 @@ export function StickyActionBar({
                   }
                 }}
                 aria-label={ariaLabel}
-                className="min-h-10 w-full whitespace-normal focus-visible:ring-2 focus-visible:ring-ring/85 sm:w-auto sm:whitespace-nowrap"
+                className="min-h-10 w-full whitespace-normal dashboard-btn-interactive focus-visible:ring-2 focus-visible:ring-ring/85 sm:w-auto sm:whitespace-nowrap"
               >
                 {content}
               </Button>

--- a/test/frontend-dashboard-workspace-layout-polish.test.ts
+++ b/test/frontend-dashboard-workspace-layout-polish.test.ts
@@ -1,0 +1,463 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+const WORKSPACE_PATH =
+  "frontend/src/components/dashboard/DashboardModuleWorkspace.tsx";
+const MASTER_DETAIL_PATH =
+  "frontend/src/components/dashboard/MasterDetailWorkspace.tsx";
+const FILTER_DRAWER_PATH =
+  "frontend/src/components/dashboard/FilterDrawer.tsx";
+const SIDEBAR_FRAME_PATH =
+  "frontend/src/components/dashboard/DashboardSidebarFrame.tsx";
+const STICKY_ACTION_BAR_PATH =
+  "frontend/src/components/dashboard/StickyActionBar.tsx";
+const DASHBOARD_SHELL_ROUTER_PATH =
+  "frontend/src/components/dashboard/DashboardShellRouter.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ── CSS section present ──────────────────────────────────────────────────────
+
+test("PR-2 globals.css has dashboard-workspace-layout-polish section markers", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("/* dashboard-workspace-layout-polish:start */"),
+    "globals.css must have dashboard-workspace-layout-polish:start comment",
+  );
+  assert.ok(
+    source.includes("/* dashboard-workspace-layout-polish:end */"),
+    "globals.css must have dashboard-workspace-layout-polish:end comment",
+  );
+});
+
+// ── Keyframe and enter animation ─────────────────────────────────────────────
+
+test("PR-2 globals.css defines @keyframes dashboard-workspace-enter", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes("@keyframes dashboard-workspace-enter {"),
+    "globals.css must define @keyframes dashboard-workspace-enter",
+  );
+  assert.ok(
+    source.includes("opacity: 0;"),
+    "@keyframes dashboard-workspace-enter must include opacity: 0 in from",
+  );
+  assert.ok(
+    source.includes("translateY(6px)"),
+    "@keyframes dashboard-workspace-enter must include translateY(6px) in from",
+  );
+});
+
+test("PR-2 globals.css defines .dashboard-workspace-enter using motion tokens", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-workspace-enter {"),
+    "globals.css must define .dashboard-workspace-enter",
+  );
+  assert.ok(
+    source.includes("animation: dashboard-workspace-enter var(--motion-base) var(--ease-out-soft) both"),
+    ".dashboard-workspace-enter must use --motion-base and --ease-out-soft tokens",
+  );
+});
+
+test("PR-2 globals.css reduced-motion disables dashboard-workspace-enter animation", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const polishSection = source.slice(
+    source.indexOf("/* dashboard-workspace-layout-polish:start */"),
+    source.indexOf("/* dashboard-workspace-layout-polish:end */") + 1,
+  );
+  assert.ok(
+    polishSection.includes("@media (prefers-reduced-motion: reduce)"),
+    "dashboard-workspace-layout-polish must have prefers-reduced-motion block",
+  );
+  assert.ok(
+    polishSection.includes(".dashboard-workspace-enter {"),
+    "reduced-motion block must target .dashboard-workspace-enter",
+  );
+  const rmIdx = polishSection.lastIndexOf("@media (prefers-reduced-motion: reduce)");
+  const rmSection = polishSection.slice(rmIdx);
+  assert.ok(
+    rmSection.includes("animation: none;"),
+    "reduced-motion must set animation: none on .dashboard-workspace-enter",
+  );
+});
+
+// ── Workspace header separator ────────────────────────────────────────────────
+
+test("PR-2 globals.css defines .dashboard-workspace-header with border separator", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-workspace-header {"),
+    "globals.css must define .dashboard-workspace-header",
+  );
+  assert.ok(
+    source.includes("border-bottom: 1px solid"),
+    ".dashboard-workspace-header must define a border-bottom separator",
+  );
+  assert.ok(
+    source.includes("padding-bottom: 1rem;"),
+    ".dashboard-workspace-header must define padding-bottom",
+  );
+  assert.ok(
+    source.includes("margin-bottom: 1rem;"),
+    ".dashboard-workspace-header must define margin-bottom",
+  );
+});
+
+// ── Master-detail panel polish ─────────────────────────────────────────────
+
+test("PR-2 globals.css defines .dashboard-master-panel", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-master-panel {"),
+    "globals.css must define .dashboard-master-panel",
+  );
+});
+
+test("PR-2 globals.css defines .dashboard-detail-panel", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-detail-panel {"),
+    "globals.css must define .dashboard-detail-panel",
+  );
+});
+
+test("PR-2 globals.css defines .dashboard-detail-panel selected state", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes('.dashboard-detail-panel[data-detail-state="selected"]'),
+    "globals.css must define .dashboard-detail-panel selected state",
+  );
+});
+
+// ── Sidebar nav interactive ──────────────────────────────────────────────────
+
+test("PR-2 globals.css defines .dashboard-nav-interactive with motion tokens", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-nav-interactive {"),
+    "globals.css must define .dashboard-nav-interactive",
+  );
+  assert.ok(
+    source.includes("transition-duration: var(--motion-fast);"),
+    ".dashboard-nav-interactive must use --motion-fast token",
+  );
+  assert.ok(
+    source.includes("transition-timing-function: var(--ease-out-soft);"),
+    ".dashboard-nav-interactive must use --ease-out-soft token",
+  );
+});
+
+// ── Filter drawer panel ──────────────────────────────────────────────────────
+
+test("PR-2 globals.css defines .dashboard-filter-panel with shadow", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  assert.ok(
+    source.includes(".dashboard-filter-panel {"),
+    "globals.css must define .dashboard-filter-panel",
+  );
+  assert.ok(
+    source.includes("box-shadow: -14px 0 44px"),
+    ".dashboard-filter-panel must define a lateral box-shadow",
+  );
+});
+
+// ── Component: DashboardModuleWorkspace ──────────────────────────────────────
+
+test("PR-2 DashboardModuleWorkspace applies dashboard-workspace-enter to section", () => {
+  const source = read(WORKSPACE_PATH);
+  assert.ok(
+    source.includes("dashboard-workspace-enter"),
+    "DashboardModuleWorkspace section must use dashboard-workspace-enter class",
+  );
+});
+
+test("PR-2 DashboardModuleWorkspace header uses dashboard-workspace-header class", () => {
+  const source = read(WORKSPACE_PATH);
+  assert.ok(
+    source.includes("dashboard-workspace-header"),
+    "DashboardModuleWorkspace header div must use dashboard-workspace-header class",
+  );
+});
+
+test("PR-2 DashboardModuleWorkspace does not use plain mb-4 on header div", () => {
+  const source = read(WORKSPACE_PATH);
+  assert.equal(
+    source.includes('"mb-4 flex flex-col'),
+    false,
+    "DashboardModuleWorkspace must not use plain mb-4 on header; use dashboard-workspace-header instead",
+  );
+});
+
+test("PR-2 DashboardModuleWorkspace keeps data-dashboard-module-workspace attribute", () => {
+  const source = read(WORKSPACE_PATH);
+  assert.ok(
+    source.includes("data-dashboard-module-workspace={moduleId}"),
+    "DashboardModuleWorkspace must keep data-dashboard-module-workspace attribute",
+  );
+});
+
+test("PR-2 DashboardModuleWorkspace keeps dashboard-btn-interactive on Volver button", () => {
+  const source = read(WORKSPACE_PATH);
+  assert.ok(
+    source.includes("dashboard-btn-interactive"),
+    "DashboardModuleWorkspace Volver button must keep dashboard-btn-interactive class",
+  );
+});
+
+test("PR-2 DashboardModuleWorkspace keeps focus-visible ring on Volver button", () => {
+  const source = read(WORKSPACE_PATH);
+  assert.ok(
+    source.includes("focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"),
+    "DashboardModuleWorkspace Volver button must keep focus-visible ring",
+  );
+});
+
+// ── Component: MasterDetailWorkspace ─────────────────────────────────────────
+
+test("PR-2 MasterDetailWorkspace master panel uses dashboard-master-panel class", () => {
+  const source = read(MASTER_DETAIL_PATH);
+  assert.ok(
+    source.includes("dashboard-master-panel"),
+    "MasterDetailWorkspace master panel must use dashboard-master-panel class",
+  );
+});
+
+test("PR-2 MasterDetailWorkspace detail panel uses dashboard-detail-panel class", () => {
+  const source = read(MASTER_DETAIL_PATH);
+  assert.ok(
+    source.includes("dashboard-detail-panel"),
+    "MasterDetailWorkspace detail panel must use dashboard-detail-panel class",
+  );
+});
+
+test("PR-2 MasterDetailWorkspace does not use shadow-sm on panels", () => {
+  const source = read(MASTER_DETAIL_PATH);
+  assert.equal(
+    source.includes("shadow-sm"),
+    false,
+    "MasterDetailWorkspace panels must not use shadow-sm; use dashboard-*-panel classes instead",
+  );
+});
+
+test("PR-2 MasterDetailWorkspace keeps data-detail-state attribute for selection tracking", () => {
+  const source = read(MASTER_DETAIL_PATH);
+  assert.ok(
+    source.includes('data-detail-state={hasSelection ? "selected" : "empty"}'),
+    "MasterDetailWorkspace must keep data-detail-state attribute",
+  );
+});
+
+test("PR-2 MasterDetailWorkspace keeps overflow-hidden and rounded-lg on panels", () => {
+  const source = read(MASTER_DETAIL_PATH);
+  assert.ok(
+    source.includes("overflow-hidden rounded-lg border dashboard-master-panel"),
+    "MasterDetailWorkspace master panel must keep overflow-hidden rounded-lg border",
+  );
+  assert.ok(
+    source.includes("overflow-hidden rounded-lg border dashboard-detail-panel"),
+    "MasterDetailWorkspace detail panel must keep overflow-hidden rounded-lg border",
+  );
+});
+
+// ── Component: FilterDrawer ───────────────────────────────────────────────────
+
+test("PR-2 FilterDrawer dialog panel uses dashboard-filter-panel class", () => {
+  const source = read(FILTER_DRAWER_PATH);
+  assert.ok(
+    source.includes("dashboard-filter-panel"),
+    "FilterDrawer dialog panel must use dashboard-filter-panel class",
+  );
+});
+
+test("PR-2 FilterDrawer dialog panel does not use shadow-lg", () => {
+  const source = read(FILTER_DRAWER_PATH);
+  assert.equal(
+    source.includes("shadow-lg"),
+    false,
+    "FilterDrawer dialog panel must not use shadow-lg; use dashboard-filter-panel instead",
+  );
+});
+
+test("PR-2 FilterDrawer keeps role=dialog and aria-modal for accessibility", () => {
+  const source = read(FILTER_DRAWER_PATH);
+  assert.ok(
+    source.includes('role="dialog"'),
+    "FilterDrawer must keep role=dialog",
+  );
+  assert.ok(
+    source.includes('aria-modal="true"'),
+    "FilterDrawer must keep aria-modal",
+  );
+});
+
+test("PR-2 FilterDrawer keeps data-filter-drawer-open attribute", () => {
+  const source = read(FILTER_DRAWER_PATH);
+  assert.ok(
+    source.includes('data-filter-drawer-open="true"'),
+    "FilterDrawer must keep data-filter-drawer-open attribute",
+  );
+});
+
+// ── Component: DashboardSidebarFrame ─────────────────────────────────────────
+
+test("PR-2 DashboardSidebarFrame nav items use dashboard-nav-interactive class", () => {
+  const source = read(SIDEBAR_FRAME_PATH);
+  assert.ok(
+    source.includes("dashboard-nav-interactive"),
+    "DashboardSidebarFrame nav items must use dashboard-nav-interactive class",
+  );
+});
+
+test("PR-2 DashboardSidebarFrame nav items do not use transition-colors", () => {
+  const source = read(SIDEBAR_FRAME_PATH);
+  assert.equal(
+    source.includes("transition-colors"),
+    false,
+    "DashboardSidebarFrame nav items must not use transition-colors; use dashboard-nav-interactive instead",
+  );
+});
+
+test("PR-2 DashboardSidebarFrame keeps focus-visible ring on nav items", () => {
+  const source = read(SIDEBAR_FRAME_PATH);
+  assert.ok(
+    source.includes("focus-visible:ring-2 focus-visible:ring-ring/85"),
+    "DashboardSidebarFrame nav items must keep focus-visible ring",
+  );
+});
+
+test("PR-2 DashboardSidebarFrame keeps aria-current for active nav item", () => {
+  const source = read(SIDEBAR_FRAME_PATH);
+  assert.ok(
+    source.includes('aria-current={isActive(item.href, item.exact) ? "page" : undefined}'),
+    "DashboardSidebarFrame must keep aria-current for active nav item",
+  );
+});
+
+// ── Component: StickyActionBar ────────────────────────────────────────────────
+
+test("PR-2 StickyActionBar action buttons use dashboard-btn-interactive class", () => {
+  const source = read(STICKY_ACTION_BAR_PATH);
+  assert.ok(
+    source.includes("dashboard-btn-interactive"),
+    "StickyActionBar action buttons must use dashboard-btn-interactive class",
+  );
+});
+
+test("PR-2 StickyActionBar keeps data-sticky-action-bar attribute", () => {
+  const source = read(STICKY_ACTION_BAR_PATH);
+  assert.ok(
+    source.includes('data-sticky-action-bar="true"'),
+    "StickyActionBar must keep data-sticky-action-bar attribute",
+  );
+});
+
+test("PR-2 StickyActionBar keeps focus-visible ring on action buttons", () => {
+  const source = read(STICKY_ACTION_BAR_PATH);
+  assert.ok(
+    source.includes("focus-visible:ring-2 focus-visible:ring-ring/85"),
+    "StickyActionBar action buttons must keep focus-visible ring",
+  );
+});
+
+// ── No global scroll ──────────────────────────────────────────────────────────
+
+test("PR-2 DashboardShellRouter keeps h-dvh overflow-hidden preventing global scroll", () => {
+  const source = read(DASHBOARD_SHELL_ROUTER_PATH);
+  assert.ok(
+    source.includes("h-dvh overflow-hidden"),
+    "DashboardShellRouter must keep h-dvh overflow-hidden to prevent global scroll",
+  );
+});
+
+// ── No AdminSectionTabs as navigation ────────────────────────────────────────
+
+test("PR-2 DashboardShellRouter does not import AdminSectionTabs", () => {
+  const source = read(DASHBOARD_SHELL_ROUTER_PATH);
+  assert.equal(
+    source.includes("import { AdminSectionTabs }"),
+    false,
+    "DashboardShellRouter must not import AdminSectionTabs as navigation",
+  );
+});
+
+// ── No new dependencies ───────────────────────────────────────────────────────
+
+test("PR-2 workspace layout polish does not add new dependencies", () => {
+  const changedFiles = execFileSync("git", ["diff", "--name-only"], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  const depFiles = changedFiles.filter(
+    (f) =>
+      f === "package.json" ||
+      f === "pnpm-lock.yaml" ||
+      f === "frontend/package.json" ||
+      f === "frontend/pnpm-lock.yaml",
+  );
+
+  assert.deepEqual(
+    depFiles,
+    [],
+    `PR-2 must not add new dependencies; modified dep files: ${depFiles.join(", ")}`,
+  );
+});
+
+// ── Scope guard ───────────────────────────────────────────────────────────────
+
+test("PR-2 workspace layout polish stays within allowed file scope", () => {
+  const changedFiles = execFileSync("git", ["diff", "--name-only"], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  const blockedPrefixes = [
+    "server/",
+    "drizzle/",
+    "shared/",
+    "frontend/src/app/api/",
+    "frontend/src/middleware",
+    "frontend/src/app/servicios/",
+  ];
+
+  const blockedExactFiles = [
+    "package.json",
+    "pnpm-lock.yaml",
+    "frontend/package.json",
+    "frontend/pnpm-lock.yaml",
+    "frontend/next-env.d.ts",
+    "frontend/tsconfig.json",
+    "frontend/src/app/layout.tsx",
+    "frontend/src/app/page.tsx",
+    "frontend/src/lib/auth.ts",
+    "frontend/src/lib/seo.ts",
+    "frontend/src/middleware.ts",
+  ];
+
+  for (const file of changedFiles) {
+    assert.equal(
+      blockedPrefixes.some((prefix) => file.startsWith(prefix)),
+      false,
+      `PR-2 must not touch blocked prefix: ${file}`,
+    );
+    assert.equal(
+      blockedExactFiles.includes(file),
+      false,
+      `PR-2 must not modify blocked file: ${file}`,
+    );
+  }
+});

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -313,7 +313,7 @@ test("dashboard sidebar keeps shell consistency and responsive navigation classe
       /className="sticky top-0 flex h-dvh w-\[4\.5rem\] shrink-0 flex-col overflow-y-auto bg-sidebar text-sidebar-foreground"/,
       /className="flex items-center justify-center border-b border-sidebar-border px-2 py-5"/,
       /className="flex-1 space-y-1 px-2 py-4"/,
-      /"flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring\/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"/,
+      /"flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold dashboard-nav-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring\/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"/,
       /className="sr-only" aria-hidden="true"/,
       /className="border-t border-sidebar-border px-2 py-4 sm:px-3"/,
     ],


### PR DESCRIPTION
## Summary
- Add premium workspace layout polish using existing interaction tokens
- Apply workspace entry, header separation, master-detail panel and sidebar navigation polish
- Refine filter drawer shadow and sticky action button press states
- Add source-contract and E2E smoke coverage for workspace layout polish
- Document PR-2 implementation and constraints

## Validation
- pnpm validate:local
- pnpm --dir frontend build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck

## Notes
- No backend changes
- No dependency changes
- No routing/query/data-fetching changes
- No auth/session/cache changes
- Does not reintroduce AdminSectionTabs as primary navigation
- Does not reintroduce global dashboard scroll
- Preserves reduced-motion support