### PR TITLE
feat(public): refine nav and footer information architecture

### DIFF
--- a/frontend/e2e/public-navigation-footer.spec.ts
+++ b/frontend/e2e/public-navigation-footer.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+const primaryDestinations = [
+  "Servicios",
+  "Profesionales",
+  "Clínicas",
+  "Precios",
+  "Particulares",
+  "Contacto",
+];
+
+const prohibitedPublicCopy = [
+  "MUESTRA",
+  "DEMOSTRATIVO",
+  "ejemplo visual",
+  "sin datos reales",
+  "caso demo",
+  "DEMO-000",
+  "DEMO-CLINICA-001",
+  "paciente demostrativo",
+  "clínica demostrativa",
+  "preview de informe simulado",
+  "panel operativo simulado",
+  "dashboard ficticio",
+  "informe inventado",
+  "datos ficticios visibles",
+];
+
+test("desktop navbar and footer preserve the public information architecture", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const desktopNav = page.getByRole("navigation", {
+    name: "Navegación principal",
+  });
+  await expect(desktopNav).toBeVisible();
+  await expect(desktopNav).toContainText("Diagnóstico");
+  await expect(desktopNav).toContainText("Operación");
+  await expect(desktopNav).toContainText("Acceso");
+
+  for (const destination of primaryDestinations) {
+    await expect(
+      desktopNav.getByRole("button", { name: destination, exact: true }),
+    ).toBeVisible();
+  }
+
+  const header = page.getByRole("banner");
+  await expect(
+    header.getByRole("button", { name: "Iniciar sesión", exact: true }),
+  ).toBeVisible();
+  await expect(
+    header.getByRole("button", { name: "Solicitar acceso", exact: true }),
+  ).toBeVisible();
+
+  const footer = page.getByRole("contentinfo");
+  await expect(footer).toContainText("Diagnóstico / Servicios");
+  await expect(footer).toContainText("Operación clínica");
+  await expect(footer).toContainText("Acceso");
+  await expect(footer).toContainText("Contacto");
+  await expect(footer).toContainText("Blvd. Italia 274 - Villa María - Córdoba");
+  await expect(footer).toContainText("Lunes a viernes de 8 a 17hs");
+  await expect(footer).toContainText("WhatsApp");
+  await expect(footer).toContainText("lab.vetneb@gmail.com");
+  await expect(
+    footer.getByTitle("Mapa de ubicación de Servicio Patológico VETNEB"),
+  ).toHaveCount(1);
+
+  for (const text of prohibitedPublicCopy) {
+    await expect(page.locator("body")).not.toContainText(text);
+  }
+});
+
+test("mobile navigation opens closes and retains links and access actions", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto("/");
+
+  const toggle = page.getByLabel("Abrir navegación VETNEB");
+  const mobileNav = page.getByRole("navigation", {
+    name: "Navegación mobile",
+  });
+
+  await expect(mobileNav).not.toBeVisible();
+  await toggle.click();
+  await expect(mobileNav).toBeVisible();
+
+  for (const destination of primaryDestinations) {
+    await expect(
+      mobileNav.getByRole("button", { name: destination, exact: true }),
+    ).toBeVisible();
+  }
+
+  await expect(
+    mobileNav.getByRole("button", { name: "Iniciar sesión", exact: true }),
+  ).toBeVisible();
+  await expect(
+    mobileNav.getByRole("button", { name: "Solicitar acceso", exact: true }),
+  ).toBeVisible();
+
+  await toggle.click();
+  await expect(mobileNav).not.toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+    await page.evaluate(() => document.documentElement.clientWidth),
+  );
+});

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -45,13 +45,22 @@ const labInfo = [
   "Horario: Lunes a viernes de 8 a 17hs",
 ];
 
