### PR TITLE
fix(public): make home hero brand-led

### DIFF
--- a/frontend/e2e/home-hero-evidence-first.spec.ts
+++ b/frontend/e2e/home-hero-evidence-first.spec.ts
@@ -6,10 +6,11 @@ test.describe("home hero — evidence-first (PR-10)", () => {
     await page.waitForLoadState("domcontentloaded");
   });
 
-  test("H1 contiene diagnóstico anatomopatológico", async ({ page }) => {
+  test("H1 es VETNEB como marca principal del hero", async ({ page }) => {
     const h1 = page.locator("h1#hero-heading");
     await expect(h1).toBeVisible();
-    await expect(h1).toContainText(/anatomopatológico/i);
+    await expect(h1).toContainText("VETNEB");
+    await expect(page.locator("body")).toContainText(/anatomopatológico/i);
   });
 
   test("firma profesional Dr. Nicolás E. Barbé visible", async ({ page }) => {
@@ -25,20 +26,16 @@ test.describe("home hero — evidence-first (PR-10)", () => {
     await expect(page.locator("body")).toContainText("Seguir con código");
   });
 
-  test("banda utilitaria fuera del hero contiene horario y WhatsApp", async ({ page }) => {
+  test("hero integra horario y WhatsApp como información operativa", async ({ page }) => {
     await expect(page.locator("body")).toContainText(/lunes a viernes/i);
     await expect(page.locator("body")).toContainText("WhatsApp: 3534138946");
   });
 
-  test("hero compone diagrama estructural del proceso (PR-17)", async ({ page }) => {
-    const diagram = page.locator("[data-hero-system-diagram]");
-    await expect(diagram).toBeVisible();
-    await expect(diagram).toContainText("De la muestra al informe");
-    await expect(diagram).toContainText("Muestra");
-    await expect(diagram).toContainText("Laboratorio");
-    await expect(diagram).toContainText("Evaluación diagnóstica");
-    await expect(diagram).toContainText("Informe");
-    await expect(diagram).toContainText("Acceso digital");
+  test("hero presenta marca VETNEB y no contiene diagrama de proceso", async ({ page }) => {
+    const hero = page.locator('section[aria-labelledby="hero-heading"]');
+    await expect(hero).toContainText("VETNEB");
+    await expect(page.locator("[data-hero-system-diagram]")).toHaveCount(0);
+    await expect(hero).not.toContainText("De la muestra al informe");
   });
 
   test("hero no renderiza términos demo ni datos ficticios (PR-17)", async ({ page }) => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -148,14 +148,6 @@ const specimenJourneyStages = [
   },
 ];
 
-const heroSystemNodes = [
-  { icon: PackageCheck, label: "Muestra" },
-  { icon: Microscope, label: "Laboratorio" },
-  { icon: ClipboardCheck, label: "Evaluación diagnóstica" },
-  { icon: FileText, label: "Informe" },
-  { icon: ShieldCheck, label: "Acceso digital" },
-];
-
 export default function HomePage() {
   return (
     <PublicLayout>
@@ -179,22 +171,17 @@ export default function HomePage() {
           aria-hidden="true"
         />
         <div className="relative container mx-auto px-4 py-12 sm:py-14 sm:px-6 md:py-16 lg:py-20 lg:px-8">
-          <div className="grid grid-cols-1 items-center gap-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:gap-14">
+          <div>
             <div>
-              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-primary-foreground/72">
-                Anatomía Patológica Veterinaria
-              </p>
-
               <h1
                 id="hero-heading"
-                className="public-display max-w-2xl break-words font-bold text-primary-foreground"
+                className="text-[clamp(4rem,10vw,8rem)] font-black uppercase tracking-[0.06em] leading-none text-primary-foreground"
               >
-                Diagnóstico anatomopatológico veterinario con trazabilidad de muestra a informe
+                VETNEB
               </h1>
 
-              <p className="mt-5 max-w-xl text-base leading-relaxed text-primary-foreground/88 sm:text-lg">
-                Histopatología, citología y tinciones especiales con criterio clínico-patológico
-                y seguimiento completo para clínicas y profesionales.
+              <p className="mt-4 max-w-2xl text-lg font-semibold leading-snug text-primary-foreground/85 sm:text-xl">
+                Diagnóstico anatomopatológico veterinario con trazabilidad de informes
               </p>
 
               {/* Firma profesional */}
@@ -242,63 +229,24 @@ export default function HomePage() {
                   </p>
                 </PublicRouteControl>
               </div>
-            </div>
 
-            {/* Diagrama estructural del proceso — etapas conceptuales del sistema */}
-            <div
-              role="group"
-              aria-label="Diagrama del proceso diagnóstico: de la muestra al acceso digital"
-              data-hero-system-diagram
-              className="w-full max-w-md rounded-xl border border-white/22 bg-white/[0.08] p-5 sm:p-6 lg:justify-self-end"
-            >
-              <p className="text-xs font-semibold tracking-[0.08em] text-primary-foreground/72">
-                De la muestra al informe
-              </p>
-              <ol className="mt-4">
-                {heroSystemNodes.map((node, index) => {
-                  const NodeIcon = node.icon;
-                  const isLastNode = index === heroSystemNodes.length - 1;
-
-                  return (
-                    <li key={node.label} className="flex gap-3.5">
-                      <div className="flex flex-col items-center">
-                        <span
-                          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/26 bg-white/[0.10] text-primary-foreground"
-                          aria-hidden="true"
-                        >
-                          <NodeIcon className="h-4 w-4" />
-                        </span>
-                        {!isLastNode && (
-                          <span className="my-1 h-4 w-px bg-white/35" aria-hidden="true" />
-                        )}
-                      </div>
-                      <p className="pt-2 text-sm font-semibold leading-snug text-primary-foreground/92">
-                        {node.label}
-                      </p>
-                    </li>
-                  );
-                })}
-              </ol>
+              {/* Información operativa integrada al hero */}
+              <div className="mt-6 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-5">
+                <p className="text-sm text-primary-foreground/68">
+                  Resultados disponibles las 24 hs · Atención de lunes a viernes de 8 a 17 h
+                </p>
+                <PublicExternalControl
+                  href="https://wa.me/5493534138946"
+                  target="_blank"
+                  className="text-sm text-primary-foreground/68 underline underline-offset-4 transition hover:text-primary-foreground/90"
+                >
+                  WhatsApp: 3534138946
+                </PublicExternalControl>
+              </div>
             </div>
           </div>
         </div>
       </section>
-
-      {/* Banda utilitaria compacta — fuera del hero */}
-      <div className="border-b border-vetneb-line/70 bg-vetneb-surface-muted/60 py-2.5 sm:py-3">
-        <div className="container mx-auto flex flex-col gap-1.5 px-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-6 lg:px-8">
-          <p className="text-sm font-semibold text-vetneb-navy">
-            Resultados disponibles las 24 hs · Atención de lunes a viernes de 8 a 17 h
-          </p>
-          <PublicExternalControl
-            href="https://wa.me/5493534138946"
-            target="_blank"
-            className="text-sm font-semibold text-vetneb-navy underline decoration-vetneb-navy/55 underline-offset-4 transition hover:text-vetneb-teal"
-          >
-            WhatsApp: 3534138946
-          </PublicExternalControl>
-        </div>
-      </div>
 
       <div className="public-soft-canvas">
         <section

--- a/test/frontend-home-page-content.test.ts
+++ b/test/frontend-home-page-content.test.ts
@@ -291,52 +291,47 @@ test("home page renders one unified end-to-end journey section (PR-17)", () => {
   }
 });
 
-test("home page hero composes structural system diagram without fictional data (PR-17)", () => {
+test("home page hero is single-column with brand mark and integrated operational info (PR-17 refine)", () => {
   const source = read(HOME_PAGE_PATH);
-  const heroSection = extractBetween(
-    source,
-    'aria-labelledby="hero-heading"',
-    "Banda utilitaria",
-  );
-  const nodesData = extractBetween(
-    source,
-    "const heroSystemNodes = [",
-    "export default function HomePage()",
+  const heroSection = source.slice(
+    source.indexOf('aria-labelledby="hero-heading"'),
+    source.indexOf("public-soft-canvas"),
   );
 
-  // h1 usa la tipografía display de PR-16
+  // H1 es VETNEB — portada de marca, tipografía clamp dominante
   assert.ok(
     source.includes(
-      'className="public-display max-w-2xl break-words font-bold text-primary-foreground"',
+      'className="text-[clamp(4rem,10vw,8rem)] font-black uppercase tracking-[0.06em] leading-none text-primary-foreground"',
     ),
   );
+  assert.equal(
+    source.includes('className="public-display max-w-2xl break-words font-bold text-primary-foreground"'),
+    false,
+  );
 
-  // Composición en dos zonas en desktop, una columna en mobile
+  // Descriptor diagnóstico debajo del H1, como párrafo secundario
+  assert.ok(source.includes("trazabilidad de informes"));
+  assert.equal(source.includes("trazabilidad de muestra a informe"), false);
+
+  // Hero de una columna — sin grid de dos zonas
+  assert.equal(source.includes("lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]"), false);
+
+  // Descriptor diagnóstico en párrafo subordinado
   assert.ok(
-    heroSection.includes(
-      "grid grid-cols-1 items-center gap-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]",
+    source.includes(
+      '"mt-4 max-w-2xl text-lg font-semibold leading-snug text-primary-foreground/85 sm:text-xl"',
     ),
   );
 
-  // Diagrama estructural del proceso — nodos conceptuales conectados
-  assert.ok(heroSection.includes("data-hero-system-diagram"));
-  assert.ok(
-    heroSection.includes(
-      'aria-label="Diagrama del proceso diagnóstico: de la muestra al acceso digital"',
-    ),
-  );
-  assert.ok(heroSection.includes("De la muestra al informe"));
-  assert.ok(heroSection.includes("heroSystemNodes.map((node, index)"));
+  // Diagrama eliminado — hero limpio sin panel secundario
+  assert.equal(source.includes("data-hero-system-diagram"), false);
+  assert.equal(source.includes("heroSystemNodes"), false);
+  assert.equal(heroSection.includes("De la muestra al informe"), false);
 
-  assert.equal(count(nodesData, "label:"), 5);
-  assert.ok(nodesData.includes('label: "Muestra"'));
-  assert.ok(nodesData.includes('label: "Laboratorio"'));
-  assert.ok(nodesData.includes('label: "Evaluación diagnóstica"'));
-  assert.ok(nodesData.includes('label: "Informe"'));
-  assert.ok(nodesData.includes('label: "Acceso digital"'));
-
-  // El diagrama no contiene datos: ni códigos, ni fechas, ni cifras
-  assert.equal(/\d/.test(nodesData), false);
+  // Información operativa integrada dentro del hero
+  assert.ok(heroSection.includes("Resultados disponibles las 24 hs"));
+  assert.ok(heroSection.includes("WhatsApp: 3534138946"));
+  assert.ok(heroSection.includes("wa.me/5493534138946"));
 });
 
 test("home page refines section rhythm without homogeneous card grids (PR-18)", () => {

--- a/test/frontend-public-perspective-scroll.test.ts
+++ b/test/frontend-public-perspective-scroll.test.ts
@@ -178,7 +178,7 @@ test("home applies perspective to several sections and excludes hero h1", () => 
     `home must animate several sections (expected >= 4, got ${wrapperCount})`,
   );
 
-  const heroBlock = source.slice(source.indexOf("hero-heading"), source.indexOf("Banda utilitaria"));
+  const heroBlock = source.slice(source.indexOf("hero-heading"), source.indexOf("public-soft-canvas"));
   assert.equal(heroBlock.includes("PerspectiveScrollSection"), false);
 });
 


### PR DESCRIPTION
## Summary
- Make VETNEB the dominant H1 brand title in the public Home hero
- Move the diagnostic descriptor below VETNEB as secondary supporting text
- Remove the hero process diagram and previous descriptive paragraph
- Keep operational info, professional signature and access CTAs visible in the hero

## Scope
- Public Home hero and related tests only
- No navbar, footer, perspective scroll logic, dashboard, API, auth, DB, workflow, dependency, middleware or production changes

## Safety
- VETNEB is now the visual and semantic H1 of the hero
- Diagnostic descriptor remains visible but subordinated
- No return of the previous histopathology/cytology descriptive paragraph
- No return of the 'De la muestra al informe' process diagram
- Existing CTAs and professional signature remain available
- No demos, mocks, fictitious cases, dashboard previews or fake report data

## Validation
- pnpm test
- git diff --check
- git diff --cached --check
- Visual verification desktop/mobile