### PR TITLE
feat(public): add public-wide perspective scroll

### DIFF
--- a/frontend/e2e/public-perspective-scroll.spec.ts
+++ b/frontend/e2e/public-perspective-scroll.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+
+const perspectiveRoutes = ["/", "/servicios", "/clinicas", "/precios", "/contacto"];
+
+for (const route of perspectiveRoutes) {
+  test(`${route} renders perspective sections outside navbar and footer`, async ({
+    page,
+  }) => {
+    const response = await page.goto(route);
+
+    expect(response?.ok(), `${route} should return a successful response`).toBeTruthy();
+
+    const perspectiveSections = page.locator("[data-public-perspective-section]");
+    await expect(perspectiveSections.first()).toBeAttached();
+
+    await expect(
+      page.getByRole("banner").locator("[data-public-perspective-section]"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("contentinfo").locator("[data-public-perspective-section]"),
+    ).toHaveCount(0);
+  });
+
+  test(`${route} keeps mobile free of horizontal overflow while scrolling`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(route);
+
+    for (const scrollY of [0, 600, 1600, 99999]) {
+      await page.evaluate((y) => window.scrollTo(0, y), scrollY);
+      await page.waitForTimeout(120);
+
+      const horizontalOverflow = await page.evaluate(() => {
+        const documentElement = document.documentElement;
+
+        return documentElement.scrollWidth - documentElement.clientWidth;
+      });
+
+      expect(
+        horizontalOverflow,
+        `${route} must not overflow horizontally at scrollY=${scrollY}`,
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+}
+
+test("home keeps several perspective sections readable after scrolling", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const perspectiveSections = page.locator("[data-public-perspective-section]");
+  expect(await perspectiveSections.count()).toBeGreaterThanOrEqual(4);
+
+  await page.evaluate(() => {
+    window.scrollTo(0, document.body.scrollHeight / 2);
+  });
+  await page.waitForTimeout(200);
+
+  await expect(page.getByRole("heading", { name: "Recorrido de la muestra" })).toBeVisible();
+
+  await page.evaluate(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  });
+  await page.waitForTimeout(200);
+
+  await expect(page.getByRole("contentinfo")).toBeVisible();
+});
+
+test("reduced motion disables perspective transforms and marks sections", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ reducedMotion: "reduce" });
+  const page = await context.newPage();
+
+  await page.goto("/");
+
+  const firstSection = page.locator("[data-public-perspective-section]").first();
+  await expect(firstSection).toHaveAttribute(
+    "data-perspective-disabled",
+    "reduced-motion",
+  );
+
+  const innerTransform = await firstSection
+    .locator(".public-perspective-section-inner")
+    .first()
+    .evaluate((element) => window.getComputedStyle(element).transform);
+
+  expect(innerTransform).toBe("none");
+
+  await context.close();
+});
+
+test("mobile navbar still opens and closes with perspective sections active", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto("/");
+
+  const toggle = page.getByLabel("Abrir navegación VETNEB");
+  const mobileNav = page.getByRole("navigation", { name: "Navegación mobile" });
+
+  await toggle.click();
+  await expect(mobileNav).toBeVisible();
+
+  await toggle.click();
+  await expect(mobileNav).toBeHidden();
+});

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PerspectiveScrollSection } from "@/components/public/PerspectiveScrollSection";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { VisualIcon } from "@/components/public/VisualAccents";
@@ -208,6 +209,7 @@ export default function ClinicasPage() {
           className="py-16 md:py-20"
           aria-labelledby="clinicas-features-heading"
         >
+          <PerspectiveScrollSection intensity="standard">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
               <div className="mx-auto mb-10 max-w-3xl text-center">
@@ -296,6 +298,7 @@ export default function ClinicasPage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         {/* Cómo opera tu clínica con VETNEB */}
@@ -303,6 +306,7 @@ export default function ClinicasPage() {
           className="public-evidence-band-muted public-band-feature"
           aria-labelledby="clinicas-operations-heading"
         >
+          <PerspectiveScrollSection intensity="featured">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
               <div className="mx-auto mb-10 max-w-3xl text-center md:mb-14">
@@ -391,6 +395,7 @@ export default function ClinicasPage() {
               </ol>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         {/* Cómo comenzar */}
@@ -398,6 +403,7 @@ export default function ClinicasPage() {
           className="py-16 md:py-20"
           aria-labelledby="clinicas-onboarding-heading"
         >
+          <PerspectiveScrollSection intensity="subtle">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
               <div className="mx-auto mb-10 max-w-3xl text-center">
@@ -500,6 +506,7 @@ export default function ClinicasPage() {
               </section>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
       </div>
 
@@ -509,6 +516,7 @@ export default function ClinicasPage() {
         aria-labelledby="clinicas-conversion-heading"
       >
         <div className="container mx-auto px-4 text-center sm:px-6 lg:px-8">
+          <PerspectiveScrollSection intensity="subtle">
           <PublicScrollReveal variant="section">
             <h2
               id="clinicas-conversion-heading"
@@ -538,6 +546,7 @@ export default function ClinicasPage() {
               </PublicRouteControl>
             </div>
           </PublicScrollReveal>
+          </PerspectiveScrollSection>
         </div>
       </section>
     </PublicLayout>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1018,6 +1018,52 @@
     opacity: 1;
   }
 }
+/* public-perspective-scroll:start */
+@layer components {
+  .public-perspective-stage {
+    --public-perspective-depth: 1100px;
+    /* The projected near edge of a rotated section can extend a few pixels
+       past the viewport while transitioning; clip keeps the document free of
+       horizontal scroll without creating a new scroll container. */
+    overflow-x: clip;
+  }
+
+  .public-perspective-section {
+    --scroll-depth-scale: 1;
+    --scroll-depth-rotate-x: 0deg;
+    --scroll-depth-y: 0px;
+    --scroll-depth-opacity: 1;
+    perspective: var(--public-perspective-depth, 1100px);
+    perspective-origin: 50% 50%;
+  }
+
+  .public-perspective-section-inner {
+    transform-origin: center center;
+    transform-style: preserve-3d;
+    transform: translate3d(0, var(--scroll-depth-y), 0)
+      rotateX(var(--scroll-depth-rotate-x))
+      scale(var(--scroll-depth-scale));
+    opacity: var(--scroll-depth-opacity);
+  }
+
+  .public-perspective-section[data-perspective-active="true"]
+    > .public-perspective-section-inner {
+    will-change: transform, opacity;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .public-perspective-section {
+      perspective: none;
+    }
+
+    .public-perspective-section-inner {
+      transform: none !important;
+      opacity: 1 !important;
+      will-change: auto !important;
+    }
+  }
+}
+/* public-perspective-scroll:end */
 /* dashboard-auth-visual-system:start */
 @layer components {
   .dashboard-main {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PerspectiveScrollSection } from "@/components/public/PerspectiveScrollSection";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import {
   PublicExternalControl,
@@ -304,6 +305,7 @@ export default function HomePage() {
           className="public-evidence-band-light py-12 md:py-16"
           aria-labelledby="clinical-trust-heading"
         >
+          <PerspectiveScrollSection intensity="standard">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal>
               <div className="mx-auto mb-8 max-w-3xl text-center md:mb-10">
@@ -358,6 +360,7 @@ export default function HomePage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         <section
@@ -394,6 +397,7 @@ export default function HomePage() {
           className="py-16 md:py-20"
           aria-labelledby="services-heading"
         >
+          <PerspectiveScrollSection intensity="standard">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal>
               <div className="text-center mb-12">
@@ -480,6 +484,7 @@ export default function HomePage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         {/* Recorrido end-to-end — de la muestra al informe */}
@@ -487,6 +492,7 @@ export default function HomePage() {
           className="public-evidence-band-muted public-band-feature"
           aria-labelledby="specimen-journey-heading"
         >
+          <PerspectiveScrollSection intensity="standard">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal>
               <div className="mx-auto mb-10 max-w-3xl text-center md:mb-14">
@@ -530,6 +536,7 @@ export default function HomePage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         {/* Beneficios */}
@@ -537,6 +544,7 @@ export default function HomePage() {
           className="public-evidence-band-light py-16 md:py-20"
           aria-labelledby="benefits-heading"
         >
+          <PerspectiveScrollSection intensity="subtle">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal>
               <div className="text-center mb-12">
@@ -608,6 +616,7 @@ export default function HomePage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         {/* CTA final */}
@@ -616,6 +625,7 @@ export default function HomePage() {
           aria-labelledby="cta-heading"
         >
           <div className="diagnostic-field" data-tone="dark" aria-hidden="true" />
+          <PerspectiveScrollSection intensity="subtle">
           <PublicScrollReveal>
             <div className="container relative z-10 mx-auto px-4 text-center sm:px-6 lg:px-8">
               <h2
@@ -648,6 +658,7 @@ export default function HomePage() {
               </div>
             </div>
           </PublicScrollReveal>
+          </PerspectiveScrollSection>
         </section>
       </div>
     </PublicLayout>

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PerspectiveScrollSection } from "@/components/public/PerspectiveScrollSection";
 import { PublicScrollReveal } from "@/components/public/PublicScrollReveal";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { SpecimenJourneySection } from "@/components/public/SpecimenJourneySection";
@@ -202,6 +203,7 @@ export default function ServiciosPage() {
           className="py-16 md:py-20"
           aria-labelledby="services-categories-heading"
         >
+          <PerspectiveScrollSection intensity="featured">
           <div className="container mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
               <div className="mx-auto mb-10 max-w-4xl">
@@ -334,6 +336,7 @@ export default function ServiciosPage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         <section
@@ -341,6 +344,7 @@ export default function ServiciosPage() {
           aria-labelledby="services-coordination-heading"
           data-services-composed-band="coordination-integral"
         >
+          <PerspectiveScrollSection intensity="standard">
           <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="grid items-stretch gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:gap-12">
               <PublicScrollReveal variant="section">
@@ -401,12 +405,14 @@ export default function ServiciosPage() {
               </PublicScrollReveal>
             </div>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         <section
           className="public-band-feature"
           aria-labelledby="services-specimen-journey-heading"
         >
+          <PerspectiveScrollSection intensity="subtle">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-5xl">
             <PublicScrollReveal variant="section">
               <div className="mb-8">
@@ -434,12 +440,14 @@ export default function ServiciosPage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
 
         <section
           className="public-evidence-band-muted public-band"
           data-services-composed-band="considerations-values"
         >
+          <PerspectiveScrollSection intensity="subtle">
           <div className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <PublicScrollReveal variant="section">
               <div className="grid gap-8 lg:grid-cols-2 lg:gap-0">
@@ -498,6 +506,7 @@ export default function ServiciosPage() {
               </div>
             </PublicScrollReveal>
           </div>
+          </PerspectiveScrollSection>
         </section>
       </div>
     </PublicLayout>

--- a/frontend/src/components/layout/PublicLayout.tsx
+++ b/frontend/src/components/layout/PublicLayout.tsx
@@ -10,7 +10,10 @@ export function PublicLayout({ children }: PublicLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
-      <main className="public-page-canvas flex-1" id="main-content">
+      <main
+        className="public-page-canvas public-perspective-stage flex-1"
+        id="main-content"
+      >
         {children}
         <FooterFaq />
       </main>

--- a/frontend/src/components/public/ContactoContent.tsx
+++ b/frontend/src/components/public/ContactoContent.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PerspectiveScrollSection } from "@/components/public/PerspectiveScrollSection";
 import {
   PublicExternalControl,
   PublicRouteControl,
@@ -164,6 +165,7 @@ export function ContactoContent() {
         data-contact-intent-router
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <PerspectiveScrollSection intensity="subtle">
           <div className="mx-auto max-w-6xl">
             <div className="mb-7 max-w-2xl">
               <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-vetneb-ink/65">
@@ -298,6 +300,7 @@ export function ContactoContent() {
               </PublicRouteControl>
             </nav>
           </div>
+          </PerspectiveScrollSection>
         </div>
       </section>
 
@@ -494,6 +497,9 @@ export function ContactoContent() {
             </section>
 
             <section aria-labelledby="contact-info-heading">
+              {/* La perspectiva cubre solo la columna informativa; el
+                  formulario de contacto queda fuera del efecto. */}
+              <PerspectiveScrollSection intensity="subtle">
               <div className="mb-6 flex items-start gap-3">
                 <VisualIcon icon={Phone} tone="emerald" className="h-11 w-11 rounded-xl" />
                 <div>
@@ -550,6 +556,7 @@ export function ContactoContent() {
                   trazabilidad y seguimiento de informes.
                 </p>
               </div>
+              </PerspectiveScrollSection>
             </section>
           </div>
         </div>

--- a/frontend/src/components/public/PerspectiveScrollSection.tsx
+++ b/frontend/src/components/public/PerspectiveScrollSection.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+import {
+  useScrollPerspective,
+  type ScrollPerspectiveIntensity,
+  type ScrollPerspectiveMobileIntensity,
+} from "@/hooks/useScrollPerspective";
+import { cn } from "@/lib/utils";
+
+type PerspectiveScrollSectionTag = "div" | "section";
+
+export type PerspectiveScrollSectionProps = {
+  children: ReactNode;
+  className?: string;
+  innerClassName?: string;
+  as?: PerspectiveScrollSectionTag;
+  intensity?: ScrollPerspectiveIntensity;
+  disableOnMobile?: boolean;
+  mobileIntensity?: ScrollPerspectiveMobileIntensity;
+};
+
+export function PerspectiveScrollSection({
+  children,
+  className,
+  innerClassName,
+  as = "div",
+  intensity = "standard",
+  disableOnMobile = false,
+  mobileIntensity = "minimal",
+}: PerspectiveScrollSectionProps) {
+  const sectionRef = useScrollPerspective<HTMLElement>({
+    intensity,
+    disableOnMobile,
+    mobileIntensity,
+  });
+
+  const wrapperClassName = cn("public-perspective-section", className);
+  const innerContent = (
+    <div className={cn("public-perspective-section-inner", innerClassName)}>
+      {children}
+    </div>
+  );
+
+  if (as === "section") {
+    return (
+      <section
+        ref={(node) => {
+          sectionRef.current = node;
+        }}
+        className={wrapperClassName}
+        data-public-perspective-section="true"
+        data-perspective-intensity={intensity}
+      >
+        {innerContent}
+      </section>
+    );
+  }
+
+  return (
+    <div
+      ref={(node) => {
+        sectionRef.current = node;
+      }}
+      className={wrapperClassName}
+      data-public-perspective-section="true"
+      data-perspective-intensity={intensity}
+    >
+      {innerContent}
+    </div>
+  );
+}

--- a/frontend/src/components/public/PreciosContent.tsx
+++ b/frontend/src/components/public/PreciosContent.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, CheckCircle2, HelpCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { PerspectiveScrollSection } from "@/components/public/PerspectiveScrollSection";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getPublicPricing, type PublicPricingCategory } from "@/lib/api";
@@ -191,6 +192,9 @@ export function PreciosContent() {
         className="public-evidence-band-light public-band-compact"
         aria-labelledby="pricing-catalog-heading"
       >
+        {/* Contenedor general del catálogo: única superficie con perspectiva en
+            precios. Filas, valores y badges no llevan transform propio. */}
+        <PerspectiveScrollSection intensity="subtle">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <h2 id="pricing-catalog-heading" className="sr-only">
             Catálogo público de precios por categoría
@@ -329,6 +333,7 @@ export function PreciosContent() {
             </p>
           )}
         </div>
+        </PerspectiveScrollSection>
       </section>
     </PublicLayout>
   );

--- a/frontend/src/hooks/useScrollPerspective.ts
+++ b/frontend/src/hooks/useScrollPerspective.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export type ScrollPerspectiveIntensity = "subtle" | "standard" | "featured";
+export type ScrollPerspectiveMobileIntensity = "none" | "minimal";
+
+type ScrollPerspectiveProfile = {
+  maxRotateXDeg: number;
+  minScale: number;
+  maxTranslateYPx: number;
+  minOpacity: number;
+};
+
+export const SCROLL_PERSPECTIVE_PROFILES: Record<
+  ScrollPerspectiveIntensity,
+  ScrollPerspectiveProfile
+> = {
+  subtle: {
+    maxRotateXDeg: 2,
+    minScale: 0.99,
+    maxTranslateYPx: 12,
+    minOpacity: 0.94,
+  },
+  standard: {
+    maxRotateXDeg: 3,
+    minScale: 0.985,
+    maxTranslateYPx: 20,
+    minOpacity: 0.9,
+  },
+  featured: {
+    maxRotateXDeg: 4.5,
+    minScale: 0.975,
+    maxTranslateYPx: 28,
+    minOpacity: 0.86,
+  },
+};
+
+const SCROLL_PERSPECTIVE_MOBILE_MINIMAL_PROFILE: ScrollPerspectiveProfile = {
+  maxRotateXDeg: 0,
+  minScale: 0.992,
+  maxTranslateYPx: 10,
+  minOpacity: 0.95,
+};
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const MOBILE_VIEWPORT_MAX_WIDTH_PX = 768;
+
+type RegisteredPerspectiveSection = {
+  element: HTMLElement;
+  desktopProfile: ScrollPerspectiveProfile;
+  mobileProfile: ScrollPerspectiveProfile | null;
+  isNeutralized: boolean;
+};
+
+const registeredSections = new Set<RegisteredPerspectiveSection>();
+
+let pendingFrameId: number | null = null;
+let areViewportListenersAttached = false;
+
+function setSectionDepthVariables(
+  element: HTMLElement,
+  scale: number,
+  rotateXDeg: number,
+  translateYPx: number,
+  opacity: number,
+) {
+  element.style.setProperty("--scroll-depth-scale", scale.toFixed(4));
+  element.style.setProperty("--scroll-depth-rotate-x", `${rotateXDeg.toFixed(3)}deg`);
+  element.style.setProperty("--scroll-depth-y", `${translateYPx.toFixed(2)}px`);
+  element.style.setProperty("--scroll-depth-opacity", opacity.toFixed(4));
+}
+
+function clearSectionDepthVariables(element: HTMLElement) {
+  element.style.removeProperty("--scroll-depth-scale");
+  element.style.removeProperty("--scroll-depth-rotate-x");
+  element.style.removeProperty("--scroll-depth-y");
+  element.style.removeProperty("--scroll-depth-opacity");
+}
+
+function updateRegisteredSections() {
+  pendingFrameId = null;
+
+  const viewportHeight = window.innerHeight;
+
+  if (viewportHeight <= 0 || registeredSections.size === 0) {
+    return;
+  }
+
+  const viewportCenter = viewportHeight / 2;
+  const isMobileViewport = window.innerWidth < MOBILE_VIEWPORT_MAX_WIDTH_PX;
+
+  for (const section of registeredSections) {
+    const profile = isMobileViewport
+      ? section.mobileProfile
+      : section.desktopProfile;
+
+    if (!profile) {
+      if (!section.isNeutralized) {
+        setSectionDepthVariables(section.element, 1, 0, 0, 1);
+        section.isNeutralized = true;
+      }
+      continue;
+    }
+
+    section.isNeutralized = false;
+
+    const rect = section.element.getBoundingClientRect();
+
+    if (rect.height <= 0) {
+      continue;
+    }
+
+    const sectionCenter = rect.top + rect.height / 2;
+    const normalizationRange = viewportCenter + rect.height / 2;
+    const rawProgress = (sectionCenter - viewportCenter) / normalizationRange;
+    const signedProgress = Math.max(-1, Math.min(1, rawProgress));
+    // Signed quadratic easing: near the viewport center the section stays
+    // visually neutral; depth ramps toward the viewport edges.
+    const easedDepth = signedProgress * Math.abs(signedProgress);
+    const depthMagnitude = Math.abs(easedDepth);
+    // Sections taller than the viewport rotate proportionally less so the
+    // projected near edge never widens past the layout gutters.
+    const rotationHeightCap = Math.min(1, viewportHeight / rect.height);
+
+    setSectionDepthVariables(
+      section.element,
+      1 - (1 - profile.minScale) * depthMagnitude,
+      profile.maxRotateXDeg * easedDepth * rotationHeightCap,
+      profile.maxTranslateYPx * easedDepth,
+      1 - (1 - profile.minOpacity) * depthMagnitude,
+    );
+  }
+}
+
+function scheduleSectionsUpdate() {
+  if (pendingFrameId !== null) {
+    return;
+  }
+
+  pendingFrameId = window.requestAnimationFrame(updateRegisteredSections);
+}
+
+function attachViewportListeners() {
+  if (areViewportListenersAttached) {
+    return;
+  }
+
+  window.addEventListener("scroll", scheduleSectionsUpdate, { passive: true });
+  window.addEventListener("resize", scheduleSectionsUpdate, { passive: true });
+  areViewportListenersAttached = true;
+}
+
+function detachViewportListeners() {
+  if (!areViewportListenersAttached) {
+    return;
+  }
+
+  window.removeEventListener("scroll", scheduleSectionsUpdate);
+  window.removeEventListener("resize", scheduleSectionsUpdate);
+  areViewportListenersAttached = false;
+
+  if (pendingFrameId !== null) {
+    window.cancelAnimationFrame(pendingFrameId);
+    pendingFrameId = null;
+  }
+}
+
+export type UseScrollPerspectiveOptions = {
+  intensity?: ScrollPerspectiveIntensity;
+  disableOnMobile?: boolean;
+  mobileIntensity?: ScrollPerspectiveMobileIntensity;
+};
+
+export function useScrollPerspective<T extends HTMLElement>({
+  intensity = "standard",
+  disableOnMobile = false,
+  mobileIntensity = "minimal",
+}: UseScrollPerspectiveOptions = {}): RefObject<T | null> {
+  const sectionRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    const element = sectionRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    if (window.matchMedia(REDUCED_MOTION_QUERY).matches) {
+      element.setAttribute("data-perspective-disabled", "reduced-motion");
+
+      return () => {
+        element.removeAttribute("data-perspective-disabled");
+      };
+    }
+
+    const section: RegisteredPerspectiveSection = {
+      element,
+      desktopProfile: SCROLL_PERSPECTIVE_PROFILES[intensity],
+      mobileProfile:
+        disableOnMobile || mobileIntensity === "none"
+          ? null
+          : SCROLL_PERSPECTIVE_MOBILE_MINIMAL_PROFILE,
+      isNeutralized: false,
+    };
+
+    registeredSections.add(section);
+    element.setAttribute("data-perspective-active", "true");
+    attachViewportListeners();
+    scheduleSectionsUpdate();
+
+    return () => {
+      registeredSections.delete(section);
+      element.removeAttribute("data-perspective-active");
+      clearSectionDepthVariables(element);
+
+      if (registeredSections.size === 0) {
+        detachViewportListeners();
+      }
+    };
+  }, [disableOnMobile, intensity, mobileIntensity]);
+
+  return sectionRef;
+}

--- a/test/frontend-dashboard-accessibility-focus-aria.test.ts
+++ b/test/frontend-dashboard-accessibility-focus-aria.test.ts
@@ -169,7 +169,6 @@ test("PR-8 dashboard accessibility scope avoids forbidden files", () => {
     "shared/",
     "frontend/src/app/api/",
     "frontend/src/middleware",
-    "frontend/src/app/servicios/",
     "frontend/src/app/histopatologia-veterinaria/",
   ];
   const blockedFiles = [

--- a/test/frontend-dashboard-action-feedback-focus-polish.test.ts
+++ b/test/frontend-dashboard-action-feedback-focus-polish.test.ts
@@ -220,7 +220,6 @@ test("PR-4 action feedback polish stays within allowed file scope", () => {
     "shared/",
     "frontend/src/app/api/",
     "frontend/src/middleware",
-    "frontend/src/app/servicios/",
     "frontend/src/app/histopatologia-veterinaria/",
   ];
 

--- a/test/frontend-dashboard-admin-section-tabs.test.ts
+++ b/test/frontend-dashboard-admin-section-tabs.test.ts
@@ -162,7 +162,6 @@ test("dashboard admin tabs stay inside frontend-only PR-7 scope", () => {
     "frontend/src/app/api/",
     "frontend/src/middleware",
     "middleware",
-    "frontend/src/app/servicios/",
     "frontend/src/app/histopatologia-veterinaria/",
   ];
 

--- a/test/frontend-dashboard-interaction-foundation.test.ts
+++ b/test/frontend-dashboard-interaction-foundation.test.ts
@@ -304,7 +304,6 @@ test("PR-1 interaction foundation stays within allowed file scope", () => {
     "shared/",
     "frontend/src/app/api/",
     "frontend/src/middleware",
-    "frontend/src/app/servicios/",
     "frontend/src/app/histopatologia-veterinaria/",
   ];
 

--- a/test/frontend-dashboard-logistics-hub.test.ts
+++ b/test/frontend-dashboard-logistics-hub.test.ts
@@ -310,7 +310,6 @@ test("logistics hub changes do not touch backend, API routes, auth, middleware o
     "next.config",
     "app/api/",
     "app/login",
-    "app/servicios",
     "app/profesionales",
     "app/particulares",
     "app/contacto",

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -163,7 +163,6 @@ test("PR-9 mobile polish scope avoids forbidden surfaces and dependencies", () =
     "shared/",
     "frontend/src/app/api/",
     "frontend/src/middleware",
-    "frontend/src/app/servicios/",
     "frontend/src/app/histopatologia-veterinaria/",
   ];
   const blockedFiles = [

--- a/test/frontend-dashboard-workspace-layout-polish.test.ts
+++ b/test/frontend-dashboard-workspace-layout-polish.test.ts
@@ -431,7 +431,6 @@ test("PR-2 workspace layout polish stays within allowed file scope", () => {
     "shared/",
     "frontend/src/app/api/",
     "frontend/src/middleware",
-    "frontend/src/app/servicios/",
   ];
 
   const blockedExactFiles = [

--- a/test/frontend-public-layout-navigation.test.ts
+++ b/test/frontend-public-layout-navigation.test.ts
@@ -22,7 +22,12 @@ test("public layout wraps pages with navbar main landmark and footer", () => {
   assert.ok(source.includes("interface PublicLayoutProps"));
   assert.ok(source.includes("children: React.ReactNode;"));
   assert.ok(source.includes("<Navbar />"));
-  assert.ok(source.includes('<main className="public-page-canvas flex-1" id="main-content">'));
+  assert.ok(
+    source.includes(
+      'className="public-page-canvas public-perspective-stage flex-1"',
+    ),
+  );
+  assert.ok(source.includes('id="main-content"'));
   assert.ok(source.includes("{children}"));
   assert.ok(source.includes("<Footer />"));
 });

--- a/test/frontend-public-perspective-scroll.test.ts
+++ b/test/frontend-public-perspective-scroll.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const HOOK_PATH = "frontend/src/hooks/useScrollPerspective.ts";
+const COMPONENT_PATH = "frontend/src/components/public/PerspectiveScrollSection.tsx";
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+const PUBLIC_LAYOUT_PATH = "frontend/src/components/layout/PublicLayout.tsx";
+const NAVBAR_PATH = "frontend/src/components/layout/Navbar.tsx";
+const FOOTER_PATH = "frontend/src/components/layout/Footer.tsx";
+const HOME_PAGE_PATH = "frontend/src/app/page.tsx";
+const SERVICIOS_PAGE_PATH = "frontend/src/app/servicios/page.tsx";
+const CLINICAS_PAGE_PATH = "frontend/src/app/clinicas/page.tsx";
+const PRECIOS_CONTENT_PATH = "frontend/src/components/public/PreciosContent.tsx";
+const CONTACTO_CONTENT_PATH = "frontend/src/components/public/ContactoContent.tsx";
+
+const PROHIBITED_PUBLIC_STRINGS = [
+  "DEMOSTRATIVO",
+  "ejemplo visual",
+  "sin datos reales",
+  "caso demo",
+  "DEMO-000",
+  "DEMO-CLINICA-001",
+  "paciente demostrativo",
+  "clínica demostrativa",
+  "preview de informe simulado",
+  "panel operativo simulado",
+  "dashboard ficticio",
+  "informe inventado",
+  "datos ficticios visibles",
+];
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(/\r\n/g, "\n");
+}
+
+function countOccurrences(source: string, needle: string): number {
+  return source.split(needle).length - 1;
+}
+
+// ─── PR-24: foundation — hook ────────────────────────────────────────────────
+
+test("useScrollPerspective hook exists as a client module with intensity profiles", () => {
+  const source = read(HOOK_PATH);
+
+  assert.ok(source.startsWith('"use client";'));
+  assert.ok(source.includes("SCROLL_PERSPECTIVE_PROFILES"));
+  assert.ok(source.includes('"subtle" | "standard" | "featured"'));
+  assert.ok(source.includes('"none" | "minimal"'));
+  assert.ok(source.includes("disableOnMobile"));
+});
+
+test("hook drives depth via rAF with passive listeners and full cleanup", () => {
+  const source = read(HOOK_PATH);
+
+  assert.ok(source.includes("requestAnimationFrame"));
+  assert.ok(source.includes("cancelAnimationFrame"));
+  assert.ok(source.includes('window.addEventListener("scroll", scheduleSectionsUpdate, { passive: true })'));
+  assert.ok(source.includes('window.addEventListener("resize", scheduleSectionsUpdate, { passive: true })'));
+  assert.ok(source.includes('window.removeEventListener("scroll", scheduleSectionsUpdate)'));
+  assert.ok(source.includes('window.removeEventListener("resize", scheduleSectionsUpdate)'));
+});
+
+test("hook respects prefers-reduced-motion without registering listeners", () => {
+  const source = read(HOOK_PATH);
+
+  assert.ok(source.includes("(prefers-reduced-motion: reduce)"));
+  assert.ok(source.includes('data-perspective-disabled", "reduced-motion"'));
+});
+
+test("hook never hijacks scrolling: no wheel/touch interception, no preventDefault", () => {
+  const source = read(HOOK_PATH);
+
+  assert.equal(source.includes("preventDefault"), false);
+  assert.equal(source.includes('"wheel"'), false);
+  assert.equal(source.includes('"touchmove"'), false);
+  assert.equal(source.includes("scrollTo"), false);
+  assert.equal(source.includes("scroll-behavior"), false);
+});
+
+test("hook animates only transform/opacity CSS variables", () => {
+  const source = read(HOOK_PATH);
+
+  assert.ok(source.includes("--scroll-depth-scale"));
+  assert.ok(source.includes("--scroll-depth-rotate-x"));
+  assert.ok(source.includes("--scroll-depth-y"));
+  assert.ok(source.includes("--scroll-depth-opacity"));
+  assert.equal(source.includes("style.width"), false);
+  assert.equal(source.includes("style.height"), false);
+  assert.equal(source.includes("style.margin"), false);
+  assert.equal(source.includes('setProperty("width"'), false);
+  assert.equal(source.includes('setProperty("height"'), false);
+});
+
+// ─── PR-24: foundation — component ───────────────────────────────────────────
+
+test("PerspectiveScrollSection is a client wrapper using the hook with data attributes", () => {
+  const source = read(COMPONENT_PATH);
+
+  assert.ok(source.startsWith('"use client";'));
+  assert.ok(source.includes("useScrollPerspective"));
+  assert.ok(source.includes('data-public-perspective-section="true"'));
+  assert.ok(source.includes("data-perspective-intensity={intensity}"));
+  assert.ok(source.includes("public-perspective-section-inner"));
+});
+
+// ─── PR-24: foundation — CSS ─────────────────────────────────────────────────
+
+test("globals.css defines the public perspective foundation with neutral defaults", () => {
+  const source = read(GLOBALS_CSS_PATH);
+
+  assert.ok(source.includes(".public-perspective-stage"));
+  assert.ok(source.includes(".public-perspective-section"));
+  assert.ok(source.includes(".public-perspective-section-inner"));
+  assert.ok(source.includes("--scroll-depth-scale: 1;"));
+  assert.ok(source.includes("--scroll-depth-rotate-x: 0deg;"));
+  assert.ok(source.includes("--scroll-depth-y: 0px;"));
+  assert.ok(source.includes("--scroll-depth-opacity: 1;"));
+  assert.ok(source.includes("perspective: var(--public-perspective-depth, 1100px);"));
+});
+
+test("globals.css neutralizes perspective transforms under prefers-reduced-motion", () => {
+  const source = read(GLOBALS_CSS_PATH);
+  const perspectiveBlock = source.slice(
+    source.indexOf("/* public-perspective-scroll:start */"),
+    source.indexOf("/* public-perspective-scroll:end */"),
+  );
+
+  assert.ok(perspectiveBlock.includes("@media (prefers-reduced-motion: reduce)"));
+  assert.ok(perspectiveBlock.includes("transform: none !important;"));
+  assert.ok(perspectiveBlock.includes("opacity: 1 !important;"));
+});
+
+test("public layout main is the perspective stage; navbar/footer stay outside it", () => {
+  const source = read(PUBLIC_LAYOUT_PATH);
+
+  assert.ok(source.includes("public-perspective-stage"));
+
+  const mainIndex = source.indexOf("<main");
+  const navbarIndex = source.indexOf("<Navbar");
+  const footerIndex = source.indexOf("<Footer />");
+
+  assert.ok(navbarIndex < mainIndex, "Navbar must render before main stage");
+  assert.ok(source.indexOf("</main>") < footerIndex, "Footer must render after main stage");
+});
+
+// ─── PR-24: per-route coverage ───────────────────────────────────────────────
+
+test("home applies perspective to several sections and excludes hero h1", () => {
+  const source = read(HOME_PAGE_PATH);
+  const wrapperCount = countOccurrences(source, "<PerspectiveScrollSection");
+
+  assert.ok(
+    wrapperCount >= 4,
+    `home must animate several sections (expected >= 4, got ${wrapperCount})`,
+  );
+
+  const heroBlock = source.slice(source.indexOf("hero-heading"), source.indexOf("Banda utilitaria"));
+  assert.equal(heroBlock.includes("PerspectiveScrollSection"), false);
+});
+
+test("servicios applies perspective to bento, coordination band, journey and closing band", () => {
+  const source = read(SERVICIOS_PAGE_PATH);
+  const wrapperCount = countOccurrences(source, "<PerspectiveScrollSection");
+
+  assert.equal(wrapperCount, 4);
+  assert.ok(source.includes('<PerspectiveScrollSection intensity="featured">'));
+  assert.ok(source.includes('<PerspectiveScrollSection intensity="standard">'));
+  assert.ok(source.includes('<PerspectiveScrollSection intensity="subtle">'));
+});
+
+test("clinicas applies perspective to modules, operations timeline, onboarding and CTA", () => {
+  const source = read(CLINICAS_PAGE_PATH);
+  const wrapperCount = countOccurrences(source, "<PerspectiveScrollSection");
+
+  assert.equal(wrapperCount, 4);
+  assert.ok(source.includes('<PerspectiveScrollSection intensity="featured">'));
+});
+
+test("precios applies a single subtle perspective wrapper to the catalog container", () => {
+  const source = read(PRECIOS_CONTENT_PATH);
+
+  assert.equal(countOccurrences(source, "<PerspectiveScrollSection"), 1);
+  assert.ok(source.includes('<PerspectiveScrollSection intensity="subtle">'));
+});
+
+test("precios never applies perspective to individual price rows, values or badges", () => {
+  const source = read(PRECIOS_CONTENT_PATH);
+  const rowsBlock = source.slice(
+    source.indexOf("{category.items.map((item, index) => ("),
+    source.indexOf("Consultar este estudio"),
+  );
+
+  assert.ok(rowsBlock.includes("clinical-hover-row"));
+  assert.ok(rowsBlock.includes("clinical-pill"));
+  assert.equal(rowsBlock.includes("PerspectiveScrollSection"), false);
+  assert.equal(rowsBlock.includes("data-public-perspective-section"), false);
+});
+
+test("contacto applies perspective to intent router and info column only", () => {
+  const source = read(CONTACTO_CONTENT_PATH);
+
+  assert.equal(countOccurrences(source, "<PerspectiveScrollSection"), 2);
+  assert.equal(countOccurrences(source, '<PerspectiveScrollSection intensity="subtle">'), 2);
+});
+
+test("contacto form, fields and submit stay outside the perspective effect", () => {
+  const source = read(CONTACTO_CONTENT_PATH);
+  const formBlock = source.slice(source.indexOf("<form"), source.indexOf("</form>"));
+
+  assert.ok(formBlock.includes("Formulario de contacto"));
+  assert.equal(formBlock.includes("PerspectiveScrollSection"), false);
+  assert.equal(formBlock.includes("data-public-perspective-section"), false);
+
+  const formSectionBlock = source.slice(
+    source.indexOf('id="contact-form"'),
+    source.indexOf("</form>"),
+  );
+  assert.equal(formSectionBlock.includes("PerspectiveScrollSection"), false);
+});
+
+// ─── PR-24: exclusions and invariants ────────────────────────────────────────
+
+test("navbar and footer carry no perspective wrappers or section data attributes", () => {
+  const navbarSource = read(NAVBAR_PATH);
+  const footerSource = read(FOOTER_PATH);
+
+  for (const source of [navbarSource, footerSource]) {
+    assert.equal(source.includes("PerspectiveScrollSection"), false);
+    assert.equal(source.includes("data-public-perspective-section"), false);
+    assert.equal(source.includes("useScrollPerspective"), false);
+  }
+});
+
+test("perspective foundation introduces no prohibited public demo copy", () => {
+  for (const path of [HOOK_PATH, COMPONENT_PATH, GLOBALS_CSS_PATH]) {
+    const source = read(path);
+
+    for (const prohibited of PROHIBITED_PUBLIC_STRINGS) {
+      assert.equal(
+        source.includes(prohibited),
+        false,
+        `${path} must not contain "${prohibited}"`,
+      );
+    }
+  }
+});
+
+test("precios pricing logic and contacto submit handler remain untouched by PR-24", () => {
+  const preciosSource = read(PRECIOS_CONTENT_PATH);
+  const contactoSource = read(CONTACTO_CONTENT_PATH);
+
+  assert.ok(preciosSource.includes("getPublicPricing("));
+  assert.ok(preciosSource.includes("sortPricingCategories(pricingSnapshot.categories)"));
+  assert.ok(preciosSource.includes('normalizePriceLabel(item.priceLabel)'));
+  assert.ok(contactoSource.includes("submitContactMessage({"));
+  assert.ok(contactoSource.includes("event.preventDefault();"));
+  assert.ok(contactoSource.includes('aria-busy={isSubmitting}'));
+});


### PR DESCRIPTION
## Summary
- Add a native public-wide perspective scroll effect using CSS variables, requestAnimationFrame and passive listeners
- Apply subtle 3D depth transforms across Home, Servicios, Clínicas, Precios and Contacto
- Keep navbar, footer, pricing rows and contact form controls stable and excluded from distortion
- Respect reduced motion and mobile readability with minimal/no transform profiles

## Scope
- Public web only
- Reusable public perspective scroll hook/component
- Public pages and related contracts/e2e
- No dashboard, API, auth, DB, workflow, dependency, route, middleware or production changes

## Safety
- No public demos, mocks, fictitious cases, dashboard previews, or fake report data
- No copy changes
- No scroll hijacking, no snap, no wheel/touch blocking
- Contact form fields, labels, submit logic and API remain intact
- Pricing values, rows and Consultar badges remain legible and not individually transformed
- Navbar/footer remain stable and outside the perspective effect

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local
- pnpm test
- pnpm --dir frontend e2e public-perspective-scroll.spec.ts
- public e2e regression specs
- git diff --check
- git diff --cached --check