### PR TITLE
feat(public): refine services diagnostic layout

### DIFF
--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -37,6 +37,7 @@ export const metadata: Metadata = createPageMetadata(
 const serviceCategories = [
   {
     id: "anatomopatologia",
+    layout: "dominant" as const,
     title: "Estudio anatomopatológico de tejidos",
     icon: Microscope,
     tone: "blue" as const,
@@ -55,6 +56,7 @@ const serviceCategories = [
   },
   {
     id: "citologia",
+    layout: "medium" as const,
     title: "Estudio citológico de muestras",
     icon: FlaskConical,
     tone: "emerald" as const,
@@ -73,6 +75,7 @@ const serviceCategories = [
   },
   {
     id: "tinciones",
+    layout: "medium" as const,
     title: "Tinciones especiales aplicadas",
     icon: Sparkles,
     tone: "amber" as const,
@@ -91,6 +94,7 @@ const serviceCategories = [
   },
   {
     id: "integral",
+    layout: "connector" as const,
     title: "Diagnóstico integral interdisciplinario",
     icon: Network,
     tone: "slate" as const,
@@ -109,6 +113,7 @@ const serviceCategories = [
   },
   {
     id: "informes",
+    layout: "connector" as const,
     title: "Informes y seguimiento",
     icon: MonitorCheck,
     tone: "blue" as const,
@@ -216,49 +221,90 @@ export default function ServiciosPage() {
 
             <PublicScrollReveal variant="cards" staggerChildren>
               <div
-                className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"
+                className="grid grid-cols-1 gap-5 lg:grid-cols-12 lg:gap-6"
                 data-services-polished="true"
+                data-services-diagnostic-bento="true"
               >
                 {serviceCategories.map((service) => {
                   const serviceHeadingId = `service-card-${service.id}-title`;
-                  const isFeatured = service.id === "anatomopatologia";
+                  const isDominant = service.layout === "dominant";
+                  const isMedium = service.layout === "medium";
+                  const isConnector = service.layout === "connector";
+                  const isWideConnector = service.id === "integral";
 
                   return (
                     <article
                       key={service.id}
                       data-scroll-reveal-item
+                      data-service-layout={service.layout}
                       aria-labelledby={serviceHeadingId}
                       className={cn(
                         "[&_.premium-card]:transition-colors [&_.premium-card]:duration-200 hover:[&_.premium-card]:bg-vetneb-surface-muted/40 hover:[&_.premium-card]:border-vetneb-teal/48 hover:[&_.premium-card]:shadow-[0_22px_66px_rgba(15,45,62,0.145)]",
-                        isFeatured && "lg:col-span-2",
+                        isDominant && "lg:col-span-12",
+                        isMedium && "lg:col-span-6",
+                        isConnector &&
+                          (isWideConnector
+                            ? "lg:col-span-7"
+                            : "lg:col-span-5"),
                       )}
                     >
                       <Card
                         id={service.id}
-                        className="premium-card h-full"
+                        className={cn(
+                          "h-full",
+                          isConnector
+                            ? "premium-card-muted"
+                            : "premium-card",
+                          isDominant &&
+                            "lg:grid lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] lg:items-stretch",
+                        )}
                       >
-                        <CardHeader>
+                        <CardHeader
+                          className={cn(
+                            isDominant && "lg:justify-center lg:p-8",
+                          )}
+                        >
                           <VisualIcon
                             icon={service.icon}
                             tone={service.tone}
                             className="mb-2"
                           />
-                          {isFeatured && (
+                          {isDominant && (
                             <p className="text-xs font-semibold uppercase tracking-[0.08em] text-vetneb-teal">
                               Servicio principal
                             </p>
                           )}
-                          <CardTitle id={serviceHeadingId} className={cn("text-xl text-vetneb-ink", isFeatured && "lg:text-2xl")}>
+                          <CardTitle
+                            id={serviceHeadingId}
+                            className={cn(
+                              "text-xl text-vetneb-ink",
+                              isDominant && "lg:text-3xl",
+                            )}
+                          >
                             {service.title}
                           </CardTitle>
                           <CardDescription className="public-copy-tight text-sm text-muted-foreground">
                             {service.description}
                           </CardDescription>
                         </CardHeader>
-                        <CardContent>
-                          <ul className={cn("space-y-2.5", isFeatured && "lg:grid lg:grid-cols-2 lg:gap-x-6 lg:space-y-0")}>
+                        <CardContent
+                          className={cn(
+                            isDominant &&
+                              "lg:flex lg:flex-col lg:justify-center lg:border-l lg:border-vetneb-line/60 lg:p-8",
+                          )}
+                        >
+                          <ul
+                            className={cn(
+                              "space-y-2.5",
+                              isDominant &&
+                                "lg:grid lg:grid-cols-2 lg:gap-x-6 lg:gap-y-3 lg:space-y-0",
+                            )}
+                          >
                             {service.features.map((feature) => (
-                              <li key={feature} className={cn("flex items-start gap-2", isFeatured && "lg:space-y-0")}>
+                              <li
+                                key={feature}
+                                className="flex items-start gap-2"
+                              >
                                 <span
                                   className="mt-0.5 text-primary font-bold text-xs"
                                   aria-hidden="true"
@@ -290,99 +336,77 @@ export default function ServiciosPage() {
           </div>
         </section>
 
-        <section className="py-16" aria-labelledby="services-coordination-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center">
-            <PublicScrollReveal variant="minimal">
-              <div className="premium-card p-8">
-                <h2
-                  id="services-coordination-heading"
-                  className="text-2xl font-bold text-vetneb-ink mb-4"
-                >
-                  Coordinación diagnóstica para clínicas y profesionales
-                </h2>
-                <p className="public-copy text-muted-foreground mb-8">
-                  Coordinamos recepción de muestras, priorización por complejidad y
-                  entrega de informes trazables. Los tiempos se ajustan al criterio
-                  diagnóstico y a las necesidades clínicas de cada caso.
-                </p>
-                <div className="flex flex-col justify-center gap-3 sm:flex-row">
-                  <PublicRouteControl
-                    href={ROUTES.contacto}
-                    variant="primaryDark"
-                    className="public-cta-primary w-full sm:w-auto"
+        <section
+          className="public-evidence-band-light public-band"
+          aria-labelledby="services-coordination-heading"
+          data-services-composed-band="coordination-integral"
+        >
+          <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="grid items-stretch gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:gap-12">
+              <PublicScrollReveal variant="section">
+                <div className="flex h-full flex-col justify-center">
+                  <h2
+                    id="services-coordination-heading"
+                    className="text-2xl font-bold text-vetneb-ink md:text-3xl"
                   >
-                    Solicitar coordinación diagnóstica
-                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                  </PublicRouteControl>
-                  <PublicRouteControl
-                    href={ROUTES.clinicas}
-                    variant="primaryLight"
-                    className="public-cta-outline w-full sm:w-auto"
-                  >
-                    Conocer solución para clínicas
-                  </PublicRouteControl>
+                    Coordinación diagnóstica para clínicas y profesionales
+                  </h2>
+                  <p className="mt-4 public-copy text-muted-foreground">
+                    Coordinamos recepción de muestras, priorización por complejidad y
+                    entrega de informes trazables. Los tiempos se ajustan al criterio
+                    diagnóstico y a las necesidades clínicas de cada caso.
+                  </p>
+                  <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                    <PublicRouteControl
+                      href={ROUTES.contacto}
+                      variant="primaryDark"
+                      className="public-cta-primary w-full sm:w-auto"
+                    >
+                      Solicitar coordinación diagnóstica
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </PublicRouteControl>
+                    <PublicRouteControl
+                      href={ROUTES.clinicas}
+                      variant="primaryLight"
+                      className="public-cta-outline w-full sm:w-auto"
+                    >
+                      Conocer solución para clínicas
+                    </PublicRouteControl>
+                  </div>
                 </div>
-              </div>
-            </PublicScrollReveal>
+              </PublicScrollReveal>
+
+              <PublicScrollReveal variant="minimal">
+                <div className="premium-card-muted h-full p-7 md:p-8">
+                  <h2
+                    id="services-integral-heading"
+                    className="text-2xl font-bold text-vetneb-ink mb-4"
+                  >
+                    Diagnóstico integral para medicina veterinaria
+                  </h2>
+                  <p className="public-copy text-muted-foreground mb-4">
+                    El diagnóstico anatomopatológico veterinario requiere integrar no
+                    sólo el análisis de tejido y citología, sino también el
+                    conocimiento clínico global de cada paciente. Esta articulación
+                    permite enriquecer la lectura diagnóstica junto con otras áreas
+                    de práctica veterinaria.
+                  </p>
+                  <p className="public-copy text-muted-foreground">
+                    Nuestro objetivo es colaborar de forma permanente con equipos
+                    quirúrgicos y clínicos, estudiando tejidos extirpados y muestras
+                    de punción para construir diagnósticos específicos y apoyar
+                    planes de tratamiento personalizados.
+                  </p>
+                </div>
+              </PublicScrollReveal>
+            </div>
           </div>
         </section>
 
-        <section className="py-16" aria-labelledby="services-integral-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-            <PublicScrollReveal variant="section">
-              <div className="premium-card-muted p-6">
-                <h2
-                  id="services-integral-heading"
-                  className="text-2xl font-bold text-vetneb-ink mb-4"
-                >
-                  Diagnóstico integral para medicina veterinaria
-                </h2>
-                <p className="public-copy text-muted-foreground mb-4">
-                  El diagnóstico anatomopatológico veterinario requiere integrar no
-                  sólo el análisis de tejido y citología, sino también el
-                  conocimiento clínico global de cada paciente. Esta articulación
-                  permite enriquecer la lectura diagnóstica junto con otras áreas
-                  de práctica veterinaria.
-                </p>
-                <p className="public-copy text-muted-foreground">
-                  Nuestro objetivo es colaborar de forma permanente con equipos
-                  quirúrgicos y clínicos, estudiando tejidos extirpados y muestras
-                  de punción para construir diagnósticos específicos y apoyar
-                  planes de tratamiento personalizados.
-                </p>
-              </div>
-            </PublicScrollReveal>
-          </div>
-        </section>
-
-        <section className="py-16" aria-labelledby="services-considerations-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl">
-            <PublicScrollReveal variant="section">
-              <div className="premium-card-muted p-6">
-                <h2
-                  id="services-considerations-heading"
-                  className="text-2xl font-bold text-vetneb-ink mb-4"
-                >
-                  Para tener en cuenta
-                </h2>
-                <p className="public-copy text-muted-foreground mb-4">
-                  El estudio anatomopatológico requiere integrar datos clínicos con
-                  la evaluación histológica y citológica realizada por el médico
-                  veterinario patólogo en microscopía.
-                </p>
-                <p className="public-copy text-muted-foreground">
-                  No se trata de un diagnóstico automatizado, por lo que los
-                  tiempos son variables según complejidad y técnicas
-                  complementarias requeridas. En ciertos casos se requiere
-                  interconsulta profesional para alcanzar mayor precisión
-                  diagnóstica.
-                </p>
-              </div>
-            </PublicScrollReveal>
-          </div>
-        </section>
-
-        <section className="py-16" aria-labelledby="services-specimen-journey-heading">
+        <section
+          className="public-band-feature"
+          aria-labelledby="services-specimen-journey-heading"
+        >
           <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-5xl">
             <PublicScrollReveal variant="section">
               <div className="mb-8">
@@ -405,40 +429,72 @@ export default function ServiciosPage() {
             </PublicScrollReveal>
 
             <PublicScrollReveal variant="minimal">
-              <div className="rounded-xl border border-vetneb-line/70 bg-card/72 p-6 shadow-sm">
+              <div className="rounded-xl border border-vetneb-line/70 bg-card/72 p-6 shadow-sm md:p-8">
                 <SpecimenJourneySection stages={specimenJourneyStages} />
               </div>
             </PublicScrollReveal>
           </div>
         </section>
 
-        <section className="py-16" aria-labelledby="services-values-heading">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-4xl">
-            <PublicScrollReveal variant="minimal">
-              <div className="clinical-muted-band rounded-lg p-6 clinical-surface-shadow">
-                <div className="flex items-start gap-3">
-                  <VisualIcon
-                    icon={ClipboardCheck}
-                    tone="emerald"
-                    className="h-11 w-11 shrink-0 rounded-xl"
-                  />
-                  <div>
-                    <h2
-                      id="services-values-heading"
-                      className="text-2xl font-bold text-vetneb-ink mb-4"
-                    >
-                      Valores que guían el servicio
-                    </h2>
-                    <p className="public-copy text-muted-foreground">
-                      Basamos nuestro trabajo en compromiso, seriedad, respeto,
-                      responsabilidad, confianza, diálogo, criterio clínico y ética
-                      profesional. Queremos ser un laboratorio de anatomía
-                      patológica veterinaria confiable, comprometido con la calidad
-                      diagnóstica y con el bienestar animal en cada caso que
-                      recibimos.
-                    </p>
+        <section
+          className="public-evidence-band-muted public-band"
+          data-services-composed-band="considerations-values"
+        >
+          <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <PublicScrollReveal variant="section">
+              <div className="grid gap-8 lg:grid-cols-2 lg:gap-0">
+                <article
+                  aria-labelledby="services-considerations-heading"
+                  className="lg:pr-10"
+                >
+                  <h2
+                    id="services-considerations-heading"
+                    className="text-2xl font-bold text-vetneb-ink mb-4"
+                  >
+                    Para tener en cuenta
+                  </h2>
+                  <p className="public-copy text-muted-foreground mb-4">
+                    El estudio anatomopatológico requiere integrar datos clínicos con
+                    la evaluación histológica y citológica realizada por el médico
+                    veterinario patólogo en microscopía.
+                  </p>
+                  <p className="public-copy text-muted-foreground">
+                    No se trata de un diagnóstico automatizado, por lo que los
+                    tiempos son variables según complejidad y técnicas
+                    complementarias requeridas. En ciertos casos se requiere
+                    interconsulta profesional para alcanzar mayor precisión
+                    diagnóstica.
+                  </p>
+                </article>
+
+                <article
+                  aria-labelledby="services-values-heading"
+                  className="border-t border-vetneb-line/70 pt-8 lg:border-l lg:border-t-0 lg:pl-10 lg:pt-0"
+                >
+                  <div className="flex items-start gap-3">
+                    <VisualIcon
+                      icon={ClipboardCheck}
+                      tone="emerald"
+                      className="h-11 w-11 shrink-0 rounded-xl"
+                    />
+                    <div>
+                      <h2
+                        id="services-values-heading"
+                        className="text-2xl font-bold text-vetneb-ink mb-4"
+                      >
+                        Valores que guían el servicio
+                      </h2>
+                      <p className="public-copy text-muted-foreground">
+                        Basamos nuestro trabajo en compromiso, seriedad, respeto,
+                        responsabilidad, confianza, diálogo, criterio clínico y ética
+                        profesional. Queremos ser un laboratorio de anatomía
+                        patológica veterinaria confiable, comprometido con la calidad
+                        diagnóstica y con el bienestar animal en cada caso que
+                        recibimos.
+                      </p>
+                    </div>
                   </div>
-                </div>
+                </article>
               </div>
             </PublicScrollReveal>
           </div>

--- a/test/frontend-public-service-bento-specimen-journey.test.ts
+++ b/test/frontend-public-service-bento-specimen-journey.test.ts
@@ -188,12 +188,18 @@ test("servicios page specimen journey contains verified protocol data", () => {
   assert.ok(source.includes("15 días hábiles"));
 });
 
-test("servicios page bento makes anatomopatología featured with lg:col-span-2", () => {
+test("servicios page bento gives each diagnostic layer explicit hierarchy", () => {
   const source = read(SERVICIOS_PATH);
 
-  assert.ok(source.includes('isFeatured && "lg:col-span-2"'));
+  assert.ok(source.includes('data-services-diagnostic-bento="true"'));
+  assert.ok(source.includes('layout: "dominant" as const'));
+  assert.equal((source.match(/layout: "medium" as const/g) ?? []).length, 2);
+  assert.equal((source.match(/layout: "connector" as const/g) ?? []).length, 2);
+  assert.ok(source.includes('isDominant && "lg:col-span-12"'));
+  assert.ok(source.includes('isMedium && "lg:col-span-6"'));
+  assert.ok(source.includes('"lg:col-span-7"'));
+  assert.ok(source.includes('"lg:col-span-5"'));
   assert.ok(source.includes("Servicio principal"));
-  assert.ok(source.includes('service.id === "anatomopatologia"'));
 });
 
 test("servicios page preserves conversion CTAs and service content", () => {

--- a/test/frontend-servicios-page-content.test.ts
+++ b/test/frontend-servicios-page-content.test.ts
@@ -40,23 +40,60 @@ test("servicios page lists laboratory service categories", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes("const serviceCategories = ["));
-  assert.ok(source.includes("Estudio anatomopatológico de tejidos"));
-  assert.ok(source.includes("Estudio citológico de muestras"));
-  assert.ok(source.includes("Tinciones especiales aplicadas"));
-  assert.ok(source.includes("Diagnóstico integral interdisciplinario"));
-  assert.ok(source.includes("Informes y seguimiento"));
+  const serviceTitles = [
+    "Estudio anatomopatológico de tejidos",
+    "Estudio citológico de muestras",
+    "Tinciones especiales aplicadas",
+    "Diagnóstico integral interdisciplinario",
+    "Informes y seguimiento",
+  ];
+
+  for (const title of serviceTitles) {
+    assert.ok(source.includes(title), `servicios page must keep "${title}"`);
+  }
+
   assert.ok(source.includes("serviceCategories.map((service) =>"));
 });
 
 test("servicios page keeps detailed service feature bullets", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
-  assert.ok(source.includes("Recepción y procesamiento de muestras de tejidos"));
-  assert.ok(source.includes("Estudio citológico de líquidos y punciones"));
-  assert.ok(source.includes("Complemento de histopatología y citopatología"));
-  assert.ok(source.includes("Interconsulta profesional cuando el caso lo requiere"));
-  assert.ok(source.includes("Consulta de resultados de informes las 24 hs"));
-  assert.ok(source.includes("Priorización según complejidad diagnóstica"));
+  const serviceFeatures = [
+    "Recepción y procesamiento de muestras de tejidos",
+    "Evaluación microscópica de lesiones histológicas",
+    "Correlación anatomopatológica del caso clínico",
+    "Informe diagnóstico con hallazgos relevantes",
+    "Apoyo para decisiones terapéuticas",
+    "Seguimiento del caso con el equipo tratante",
+    "Estudio citológico de líquidos y punciones",
+    "Valoración celular orientada a diagnóstico",
+    "Identificación de patrones inflamatorios y proliferativos",
+    "Apoyo diagnóstico en lesiones de tejidos blandos",
+    "Integración con antecedentes clínicos del paciente",
+    "Informe citológico con conclusión profesional",
+    "Selección de técnicas según complejidad del caso",
+    "Caracterización adicional de lesiones tisulares",
+    "Soporte para diagnósticos diferenciales",
+    "Complemento de histopatología y citopatología",
+    "Mayor precisión frente a hallazgos complejos",
+    "Registro diagnóstico trazable",
+    "Integración de análisis histológico y citológico",
+    "Trabajo conjunto con diagnóstico por imágenes",
+    "Articulación con cirugía y clínica veterinaria",
+    "Interconsulta profesional cuando el caso lo requiere",
+    "Definición diagnóstica específica por paciente",
+    "Orientación para tratamiento personalizado",
+    "Consulta de resultados de informes las 24 hs",
+    "Seguimiento del estado del estudio en portal",
+    "Comunicación directa para coordinación de muestras",
+    "Priorización según complejidad diagnóstica",
+    "Tiempos variables según necesidad del caso",
+    "Entrega final con criterio profesional y responsable",
+  ];
+
+  for (const feature of serviceFeatures) {
+    assert.ok(source.includes(feature), `servicios page must keep "${feature}"`);
+  }
 });
 
 test("servicios page exposes conversion CTAs and SEO copy", () => {
@@ -81,16 +118,62 @@ test("servicios page remains public and avoids direct backend/API calls", () => 
   assert.equal(source.includes("fetch("), false);
 });
 
-test("servicios page keeps one continuous soft canvas through middle sections", () => {
+test("servicios page composes its diagnostic sections on the public rhythm system", () => {
   const source = read(SERVICIOS_PAGE_PATH);
 
   assert.ok(source.includes('className="public-soft-canvas"'));
   assert.ok(source.includes('className="py-16 md:py-20"'));
-  assert.ok(source.includes('className="py-16"'));
+  assert.ok(source.includes('className="public-evidence-band-light public-band"'));
+  assert.ok(source.includes('className="public-band-feature"'));
+  assert.ok(source.includes('className="public-evidence-band-muted public-band"'));
   assert.equal(source.includes('className="bg-white py-16"'), false);
   assert.equal(source.includes('className="bg-blue-50 py-16"'), false);
   assert.equal(source.includes('className="bg-gray-50 py-16"'), false);
   assert.equal(source.includes('data-public-soft-canvas="true"'), false);
+});
+
+test("servicios page uses a hierarchical diagnostic bento", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  assert.ok(source.includes('layout: "dominant" as const'));
+  assert.equal((source.match(/layout: "medium" as const/g) ?? []).length, 2);
+  assert.equal((source.match(/layout: "connector" as const/g) ?? []).length, 2);
+  assert.ok(source.includes('data-services-diagnostic-bento="true"'));
+  assert.ok(source.includes("grid grid-cols-1 gap-5 lg:grid-cols-12 lg:gap-6"));
+  assert.ok(source.includes('isDominant && "lg:col-span-12"'));
+  assert.ok(source.includes('isMedium && "lg:col-span-6"'));
+  assert.ok(source.includes('"lg:col-span-7"'));
+  assert.ok(source.includes('"lg:col-span-5"'));
+  assert.ok(source.includes('data-service-layout={service.layout}'));
+  assert.ok(source.includes("isConnector"));
+  assert.ok(source.includes('"premium-card-muted"'));
+});
+
+test("servicios page consolidates repeated bands into composed sections", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+
+  assert.ok(source.includes('data-services-composed-band="coordination-integral"'));
+  assert.ok(source.includes('data-services-composed-band="considerations-values"'));
+
+  const coordinationBandIndex = source.indexOf(
+    'data-services-composed-band="coordination-integral"',
+  );
+  const coordinationHeadingIndex = source.indexOf(
+    'id="services-coordination-heading"',
+  );
+  const integralHeadingIndex = source.indexOf('id="services-integral-heading"');
+  const closingBandIndex = source.indexOf(
+    'data-services-composed-band="considerations-values"',
+  );
+  const considerationsHeadingIndex = source.indexOf(
+    'id="services-considerations-heading"',
+  );
+  const valuesHeadingIndex = source.indexOf('id="services-values-heading"');
+
+  assert.ok(coordinationBandIndex < coordinationHeadingIndex);
+  assert.ok(coordinationHeadingIndex < integralHeadingIndex);
+  assert.ok(closingBandIndex < considerationsHeadingIndex);
+  assert.ok(considerationsHeadingIndex < valuesHeadingIndex);
 });
 
 test("servicios page hides service link typography while keeping link semantics", () => {
@@ -126,19 +209,30 @@ test("servicios page shows unified card CTA while preserving hidden SEO labels",
 
 test("servicios page does not contain demo or simulated content (PR-15 guard)", () => {
   const source = read(SERVICIOS_PAGE_PATH);
+  const normalizedSource = source.toLowerCase();
   const demoTerms = [
-    "DEMOSTRATIVO",
-    "DEMO-000",
-    "Paciente demostrativo",
-    "Ejemplo visual sin datos reales",
+    "demostrativo",
+    "ejemplo visual",
+    "sin datos reales",
+    "caso demo",
+    "demo-000",
+    "demo-clinica-001",
+    "paciente demostrativo",
+    "clínica demostrativa",
+    "preview de informe simulado",
     "panel operativo simulado",
+    "dashboard ficticio",
+    "informe inventado",
+    "datos ficticios visibles",
     "report-preview-card-title",
-    "ReportPreviewCard",
+    "reportpreviewcard",
   ];
+
+  assert.equal(source.includes("MUESTRA"), false);
 
   for (const term of demoTerms) {
     assert.equal(
-      source.includes(term),
+      normalizedSource.includes(term),
       false,
       `servicios page must not contain "${term}"`,
     );

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -236,6 +236,9 @@ test("servicios page keeps professional section/card structure and responsive la
       "serviceCategories.map((service) =>",
       "service.features.map((feature) =>",
       "data-services-polished=\"true\"",
+      "data-services-diagnostic-bento=\"true\"",
+      "data-services-composed-band=\"coordination-integral\"",
+      "data-services-composed-band=\"considerations-values\"",
     ],
     "servicios visual structure",
   );
@@ -244,11 +247,11 @@ test("servicios page keeps professional section/card structure and responsive la
     source,
     [
       /className="public-secondary-hero-surface py-16 text-white md:py-20"/,
-      /className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8"/,
-      /className="premium-card h-full"/,
-      /className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-3xl text-center"/,
-      /className="flex flex-col justify-center gap-3 sm:flex-row"/,
-      /className="py-16"/,
+      /className="grid grid-cols-1 gap-5 lg:grid-cols-12 lg:gap-6"/,
+      /className="public-evidence-band-light public-band"/,
+      /className="public-band-feature"/,
+      /className="public-evidence-band-muted public-band"/,
+      /className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap"/,
     ],
     "servicios class contracts",
   );


### PR DESCRIPTION
## Summary
- Rework /servicios into a hierarchical diagnostic bento
- Promote anatomopathology as the dominant service module
- Keep citology and special stains as medium diagnostic modules
- Preserve integral diagnosis and reports as connector modules
- Consolidate repeated service bands while keeping specimen journey intact

## Scope
- /servicios public page only for active visual changes
- Services contracts updated for the diagnostic layout
- No API, auth, DB, workflow, dependency, dashboard, navbar, footer or production changes

## Safety
- No public demos, mocks, fictitious cases, dashboard previews, or fake report data
- No copy-commercial expansion; visible text is preserved/reorganized only
- Services, features, SEO hrefs and JSON-LD remain intact

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- focused services tests
- desktop/mobile visual QA
- pnpm validate:local after staging to avoid legacy unstaged-diff dashboard guard false positives
- pnpm test after staging
- git diff --check
- git diff --cached --check