### PR TITLE
feat(ui): add dark gray theme mode

### DIFF
--- a/IMPLEMENTATION_DARK_GRAY_MODE.md
+++ b/IMPLEMENTATION_DARK_GRAY_MODE.md
@@ -1,0 +1,59 @@
+# Dark Gray Mode
+
+## Scope
+Implementacion de opcion global Normal / Dark Gray Mode en frontend, con persistencia y sin flash visual.
+
+## Problem
+El proyecto no tenia una opcion persistente para usar modo oscuro. Existia un bloque `.dark` legacy en `globals.css` (azul marino, estilo scaffold) que ningun codigo aplicaba; se dejo intacto y fuera de este modelo.
+
+## Files changed
+- `frontend/src/app/globals.css` — bloque `theme-mode-dark-gray` al final del archivo (tokens + overrides puntuales).
+- `frontend/src/app/layout.tsx` — `data-theme="normal"` + `suppressHydrationWarning` en `<html>`, `<script src="/theme-init.js">` sincronico en `<head>`.
+- `frontend/src/lib/theme.ts` — nuevo: constantes `THEME_STORAGE_KEY`, modos y tipo `ThemeMode`.
+- `frontend/src/components/theme/ThemeModeToggle.tsx` — nuevo: control cliente accesible (button + `aria-pressed`).
+- `frontend/src/components/layout/Navbar.tsx` — toggle en el grupo de acciones derecho del header publico.
+- `frontend/src/components/dashboard/DashboardTopbar.tsx` — mismo toggle reutilizado en el topbar del dashboard.
+- `frontend/public/theme-init.js` — nuevo: init estatico pre-paint (lee localStorage y setea `dataset.theme`).
+- `frontend/e2e/theme-mode.spec.ts` — nuevo: contrato e2e del tema.
+- `test/auth-cookie-persistence-contract.test.ts` — allowlist quirurgica (ver Validation).
+- `test/frontend-csp-inline-blockers-contract.test.ts` — allowlist quirurgica (ver Validation).
+
+## Implementation
+- Modelo por atributo estable en `<html>`: `data-theme="normal"` (default SSR) / `data-theme="dark-gray"`.
+- Todos los tokens HSL existentes (`--background`, `--card`, `--vetneb-*`, `--sidebar-*`, etc.) se sobreescriben bajo `:root[data-theme="dark-gray"]`; `:root` no se toca, por lo que Normal queda bit a bit igual.
+- El bloque nuevo va sin `@layer` a proposito: gana de forma determinista sobre `components`/`utilities` de Tailwind v4.
+- Overrides puntuales solo donde habia colores literales claros: `public-cta-secondary`/`public-cta-outline` (superficie elevada gris oscura), `public-cta-on-hero` (mantiene texto navy sobre su fondo claro fijo, ya que el hero conserva su gradiente navy de marca en ambos modos), textos ambar (`text-amber-6/7/8xx`, `clinical-alert-warning`, `dashboard-kpi-pill[data-tone="critical"]`) a ambar claro legible.
+- Gradientes de marca hardcodeados (heroes, CTA primario, headers clinicos, sidebar) se conservan: ya son superficies oscuras compatibles. Sin filtros globales, sin invertir imagenes/logos.
+- El dashboard hereda el tema via tokens del layout raiz; el toggle se reutiliza en su topbar (un control por shell, sin duplicar logica).
+
+## Theme model
+- Normal: tokens actuales de `:root` sin cambios; `color-scheme: light`.
+- Dark Gray: grises oscuros premium con tinte frio sutil (hue 210, saturacion 8-16%) — fondo `hsl(210 8% 12%)` (#1c2024, no negro), cards `hsl(210 9% 16%)`, bordes `hsl(210 8% 28-30%)`, texto principal `hsl(210 16% 90%)`, secundario `hsl(210 10% 68%)`, links/acentos en azul acero y teal aclarados (`--vetneb-navy: 205 58% 68%`, `--vetneb-teal: 177 50% 48%`); `color-scheme: dark` (controles nativos y scrollbars correctos). Contrastes verificados ≥ 4.5:1 en texto normal.
+- Persistence: `localStorage["vetneb-theme-mode"] = "normal" | "dark-gray"`; default `normal`; escritura en `try/catch` (si falla, el tema aplica igual en la vista).
+- Hydration strategy: el HTML SSR sale con `data-theme="normal"`; `/theme-init.js` (externo, sincronico, primero en `<head>`) aplica el valor persistido antes del primer paint — el parser no pinta `<body>` antes de ejecutarlo, asi que no hay flash. `suppressHydrationWarning` en `<html>` cubre la diferencia de atributo; el toggle monta en estado `normal` y se sincroniza con `dataset.theme` en `useEffect` (sin mismatch). Se eligio script externo y no inline para no introducir un bloqueador del enforcement CSP futuro (cubierto por `script-src 'self'`).
+
+## Accessibility
+- `button` nativo con `aria-pressed`, `aria-label` ("Cambiar a modo oscuro/normal") y `title`; operable por teclado con foco visible (`focus-visible:ring`).
+- `color-scheme` correcto por modo; contraste AA en texto/control; sin animaciones nuevas.
+
+## Validation
+- `pnpm --dir frontend lint` — PASS.
+- `pnpm --dir frontend typecheck` — PASS.
+- `pnpm --dir frontend build` — PASS (25/25 paginas, mismas rutas estaticas/dinamicas).
+- `pnpm --dir frontend e2e theme-mode.spec.ts` — PASS (2/2): existe el selector, alterna Normal/Dark Gray, persiste en `localStorage`, aplica `data-theme="dark-gray"` al `documentElement`, vuelve a normal, aplica pre-hidratacion sin errores de hydration.
+- `pnpm test` — 2651/2657 PASS. Los 6 fallos locales son exclusivamente guardrails historicos por diff (`PR-1/2/4/6/8/9 ... stays within allowed file scope`): ejecutan `git diff --name-only` sobre el working tree y disparan ante cualquier cambio sin commitear en archivos como `layout.tsx`/`globals.css`. Verificado empiricamente: con `git stash -u` (arbol limpio) los 6 pasan; en CI post-commit el diff esta vacio y quedan verdes. No se modificaron.
+- `pnpm build` — PASS.
+- `pnpm security:public-surface` — PASS (los 2 hallazgos `[server-only]` de `proxy.ts` son informativos y preexistentes en `main`).
+- Verificacion visual con screenshots (home, precios, login): Normal identico al actual; Dark Gray gris oscuro premium con jerarquia intacta.
+- Tests de contrato actualizados (dentro del scope del PR, que exige persistencia via `localStorage` y testing actualizado):
+  - `auth-cookie-persistence-contract`: el ban global del literal `localStorage` en `frontend/src` ahora exceptua solo los 2 archivos de tema; para ellos exige que usen unicamente la key `vetneb-theme-mode` y prohibe referencias a `session`/`auth`/`cookie`/`token`. El invariante de auth queda igual de fuerte.
+  - `frontend-csp-inline-blockers-contract`: el scan de `<script>` JSX exceptua unicamente el src exacto `/theme-init.js` (script externo same-origin: no requiere `unsafe-inline` ni nonce, no es bloqueador de enforcement segun el criterio documentado del propio contrato). Los scripts inline siguen prohibidos.
+
+## Out of scope
+- Sin rediseño de secciones.
+- Sin cambios de copy institucional (solo labels del control de tema).
+- Sin cambios backend.
+- Sin cambios de negocio.
+- Sin dependencias nuevas (icons via `lucide-react` ya existente).
+- Bloque `.dark` legacy de `globals.css` intacto (no usado por nadie).
+- `theme-color` PWA/manifest sin cambios.

--- a/frontend/e2e/theme-mode.spec.ts
+++ b/frontend/e2e/theme-mode.spec.ts
@@ -1,0 +1,112 @@
+import { type Page, expect, test } from "@playwright/test";
+
+const STORAGE_KEY = "vetneb-theme-mode";
+
+function collectHydrationFailures(page: Page) {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  return {
+    assertClean() {
+      const hydrationConsoleErrors = consoleErrors.filter((message) =>
+        /hydration|server rendered html|text content does not match/i.test(
+          message,
+        ),
+      );
+
+      expect(pageErrors).toEqual([]);
+      expect(hydrationConsoleErrors).toEqual([]);
+    },
+  };
+}
+
+test("theme toggle switches to dark gray, persists, and returns to normal", async ({
+  page,
+}) => {
+  const hydrationFailures = collectHydrationFailures(page);
+
+  const response = await page.goto("/", { waitUntil: "domcontentloaded" });
+  expect(response?.ok(), "/ should render successfully").toBeTruthy();
+
+  const html = page.locator("html");
+  const toggle = page.locator('[data-theme-toggle="true"]').first();
+
+  await expect(html).toHaveAttribute("data-theme", "normal");
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(toggle).toHaveAccessibleName("Cambiar a modo oscuro");
+
+  await toggle.click();
+
+  await expect(html).toHaveAttribute("data-theme", "dark-gray");
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(toggle).toHaveAccessibleName("Cambiar a modo normal");
+
+  const storedAfterEnable = await page.evaluate(
+    (key) => window.localStorage.getItem(key),
+    STORAGE_KEY,
+  );
+  expect(storedAfterEnable).toBe("dark-gray");
+
+  const colorScheme = await page.evaluate(
+    () => getComputedStyle(document.documentElement).colorScheme,
+  );
+  expect(colorScheme).toBe("dark");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+
+  await expect(html).toHaveAttribute("data-theme", "dark-gray");
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+  await toggle.click();
+
+  await expect(html).toHaveAttribute("data-theme", "normal");
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+  const storedAfterDisable = await page.evaluate(
+    (key) => window.localStorage.getItem(key),
+    STORAGE_KEY,
+  );
+  expect(storedAfterDisable).toBe("normal");
+
+  const normalColorScheme = await page.evaluate(
+    () => getComputedStyle(document.documentElement).colorScheme,
+  );
+  expect(normalColorScheme).toBe("light");
+
+  hydrationFailures.assertClean();
+});
+
+test("persisted dark gray theme applies before hydration without mismatch", async ({
+  page,
+}) => {
+  const hydrationFailures = collectHydrationFailures(page);
+
+  await page.addInitScript(
+    ([key, value]) => {
+      window.localStorage.setItem(key, value);
+    },
+    [STORAGE_KEY, "dark-gray"] as const,
+  );
+
+  const response = await page.goto("/", { waitUntil: "domcontentloaded" });
+  expect(response?.ok(), "/ should render successfully").toBeTruthy();
+
+  const html = page.locator("html");
+  await expect(html).toHaveAttribute("data-theme", "dark-gray");
+
+  const toggle = page.locator('[data-theme-toggle="true"]').first();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+  hydrationFailures.assertClean();
+});

--- a/frontend/public/theme-init.js
+++ b/frontend/public/theme-init.js
@@ -1,0 +1,7 @@
+(function () {
+  try {
+    if (window.localStorage.getItem("vetneb-theme-mode") === "dark-gray") {
+      document.documentElement.dataset.theme = "dark-gray";
+    }
+  } catch (e) {}
+})();

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1604,3 +1604,102 @@
   }
 }
 /* public-secondary-hero-surface:end */
