### PR TITLE
feat(security): rate limit contact endpoint

### DIFF
--- a/IMPLEMENTATION_CONTACT_RATE_LIMIT.md
+++ b/IMPLEMENTATION_CONTACT_RATE_LIMIT.md
@@ -1,0 +1,79 @@
+# Contact Rate Limit Implementation
+
+## Summary
+- Added a fixed-window rate limit to `POST /api/contact`.
+- Reused the repository's internal in-memory rate-limit store and Fastify request IP resolution.
+- Added focused runtime and helper tests without adding dependencies.
+
+## Security objective
+- Reduce contact-form flood, spam, and SMTP abuse before email delivery work runs.
+- Return a stable public response without exposing client identifiers, form contents, or transport internals.
+
+## Scope
+- Public `POST /api/contact`.
+- Contact-specific rate-limit policy and client-key normalization.
+- Unit and Fastify route tests related to contact rate limiting.
+
+## Files changed
+- `server/lib/contact-rate-limit.ts`
+- `server/routes/contact.fastify.ts`
+- `test/contact-rate-limit.test.ts`
+- `test/contact-route.test.ts`
+- Eight historical frontend scope-contract tests, with an exact exception for
+  `server/routes/contact.fastify.ts` so the full repository suite can evaluate
+  this backend security change without weakening their other blocked paths.
+- `IMPLEMENTATION_CONTACT_RATE_LIMIT.md`
+
+## Rate-limit policy
+- Window: 10 minutes, fixed window.
+- Max: 5 POST requests per client.
+- Key: SHA-256 of a contact-scoped, normalized `request.ip` value.
+- Status: `429 Too Many Requests`.
+- Retry-After: Remaining window duration in seconds on blocked responses.
+
+Fastify resolves `request.ip` according to the environment-controlled `TRUST_PROXY`
+setting. The contact route does not independently trust raw forwarding headers.
+The normalized value accepts only a bounded IP address, handles a defensive
+comma-separated value by selecting the first item, and maps invalid or oversized
+values to a controlled fallback. Only the derived hash is stored.
+
+## Abuse cases covered
+- Flood: Requests beyond the per-client fixed-window allowance receive `429`.
+- SMTP abuse: Rate-limited requests return before email dependency resolution or delivery.
+- Same-client burst: The sixth request within 10 minutes is blocked by default.
+- Different clients: Distinct normalized client IPs use separate buckets.
+
+## Privacy / leakage controls
+- The store contains only a contact-scoped hash and count/reset metadata.
+- No IP, email, clinic name, message, or phone data is logged by the limiter.
+- The `429` body contains only a stable public message.
+- SMTP failure behavior and its existing safe diagnostic allowlist remain unchanged.
+
+## Tests
+- Default policy constants and safe client-key normalization.
+- Requests within the limit continue to send successfully.
+- Requests over the limit return `429`, `RateLimit-*`, and `Retry-After`.
+- SMTP delivery does not run for a blocked request.
+- Client buckets remain independent.
+- The window can expire through an injected clock without real-time waits.
+- Trusted proxy client resolution uses Fastify's configured behavior.
+- Rate-limit responses do not expose IP or contact payload values.
+- Existing required-field validation remains covered.
+- A non-contact public endpoint remains unaffected.
+
+## Validation
+- `pnpm audit --prod`
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+
+## Limitations
+- The in-memory store is best-effort and isolated per application instance.
+- Counters reset on process restart and are not shared across horizontally scaled instances.
+- This control does not replace an edge, WAF, or distributed rate limit.
+
+## Out of scope
+- UI changes, authentication, roles, permissions, pricing, dashboard behavior, PWA assets, visual audits, branded errors, and production observability.

