### PR TITLE
fix(ui): align theme color with dark gray mode

### DIFF
--- a/IMPLEMENTATION_THEME_COLOR_DARK_GRAY.md
+++ b/IMPLEMENTATION_THEME_COLOR_DARK_GRAY.md
@@ -1,0 +1,58 @@
+# Theme Color Dark Gray Alignment
+
+## Summary
+- The browser and PWA theme color now follows the active Normal or Dark Gray visual mode.
+- The existing pre-paint theme initialization remains synchronous and updates both `data-theme` and the existing Next metadata tag.
+
+## Problem
+- Next emitted a fixed institutional `theme-color` even when `data-theme="dark-gray"` was active.
+- Mobile browser and installed PWA chrome could therefore remain navy while the page used the dark gray surface.
+
+## Scope
+- Theme metadata.
+- Pre-hydration theme initialization.
+- Theme toggle synchronization.
+- Focused Playwright coverage.
+
+## Files changed
+- `frontend/src/lib/theme.ts`
+- `frontend/public/theme-init.js`
+- `frontend/src/components/theme/ThemeModeToggle.tsx`
+- `frontend/e2e/theme-mode.spec.ts`
+- `IMPLEMENTATION_THEME_COLOR_DARK_GRAY.md`
+
+## Implementation
+- Theme mode and browser color constants live in `frontend/src/lib/theme.ts`.
+- Next viewport metadata continues to emit the normal institutional theme color.
+- `/theme-init.js` applies the persisted mode and updates that tag before hydration and first paint.
+- During startup, a short-lived `MutationObserver` removes the duplicate tag that Next can insert while reconciling pre-hydration metadata; it disconnects on window load.
+- `ThemeModeToggle` uses the shared client helper to update `data-theme`, update the surviving tag, and remove any duplicate before persisting the mode.
+- The web app manifest keeps its existing Normal installation and launch default.
+
+## Theme-color policy
+- Normal: `#0c354e`, the existing institutional navy.
+- Dark Gray: `#1c1f21`, matching the rendered `hsl(210 8% 12%)` base background.
+
+## Tests
+- Normal mode exposes exactly one theme-color tag with the institutional value.
+- Enabling Dark Gray updates the tag to the dark gray value.
+- Returning to Normal restores the institutional value.
+- A persisted Dark Gray preference applies `data-theme` and `theme-color` before hydration without hydration errors.
+- The toggle keeps its `aria-pressed` state and accessible name contract.
+
+## Validation
+- `pnpm audit --prod` - PASS, no known vulnerabilities.
+- `pnpm --dir frontend e2e theme-mode.spec.ts --project=chromium` - PASS, 2/2.
+- `pnpm --dir frontend e2e theme-mode.spec.ts --project=chromium --repeat-each=3` - PASS, 6/6.
+- `pnpm test` - PASS, 2671/2671.
+- `pnpm build` - PASS.
+- `pnpm security:public-surface` - PASS.
+- `pnpm --dir frontend lint` - PASS.
+- `pnpm --dir frontend typecheck` - PASS.
+- `pnpm --dir frontend build` - PASS, 25/25 pages generated.
+
+## Out of scope
+- General visual redesigns or dashboard changes.
+- Backend, contact API, pricing, role, or authentication changes.
+- Open Graph images, PWA icons, and unrelated production-readiness work.
+- New dependencies.

--- a/frontend/e2e/theme-mode.spec.ts
+++ b/frontend/e2e/theme-mode.spec.ts
@@ -1,6 +1,8 @@
 import { type Page, expect, test } from "@playwright/test";
 
 const STORAGE_KEY = "vetneb-theme-mode";
