### PR TITLE
ops(production): verify observability and launch readiness

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build frontend
         run: pnpm --dir frontend build
 
+      - name: Audit built public surface
+        run: pnpm security:public-surface
+
       - name: Install Playwright browsers
         run: pnpm --dir frontend exec playwright install --with-deps chromium
 

--- a/IMPLEMENTATION_PRODUCTION_OBSERVABILITY_READINESS.md
+++ b/IMPLEMENTATION_PRODUCTION_OBSERVABILITY_READINESS.md
@@ -1,0 +1,203 @@
+# Production Observability and Launch Readiness
+
+## Summary
+
+- Verifies the existing public health contract for database and private storage.
+- Adds a credential-free, read-only readiness command for local or deployed APIs.
+- Prevents raw dependency errors from appearing in the public health payload.
+- Runs the public-surface security audit immediately after the frontend build in CI.
+
+## Problem
+
+- The degraded health response could include raw database or storage error messages.
+- The existing production smoke is broader than an operational health probe.
+- Frontend CI built the application without an explicit post-build public-surface gate.
+- Launch information was spread across several operational documents.
+
+## Scope
+
+- Public `/health` and `/api/health` response safety.
+- Read-only verification of `GET /health`.
+- Environment-variable presence checklist using names only.
+- Existing request ID, safe error, logging, CORS, cookie, proxy, CI, and incident contracts.
+- Manual production checks that cannot be completed without controlled access.
+
+## Explicitly out of scope
+
+- SEO
+- Metadata
+- Sitemap
+- Robots
+- OpenGraph
+- JSON-LD/schema
+- Public copy changes
+
+## Files changed
+
+- `server/lib/http-runtime.ts`
+- `scripts/ops/verify-production-readiness.mjs`
+- `test/production-readiness.test.ts`
+- `test/helpers/report-foreign-access-scope.ts`
+- `.github/workflows/frontend-ci.yml`
+- `test/frontend-ci-workflow.test.ts`
+- `IMPLEMENTATION_PRODUCTION_OBSERVABILITY_READINESS.md`
+
+## Health checks
+
+- `GET /health` and `GET /api/health` share the existing runtime health handler.
+- Healthy status is HTTP `200` with `success`, `status`, `checks.database`,
+  `checks.storage`, `uptimeSeconds`, `responseTimeMs`, and `timestamp`.
+- Database and Storage checks are read-only.
+- Degraded status remains HTTP `503`, with dependency state reported only as
+  `up` or `down`.
+- Raw dependency error messages, stack traces, paths, credentials, and
+  connection details are not included.
+
+Run the focused verifier with one of these forms:
+
+```powershell
+node scripts/ops/verify-production-readiness.mjs --url <backend-base-url>
+node scripts/ops/verify-production-readiness.mjs <backend-base-url>
+```
+
+The optional `READINESS_BASE_URL` variable can supply the same base URL. The
+script performs one `GET /health`, sends no credentials, writes nothing, does
+not print the response body, and exits nonzero for configuration, network,
+HTTP, JSON, shape, database, or storage failures.
+
+## Observability
+
+- API responses retain the existing safe `x-request-id` correlation contract.
+- Internal API failures return a generic public error while server logs retain
+  method, path, status, message, and request ID.
+- Existing logging contracts redact public access tokens and prevent direct
+  logging of cookies, passwords, SMTP credentials, and service credentials.
+- The readiness verifier prints only a pass/fail summary and never dumps
+  environment variables or health payloads.
+
+## Required environment variables
+
+Presence and deployment-policy checklist, names only:
+
+- `ADMIN_COOKIE_NAME`
+- `CONTACT_TO`
+- `COOKIE_NAME`
+- `CORS_ORIGIN`
+- `DATABASE_MAX_CONNECTIONS`
+- `DATABASE_URL`
+- `GMAIL_API_CLIENT_ID`
+- `GMAIL_API_CLIENT_SECRET`
+- `GMAIL_API_FROM`
+- `GMAIL_API_REFRESH_TOKEN`
+- `LAB_UPLOAD_USERNAMES`
+- `MAX_UPLOAD_FILE_SIZE_MB`
+- `NODE_ENV`
+- `OWNER_OPEN_ID`
+- `PARTICULAR_COOKIE_NAME`
+- `PORT`
+- `SESSION_TTL_HOURS`
+- `SMTP_FROM`
+- `SMTP_HOST`
+- `SMTP_PASS`
+- `SMTP_PORT`
+- `SMTP_SECURE`
+- `SMTP_USER`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_DB_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_SIGNED_URL_EXPIRES_IN_SECONDS`
+- `SUPABASE_STORAGE_BUCKET`
+- `SUPABASE_URL`
+- `TRUST_PROXY`
+
+Database connectivity requires one of `SUPABASE_DB_URL` or `DATABASE_URL`.
+Email readiness requires one complete transport configuration plus
+`CONTACT_TO` when email is part of the launch.
+
+## Secret leakage controls
+
+- Public health fields are allowlisted by the readiness verifier.
+- Unexpected top-level or dependency fields fail verification.
+- Degraded dependency exceptions are converted to generic `down` states.
+- Tests inject connection and credential-shaped sentinel strings and assert
+  that neither the health payload nor command output contains them.
+- The command rejects URLs containing embedded credentials.
+
+## CORS / cookies / proxy
+
+- Production CORS origins must exactly match approved frontend origins.
+- Credentialed CORS must never use a wildcard origin.
+- Clinic, admin, and particular sessions retain separate cookie names.
+- Production cookies remain `HttpOnly`, `Secure`, and `SameSite=None`.
+- `TRUST_PROXY` must match the deployed reverse-proxy topology and remain
+  governed by the typed environment contract.
+- Real HTTPS login, persistence, logout, and preflight behavior remain manual
+  launch checks.
+
+## Storage / database / email readiness
+
+- Public health directly verifies database connectivity and Storage bucket
+  access without writes.
+- Storage health uses bucket metadata lookup only; it does not upload, delete,
+  or create objects.
+- Email configuration is visible indirectly through the authenticated admin
+  system health surface.
+- No email is sent by the readiness command or this PR.
+- Delivery must be confirmed manually only when email is included in the
+  release scope.
+
+## Launch checklist
+
+- [ ] Candidate commit and deployment artifact are identified.
+- [ ] Required backend environment-variable names are present in the provider.
+- [ ] No environment values are copied into logs, tickets, screenshots, or PRs.
+- [ ] Database backup and Storage backup evidence are current.
+- [ ] `GET /health` passes the read-only verifier.
+- [ ] Authenticated admin health reports expected service configuration.
+- [ ] Frontend build completes before `security:public-surface`.
+- [ ] CORS preflight and all three session-cookie domains work over real HTTPS.
+- [ ] Relevant authenticated smoke tests pass without exposing credentials.
+- [ ] Rollback owner, previous deployment, and decision threshold are recorded.
+
+## Incident checklist
+
+- [ ] Record UTC time, deployment identifier, HTTP status, and request ID only.
+- [ ] Stop launch progression when public health is not HTTP `200`.
+- [ ] Distinguish database `down` from storage `down` using generic health state.
+- [ ] Review provider logs without copying request bodies, cookies, tokens, or
+  environment values.
+- [ ] Verify provider status and dependency connectivity with read-only tools.
+- [ ] Roll back the application when the failure began with the candidate deploy.
+- [ ] Escalate database or Storage recovery through the existing backup and
+  rollback runbook.
+- [ ] Re-run health, CORS, cookie, and critical endpoint checks after recovery.
+
+## Validation
+
+- `pnpm audit --prod`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `pnpm test`
+- `pnpm build`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+- `pnpm security:public-surface`
+- Relevant E2E: `dashboard-auth-redirect.spec.ts` and `visual-smoke.spec.ts`
+
+## Remaining manual checks
+
+- Provider-side environment presence with all values hidden.
+- Production health against the deployed candidate.
+- Authenticated admin system and schema health.
+- Real HTTPS CORS, cookie persistence, and logout behavior.
+- Private Storage policy, signed URL expiry, upload, download, and restore drill.
+- Email provider configuration and controlled delivery when included in launch.
+- Provider logs, alerts, backup evidence, rollback access, and on-call ownership.
+
+## Out of scope
+
+- SEO changes
+- Feature changes
+- Data migrations
+- Provider changes

--- a/scripts/ops/verify-production-readiness.mjs
+++ b/scripts/ops/verify-production-readiness.mjs
@@ -1,0 +1,184 @@
+const TIMEOUT_MS = 20_000;
+const ALLOWED_TOP_LEVEL_FIELDS = new Set([
+  "success",
+  "status",
+  "checks",
+  "uptimeSeconds",
+  "responseTimeMs",
+  "timestamp",
+]);
+const ALLOWED_CHECK_FIELDS = new Set(["database", "storage"]);
+
+class ReadinessConfigurationError extends Error {}
+
+function parseBaseUrl(args, env) {
+  let candidate = "";
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+
+    if (argument === "--url") {
+      candidate = args[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith("--url=")) {
+      candidate = argument.slice("--url=".length);
+      continue;
+    }
+
+    if (!argument.startsWith("-") && !candidate) {
+      candidate = argument;
+    }
+  }
+
+  candidate ||= env.READINESS_BASE_URL ?? "";
+
+  if (!candidate.trim()) {
+    throw new ReadinessConfigurationError(
+      "READINESS_BASE_URL or --url is required.",
+    );
+  }
+
+  let baseUrl;
+
+  try {
+    baseUrl = new URL(candidate);
+  } catch {
+    throw new ReadinessConfigurationError(
+      "The readiness URL must be a valid absolute URL.",
+    );
+  }
+
+  if (!["http:", "https:"].includes(baseUrl.protocol)) {
+    throw new ReadinessConfigurationError(
+      "The readiness URL must use HTTP or HTTPS.",
+    );
+  }
+
+  if (baseUrl.username || baseUrl.password) {
+    throw new ReadinessConfigurationError(
+      "Credentials are not allowed in the readiness URL.",
+    );
+  }
+
+  baseUrl.search = "";
+  baseUrl.hash = "";
+  if (!baseUrl.pathname.endsWith("/")) {
+    baseUrl.pathname += "/";
+  }
+
+  return baseUrl;
+}
+
+function assertExactFields(record, allowedFields, context) {
+  const keys = Object.keys(record);
+
+  if (keys.some((key) => !allowedFields.has(key))) {
+    throw new Error(`${context} contains unexpected fields.`);
+  }
+}
+
+function assertFiniteNonNegativeNumber(value, fieldName) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${fieldName} must be a non-negative number.`);
+  }
+}
+
+function validateHealthPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Health response must be a JSON object.");
+  }
+
+  assertExactFields(payload, ALLOWED_TOP_LEVEL_FIELDS, "Health response");
+
+  if (payload.success !== true || payload.status !== "ok") {
+    throw new Error("Health response is not ready.");
+  }
+
+  if (
+    !payload.checks ||
+    typeof payload.checks !== "object" ||
+    Array.isArray(payload.checks)
+  ) {
+    throw new Error("Health checks must be a JSON object.");
+  }
+
+  assertExactFields(payload.checks, ALLOWED_CHECK_FIELDS, "Health checks");
+
+  if (
+    payload.checks.database !== "up" ||
+    payload.checks.storage !== "up"
+  ) {
+    throw new Error("Database or storage is not ready.");
+  }
+
+  assertFiniteNonNegativeNumber(payload.uptimeSeconds, "uptimeSeconds");
+  assertFiniteNonNegativeNumber(payload.responseTimeMs, "responseTimeMs");
+
+  if (
+    typeof payload.timestamp !== "string" ||
+    !Number.isFinite(Date.parse(payload.timestamp))
+  ) {
+    throw new Error("timestamp must be a valid date string.");
+  }
+}
+
+async function fetchHealth(healthUrl) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    return await fetch(healthUrl, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+      },
+      redirect: "error",
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Health request timed out.");
+    }
+
+    throw new Error("Health request failed.");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function run() {
+  const baseUrl = parseBaseUrl(process.argv.slice(2), process.env);
+  const healthUrl = new URL("health", baseUrl);
+  const response = await fetchHealth(healthUrl);
+
+  if (response.status !== 200) {
+    throw new Error(`Health request returned HTTP ${response.status}.`);
+  }
+
+  let payload;
+
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("Health response is not valid JSON.");
+  }
+
+  validateHealthPayload(payload);
+  process.stdout.write(
+    "PASS readiness: /health returned 200 with database and storage up.\n",
+  );
+}
+
+run().catch((error) => {
+  const message = error instanceof Error ? error.message : "Readiness failed.";
+  const prefix =
+    error instanceof ReadinessConfigurationError
+      ? "CONFIG readiness"
+      : "FAIL readiness";
+
+  process.stderr.write(`${prefix}: ${message}\n`);
+  process.exitCode = error instanceof ReadinessConfigurationError ? 2 : 1;
+});

