### PR TITLE
test(dashboard): lock persisted module contracts

### DIFF
--- a/IMPLEMENTATION_NOTES/test-dashboard-persisted-module-contracts.md
+++ b/IMPLEMENTATION_NOTES/test-dashboard-persisted-module-contracts.md
@@ -1,0 +1,75 @@
+# test(dashboard): lock persisted module contracts
+
+## Summary
+- Added regression coverage for the persisted dashboard module behavior shipped in PR #997.
+- Locked the storage keys, SSR/error safety, invalid-storage handling and non-sensitive
+  `localStorage` usage with real runtime tests on the helper.
+- Locked admin/clinic separation, URL-over-storage priority, replace-only restore (no loops) and
+  hub accessibility via source-level controller contracts.
+- Test-only: no implementation change was needed (no bug found).
+
+## Problem
+PR #997 introduced last-active-module persistence/restoration. The behavior was only covered by
+light source-level assertions, leaving the security and navigation invariants under-protected
+against future regressions.
+
+## Scope
+Files changed:
+- `test/frontend-dashboard-last-module.test.ts` (reinforced: runtime helper tests + contract tests)
+
+Not changed (no need):
+- `test/auth-cookie-persistence-contract.test.ts` — its localStorage allowlist already covers the
+  helper (added in PR #997) and the security invariant is green.
+- Implementation files (`dashboard-last-module.ts`, both controllers) — behavior verified correct
+  by the new runtime tests; no bug found, so nothing was modified.
+
+Out of scope (untouched): `package.json`, `pnpm-lock.yaml`, `server/**`, `shared/**`,
+`migrations/**`, `frontend/src/proxy.ts`, public routes, sidebar/frame/router/hub/workspace
+components, `notification-destinations.ts`, CSS, FlexSearch, profile, password change. No
+dependencies added; no UI/route/copy changes.
+
+## What is locked
+Helper (runtime tests — the helper is dependency-free, imported via `await import`):
+- `readDashboardLastModule` returns `null` when `window` is unavailable (SSR).
+- `readDashboardLastModule` returns `null` when `localStorage.getItem` throws.
+- `writeDashboardLastModule` does not throw when `localStorage.setItem` throws.
+- write→read round-trips a module id under the exact role key and isolates roles.
+- exact keys: `vetneb:dashboard:last-module:clinic` / `vetneb:dashboard:last-module:admin`.
+
+Security (source-level):
+- The helper references none of: `session`, `auth`, `cookie`, `token`, `password`, `secret`,
+  `jwt`, `bearer`, `clinicid`, `userid` — only a module id is stored.
+
+Navigation (source-level controller contracts, both admin and clinic):
+- URL `?module=` takes priority over storage (`if (searchParams.get("module")) return;`).
+- Invalid stored value is ignored (`if (!lastModule) return;` after `parseModuleFromUrl`).
+- Restore uses `router.replace`, never `router.push` (asserted both ways) → no history pollution,
+  no loop (also guarded by `hasRestoredLastModule` / `hasManuallyReturnedToHub`).
+- Manual "Volver a módulos" keeps the hub accessible (`setHasManuallyReturnedToHub(true)`).
+- Admin uses only the admin key; clinic uses only the clinic key (cross-references asserted absent).
+- Controllers contain no `localStorage` literal — storage stays centralized in the allowlisted helper.
+
+Scope (source-level):
+- The helper imports nothing; helper + both controllers reference none of `next/server`, `/api/`,
+  `server/`, `fetch(`, `proxy` — the persisted-module surface stays client-side and self-contained.
+
+## Security
+The persisted value is only a module ID. No auth/session/token/cookie/user/clinic/patient data is
+stored, and the tests fail fast if that ever changes.
+
+## Validation
+Commands executed and results:
+- `git diff --check` → OK.
+- `pnpm --dir frontend lint` → pass.
+- `pnpm --dir frontend typecheck` → pass.
+- `pnpm --dir frontend build` → pass.
+- `pnpm test` → 2716 passed, 0 failed.
+- `pnpm typecheck:test` → pass.
+- `pnpm security:public-surface` → PASS (only pre-existing `[server-only]` markers in
+  `frontend/src/proxy.ts`, untouched).
+
+## Risk
+Low. Test/contract hardening only; no runtime behavior changed.
+
+## Rollback
+Revert this PR.

--- a/test/frontend-dashboard-last-module.test.ts
+++ b/test/frontend-dashboard-last-module.test.ts
@@ -3,6 +3,13 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
+const {
+  CLINIC_LAST_MODULE_STORAGE_KEY,
+  ADMIN_LAST_MODULE_STORAGE_KEY,
+  readDashboardLastModule,
+  writeDashboardLastModule,
+} = await import("../frontend/src/lib/dashboard-last-module.ts");
+
 const STORAGE_PATH = "frontend/src/lib/dashboard-last-module.ts";
 const ADMIN_CONTROLLER_PATH =
   "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
@@ -16,66 +23,177 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard last-module helper uses role-separated keys and is SSR/error safe", () => {
-  const source = read(STORAGE_PATH);
+const globalRef = globalThis as { window?: unknown };
 
-  assert.ok(source.includes('"vetneb:dashboard:last-module:clinic"'));
-  assert.ok(source.includes('"vetneb:dashboard:last-module:admin"'));
+function withStubbedWindow(stub: unknown, run: () => void): void {
+  const had = "window" in globalRef;
+  const prev = globalRef.window;
+  globalRef.window = stub;
+  try {
+    run();
+  } finally {
+    if (had) globalRef.window = prev;
+    else delete globalRef.window;
+  }
+}
 
-  // Client-only and resilient to disabled/unavailable storage.
-  assert.ok(source.includes('typeof window === "undefined"'));
-  assert.ok(source.includes("try {"));
-  assert.ok(source.includes("catch"));
+// ── 9.1 Helper runtime behavior ─────────────────────────────────────────────
 
-  // Only a module id is read/written — no sensitive data handling.
+test("readDashboardLastModule returns null when window is unavailable (SSR)", () => {
+  const had = "window" in globalRef;
+  const prev = globalRef.window;
+  if (had) delete globalRef.window;
+  try {
+    assert.equal(readDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY), null);
+  } finally {
+    if (had) globalRef.window = prev;
+  }
+});
+
+test("readDashboardLastModule returns null when localStorage.getItem throws", () => {
+  withStubbedWindow(
+    {
+      localStorage: {
+        getItem() {
+          throw new Error("storage blocked");
+        },
+      },
+    },
+    () => {
+      assert.equal(
+        readDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY),
+        null,
+      );
+    },
+  );
+});
+
+test("writeDashboardLastModule does not throw when localStorage.setItem throws", () => {
+  withStubbedWindow(
+    {
+      localStorage: {
+        setItem() {
+          throw new Error("quota exceeded");
+        },
+      },
+    },
+    () => {
+      assert.doesNotThrow(() =>
+        writeDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY, "admin-clinics"),
+      );
+    },
+  );
+});
+
+test("write/read round-trips a module id under the exact role key and isolates roles", () => {
+  const store = new Map<string, string>();
+  withStubbedWindow(
+    {
+      localStorage: {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+      },
+    },
+    () => {
+      writeDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY, "perfil");
+      writeDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY, "admin-clinics");
+
+      assert.equal(store.get("vetneb:dashboard:last-module:clinic"), "perfil");
+      assert.equal(
+        store.get("vetneb:dashboard:last-module:admin"),
+        "admin-clinics",
+      );
+      assert.equal(
+        readDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY),
+        "perfil",
+      );
+      assert.equal(
+        readDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY),
+        "admin-clinics",
+      );
+    },
+  );
+});
+
+test("storage keys are the exact namespaced contract values", () => {
+  assert.equal(
+    CLINIC_LAST_MODULE_STORAGE_KEY,
+    "vetneb:dashboard:last-module:clinic",
+  );
+  assert.equal(
+    ADMIN_LAST_MODULE_STORAGE_KEY,
+    "vetneb:dashboard:last-module:admin",
+  );
+});
+
+// ── 9.2 Storage stays non-sensitive ─────────────────────────────────────────
+
+test("dashboard last-module helper stores no sensitive identifiers", () => {
+  const source = read(STORAGE_PATH).toLowerCase();
+
   for (const forbidden of [
-    "token",
     "session",
+    "auth",
     "cookie",
+    "token",
     "password",
+    "secret",
+    "jwt",
+    "bearer",
     "clinicid",
     "userid",
   ]) {
     assert.equal(
-      source.toLowerCase().includes(forbidden),
+      source.includes(forbidden),
       false,
-      `storage helper must not reference ${forbidden}`,
+      `helper must not reference ${forbidden}`,
     );
   }
 });
 
