### PR TITLE
fix(admin): align sidebar module navigation

### DIFF
--- a/IMPLEMENTATION_NOTES/fix-admin-sidebar-module-navigation.md
+++ b/IMPLEMENTATION_NOTES/fix-admin-sidebar-module-navigation.md
@@ -1,0 +1,99 @@
+# fix(admin): sidebar module navigation
+
+## Summary
+- Replaced admin sidebar hash-anchor module links (`#admin-*`) with query-param module links (`?module=admin-*`).
+- Updated the shared sidebar active-state logic to resolve the active item from the `module` query param.
+- Preserved existing sidebar labels, icons, order, accessibility attributes and clinical sidebar behavior.
+- No visual redesign, no new labels, no FlexSearch, no password change, no module refactors.
+
+## Problem
+The admin sidebar linked to hash anchors (e.g. `${ROUTES.dashboardAdmin}#admin-clinics`), while
+`AdminDashboardWorkspaceController` activates modules via `?module=...` query params
+(`searchParams.get("module")`).
+
+Consequences:
+- Clicking a sidebar item did not activate the corresponding workspace module.
+- `DashboardSidebarFrame.isActive` compared only `pathname` (it stripped the `#`), so on
+  `/dashboard/admin` every hash item resolved to the same pathname and **all** admin items were
+  marked active at once (plus the home item), making `aria-current="page"` appear multiple times.
+- The lateral navigation was effectively decorative; users had to rely on the card hub.
+
+The clinic sidebar already used `?module=perfil` / `?module=tokens` but, because the shared frame
+ignored query params, those items were never highlighted either — the same root defect.
+
+## Root cause
+`DashboardSidebarFrame.isActive()` derived the active state from `pathname` only and discarded the
+query string, so query-param-based module navigation could never be reflected in the active item.
+
+## Fix
+- `AdminDashboardSidebar.tsx`: each module item now uses `${ROUTES.dashboardAdmin}?module=<moduleId>`.
+  The 9 module ids map 1:1 to the controller's `AdminModule` union
+  (`admin-report-upload`, `admin-health`, `admin-clinics`, `admin-particular-tokens`,
+  `admin-pricing`, `admin-sessions`, `admin-users-roles`, `audit-log`, `admin-maintenance`).
+  The "Administración" home item stays an exact, no-module link to `ROUTES.dashboardAdmin`.
+- `DashboardSidebarFrame.tsx`:
+  - Reads the active module with `useSearchParams().get("module")`.
+  - `getPathFromHref` now strips both `?` and `#` before comparing paths.
+  - New `getModuleFromHref` parses the module id from an item href via `URLSearchParams` (returns
+    `null` when the href has no query — safe for hrefs without a module).
+  - `isActive` rules:
+    - module item → active only when `pathname` matches **and** `activeModule === hrefModule`;
+    - exact/home item → active only when `pathname` matches **and** no module is selected;
+    - other items → unchanged (`pathname` equality / prefix), preserving clinic behavior.
+  - The search-param-dependent nav was extracted into an inner `DashboardSidebarNav` wrapped in a
+    React `<Suspense>` boundary. This is required by Next.js App Router: `useSearchParams()` in a
+    layout-level client component otherwise fails the production build with
+    "useSearchParams() should be wrapped in a suspense boundary" during the prerender pass.
+
+## Accessibility
+- Exactly one item carries `aria-current="page"` per URL state (verified by the active-state rules).
+- `aria-label`, `title`, `sr-only` text and keyboard focus rings are unchanged.
+
+## Scope
+Files changed:
+- `frontend/src/components/dashboard/AdminDashboardSidebar.tsx`
+- `frontend/src/components/dashboard/DashboardSidebarFrame.tsx`
+- `test/frontend-admin-sidebar-module-navigation.test.ts` (new regression test)
+- `test/admin-dashboard-sections-contract.test.ts` (href contract updated to `?module=`)
+- `test/frontend-dashboard-shell.test.ts` (import + `isActive` + admin href assertions updated)
+- `test/frontend-admin-particular-tokens.test.ts` (sidebar href assertion updated to `?module=`)
+
+Out of scope (not modified):
+- `AdminDashboardWorkspaceController.tsx`, `ClinicDashboardSidebar.tsx`,
+  `ClinicDashboardWorkspaceController.tsx`, `DashboardModuleHub.tsx`,
+  `DashboardModuleWorkspace.tsx`, `MasterDetailWorkspace.tsx`.
+- `frontend/src/lib/notification-destinations.ts` (uses `#admin-*` anchors; separate concern,
+  its test `frontend-notification-destinations.test.ts` stays green).
+- Visual redesign, sidebar labels, FlexSearch, password change, dashboard module refactors,
+  global CSS, backend, APIs, database, public routes.
+
+## Validation
+Commands executed and results:
+- `git diff --check` → OK, no whitespace/conflict errors.
+- `pnpm --dir frontend lint` → pass (eslint, no findings).
+- `pnpm --dir frontend typecheck` → pass (`tsc --noEmit`, no errors).
+- `pnpm --dir frontend build` → pass. All `/dashboard/*` routes report as `ƒ (Dynamic)`.
+  (First build before the Suspense fix failed on `/dashboard/logistica/metricas` with the
+  useSearchParams suspense-boundary error; resolved by the `<Suspense>` boundary.)
+- `pnpm test` → 2703 passed, 0 failed.
+- `pnpm security:public-surface` → PASS, no public devtools exposure findings
+  (only pre-existing `[server-only]` markers in `frontend/src/proxy.ts`, untouched).
+
+## Manual QA (expected behavior)
+- `/dashboard/admin` → only "Administración" (home) active; no other item active.
+- `/dashboard/admin?module=admin-clinics` → only "Clínicas" active; workspace shows Clínicas.
+- `/dashboard/admin?module=audit-log` → only "Auditoría" active.
+- `/dashboard/admin?module=admin-health` → only "Estado" active (system health).
+- Clicking any admin sidebar item switches the workspace to the matching module.
+- Clinic sidebar: `/dashboard` → "Dashboard" active; `/dashboard/informes` → "Informes" active;
+  `/dashboard/logistica` → "Logística" active. Module links (`?module=perfil`, `?module=tokens`)
+  now also highlight their own item.
+
+## Risk
+Low. Change is limited to admin sidebar hrefs and the shared active-state detection. The clinic
+sidebar's standard-path behavior is preserved; its pre-existing `?module=` links now highlight
+correctly (latent fix). The added `<Suspense>` boundary only affects the brief prerender shell;
+private dashboard routes render dynamically.
+
+## Rollback
+Revert this PR.