--- a/server/lib/http-runtime.ts
+++ b/server/lib/http-runtime.ts
@@ -16,12 +16,18 @@ export type HealthCheckPayload = {
   uptimeSeconds: number;
   responseTimeMs: number;
   timestamp: string;
-  details?: Record<string, unknown>;
 };
 
 export type HealthCheckResponse = {
   statusCode: 200 | 503;
   payload: HealthCheckPayload;
+};
+
+type HealthCheckDependencies = {
+  checkDatabase: () => Promise<unknown>;
+  checkStorage: () => Promise<unknown>;
+  now: () => number;
+  uptime: () => number;
 };
 
 export function buildServiceInfoPayload() {
@@ -32,30 +38,35 @@ export function buildServiceInfoPayload() {
   };
 }
 
-export async function getHealthCheckResponse(): Promise<HealthCheckResponse> {
-  const startedAt = Date.now();
+export async function getHealthCheckResponse(
+  dependencies: Partial<HealthCheckDependencies> = {},
+): Promise<HealthCheckResponse> {
+  const checkDatabase =
+    dependencies.checkDatabase ?? (() => db.execute(sql`select 1`));
+  const checkStorage = dependencies.checkStorage ?? checkStorageHealth;
+  const now = dependencies.now ?? Date.now;
+  const uptime = dependencies.uptime ?? process.uptime;
+  const startedAt = now();
 
   let database: DependencyStatus = "down";
   let storage: DependencyStatus = "down";
-  const details: Record<string, unknown> = {};
 
   try {
-    await db.execute(sql`select 1`);
+    await checkDatabase();
     database = "up";
-  } catch (error) {
-    details.databaseError =
-      error instanceof Error ? error.message : "unknown database error";
+  } catch {
+    database = "down";
   }
 
   try {
-    await checkStorageHealth();
+    await checkStorage();
     storage = "up";
-  } catch (error) {
-    details.storageError =
-      error instanceof Error ? error.message : "unknown storage error";
+  } catch {
+    storage = "down";
   }
 
   const ok = database === "up" && storage === "up";
+  const finishedAt = now();
 
   return {
     statusCode: ok ? 200 : 503,
@@ -66,10 +77,9 @@ export async function getHealthCheckResponse(): Promise<HealthCheckResponse> {
         database,
         storage,
       },
-      uptimeSeconds: Math.round(process.uptime()),
-      responseTimeMs: Date.now() - startedAt,
-      timestamp: new Date().toISOString(),
-      ...(Object.keys(details).length ? { details } : {}),
+      uptimeSeconds: Math.round(uptime()),
+      responseTimeMs: Math.max(0, finishedAt - startedAt),
+      timestamp: new Date(finishedAt).toISOString(),
     },
   };
 }