-test("admin controller persists/restores the last module with the admin key", () => {
+// ── 9.3 Admin / clinic navigation contracts ─────────────────────────────────
+
+test("admin controller persists/restores with the admin key and replace-only restore", () => {
   const source = read(ADMIN_CONTROLLER_PATH);
 
   assert.ok(source.includes("ADMIN_LAST_MODULE_STORAGE_KEY"));
   assert.equal(source.includes("CLINIC_LAST_MODULE_STORAGE_KEY"), false);
 
-  // Persist only a valid active module.
   assert.ok(
     source.includes(
       "writeDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY, activeModule)",
     ),
   );
-
-  // Restore: only when the URL has no module, validating the stored value.
-  assert.ok(source.includes('if (searchParams.get("module")) return;'));
   assert.ok(
     source.includes("readDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY)"),
   );
+
+  // URL takes priority over storage; invalid stored value is ignored.
+  assert.ok(source.includes('if (searchParams.get("module")) return;'));
+  assert.ok(source.includes("if (!lastModule) return;"));
+
+  // Restore uses replace, never push (no history pollution, no loop).
   assert.ok(
     source.includes("router.replace(`/dashboard/admin?module=${lastModule}`"),
   );
-
-  // Hub stays accessible: manual return suppresses immediate restore.
-  assert.ok(source.includes("setHasManuallyReturnedToHub(true);"));
+  assert.equal(
+    source.includes("router.push(`/dashboard/admin?module=${lastModule}`"),
+    false,
+  );
   assert.ok(
     source.includes(
       "if (hasRestoredLastModule.current || hasManuallyReturnedToHub) return;",
     ),
   );
+
+  // Hub stays accessible; storage stays centralized in the allowlisted helper.
+  assert.ok(source.includes("setHasManuallyReturnedToHub(true);"));
+  assert.equal(source.includes("localStorage"), false);
 });
 
-test("clinic controller persists/restores the last module with the clinic key", () => {
+test("clinic controller persists/restores with the clinic key and replace-only restore", () => {
   const source = read(CLINIC_CONTROLLER_PATH);
 
   assert.ok(source.includes("CLINIC_LAST_MODULE_STORAGE_KEY"));
@@ -86,19 +204,53 @@ test("clinic controller persists/restores the last module with the clinic key", 
       "writeDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY, activeModule)",
     ),
   );
-
-  assert.ok(source.includes('if (searchParams.get("module")) return;'));
   assert.ok(
     source.includes("readDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY)"),
   );
+
+  assert.ok(source.includes('if (searchParams.get("module")) return;'));
+  assert.ok(source.includes("if (!lastModule) return;"));
+
   assert.ok(
     source.includes("router.replace(`${ROUTES.dashboard}?module=${lastModule}`"),
   );
-
-  assert.ok(source.includes("setHasManuallyReturnedToHub(true);"));
+  assert.equal(
+    source.includes("router.push(`${ROUTES.dashboard}?module=${lastModule}`"),
+    false,
+  );
   assert.ok(
     source.includes(
       "if (hasRestoredLastModule.current || hasManuallyReturnedToHub) return;",
     ),
   );
+
+  assert.ok(source.includes("setHasManuallyReturnedToHub(true);"));
+  assert.equal(source.includes("localStorage"), false);
+});
+
+// ── 9.4 Scope: persisted-module surface stays client-side and self-contained ─
+
+test("persisted-module surface does not reach backend, api, proxy or public layers", () => {
+  const helper = read(STORAGE_PATH);
+
+  // Helper is dependency-free.
+  assert.equal(
+    /^\s*import\s/m.test(helper),
+    false,
+    "storage helper must not import any module",
+  );
+
+  for (const source of [
+    helper,
+    read(ADMIN_CONTROLLER_PATH),
+    read(CLINIC_CONTROLLER_PATH),
+  ]) {
+    for (const forbidden of ["next/server", "/api/", "server/", "fetch(", "proxy"]) {
+      assert.equal(
+        source.includes(forbidden),
+        false,
+        `persisted-module surface must not reference ${forbidden}`,
+      );
+    }
+  }
 });


### PR DESCRIPTION
# test(dashboard): lock persisted module contracts

## Summary
- Added regression coverage for the persisted dashboard module behavior shipped in PR #997.
- Locked the storage keys, SSR/error safety, invalid-storage handling and non-sensitive
  `localStorage` usage with real runtime tests on the helper.
- Locked admin/clinic separation, URL-over-storage priority, replace-only restore (no loops) and
  hub accessibility via source-level controller contracts.
- Test-only: no implementation change was needed (no bug found).

## Problem
PR #997 introduced last-active-module persistence/restoration. The behavior was only covered by
light source-level assertions, leaving the security and navigation invariants under-protected
against future regressions.

## Scope
Files changed:
- `test/frontend-dashboard-last-module.test.ts` (reinforced: runtime helper tests + contract tests)

Not changed (no need):
- `test/auth-cookie-persistence-contract.test.ts` — its localStorage allowlist already covers the
  helper (added in PR #997) and the security invariant is green.
- Implementation files (`dashboard-last-module.ts`, both controllers) — behavior verified correct
  by the new runtime tests; no bug found, so nothing was modified.

Out of scope (untouched): `package.json`, `pnpm-lock.yaml`, `server/**`, `shared/**`,
`migrations/**`, `frontend/src/proxy.ts`, public routes, sidebar/frame/router/hub/workspace
components, `notification-destinations.ts`, CSS, FlexSearch, profile, password change. No
dependencies added; no UI/route/copy changes.

## What is locked
Helper (runtime tests — the helper is dependency-free, imported via `await import`):
- `readDashboardLastModule` returns `null` when `window` is unavailable (SSR).
- `readDashboardLastModule` returns `null` when `localStorage.getItem` throws.
- `writeDashboardLastModule` does not throw when `localStorage.setItem` throws.
- write→read round-trips a module id under the exact role key and isolates roles.
- exact keys: `vetneb:dashboard:last-module:clinic` / `vetneb:dashboard:last-module:admin`.

Security (source-level):
- The helper references none of: `session`, `auth`, `cookie`, `token`, `password`, `secret`,
  `jwt`, `bearer`, `clinicid`, `userid` — only a module id is stored.

Navigation (source-level controller contracts, both admin and clinic):
- URL `?module=` takes priority over storage (`if (searchParams.get("module")) return;`).
- Invalid stored value is ignored (`if (!lastModule) return;` after `parseModuleFromUrl`).
- Restore uses `router.replace`, never `router.push` (asserted both ways) → no history pollution,
  no loop (also guarded by `hasRestoredLastModule` / `hasManuallyReturnedToHub`).
- Manual "Volver a módulos" keeps the hub accessible (`setHasManuallyReturnedToHub(true)`).
- Admin uses only the admin key; clinic uses only the clinic key (cross-references asserted absent).
- Controllers contain no `localStorage` literal — storage stays centralized in the allowlisted helper.

Scope (source-level):
- The helper imports nothing; helper + both controllers reference none of `next/server`, `/api/`,
  `server/`, `fetch(`, `proxy` — the persisted-module surface stays client-side and self-contained.

## Security
The persisted value is only a module ID. No auth/session/token/cookie/user/clinic/patient data is
stored, and the tests fail fast if that ever changes.

## Validation
Commands executed and results:
- `git diff --check` → OK.
- `pnpm --dir frontend lint` → pass.
- `pnpm --dir frontend typecheck` → pass.
- `pnpm --dir frontend build` → pass.
- `pnpm test` → 2716 passed, 0 failed.
- `pnpm typecheck:test` → pass.
- `pnpm security:public-surface` → PASS (only pre-existing `[server-only]` markers in
  `frontend/src/proxy.ts`, untouched).

## Risk
Low. Test/contract hardening only; no runtime behavior changed.

## Rollback
Revert this PR.