+const NORMAL_THEME_COLOR = "#0c354e";
+const DARK_GRAY_THEME_COLOR = "#1c1f21";
 
 function collectHydrationFailures(page: Page) {
   const pageErrors: string[] = [];
@@ -39,9 +41,12 @@ test("theme toggle switches to dark gray, persists, and returns to normal", asyn
   expect(response?.ok(), "/ should render successfully").toBeTruthy();
 
   const html = page.locator("html");
+  const themeColor = page.locator('meta[name="theme-color"]');
   const toggle = page.locator('[data-theme-toggle="true"]').first();
 
   await expect(html).toHaveAttribute("data-theme", "normal");
+  await expect(themeColor).toHaveCount(1);
+  await expect(themeColor).toHaveAttribute("content", NORMAL_THEME_COLOR);
   await expect(toggle).toBeVisible();
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
   await expect(toggle).toHaveAccessibleName("Cambiar a modo oscuro");
@@ -49,6 +54,7 @@ test("theme toggle switches to dark gray, persists, and returns to normal", asyn
   await toggle.click();
 
   await expect(html).toHaveAttribute("data-theme", "dark-gray");
+  await expect(themeColor).toHaveAttribute("content", DARK_GRAY_THEME_COLOR);
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
   await expect(toggle).toHaveAccessibleName("Cambiar a modo normal");
 
@@ -66,11 +72,15 @@ test("theme toggle switches to dark gray, persists, and returns to normal", asyn
   await page.reload({ waitUntil: "domcontentloaded" });
 
   await expect(html).toHaveAttribute("data-theme", "dark-gray");
+  await expect(themeColor).toHaveCount(1);
+  await expect(themeColor).toHaveAttribute("content", DARK_GRAY_THEME_COLOR);
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
 
   await toggle.click();
 
   await expect(html).toHaveAttribute("data-theme", "normal");
+  await expect(themeColor).toHaveCount(1);
+  await expect(themeColor).toHaveAttribute("content", NORMAL_THEME_COLOR);
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
 
   const storedAfterDisable = await page.evaluate(
@@ -105,8 +115,13 @@ test("persisted dark gray theme applies before hydration without mismatch", asyn
   const html = page.locator("html");
   await expect(html).toHaveAttribute("data-theme", "dark-gray");
 
+  const themeColor = page.locator('meta[name="theme-color"]');
+  await expect(themeColor).toHaveCount(1);
+  await expect(themeColor).toHaveAttribute("content", DARK_GRAY_THEME_COLOR);
+
   const toggle = page.locator('[data-theme-toggle="true"]').first();
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(toggle).toHaveAccessibleName("Cambiar a modo normal");
 
   hydrationFailures.assertClean();
 });

--- a/frontend/public/theme-init.js
+++ b/frontend/public/theme-init.js
@@ -1,7 +1,46 @@
 (function () {
+  var theme = "normal";
+  var normalThemeColor = "#0c354e";
+  var darkGrayThemeColor = "#1c1f21";
+
   try {
     if (window.localStorage.getItem("vetneb-theme-mode") === "dark-gray") {
-      document.documentElement.dataset.theme = "dark-gray";
+      theme = "dark-gray";
     }
   } catch (e) {}
+
+  document.documentElement.dataset.theme = theme;
+
+  function syncThemeColor() {
+    var themeColors = document.querySelectorAll('meta[name="theme-color"]');
+    var themeColor = themeColors.item(0);
+
+    if (!themeColor) {
+      themeColor = document.createElement("meta");
+      themeColor.name = "theme-color";
+      document.head.appendChild(themeColor);
+    }
+
+    themeColor.content =
+      document.documentElement.dataset.theme === "dark-gray"
+        ? darkGrayThemeColor
+        : normalThemeColor;
+
+    for (var index = 1; index < themeColors.length; index += 1) {
+      themeColors.item(index).remove();
+    }
+  }
+
+  syncThemeColor();
+
+  var observer = new MutationObserver(syncThemeColor);
+  observer.observe(document.head, { childList: true });
+  window.addEventListener(
+    "load",
+    function () {
+      syncThemeColor();
+      observer.disconnect();
+    },
+    { once: true },
+  );
 })();

--- a/frontend/src/components/theme/ThemeModeToggle.tsx
+++ b/frontend/src/components/theme/ThemeModeToggle.tsx
@@ -4,6 +4,7 @@ import { Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import {
+  applyThemeMode,
   DARK_GRAY_THEME_MODE,
   NORMAL_THEME_MODE,
   THEME_STORAGE_KEY,
@@ -26,7 +27,7 @@ export function ThemeModeToggle({ className }: { className?: string }) {
     const next: ThemeMode = isDarkGray
       ? NORMAL_THEME_MODE
       : DARK_GRAY_THEME_MODE;
-    document.documentElement.dataset.theme = next;
+    applyThemeMode(next);
     try {
       window.localStorage.setItem(THEME_STORAGE_KEY, next);
     } catch {

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -2,7 +2,28 @@
 export const THEME_STORAGE_KEY = "vetneb-theme-mode";
 export const NORMAL_THEME_MODE = "normal";
 export const DARK_GRAY_THEME_MODE = "dark-gray";
+export const NORMAL_THEME_COLOR = "#0c354e";
+export const DARK_GRAY_THEME_COLOR = "#1c1f21";
 
 export type ThemeMode =
   | typeof NORMAL_THEME_MODE
   | typeof DARK_GRAY_THEME_MODE;
+
+export function applyThemeMode(theme: ThemeMode): void {
+  document.documentElement.dataset.theme = theme;
+
+  const themeColors = document.querySelectorAll<HTMLMetaElement>(
+    'meta[name="theme-color"]',
+  );
+  const themeColor = themeColors.item(0);
+  if (themeColor) {
+    themeColor.content =
+      theme === DARK_GRAY_THEME_MODE
+        ? DARK_GRAY_THEME_COLOR
+        : NORMAL_THEME_COLOR;
+  }
+
+  for (let index = 1; index < themeColors.length; index += 1) {
+    themeColors.item(index)?.remove();
+  }
+}


### PR DESCRIPTION
## Summary
- Align browser/PWA theme-color with Normal and Dark Gray theme modes
- Keep Normal theme-color as #0c354e
- Add Dark Gray theme-color as #1c1f21
- Synchronize theme-color before hydration through theme-init.js
- Synchronize theme-color from ThemeModeToggle on mode changes
- Preserve a single meta[name="theme-color"] tag
- Extend theme-mode E2E coverage for normal, dark gray, return, persistence, unique tag and accessibility

## Validation
- pnpm audit --prod
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm --dir frontend e2e theme-mode.spec.ts --project=chromium
- pnpm --dir frontend e2e theme-mode.spec.ts --project=chromium --repeat-each=3

## Scope
- Theme-color behavior only
- No backend changes
- No dashboard changes
- No product UI redesign
- No copy changes
- No dependencies