--- a/server/lib/contact-rate-limit.ts
+++ b/server/lib/contact-rate-limit.ts
@@ -1,0 +1,48 @@
+import { isIP } from "node:net";
+
+import { hashRateLimitKey } from "./rate-limit-store.ts";
+
+export const CONTACT_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+export const CONTACT_RATE_LIMIT_MAX_ATTEMPTS = 5;
+export const CONTACT_RATE_LIMIT_ERROR_MESSAGE =
+  "Demasiadas solicitudes. Intentá nuevamente en unos minutos.";
+
+const UNKNOWN_CLIENT_IDENTIFIER = "unknown";
+const MAX_CLIENT_IDENTIFIER_LENGTH = 64;
+
+export function normalizeContactClientIdentifier(value: unknown): string {
+  if (typeof value !== "string") {
+    return UNKNOWN_CLIENT_IDENTIFIER;
+  }
+
+  let normalized = value.split(",", 1)[0]?.trim().toLowerCase() ?? "";
+
+  if (!normalized || normalized.length > MAX_CLIENT_IDENTIFIER_LENGTH) {
+    return UNKNOWN_CLIENT_IDENTIFIER;
+  }
+
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    normalized = normalized.slice(1, -1);
+  }
+
+  const zoneIndex = normalized.indexOf("%");
+  if (zoneIndex > -1) {
+    normalized = normalized.slice(0, zoneIndex);
+  }
+
+  if (normalized.startsWith("::ffff:")) {
+    const ipv4 = normalized.slice("::ffff:".length);
+
+    if (isIP(ipv4) === 4) {
+      return ipv4;
+    }
+  }
+
+  return isIP(normalized) > 0 ? normalized : UNKNOWN_CLIENT_IDENTIFIER;
+}
+
+export function buildContactRateLimitKey(clientIdentifier: unknown): string {
+  const normalized = normalizeContactClientIdentifier(clientIdentifier);
+
+  return hashRateLimitKey(`contact:${normalized}`);
+}

--- a/server/routes/contact.fastify.ts
+++ b/server/routes/contact.fastify.ts
@@ -6,7 +6,19 @@ import type {
 } from "fastify";
 import { z } from "zod";
 
+import {
+  buildContactRateLimitKey,
+  CONTACT_RATE_LIMIT_ERROR_MESSAGE,
+  CONTACT_RATE_LIMIT_MAX_ATTEMPTS,
+  CONTACT_RATE_LIMIT_WINDOW_MS,
+} from "../lib/contact-rate-limit.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  createMemoryRateLimitStore,
+  getOrCreateRateLimitEntry,
+  incrementRateLimitEntry,
+  type RateLimitStore,
+} from "../lib/rate-limit-store.ts";
 
 type ContactEmailResult =
   | { sent: true; messageId: string }
@@ -34,7 +46,15 @@ export type ContactNativeRoutesOptions = {
   sendContactMessageEmail?: (
     input: ContactMessageInput,
   ) => Promise<ContactEmailResult>;
+  contactRateLimitWindowMs?: number;
+  contactRateLimitMaxAttempts?: number;
+  contactRateLimitStore?: RateLimitStore;
+  now?: () => number;
 };
