### PR TITLE
fix(dashboard): redirect server 401 to login

### DIFF
--- a/IMPLEMENTATION_DASHBOARD_401_LOGIN_REDIRECT.md
+++ b/IMPLEMENTATION_DASHBOARD_401_LOGIN_REDIRECT.md
@@ -1,0 +1,96 @@
+# Dashboard 401 Login Redirect
+
+## Summary
+- Dashboard Server Components now redirect to `/login` when a backend read returns HTTP 401.
+- HTTP 403, 404, network failures, and 5xx responses keep their existing controlled error behavior.
+- Missing clinic or admin session cookies are redirected by the existing dashboard proxy.
+
+## Problem
+- The proxy validated only whether the expected cookie was present.
+- Expired, revoked, or invalid cookies reached server-rendered dashboard pages.
+- API errors lost their HTTP status and were caught as generic load failures, leaving partial or error-state dashboard content visible.
+
+## Scope
+- Clinic dashboard, reports, logistics hub, logistics visits, logistics routes, and logistics metrics Server Components.
+- Admin dashboard server reads.
+- Shared frontend API error metadata and dashboard server auth handling.
+- Existing dashboard proxy behavior for absent session cookies.
+- Focused contract and Playwright coverage.
+
+## Files changed
+- `frontend/src/lib/api-error.ts`
+- `frontend/src/lib/api.ts`
+- `frontend/src/lib/dashboard-server-auth.ts`
+- `frontend/src/proxy.ts`
+- `frontend/src/app/dashboard/page.tsx`
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `frontend/src/app/dashboard/informes/page.tsx`
+- `frontend/src/app/dashboard/logistica/page.tsx`
+- `frontend/src/app/dashboard/logistica/visitas/page.tsx`
+- `frontend/src/app/dashboard/logistica/rutas/page.tsx`
+- `frontend/src/app/dashboard/logistica/metricas/page.tsx`
+- `test/frontend-api-client-request.test.ts`
+- `test/frontend-dashboard-middleware.test.ts`
+- `test/frontend-dashboard-server-401-redirect.test.ts`
+- `test/frontend-extreme-speed-guardrails.test.ts`
+- `test/frontend-middleware.test.ts`
+- `test/frontend-next-config-security-headers.test.ts`
+- `test/global-auth-boundary-contract.test.ts`
+- `frontend/e2e/dashboard-auth-redirect.spec.ts`
+
+## Current behavior
+- Missing clinic cookies redirected to login with a safe `next` path.
+- Missing admin cookies returned 404.
+- Present but invalid or expired cookies passed the proxy.
+- Server-side API reads converted non-success responses to generic `Error` values.
+- Dashboard pages caught those errors and rendered partial data or controlled load-error states, including for 401.
+
+## New behavior
+- API response errors retain their HTTP status in `ApiResponseError`.
+- Dashboard Server Components call a server-only unauthorized handler before rendering fallback UI.
+- A classified HTTP 401 redirects to the fixed `/login` route.
+- Missing admin and clinic cookies follow the existing proxy login redirect.
+
+## 401 handling
+- Missing cookie: the dashboard proxy redirects to `/login?next=<requested-dashboard-path>`.
+- Invalid, expired, or revoked cookie: the backend returns 401, the API client preserves status 401, and the Server Component redirects to `/login`.
+- Backend error text is not rendered during this redirect flow.
+
+## 403 / 500 behavior
+- HTTP 403 is not classified as an authentication failure and does not redirect to login.
+- HTTP 404 is not classified as an authentication failure.
+- HTTP 5xx and network failures do not redirect to login.
+- Existing controlled page error states remain responsible for non-401 failures.
+- Report foreign-access behavior is unchanged.
+
+## Loop prevention
+- The proxy matcher remains limited to `/dashboard/:path*`; `/login` is not matched.
+- Server-side redirects use the fixed `ROUTES.login` value and do not accept user-provided destinations.
+- Proxy `next` values are derived from the requested same-origin dashboard URL.
+- Login already validates `next` against internal clinic dashboard routes and rejects external or admin destinations for clinic sessions.
+
+## Tests
+- API error classification covers 401, 403, 500, and generic errors.
+- Static contracts verify all server-rendered dashboard pages invoke the 401 handler.
+- Proxy contracts verify clinic/admin missing-cookie redirects and absence of a login loop.
+- Login contracts verify the existing open-redirect boundary.
+- Focused Playwright coverage verifies unauthenticated `/dashboard` and `/dashboard/admin` reach a stable, normally rendered login page without technical 401 text.
+
+## Validation
+- `pnpm audit --prod`
+- `pnpm test`
+- `pnpm build`
+- `pnpm security:public-surface`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+- `pnpm --dir frontend e2e dashboard-auth-redirect.spec.ts --project=chromium --workers=1`
+- `pnpm --dir frontend e2e visual-smoke.spec.ts --project=chromium --workers=1`
+
+## Out of scope
+- Dashboard visual redesign.
+- Role or permission changes.
+- Backend authentication changes.
+- Report foreign-access 404 behavior.
+- SEO, PWA, pricing, contact, cookies, secrets, or dependencies.
+- A new global authentication strategy or new middleware.

