### PR TITLE
fix(public): make perspective scroll perceptible

### DIFF
--- a/frontend/e2e/public-perspective-scroll.spec.ts
+++ b/frontend/e2e/public-perspective-scroll.spec.ts
@@ -1,6 +1,60 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 const perspectiveRoutes = ["/", "/servicios", "/clinicas", "/precios", "/contacto"];
+
+type PerspectiveMetrics = {
+  rotateXDeg: number;
+  transform: string;
+  translateZPx: number;
+};
+
+async function waitForPerspectiveFrame(page: Page) {
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+  });
+}
+
+async function positionSectionAtProgress(
+  page: Page,
+  section: Locator,
+  progress: number,
+) {
+  await section.evaluate((element, targetProgress) => {
+    const rect = element.getBoundingClientRect();
+    const viewportCenter = window.innerHeight / 2;
+    const targetCenter =
+      viewportCenter + targetProgress * (viewportCenter + rect.height / 2);
+    const currentCenter = rect.top + rect.height / 2;
+
+    window.scrollBy(0, currentCenter - targetCenter);
+  }, progress);
+  await waitForPerspectiveFrame(page);
+}
+
+async function readPerspectiveMetrics(section: Locator): Promise<PerspectiveMetrics> {
+  return section
+    .locator(".public-perspective-section-inner")
+    .first()
+    .evaluate((element) => {
+      const transform = window.getComputedStyle(element).transform;
+
+      if (transform === "none") {
+        return { rotateXDeg: 0, transform, translateZPx: 0 };
+      }
+
+      const matrix = new DOMMatrixReadOnly(transform);
+
+      return {
+        rotateXDeg: Math.atan2(matrix.m23, matrix.m22) * (180 / Math.PI),
+        transform,
+        translateZPx: matrix.m43,
+      };
+    });
+}
 
 for (const route of perspectiveRoutes) {
   test(`${route} renders perspective sections outside navbar and footer`, async ({
@@ -18,6 +72,12 @@ for (const route of perspectiveRoutes) {
     ).toHaveCount(0);
     await expect(
       page.getByRole("contentinfo").locator("[data-public-perspective-section]"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("banner").locator(".public-perspective-section-inner"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("contentinfo").locator(".public-perspective-section-inner"),
     ).toHaveCount(0);
   });
 
@@ -42,8 +102,91 @@ for (const route of perspectiveRoutes) {
         `${route} must not overflow horizontally at scrollY=${scrollY}`,
       ).toBeLessThanOrEqual(1);
     }
+
+    const firstSection = page.locator("[data-public-perspective-section]").first();
+    await positionSectionAtProgress(page, firstSection, 0.6);
+    const mobileMetrics = await readPerspectiveMetrics(firstSection);
+
+    expect(Math.abs(mobileMetrics.rotateXDeg)).toBeLessThan(0.1);
+    expect(Math.abs(mobileMetrics.translateZPx)).toBeLessThan(0.1);
   });
 }