--- a/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
+++ b/frontend/src/components/dashboard/AdminDashboardSidebar.tsx
@@ -25,47 +25,47 @@ const adminNavItems: DashboardNavItem[] = [
   },
   {
     label: "Subir informe",
-    href: `${ROUTES.dashboardAdmin}#admin-report-upload`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-report-upload`,
     icon: ClipboardPlus,
   },
   {
     label: "Estado",
-    href: `${ROUTES.dashboardAdmin}#admin-health`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-health`,
     icon: Activity,
   },
   {
     label: "Clínicas",
-    href: `${ROUTES.dashboardAdmin}#admin-clinics`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-clinics`,
     icon: Building2,
   },
   {
     label: "Tokens particulares",
-    href: `${ROUTES.dashboardAdmin}#admin-particular-tokens`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-particular-tokens`,
     icon: TicketCheck,
   },
   {
     label: "Precios",
-    href: `${ROUTES.dashboardAdmin}#admin-pricing`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-pricing`,
     icon: ReceiptText,
   },
   {
     label: "Sesiones",
-    href: `${ROUTES.dashboardAdmin}#admin-sessions`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-sessions`,
     icon: KeyRound,
   },
   {
     label: "Roles clínica",
-    href: `${ROUTES.dashboardAdmin}#admin-users-roles`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-users-roles`,
     icon: UsersRound,
   },
   {
     label: "Auditoría",
-    href: `${ROUTES.dashboardAdmin}#audit-log`,
+    href: `${ROUTES.dashboardAdmin}?module=audit-log`,
     icon: ScrollText,
   },
   {
     label: "Mantenimiento",
-    href: `${ROUTES.dashboardAdmin}#admin-maintenance`,
+    href: `${ROUTES.dashboardAdmin}?module=admin-maintenance`,
     icon: ShieldCheck,
   },
 ];

