### PR TITLE
feat(public): compose home hero and journey

### DIFF
--- a/frontend/e2e/home-hero-evidence-first.spec.ts
+++ b/frontend/e2e/home-hero-evidence-first.spec.ts
@@ -30,4 +30,35 @@ test.describe("home hero — evidence-first (PR-10)", () => {
     await expect(page.locator("body")).toContainText("WhatsApp: 3534138946");
   });
 
+  test("hero compone diagrama estructural del proceso (PR-17)", async ({ page }) => {
+    const diagram = page.locator("[data-hero-system-diagram]");
+    await expect(diagram).toBeVisible();
+    await expect(diagram).toContainText("De la muestra al informe");
+    await expect(diagram).toContainText("Muestra");
+    await expect(diagram).toContainText("Laboratorio");
+    await expect(diagram).toContainText("Evaluación diagnóstica");
+    await expect(diagram).toContainText("Informe");
+    await expect(diagram).toContainText("Acceso digital");
+  });
+
+  test("hero no renderiza términos demo ni datos ficticios (PR-17)", async ({ page }) => {
+    const body = page.locator("body");
+    const forbiddenTerms = [
+      "DEMOSTRATIVO",
+      "DEMO-000",
+      "DEMO-CLINICA",
+      "Paciente demostrativo",
+      "clínica demostrativa",
+      "sin datos reales",
+      "caso demo",
+      "datos ficticios",
+      "informe simulado",
+      "panel operativo simulado",
+    ];
+
+    for (const term of forbiddenTerms) {
+      await expect(body).not.toContainText(term);
+    }
+  });
+
 });

--- a/frontend/e2e/public-service-bento-specimen-journey.spec.ts
+++ b/frontend/e2e/public-service-bento-specimen-journey.spec.ts
@@ -22,6 +22,14 @@ test.describe("service bento + specimen journey (PR-12)", () => {
       );
     });
 
