### PR TITLE
fix(dashboard): clear last module preferences on logout

### DIFF
--- a/IMPLEMENTATION_NOTES/fix-dashboard-clear-last-module-on-logout.md
+++ b/IMPLEMENTATION_NOTES/fix-dashboard-clear-last-module-on-logout.md
@@ -1,0 +1,42 @@
+# fix(dashboard): clear last module preferences on logout
+
+## Summary
+- Added a safe helper to clear persisted dashboard module preferences.
+- Invoked it from the client-side logout flow.
+- Added regression coverage for key removal and failure-safe behavior.
+
+## Problem
+Last active module preferences were intentionally non-sensitive, but remained after logout.
+
+## Scope
+Files changed:
+- frontend/src/lib/dashboard-last-module.ts
+- frontend/src/context/AuthContext.tsx
+- frontend/src/components/dashboard/DashboardTopbar.tsx
+- test/frontend-dashboard-last-module.test.ts
+- IMPLEMENTATION_NOTES/fix-dashboard-clear-last-module-on-logout.md
+
+Out of scope:
+- auth backend changes
+- cookie/session changes
+- visual changes
+- dependencies
+
+## Security
+Only non-sensitive dashboard module preference keys are cleared. No auth/session/token/cookie state is stored or modified by the helper.
+
+## Validation
+- `pnpm exec tsx --test test/frontend-dashboard-last-module.test.ts` - pass (14 tests).
+- `git diff --check` - pass.
+- `pnpm --dir frontend lint` - pass.
+- `pnpm --dir frontend typecheck` - pass.
+- `pnpm --dir frontend build` - pass after keeping the dashboard topbar inside the client boundary.
+- `pnpm test` - pass (2721 tests).
+- `pnpm typecheck:test` - pass.
+- `pnpm security:public-surface` - pass (existing server-only proxy findings reported by the script).
+
+## Risk
+Low. Client-side preference cleanup only.
+
+## Rollback
+Revert this PR.

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
+import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
 import { ROUTES } from "@/lib/routes";
 import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 
@@ -53,6 +56,7 @@ export function DashboardTopbar({
         <PublicRouteControl
           href={ROUTES.login}
           variant="bare"
+          onClick={clearDashboardLastModules}
           className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
         >
           Cerrar sesión

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import { getClinicSession, logout as logoutClinic } from "@/lib/api";
+import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
 import type { AuthUser } from "@/types";
 
 type AuthContextValue = {
@@ -40,6 +41,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     await logoutClinic();
+    clearDashboardLastModules();
     setUser(null);
   }, []);
 

--- a/frontend/src/lib/dashboard-last-module.ts
+++ b/frontend/src/lib/dashboard-last-module.ts
@@ -20,3 +20,13 @@ export function writeDashboardLastModule(key: string, moduleId: string): void {
     // localStorage unavailable (private mode / disabled) — ignore.
   }
 }
+
+export function clearDashboardLastModules(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(CLINIC_LAST_MODULE_STORAGE_KEY);
+    window.localStorage.removeItem(ADMIN_LAST_MODULE_STORAGE_KEY);
+  } catch {
+    // localStorage unavailable - ignore.
+  }
+}

--- a/test/frontend-dashboard-last-module.test.ts
+++ b/test/frontend-dashboard-last-module.test.ts
@@ -6,11 +6,15 @@ import test from "node:test";
 const {
   CLINIC_LAST_MODULE_STORAGE_KEY,
   ADMIN_LAST_MODULE_STORAGE_KEY,
+  clearDashboardLastModules,
   readDashboardLastModule,
   writeDashboardLastModule,
 } = await import("../frontend/src/lib/dashboard-last-module.ts");
 
 const STORAGE_PATH = "frontend/src/lib/dashboard-last-module.ts";
+const AUTH_CONTEXT_PATH = "frontend/src/context/AuthContext.tsx";
+const DASHBOARD_TOPBAR_PATH =
+  "frontend/src/components/dashboard/DashboardTopbar.tsx";
 const ADMIN_CONTROLLER_PATH =
   "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
 const CLINIC_CONTROLLER_PATH =
@@ -24,6 +28,17 @@ function read(relativePath: string): string {
 }
 
 const globalRef = globalThis as { window?: unknown };