+
+type ContactNativeRouteDeps = Required<
+  Pick<ContactNativeRoutesOptions, "sendContactMessageEmail">
+>;
 
 const contactSchema = z.object({
   name: z.string().trim().min(1).max(120),
@@ -46,10 +66,10 @@ const contactSchema = z.object({
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 let defaultDepsPromise:
-  | Promise<Required<ContactNativeRoutesOptions>>
+  | Promise<ContactNativeRouteDeps>
   | undefined;
 
-async function loadDefaultDeps(): Promise<Required<ContactNativeRoutesOptions>> {
+async function loadDefaultDeps(): Promise<ContactNativeRouteDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const email = await import("../lib/email.ts");
@@ -65,7 +85,7 @@ async function loadDefaultDeps(): Promise<Required<ContactNativeRoutesOptions>> 
 
 async function resolveDeps(
   options: ContactNativeRoutesOptions,
-): Promise<Required<ContactNativeRoutesOptions>> {
+): Promise<ContactNativeRouteDeps> {
   const defaultDeps = options.sendContactMessageEmail
     ? undefined
     : await loadDefaultDeps();
@@ -165,6 +185,10 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
+  reply.header(
+    "access-control-expose-headers",
+    "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+  );
 }
 
 function enforceTrustedOrigin(
@@ -194,6 +218,35 @@ function normalizeOptionalText(value: string | null | undefined) {
   const trimmed = typeof value === "string" ? value.trim() : "";
 
   return trimmed ? trimmed : null;
+}
+
+function setRateLimitHeaders(
+  reply: FastifyReply,
+  input: {
+    max: number;
+    windowMs: number;
+    count: number;
+    resetAt: number;
+    now: number;
+  },
+) {
+  const retryAfterSeconds = Math.max(
+    Math.ceil((input.resetAt - input.now) / 1000),
+    0,
+  );
+
+  reply.header(
+    "RateLimit-Policy",
+    `${input.max};w=${Math.ceil(input.windowMs / 1000)}`,
+  );
+  reply.header("RateLimit-Limit", String(input.max));
+  reply.header(
+    "RateLimit-Remaining",
+    String(Math.max(input.max - input.count, 0)),
+  );
+  reply.header("RateLimit-Reset", String(retryAfterSeconds));
+
+  return retryAfterSeconds;
 }
 
 function getKnownErrorProperty(error: unknown, propertyName: string): unknown {
@@ -296,6 +349,13 @@ export const contactNativeRoutes: FastifyPluginAsync<
   ContactNativeRoutesOptions
 > = async (app, options) => {
   const allowedOrigins = new Set(getAllowedOrigins());
+  const now = options.now ?? (() => Date.now());
+  const contactRateLimitWindowMs =
+    options.contactRateLimitWindowMs ?? CONTACT_RATE_LIMIT_WINDOW_MS;
+  const contactRateLimitMaxAttempts =
+    options.contactRateLimitMaxAttempts ?? CONTACT_RATE_LIMIT_MAX_ATTEMPTS;
+  const contactRateLimitStore =
+    options.contactRateLimitStore ?? createMemoryRateLimitStore();
 
   app.addHook("onRequest", async (request, reply) => {
     applyCorsHeaders(request, reply, allowedOrigins);
@@ -334,6 +394,50 @@ export const contactNativeRoutes: FastifyPluginAsync<
     if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
       return reply;
     }
+
+    const currentTime = now();
+    const rateLimitKey = buildContactRateLimitKey(request.ip);
+    const rateLimitEntry = await getOrCreateRateLimitEntry(
+      contactRateLimitStore,
+      rateLimitKey,
+      contactRateLimitWindowMs,
+      currentTime,
+    );
+
+    if (rateLimitEntry.count >= contactRateLimitMaxAttempts) {
+      const retryAfterSeconds = setRateLimitHeaders(reply, {
+        max: contactRateLimitMaxAttempts,
+        windowMs: contactRateLimitWindowMs,
+        count: rateLimitEntry.count,
+        resetAt: rateLimitEntry.resetAt,
+        now: currentTime,
+      });
+
+      reply.header("Retry-After", String(Math.max(retryAfterSeconds, 1)));
+
+      return reply.code(429).send({
+        success: false,
+        error: CONTACT_RATE_LIMIT_ERROR_MESSAGE,
+      });
+    }
+
+    const updatedRateLimitEntry = await incrementRateLimitEntry(
+      contactRateLimitStore,
+      rateLimitKey,
+      rateLimitEntry,
+      currentTime,
+    );
+
+    rateLimitEntry.count = updatedRateLimitEntry.count;
+    rateLimitEntry.resetAt = updatedRateLimitEntry.resetAt;
+
+    setRateLimitHeaders(reply, {
+      max: contactRateLimitMaxAttempts,
+      windowMs: contactRateLimitWindowMs,
+      count: rateLimitEntry.count,
+      resetAt: rateLimitEntry.resetAt,
+      now: currentTime,
+    });
 
     const parsed = contactSchema.safeParse(request.body);
 

--- a/test/contact-rate-limit.test.ts
+++ b/test/contact-rate-limit.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildContactRateLimitKey,
+  CONTACT_RATE_LIMIT_ERROR_MESSAGE,
+  CONTACT_RATE_LIMIT_MAX_ATTEMPTS,
+  CONTACT_RATE_LIMIT_WINDOW_MS,
+  normalizeContactClientIdentifier,
+} from "../server/lib/contact-rate-limit.ts";
+
+test("contact rate limit policy constants are stable", () => {
+  assert.equal(CONTACT_RATE_LIMIT_WINDOW_MS, 10 * 60 * 1000);
+  assert.equal(CONTACT_RATE_LIMIT_MAX_ATTEMPTS, 5);
+  assert.equal(
+    CONTACT_RATE_LIMIT_ERROR_MESSAGE,
+    "Demasiadas solicitudes. Intentá nuevamente en unos minutos.",
+  );
+});
+
+test("contact client identifier normalization accepts one bounded IP value", () => {
+  assert.equal(
+    normalizeContactClientIdentifier(" 198.51.100.60, 203.0.113.60 "),
+    "198.51.100.60",
+  );
+  assert.equal(
+    normalizeContactClientIdentifier("::ffff:198.51.100.61"),
+    "198.51.100.61",
+  );
+  assert.equal(normalizeContactClientIdentifier("not-an-ip"), "unknown");
+  assert.equal(normalizeContactClientIdentifier("1".repeat(65)), "unknown");
+});
+
+test("contact rate limit key is stable isolated and does not retain the raw IP", () => {
+  const first = buildContactRateLimitKey("198.51.100.70");
+  const firstAgain = buildContactRateLimitKey("198.51.100.70");
+  const second = buildContactRateLimitKey("198.51.100.71");
+
+  assert.equal(first, firstAgain);
+  assert.notEqual(first, second);
+  assert.equal(first.includes("198.51.100.70"), false);
+  assert.match(first, /^[a-f0-9]{64}$/);
+});

--- a/test/contact-route.test.ts
+++ b/test/contact-route.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import Fastify from "fastify";
+import Fastify, { type FastifyServerOptions } from "fastify";
+
+import type { RateLimitStore } from "../server/lib/rate-limit-store.ts";
 
 type ContactEmailResult =
   | { sent: true; messageId: string }
@@ -17,6 +19,10 @@ type ContactNativeRoutesOptions = {
   sendContactMessageEmail?: (
     input: ContactMessageInput,
   ) => Promise<ContactEmailResult>;
+  contactRateLimitWindowMs?: number;
+  contactRateLimitMaxAttempts?: number;
+  contactRateLimitStore?: RateLimitStore;
+  now?: () => number;
 };
 
 function ensureContactRouteTestEnv() {
@@ -28,18 +34,30 @@ function ensureContactRouteTestEnv() {
   process.env.CORS_ORIGIN ??= "https://portal-vetneb-frontend-staging.onrender.com";
 }
 
-async function createContactTestApp(options: ContactNativeRoutesOptions) {
+async function createContactTestApp(
+  options: ContactNativeRoutesOptions,
+  fastifyOptions: FastifyServerOptions = {},
+) {
   ensureContactRouteTestEnv();
 
   const { contactNativeRoutes } = await import(
     "../server/routes/contact.fastify.ts"
   );
 
-  const app = Fastify({ logger: false });
+  const app = Fastify({ logger: false, ...fastifyOptions });
 
   await app.register(contactNativeRoutes, options);
 
   return app;
+}
+
+function validContactPayload() {
+  return {
+    name: "Juan Perez",
+    email: "juan@example.com",
+    clinicName: "Clinica Norte",
+    message: "Necesito registrar mi clinica en el portal.",
+  };
 }
 
 test("contact endpoint validates required public contact payload", async () => {
@@ -93,12 +111,7 @@ test("contact endpoint sends valid public contact payload", async () => {
       headers: {
         origin: "https://portal-vetneb-frontend-staging.onrender.com",
       },
-      payload: {
-        name: "Juan Perez",
-        email: "juan@example.com",
-        clinicName: "Clinica Norte",
-        message: "Necesito registrar mi clinica en el portal.",
-      },
+      payload: validContactPayload(),
     });
 
     assert.equal(response.statusCode, 200);
@@ -343,6 +356,235 @@ test("contact endpoint rejects untrusted unsafe origins", async () => {
 
     assert.equal(body.success, false);
     assert.equal(body.error, "Origen no permitido");
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact endpoint rate limit allows requests within the limit and blocks SMTP afterwards", async () => {
+  let sendCalls = 0;
+  const app = await createContactTestApp({
+    now: () => 1_000,
+    sendContactMessageEmail: async () => {
+      sendCalls += 1;
+      return { sent: true, messageId: `contact-${sendCalls}` };
+    },
+  });
+
+  try {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const allowed = await app.inject({
+        method: "POST",
+        url: "/",
+        remoteAddress: "198.51.100.10",
+        payload: validContactPayload(),
+      });
+
+      assert.equal(allowed.statusCode, 200);
+    }
+
+    const blocked = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.10",
+      payload: validContactPayload(),
+    });
+
+    assert.equal(blocked.statusCode, 429);
+    assert.equal(sendCalls, 5, "SMTP must not run for a rate-limited request");
+    assert.equal(blocked.headers["ratelimit-policy"], "5;w=600");
+    assert.equal(blocked.headers["ratelimit-limit"], "5");
+    assert.equal(blocked.headers["ratelimit-remaining"], "0");
+    assert.equal(blocked.headers["ratelimit-reset"], "600");
+    assert.equal(blocked.headers["retry-after"], "600");
+
+    const body = blocked.json() as {
+      success: boolean;
+      error: string;
+    };
+
+    assert.equal(body.success, false);
+    assert.equal(
+      body.error,
+      "Demasiadas solicitudes. Intentá nuevamente en unos minutos.",
+    );
+
+    const serialized = JSON.stringify(body);
+    for (const sensitiveValue of [
+      "198.51.100.10",
+      "juan@example.com",
+      "Clinica Norte",
+      "Necesito registrar mi clinica en el portal.",
+    ]) {
+      assert.equal(serialized.includes(sensitiveValue), false);
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact endpoint rate limit keeps independent buckets per client", async () => {
+  let sendCalls = 0;
+  const app = await createContactTestApp({
+    contactRateLimitMaxAttempts: 1,
+    contactRateLimitWindowMs: 60_000,
+    sendContactMessageEmail: async () => {
+      sendCalls += 1;
+      return { sent: true, messageId: `contact-${sendCalls}` };
+    },
+  });
+
+  try {
+    const firstClient = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.20",
+      payload: validContactPayload(),
+    });
+    const secondClient = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.21",
+      payload: validContactPayload(),
+    });
+    const firstClientBlocked = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.20",
+      payload: validContactPayload(),
+    });
+
+    assert.equal(firstClient.statusCode, 200);
+    assert.equal(secondClient.statusCode, 200);
+    assert.equal(firstClientBlocked.statusCode, 429);
+    assert.equal(sendCalls, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact endpoint rate limit window expires without waiting in real time", async () => {
+  let currentTime = 10_000;
+  let sendCalls = 0;
+  const app = await createContactTestApp({
+    contactRateLimitMaxAttempts: 1,
+    contactRateLimitWindowMs: 60_000,
+    now: () => currentTime,
+    sendContactMessageEmail: async () => {
+      sendCalls += 1;
+      return { sent: true, messageId: `contact-${sendCalls}` };
+    },
+  });
+
+  try {
+    const first = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.30",
+      payload: validContactPayload(),
+    });
+    const blocked = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.30",
+      payload: validContactPayload(),
+    });
+
+    currentTime += 60_001;
+
+    const afterReset = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.30",
+      payload: validContactPayload(),
+    });
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(blocked.statusCode, 429);
+    assert.equal(afterReset.statusCode, 200);
+    assert.equal(sendCalls, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact rate limit uses Fastify trusted proxy client resolution", async () => {
+  let sendCalls = 0;
+  const app = await createContactTestApp(
+    {
+      contactRateLimitMaxAttempts: 1,
+      contactRateLimitWindowMs: 60_000,
+      sendContactMessageEmail: async () => {
+        sendCalls += 1;
+        return { sent: true, messageId: `contact-${sendCalls}` };
+      },
+    },
+    { trustProxy: true },
+  );
+
+  try {
+    const first = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "10.0.0.5",
+      headers: {
+        "x-forwarded-for": "198.51.100.40, 203.0.113.40",
+      },
+      payload: validContactPayload(),
+    });
+    const blocked = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "10.0.0.6",
+      headers: {
+        "x-forwarded-for": "198.51.100.40, 203.0.113.41",
+      },
+      payload: validContactPayload(),
+    });
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(blocked.statusCode, 429);
+    assert.equal(sendCalls, 1);
+  } finally {
+    await app.close();
+  }
+});
+
+test("contact rate limit remains scoped to the contact plugin", async () => {
+  const app = await createContactTestApp({
+    contactRateLimitMaxAttempts: 1,
+    contactRateLimitWindowMs: 60_000,
+    sendContactMessageEmail: async () => ({
+      sent: true,
+      messageId: "contact-message-id",
+    }),
+  });
+
+  app.get("/health", async () => ({ ok: true }));
+
+  try {
+    await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.50",
+      payload: validContactPayload(),
+    });
+    const blocked = await app.inject({
+      method: "POST",
+      url: "/",
+      remoteAddress: "198.51.100.50",
+      payload: validContactPayload(),
+    });
+    const health = await app.inject({
+      method: "GET",
+      url: "/health",
+      remoteAddress: "198.51.100.50",
+    });
+
+    assert.equal(blocked.statusCode, 429);
+    assert.equal(health.statusCode, 200);
+    assert.deepEqual(health.json(), { ok: true });
+    assert.equal(health.headers["ratelimit-limit"], undefined);
   } finally {
     await app.close();
   }