--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -116,6 +116,7 @@ test("Frontend CI ejecuta gates obligatorios en orden", () => {
     "      - name: Lint frontend\n        run: pnpm --dir frontend lint",
     "      - name: Typecheck frontend\n        run: pnpm --dir frontend typecheck",
     "      - name: Build frontend\n        run: pnpm --dir frontend build",
+    "      - name: Audit built public surface\n        run: pnpm security:public-surface",
     "      - name: Install Playwright browsers\n        run: pnpm --dir frontend exec playwright install --with-deps chromium",
     "      - name: Run frontend E2E smoke tests\n        run: pnpm --dir frontend e2e",
   ]);

--- a/test/helpers/report-foreign-access-scope.ts
+++ b/test/helpers/report-foreign-access-scope.ts
@@ -1,6 +1,7 @@
-const REPORT_FOREIGN_ACCESS_BACKEND_FILES = new Set([
+const SHARED_BACKEND_SCOPE_EXCEPTIONS = new Set([
   "server/db-report-access.ts",
   "server/db.ts",
+  "server/lib/http-runtime.ts",
   "server/routes/particular-auth.fastify.ts",
   "server/routes/particular-tokens.fastify.ts",
   "server/routes/public-report-access.fastify.ts",
@@ -10,6 +11,10 @@ const REPORT_FOREIGN_ACCESS_BACKEND_FILES = new Set([
   "server/routes/study-tracking.fastify.ts",
 ]);
 
+export function isSharedBackendScopeException(file: string): boolean {
+  return SHARED_BACKEND_SCOPE_EXCEPTIONS.has(file.replace(/\\/g, "/"));
+}
+
 export function isReportForeignAccessBackendFile(file: string): boolean {
-  return REPORT_FOREIGN_ACCESS_BACKEND_FILES.has(file.replace(/\\/g, "/"));
+  return isSharedBackendScopeException(file);
 }

--- a/test/production-readiness.test.ts
+++ b/test/production-readiness.test.ts
@@ -1,0 +1,296 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+process.env.NODE_ENV ??= "test";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { getHealthCheckResponse } = await import(
+  "../server/lib/http-runtime.ts"
+);
+
+const readinessScript = resolve(
+  process.cwd(),
+  "scripts",
+  "ops",
+  "verify-production-readiness.mjs",
+);
+
+type ScriptResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function runReadinessScript(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+): Promise<ScriptResult> {
+  const env = {
+    ...process.env,
+    ...envOverrides,
+  };
+
+  delete env.READINESS_BASE_URL;
+
+  if (envOverrides.READINESS_BASE_URL) {
+    env.READINESS_BASE_URL = envOverrides.READINESS_BASE_URL;
+  }
+
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [readinessScript, ...args], {
+      cwd: process.cwd(),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolveResult({ code, stdout, stderr });
+    });
+  });
+}
+
+async function withHealthServer(
+  payload: Record<string, unknown>,
+  callback: (input: {
+    baseUrl: string;
+    requests: Array<{
+      method: string | undefined;
+      url: string | undefined;
+      headers: IncomingHttpHeaders;
+    }>;
+  }) => Promise<void>,
+) {
+  const requests: Array<{
+    method: string | undefined;
+    url: string | undefined;
+    headers: IncomingHttpHeaders;
+  }> = [];
+  const server = createServer((request, response) => {
+    requests.push({
+      method: request.method,
+      url: request.url,
+      headers: request.headers,
+    });
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(payload));
+  });
+
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    await callback({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      requests,
+    });
+  } finally {
+    await new Promise<void>((resolveClose, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolveClose();
+      });
+    });
+  }
+}
+
+function healthyPayload() {
+  return {
+    success: true,
+    status: "ok",
+    checks: {
+      database: "up",
+      storage: "up",
+    },
+    uptimeSeconds: 120,
+    responseTimeMs: 8,
+    timestamp: "2026-06-14T12:00:00.000Z",
+  };
+}
+
+test("public health keeps a stable safe shape without raw dependency errors", async () => {
+  const databaseSecret =
+    "postgresql://runtime-user:runtime-password@private-db/portal";
+  const storageSecret = "service-role-runtime-secret";
+  const timestamps = [1_000, 1_025];
+
+  const response = await getHealthCheckResponse({
+    checkDatabase: async () => {
+      throw new Error(databaseSecret);
+    },
+    checkStorage: async () => {
+      throw new Error(storageSecret);
+    },
+    now: () => timestamps.shift() ?? 1_025,
+    uptime: () => 42.4,
+  });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.payload, {
+    success: false,
+    status: "degraded",
+    checks: {
+      database: "down",
+      storage: "down",
+    },
+    uptimeSeconds: 42,
+    responseTimeMs: 25,
+    timestamp: "1970-01-01T00:00:01.025Z",
+  });
+
+  const serialized = JSON.stringify(response.payload);
+  assert.equal(serialized.includes(databaseSecret), false);
+  assert.equal(serialized.includes(storageSecret), false);
+  assert.equal(serialized.includes("details"), false);
+  assert.equal(serialized.includes("stack"), false);
+});
+
+test("readiness script fails clearly when URL is missing without printing env secrets", async () => {
+  const sentinelSecret = "readiness-sentinel-secret-value";
+  const result = await runReadinessScript([], {
+    SUPABASE_SERVICE_ROLE_KEY: sentinelSecret,
+    SMTP_PASS: sentinelSecret,
+  });
+  const output = result.stdout + result.stderr;
+
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /READINESS_BASE_URL or --url is required/);
+  assert.equal(output.includes(sentinelSecret), false);
+});
+
+test("readiness script calls only GET /health without credentials", async () => {
+  await withHealthServer(healthyPayload(), async ({ baseUrl, requests }) => {
+    const result = await runReadinessScript(["--url", baseUrl]);
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /PASS readiness/);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]?.method, "GET");
+    assert.equal(requests[0]?.url, "/health");
+    assert.equal(requests[0]?.headers.authorization, undefined);
+    assert.equal(requests[0]?.headers.cookie, undefined);
+  });
+});
+
+test("readiness script rejects unexpected health fields without echoing values", async () => {
+  const sentinelSecret = "postgresql://user:password@private-db/portal";
+
+  await withHealthServer(
+    {
+      ...healthyPayload(),
+      details: {
+        databaseError: sentinelSecret,
+      },
+    },
+    async ({ baseUrl }) => {
+      const result = await runReadinessScript([baseUrl]);
+      const output = result.stdout + result.stderr;
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /unexpected fields/);
+      assert.equal(output.includes(sentinelSecret), false);
+    },
+  );
+});
+
+test("production readiness documentation lists env names without assignments", () => {
+  const documentation = read(
+    "IMPLEMENTATION_PRODUCTION_OBSERVABILITY_READINESS.md",
+  );
+  const requiredNames = [
+    "ADMIN_COOKIE_NAME",
+    "CONTACT_TO",
+    "COOKIE_NAME",
+    "CORS_ORIGIN",
+    "DATABASE_MAX_CONNECTIONS",
+    "DATABASE_URL",
+    "GMAIL_API_CLIENT_ID",
+    "GMAIL_API_CLIENT_SECRET",
+    "GMAIL_API_FROM",
+    "GMAIL_API_REFRESH_TOKEN",
+    "LAB_UPLOAD_USERNAMES",
+    "MAX_UPLOAD_FILE_SIZE_MB",
+    "NODE_ENV",
+    "OWNER_OPEN_ID",
+    "PARTICULAR_COOKIE_NAME",
+    "PORT",
+    "SESSION_TTL_HOURS",
+    "SMTP_FROM",
+    "SMTP_HOST",
+    "SMTP_PASS",
+    "SMTP_PORT",
+    "SMTP_SECURE",
+    "SMTP_USER",
+    "SUPABASE_ANON_KEY",
+    "SUPABASE_DB_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_SIGNED_URL_EXPIRES_IN_SECONDS",
+    "SUPABASE_STORAGE_BUCKET",
+    "SUPABASE_URL",
+    "TRUST_PROXY",
+  ];
+
+  for (const name of requiredNames) {
+    assert.ok(documentation.includes(`\`${name}\``), `missing ${name}`);
+    assert.doesNotMatch(
+      documentation,
+      new RegExp(`${name}\\s*=`),
+      `${name} must be documented without a value`,
+    );
+  }
+
+  assert.doesNotMatch(documentation, /postgres(?:ql)?:\/\//i);
+  assert.doesNotMatch(documentation, /service[_ -]?role[_ -]?key\s*[:=]/i);
+  assert.doesNotMatch(documentation, /refresh[_ -]?token\s*[:=]/i);
+});
+
+test("frontend CI audits the built public surface before E2E", () => {
+  const workflow = read(".github/workflows/frontend-ci.yml");
+  const buildIndex = workflow.indexOf(
+    "      - name: Build frontend\n        run: pnpm --dir frontend build",
+  );
+  const auditIndex = workflow.indexOf(
+    "      - name: Audit built public surface\n        run: pnpm security:public-surface",
+  );
+  const e2eIndex = workflow.indexOf(
+    "      - name: Run frontend E2E smoke tests\n        run: pnpm --dir frontend e2e",
+  );
+
+  assert.ok(buildIndex >= 0);
+  assert.ok(auditIndex > buildIndex);
+  assert.ok(e2eIndex > auditIndex);
+});


### PR DESCRIPTION
## Summary
- Add a read-only production readiness verifier for GET /health
- Harden degraded health responses so public payloads do not expose raw internal error messages
- Document launch readiness, observability, required environment variables by name only, incident checklist and manual production checks
- Add production readiness/security contracts for health payloads, secret leakage, script behavior and no SEO changes
- Add security:public-surface as an explicit frontend CI post-build gate

## Validation
- pnpm audit --prod
- pnpm typecheck
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm security:public-surface
- pnpm --dir frontend e2e dashboard-auth-redirect.spec.ts visual-smoke.spec.ts --project=chromium --workers=1
- node scripts/ops/verify-production-readiness.mjs --url https://api.vetneb.com.ar

## Results
- pnpm test: 2697/2697
- E2E relevant: 12/12
- Production health read-only: 200, DB/Storage up
- No SEO changes
- No dependencies
- No migrations
- No generated artifacts

## Scope
- Observability/readiness documentation
- Public health payload hardening
- Read-only production readiness script
- Frontend CI public-surface gate
- No SEO, metadata, sitemap, robots, OpenGraph, JSON-LD/schema or public copy changes
- No feature changes
- No provider changes
- No deploy or production writes