--- a/frontend/e2e/dashboard-auth-redirect.spec.ts
+++ b/frontend/e2e/dashboard-auth-redirect.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+const LOGIN_FORM_NAME = "Formulario de inicio de sesión";
+
+for (const dashboardPath of ["/dashboard", "/dashboard/admin"] as const) {
+  test(`unauthenticated ${dashboardPath} redirects to a stable login page`, async ({
+    page,
+  }) => {
+    const pageErrors: string[] = [];
+
+    page.on("pageerror", (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await page.goto(dashboardPath, { waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveURL((url) => {
+      return (
+        url.pathname === "/login" &&
+        url.searchParams.get("next") === dashboardPath
+      );
+    });
+    await expect(
+      page.getByRole("form", { name: LOGIN_FORM_NAME }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Iniciar sesión" }),
+    ).toBeVisible();
+    await expect(page.getByText(/HTTP 401|Unauthorized|Sesión expirada/i)).toHaveCount(
+      0,
+    );
+
+    await page.waitForTimeout(250);
+    await expect(page).toHaveURL((url) => url.pathname === "/login");
+    expect(pageErrors).toEqual([]);
+  });
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -32,6 +32,7 @@ import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
 import { AdminDashboardWorkspaceController } from "./AdminDashboardWorkspaceController";
 import type { AdminModule } from "./AdminDashboardWorkspaceController";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 import { formatDateTime } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -320,7 +321,8 @@ export default async function AdminPage({
     auditEntries = await getAuditEntries(await getAdminRequestOptions(), {
       throwOnError: true,
     });
-  } catch {
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
     auditEntriesLoadError = true;
   }
 

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -39,6 +39,7 @@ import {
   searchReportsPaginated,
   type PaginatedReports,
 } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 import {
   cn,
   getReportStatusLabel,
@@ -284,7 +285,8 @@ export default async function InformesPage({
           },
           { throwOnError: true },
         );
-  } catch {
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
     reportsLoadError = true;
   }
 

--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { getRoutePlanMetrics, getRoutePlans } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 
 export const metadata: Metadata = {
   title: "Métricas de logística — Portal VETNEB",
@@ -36,7 +37,8 @@ export default async function MetricasPage() {
     routePlans = await getRoutePlans(requestOptions, {
       throwOnError: true,
     });
-  } catch {
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
     routePlansLoadError = true;
   }
 
@@ -51,7 +53,8 @@ export default async function MetricasPage() {
           ),
         )
       ).flat();
-    } catch {
+    } catch (error) {
+      redirectToLoginOnUnauthorized(error);
       routeMetricsLoadError = true;
     }
   }

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -12,6 +12,7 @@ import {
   getLogisticsFieldVisits,
   getRoutePlans,
 } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 import { LogisticsCommandCenter } from "./LogisticsCommandCenter";
 
 export const metadata: Metadata = {
@@ -41,7 +42,8 @@ export default async function LogisticaPage() {
         fieldVisits = await getLogisticsFieldVisits(requestOptions, {
           throwOnError: true,
         });
-      } catch {
+      } catch (error) {
+        redirectToLoginOnUnauthorized(error);
         fieldVisitsLoadError = true;
       }
     })(),
@@ -50,7 +52,8 @@ export default async function LogisticaPage() {
         routePlans = await getRoutePlans(requestOptions, {
           throwOnError: true,
         });
-      } catch {
+      } catch (error) {
+        redirectToLoginOnUnauthorized(error);
         routePlansLoadError = true;
       }
     })(),

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getRoutePlans } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 import {
   getRoutePlanStatusLabel,
   getRoutePlanStatusVariant,
@@ -40,7 +41,8 @@ export default async function RutasPage() {
     routePlans = await getRoutePlans(await getLogisticsRequestOptions(), {
       throwOnError: true,
     });
-  } catch {
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
     routePlansLoadError = true;
   }
 

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getLogisticsFieldVisits } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 import {
   getFieldVisitStatusLabel,
   getFieldVisitStatusVariant,
@@ -41,7 +42,8 @@ export default async function VisitasPage() {
       await getLogisticsRequestOptions(),
       { throwOnError: true },
     );
-  } catch {
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
     visitsLoadError = true;
   }
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import {
   getLogisticsFieldVisits,
   getReports,
 } from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
 
 export const metadata: Metadata = {
   title: "Dashboard Clínica — Portal VETNEB",
@@ -67,7 +68,8 @@ export default async function DashboardPage({
 
   try {
     stats = await getDashboardStats(requestOptions);
-  } catch {
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
     statsLoadError = true;
   }
 
@@ -77,7 +79,8 @@ export default async function DashboardPage({
         reports = await getReports(requestOptions, undefined, {
           throwOnError: true,
         });
-      } catch {
+      } catch (error) {
+        redirectToLoginOnUnauthorized(error);
         reportsLoadError = true;
       }
     })(),
@@ -86,7 +89,8 @@ export default async function DashboardPage({
         visits = await getLogisticsFieldVisits(requestOptions, {
           throwOnError: true,
         });
-      } catch {
+      } catch (error) {
+        redirectToLoginOnUnauthorized(error);
         visitsLoadError = true;
       }
     })(),

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -1,0 +1,15 @@
+export class ApiResponseError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiResponseError";
+    this.status = status;
+  }
+}
+
+export function isUnauthorizedApiError(
+  error: unknown,
+): error is ApiResponseError {
+  return error instanceof ApiResponseError && error.status === 401;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -46,6 +46,7 @@ import type {
   AdminFailedLoginAlertsQuery,
   AdminFailedLoginAlertsSnapshot,
 } from "@/types";
+import { ApiResponseError } from "@/lib/api-error";
 
 const LOCAL_DEVELOPMENT_API_BASE_URL = "http://localhost:3000";
 const SAME_ORIGIN_API_BASE_URL = "";
@@ -278,14 +279,17 @@ async function apiFetch<T>(
     }
 
     if (backendMessage) {
-      throw new Error(backendMessage);
+      throw new ApiResponseError(res.status, backendMessage);
     }
 
     if (res.status >= 500) {
-      throw new Error(BACKEND_OPERATION_ERROR_MESSAGE);
+      throw new ApiResponseError(
+        res.status,
+        BACKEND_OPERATION_ERROR_MESSAGE,
+      );
     }
 
-    throw new Error(`HTTP ${res.status}`);
+    throw new ApiResponseError(res.status, `HTTP ${res.status}`);
   }
 
   if (res.status === 204) {

--- a/frontend/src/lib/dashboard-server-auth.ts
+++ b/frontend/src/lib/dashboard-server-auth.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+import { redirect } from "next/navigation";
+
+import { isUnauthorizedApiError } from "@/lib/api-error";
+import { ROUTES } from "@/lib/routes";
+
+export function redirectToLoginOnUnauthorized(error: unknown): void {
+  if (isUnauthorizedApiError(error)) {
+    redirect(ROUTES.login);
+  }
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -29,10 +29,6 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (isAdminDashboardPath(pathname)) {
-    return new NextResponse("Not Found", { status: 404 });
-  }
-
   const loginUrl = request.nextUrl.clone();
   const nextPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
 

--- a/test/frontend-api-client-request.test.ts
+++ b/test/frontend-api-client-request.test.ts
@@ -77,6 +77,7 @@ test("frontend API client manages JSON content type without overriding FormData"
 test("frontend API client surfaces backend errors safely", () => {
   const source = read(API_CLIENT_PATH);
 
+  assert.ok(source.includes('import { ApiResponseError } from "@/lib/api-error";'));
   assert.ok(source.includes("if (!res.ok) {"));
   assert.ok(source.includes("const body = (await res.json().catch(() => ({}))) as {"));
   assert.ok(source.includes("error?: unknown;"));
@@ -87,10 +88,19 @@ test("frontend API client surfaces backend errors safely", () => {
   assert.ok(source.includes("buildRateLimitErrorMessage(retryAfterSeconds)"));
   assert.equal(source.includes("buildRateLimitErrorMessage(backendMessage,"), false);
   assert.ok(source.includes("if (backendMessage) {"));
-  assert.ok(source.includes("throw new Error(backendMessage);"));
+  assert.ok(
+    source.includes(
+      "throw new ApiResponseError(res.status, backendMessage);",
+    ),
+  );
   assert.ok(source.includes("if (res.status >= 500) {"));
-  assert.ok(source.includes("throw new Error(BACKEND_OPERATION_ERROR_MESSAGE);"));
-  assert.ok(source.includes("throw new Error(`HTTP ${res.status}`);"));
+  assert.ok(source.includes("throw new ApiResponseError("));
+  assert.ok(source.includes("BACKEND_OPERATION_ERROR_MESSAGE,"));
+  assert.ok(
+    source.includes(
+      "throw new ApiResponseError(res.status, `HTTP ${res.status}`);",
+    ),
+  );
 });
 
 test("frontend API client formats 429 rate-limit guidance from headers or JSON metadata", () => {

--- a/test/frontend-dashboard-middleware.test.ts
+++ b/test/frontend-dashboard-middleware.test.ts
@@ -27,7 +27,6 @@ test("frontend dashboard proxy exists and protects dashboard routes", () => {
   assert.ok(source.includes('LOGIN_PATH = "/login"'));
   assert.ok(source.includes('ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin"'));
   assert.ok(source.includes("NextResponse.next()"));
-  assert.ok(source.includes('new NextResponse("Not Found", { status: 404 })'));
   assert.ok(source.includes("NextResponse.redirect(loginUrl)"));
   assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
 });
@@ -49,16 +48,19 @@ test("frontend dashboard proxy separates clinic and admin sessions", () => {
   assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
-test("frontend dashboard proxy blocks unauthenticated admin dashboard from public login", () => {
+test("frontend dashboard proxy redirects unauthenticated admin dashboard to login", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("const pathname = request.nextUrl.pathname;"));
-  assert.ok(source.includes("if (isAdminDashboardPath(pathname)) {"));
-  assert.ok(source.includes('return new NextResponse("Not Found", { status: 404 });'));
-  assert.equal(source.includes("loginUrl.pathname = LOGIN_PATH;\\n  loginUrl.searchParams.set"), false);
+  assert.equal(
+    source.includes('new NextResponse("Not Found", { status: 404 })'),
+    false,
+  );
+  assert.ok(source.includes("loginUrl.pathname = LOGIN_PATH;"));
+  assert.ok(source.includes('loginUrl.searchParams.set("next", nextPath);'));
 });
 
-test("frontend dashboard proxy preserves requested clinic dashboard path on login redirect", () => {
+test("frontend dashboard proxy preserves requested dashboard path on login redirect", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes("request.nextUrl.clone()"));

--- a/test/frontend-dashboard-server-401-redirect.test.ts
+++ b/test/frontend-dashboard-server-401-redirect.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+  ApiResponseError,
+  isUnauthorizedApiError,
+} from "../frontend/src/lib/api-error.ts";
+
+const SERVER_AUTH_PATH = "frontend/src/lib/dashboard-server-auth.ts";
+const PROXY_PATH = "frontend/src/proxy.ts";
+const LOGIN_CONTENT_PATH = "frontend/src/components/public/LoginContent.tsx";
+const DASHBOARD_SERVER_PAGES = [
+  "frontend/src/app/dashboard/page.tsx",
+  "frontend/src/app/dashboard/admin/page.tsx",
+  "frontend/src/app/dashboard/informes/page.tsx",
+  "frontend/src/app/dashboard/logistica/page.tsx",
+  "frontend/src/app/dashboard/logistica/visitas/page.tsx",
+  "frontend/src/app/dashboard/logistica/rutas/page.tsx",
+  "frontend/src/app/dashboard/logistica/metricas/page.tsx",
+] as const;
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("dashboard API error policy classifies only HTTP 401 as unauthenticated", () => {
+  assert.equal(
+    isUnauthorizedApiError(new ApiResponseError(401, "session expired")),
+    true,
+  );
+  assert.equal(
+    isUnauthorizedApiError(new ApiResponseError(403, "forbidden")),
+    false,
+  );
+  assert.equal(
+    isUnauthorizedApiError(new ApiResponseError(500, "backend unavailable")),
+    false,
+  );
+  assert.equal(isUnauthorizedApiError(new Error("HTTP 401")), false);
+});
+
+test("dashboard server auth redirects classified 401 errors to the fixed login route", () => {
+  const source = read(SERVER_AUTH_PATH);
+
+  assert.ok(source.includes('import "server-only";'));
+  assert.ok(source.includes('import { redirect } from "next/navigation";'));
+  assert.ok(source.includes("isUnauthorizedApiError(error)"));
+  assert.ok(source.includes("redirect(ROUTES.login);"));
+  assert.equal(source.includes("error.message"), false);
+  assert.equal(source.includes("?next="), false);
+  assert.equal(source.includes("searchParams"), false);
+});
+
+test("all dashboard server pages apply the unauthorized redirect before fallback UI", () => {
+  for (const pagePath of DASHBOARD_SERVER_PAGES) {
+    const source = read(pagePath);
+
+    assert.ok(
+      source.includes(
+        'import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";',
+      ),
+      `${pagePath} must import the server unauthorized handler`,
+    );
+    assert.ok(
+      source.includes("redirectToLoginOnUnauthorized(error);"),
+      `${pagePath} must handle server-side 401 errors`,
+    );
+  }
+});
+
+test("dashboard proxy redirects missing clinic and admin sessions without a login loop", () => {
+  const source = read(PROXY_PATH);
+
+  assert.ok(source.includes('matcher: ["/dashboard/:path*"]'));
+  assert.ok(source.includes("loginUrl.pathname = LOGIN_PATH;"));
+  assert.ok(source.includes('loginUrl.searchParams.set("next", nextPath);'));
+  assert.equal(source.includes('matcher: ["/login'), false);
+  assert.equal(
+    source.includes('new NextResponse("Not Found", { status: 404 })'),
+    false,
+  );
+});
+
+test("login next handling rejects external and admin paths for clinic sessions", () => {
+  const source = read(LOGIN_CONTENT_PATH);
+
+  assert.ok(source.includes('candidate.startsWith("//")'));
+  assert.ok(source.includes("parsedNextPath.origin !== SAFE_LOGIN_REDIRECT_ORIGIN"));
+  assert.ok(source.includes("parsedNextPath.pathname === ROUTES.dashboardAdmin"));
+  assert.ok(
+    source.includes(
+      "parsedNextPath.pathname.startsWith(`${ROUTES.dashboardAdmin}/`)",
+    ),
+  );
+  assert.equal(source.includes("return candidate;"), false);
+});

--- a/test/frontend-extreme-speed-guardrails.test.ts
+++ b/test/frontend-extreme-speed-guardrails.test.ts
@@ -335,8 +335,8 @@ test("proxy protects /dashboard and /dashboard/admin with correct cookies", () =
     "middleware matcher must cover /dashboard/:path*",
   );
   assert.ok(
-    source.includes("status: 404"),
-    "admin without valid session must return 404 not 401/redirect",
+    source.includes("return NextResponse.redirect(loginUrl)"),
+    "dashboard requests without the required session must redirect to login",
   );
 });
 

--- a/test/frontend-middleware.test.ts
+++ b/test/frontend-middleware.test.ts
@@ -37,17 +37,20 @@ test("frontend proxy separates clinic and admin dashboard session cookies", () =
   assert.equal(source.includes("hasClinicSession || hasAdminSession"), false);
 });
 
-test("frontend proxy blocks unauthenticated admin dashboard without public login redirect", () => {
+test("frontend proxy redirects unauthenticated admin dashboard to login", () => {
   const source = read(MIDDLEWARE_PATH);
 
-  assert.ok(source.includes("if (isAdminDashboardPath(pathname)) {"));
-  assert.ok(source.includes('return new NextResponse("Not Found", { status: 404 });'));
+  assert.equal(
+    source.includes('return new NextResponse("Not Found", { status: 404 });'),
+    false,
+  );
   assert.equal(source.includes("notFoundUrl"), false);
   assert.equal(source.includes("NOT_FOUND_PATH"), false);
-  assert.equal(source.includes('loginUrl.searchParams.set("next", nextPath);\\n\\n  return NextResponse.redirect(loginUrl);\\n}'), false);
+  assert.ok(source.includes('loginUrl.searchParams.set("next", nextPath);'));
+  assert.ok(source.includes("return NextResponse.redirect(loginUrl);"));
 });
 
-test("frontend proxy redirects unauthenticated clinic dashboard requests to login with next path", () => {
+test("frontend proxy redirects unauthenticated dashboard requests to login with next path", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('const LOGIN_PATH = "/login";'));

--- a/test/frontend-next-config-security-headers.test.ts
+++ b/test/frontend-next-config-security-headers.test.ts
@@ -183,8 +183,8 @@ test("middleware session separation contract is intact after next.config changes
     "admin session cookie name must be admin_session_id",
   );
   assert.ok(
-    source.includes('return new NextResponse("Not Found", { status: 404 })'),
-    "unauthenticated admin dashboard must return 404",
+    source.includes("return NextResponse.redirect(loginUrl)"),
+    "unauthenticated dashboard requests must redirect to login",
   );
   assert.equal(
     source.includes("hasClinicSession || hasAdminSession"),

--- a/test/global-auth-boundary-contract.test.ts
+++ b/test/global-auth-boundary-contract.test.ts
@@ -153,7 +153,7 @@ test("session cookie names remain separated across backend and dashboard proxy",
   );
   assertContains(
     middlewareSource,
-    'return new NextResponse("Not Found", { status: 404 })',
+    "return NextResponse.redirect(loginUrl)",
     "frontend admin dashboard unauth response",
   );
 });


### PR DESCRIPTION
## Summary
- Redirect dashboard server-side 401 responses to /login
- Preserve 403, 404, network and 500 errors as controlled non-login states
- Add ApiResponseError to preserve backend HTTP status in frontend API calls
- Add a dashboard server auth helper for centralized 401 redirect handling
- Cover dashboard, admin, informes and logistics server-rendered pages
- Align proxy/auth contracts so admin without cookie redirects to login
- Add E2E coverage for unauthenticated dashboard and admin access

## Validation
- pnpm audit --prod
- pnpm test
- pnpm build
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm security:public-surface
- pnpm --dir frontend e2e dashboard-auth-redirect.spec.ts visual-smoke.spec.ts --project=chromium --workers=1

## Results
- pnpm test: 2686/2686
- E2E dashboard auth redirect: 2/2
- Visual smoke: 10/10

## Scope
- Dashboard server-side 401 handling
- API error status preservation
- Auth/proxy contracts
- No backend changes
- No SEO/PWA changes
- No reports foreign access 404 changes
- No dependencies