+/* theme-mode-dark-gray:start */
+/* Unlayered on purpose: must win over @layer components/utilities tokens. */
+:root {
+  color-scheme: light;
+}
+
+:root[data-theme="dark-gray"] {
+  color-scheme: dark;
+  --background: 210 8% 12%;
+  --foreground: 210 16% 90%;
+  --card: 210 9% 16%;
+  --card-foreground: 210 16% 90%;
+  --popover: 210 9% 15%;
+  --popover-foreground: 210 16% 90%;
+  --primary: 205 62% 44%;
+  --primary-foreground: 190 36% 97%;
+  --secondary: 210 8% 22%;
+  --secondary-foreground: 210 14% 88%;
+  --muted: 210 8% 20%;
+  --muted-foreground: 210 10% 68%;
+  --accent: 195 14% 24%;
+  --accent-foreground: 190 30% 90%;
+  --destructive: 355 62% 52%;
+  --destructive-foreground: 18 40% 97%;
+  --border: 210 8% 28%;
+  --input: 210 8% 32%;
+  --ring: 181 60% 50%;
+  --chart-1: 207 62% 56%;
+  --chart-2: 177 52% 50%;
+  --chart-3: 196 70% 56%;
+  --chart-4: 38 82% 58%;
+  --chart-5: 347 60% 60%;
+  --vetneb-ink: 210 16% 90%;
+  --vetneb-navy: 205 58% 68%;
+  --vetneb-teal: 177 50% 48%;
+  --vetneb-cyan: 196 72% 56%;
+  --vetneb-amber: 38 84% 58%;
+  --vetneb-surface: 210 8% 12%;
+  --vetneb-surface-raised: 210 9% 15%;
+  --vetneb-surface-muted: 210 8% 18%;
+  --vetneb-line: 210 8% 30%;
+  --sidebar-background: 210 10% 10%;
+  --sidebar-foreground: 210 16% 92%;
+  --sidebar-primary: 181 60% 48%;
+  --sidebar-primary-foreground: 210 15% 8%;
+  --sidebar-accent: 210 9% 17%;
+  --sidebar-accent-foreground: 210 16% 92%;
+  --sidebar-border: 210 9% 20%;
+  --sidebar-ring: 181 60% 50%;
+}
+
+:root[data-theme="dark-gray"] .public-cta-secondary,
+:root[data-theme="dark-gray"] .public-cta-outline {
+  color: hsl(var(--foreground));
+  border-color: hsl(210 10% 38%);
+  background-image: linear-gradient(135deg, hsl(210 9% 23%) 0%, hsl(210 9% 20%) 52%, hsl(210 9% 18%) 100%);
+  box-shadow:
+    inset 0 1px 0 hsl(210 12% 32% / 0.6),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.4),
+    0 10px 24px rgba(0, 0, 0, 0.3);
+}
+
+:root[data-theme="dark-gray"] .public-cta-secondary:hover,
+:root[data-theme="dark-gray"] .public-cta-outline:hover {
+  border-color: hsl(181 40% 44% / 0.65);
+  background-image: linear-gradient(135deg, hsl(210 9% 26%) 0%, hsl(210 9% 23%) 52%, hsl(210 9% 21%) 100%);
+  box-shadow:
+    inset 0 1px 0 hsl(210 12% 36% / 0.6),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.42),
+    0 13px 28px rgba(0, 0, 0, 0.34);
+}
+
+:root[data-theme="dark-gray"] .public-cta-secondary:active,
+:root[data-theme="dark-gray"] .public-cta-outline:active {
+  border-color: hsl(181 40% 44% / 0.55);
+  background-image: linear-gradient(135deg, hsl(210 9% 21%) 0%, hsl(210 9% 19%) 52%, hsl(210 9% 17%) 100%);
+  box-shadow:
+    inset 0 1px 0 hsl(210 12% 30% / 0.55),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.4),
+    0 7px 18px rgba(0, 0, 0, 0.28);
+}
+
+/* On-hero CTA keeps its light surface over the fixed navy hero gradient. */
+:root[data-theme="dark-gray"] .public-cta-on-hero {
+  color: hsl(207 72% 22%);
+}
+
+:root[data-theme="dark-gray"] .clinical-alert-warning,
+:root[data-theme="dark-gray"] .clinical-table-state.clinical-alert-warning,
+:root[data-theme="dark-gray"] [class*="text-amber-6"],
+:root[data-theme="dark-gray"] [class*="text-amber-7"],
+:root[data-theme="dark-gray"] [class*="text-amber-8"] {
+  color: hsl(38 88% 64%);
+}
+
+:root[data-theme="dark-gray"] .dashboard-kpi-pill[data-tone="critical"] {
+  color: hsl(38 84% 64%);
+}
+/* theme-mode-dark-gray:end */

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { PwaServiceWorkerRegistrar } from "@/components/pwa/PwaServiceWorkerRegistrar";
 import { baseMetadata, getOrganizationJsonLd } from "@/lib/seo";
 import { SITE_THEME_COLOR } from "@/lib/seo";