+
+test("desktop perspective transform changes across visible scroll positions", async ({
+  page,
+}) => {
+  await page.goto("/servicios");
+
+  const section = page.locator(
+    '[data-public-perspective-section][data-perspective-intensity="standard"]',
+  );
+
+  await positionSectionAtProgress(page, section, 0.55);
+  const belowCenter = await readPerspectiveMetrics(section);
+  await positionSectionAtProgress(page, section, -0.55);
+  const aboveCenter = await readPerspectiveMetrics(section);
+
+  expect(belowCenter.transform).not.toBe(aboveCenter.transform);
+  expect(belowCenter.rotateXDeg).toBeGreaterThan(1.5);
+  expect(aboveCenter.rotateXDeg).toBeLessThan(-1.5);
+  expect(belowCenter.translateZPx).toBeLessThan(-1);
+  expect(aboveCenter.translateZPx).toBeLessThan(-1);
+});
+
+test("standard and featured sections are perceptible off-center and neutral at center", async ({
+  page,
+}) => {
+  await page.goto("/servicios");
+
+  for (const intensity of ["standard", "featured"] as const) {
+    const section = page.locator(
+      `[data-public-perspective-section][data-perspective-intensity="${intensity}"]`,
+    ).first();
+
+    await positionSectionAtProgress(page, section, 0);
+    const centered = await readPerspectiveMetrics(section);
+    expect(Math.abs(centered.rotateXDeg), `${intensity} should be neutral at center`).toBeLessThan(
+      0.5,
+    );
+
+    await positionSectionAtProgress(page, section, 0.6);
+    const offCenter = await readPerspectiveMetrics(section);
+    expect(
+      Math.abs(offCenter.rotateXDeg),
+      `${intensity} should be perceptible while still visible`,
+    ).toBeGreaterThanOrEqual(1.5);
+    expect(Math.abs(offCenter.translateZPx)).toBeGreaterThanOrEqual(30);
+    await expect(section).toBeInViewport();
+  }
+});
+
+test("desktop intensity hierarchy increases real depth", async ({ page }) => {
+  await page.goto("/servicios");
+
+  const metricsByIntensity: Record<string, PerspectiveMetrics> = {};
+
+  for (const intensity of ["subtle", "standard", "featured"] as const) {
+    const section = page.locator(
+      `[data-public-perspective-section][data-perspective-intensity="${intensity}"]`,
+    ).first();
+
+    await positionSectionAtProgress(page, section, 0.6);
+    metricsByIntensity[intensity] = await readPerspectiveMetrics(section);
+  }
+
+  expect(Math.abs(metricsByIntensity.standard.translateZPx)).toBeGreaterThan(
+    Math.abs(metricsByIntensity.subtle.translateZPx),
+  );
+  expect(Math.abs(metricsByIntensity.featured.translateZPx)).toBeGreaterThan(
+    Math.abs(metricsByIntensity.standard.translateZPx),
+  );
+  expect(Math.abs(metricsByIntensity.standard.rotateXDeg)).toBeGreaterThan(
+    Math.abs(metricsByIntensity.subtle.rotateXDeg),
+  );
+  expect(Math.abs(metricsByIntensity.featured.rotateXDeg)).toBeGreaterThan(
+    Math.abs(metricsByIntensity.standard.rotateXDeg),
+  );
+});
 
 test("home keeps several perspective sections readable after scrolling", async ({
   page,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1032,6 +1032,7 @@
     --scroll-depth-scale: 1;
     --scroll-depth-rotate-x: 0deg;
     --scroll-depth-y: 0px;
+    --scroll-depth-z: 0px;
     --scroll-depth-opacity: 1;
     perspective: var(--public-perspective-depth, 1100px);
     perspective-origin: 50% 50%;
@@ -1040,7 +1041,11 @@
   .public-perspective-section-inner {
     transform-origin: center center;
     transform-style: preserve-3d;
-    transform: translate3d(0, var(--scroll-depth-y), 0)
+    transform: translate3d(
+        0,
+        var(--scroll-depth-y),
+        var(--scroll-depth-z)
+      )
       rotateX(var(--scroll-depth-rotate-x))
       scale(var(--scroll-depth-scale));
     opacity: var(--scroll-depth-opacity);

--- a/frontend/src/hooks/useScrollPerspective.ts
+++ b/frontend/src/hooks/useScrollPerspective.ts
@@ -9,6 +9,7 @@ type ScrollPerspectiveProfile = {
   maxRotateXDeg: number;
   minScale: number;
   maxTranslateYPx: number;
+  maxTranslateZPx: number;
   minOpacity: number;
 };
 
@@ -17,22 +18,25 @@ export const SCROLL_PERSPECTIVE_PROFILES: Record<
   ScrollPerspectiveProfile
 > = {
   subtle: {
-    maxRotateXDeg: 2,
-    minScale: 0.99,
-    maxTranslateYPx: 12,
+    maxRotateXDeg: 3,
+    minScale: 0.995,
+    maxTranslateYPx: 16,
+    maxTranslateZPx: -28,
     minOpacity: 0.94,
   },
   standard: {
-    maxRotateXDeg: 3,
-    minScale: 0.985,
-    maxTranslateYPx: 20,
-    minOpacity: 0.9,
+    maxRotateXDeg: 4.5,
+    minScale: 0.991,
+    maxTranslateYPx: 28,
+    maxTranslateZPx: -40,
+    minOpacity: 0.89,
   },
   featured: {
-    maxRotateXDeg: 4.5,
-    minScale: 0.975,
-    maxTranslateYPx: 28,
-    minOpacity: 0.86,
+    maxRotateXDeg: 6.5,
+    minScale: 0.988,
+    maxTranslateYPx: 40,
+    maxTranslateZPx: -60,
+    minOpacity: 0.84,
   },
 };
 
@@ -40,6 +44,7 @@ const SCROLL_PERSPECTIVE_MOBILE_MINIMAL_PROFILE: ScrollPerspectiveProfile = {
   maxRotateXDeg: 0,
   minScale: 0.992,
   maxTranslateYPx: 10,
+  maxTranslateZPx: 0,
   minOpacity: 0.95,
 };
 
@@ -63,11 +68,13 @@ function setSectionDepthVariables(
   scale: number,
   rotateXDeg: number,
   translateYPx: number,
+  translateZPx: number,
   opacity: number,
 ) {
   element.style.setProperty("--scroll-depth-scale", scale.toFixed(4));
   element.style.setProperty("--scroll-depth-rotate-x", `${rotateXDeg.toFixed(3)}deg`);
   element.style.setProperty("--scroll-depth-y", `${translateYPx.toFixed(2)}px`);
+  element.style.setProperty("--scroll-depth-z", `${translateZPx.toFixed(2)}px`);
   element.style.setProperty("--scroll-depth-opacity", opacity.toFixed(4));
 }
 
@@ -75,7 +82,17 @@ function clearSectionDepthVariables(element: HTMLElement) {
   element.style.removeProperty("--scroll-depth-scale");
   element.style.removeProperty("--scroll-depth-rotate-x");
   element.style.removeProperty("--scroll-depth-y");
+  element.style.removeProperty("--scroll-depth-z");
   element.style.removeProperty("--scroll-depth-opacity");
+}
+
+function smoothstep(edge0: number, edge1: number, value: number) {
+  const normalized = Math.max(
+    0,
+    Math.min(1, (value - edge0) / (edge1 - edge0)),
+  );
+
+  return normalized * normalized * (3 - 2 * normalized);
 }
 
 function updateRegisteredSections() {
@@ -97,7 +114,7 @@ function updateRegisteredSections() {
 
     if (!profile) {
       if (!section.isNeutralized) {
-        setSectionDepthVariables(section.element, 1, 0, 0, 1);
+        setSectionDepthVariables(section.element, 1, 0, 0, 0, 1);
         section.isNeutralized = true;
       }
       continue;
@@ -115,19 +132,22 @@ function updateRegisteredSections() {
     const normalizationRange = viewportCenter + rect.height / 2;
     const rawProgress = (sectionCenter - viewportCenter) / normalizationRange;
     const signedProgress = Math.max(-1, Math.min(1, rawProgress));
-    // Signed quadratic easing: near the viewport center the section stays
-    // visually neutral; depth ramps toward the viewport edges.
-    const easedDepth = signedProgress * Math.abs(signedProgress);
-    const depthMagnitude = Math.abs(easedDepth);
-    // Sections taller than the viewport rotate proportionally less so the
-    // projected near edge never widens past the layout gutters.
-    const rotationHeightCap = Math.min(1, viewportHeight / rect.height);
+    const depthMagnitude = smoothstep(0.1, 0.8, Math.abs(signedProgress));
+    const easedDepth = Math.sign(signedProgress) * depthMagnitude;
+    // Ease the height reduction toward a 0.5 floor so tall featured bands
+    // remain stronger than standard sections without widening past gutters.
+    const viewportHeightRatio = Math.min(1, viewportHeight / rect.height);
+    const rotationHeightCap = Math.max(
+      0.5,
+      0.5 + viewportHeightRatio / 2,
+    );
 
     setSectionDepthVariables(
       section.element,
       1 - (1 - profile.minScale) * depthMagnitude,
       profile.maxRotateXDeg * easedDepth * rotationHeightCap,
       profile.maxTranslateYPx * easedDepth,
+      profile.maxTranslateZPx * depthMagnitude,
       1 - (1 - profile.minOpacity) * depthMagnitude,
     );
   }

--- a/test/frontend-public-perspective-scroll.test.ts
+++ b/test/frontend-public-perspective-scroll.test.ts
@@ -85,12 +85,31 @@ test("hook animates only transform/opacity CSS variables", () => {
   assert.ok(source.includes("--scroll-depth-scale"));
   assert.ok(source.includes("--scroll-depth-rotate-x"));
   assert.ok(source.includes("--scroll-depth-y"));
+  assert.ok(source.includes("--scroll-depth-z"));
   assert.ok(source.includes("--scroll-depth-opacity"));
   assert.equal(source.includes("style.width"), false);
   assert.equal(source.includes("style.height"), false);
   assert.equal(source.includes("style.margin"), false);
   assert.equal(source.includes('setProperty("width"'), false);
   assert.equal(source.includes('setProperty("height"'), false);
+});
+
+test("hook uses a perceptible smoothstep curve with real desktop depth", () => {
+  const source = read(HOOK_PATH);
+
+  assert.ok(source.includes("function smoothstep("));
+  assert.ok(source.includes("smoothstep(0.1, 0.8, Math.abs(signedProgress))"));
+  assert.ok(source.includes("Math.sign(signedProgress) * depthMagnitude"));
+  assert.equal(source.includes("signedProgress * Math.abs(signedProgress)"), false);
+
+  assert.ok(source.includes("maxRotateXDeg: 3"));
+  assert.ok(source.includes("maxRotateXDeg: 4.5"));
+  assert.ok(source.includes("maxRotateXDeg: 6.5"));
+  assert.ok(source.includes("maxTranslateZPx: -28"));
+  assert.ok(source.includes("maxTranslateZPx: -40"));
+  assert.ok(source.includes("maxTranslateZPx: -60"));
+  assert.ok(source.includes("maxTranslateZPx: 0"));
+  assert.ok(source.includes("Math.max(\n      0.5,"));
 });
 
 // ─── PR-24: foundation — component ───────────────────────────────────────────
@@ -116,8 +135,11 @@ test("globals.css defines the public perspective foundation with neutral default
   assert.ok(source.includes("--scroll-depth-scale: 1;"));
   assert.ok(source.includes("--scroll-depth-rotate-x: 0deg;"));
   assert.ok(source.includes("--scroll-depth-y: 0px;"));
+  assert.ok(source.includes("--scroll-depth-z: 0px;"));
   assert.ok(source.includes("--scroll-depth-opacity: 1;"));
   assert.ok(source.includes("perspective: var(--public-perspective-depth, 1100px);"));
+  assert.ok(source.includes("var(--scroll-depth-z)"));
+  assert.ok(source.includes("translate3d("));
 });
 
 test("globals.css neutralizes perspective transforms under prefers-reduced-motion", () => {


### PR DESCRIPTION
## Summary
- Make the public perspective scroll effect visibly perceptible on desktop
- Replace the previous quadratic easing with a smoothstep depth curve and narrow neutral band
- Add real translateZ depth while preserving reduced motion and mobile minimal behavior
- Increase desktop intensity profiles moderately and add a floor to height attenuation

## Scope
- Public perspective scroll calibration only
- Runtime/static tests for perceptible transforms
- No navbar, footer, page copy, dashboard, API, auth, DB, workflow, dependency, middleware or production changes

## Safety
- Navbar and footer remain excluded from perspective transforms
- Mobile keeps rotateX and Z depth disabled
- Reduced motion keeps transform disabled
- Pricing rows/values and contact form controls remain untouched
- No scroll hijacking, no wheel/touch blocking, no snap
- No demos, mocks, fictitious cases, dashboard previews or fake report data

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local
- pnpm test
- pnpm --dir frontend e2e public-perspective-scroll.spec.ts
- git diff --check
- git diff --cached --check