### PR TITLE
fix(public): center step numbers over content

### DIFF
--- a/IMPLEMENTATION_PUBLIC_STEP_NUMBER_CENTER_ALIGNMENT.md
+++ b/IMPLEMENTATION_PUBLIC_STEP_NUMBER_CENTER_ALIGNMENT.md
@@ -1,0 +1,38 @@
+# Public Step Number Center Alignment
+
+## Scope
+Corrección de alineación de números circulares en steps/timelines públicos.
+
+## Problem
+Los números no estaban centrados respecto al bloque descriptivo de cada paso.
+
+## Files changed
+- `frontend/src/components/public/SpecimenJourneySection.tsx`
+- `frontend/src/app/clinicas/page.tsx`
+- `frontend/e2e/public-service-bento-specimen-journey.spec.ts`
+- `frontend/e2e/public-clinics-b2b-operations.spec.ts`
+- `IMPLEMENTATION_PUBLIC_STEP_NUMBER_CENTER_ALIGNMENT.md`
+
+## Implementation
+- Los badges se centran en desktop dentro del mismo ancho que usa el bloque de contenido.
+- Las líneas horizontales se posicionan detrás de los badges y conectan el centro de columnas adyacentes.
+- El flujo de clínicas usa un gap de grid uniforme en lugar de padding por step.
+- Se mantienen sin cambios los layouts móviles en fila y sus líneas verticales.
+- Se agregaron aserciones E2E que comparan el centro horizontal del badge con el centro del contenido.
+
+## Visual acceptance
+- Números centrados respecto al párrafo descriptivo.
+- Aplicado en Recorrido de la muestra.
+- Aplicado en Cómo opera tu clínica con VETNEB.
+
+## Validation
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+- Pruebas E2E focalizadas de recorrido de muestra y flujo de clínicas.
+
+## Out of scope
+- Sin cambios de copy.
+- Sin rediseño.
+- Sin cambios de colores.
+- Sin cambios backend/dashboard.

--- a/frontend/e2e/public-clinics-b2b-operations.spec.ts
+++ b/frontend/e2e/public-clinics-b2b-operations.spec.ts
@@ -28,6 +28,42 @@ test.describe("clinicas product landing (PR-20)", () => {
       await expect(ol.locator("[data-clinic-op-step]")).toHaveCount(5);
     });
 