--- a/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
+++ b/frontend/src/components/dashboard/DashboardSidebarFrame.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { Suspense } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
 import { ArrowLeft, Microscope } from "lucide-react";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
@@ -24,24 +25,81 @@ type DashboardSidebarFrameProps = {
 };
 
 function getPathFromHref(href: string) {
-  return href.split("#")[0] || href;
+  return href.split(/[?#]/)[0] || href;
+}
+
+function getModuleFromHref(href: string): string | null {
+  const queryStart = href.indexOf("?");
+  if (queryStart === -1) return null;
+  const query = href.slice(queryStart + 1).split("#")[0];
+  return new URLSearchParams(query).get("module");
+}
+
+function DashboardSidebarNav({ navItems }: { navItems: DashboardNavItem[] }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const activeModule = searchParams.get("module");
+
+  function isActive(href: string, exact = false) {
+    if (href.startsWith("#")) return false;
+
+    const hrefPath = getPathFromHref(href);
+    const hrefModule = getModuleFromHref(href);
+
+    if (hrefModule) {
+      return pathname === hrefPath && activeModule === hrefModule;
+    }
+
+    if (exact) return pathname === hrefPath && !activeModule;
+    return pathname === hrefPath || pathname.startsWith(`${hrefPath}/`);
+  }
+
+  return (
+    <nav className="flex-1 space-y-1 px-2 py-4" aria-label="Menú principal">
+      {navItems.map((item) => (
+        <div key={item.href}>
+          <PublicRouteControl
+            href={item.href}
+            variant="bare"
+            className={cn(
+              "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold dashboard-nav-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+              isActive(item.href, item.exact)
+                ? "bg-sidebar-accent/90 text-sidebar-accent-foreground shadow-[0_10px_28px_rgba(8,35,50,0.24)] ring-1 ring-white/15"
+                : "text-sidebar-foreground/72 hover:bg-sidebar-accent/45 hover:text-sidebar-foreground",
+            )}
+            aria-label={item.label}
+            aria-current={isActive(item.href, item.exact) ? "page" : undefined}
+            title={item.label}
+          >
+            <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span className="sr-only">{item.label}</span>
+          </PublicRouteControl>
+
+          {item.children && isActive(item.href) && (
+            <div className="sr-only" aria-hidden="true">
+              {item.children.map((child) => (
+                <PublicRouteControl
+                  key={child.href}
+                  href={child.href}
+                  variant="bare"
+                  aria-label={child.label}
+                  aria-current={pathname === child.href ? "page" : undefined}
+                >
+                  {child.label}
+                </PublicRouteControl>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </nav>
+  );
 }
 
 export function DashboardSidebarFrame({
   dashboardLabel,
   navItems,
 }: DashboardSidebarFrameProps) {
-  const pathname = usePathname();
-
-  function isActive(href: string, exact = false) {
-    if (href.startsWith("#")) return false;
-
-    const hrefPath = getPathFromHref(href);
-
-    if (exact) return pathname === hrefPath;
-    return pathname === hrefPath || pathname.startsWith(`${hrefPath}/`);
-  }
-
   return (
     <aside
       role="navigation"
@@ -59,44 +117,9 @@ export function DashboardSidebarFrame({
         <span className="sr-only">Portal VETNEB — {dashboardLabel}</span>
       </div>
 
-      <nav className="flex-1 space-y-1 px-2 py-4" aria-label="Menú principal">
-        {navItems.map((item) => (
-          <div key={item.href}>
-            <PublicRouteControl
-              href={item.href}
-              variant="bare"
-              className={cn(
-                "flex items-center justify-center gap-3 rounded-md px-2 py-2 text-sm font-semibold dashboard-nav-interactive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
-                isActive(item.href, item.exact)
-                  ? "bg-sidebar-accent/90 text-sidebar-accent-foreground shadow-[0_10px_28px_rgba(8,35,50,0.24)] ring-1 ring-white/15"
-                  : "text-sidebar-foreground/72 hover:bg-sidebar-accent/45 hover:text-sidebar-foreground",
-              )}
-              aria-label={item.label}
-              aria-current={isActive(item.href, item.exact) ? "page" : undefined}
-              title={item.label}
-            >
-              <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-              <span className="sr-only">{item.label}</span>
-            </PublicRouteControl>
-
-            {item.children && isActive(item.href) && (
-              <div className="sr-only" aria-hidden="true">
-                {item.children.map((child) => (
-                  <PublicRouteControl
-                    key={child.href}
-                    href={child.href}
-                    variant="bare"
-                    aria-label={child.label}
-                    aria-current={pathname === child.href ? "page" : undefined}
-                  >
-                    {child.label}
-                  </PublicRouteControl>
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
-      </nav>
+      <Suspense fallback={<div className="flex-1" aria-hidden="true" />}>
+        <DashboardSidebarNav navItems={navItems} />
+      </Suspense>
 
       <div className="border-t border-sidebar-border px-2 py-4 sm:px-3">
         <PublicRouteControl
@@ -113,4 +136,3 @@ export function DashboardSidebarFrame({
     </aside>
   );
 }
-

--- a/test/admin-dashboard-sections-contract.test.ts
+++ b/test/admin-dashboard-sections-contract.test.ts
@@ -19,47 +19,47 @@ const API_CLIENT_PATH = "frontend/src/lib/api.ts";
 const SIDEBAR_SECTIONS = [
   {
     label: "Subir informe",
-    href: '#admin-report-upload',
+    href: '?module=admin-report-upload',
     anchor: 'id="admin-report-upload"',
   },
   {
     label: "Estado",
-    href: '#admin-health',
+    href: '?module=admin-health',
     anchor: 'id="admin-health"',
   },
   {
     label: "Clínicas",
-    href: '#admin-clinics',
+    href: '?module=admin-clinics',
     anchor: 'id="admin-clinics"',
   },
   {
     label: "Tokens particulares",
-    href: '#admin-particular-tokens',
+    href: '?module=admin-particular-tokens',
     anchor: 'id="admin-particular-tokens"',
   },
   {
     label: "Precios",
-    href: '#admin-pricing',
+    href: '?module=admin-pricing',
     anchor: 'id="admin-pricing"',
   },
   {
     label: "Sesiones",
-    href: '#admin-sessions',
+    href: '?module=admin-sessions',
     anchor: 'id="admin-sessions"',
   },
   {
     label: "Roles clínica",
-    href: '#admin-users-roles',
+    href: '?module=admin-users-roles',
     anchor: 'id="admin-users-roles"',
   },
   {
     label: "Auditoría",
-    href: '#audit-log',
+    href: '?module=audit-log',
     anchor: 'id="audit-log"',
   },
   {
     label: "Mantenimiento",
-    href: '#admin-maintenance',
+    href: '?module=admin-maintenance',
     anchor: 'id="admin-maintenance"',
   },
 ] as const;

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -291,7 +291,7 @@ test("admin dashboard mounts token generator and exposes admin navigation anchor
   assert.ok(page.includes('id="admin-particular-tokens"'));
   assert.ok(page.includes("<AdminParticularTokensCard />"));
   assert.ok(sidebar.includes('label: "Tokens particulares"'));
-  assert.ok(sidebar.includes('`${ROUTES.dashboardAdmin}#admin-particular-tokens`'));
+  assert.ok(sidebar.includes('`${ROUTES.dashboardAdmin}?module=admin-particular-tokens`'));
 });
 
 test("clinic token generator remains clinic-scoped and separate from admin generator", () => {

--- a/test/frontend-admin-sidebar-module-navigation.test.ts
+++ b/test/frontend-admin-sidebar-module-navigation.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const ADMIN_SIDEBAR_PATH =
+  "frontend/src/components/dashboard/AdminDashboardSidebar.tsx";
+const SIDEBAR_FRAME_PATH =
+  "frontend/src/components/dashboard/DashboardSidebarFrame.tsx";
+const ADMIN_CONTROLLER_PATH =
+  "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("admin sidebar module items navigate with ?module= query params", () => {
+  const sidebar = read(ADMIN_SIDEBAR_PATH);
+
+  for (const moduleId of [
+    "admin-report-upload",
+    "admin-health",
+    "admin-clinics",
+    "admin-particular-tokens",
+    "admin-pricing",
+    "admin-sessions",
+    "admin-users-roles",
+    "audit-log",
+    "admin-maintenance",
+  ]) {
+    assert.ok(
+      sidebar.includes(`\`\${ROUTES.dashboardAdmin}?module=${moduleId}\``),
+      `admin sidebar must navigate to module ${moduleId} via ?module=`,
+    );
+  }
+});
+
+test("admin sidebar drops legacy hash-anchor module links", () => {
+  const sidebar = read(ADMIN_SIDEBAR_PATH);
+
+  assert.equal(
+    /\$\{ROUTES\.dashboardAdmin\}#/.test(sidebar),
+    false,
+    "admin sidebar must not keep hash-anchor module links",
+  );
+});
+
+test("admin sidebar keeps the home item as an exact non-module link", () => {
+  const sidebar = read(ADMIN_SIDEBAR_PATH);
+
+  assert.ok(sidebar.includes('label: "Administración"'));
+  assert.ok(sidebar.includes("href: ROUTES.dashboardAdmin,"));
+  assert.ok(sidebar.includes("exact: true,"));
+});
+
+test("every admin sidebar module id is a valid controller AdminModule", () => {
+  const sidebar = read(ADMIN_SIDEBAR_PATH);
+  const controller = read(ADMIN_CONTROLLER_PATH);
+
+  const moduleIds = [...sidebar.matchAll(/\?module=([a-z-]+)/g)].map(
+    (match) => match[1],
+  );
+
+  assert.equal(
+    moduleIds.length,
+    9,
+    `expected 9 module links in admin sidebar, got ${moduleIds.length}`,
+  );
+
+  for (const moduleId of moduleIds) {
+    assert.ok(
+      controller.includes(`"${moduleId}"`),
+      `controller must define module ${moduleId} as an AdminModule`,
+    );
+  }
+});
+
+test("sidebar frame resolves active state from the module query param", () => {
+  const frame = read(SIDEBAR_FRAME_PATH);
+
+  assert.ok(
+    frame.includes('import { usePathname, useSearchParams } from "next/navigation";'),
+    "frame must read pathname and search params from next/navigation",
+  );
+  assert.ok(
+    frame.includes('const activeModule = searchParams.get("module");'),
+    "frame must read the active module from search params",
+  );
+  assert.ok(
+    frame.includes("function getModuleFromHref(href: string)"),
+    "frame must parse the module id from nav item hrefs",
+  );
+  assert.ok(
+    frame.includes("return pathname === hrefPath && activeModule === hrefModule;"),
+    "module items must match path and module exactly",
+  );
+  assert.ok(
+    frame.includes("if (exact) return pathname === hrefPath && !activeModule;"),
+    "exact home items must deactivate once a module is selected",
+  );
+});
+
+test("sidebar frame strips query and hash before comparing paths", () => {
+  const frame = read(SIDEBAR_FRAME_PATH);
+
+  assert.ok(
+    frame.includes("return href.split(/[?#]/)[0] || href;"),
+    "getPathFromHref must strip both query and hash segments",
+  );
+});

--- a/test/frontend-dashboard-shell.test.ts
+++ b/test/frontend-dashboard-shell.test.ts
@@ -60,7 +60,7 @@ test("dashboard sidebar frame is the shared visual shell for both roles", () => 
   const source = read(DASHBOARD_SIDEBAR_FRAME_PATH);
 
   assert.ok(source.includes('"use client";'));
-  assert.ok(source.includes('import { usePathname } from "next/navigation";'));
+  assert.ok(source.includes('import { usePathname, useSearchParams } from "next/navigation";'));
   assert.ok(source.includes('import { ROUTES } from "@/lib/routes";'));
   assert.ok(source.includes("export type DashboardNavItem = {"));
   assert.ok(source.includes("dashboardLabel: string;"));
@@ -72,7 +72,8 @@ test("dashboard sidebar frame is the shared visual shell for both roles", () => 
   assert.ok(source.includes('aria-label="Menú principal"'));
   assert.ok(source.includes("focus-visible:ring-2 focus-visible:ring-ring/85"));
   assert.ok(source.includes("function isActive(href: string, exact = false)"));
-  assert.ok(source.includes("if (exact) return pathname === hrefPath;"));
+  assert.ok(source.includes('const activeModule = searchParams.get("module");'));
+  assert.ok(source.includes("if (exact) return pathname === hrefPath && !activeModule;"));
   assert.ok(source.includes("item.children && isActive(item.href)"));
   assert.ok(source.includes("item.children.map((child) =>"));
   assert.ok(source.includes("Portal VETNEB"));
@@ -110,9 +111,9 @@ test("admin dashboard sidebar keeps admin operations and excludes clinic navigat
   assert.ok(source.includes('label: "Auditoría"'));
   assert.ok(source.includes('label: "Mantenimiento"'));
   assert.ok(source.includes("ROUTES.dashboardAdmin"));
-  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}#admin-clinics`'));
-  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}#admin-pricing`'));
-  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}#admin-users-roles`'));
+  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}?module=admin-clinics`'));
+  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}?module=admin-pricing`'));
+  assert.ok(source.includes('href: `${ROUTES.dashboardAdmin}?module=admin-users-roles`'));
   assert.equal(source.includes('href: `${ROUTES.dashboardAdmin}#audit-role-changes`'), false);
   assert.equal(source.includes("clinic-public-profile"), false);
   assert.equal(source.includes("clinic-particular-tokens"), false);


### PR DESCRIPTION
# fix(admin): sidebar module navigation

## Summary
- Replaced admin sidebar hash-anchor module links (`#admin-*`) with query-param module links (`?module=admin-*`).
- Updated the shared sidebar active-state logic to resolve the active item from the `module` query param.
- Preserved existing sidebar labels, icons, order, accessibility attributes and clinical sidebar behavior.
- No visual redesign, no new labels, no FlexSearch, no password change, no module refactors.

## Problem
The admin sidebar linked to hash anchors (e.g. `${ROUTES.dashboardAdmin}#admin-clinics`), while
`AdminDashboardWorkspaceController` activates modules via `?module=...` query params
(`searchParams.get("module")`).

Consequences:
- Clicking a sidebar item did not activate the corresponding workspace module.
- `DashboardSidebarFrame.isActive` compared only `pathname` (it stripped the `#`), so on
  `/dashboard/admin` every hash item resolved to the same pathname and **all** admin items were
  marked active at once (plus the home item), making `aria-current="page"` appear multiple times.
- The lateral navigation was effectively decorative; users had to rely on the card hub.

The clinic sidebar already used `?module=perfil` / `?module=tokens` but, because the shared frame
ignored query params, those items were never highlighted either — the same root defect.

## Root cause
`DashboardSidebarFrame.isActive()` derived the active state from `pathname` only and discarded the
query string, so query-param-based module navigation could never be reflected in the active item.

## Fix
- `AdminDashboardSidebar.tsx`: each module item now uses `${ROUTES.dashboardAdmin}?module=<moduleId>`.
  The 9 module ids map 1:1 to the controller's `AdminModule` union
  (`admin-report-upload`, `admin-health`, `admin-clinics`, `admin-particular-tokens`,
  `admin-pricing`, `admin-sessions`, `admin-users-roles`, `audit-log`, `admin-maintenance`).
  The "Administración" home item stays an exact, no-module link to `ROUTES.dashboardAdmin`.
- `DashboardSidebarFrame.tsx`:
  - Reads the active module with `useSearchParams().get("module")`.
  - `getPathFromHref` now strips both `?` and `#` before comparing paths.
  - New `getModuleFromHref` parses the module id from an item href via `URLSearchParams` (returns
    `null` when the href has no query — safe for hrefs without a module).
  - `isActive` rules:
    - module item → active only when `pathname` matches **and** `activeModule === hrefModule`;
    - exact/home item → active only when `pathname` matches **and** no module is selected;
    - other items → unchanged (`pathname` equality / prefix), preserving clinic behavior.
  - The search-param-dependent nav was extracted into an inner `DashboardSidebarNav` wrapped in a
    React `<Suspense>` boundary. This is required by Next.js App Router: `useSearchParams()` in a
    layout-level client component otherwise fails the production build with
    "useSearchParams() should be wrapped in a suspense boundary" during the prerender pass.

## Accessibility
- Exactly one item carries `aria-current="page"` per URL state (verified by the active-state rules).
- `aria-label`, `title`, `sr-only` text and keyboard focus rings are unchanged.

## Scope
Files changed:
- `frontend/src/components/dashboard/AdminDashboardSidebar.tsx`
- `frontend/src/components/dashboard/DashboardSidebarFrame.tsx`
- `test/frontend-admin-sidebar-module-navigation.test.ts` (new regression test)
- `test/admin-dashboard-sections-contract.test.ts` (href contract updated to `?module=`)
- `test/frontend-dashboard-shell.test.ts` (import + `isActive` + admin href assertions updated)
- `test/frontend-admin-particular-tokens.test.ts` (sidebar href assertion updated to `?module=`)

Out of scope (not modified):
- `AdminDashboardWorkspaceController.tsx`, `ClinicDashboardSidebar.tsx`,
  `ClinicDashboardWorkspaceController.tsx`, `DashboardModuleHub.tsx`,
  `DashboardModuleWorkspace.tsx`, `MasterDetailWorkspace.tsx`.
- `frontend/src/lib/notification-destinations.ts` (uses `#admin-*` anchors; separate concern,
  its test `frontend-notification-destinations.test.ts` stays green).
- Visual redesign, sidebar labels, FlexSearch, password change, dashboard module refactors,
  global CSS, backend, APIs, database, public routes.

## Validation
Commands executed and results:
- `git diff --check` → OK, no whitespace/conflict errors.
- `pnpm --dir frontend lint` → pass (eslint, no findings).
- `pnpm --dir frontend typecheck` → pass (`tsc --noEmit`, no errors).
- `pnpm --dir frontend build` → pass. All `/dashboard/*` routes report as `ƒ (Dynamic)`.
  (First build before the Suspense fix failed on `/dashboard/logistica/metricas` with the
  useSearchParams suspense-boundary error; resolved by the `<Suspense>` boundary.)
- `pnpm test` → 2703 passed, 0 failed.
- `pnpm security:public-surface` → PASS, no public devtools exposure findings
  (only pre-existing `[server-only]` markers in `frontend/src/proxy.ts`, untouched).

## Manual QA (expected behavior)
- `/dashboard/admin` → only "Administración" (home) active; no other item active.
- `/dashboard/admin?module=admin-clinics` → only "Clínicas" active; workspace shows Clínicas.
- `/dashboard/admin?module=audit-log` → only "Auditoría" active.
- `/dashboard/admin?module=admin-health` → only "Estado" active (system health).
- Clicking any admin sidebar item switches the workspace to the matching module.
- Clinic sidebar: `/dashboard` → "Dashboard" active; `/dashboard/informes` → "Informes" active;
  `/dashboard/logistica` → "Logística" active. Module links (`?module=perfil`, `?module=tokens`)
  now also highlight their own item.

## Risk
Low. Change is limited to admin sidebar hrefs and the shared active-state detection. The clinic
sidebar's standard-path behavior is preserved; its pre-existing `?module=` links now highlight
correctly (latent fix). The added `<Suspense>` boundary only affects the brief prerender shell;
private dashboard routes render dynamically.

## Rollback
Revert this PR.
