### PR TITLE
feat(public): refine pricing decision surface

### DIFF
--- a/frontend/src/components/public/PreciosContent.tsx
+++ b/frontend/src/components/public/PreciosContent.tsx
@@ -79,7 +79,7 @@ function PricingSkeletonGrid() {
     <div data-pricing-skeleton="true">
       <p className="sr-only">Cargando precios disponibles...</p>
       <div
-        className="mx-auto grid max-w-7xl grid-cols-1 gap-7 lg:grid-cols-2"
+        className="mx-auto grid max-w-7xl grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10"
         aria-hidden="true"
       >
         {[0, 1].map((i) => (
@@ -153,11 +153,11 @@ export function PreciosContent() {
   return (
     <PublicLayout>
       <section
-        className="public-secondary-hero-surface py-16 text-white md:py-20"
+        className="public-secondary-hero-surface public-band-compact text-white"
         aria-labelledby="pricing-page-title"
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mx-auto mb-10 max-w-2xl text-center">
+          <div className="mx-auto max-w-2xl text-center">
             <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-primary-foreground/90">
               Histopatología · Citología
             </p>
@@ -184,144 +184,150 @@ export function PreciosContent() {
             </div>
           </div>
 
-          <section aria-labelledby="pricing-catalog-heading">
-            <h2 id="pricing-catalog-heading" className="sr-only">
-              Catálogo público de precios por categoría
-            </h2>
+        </div>
+      </section>
 
-            {state.status === "loading" ? (
-              <PricingSkeletonGrid />
-            ) : pricingLoadError ? (
-              <p
-                role="alert"
-                className="mx-auto max-w-4xl rounded-lg bg-vetneb-surface-raised/92 px-5 py-4 text-center text-sm font-medium text-vetneb-navy shadow-none"
-              >
-                No se pudieron cargar los precios. Intente nuevamente.
-              </p>
-            ) : hasPricingItems(pricingCategories) ? (
-              <>
-                <div className="mx-auto grid max-w-7xl grid-cols-1 gap-7 lg:grid-cols-2">
-                  {pricingCategories.map((category) => {
-                    const categoryHeadingId = `pricing-category-${toSemanticId(category.category)}`;
+      <section
+        className="public-evidence-band-light public-band-compact"
+        aria-labelledby="pricing-catalog-heading"
+      >
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 id="pricing-catalog-heading" className="sr-only">
+            Catálogo público de precios por categoría
+          </h2>
 
-                    return (
-                      <article
-                        key={category.category}
-                        aria-labelledby={categoryHeadingId}
+          {state.status === "loading" ? (
+            <PricingSkeletonGrid />
+          ) : pricingLoadError ? (
+            <p
+              role="alert"
+              className="mx-auto max-w-4xl rounded-lg border border-vetneb-line/80 bg-vetneb-surface-raised/92 px-5 py-4 text-center text-sm font-medium text-vetneb-navy shadow-none"
+            >
+              No se pudieron cargar los precios. Intente nuevamente.
+            </p>
+          ) : hasPricingItems(pricingCategories) ? (
+            <>
+              <div className="mx-auto mb-8 max-w-7xl">
+                <div className="clinical-card px-6 py-5">
+                  <p className="mb-4 text-xs font-semibold uppercase tracking-[0.18em] text-vetneb-ink/70">
+                    Incluido en cada estudio
+                  </p>
+                  <ul className="grid gap-3 sm:grid-cols-3">
+                    {[
+                      "Informe diagnóstico digital",
+                      "Acceso al portal para consulta del caso",
+                      "Seguimiento disponible según complejidad del caso",
+                    ].map((value) => (
+                      <li
+                        key={value}
+                        className="flex items-center gap-2 text-sm text-vetneb-ink"
                       >
-                        <Card className="clinical-card overflow-hidden">
-                          <CardHeader className="clinical-card-header border-b border-vetneb-line px-6 py-5 text-center">
-                            <CardTitle
-                              id={categoryHeadingId}
-                              className="text-center text-base font-semibold uppercase tracking-[0.22em] text-white"
-                            >
-                              {category.category}
-                            </CardTitle>
-                          </CardHeader>
-
-                          <CardContent className="bg-vetneb-surface-raised/60 p-4">
-                            <div className="overflow-hidden rounded-lg border border-vetneb-line bg-card shadow-sm">
-                              {category.items.map((item, index) => (
-                                <div
-                                  key={item.id}
-                                  className={`clinical-hover-row flex flex-col items-start gap-3 px-5 py-4 sm:flex-row sm:items-start sm:justify-between sm:gap-5 ${
-                                    index < category.items.length - 1
-                                      ? "border-b border-vetneb-line/80"
-                                      : ""
-                                  }`}
-                                >
-                                  <p className="w-full min-w-0 break-words text-sm font-semibold uppercase tracking-[0.04em] text-vetneb-ink sm:flex-1">
-                                    {item.studyName}
-                                  </p>
-                                  <p className="clinical-pill max-w-full self-start break-words px-3 py-1 text-sm font-bold tracking-normal shadow-sm sm:ml-auto sm:shrink-0">
-                                    {normalizePriceLabel(item.priceLabel)}
-                                  </p>
-                                </div>
-                              ))}
-                            </div>
-
-                            <div className="mt-4 flex justify-end border-t border-vetneb-line/50 pt-4">
-                              <PublicRouteControl
-                                href="/contacto"
-                                variant="primaryDark"
-                                className="public-cta-primary w-full text-sm sm:w-auto"
-                              >
-                                Consultar este estudio
-                                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                              </PublicRouteControl>
-                            </div>
-                          </CardContent>
-                        </Card>
-                      </article>
-                    );
-                  })}
+                        <CheckCircle2
+                          className="h-4 w-4 shrink-0 text-vetneb-teal"
+                          aria-hidden="true"
+                        />
+                        {value}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
+              </div>
 
+              <div className="mx-auto grid max-w-7xl grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10">
+                {pricingCategories.map((category) => {
+                  const categoryHeadingId = `pricing-category-${toSemanticId(category.category)}`;
+
+                  return (
+                    <article
+                      key={category.category}
+                      aria-labelledby={categoryHeadingId}
+                    >
+                      <Card className="clinical-card overflow-hidden">
+                        <CardHeader className="clinical-card-header border-b border-vetneb-line px-6 py-5 text-center">
+                          <CardTitle
+                            id={categoryHeadingId}
+                            className="text-center text-base font-semibold uppercase tracking-[0.22em] text-white"
+                          >
+                            {category.category}
+                          </CardTitle>
+                        </CardHeader>
+
+                        <CardContent className="bg-vetneb-surface-raised/60 p-4">
+                          <div className="overflow-hidden rounded-lg border border-vetneb-line bg-card shadow-sm">
+                            {category.items.map((item, index) => (
+                              <div
+                                key={item.id}
+                                className={`clinical-hover-row flex flex-col items-start gap-3 px-5 py-4 sm:flex-row sm:items-start sm:justify-between sm:gap-5 ${
+                                  index < category.items.length - 1
+                                    ? "border-b border-vetneb-line/80"
+                                    : ""
+                                }`}
+                              >
+                                <p className="w-full min-w-0 break-words text-sm font-medium leading-6 text-vetneb-ink sm:flex-1">
+                                  {item.studyName}
+                                </p>
+                                <p className="clinical-pill max-w-full self-start break-words px-3.5 py-1.5 text-base font-bold tracking-normal shadow-sm sm:ml-auto sm:shrink-0">
+                                  {normalizePriceLabel(item.priceLabel)}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+
+                          <div className="mt-4 flex justify-end border-t border-vetneb-line/50 pt-4">
+                            <PublicRouteControl
+                              href="/contacto"
+                              variant="primaryDark"
+                              className="public-cta-primary w-full text-sm sm:w-auto"
+                            >
+                              Consultar este estudio
+                              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                            </PublicRouteControl>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </article>
+                  );
+                })}
+              </div>
+
+              {hasConsultarItems(pricingCategories) && (
                 <div className="mx-auto mt-8 max-w-7xl">
                   <div className="clinical-card px-6 py-5">
-                    <p className="mb-4 text-xs font-semibold uppercase tracking-[0.18em] text-vetneb-ink/70">
-                      Incluido en cada estudio
-                    </p>
-                    <ul className="grid gap-3 sm:grid-cols-3">
-                      {[
-                        "Informe diagnóstico digital",
-                        "Acceso al portal para consulta del caso",
-                        "Seguimiento disponible según complejidad del caso",
-                      ].map((value) => (
-                        <li
-                          key={value}
-                          className="flex items-center gap-2 text-sm text-vetneb-ink"
-                        >
-                          <CheckCircle2
-                            className="h-4 w-4 shrink-0 text-vetneb-teal"
-                            aria-hidden="true"
-                          />
-                          {value}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
-
-                {hasConsultarItems(pricingCategories) && (
-                  <div className="mx-auto mt-5 max-w-7xl">
-                    <div className="clinical-card px-6 py-5">
-                      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="flex items-start gap-3">
-                          <HelpCircle
-                            className="mt-0.5 h-5 w-5 shrink-0 text-vetneb-teal"
-                            aria-hidden="true"
-                          />
-                          <div>
-                            <p className="text-sm font-semibold text-vetneb-ink">
-                              Estudios con valor a Consultar
-                            </p>
-                            <p className="mt-1 max-w-xl text-sm text-muted-foreground">
-                              El precio depende de la complejidad, las tinciones
-                              especiales requeridas o la coordinación previa con
-                              el laboratorio.
-                            </p>
-                          </div>
+                    <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="flex items-start gap-3">
+                        <HelpCircle
+                          className="mt-0.5 h-5 w-5 shrink-0 text-vetneb-teal"
+                          aria-hidden="true"
+                        />
+                        <div>
+                          <p className="text-sm font-semibold text-vetneb-ink">
+                            Estudios con valor a Consultar
+                          </p>
+                          <p className="mt-1 max-w-xl text-sm text-muted-foreground">
+                            El precio depende de la complejidad, las tinciones
+                            especiales requeridas o la coordinación previa con
+                            el laboratorio.
+                          </p>
                         </div>
-                        <PublicRouteControl
-                          href="/contacto"
-                          variant="primaryDark"
-                          className="public-cta-primary w-full shrink-0 text-sm sm:w-auto"
-                        >
-                          Coordinar por contacto
-                          <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                        </PublicRouteControl>
                       </div>
+                      <PublicRouteControl
+                        href="/contacto"
+                        variant="primaryDark"
+                        className="public-cta-primary w-full shrink-0 text-sm sm:w-auto"
+                      >
+                        Coordinar por contacto
+                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                      </PublicRouteControl>
                     </div>
                   </div>
-                )}
-              </>
-            ) : (
-              <p className="surface-empty mx-auto max-w-4xl">
-                No hay precios disponibles.
-              </p>
-            )}
-          </section>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="surface-empty mx-auto max-w-4xl">
+              No hay precios disponibles.
+            </p>
+          )}
         </div>
       </section>
     </PublicLayout>

--- a/test/frontend-precios-page-content.test.ts
+++ b/test/frontend-precios-page-content.test.ts
@@ -45,7 +45,7 @@ test("precios page keeps category priority with citologías then histopatología
 test("precios page renders responsive side-by-side category cards with formal medical visual style", () => {
   const source = read(PRECIOS_CONTENT_PATH);
 
-  assert.ok(source.includes("mx-auto grid max-w-7xl grid-cols-1 gap-7 lg:grid-cols-2"));
+  assert.ok(source.includes("mx-auto grid max-w-7xl grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-10"));
   assert.ok(source.includes("clinical-card overflow-hidden"));
   assert.ok(source.includes("clinical-card-header"));
   assert.ok(source.includes("border-b border-vetneb-line px-6 py-5 text-center"));
@@ -70,12 +70,18 @@ test("precios page renders price rows with bordered pills and clear hierarchy", 
   );
   assert.ok(
     source.includes(
+      "w-full min-w-0 break-words text-sm font-medium leading-6 text-vetneb-ink sm:flex-1",
+    ),
+  );
+  assert.equal(
+    source.includes(
       "w-full min-w-0 break-words text-sm font-semibold uppercase tracking-[0.04em] text-vetneb-ink sm:flex-1",
     ),
+    false,
   );
   assert.ok(
     source.includes(
-      "clinical-pill max-w-full self-start break-words px-3 py-1 text-sm font-bold tracking-normal shadow-sm sm:ml-auto sm:shrink-0",
+      "clinical-pill max-w-full self-start break-words px-3.5 py-1.5 text-base font-bold tracking-normal shadow-sm sm:ml-auto sm:shrink-0",
     ),
   );
   assert.ok(source.includes("normalizePriceLabel(item.priceLabel)"));
@@ -126,6 +132,46 @@ test("precios page and content do not contain demo or simulated content (PR-15 g
       `precios must not contain "${term}"`,
     );
   }
+});
+
+test("precios page separates compact hero from light catalog band (PR-19)", () => {
+  const source = read(PRECIOS_CONTENT_PATH);
+
+  assert.ok(
+    source.includes("public-secondary-hero-surface public-band-compact"),
+    "hero must stay on the shared dark surface with compact band rhythm",
+  );
+  assert.ok(
+    source.includes("public-evidence-band-light public-band-compact"),
+    "catalog must live on a light evidence band outside the hero",
+  );
+
+  const heroIndex = source.indexOf("public-secondary-hero-surface");
+  const catalogBandIndex = source.indexOf("public-evidence-band-light");
+  assert.ok(heroIndex !== -1);
+  assert.ok(catalogBandIndex !== -1);
+  assert.ok(
+    heroIndex < catalogBandIndex,
+    "hero section must render before the catalog band",
+  );
+
+  const incluidoIndex = source.indexOf("Incluido en cada estudio");
+  const catalogGridIndex = source.indexOf(
+    "{pricingCategories.map((category) => {",
+  );
+  assert.ok(incluidoIndex !== -1);
+  assert.ok(catalogGridIndex !== -1);
+  assert.ok(
+    incluidoIndex < catalogGridIndex,
+    "'Incluido en cada estudio' must appear before the pricing catalog",
+  );
+
+  const consultarBlockIndex = source.indexOf("Estudios con valor a Consultar");
+  assert.ok(consultarBlockIndex !== -1);
+  assert.ok(
+    catalogGridIndex < consultarBlockIndex,
+    "'Estudios con valor a Consultar' must close the catalog as actionable CTA",
+  );
 });
 
 test("precios page renders grouped categories and study items when categories exist", () => {


### PR DESCRIPTION
## Summary
- Separate the pricing hero from the catalog into a compact dark hero plus light decision surface
- Move Included in each study before the pricing catalog so value is visible before prices
- Refine pricing rows and Consultar handling visually while preserving pricing data and behavior

## Scope
- /precios public page only
- Pricing visual structure and tests
- No API/cache/sorting/business-logic changes

## Safety
- No public demos, mocks, fictitious cases, dashboard previews, or fake report data
- No copy-commercial expansion; visible text is preserved/reordered only
- No Home, clinics, services, contact, dashboard, navbar, footer, auth, DB, workflow, dependency, or production changes

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local
- pnpm test
- git diff --check