### PR TITLE
feat(public): refine clinics product layout

### DIFF
--- a/frontend/e2e/public-clinics-b2b-operations.spec.ts
+++ b/frontend/e2e/public-clinics-b2b-operations.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("clinicas B2B operations landing (PR-14)", () => {
+test.describe("clinicas B2B product landing (PR-20)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/clinicas");
     await page.waitForLoadState("domcontentloaded");
@@ -25,6 +25,7 @@ test.describe("clinicas B2B operations landing (PR-14)", () => {
         'ol[aria-label="Pasos operativos de derivación con VETNEB"]',
       );
       await expect(ol).toBeVisible();
+      await expect(ol.locator("[data-clinic-op-step]")).toHaveCount(5);
     });
 
     test("renders derivación step", async ({ page }) => {
@@ -59,6 +60,56 @@ test.describe("clinicas B2B operations landing (PR-14)", () => {
     });
   });
 
+  test.describe("B2B product modules", () => {
+    test("groups all six capabilities into three named modules", async ({
+      page,
+    }) => {
+      const modules = page.locator("[data-clinic-module]");
+
+      await expect(modules).toHaveCount(3);
+      await expect(modules.nth(0)).toHaveAttribute(
+        "data-clinic-module",
+        "informes",
+      );
+      await expect(modules.nth(1)).toHaveAttribute(
+        "data-clinic-module",
+        "operacion",
+      );
+      await expect(modules.nth(2)).toHaveAttribute(
+        "data-clinic-module",
+        "gestion",
+      );
+
+      for (const productModule of await modules.all()) {
+        await expect(productModule.locator("article")).toHaveCount(2);
+      }
+    });
+
+    test("keeps the six existing feature titles visible", async ({ page }) => {
+      for (const title of [
+        "Recepción de informes",
+        "Búsqueda avanzada",
+        "Seguimiento de logística",
+        "Acceso seguro y auditado",
+        "Gestión de usuarios",
+        "Perfil público",
+      ]) {
+        await expect(page.getByRole("heading", { name: title })).toBeVisible();
+      }
+    });
+  });
+
+  test("renders onboarding as four connected steps", async ({ page }) => {
+    const onboarding = page.locator(
+      'ol[aria-label="Pasos para comenzar con Portal VETNEB"]',
+    );
+
+    await expect(onboarding).toBeVisible();
+    await expect(
+      onboarding.locator("[data-clinic-onboarding-step]"),
+    ).toHaveCount(4);
+  });
+
   test.describe("B2B conversion CTAs", () => {
     test("renders conversion heading", async ({ page }) => {
       await expect(
@@ -90,23 +141,30 @@ test.describe("clinicas B2B operations landing (PR-14)", () => {
   });
 
   test.describe("no demo/fictitious content", () => {
-    test("no demo badge present", async ({ page }) => {
-      await expect(page.locator("body")).not.toContainText(/DEMOSTRATIVO/i);
-      await expect(page.locator("body")).not.toContainText(/Muestra · Demostrativo/i);
-    });
+    test("does not render prohibited demo or fictitious content", async ({
+      page,
+    }) => {
+      const body = page.locator("body");
 
-    test("no fictitious patient data present", async ({ page }) => {
-      await expect(page.locator("body")).not.toContainText(
-        /Paciente demostrativo/i,
-      );
-      await expect(page.locator("body")).not.toContainText(
-        /Clínica demostrativa/i,
-      );
-    });
-
-    test("no DEMO-000 or DEMO-CLINICA case codes present", async ({ page }) => {
-      await expect(page.locator("body")).not.toContainText(/DEMO-000/i);
-      await expect(page.locator("body")).not.toContainText(/DEMO-CLINICA/i);
+      for (const prohibitedText of [
+        "MUESTRA",
+        "DEMOSTRATIVO",
+        "ejemplo visual",
+        "sin datos reales",
+        "caso demo",
+        "DEMO-000",
+        "DEMO-CLINICA-001",
+        "paciente demostrativo",
+        "clínica demostrativa",
+        "preview de informe simulado",
+        "panel operativo simulado",
+        "dashboard ficticio",
+        "informe inventado",
+        "datos ficticios visibles",
+        "mocks públicos falsos",
+      ]) {
+        await expect(body).not.toContainText(prohibitedText);
+      }
     });
 
     test("no simulated report preview", async ({ page }) => {
@@ -136,6 +194,23 @@ test.describe("clinicas B2B operations landing (PR-14)", () => {
 
     test("onboarding steps preserved", async ({ page }) => {
       await expect(page.locator("h2#clinicas-onboarding-heading")).toBeVisible();
+    });
+
+    test("clinicas JSON-LD remains present", async ({ page }) => {
+      const jsonLdScripts = await page
+        .locator('script[type="application/ld+json"]')
+        .allTextContents();
+
+      expect(jsonLdScripts.length).toBeGreaterThan(0);
+      expect(
+        jsonLdScripts.some((content) =>
+          content.includes("Portal para Clínicas Veterinarias"),
+        ),
+      ).toBe(true);
+
+      for (const content of jsonLdScripts) {
+        expect(() => JSON.parse(content)).not.toThrow();
+      }
     });
   });
 

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -14,15 +14,7 @@ import {
 import { PublicLayout } from "@/components/layout/PublicLayout";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { VisualIcon } from "@/components/public/VisualAccents";
-import { ClinicOperationsSection } from "@/components/public/ClinicOperationsSection";
 import { createPageMetadata, getClinicasPageJsonLd } from "@/lib/seo";
 import { ROUTES } from "@/lib/routes";
 
@@ -32,48 +24,66 @@ export const metadata: Metadata = createPageMetadata(
   "/clinicas",
 );
 
-const features = [
+const featureModules = [
   {
-    icon: FileText,
-    tone: "blue" as const,
-    title: "Recepción de informes",
-    description:
-      "Los informes diagnósticos de cada estudio están disponibles en el portal de la clínica, con notificación cuando están listos.",
+    id: "informes",
+    label: "Informes",
+    features: [
+      {
+        icon: FileText,
+        tone: "blue" as const,
+        title: "Recepción de informes",
+        description:
+          "Los informes diagnósticos de cada estudio están disponibles en el portal de la clínica, con notificación cuando están listos.",
+      },
+      {
+        icon: Search,
+        tone: "emerald" as const,
+        title: "Búsqueda avanzada",
+        description:
+          "Encontrá informes por paciente, tipo de estudio, fecha o estado. Filtros orientados a la operación diaria de alto volumen.",
+      },
+    ],
   },
   {
-    icon: Search,
-    tone: "emerald" as const,
-    title: "Búsqueda avanzada",
-    description:
-      "Encontrá informes por paciente, tipo de estudio, fecha o estado. Filtros orientados a la operación diaria de alto volumen.",
+    id: "operacion",
+    label: "Operación",
+    features: [
+      {
+        icon: Truck,
+        tone: "amber" as const,
+        title: "Seguimiento de logística",
+        description:
+          "Consultá el estado de las muestras derivadas y las visitas coordinadas con tu clínica. Trazabilidad en cada etapa.",
+      },
+      {
+        icon: ShieldCheck,
+        tone: "blue" as const,
+        title: "Acceso seguro y auditado",
+        description:
+          "Cada acceso a informes queda registrado. Control sobre quién accede a qué información y cuándo.",
+      },
+    ],
   },
   {
-    icon: Truck,
-    tone: "amber" as const,
-    title: "Seguimiento de logística",
-    description:
-      "Consultá el estado de las muestras derivadas y las visitas coordinadas con tu clínica. Trazabilidad en cada etapa.",
-  },
-  {
-    icon: ShieldCheck,
-    tone: "blue" as const,
-    title: "Acceso seguro y auditado",
-    description:
-      "Cada acceso a informes queda registrado. Control sobre quién accede a qué información y cuándo.",
-  },
-  {
-    icon: UsersRound,
-    tone: "slate" as const,
-    title: "Gestión de usuarios",
-    description:
-      "Administrá los usuarios de tu clínica con roles diferenciados: propietario y personal de clínica.",
-  },
-  {
-    icon: Globe2,
-    tone: "emerald" as const,
-    title: "Perfil público",
-    description:
-      "Mantené actualizado el perfil público de tu clínica en el directorio de Portal VETNEB.",
+    id: "gestion",
+    label: "Gestión",
+    features: [
+      {
+        icon: UsersRound,
+        tone: "slate" as const,
+        title: "Gestión de usuarios",
+        description:
+          "Administrá los usuarios de tu clínica con roles diferenciados: propietario y personal de clínica.",
+      },
+      {
+        icon: Globe2,
+        tone: "emerald" as const,
+        title: "Perfil público",
+        description:
+          "Mantené actualizado el perfil público de tu clínica en el directorio de Portal VETNEB.",
+      },
+    ],
   },
 ];
 
@@ -193,7 +203,7 @@ export default function ClinicasPage() {
       </section>
 
       <div className="public-soft-canvas">
-        {/* Capacidades del portal */}
+        {/* Capacidades del portal agrupadas en 3 módulos de producto */}
         <section
           className="py-16 md:py-20"
           aria-labelledby="clinicas-features-heading"
@@ -215,37 +225,72 @@ export default function ClinicasPage() {
             </PublicScrollReveal>
 
             <PublicScrollReveal variant="cards" staggerChildren>
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {features.map((feature) => {
-                  const featureHeadingId = `clinicas-feature-${feature.title.toLowerCase().replace(/\s+/g, "-")}`;
+              <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2">
+                {featureModules.map((module, moduleIndex) => {
+                  const moduleHeadingId = `clinicas-module-${module.id}`;
+                  const isLeadModule = moduleIndex === 0;
 
                   return (
-                    <article
-                      key={feature.title}
+                    <section
+                      key={module.id}
                       data-scroll-reveal-item
-                      aria-labelledby={featureHeadingId}
+                      data-clinic-module={module.id}
+                      aria-labelledby={moduleHeadingId}
+                      className={`premium-card p-6 md:p-7 ${
+                        isLeadModule ? "lg:col-span-2" : ""
+                      }`}
                     >
-                      <Card className="premium-card">
-                        <CardHeader>
-                          <VisualIcon
-                            icon={feature.icon}
-                            tone={feature.tone}
-                            className="mb-2"
-                          />
-                          <CardTitle
-                            id={featureHeadingId}
-                            className="text-lg text-vetneb-ink"
-                          >
-                            {feature.title}
-                          </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                          <CardDescription className="text-sm leading-relaxed text-muted-foreground">
-                            {feature.description}
-                          </CardDescription>
-                        </CardContent>
-                      </Card>
-                    </article>
+                      <div className="flex items-center gap-3">
+                        <h3
+                          id={moduleHeadingId}
+                          className="text-xs font-semibold uppercase tracking-[0.14em] text-vetneb-teal"
+                        >
+                          {module.label}
+                        </h3>
+                        <span
+                          className="h-px flex-1 bg-vetneb-line/70"
+                          aria-hidden="true"
+                        />
+                      </div>
+                      <div
+                        className={
+                          isLeadModule
+                            ? "mt-5 grid grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8"
+                            : "mt-5 flex flex-col divide-y divide-vetneb-line/60"
+                        }
+                      >
+                        {module.features.map((feature) => {
+                          const featureHeadingId = `clinicas-feature-${feature.title.toLowerCase().replace(/\s+/g, "-")}`;
+
+                          return (
+                            <article
+                              key={feature.title}
+                              aria-labelledby={featureHeadingId}
+                              className={
+                                isLeadModule ? "" : "py-5 first:pt-0 last:pb-0"
+                              }
+                            >
+                              <VisualIcon
+                                icon={feature.icon}
+                                tone={feature.tone}
+                                className="mb-3"
+                              />
+                              <h4
+                                id={featureHeadingId}
+                                className={`font-semibold text-vetneb-ink ${
+                                  isLeadModule ? "text-lg" : "text-base"
+                                }`}
+                              >
+                                {feature.title}
+                              </h4>
+                              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                                {feature.description}
+                              </p>
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </section>
                   );
                 })}
               </div>
@@ -255,12 +300,12 @@ export default function ClinicasPage() {
 
         {/* Cómo opera tu clínica con VETNEB */}
         <section
-          className="border-t border-vetneb-line/70 py-16 md:py-20"
+          className="public-evidence-band-muted public-band-feature"
           aria-labelledby="clinicas-operations-heading"
         >
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
-              <div className="mx-auto mb-10 max-w-3xl text-center">
+              <div className="mx-auto mb-10 max-w-3xl text-center md:mb-14">
                 <p className="text-sm font-semibold uppercase tracking-[0.08em] text-vetneb-teal">
                   Flujo operativo
                 </p>
@@ -278,10 +323,72 @@ export default function ClinicasPage() {
               </div>
             </PublicScrollReveal>
 
-            <PublicScrollReveal variant="minimal">
-              <div className="mx-auto max-w-2xl rounded-xl border border-vetneb-line/70 bg-card/72 p-6 shadow-sm md:p-8">
-                <ClinicOperationsSection steps={operationSteps} />
-              </div>
+            <PublicScrollReveal variant="cards" staggerChildren>
+              <ol
+                aria-label="Pasos operativos de derivación con VETNEB"
+                className="mx-auto grid max-w-6xl grid-cols-1 lg:grid-cols-5"
+              >
+                {operationSteps.map((step, index) => {
+                  const StepIcon = step.icon;
+                  const isLastStep = index === operationSteps.length - 1;
+
+                  return (
+                    <li
+                      key={step.step}
+                      data-scroll-reveal-item
+                      data-clinic-op-step={step.step}
+                      className={`relative flex gap-4 lg:flex-col lg:gap-0 lg:pr-6 lg:last:pr-0 ${
+                        isLastStep ? "" : "pb-9 lg:pb-0"
+                      }`}
+                    >
+                      {!isLastStep && (
+                        <span
+                          className="absolute bottom-0 left-4 top-9 w-px bg-gradient-to-b from-vetneb-teal/38 to-vetneb-line/28 lg:hidden"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <div className="flex shrink-0 items-center lg:w-full">
+                        <span
+                          className="relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-xs font-bold text-primary-foreground shadow-[0_4px_10px_hsl(var(--vetneb-navy)/0.26)] ring-2 ring-vetneb-teal/18"
+                          aria-hidden="true"
+                        >
+                          {String(step.step).padStart(2, "0")}
+                        </span>
+                        {!isLastStep && (
+                          <span
+                            className="ml-4 hidden h-px flex-1 bg-gradient-to-r from-vetneb-teal/45 to-vetneb-line/45 lg:-mr-6 lg:block"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </div>
+                      <div className="min-w-0 pt-0.5 lg:mt-6 lg:pt-0">
+                        <div className="flex items-start gap-2.5">
+                          <span
+                            className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded border border-vetneb-line/65 bg-card/85 text-vetneb-teal"
+                            aria-hidden="true"
+                          >
+                            <StepIcon
+                              className="h-4 w-4"
+                              strokeWidth={1.9}
+                            />
+                          </span>
+                          <h3 className="text-sm font-semibold leading-snug text-vetneb-ink">
+                            {step.title}
+                          </h3>
+                        </div>
+                        <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+                          {step.detail}
+                        </p>
+                        {step.tag && (
+                          <span className="mt-3 inline-block rounded border border-vetneb-teal/25 bg-vetneb-teal/[0.07] px-2 py-0.5 text-[0.68rem] font-semibold text-vetneb-navy">
+                            {step.tag}
+                          </span>
+                        )}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
             </PublicScrollReveal>
           </div>
         </section>
@@ -304,29 +411,58 @@ export default function ClinicasPage() {
             </PublicScrollReveal>
 
             <PublicScrollReveal variant="cards" staggerChildren>
-              <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-                {onboardingSteps.map((step) => (
-                  <article
-                    key={step.number}
-                    data-scroll-reveal-item
-                    aria-labelledby={`clinicas-step-${step.number}`}
-                    className="premium-card-muted p-5"
-                  >
-                    <div className="mb-4 inline-flex items-center rounded-full border border-vetneb-teal/35 bg-vetneb-teal/10 px-3 py-1 text-xs font-semibold tracking-[0.08em] text-vetneb-navy">
-                      {step.number}
-                    </div>
-                    <h3
-                      id={`clinicas-step-${step.number}`}
-                      className="mb-2 font-semibold text-vetneb-ink"
+              <ol
+                aria-label="Pasos para comenzar con Portal VETNEB"
+                className="mx-auto grid max-w-5xl grid-cols-1 lg:grid-cols-4 lg:gap-x-6"
+              >
+                {onboardingSteps.map((step, index) => {
+                  const isLastStep = index === onboardingSteps.length - 1;
+
+                  return (
+                    <li
+                      key={step.number}
+                      data-scroll-reveal-item
+                      data-clinic-onboarding-step={step.number}
+                      aria-labelledby={`clinicas-step-${step.number}`}
+                      className={`relative flex gap-4 lg:flex-col lg:gap-0 ${
+                        isLastStep ? "" : "pb-9 lg:pb-0"
+                      }`}
                     >
-                      {step.title}
-                    </h3>
-                    <p className="text-sm leading-relaxed text-muted-foreground">
-                      {step.description}
-                    </p>
-                  </article>
-                ))}
-              </div>
+                      {!isLastStep && (
+                        <span
+                          className="absolute bottom-0 left-4 top-9 w-px bg-gradient-to-b from-vetneb-teal/38 to-vetneb-line/28 lg:hidden"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <div className="flex shrink-0 items-center lg:mb-4 lg:w-full">
+                        <span
+                          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-vetneb-teal/35 bg-vetneb-teal/10 text-xs font-semibold tracking-[0.08em] text-vetneb-navy"
+                          aria-hidden="true"
+                        >
+                          {step.number}
+                        </span>
+                        {!isLastStep && (
+                          <span
+                            className="ml-4 hidden h-px flex-1 bg-vetneb-line/70 lg:-mr-6 lg:block"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </div>
+                      <div className="min-w-0 pt-0.5 lg:pt-0">
+                        <h3
+                          id={`clinicas-step-${step.number}`}
+                          className="font-semibold text-vetneb-ink"
+                        >
+                          {step.title}
+                        </h3>
+                        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                          {step.description}
+                        </p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
             </PublicScrollReveal>
 
             <PublicScrollReveal variant="minimal">

--- a/test/frontend-clinicas-page-content.test.ts
+++ b/test/frontend-clinicas-page-content.test.ts
@@ -46,20 +46,37 @@ test("clinicas page keeps hero CTAs visible on blue hero background", () => {
   assert.ok(source.includes('variant="secondaryOutline"'));
 });
 
-test("clinicas page lists operational feature cards", () => {
+test("clinicas page groups six capabilities into three product modules", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
-  assert.ok(source.includes("const features = ["));
+  assert.ok(source.includes("const featureModules = ["));
+  assert.ok(source.includes('id: "informes"'));
+  assert.ok(source.includes('id: "operacion"'));
+  assert.ok(source.includes('id: "gestion"'));
   assert.ok(source.includes("Recepción de informes"));
   assert.ok(source.includes("Búsqueda avanzada"));
   assert.ok(source.includes("Seguimiento de logística"));
   assert.ok(source.includes("Acceso seguro y auditado"));
   assert.ok(source.includes("Gestión de usuarios"));
   assert.ok(source.includes("Perfil público"));
-  assert.ok(source.includes("features.map((feature) =>"));
+  assert.ok(source.includes("featureModules.map((module, moduleIndex) =>"));
+  assert.ok(source.includes("module.features.map((feature) =>"));
+  assert.ok(source.includes("data-clinic-module={module.id}"));
 });
 
-test("clinicas page explains onboarding steps", () => {
+test("clinicas page renders a connected five-step operational timeline", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const operationSteps = ["));
+  assert.ok(source.includes("operationSteps.map((step, index) =>"));
+  assert.ok(source.includes("data-clinic-op-step={step.step}"));
+  assert.ok(source.includes('aria-label="Pasos operativos de derivación con VETNEB"'));
+  assert.ok(source.includes("lg:grid-cols-5"));
+  assert.ok(source.includes("Coordinás la derivación"));
+  assert.ok(source.includes("Tu clínica recibe el informe digital"));
+});
+
+test("clinicas page renders onboarding as a connected four-step list", () => {
   const source = read(CLINICAS_PAGE_PATH);
 
   assert.ok(source.includes("const onboardingSteps = ["));
@@ -68,7 +85,9 @@ test("clinicas page explains onboarding steps", () => {
   assert.ok(source.includes("Acceder a los informes"));
   assert.ok(source.includes("Gestionar la operación"));
   assert.ok(source.includes("Cómo comenzar"));
-  assert.ok(source.includes("onboardingSteps.map((step) =>"));
+  assert.ok(source.includes("onboardingSteps.map((step, index) =>"));
+  assert.ok(source.includes("data-clinic-onboarding-step={step.number}"));
+  assert.ok(source.includes('aria-label="Pasos para comenzar con Portal VETNEB"'));
 });
 
 test("clinicas page remains public and avoids direct backend/API calls", () => {
@@ -81,13 +100,21 @@ test("clinicas page remains public and avoids direct backend/API calls", () => {
 test("clinicas page does not contain demo or simulated content (PR-15 guard)", () => {
   const source = read(CLINICAS_PAGE_PATH);
   const demoTerms = [
+    "MUESTRA",
     "DEMOSTRATIVO",
+    "ejemplo visual",
+    "sin datos reales",
+    "caso demo",
     "DEMO-000",
-    "DEMO-CLINICA",
+    "DEMO-CLINICA-001",
     "Paciente demostrativo",
     "Clínica demostrativa",
-    "Ejemplo visual sin datos reales",
+    "preview de informe simulado",
     "panel operativo simulado",
+    "dashboard ficticio",
+    "informe inventado",
+    "datos ficticios visibles",
+    "mocks públicos falsos",
     "report-preview-card-title",
     "ReportPreviewCard",
   ];

--- a/test/frontend-public-report-preview.test.ts
+++ b/test/frontend-public-report-preview.test.ts
@@ -135,12 +135,15 @@ test("clinicas page has B2B operations section heading", () => {
   assert.ok(source.includes("Cómo opera tu clínica con VETNEB"));
 });
 
-test("clinicas page imports ClinicOperationsSection component", () => {
+test("clinicas page renders the operational flow as a five-column timeline", () => {
   const source = read(CLINICAS_PATH);
+
   assert.ok(
-    source.includes('from "@/components/public/ClinicOperationsSection"'),
+    source.includes('aria-label="Pasos operativos de derivación con VETNEB"'),
   );
-  assert.ok(source.includes("ClinicOperationsSection"));
+  assert.ok(source.includes("operationSteps.map((step, index) =>"));
+  assert.ok(source.includes("data-clinic-op-step={step.step}"));
+  assert.ok(source.includes("lg:grid-cols-5"));
 });
 
 test("clinicas page operations steps cover derivación and trazabilidad", () => {


### PR DESCRIPTION
## Summary
- Reorganize /clinicas features into three B2B product modules: Informes, Operación and Gestión
- Promote the operating flow into a five-step connected timeline
- Convert onboarding into a connected 01–04 stepper
- Preserve CTAs, routes, useful text and JSON-LD

## Scope
- /clinicas public page only for active visual changes
- Clinics contracts and e2e updated for the new B2B product layout
- No dashboard, API, auth, DB, workflow, dependency, navbar, footer or production changes

## Safety
- No public demos, mocks, fictitious cases, dashboard previews, or fake report data
- No copy-commercial expansion; visible text is preserved/reorganized only
- JSON-LD and CTAs remain intact

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e -- public-clinics-b2b-operations.spec.ts
- pnpm validate:local
- pnpm test
- git diff --check