+
+function withoutWindow(run: () => void): void {
+  const had = "window" in globalRef;
+  const prev = globalRef.window;
+  if (had) delete globalRef.window;
+  try {
+    run();
+  } finally {
+    if (had) globalRef.window = prev;
+  }
+}
 
 function withStubbedWindow(stub: unknown, run: () => void): void {
   const had = "window" in globalRef;
@@ -40,14 +55,9 @@ function withStubbedWindow(stub: unknown, run: () => void): void {
 // ── 9.1 Helper runtime behavior ─────────────────────────────────────────────
 
 test("readDashboardLastModule returns null when window is unavailable (SSR)", () => {
-  const had = "window" in globalRef;
-  const prev = globalRef.window;
-  if (had) delete globalRef.window;
-  try {
+  withoutWindow(() => {
     assert.equal(readDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY), null);
-  } finally {
-    if (had) globalRef.window = prev;
-  }
+  });
 });
 
 test("readDashboardLastModule returns null when localStorage.getItem throws", () => {
@@ -113,6 +123,58 @@ test("write/read round-trips a module id under the exact role key and isolates r
         readDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY),
         "admin-clinics",
       );
+    },
+  );
+});
+
+test("clearDashboardLastModules removes both role keys and keeps other UI preferences", () => {
+  const store = new Map<string, string>([
+    [CLINIC_LAST_MODULE_STORAGE_KEY, "perfil"],
+    [ADMIN_LAST_MODULE_STORAGE_KEY, "admin-clinics"],
+    ["vetneb-theme-mode", "dark"],
+  ]);
+  const removedKeys: string[] = [];
+
+  withStubbedWindow(
+    {
+      localStorage: {
+        removeItem: (key: string) => {
+          removedKeys.push(key);
+          store.delete(key);
+        },
+      },
+    },
+    () => {
+      clearDashboardLastModules();
+
+      assert.equal(store.has(CLINIC_LAST_MODULE_STORAGE_KEY), false);
+      assert.equal(store.has(ADMIN_LAST_MODULE_STORAGE_KEY), false);
+      assert.equal(store.get("vetneb-theme-mode"), "dark");
+      assert.deepEqual(removedKeys, [
+        CLINIC_LAST_MODULE_STORAGE_KEY,
+        ADMIN_LAST_MODULE_STORAGE_KEY,
+      ]);
+    },
+  );
+});
+
+test("clearDashboardLastModules does not throw when window is unavailable (SSR)", () => {
+  withoutWindow(() => {
+    assert.doesNotThrow(() => clearDashboardLastModules());
+  });
+});
+
+test("clearDashboardLastModules does not throw when localStorage.removeItem throws", () => {
+  withStubbedWindow(
+    {
+      localStorage: {
+        removeItem() {
+          throw new Error("storage blocked");
+        },
+      },
+    },
+    () => {
+      assert.doesNotThrow(() => clearDashboardLastModules());
     },
   );
 });
@@ -228,7 +290,38 @@ test("clinic controller persists/restores with the clinic key and replace-only r
   assert.equal(source.includes("localStorage"), false);
 });
 
-// ── 9.4 Scope: persisted-module surface stays client-side and self-contained ─
+// ── 9.4 Logout clears persisted module preferences ─────────────────────────
+
+test("dashboard topbar logout clears persisted module keys before routing to login", () => {
+  const source = read(DASHBOARD_TOPBAR_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { clearDashboardLastModules } from "@/lib/dashboard-last-module";',
+    ),
+  );
+  assert.ok(source.includes("onClick={clearDashboardLastModules}"));
+  assert.ok(source.includes("href={ROUTES.login}"));
+  assert.equal(source.includes("localStorage"), false);
+});
+
+test("AuthContext logout clears persisted module keys after backend logout succeeds", () => {
+  const source = read(AUTH_CONTEXT_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { clearDashboardLastModules } from "@/lib/dashboard-last-module";',
+    ),
+  );
+  assert.ok(
+    source.includes(
+      "await logoutClinic();\n    clearDashboardLastModules();\n    setUser(null);",
+    ),
+  );
+  assert.equal(source.includes("localStorage"), false);
+});
+
+// ── 9.5 Scope: persisted-module surface stays client-side and self-contained ─
 
 test("persisted-module surface does not reach backend, api, proxy or public layers", () => {
   const helper = read(STORAGE_PATH);


### PR DESCRIPTION
# fix(dashboard): clear last module preferences on logout

## Summary
- Added a safe helper to clear persisted dashboard module preferences.
- Invoked it from the client-side logout flow.
- Added regression coverage for key removal and failure-safe behavior.

## Problem
Last active module preferences were intentionally non-sensitive, but remained after logout.

## Scope
Files changed:
- frontend/src/lib/dashboard-last-module.ts
- frontend/src/context/AuthContext.tsx
- frontend/src/components/dashboard/DashboardTopbar.tsx
- test/frontend-dashboard-last-module.test.ts
- IMPLEMENTATION_NOTES/fix-dashboard-clear-last-module-on-logout.md

Out of scope:
- auth backend changes
- cookie/session changes
- visual changes
- dependencies

## Security
Only non-sensitive dashboard module preference keys are cleared. No auth/session/token/cookie state is stored or modified by the helper.

## Validation
- `pnpm exec tsx --test test/frontend-dashboard-last-module.test.ts` - pass (14 tests).
- `git diff --check` - pass.
- `pnpm --dir frontend lint` - pass.
- `pnpm --dir frontend typecheck` - pass.
- `pnpm --dir frontend build` - pass after keeping the dashboard topbar inside the client boundary.
- `pnpm test` - pass (2721 tests).
- `pnpm typecheck:test` - pass.
- `pnpm security:public-surface` - pass (existing server-only proxy findings reported by the script).

## Risk
Low. Client-side preference cleanup only.

## Rollback
Revert this PR.