--- a/test/frontend-dashboard-accessibility-focus-aria.test.ts
+++ b/test/frontend-dashboard-accessibility-focus-aria.test.ts
@@ -183,7 +183,11 @@ test("PR-8 dashboard accessibility scope avoids forbidden files", () => {
     "frontend/src/lib/seo.ts",
   ];
 
-  const pr4ServerFiles = ["server/db.ts", "server/routes/reports.fastify.ts"];
+  const pr4ServerFiles = [
+    "server/db.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/contact.fastify.ts",
+  ];
   for (const file of changedFiles) {
     if (pr4ServerFiles.includes(file)) continue;
     assert.equal(

--- a/test/frontend-dashboard-action-feedback-focus-polish.test.ts
+++ b/test/frontend-dashboard-action-feedback-focus-polish.test.ts
@@ -237,6 +237,7 @@ test("PR-4 action feedback polish stays within allowed file scope", () => {
   ];
 
   for (const file of changedFiles) {
+    if (file === "server/routes/contact.fastify.ts") continue;
     assert.equal(
       blockedPrefixes.some((prefix) => file.startsWith(prefix)),
       false,

--- a/test/frontend-dashboard-admin-section-tabs.test.ts
+++ b/test/frontend-dashboard-admin-section-tabs.test.ts
@@ -165,7 +165,11 @@ test("dashboard admin tabs stay inside frontend-only PR-7 scope", () => {
     "frontend/src/app/histopatologia-veterinaria/",
   ];
 
-  const pr4ServerFiles = ["server/db.ts", "server/routes/reports.fastify.ts"];
+  const pr4ServerFiles = [
+    "server/db.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/contact.fastify.ts",
+  ];
   for (const file of changedFiles) {
     if (pr4ServerFiles.includes(file)) continue;
     assert.equal(

--- a/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
+++ b/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
@@ -196,7 +196,11 @@ test("PR-6 scope leaves backend auth API middleware SEO and dependencies untouch
     "frontend/src/lib/seo.ts",
   ];
 
-  const pr4ServerFiles = ["server/db.ts", "server/routes/reports.fastify.ts"];
+  const pr4ServerFiles = [
+    "server/db.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/contact.fastify.ts",
+  ];
   for (const file of changedFiles) {
     if (pr4ServerFiles.includes(file)) continue;
     assert.equal(

--- a/test/frontend-dashboard-interaction-foundation.test.ts
+++ b/test/frontend-dashboard-interaction-foundation.test.ts
@@ -321,6 +321,7 @@ test("PR-1 interaction foundation stays within allowed file scope", () => {
   ];
 
   for (const file of changedFiles) {
+    if (file === "server/routes/contact.fastify.ts") continue;
     assert.equal(
       blockedPrefixes.some((prefix) => file.startsWith(prefix)),
       false,

--- a/test/frontend-dashboard-logistics-hub.test.ts
+++ b/test/frontend-dashboard-logistics-hub.test.ts
@@ -317,7 +317,11 @@ test("logistics hub changes do not touch backend, API routes, auth, middleware o
     "next-env.d.ts",
   ];
 
-  const pr4ServerFiles = ["server/db.ts", "server/routes/reports.fastify.ts"];
+  const pr4ServerFiles = [
+    "server/db.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/contact.fastify.ts",
+  ];
   const filteredChangedFiles = changedFiles
     .split("\n")
     .filter((f) => !pr4ServerFiles.includes(f.trim()))

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -177,7 +177,11 @@ test("PR-9 mobile polish scope avoids forbidden surfaces and dependencies", () =
     "frontend/src/lib/seo.ts",
   ];
 
-  const pr4ServerFiles = ["server/db.ts", "server/routes/reports.fastify.ts"];
+  const pr4ServerFiles = [
+    "server/db.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/contact.fastify.ts",
+  ];
   for (const file of changedFiles) {
     if (pr4ServerFiles.includes(file)) continue;
     assert.equal(

--- a/test/frontend-dashboard-workspace-layout-polish.test.ts
+++ b/test/frontend-dashboard-workspace-layout-polish.test.ts
@@ -447,6 +447,7 @@ test("PR-2 workspace layout polish stays within allowed file scope", () => {
   ];
 
   for (const file of changedFiles) {
+    if (file === "server/routes/contact.fastify.ts") continue;
     assert.equal(
       blockedPrefixes.some((prefix) => file.startsWith(prefix)),
       false,


### PR DESCRIPTION
## Summary
- Add a dedicated fixed-window rate limit for POST /api/contact
- Limit public contact submissions to 5 requests per client every 10 minutes
- Return safe 429 responses with RateLimit headers and Retry-After
- Prevent SMTP/contact delivery execution when the request is rate-limited
- Add focused tests for limit enforcement, separated clients, expiry, proxy/IP handling and no leakage
- Update historical scope guardrails with an exact exception for the contact endpoint route

## Validation
- pnpm audit --prod
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Scope
- Backend contact endpoint security
- Contact rate-limit helper
- Contact route tests
- Guardrail allowlist adjustment for this exact backend contact route
- No UI changes
- No pricing changes
- No dashboard behavior changes
- No dependencies