+import { NORMAL_THEME_MODE } from "@/lib/theme";
 
 export const metadata: Metadata = baseMetadata;
 
@@ -20,8 +21,10 @@ export default function RootLayout({
   const orgJsonLd = getOrganizationJsonLd();
 
   return (
-    <html lang="es">
+    <html lang="es" data-theme={NORMAL_THEME_MODE} suppressHydrationWarning>
       <head>
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- sync by design: applies persisted theme before first paint */}
+        <script src="/theme-init.js" />
         <link
           rel="preload"
           href="/fonts/InterVariable.woff2"

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -1,4 +1,5 @@
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
 import { ROUTES } from "@/lib/routes";
 import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 
@@ -47,6 +48,7 @@ export function DashboardTopbar({
       </div>
 
       <div className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3">
+        <ThemeModeToggle />
         {notifications ? <DashboardNotificationsBell surface={notifications} /> : null}
         <PublicRouteControl
           href={ROUTES.login}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, ChevronDown, Microscope } from "lucide-react";
 
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
 import { ROUTES } from "@/lib/routes";
 
 const navLinks = [
@@ -83,6 +84,7 @@ export function Navbar() {
         </nav>
 
         <div className="flex items-center gap-2 sm:gap-3">
+          <ThemeModeToggle />
           <PublicRouteControl
             href={ROUTES.login}
             variant="bare"

--- a/frontend/src/components/theme/ThemeModeToggle.tsx
+++ b/frontend/src/components/theme/ThemeModeToggle.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import {
+  DARK_GRAY_THEME_MODE,
+  NORMAL_THEME_MODE,
+  THEME_STORAGE_KEY,
+  type ThemeMode,
+} from "@/lib/theme";
+import { cn } from "@/lib/utils";
+
+export function ThemeModeToggle({ className }: { className?: string }) {
+  const [theme, setTheme] = useState<ThemeMode>(NORMAL_THEME_MODE);
+
+  useEffect(() => {
+    if (document.documentElement.dataset.theme === DARK_GRAY_THEME_MODE) {
+      setTheme(DARK_GRAY_THEME_MODE);
+    }
+  }, []);
+
+  const isDarkGray = theme === DARK_GRAY_THEME_MODE;
+
+  function toggleTheme() {
+    const next: ThemeMode = isDarkGray
+      ? NORMAL_THEME_MODE
+      : DARK_GRAY_THEME_MODE;
+    document.documentElement.dataset.theme = next;
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // Sin persistencia disponible: el tema igual aplica en esta vista.
+    }
+    setTheme(next);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-pressed={isDarkGray}
+      aria-label={
+        isDarkGray ? "Cambiar a modo normal" : "Cambiar a modo oscuro"
+      }
+      title={isDarkGray ? "Modo normal" : "Modo oscuro"}
+      data-theme-toggle="true"
+      className={cn(
+        "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-input bg-card/95 text-vetneb-ink/80 shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-vetneb-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+        className,
+      )}
+    >
+      {isDarkGray ? (
+        <Sun className="h-4 w-4" aria-hidden="true" />
+      ) : (
+        <Moon className="h-4 w-4" aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,8 @@
+// Literals must stay in sync with frontend/public/theme-init.js (pre-paint init).
+export const THEME_STORAGE_KEY = "vetneb-theme-mode";
+export const NORMAL_THEME_MODE = "normal";
+export const DARK_GRAY_THEME_MODE = "dark-gray";
+
+export type ThemeMode =
+  | typeof NORMAL_THEME_MODE
+  | typeof DARK_GRAY_THEME_MODE;

--- a/test/auth-cookie-persistence-contract.test.ts
+++ b/test/auth-cookie-persistence-contract.test.ts
@@ -5,6 +5,7 @@
  *  1. Login cookies for all three roles carry a positive Max-Age (persistent cookies).
  *  2. Logout builders clear with Max-Age=0 only.
  *  3. No frontend code uses sessionStorage/localStorage as auth source of truth.
+ *     (UI theme preference files are allowlisted: vetneb-theme-mode only.)
  *  4. No frontend code triggers logout on beforeunload / unload / visibilitychange.
  *
  * These are source-level contract tests — they fail fast if the invariant is broken
@@ -146,6 +147,18 @@ test("cookie persistence contract: serializeCookie emits Max-Age directive", () 
 // 4. No frontend code uses sessionStorage / localStorage as auth source
 // ---------------------------------------------------------------------------
 
+// Non-auth UI preference files allowed to persist the visual theme choice.
+// They must only touch the vetneb-theme-mode key and never session/auth state.
+const THEME_PREFERENCE_FILES = [
+  "frontend/src/lib/theme.ts",
+  "frontend/src/components/theme/ThemeModeToggle.tsx",
+];
+
+function isThemePreferenceFile(file: string): boolean {
+  const normalized = file.split("\\").join("/");
+  return THEME_PREFERENCE_FILES.some((allowed) => normalized.endsWith(allowed));
+}
+
 test("cookie persistence contract: frontend has no sessionStorage or localStorage auth source", () => {
   const frontendSrcDir = resolve(REPO_ROOT, "frontend/src");
   const files = collectTsFiles(frontendSrcDir);
@@ -159,6 +172,23 @@ test("cookie persistence contract: frontend has no sessionStorage or localStorag
       false,
       `${relPath} must not use sessionStorage`,
     );
+
+    if (isThemePreferenceFile(file)) {
+      assert.ok(
+        source.includes('"vetneb-theme-mode"') ||
+          source.includes("THEME_STORAGE_KEY"),
+        `${relPath} may only use localStorage for the vetneb-theme-mode key`,
+      );
+      for (const forbidden of ["session", "auth", "cookie", "token"]) {
+        assert.equal(
+          source.toLowerCase().includes(forbidden),
+          false,
+          `${relPath} must not reference ${forbidden} state`,
+        );
+      }
+      continue;
+    }
+
     assert.equal(
       source.includes("localStorage"),
       false,

--- a/test/frontend-csp-inline-blockers-contract.test.ts
+++ b/test/frontend-csp-inline-blockers-contract.test.ts
@@ -113,6 +113,9 @@ test("all <script> JSX elements in frontend/src declare type=\"application/ld+js
   // Under CSP enforcement it requires 'unsafe-inline' or a per-request nonce.
   // All current <script> tags are JSON-LD structured data (safe, serialized via
   // JSON.stringify). This test guards that no bare executable script is introduced.
+  // Exception: same-origin external src scripts are covered by script-src 'self'
+  // and are NOT enforcement blockers. Allowlisted exact srcs only.
+  const ALLOWED_EXTERNAL_SCRIPT_SRCS = [/src\s*=\s*["']\/theme-init\.js["']/];
   const violations: Violation[] = [];
   for (const file of runtimeFiles) {
     if (!file.endsWith(".tsx")) continue;
@@ -122,6 +125,9 @@ test("all <script> JSX elements in frontend/src declare type=\"application/ld+js
       if (/<script\b/.test(line)) {
         // Inspect up to 4 lines starting at the <script tag for the type attribute.
         const window = lines.slice(idx, idx + 4).join(" ");
+        if (ALLOWED_EXTERNAL_SCRIPT_SRCS.some((src) => src.test(window))) {
+          return;
+        }
         if (!/type\s*=\s*["']application\/ld\+json["']/.test(window)) {
           violations.push({
             file: relative(process.cwd(), file),


### PR DESCRIPTION
﻿## Summary
- Add a global Normal / Dark Gray theme mode using existing design tokens
- Add a reusable theme toggle in public navbar and dashboard topbar
- Persist the selected theme in localStorage and apply it early with a self-hosted init script
- Add E2E coverage for theme selection, persistence, and documentElement data-theme

## Validation
- pnpm test
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend e2e theme-mode.spec.ts --project=chromium

## Scope
- UI theme mode only
- Normal mode preserves current visual tokens
- No backend changes
- No business logic changes
- No institutional copy changes beyond theme control text/labels