+    test("centers each operation number over its content on desktop", async ({
+      page,
+    }) => {
+      const steps = page.locator("[data-clinic-op-step]");
+
+      for (const step of await steps.all()) {
+        const centerDelta = await step.evaluate((element) => {
+          const number = element.querySelector<HTMLElement>(
+            "[data-clinic-op-step-number]",
+          );
+          const content = element.querySelector<HTMLElement>(
+            "[data-clinic-op-step-content]",
+          );
+
+          if (!number || !content) return null;
+
+          const centerWithinStep = (child: HTMLElement) => {
+            let left = 0;
+            let current: HTMLElement | null = child;
+
+            while (current && current !== element) {
+              left += current.offsetLeft;
+              current = current.offsetParent as HTMLElement | null;
+            }
+
+            return left + child.offsetWidth / 2;
+          };
+
+          return Math.abs(centerWithinStep(number) - centerWithinStep(content));
+        });
+
+        expect(centerDelta).not.toBeNull();
+        expect(centerDelta ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(1);
+      }
+    });
+
     test("renders derivación step", async ({ page }) => {
       await expect(page.locator("body")).toContainText(
         "Coordinás la derivación",

--- a/frontend/e2e/public-service-bento-specimen-journey.spec.ts
+++ b/frontend/e2e/public-service-bento-specimen-journey.spec.ts
@@ -51,6 +51,44 @@ test.describe("service bento + specimen journey (PR-12)", () => {
       await expect(ol).toBeVisible();
     });
 
+    test("centers each journey number over its content on desktop", async ({
+      page,
+    }) => {
+      const stages = page.locator("[data-specimen-stage]");
+
+      for (const stage of await stages.all()) {
+        const centerDelta = await stage.evaluate((element) => {
+          const number = element.querySelector<HTMLElement>(
+            "[data-specimen-stage-number]",
+          );
+          const content = element.querySelector<HTMLElement>(
+            "[data-specimen-stage-content]",
+          );
+
+          if (!number || !content) return null;
+
+          const centerWithinStage = (child: HTMLElement) => {
+            let left = 0;
+            let current: HTMLElement | null = child;
+
+            while (current && current !== element) {
+              left += current.offsetLeft;
+              current = current.offsetParent as HTMLElement | null;
+            }
+
+            return left + child.offsetWidth / 2;
+          };
+
+          return Math.abs(
+            centerWithinStage(number) - centerWithinStage(content),
+          );
+        });
+
+        expect(centerDelta).not.toBeNull();
+        expect(centerDelta ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(1);
+      }
+    });
+
     test("preserves hero CTAs from PR-10", async ({ page }) => {
       await expect(page.locator("body")).toContainText("Acceder al portal");
       await expect(page.locator("body")).toContainText("Seguir con código");
@@ -112,6 +150,44 @@ test.describe("service bento + specimen journey (PR-12)", () => {
 
     test("renders verified protocol data — 15 días hábiles visible", async ({ page }) => {
       await expect(page.locator("body")).toContainText("15 días hábiles");
+    });
+
+    test("centers each journey number over its content on desktop", async ({
+      page,
+    }) => {
+      const stages = page.locator("[data-specimen-stage]");
+
+      for (const stage of await stages.all()) {
+        const centerDelta = await stage.evaluate((element) => {
+          const number = element.querySelector<HTMLElement>(
+            "[data-specimen-stage-number]",
+          );
+          const content = element.querySelector<HTMLElement>(
+            "[data-specimen-stage-content]",
+          );
+
+          if (!number || !content) return null;
+
+          const centerWithinStage = (child: HTMLElement) => {
+            let left = 0;
+            let current: HTMLElement | null = child;
+
+            while (current && current !== element) {
+              left += current.offsetLeft;
+              current = current.offsetParent as HTMLElement | null;
+            }
+
+            return left + child.offsetWidth / 2;
+          };
+
+          return Math.abs(
+            centerWithinStage(number) - centerWithinStage(content),
+          );
+        });
+
+        expect(centerDelta).not.toBeNull();
+        expect(centerDelta ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(1);
+      }
     });
 
     test("featured anatomopatológico card visible with eyebrow label", async ({ page }) => {

--- a/frontend/src/app/clinicas/page.tsx
+++ b/frontend/src/app/clinicas/page.tsx
@@ -330,7 +330,7 @@ export default function ClinicasPage() {
             <PublicScrollReveal variant="cards" staggerChildren>
               <ol
                 aria-label="Pasos operativos de derivación con VETNEB"
-                className="mx-auto grid max-w-6xl grid-cols-1 lg:grid-cols-5"
+                className="mx-auto grid max-w-6xl grid-cols-1 lg:grid-cols-5 lg:gap-x-6"
               >
                 {operationSteps.map((step, index) => {
                   const StepIcon = step.icon;
@@ -341,7 +341,7 @@ export default function ClinicasPage() {
                       key={step.step}
                       data-scroll-reveal-item
                       data-clinic-op-step={step.step}
-                      className={`relative flex gap-4 lg:flex-col lg:gap-0 lg:pr-6 lg:last:pr-0 ${
+                      className={`relative flex gap-4 lg:flex-col lg:gap-0 ${
                         isLastStep ? "" : "pb-9 lg:pb-0"
                       }`}
                     >
@@ -351,8 +351,9 @@ export default function ClinicasPage() {
                           aria-hidden="true"
                         />
                       )}
-                      <div className="flex shrink-0 items-center lg:w-full">
+                      <div className="flex shrink-0 items-center lg:relative lg:w-full lg:justify-center">
                         <span
+                          data-clinic-op-step-number
                           className="relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-xs font-bold text-primary-foreground shadow-[0_4px_10px_hsl(var(--vetneb-navy)/0.26)] ring-2 ring-vetneb-teal/18"
                           aria-hidden="true"
                         >
@@ -360,12 +361,15 @@ export default function ClinicasPage() {
                         </span>
                         {!isLastStep && (
                           <span
-                            className="ml-4 hidden h-px flex-1 bg-gradient-to-r from-vetneb-teal/45 to-vetneb-line/45 lg:-mr-6 lg:block"
+                            className="absolute left-1/2 top-1/2 hidden h-px w-[calc(100%+1.5rem)] bg-gradient-to-r from-vetneb-teal/45 to-vetneb-line/45 lg:block"
                             aria-hidden="true"
                           />
                         )}
                       </div>
-                      <div className="min-w-0 pt-0.5 lg:mt-6 lg:pt-0">
+                      <div
+                        data-clinic-op-step-content
+                        className="min-w-0 pt-0.5 lg:mt-6 lg:w-full lg:pt-0"
+                      >
                         <div className="flex items-start gap-2.5">
                           <span
                             className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded border border-vetneb-line/65 bg-card/85 text-vetneb-teal"

--- a/frontend/src/components/public/SpecimenJourneySection.tsx
+++ b/frontend/src/components/public/SpecimenJourneySection.tsx
@@ -47,22 +47,23 @@ export function SpecimenJourneySection({
                 />
               )}
 
-              <div className="flex shrink-0 items-center lg:mb-4 lg:w-full">
+              <div className="flex shrink-0 items-center lg:relative lg:mb-4 lg:w-full lg:justify-center">
                 <span
-                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)] ring-2 ring-primary/20"
+                  data-specimen-stage-number
+                  className="relative z-10 flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)] ring-2 ring-primary/20"
                   aria-hidden="true"
                 >
                   {stage.step}
                 </span>
                 {!isLastStage && (
                   <span
-                    className="ml-4 hidden h-px flex-1 bg-vetneb-navy/20 lg:-mr-6 lg:block"
+                    className="absolute left-1/2 top-1/2 hidden h-px w-[calc(100%+1.5rem)] bg-vetneb-navy/20 lg:block"
                     aria-hidden="true"
                   />
                 )}
               </div>
 
-              <div className="min-w-0">
+              <div data-specimen-stage-content className="min-w-0 lg:w-full">
                 <span
                   className="mb-2.5 hidden h-9 w-9 items-center justify-center rounded-lg border border-vetneb-line/80 bg-secondary/60 text-vetneb-teal lg:flex"
                   aria-hidden="true"
@@ -104,16 +105,17 @@ export function SpecimenJourneySection({
           <li
             key={stage.step}
             data-specimen-stage={stage.step}
-            className="flex gap-4 lg:flex-col lg:gap-3"
+            className="flex gap-4 lg:flex-col lg:items-center lg:gap-3"
           >
             <span
+              data-specimen-stage-number
               className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-vetneb-navy text-sm font-bold text-primary-foreground shadow-[0_6px_16px_hsl(var(--vetneb-navy)/0.22)] ring-2 ring-primary/20"
               aria-hidden="true"
             >
               {stage.step}
             </span>
 
-            <div className="min-w-0">
+            <div data-specimen-stage-content className="min-w-0 lg:w-full">
               <span
                 className="mb-2.5 hidden h-9 w-9 items-center justify-center rounded-lg border border-vetneb-line/80 bg-secondary/60 text-vetneb-teal lg:flex"
                 aria-hidden="true"


### PR DESCRIPTION
﻿## Summary
- Center public step number badges over each step content block
- Keep timeline connector lines behind the badges and aligned to column centers
- Add E2E geometry checks for public specimen journey and clinics operations steps
- Document implementation in Markdown

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e public-service-bento-specimen-journey.spec.ts public-clinics-b2b-operations.spec.ts --project=chromium --grep centers-each
- Focal E2E suites rerun serially; one navigation timeout passed when rerun isolated

## Scope
- Public step/timeline alignment only
- No copy changes
- No color changes
- No backend, dashboard, SEO, PWA, or navigation changes
