### PR TITLE
fix(public): remove b2b wording

### DIFF
--- a/frontend/e2e/public-clinics-b2b-operations.spec.ts
+++ b/frontend/e2e/public-clinics-b2b-operations.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("clinicas B2B product landing (PR-20)", () => {
+test.describe("clinicas product landing (PR-20)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/clinicas");
     await page.waitForLoadState("domcontentloaded");
   });
 
-  test.describe("B2B operations section", () => {
+  test.describe("clinic operations section", () => {
     test("renders 'Cómo opera tu clínica con VETNEB' heading", async ({
       page,
     }) => {
@@ -60,7 +60,7 @@ test.describe("clinicas B2B product landing (PR-20)", () => {
     });
   });
 
-  test.describe("B2B product modules", () => {
+  test.describe("clinic product modules", () => {
     test("groups all six capabilities into three named modules", async ({
       page,
     }) => {
@@ -110,7 +110,7 @@ test.describe("clinicas B2B product landing (PR-20)", () => {
     ).toHaveCount(4);
   });
 
-  test.describe("B2B conversion CTAs", () => {
+  test.describe("clinic conversion CTAs", () => {
     test("renders conversion heading", async ({ page }) => {
       await expect(
         page.locator("h2#clinicas-conversion-heading"),
@@ -141,6 +141,10 @@ test.describe("clinicas B2B product landing (PR-20)", () => {
   });
 
   test.describe("no demo/fictitious content", () => {
+    test("does not render B2B wording", async ({ page }) => {
+      await expect(page.locator("body")).not.toContainText("B2B");
+    });
+
     test("does not render prohibited demo or fictitious content", async ({
       page,
     }) => {

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -510,7 +510,7 @@ export default function ClinicasPage() {
         </section>
       </div>
 
-      {/* CTA de conversión B2B */}
+      {/* CTA para clínicas */}
       <section
         className="bg-vetneb-navy py-12 text-primary-foreground md:py-16"
         aria-labelledby="clinicas-conversion-heading"

--- a/test/frontend-public-report-preview.test.ts
+++ b/test/frontend-public-report-preview.test.ts
@@ -129,10 +129,15 @@ test("home page preserves specimen journey from PR-12", () => {
   assert.ok(source.includes("<SpecimenJourneySection"));
 });
 
-test("clinicas page has B2B operations section heading", () => {
+test("clinicas page has clinic operations section heading", () => {
   const source = read(CLINICAS_PATH);
   assert.ok(source.includes('id="clinicas-operations-heading"'));
   assert.ok(source.includes("Cómo opera tu clínica con VETNEB"));
+});
+
+test("clinicas page does not include B2B wording", () => {
+  const source = read(CLINICAS_PATH);
+  assert.ok(!source.includes("B2B"));
 });
 
 test("clinicas page renders the operational flow as a five-column timeline", () => {
@@ -154,7 +159,7 @@ test("clinicas page operations steps cover derivación and trazabilidad", () => 
   assert.ok(source.includes("trazabilidad"));
 });
 
-test("clinicas page has B2B conversion CTA band pointing to contacto", () => {
+test("clinicas page has clinic conversion CTA band pointing to contacto", () => {
   const source = read(CLINICAS_PATH);
   assert.ok(source.includes('id="clinicas-conversion-heading"'));
   assert.ok(source.includes("Coordiná una derivación"));


### PR DESCRIPTION
## Summary
- Remove remaining internal B2B wording from the public clinics surface
- Neutralize related test naming
- Add regression coverage to ensure B2B is not visibly rendered publicly

## Scope
- Public clinics wording/test guard only
- No layout, CSS, perspective scroll, navbar, footer, dashboard, API, auth, DB, workflow, dependency or production changes

## Safety
- No public copy rewrite
- No DOM/layout/class changes
- Perspective scroll remains intact
- No demos, mocks, fictitious cases, dashboard previews or fake report data

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm validate:local
- pnpm test
- pnpm --dir frontend e2e public-clinics-b2b-operations.spec.ts
- git diff --check
- git diff --cached --check