-const footerLinks = [
-  { label: "Servicios", href: ROUTES.servicios },
-  { label: "Profesionales", href: ROUTES.profesionales },
-  { label: "Clínicas", href: ROUTES.clinicas },
-  { label: "Particulares", href: ROUTES.particulares },
-  { label: "Contacto", href: ROUTES.contacto },
-];
+const footerLinkGroups = [
+  {
+    label: "Diagnóstico / Servicios",
+    links: [
+      { label: "Servicios", href: ROUTES.servicios },
+      { label: "Profesionales", href: ROUTES.profesionales },
+    ],
+  },
+  {
+    label: "Operación clínica",
+    links: [
+      { label: "Clínicas", href: ROUTES.clinicas },
+      { label: "Precios", href: ROUTES.precios },
+    ],
+  },
+] as const;
 
 const mapsLocationUrl =
   "https://www.google.com/maps?q=Blvd.%20Italia%20274%2C%20Villa%20Maria%2C%20Cordoba%2C%20Argentina";
@@ -93,147 +102,193 @@ export function Footer() {
   return (
     <footer className="bg-transparent text-sidebar-foreground" role="contentinfo">
       <section
-        className="border-t border-white/10 bg-sidebar py-8"
+        className="border-t border-white/10 bg-sidebar py-10"
         aria-labelledby="footer-lab-info-heading"
       >
-        <div className="container mx-auto grid grid-cols-1 gap-8 px-4 sm:px-6 md:grid-cols-2 lg:grid-cols-[1.35fr_0.75fr_0.75fr_1.15fr] lg:px-8">
-          <div className="text-sm text-sidebar-foreground/82">
-            <h2
-              id="footer-lab-info-heading"
-              className="mb-5 text-sm font-bold text-white"
-            >
-              Servicio Patológico VETNEB
-            </h2>
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid gap-8 lg:grid-cols-[0.85fr_1.15fr]">
+            <div className="text-sm text-sidebar-foreground/82">
+              <h2
+                id="footer-lab-info-heading"
+                className="mb-5 text-sm font-bold text-white"
+              >
+                Servicio Patológico VETNEB
+              </h2>
 
-            <address className="not-italic">
-              <ul className="space-y-3">
-                <li className="flex items-start gap-2">
-                  <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-cyan-300" aria-hidden="true" />
-                  <span>{labInfo[0]}</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
-                  <span>{labInfo[1]}</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <Phone className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" aria-hidden="true" />
-                  <span>
-                    WhatsApp:{" "}
-                    <PublicExternalControl
-                      href="https://wa.me/5493534138946"
-                      target="_blank"
-                      className="underline underline-offset-2 hover:text-vetneb-teal"
-                    >
-                      3534138946
-                    </PublicExternalControl>
-                  </span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <Mail className="mt-0.5 h-4 w-4 shrink-0 text-primary-foreground/70" aria-hidden="true" />
-                  <span>
-                    Mail:{" "}
-                    <PublicExternalControl
-                      href="mailto:lab.vetneb@gmail.com"
-                      target="_self"
-                      className="underline underline-offset-2 hover:text-vetneb-teal"
-                    >
-                      lab.vetneb@gmail.com
-                    </PublicExternalControl>
-                  </span>
-                </li>
-              </ul>
-            </address>
-          </div>
+              <address className="not-italic">
+                <ul className="space-y-3">
+                  <li className="flex items-start gap-2">
+                    <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-cyan-300" aria-hidden="true" />
+                    <span>{labInfo[0]}</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+                    <span>{labInfo[1]}</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <Phone className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" aria-hidden="true" />
+                    <span>
+                      WhatsApp:{" "}
+                      <PublicExternalControl
+                        href="https://wa.me/5493534138946"
+                        target="_blank"
+                        className="underline underline-offset-2 hover:text-vetneb-teal"
+                      >
+                        3534138946
+                      </PublicExternalControl>
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <Mail className="mt-0.5 h-4 w-4 shrink-0 text-primary-foreground/70" aria-hidden="true" />
+                    <span>
+                      Mail:{" "}
+                      <PublicExternalControl
+                        href="mailto:lab.vetneb@gmail.com"
+                        target="_self"
+                        className="underline underline-offset-2 hover:text-vetneb-teal"
+                      >
+                        lab.vetneb@gmail.com
+                      </PublicExternalControl>
+                    </span>
+                  </li>
+                </ul>
+              </address>
+            </div>
 
-          <nav aria-label="Navegación secundaria">
-            <h3 className="mb-5 text-sm font-semibold text-white">
-              Navegación
-            </h3>
-            <ul className="space-y-3">
-              {footerLinks.map((link) => (
-                <li key={link.href}>
-                  <PublicRouteControl
-                    href={link.href}
-                    variant="bare"
-                    className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-                  >
-                    {link.label}
-                  </PublicRouteControl>
-                </li>
-              ))}
-            </ul>
-          </nav>
-
-          <div>
-            <h3 className="mb-5 text-sm font-semibold text-white">
-              Acceso
-            </h3>
-            <ul className="space-y-3">
-              <li>
-                <PublicRouteControl
-                  href={ROUTES.login}
-                  variant="bare"
-                  className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+            <div className="overflow-hidden rounded-xl border border-white/14 bg-sidebar/96 shadow-[0_14px_38px_rgba(0,0,0,0.22)]">
+              <div className="relative h-52 overflow-hidden border-b border-white/18">
+                <iframe
+                  title="Mapa de ubicación de Servicio Patológico VETNEB"
+                  src={mapsEmbedUrl}
+                  loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
+                  aria-hidden="true"
+                  tabIndex={-1}
+                  className="h-full w-full border-0 pointer-events-none"
+                />
+                <div className="pointer-events-none absolute inset-x-3 top-3 rounded-md border border-white/24 bg-sidebar/86 px-3 py-2 text-white shadow-[0_10px_24px_rgba(0,0,0,0.35)] backdrop-blur-[2px]">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100/95">
+                    Ubicación
+                  </p>
+                  <p className="mt-0.5 text-sm font-semibold leading-tight">
+                    Blvd. Italia 274, Villa María
+                  </p>
+                  <p className="mt-0.5 text-xs text-sidebar-foreground/90">
+                    Córdoba, Argentina
+                  </p>
+                </div>
+              </div>
+              <div className="bg-sidebar/92 p-3">
+                <PublicExternalControl
+                  href={mapsLocationUrl}
+                  target="_blank"
+                  aria-label="Ver ubicación del laboratorio en Google Maps"
+                  className="inline-flex w-full items-center justify-center rounded-md border border-white/22 bg-white px-3 py-2 text-sm font-semibold text-vetneb-navy shadow-[0_6px_14px_rgba(255,255,255,0.22)] transition-colors hover:bg-vetneb-surface-raised hover:text-vetneb-navy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar/80"
                 >
-                  Iniciar sesión
-                </PublicRouteControl>
-              </li>
-              <li>
-                <PublicRouteControl
-                  href={ROUTES.particulares}
-                  variant="bare"
-                  className="text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-                >
-                  Acceso particulares
-                </PublicRouteControl>
-              </li>
-              <li>
-                <PublicRouteControl
-                  href={ROUTES.contacto}
-                  variant="bare"
-                  className="inline-flex items-center gap-2 rounded-md border border-white/25 bg-white/14 px-3 py-1.5 text-sm text-white shadow-sm transition-colors hover:bg-white/14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-                >
-                  <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
-                  Solicitar acceso
-                </PublicRouteControl>
-              </li>
-            </ul>
-          </div>
-
-          <div className="overflow-hidden rounded-xl border border-white/14 bg-sidebar/96 shadow-[0_14px_38px_rgba(0,0,0,0.22)]">
-            <div className="relative h-52 overflow-hidden border-b border-white/18">
-              <iframe
-                title="Mapa de ubicación de Servicio Patológico VETNEB"
-                src={mapsEmbedUrl}
-                loading="lazy"
-                referrerPolicy="no-referrer-when-downgrade"
-                aria-hidden="true"
-                tabIndex={-1}
-                className="h-full w-full border-0 pointer-events-none"
-              />
-              <div className="pointer-events-none absolute inset-x-3 top-3 rounded-md border border-white/24 bg-sidebar/86 px-3 py-2 text-white shadow-[0_10px_24px_rgba(0,0,0,0.35)] backdrop-blur-[2px]">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100/95">
-                  Ubicación
-                </p>
-                <p className="mt-0.5 text-sm font-semibold leading-tight">
-                  Blvd. Italia 274, Villa María
-                </p>
-                <p className="mt-0.5 text-xs text-sidebar-foreground/90">
-                  Córdoba, Argentina
-                </p>
+                  Ver ubicación en Maps
+                </PublicExternalControl>
               </div>
             </div>
-            <div className="bg-sidebar/92 p-3">
-              <PublicExternalControl
-                href={mapsLocationUrl}
-                target="_blank"
-                aria-label="Ver ubicación del laboratorio en Google Maps"
-                className="inline-flex w-full items-center justify-center rounded-md border border-white/22 bg-white px-3 py-2 text-sm font-semibold text-vetneb-navy shadow-[0_6px_14px_rgba(255,255,255,0.22)] transition-colors hover:bg-vetneb-surface-raised hover:text-vetneb-navy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar/80"
-              >
-                Ver ubicación en Maps
-              </PublicExternalControl>
-            </div>
           </div>
+
+          <div className="my-8 h-px bg-white/12" aria-hidden="true" />
+
+          <nav
+            className="grid grid-cols-2 gap-x-6 gap-y-8 lg:grid-cols-4"
+            aria-label="Mapa institucional y operativo"
+          >
+            {footerLinkGroups.map((group) => (
+              <div key={group.label}>
+                <h3 className="mb-4 text-xs font-bold uppercase tracking-[0.14em] text-white">
+                  {group.label}
+                </h3>
+                <ul className="space-y-3">
+                  {group.links.map((link) => (
+                    <li key={link.href}>
+                      <PublicRouteControl
+                        href={link.href}
+                        variant="bare"
+                        className="text-left text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                      >
+                        {link.label}
+                      </PublicRouteControl>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+
+            <div>
+              <h3 className="mb-4 text-xs font-bold uppercase tracking-[0.14em] text-white">
+                Acceso
+              </h3>
+              <ul className="space-y-3">
+                <li>
+                  <PublicRouteControl
+                    href={ROUTES.particulares}
+                    variant="bare"
+                    className="text-left text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                  >
+                    Particulares
+                  </PublicRouteControl>
+                </li>
+                <li>
+                  <PublicRouteControl
+                    href={ROUTES.login}
+                    variant="bare"
+                    className="text-left text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                  >
+                    Iniciar sesión
+                  </PublicRouteControl>
+                </li>
+                <li>
+                  <PublicRouteControl
+                    href={ROUTES.contacto}
+                    variant="bare"
+                    className="inline-flex items-center gap-2 rounded-md border border-white/25 bg-white/14 px-3 py-1.5 text-sm text-white shadow-sm transition-colors hover:bg-white/14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                  >
+                    <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                    Solicitar acceso
+                  </PublicRouteControl>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="mb-4 text-xs font-bold uppercase tracking-[0.14em] text-white">
+                Contacto
+              </h3>
+              <ul className="space-y-3">
+                <li>
+                  <PublicRouteControl
+                    href={ROUTES.contacto}
+                    variant="bare"
+                    className="text-left text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                  >
+                    Contacto
+                  </PublicRouteControl>
+                </li>
+                <li>
+                  <PublicExternalControl
+                    href="https://wa.me/5493534138946"
+                    target="_blank"
+                    className="text-left text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal"
+                  >
+                    WhatsApp
+                  </PublicExternalControl>
+                </li>
+                <li>
+                  <PublicExternalControl
+                    href="mailto:lab.vetneb@gmail.com"
+                    target="_self"
+                    className="text-left text-sm text-sidebar-foreground/74 transition-colors hover:text-vetneb-teal"
+                  >
+                    Email
+                  </PublicExternalControl>
+                </li>
+              </ul>
+            </div>
+          </nav>
         </div>
       </section>
 

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -3,16 +3,29 @@ import { ArrowRight, ChevronDown, Microscope } from "lucide-react";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 
-const navLinks = [
-  { label: "Servicios", href: ROUTES.servicios },
-  { label: "Profesionales", href: ROUTES.profesionales },
-  { label: "Clínicas", href: ROUTES.clinicas },
-  { label: "Particulares", href: ROUTES.particulares },
-  { label: "Contacto", href: ROUTES.contacto },
-  { label: "Precios", href: ROUTES.precios },
-];
-
-const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];
+const navGroups = [
+  {
+    label: "Diagnóstico",
+    links: [
+      { label: "Servicios", href: ROUTES.servicios },
+      { label: "Profesionales", href: ROUTES.profesionales },
+    ],
+  },
+  {
+    label: "Operación",
+    links: [
+      { label: "Clínicas", href: ROUTES.clinicas },
+      { label: "Precios", href: ROUTES.precios },
+    ],
+  },
+  {
+    label: "Acceso",
+    links: [
+      { label: "Particulares", href: ROUTES.particulares },
+      { label: "Contacto", href: ROUTES.contacto },
+    ],
+  },
+] as const;
 
 export function Navbar() {
   return (
@@ -32,20 +45,58 @@ export function Navbar() {
               className="absolute left-0 top-full z-50 mt-2 w-72 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-vetneb-line/80 bg-card p-2 shadow-[0_18px_45px_rgba(15,45,62,0.16)]"
               aria-label="Navegación mobile"
             >
-              <ul className="flex flex-col gap-1">
-                {mobileNavLinks.map((link) => (
-                  <li key={link.href}>
-                    <PublicRouteControl
-                      href={link.href}
-                      variant="bare"
-                      className="block w-full rounded-md px-3 py-2.5 text-left text-sm font-medium text-vetneb-ink/85 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-                      activeClassName="bg-accent/80 text-vetneb-ink shadow-sm"
-                    >
-                      {link.label}
-                    </PublicRouteControl>
+              <div className="border-b border-vetneb-line/70 pb-2">
+                <PublicRouteControl
+                  href={ROUTES.home}
+                  variant="bare"
+                  className="block w-full rounded-md px-3 py-2.5 text-left text-sm font-semibold text-vetneb-ink transition-colors hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                  activeClassName="bg-accent/80 text-vetneb-ink shadow-sm"
+                >
+                  Inicio
+                </PublicRouteControl>
+              </div>
+
+              <ul className="flex flex-col gap-3 py-3">
+                {navGroups.map((group) => (
+                  <li key={group.label}>
+                    <p className="px-3 text-[10px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+                      {group.label}
+                    </p>
+                    <ul className="mt-1 space-y-1">
+                      {group.links.map((link) => (
+                        <li key={link.href}>
+                          <PublicRouteControl
+                            href={link.href}
+                            variant="bare"
+                            className="block w-full rounded-md px-3 py-2 text-left text-sm font-medium text-vetneb-ink/85 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+                            activeClassName="bg-accent/80 text-vetneb-ink shadow-sm"
+                          >
+                            {link.label}
+                          </PublicRouteControl>
+                        </li>
+                      ))}
+                    </ul>
                   </li>
                 ))}
               </ul>
+
+              <div className="grid gap-2 border-t border-vetneb-line/70 pt-2">
+                <PublicRouteControl
+                  href={ROUTES.login}
+                  variant="bare"
+                  className="public-cta-outline inline-flex h-9 w-full items-center justify-center rounded-md px-3 text-sm font-semibold"
+                >
+                  Iniciar sesión
+                </PublicRouteControl>
+                <PublicRouteControl
+                  href={ROUTES.contacto}
+                  variant="bare"
+                  className="public-cta-primary inline-flex h-9 w-full items-center justify-center gap-2 rounded-md px-3 text-sm font-semibold"
+                >
+                  Solicitar acceso
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </PublicRouteControl>
+              </div>
             </nav>
           </details>
         </div>
@@ -60,25 +111,37 @@ export function Navbar() {
             <Microscope className="h-4 w-4" aria-hidden="true" />
             VETNEB
           </span>
-          <span className="hidden text-xs font-semibold text-muted-foreground lg:inline">
+          <span className="hidden text-xs font-semibold text-muted-foreground xl:inline">
             Patología veterinaria
           </span>
         </PublicRouteControl>
 
         <nav
-          className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 lg:flex"
+          className="hidden items-stretch rounded-lg border border-vetneb-line/80 bg-card/88 p-1 lg:flex"
           aria-label="Navegación principal"
         >
-          {navLinks.map((link) => (
-            <PublicRouteControl
-              key={link.href}
-              href={link.href}
-              variant="bare"
-              className="rounded-md px-3.5 py-2 text-sm font-medium text-vetneb-ink/80 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-              activeClassName="bg-accent/80 text-vetneb-ink shadow-sm"
+          {navGroups.map((group) => (
+            <div
+              key={group.label}
+              className="flex min-w-0 flex-col justify-center border-r border-vetneb-line/70 px-1.5 last:border-r-0"
             >
-              {link.label}
-            </PublicRouteControl>
+              <p className="px-2 pb-0.5 text-[9px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
+                {group.label}
+              </p>
+              <div className="flex items-center">
+                {group.links.map((link) => (
+                  <PublicRouteControl
+                    key={link.href}
+                    href={link.href}
+                    variant="bare"
+                    className="rounded-md px-2 py-1.5 text-xs font-medium text-vetneb-ink/80 transition-colors hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 xl:px-2.5 xl:text-sm"
+                    activeClassName="bg-accent/80 text-vetneb-ink shadow-sm"
+                  >
+                    {link.label}
+                  </PublicRouteControl>
+                ))}
+              </div>
+            </div>
           ))}
         </nav>
 

--- a/test/frontend-footer-lab-info.test.ts
+++ b/test/frontend-footer-lab-info.test.ts
@@ -45,11 +45,14 @@ test("footer unifies laboratory info navigation access and non-interactive real 
   assert.ok(source.includes("Lunes a viernes de 8 a 17hs"));
   assert.ok(source.includes("3534138946"));
   assert.ok(source.includes("lab.vetneb@gmail.com"));
-  assert.ok(source.includes('aria-label="Navegación secundaria"'));
-  assert.ok(source.includes("Navegación"));
+  assert.ok(source.includes('aria-label="Mapa institucional y operativo"'));
+  assert.ok(source.includes("Diagnóstico / Servicios"));
+  assert.ok(source.includes("Operación clínica"));
   assert.ok(source.includes("Acceso"));
-  assert.ok(source.includes("footerLinks.map((link) =>"));
-  assert.ok(source.includes("lg:grid-cols-[1.35fr_0.75fr_0.75fr_1.15fr]"));
+  assert.ok(source.includes("Contacto"));
+  assert.ok(source.includes("footerLinkGroups.map((group) =>"));
+  assert.ok(source.includes("lg:grid-cols-[0.85fr_1.15fr]"));
+  assert.ok(source.includes("lg:grid-cols-4"));
   assert.ok(source.includes("https://www.google.com/maps?q="));
   assert.ok(source.includes("https://www.google.com/maps?output=embed&q="));
   assert.ok(source.includes("mapsEmbedUrl"));
@@ -78,6 +81,8 @@ test("footer removes redundant brand block and keeps public routes safe", () => 
   assert.ok(source.includes("ROUTES.servicios"));
   assert.ok(source.includes("ROUTES.profesionales"));
   assert.ok(source.includes("ROUTES.clinicas"));
+  assert.ok(source.includes("ROUTES.precios"));
+  assert.ok(source.includes("ROUTES.particulares"));
   assert.ok(source.includes("ROUTES.contacto"));
   assert.ok(source.includes("ROUTES.login"));
   assert.equal(source.includes('"/dashboard"'), false);

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -33,7 +33,10 @@ test("navbar uses centralized public routes for primary navigation", () => {
   assert.equal(source.includes('"use client";'), false);
   assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
-  assert.ok(source.includes('const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];'));
+  assert.ok(source.includes("const navGroups = ["));
+  assert.ok(source.includes('label: "Diagnóstico"'));
+  assert.ok(source.includes('label: "Operación"'));
+  assert.ok(source.includes('label: "Acceso"'));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
   assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
@@ -48,7 +51,7 @@ test("navbar keeps full navigation desktop-only and exposes mobile dropdown", ()
 
   assert.ok(
     source.includes(
-      'className="hidden items-center gap-1 rounded-md border border-vetneb-line/80 bg-card/88 p-1 lg:flex"',
+      'className="hidden items-stretch rounded-lg border border-vetneb-line/80 bg-card/88 p-1 lg:flex"',
     ),
   );
   assert.equal(source.includes("p-1 md:flex"), false);
@@ -56,7 +59,9 @@ test("navbar keeps full navigation desktop-only and exposes mobile dropdown", ()
   assert.ok(source.includes("<details"));
   assert.ok(source.includes("<summary"));
   assert.ok(source.includes('aria-label="Navegación mobile"'));
-  assert.ok(source.includes("{mobileNavLinks.map((link) => ("));
+  assert.ok(source.includes("{navGroups.map((group) => ("));
+  assert.ok(source.includes("{group.links.map((link) => ("));
+  assert.ok(source.includes("max-w-[calc(100vw-2rem)]"));
   assert.equal(source.includes('className="public-cta-outline lg:hidden"'), false);
   assert.equal(source.includes("<Link href={ROUTES.profesionales}>Profesionales</Link>"), false);
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
@@ -65,16 +70,21 @@ test("navbar keeps full navigation desktop-only and exposes mobile dropdown", ()
 test("navbar mobile dropdown includes expected public links", () => {
   const source = read(NAVBAR_PATH);
 
-  assert.ok(source.includes('const mobileNavLinks = [{ label: "Inicio", href: ROUTES.home }, ...navLinks];'));
+  assert.ok(source.includes("href={ROUTES.home}"));
+  assert.ok(source.includes("Inicio"));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
   assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
   assert.ok(source.includes('{ label: "Particulares", href: ROUTES.particulares }'));
   assert.ok(source.includes('{ label: "Contacto", href: ROUTES.contacto }'));
   assert.ok(source.includes('{ label: "Precios", href: ROUTES.precios }'));
+  assert.ok(source.includes("public-cta-outline inline-flex h-9 w-full"));
+  assert.ok(source.includes("public-cta-primary inline-flex h-9 w-full"));
+  assert.ok(source.includes("Iniciar sesión"));
+  assert.ok(source.includes("Solicitar acceso"));
 });
 
-test("navbar keeps expected public link order including precios", () => {
+test("navbar keeps expected public link order within its three intent groups", () => {
   const source = read(NAVBAR_PATH);
 
   const serviciosIndex = source.indexOf('{ label: "Servicios", href: ROUTES.servicios }');
@@ -86,9 +96,9 @@ test("navbar keeps expected public link order including precios", () => {
 
   assert.ok(serviciosIndex < profesionalesIndex);
   assert.ok(profesionalesIndex < clinicasIndex);
-  assert.ok(clinicasIndex < particularesIndex);
+  assert.ok(clinicasIndex < preciosIndex);
+  assert.ok(preciosIndex < particularesIndex);
   assert.ok(particularesIndex < contactoIndex);
-  assert.ok(contactoIndex < preciosIndex);
 });
 
 test("navbar exposes home login and access CTAs with VETNEB brand", () => {
@@ -114,12 +124,15 @@ test("footer uses centralized public routes and contentinfo landmark", () => {
   assert.ok(source.includes("PublicRouteControl"));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes('role="contentinfo"'));
-  assert.ok(source.includes('const footerLinks = ['));
+  assert.ok(source.includes("const footerLinkGroups = ["));
+  assert.ok(source.includes('label: "Diagnóstico / Servicios"'));
+  assert.ok(source.includes('label: "Operación clínica"'));
   assert.ok(source.includes('{ label: "Servicios", href: ROUTES.servicios }'));
   assert.ok(source.includes('{ label: "Profesionales", href: ROUTES.profesionales }'));
   assert.ok(source.includes('{ label: "Clínicas", href: ROUTES.clinicas }'));
-  assert.ok(source.includes('{ label: "Contacto", href: ROUTES.contacto }'));
-  assert.ok(source.includes("footerLinks.map((link) =>"));
+  assert.ok(source.includes('{ label: "Precios", href: ROUTES.precios }'));
+  assert.ok(source.includes("footerLinkGroups.map((group) =>"));
+  assert.ok(source.includes('aria-label="Mapa institucional y operativo"'));
 });
 
 test("footer exposes access links and legal copy without redundant brand block", () => {
@@ -133,4 +146,32 @@ test("footer exposes access links and legal copy without redundant brand block",
   assert.equal(source.includes("Laboratorio veterinario digital — Argentina"), false);
   assert.equal(source.includes("Laboratorio veterinario digital. Informes, estudios y gestión"), false);
   assert.equal(source.includes("rounded-md bg-primary px-3"), false);
+});
+
+test("public navbar and footer stay free of private routes and prohibited demo copy", () => {
+  const source = `${read(NAVBAR_PATH)}\n${read(FOOTER_PATH)}`;
+  const prohibited = [
+    "MUESTRA",
+    "DEMOSTRATIVO",
+    "ejemplo visual",
+    "sin datos reales",
+    "caso demo",
+    "DEMO-000",
+    "DEMO-CLINICA-001",
+    "paciente demostrativo",
+    "clínica demostrativa",
+    "preview de informe simulado",
+    "panel operativo simulado",
+    "dashboard ficticio",
+    "informe inventado",
+    "datos ficticios visibles",
+  ];
+
+  for (const text of prohibited) {
+    assert.equal(source.includes(text), false, `public layout must not contain ${text}`);
+  }
+
+  assert.equal(source.includes("ROUTES.dashboard"), false);
+  assert.equal(source.includes('"/dashboard"'), false);
+  assert.equal(source.includes("admin_session_id"), false);
 });

--- a/test/frontend-public-visual-polish-regression-contract.test.ts
+++ b/test/frontend-public-visual-polish-regression-contract.test.ts
@@ -87,7 +87,7 @@ test("navbar header uses bg-card/92 and backdrop-blur-sm not bg-card/96", () => 
   assert.equal(source.includes("bg-card/96"), false);
 });
 
-test("navbar desktop and mobile nav links pass activeClassName to PublicRouteControl", () => {
+test("navbar desktop mobile and mobile-home nav links pass activeClassName to PublicRouteControl", () => {
   const source = read(NAVBAR_PATH);
 
   assert.ok(source.includes('activeClassName="bg-accent/80 text-vetneb-ink shadow-sm"'));
@@ -100,8 +100,8 @@ test("navbar CTA controls carry no activeClassName — only nav link loops do", 
 
   assert.equal(
     occurrences,
-    2,
-    `activeClassName must appear exactly in desktop and mobile nav link loops (expected 2, got ${occurrences})`,
+    3,
+    `activeClassName must appear in desktop, mobile group and mobile home controls (expected 3, got ${occurrences})`,
   );
 });
 


### PR DESCRIPTION
## Summary
- Group public desktop navigation into Diagnóstico, Operación and Acceso
- Keep mobile navigation functional with the same grouped information architecture
- Reorganize footer as an institutional/operational map while preserving lab info and map

## Scope
- Public navbar and footer only
- Navigation/footer contracts and focused e2e updated
- No public page content, dashboard, API, auth, DB, workflow, dependency or production changes

## Safety
- No public demos, mocks, fictitious cases, dashboard previews, or fake report data
- No copy-commercial expansion
- Existing routes, login, Solicitar acceso, private access, middleware and permissions remain intact
- Address, opening hours, WhatsApp, email and map remain intact

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e public-navigation-footer.spec.ts
- focused navigation/footer tests
- pnpm validate:local
- pnpm test
- git diff --check
- git diff --cached --check