+    test("narrativa end-to-end unificada — sin sección separada (PR-17)", async ({ page }) => {
+      await expect(page.locator("h2#specimen-journey-heading")).toHaveCount(1);
+      await expect(page.locator("#how-it-works-heading")).toHaveCount(0);
+      await expect(page.locator("body")).toContainText("Cómo funciona");
+      await expect(page.locator("body")).toContainText("Trabajar con VETNEB es simple");
+      await expect(page.locator("body")).toContainText("Contactanos para empezar");
+    });
+
     test("renders all 5 specimen journey stages", async ({ page }) => {
       await expect(page.locator("body")).toContainText("Toma y fijación");
       await expect(page.locator("body")).toContainText("Envío coordinado");

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -90,27 +90,6 @@ const clinicalTrustItems = [
   },
 ];
 
-const howItWorksSteps = [
-  {
-    icon: PackageCheck,
-    title: "Enviás la muestra",
-    description:
-      "Preparás la muestra según el protocolo de VETNEB y la enviás con los datos del caso y de la clínica.",
-  },
-  {
-    icon: Microscope,
-    title: "VETNEB analiza",
-    description:
-      "El anatomopatólogo examina el tejido o la muestra citológica y elabora el informe diagnóstico.",
-  },
-  {
-    icon: FileText,
-    title: "Recibís el informe",
-    description:
-      "La clínica lo descarga directamente desde el portal. Si corresponde, el tutor del animal recibe acceso con un código privado.",
-  },
-];
-
 const benefits = [
   {
     title: "Diagnóstico integral",
@@ -144,7 +123,7 @@ const specimenJourneyStages = [
     step: 2,
     icon: PackageCheck,
     title: "Envío coordinado",
-    detail: "La muestra fijada se envía en bolsa tipo ziploc. El envío debe coordinarse previamente vía Web o WhatsApp.",
+    detail: "La muestra fijada se envía en bolsa tipo ziploc, con los datos del caso y de la clínica. El envío debe coordinarse previamente vía Web o WhatsApp.",
     protocol: "Coordinar antes del despacho",
   },
   {
@@ -166,6 +145,14 @@ const specimenJourneyStages = [
     detail: "El informe diagnóstico queda disponible en el portal para la clínica. El tutor del animal puede acceder con código privado.",
     protocol: "Hasta 15 días hábiles desde recepción",
   },
+];
+
+const heroSystemNodes = [
+  { icon: PackageCheck, label: "Muestra" },
+  { icon: Microscope, label: "Laboratorio" },
+  { icon: ClipboardCheck, label: "Evaluación diagnóstica" },
+  { icon: FileText, label: "Informe" },
+  { icon: ShieldCheck, label: "Acceso digital" },
 ];
 
 export default function HomePage() {
@@ -191,67 +178,106 @@ export default function HomePage() {
           aria-hidden="true"
         />
         <div className="relative container mx-auto px-4 py-12 sm:py-14 sm:px-6 md:py-16 lg:py-20 lg:px-8">
-          <div>
-            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-primary-foreground/72">
-              Anatomía Patológica Veterinaria
-            </p>
+          <div className="grid grid-cols-1 items-center gap-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:gap-14">
+            <div>
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-primary-foreground/72">
+                Anatomía Patológica Veterinaria
+              </p>
 
-            <h1
-              id="hero-heading"
-              className="max-w-2xl text-[clamp(1.75rem,4vw,3rem)] font-bold leading-[1.06] tracking-[-0.01em] text-primary-foreground"
-            >
-              Diagnóstico anatomopatológico veterinario con trazabilidad de muestra a informe
-            </h1>
+              <h1
+                id="hero-heading"
+                className="public-display max-w-2xl break-words font-bold text-primary-foreground"
+              >
+                Diagnóstico anatomopatológico veterinario con trazabilidad de muestra a informe
+              </h1>
 
-            <p className="mt-5 max-w-xl text-base leading-relaxed text-primary-foreground/88 sm:text-lg">
-              Histopatología, citología y tinciones especiales con criterio clínico-patológico
-              y seguimiento completo para clínicas y profesionales.
-            </p>
+              <p className="mt-5 max-w-xl text-base leading-relaxed text-primary-foreground/88 sm:text-lg">
+                Histopatología, citología y tinciones especiales con criterio clínico-patológico
+                y seguimiento completo para clínicas y profesionales.
+              </p>
 
-            {/* Firma profesional */}
-            <div className="mt-5 flex w-fit items-center gap-3 rounded-lg border border-white/22 bg-white/[0.08] px-4 py-2.5">
-              <Microscope className="h-5 w-5 shrink-0 text-primary-foreground/72" aria-hidden="true" />
-              <div>
-                <p className="text-sm font-bold leading-tight text-primary-foreground">
-                  Dr. Nicolás E. Barbé
-                </p>
-                <p className="text-xs text-primary-foreground/72">
-                  Médico veterinario patólogo · Responsable de diagnóstico
-                </p>
+              {/* Firma profesional */}
+              <div className="mt-5 flex w-fit items-center gap-3 rounded-lg border border-white/22 bg-white/[0.08] px-4 py-2.5">
+                <Microscope className="h-5 w-5 shrink-0 text-primary-foreground/72" aria-hidden="true" />
+                <div>
+                  <p className="text-sm font-bold leading-tight text-primary-foreground">
+                    Dr. Nicolás E. Barbé
+                  </p>
+                  <p className="text-xs text-primary-foreground/72">
+                    Médico veterinario patólogo · Responsable de diagnóstico
+                  </p>
+                </div>
+              </div>
+
+              {/* CTAs — action tiles */}
+              <div className="public-hero-action-grid">
+                <PublicRouteControl
+                  href={ROUTES.login}
+                  variant="bare"
+                  className="public-hero-action-tile"
+                >
+                  <p className="public-hero-action-tile-label">Portal de informes</p>
+                  <div className="public-hero-action-tile-title">
+                    Acceder al portal
+                    <ArrowRight className="public-hero-action-tile-arrow h-4 w-4" aria-hidden="true" />
+                  </div>
+                  <p className="public-hero-action-tile-copy">
+                    Para clínicas y profesionales con acceso a VETNEB.
+                  </p>
+                </PublicRouteControl>
+
+                <PublicRouteControl
+                  href={ROUTES.particulares}
+                  variant="bare"
+                  className="public-hero-action-tile"
+                >
+                  <p className="public-hero-action-tile-label">Particulares</p>
+                  <div className="public-hero-action-tile-title">
+                    Seguir con código
+                    <ArrowRight className="public-hero-action-tile-arrow h-4 w-4" aria-hidden="true" />
+                  </div>
+                  <p className="public-hero-action-tile-copy">
+                    Consultá el estado de tu muestra las 24 h con tu código privado.
+                  </p>
+                </PublicRouteControl>
               </div>
             </div>
 
-            {/* CTAs — action tiles */}
-            <div className="public-hero-action-grid">
-              <PublicRouteControl
-                href={ROUTES.login}
-                variant="bare"
-                className="public-hero-action-tile"
-              >
-                <p className="public-hero-action-tile-label">Portal de informes</p>
-                <div className="public-hero-action-tile-title">
-                  Acceder al portal
-                  <ArrowRight className="public-hero-action-tile-arrow h-4 w-4" aria-hidden="true" />
-                </div>
-                <p className="public-hero-action-tile-copy">
-                  Para clínicas y profesionales con acceso a VETNEB.
-                </p>
-              </PublicRouteControl>
+            {/* Diagrama estructural del proceso — etapas conceptuales del sistema */}
+            <div
+              role="group"
+              aria-label="Diagrama del proceso diagnóstico: de la muestra al acceso digital"
+              data-hero-system-diagram
+              className="w-full max-w-md rounded-xl border border-white/22 bg-white/[0.08] p-5 sm:p-6 lg:justify-self-end"
+            >
+              <p className="text-xs font-semibold tracking-[0.08em] text-primary-foreground/72">
+                De la muestra al informe
+              </p>
+              <ol className="mt-4">
+                {heroSystemNodes.map((node, index) => {
+                  const NodeIcon = node.icon;
+                  const isLastNode = index === heroSystemNodes.length - 1;
 
-              <PublicRouteControl
-                href={ROUTES.particulares}
-                variant="bare"
-                className="public-hero-action-tile"
-              >
-                <p className="public-hero-action-tile-label">Particulares</p>
-                <div className="public-hero-action-tile-title">
-                  Seguir con código
-                  <ArrowRight className="public-hero-action-tile-arrow h-4 w-4" aria-hidden="true" />
-                </div>
-                <p className="public-hero-action-tile-copy">
-                  Consultá el estado de tu muestra las 24 h con tu código privado.
-                </p>
-              </PublicRouteControl>
+                  return (
+                    <li key={node.label} className="flex gap-3.5">
+                      <div className="flex flex-col items-center">
+                        <span
+                          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/26 bg-white/[0.10] text-primary-foreground"
+                          aria-hidden="true"
+                        >
+                          <NodeIcon className="h-4 w-4" />
+                        </span>
+                        {!isLastNode && (
+                          <span className="my-1 h-4 w-px bg-white/35" aria-hidden="true" />
+                        )}
+                      </div>
+                      <p className="pt-2 text-sm font-semibold leading-snug text-primary-foreground/92">
+                        {node.label}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ol>
             </div>
           </div>
         </div>
@@ -434,96 +460,16 @@ export default function HomePage() {
           </div>
         </section>
 
+        {/* Recorrido end-to-end — de la muestra al informe */}
         <section
-          className="border-y border-vetneb-line/70 bg-card/72 py-14 md:py-20"
-          aria-labelledby="how-it-works-heading"
-        >
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-            <PublicScrollReveal>
-              <div className="mx-auto mb-10 max-w-2xl text-center">
-                <p className="text-sm font-semibold uppercase tracking-[0.08em] text-vetneb-teal">
-                  Cómo funciona
-                </p>
-                <h2
-                  id="how-it-works-heading"
-                  className="mt-3 text-3xl font-bold text-vetneb-ink md:text-4xl"
-                >
-                  Trabajar con VETNEB es simple
-                </h2>
-                <p className="mt-4 text-base leading-relaxed text-muted-foreground md:text-lg">
-                  Desde el envío de la muestra hasta la entrega del informe, el
-                  flujo está pensado para clínicas y profesionales veterinarios.
-                </p>
-              </div>
-            </PublicScrollReveal>
-
-            <PublicScrollReveal staggerChildren>
-              <div className="grid grid-cols-1 gap-5 md:grid-cols-3 md:gap-6">
-                {howItWorksSteps.map((step, index) => {
-                  const StepIcon = step.icon;
-                  const stepHeadingId = `home-how-it-works-step-${index + 1}`;
-
-                  return (
-                    <article
-                      key={step.title}
-                      data-scroll-reveal-item
-                      data-home-how-it-works-step
-                      aria-labelledby={stepHeadingId}
-                      className="h-full rounded-lg border border-vetneb-line/80 bg-card p-5 shadow-sm"
-                    >
-                      <div className="flex items-center gap-4">
-                        <span
-                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)] ring-2 ring-primary/20"
-                          aria-hidden="true"
-                        >
-                          {index + 1}
-                        </span>
-                        <span
-                          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-vetneb-line/80 bg-secondary/60 text-vetneb-teal"
-                          aria-hidden="true"
-                        >
-                          <StepIcon className="h-5 w-5" />
-                        </span>
-                      </div>
-                      <h3
-                        id={stepHeadingId}
-                        className="mt-5 text-xl font-semibold text-vetneb-ink"
-                      >
-                        {step.title}
-                      </h3>
-                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                        {step.description}
-                      </p>
-                    </article>
-                  );
-                })}
-              </div>
-            </PublicScrollReveal>
-
-            <PublicScrollReveal>
-              <div className="mt-8 text-center">
-                <PublicRouteControl
-                  href={ROUTES.contacto}
-                  variant="primaryDark"
-                  className="public-cta-primary w-full sm:w-auto"
-                >
-                  Contactanos para empezar
-                </PublicRouteControl>
-              </div>
-            </PublicScrollReveal>
-          </div>
-        </section>
-
-        {/* Specimen Journey */}
-        <section
-          className="py-14 md:py-20"
+          className="public-evidence-band-muted public-band-feature"
           aria-labelledby="specimen-journey-heading"
         >
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal>
-              <div className="mx-auto mb-10 max-w-3xl text-center">
+              <div className="mx-auto mb-10 max-w-3xl text-center md:mb-14">
                 <p className="text-sm font-semibold uppercase tracking-[0.08em] text-vetneb-teal">
-                  Trazabilidad
+                  Cómo funciona
                 </p>
                 <h2
                   id="specimen-journey-heading"
@@ -532,18 +478,33 @@ export default function HomePage() {
                   Recorrido de la muestra
                 </h2>
                 <p className="mt-4 text-base leading-relaxed text-muted-foreground md:text-lg">
-                  Desde la toma hasta el informe digital, cada etapa del proceso
-                  sigue el protocolo del laboratorio para asegurar la trazabilidad
-                  del diagnóstico.
+                  Trabajar con VETNEB es simple: desde el envío de la muestra
+                  hasta la entrega del informe, el flujo está pensado para
+                  clínicas y profesionales veterinarios.
+                </p>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground md:text-base">
+                  Cada etapa del proceso sigue el protocolo del laboratorio para
+                  asegurar la trazabilidad del diagnóstico.
                 </p>
               </div>
             </PublicScrollReveal>
 
             <PublicScrollReveal>
-              <div className="rounded-xl border border-vetneb-line/70 bg-card/72 p-6 shadow-sm md:p-8">
-                <SpecimenJourneySection
-                  stages={specimenJourneyStages}
-                />
+              <SpecimenJourneySection
+                stages={specimenJourneyStages}
+                variant="timeline"
+              />
+            </PublicScrollReveal>
+
+            <PublicScrollReveal>
+              <div className="mt-10 text-center md:mt-12">
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="primaryDark"
+                  className="public-cta-primary w-full sm:w-auto"
+                >
+                  Contactanos para empezar
+                </PublicRouteControl>
               </div>
             </PublicScrollReveal>
           </div>

--- a/frontend/src/components/public/SpecimenJourneySection.tsx
+++ b/frontend/src/components/public/SpecimenJourneySection.tsx
@@ -12,13 +12,83 @@ export interface SpecimenStage {
 
 interface SpecimenJourneySectionProps {
   stages: SpecimenStage[];
+  variant?: "grid" | "timeline";
   className?: string;
 }
 
 export function SpecimenJourneySection({
   stages,
+  variant = "grid",
   className,
 }: SpecimenJourneySectionProps) {
+  if (variant === "timeline") {
+    return (
+      <ol
+        aria-label="Etapas del recorrido de la muestra"
+        className={cn("grid grid-cols-1 lg:grid-cols-5 lg:gap-x-6", className)}
+      >
+        {stages.map((stage, index) => {
+          const StageIcon = stage.icon;
+          const isLastStage = index === stages.length - 1;
+
+          return (
+            <li
+              key={stage.step}
+              data-specimen-stage={stage.step}
+              className={cn(
+                "relative flex gap-4 lg:flex-col lg:gap-0",
+                !isLastStage && "pb-9 lg:pb-0",
+              )}
+            >
+              {!isLastStage && (
+                <span
+                  className="absolute bottom-0 left-[1.375rem] top-12 w-px bg-vetneb-navy/20 lg:hidden"
+                  aria-hidden="true"
+                />
+              )}
+
+              <div className="flex shrink-0 items-center lg:mb-4 lg:w-full">
+                <span
+                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)] ring-2 ring-primary/20"
+                  aria-hidden="true"
+                >
+                  {stage.step}
+                </span>
+                {!isLastStage && (
+                  <span
+                    className="ml-4 hidden h-px flex-1 bg-vetneb-navy/20 lg:-mr-6 lg:block"
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+
+              <div className="min-w-0">
+                <span
+                  className="mb-2.5 hidden h-9 w-9 items-center justify-center rounded-lg border border-vetneb-line/80 bg-secondary/60 text-vetneb-teal lg:flex"
+                  aria-hidden="true"
+                >
+                  <StageIcon className="h-5 w-5" />
+                </span>
+
+                <p className="text-sm font-semibold leading-snug text-vetneb-ink">
+                  {stage.title}
+                </p>
+                <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+                  {stage.detail}
+                </p>
+                {stage.protocol && (
+                  <span className="mt-2 inline-block rounded border border-vetneb-teal/28 bg-vetneb-teal/[0.08] px-2 py-0.5 text-[0.68rem] font-semibold text-vetneb-navy">
+                    {stage.protocol}
+                  </span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    );
+  }
+
   return (
     <ol
       aria-label="Etapas del recorrido de la muestra"

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -110,7 +110,7 @@ test("home page exposes clinical trust institutional data before services", () =
   const clinicalTrustData = extractBetween(
     source,
     "const clinicalTrustItems = [",
-    "const howItWorksSteps = [",
+    "const benefits = [",
   );
   const forbiddenWords = [
     "marketplace",
@@ -226,19 +226,16 @@ test("home page lists core laboratory services and services route CTA", () => {
   assert.ok(source.includes("Ver todos los servicios"));
 });
 
-test("home page renders how it works section with exactly three operational steps", () => {
+test("home page renders one unified end-to-end journey section (PR-17)", () => {
   const source = read(HOME_PAGE_PATH);
   const servicesIndex = source.indexOf('aria-labelledby="services-heading"');
-  const howItWorksIndex = source.indexOf('aria-labelledby="how-it-works-heading"');
-  const benefitsIndex = source.indexOf('aria-labelledby="benefits-heading"');
-  const stepData = extractBetween(
-    source,
-    "const howItWorksSteps = [",
-    "const benefits = [",
+  const journeyIndex = source.indexOf(
+    'aria-labelledby="specimen-journey-heading"',
   );
+  const benefitsIndex = source.indexOf('aria-labelledby="benefits-heading"');
   const sectionSource = extractBetween(
     source,
-    'aria-labelledby="how-it-works-heading"',
+    'aria-labelledby="specimen-journey-heading"',
     "{/* Beneficios */}",
   );
   const forbiddenWords = [
@@ -250,52 +247,92 @@ test("home page renders how it works section with exactly three operational step
   ];
 
   assert.ok(servicesIndex !== -1);
-  assert.ok(howItWorksIndex !== -1);
+  assert.ok(journeyIndex !== -1);
   assert.ok(benefitsIndex !== -1);
-  assert.ok(servicesIndex < howItWorksIndex);
-  assert.ok(howItWorksIndex < benefitsIndex);
-  assert.ok(source.includes("Cómo funciona"));
-  assert.ok(source.includes("Trabajar con VETNEB es simple"));
-  assert.ok(source.includes('id="how-it-works-heading"'));
-  assert.ok(source.includes("grid grid-cols-1 gap-5 md:grid-cols-3"));
-  assert.ok(source.includes("Contactanos para empezar"));
-  assert.ok(source.includes("href={ROUTES.contacto}"));
+  assert.ok(servicesIndex < journeyIndex);
+  assert.ok(journeyIndex < benefitsIndex);
 
-  assert.equal(count(stepData, "title:"), 3);
-  assert.equal(count(stepData, "description:"), 3);
-  assert.equal(count(stepData, 'title: "Enviás la muestra"'), 1);
-  assert.equal(count(stepData, 'title: "VETNEB analiza"'), 1);
-  assert.equal(count(stepData, 'title: "Recibís el informe"'), 1);
-  assert.equal(
-    count(
-      stepData,
-      "Preparás la muestra según el protocolo de VETNEB y la enviás con los datos del caso y de la clínica.",
+  // Narrativa end-to-end única — sin sección "Cómo funciona" separada
+  assert.equal(count(source, 'aria-labelledby="specimen-journey-heading"'), 1);
+  assert.equal(source.includes('aria-labelledby="how-it-works-heading"'), false);
+  assert.equal(source.includes("const howItWorksSteps"), false);
+  assert.equal(count(source, "Recorrido de la muestra"), 1);
+  assert.equal(count(source, "Cómo funciona"), 1);
+
+  // La fusión conserva contenido funcional, etapas y CTA existentes
+  assert.ok(source.includes('id="specimen-journey-heading"'));
+  assert.ok(
+    source.includes(
+      "Trabajar con VETNEB es simple: desde el envío de la muestra",
     ),
-    1,
   );
-  assert.equal(
-    count(
-      stepData,
-      "El anatomopatólogo examina el tejido o la muestra citológica y elabora el informe diagnóstico.",
+  assert.ok(sectionSource.includes("asegurar la trazabilidad del diagnóstico."));
+  assert.ok(sectionSource.includes("stages={specimenJourneyStages}"));
+  assert.ok(sectionSource.includes('variant="timeline"'));
+  assert.ok(sectionSource.includes("Contactanos para empezar"));
+  assert.ok(sectionSource.includes("href={ROUTES.contacto}"));
+  assert.ok(
+    source.includes(
+      'className="public-evidence-band-muted public-band-feature"\n          aria-labelledby="specimen-journey-heading"',
     ),
-    1,
-  );
-  assert.equal(
-    count(
-      stepData,
-      "La clínica lo descarga directamente desde el portal. Si corresponde, el tutor del animal recibe acceso con un código privado.",
-    ),
-    1,
   );
 
-  const howItWorksSurface = `${stepData}\n${sectionSource}`.toLowerCase();
+  const journeySurface = sectionSource.toLowerCase();
   for (const forbiddenWord of forbiddenWords) {
     assert.equal(
-      howItWorksSurface.includes(forbiddenWord),
+      journeySurface.includes(forbiddenWord),
       false,
-      `how it works section must not contain ${forbiddenWord}`,
+      `unified journey section must not contain ${forbiddenWord}`,
     );
   }
+});
+
+test("home page hero composes structural system diagram without fictional data (PR-17)", () => {
+  const source = read(HOME_PAGE_PATH);
+  const heroSection = extractBetween(
+    source,
+    'aria-labelledby="hero-heading"',
+    "Banda utilitaria",
+  );
+  const nodesData = extractBetween(
+    source,
+    "const heroSystemNodes = [",
+    "export default function HomePage()",
+  );
+
+  // h1 usa la tipografía display de PR-16
+  assert.ok(
+    source.includes(
+      'className="public-display max-w-2xl break-words font-bold text-primary-foreground"',
+    ),
+  );
+
+  // Composición en dos zonas en desktop, una columna en mobile
+  assert.ok(
+    heroSection.includes(
+      "grid grid-cols-1 items-center gap-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]",
+    ),
+  );
+
+  // Diagrama estructural del proceso — nodos conceptuales conectados
+  assert.ok(heroSection.includes("data-hero-system-diagram"));
+  assert.ok(
+    heroSection.includes(
+      'aria-label="Diagrama del proceso diagnóstico: de la muestra al acceso digital"',
+    ),
+  );
+  assert.ok(heroSection.includes("De la muestra al informe"));
+  assert.ok(heroSection.includes("heroSystemNodes.map((node, index)"));
+
+  assert.equal(count(nodesData, "label:"), 5);
+  assert.ok(nodesData.includes('label: "Muestra"'));
+  assert.ok(nodesData.includes('label: "Laboratorio"'));
+  assert.ok(nodesData.includes('label: "Evaluación diagnóstica"'));
+  assert.ok(nodesData.includes('label: "Informe"'));
+  assert.ok(nodesData.includes('label: "Acceso digital"'));
+
+  // El diagrama no contiene datos: ni códigos, ni fechas, ni cifras
+  assert.equal(/\d/.test(nodesData), false);
 });
 
 test("home page lists benefits for clinics and professionals", () => {
@@ -310,16 +347,25 @@ test("home page lists benefits for clinics and professionals", () => {
   assert.ok(source.includes("El análisis no es automatizado: requiere evaluación microscópica especializada"));
 });
 
-test("home page does not contain demo or simulated content (PR-15 guard)", () => {
+test("home page does not contain demo or simulated content (PR-15/PR-17 guard)", () => {
   const source = read(HOME_PAGE_PATH);
   const demoTerms = [
+    "MUESTRA",
     "DEMOSTRATIVO",
     "DEMO-000",
     "DEMO-CLINICA",
     "Paciente demostrativo",
     "Canino demostrativo",
+    "paciente demostrativo",
+    "clínica demostrativa",
     "Ejemplo visual sin datos reales",
+    "sin datos reales",
+    "caso demo",
+    "datos ficticios",
+    "informe simulado",
+    "informe inventado",
     "panel operativo simulado",
+    "dashboard ficticio",
     "report-preview-card-title",
     "ReportPreviewCard",
   ];

--- a/test/frontend-public-service-bento-specimen-journey.test.ts
+++ b/test/frontend-public-service-bento-specimen-journey.test.ts
@@ -41,6 +41,14 @@ test("SpecimenJourneySection uses protocol-badge slot for optional protocol text
   assert.ok(source.includes("{stage.protocol}"));
 });
 
+test("SpecimenJourneySection supports timeline variant with grid default (PR-17)", () => {
+  const source = read(SPECIMEN_JOURNEY_COMPONENT_PATH);
+
+  assert.ok(source.includes('variant?: "grid" | "timeline"'));
+  assert.ok(source.includes('variant = "grid"'));
+  assert.ok(source.includes('if (variant === "timeline")'));
+});
+
 test("SpecimenJourneySection does not import gsap or add animations", () => {
   const source = read(SPECIMEN_JOURNEY_COMPONENT_PATH);
 
@@ -82,21 +90,23 @@ test("home page bento preserves services-heading contract", () => {
 
 // ─── Home page — specimen journey section ────────────────────────────────────
 
-test("home page has Specimen Journey section with correct heading contract", () => {
+test("home page has unified journey section with correct heading contract (PR-17)", () => {
   const source = read(HOME_PATH);
 
   assert.ok(source.includes('aria-labelledby="specimen-journey-heading"'));
   assert.ok(source.includes('id="specimen-journey-heading"'));
   assert.ok(source.includes("Recorrido de la muestra"));
-  assert.ok(source.includes("Trazabilidad"));
+  assert.ok(source.includes("Cómo funciona"));
+  assert.ok(source.includes("asegurar la trazabilidad del diagnóstico."));
 });
 
-test("home page Specimen Journey uses SpecimenJourneySection component", () => {
+test("home page Specimen Journey uses SpecimenJourneySection timeline variant", () => {
   const source = read(HOME_PATH);
 
   assert.ok(source.includes('from "@/components/public/SpecimenJourneySection"'));
   assert.ok(source.includes("<SpecimenJourneySection"));
   assert.ok(source.includes("stages={specimenJourneyStages}"));
+  assert.ok(source.includes('variant="timeline"'));
 });
 
 test("home page specimen journey stages contain all 5 required stages", () => {

--- a/test/frontend-public-visual-polish-regression-contract.test.ts
+++ b/test/frontend-public-visual-polish-regression-contract.test.ts
@@ -8,6 +8,8 @@ const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
 const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
 const SERVICIOS_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
 const PUBLIC_ROUTE_CONTROL_PATH = "frontend/src/components/public/PublicRouteControl.tsx";
+const SPECIMEN_JOURNEY_COMPONENT_PATH =
+  "frontend/src/components/public/SpecimenJourneySection.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(/\r\n/g, "\n");
@@ -64,8 +66,8 @@ test("footer FAQ section uses bg-vetneb-surface-muted/40 depth background", () =
 
 // ─── PR #902: Scroll reveal + process step depth ──────────────────────────────
 
-test("home how-it-works step circles have depth shadow and primary ring", () => {
-  const source = read(HOME_PAGE_PATH);
+test("home journey step circles have depth shadow and primary ring", () => {
+  const source = read(SPECIMEN_JOURNEY_COMPONENT_PATH);
 
   assert.ok(source.includes("shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)]"));
   assert.ok(source.includes("ring-2 ring-primary/20"));


### PR DESCRIPTION
## Summary
- Compose the Home hero into content plus a structural VETNEB system diagram
- Apply the PR-16 public display and evidence band utilities to the Home hero/journey flow
- Fuse the previous How it works and Specimen Journey areas into a single end-to-end section
- Add a timeline variant to SpecimenJourneySection while keeping the default grid variant unchanged

## Scope
- Home public page only for active visual changes
- SpecimenJourneySection variant support, default behavior preserved
- Contract/e2e updates for the new Home structure

## Safety
- No public demos, mocks, fictitious cases, dashboard previews, or fake report data
- No copy-commercial expansion; visible text is preserved/recombined from existing content
- No API, auth, DB, workflow, dependency, production, or dashboard changes

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local
- pnpm --dir frontend e2e
- pnpm test
- git diff --check