### PR TITLE
feat(auth): add authenticated password change endpoints

### DIFF
--- a/IMPLEMENTATION_NOTES/feat-auth-password-change-endpoints.md
+++ b/IMPLEMENTATION_NOTES/feat-auth-password-change-endpoints.md
@@ -1,0 +1,53 @@
+# feat(auth): authenticated password change endpoints
+
+## Scope
+
+- Added `POST /api/auth/change-password` for authenticated clinic users.
+- Added `POST /api/admin/auth/change-password` for authenticated admin users.
+- Request body: `{ currentPassword, newPassword }`.
+- Success body: `{ success: true }`.
+- Particular auth remains excluded because it is token-backed and has no password hash contract.
+
+## Security contracts
+
+- Both endpoints require the existing cookie-backed authenticated session.
+- Both endpoints enforce the existing trusted-origin/CORS boundary before auth deps are touched.
+- `currentPassword` is verified with the existing `verifyPassword` helper.
+- `newPassword` is hashed with the existing `hashPassword` helper.
+- Legacy/current hashes that return `needsRehash` do not block the flow; changing the password writes a fresh hash.
+- New passwords follow the existing backend minimum: at least 8 characters and at least 8 non-whitespace-trimmed characters.
+- New password equal to the current credential is rejected after the current password has been verified.
+- Public failure responses for invalid body/current password/policy/same-password use the same generic error.
+- No password/hash is returned in responses or included in audit metadata.
+- Sensitive response no-store remains delegated to the global `/api/*` backend hook.
+
+## Rate limit
+
+The endpoints reuse the existing auth rate-limit store with keys scoped as
+`password-change:<userId>` plus IP and the current auth surface (`clinic` or
+`admin`). This avoids schema or migration changes while preserving per-user/IP
+throttling. Failed attempts increment the store; success clears the endpoint key
+when the store supports delete.
+
+## Audit and session behavior
+
+- Clinic self-service changes write `clinic_user.credentials.updated` with actor,
+  target clinic user, username, role, `selfService`, and `sessionMaintained`.
+- Admin self-service changes write `auth.admin.password.changed` with actor,
+  target admin user, username, `selfService`, and `sessionMaintained`.
+- The current session is maintained. Invalidating other active sessions remains
+  a future hardening step because this PR intentionally avoids session schema or
+  broad DB helper changes.
+- The admin event is written to the existing varchar audit table without adding
+  a schema/migration/catalog change; formal catalog inclusion can be handled in
+  a later audit taxonomy PR.
+
+## Test coverage
+
+- `test/auth-password-change.test.ts` covers clinic/admin success, login with the
+  new password, generic failures, auth requirement, rate limit behavior, audit
+  secret boundaries, and particular exclusion.
+- CSRF mutation counts were updated for `auth.fastify.ts` and
+  `admin-auth.fastify.ts`; particular remains unchanged.
+- Trusted-origin/preflight coverage now includes both change-password endpoints.
+- Backend no-store cache contract includes both endpoints.

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -3,7 +3,9 @@ import type {
   FastifyReply,
   FastifyRequest,
 } from "fastify";
+import { eq } from "drizzle-orm";
 
+import { adminUsers } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
@@ -105,8 +107,16 @@ export type AdminAuthNativeRoutesOptions = {
   getAdminUserByUsername?: (
     username: string,
   ) => Promise<AdminUserRecord | null>;
+  getAdminUserForPasswordChange?: (
+    adminUserId: number,
+  ) => Promise<AdminUserRecord | null>;
   updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  updateAdminPasswordHash?: (
+    adminUserId: number,
+    passwordHash: string,
+  ) => Promise<unknown>;
   generateSessionToken?: () => string;
+  hashPassword?: (password: string) => Promise<string>;
   hashSessionToken?: (token: string) => string;
   verifyPassword?: (
     password: string,
@@ -124,6 +134,9 @@ export type AdminAuthNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__adminAuthRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const PASSWORD_CHANGE_MIN_LENGTH = 8;
+const PASSWORD_CHANGE_ERROR_MESSAGE = "No se pudo actualizar la credencial.";
+const ADMIN_PASSWORD_CHANGED_AUDIT_EVENT = "auth.admin.password.changed";
 
 type AdminAuthFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -137,8 +150,11 @@ type NativeAdminAuthDeps = Required<
     | "getAdminSessionByToken"
     | "getAdminUserById"
     | "getAdminUserByUsername"
+    | "getAdminUserForPasswordChange"
     | "updateAdminSessionLastAccess"
+    | "updateAdminPasswordHash"
     | "generateSessionToken"
+    | "hashPassword"
     | "hashSessionToken"
     | "verifyPassword"
     | "writeAuditLog"
@@ -165,8 +181,22 @@ async function loadDefaultDeps(): Promise<NativeAdminAuthDefaultDeps> {
         getAdminSessionByToken: db.getAdminSessionByToken,
         getAdminUserById: db.getAdminUserById,
         getAdminUserByUsername: db.getAdminUserByUsername,
+        getAdminUserForPasswordChange: db.getAdminUserById,
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        updateAdminPasswordHash: async (
+          adminUserId: number,
+          passwordHash: string,
+        ) => {
+          await db.db
+            .update(adminUsers)
+            .set({
+              passwordHash,
+              updatedAt: new Date(),
+            })
+            .where(eq(adminUsers.id, adminUserId));
+        },
         generateSessionToken: authSecurity.generateSessionToken,
+        hashPassword: authSecurity.hashPassword,
         hashSessionToken: authSecurity.hashSessionToken,
         verifyPassword: authSecurity.verifyPassword,
         writeAuditLog: audit.writeAuditLog as (
@@ -378,6 +408,40 @@ function setLoginRateLimitHeaders(
   }
 }
 
+function isPasswordChangeBody(
+  body: unknown,
+): body is { currentPassword: string; newPassword: string } {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const candidate = body as {
+    currentPassword?: unknown;
+    newPassword?: unknown;
+  };
+
+  return (
+    typeof candidate.currentPassword === "string" &&
+    candidate.currentPassword.length > 0 &&
+    typeof candidate.newPassword === "string" &&
+    candidate.newPassword.length >= PASSWORD_CHANGE_MIN_LENGTH &&
+    candidate.newPassword.trim().length >= PASSWORD_CHANGE_MIN_LENGTH
+  );
+}
+
+function sendPasswordChangeRejected(reply: FastifyReply) {
+  return reply.code(400).send({
+    success: false,
+    error: PASSWORD_CHANGE_ERROR_MESSAGE,
+  });
+}
+
+function createMissingAdminPasswordChangeDep(name: string) {
+  return async () => {
+    throw new Error(`${name} dependency is required for admin password change`);
+  };
+}
+
 
 
 function getUserAgent(request: FastifyRequest) {
@@ -448,11 +512,31 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       options.getAdminUserById ?? defaultDeps!.getAdminUserById,
     getAdminUserByUsername:
       options.getAdminUserByUsername ?? defaultDeps!.getAdminUserByUsername,
+    getAdminUserForPasswordChange:
+      options.getAdminUserForPasswordChange ??
+      defaultDeps?.getAdminUserForPasswordChange ??
+      (async (adminUserId: number) => {
+        const getAdminUserById =
+          options.getAdminUserById ?? defaultDeps?.getAdminUserById;
+        const record = await getAdminUserById?.(adminUserId);
+
+        return record && "passwordHash" in record
+          ? (record as AdminUserRecord)
+          : null;
+      }),
     updateAdminSessionLastAccess:
       options.updateAdminSessionLastAccess ??
       defaultDeps!.updateAdminSessionLastAccess,
+    updateAdminPasswordHash:
+      options.updateAdminPasswordHash ??
+      defaultDeps?.updateAdminPasswordHash ??
+      createMissingAdminPasswordChangeDep("updateAdminPasswordHash"),
     generateSessionToken:
       options.generateSessionToken ?? defaultDeps!.generateSessionToken,
+    hashPassword:
+      options.hashPassword ??
+      defaultDeps?.hashPassword ??
+      createMissingAdminPasswordChangeDep("hashPassword"),
     hashSessionToken:
       options.hashSessionToken ?? defaultDeps!.hashSessionToken,
     verifyPassword: options.verifyPassword ?? defaultDeps!.verifyPassword,
@@ -530,6 +614,7 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
   app.options("/login", optionsHandler);
   app.options("/me", optionsHandler);
   app.options("/logout", optionsHandler);
+  app.options("/change-password", optionsHandler);
 
   app.post<{
     Body: {
@@ -832,6 +917,202 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
         id: admin.id,
         username: admin.username,
       },
+    });
+  });
+
+  app.post<{
+    Body: {
+      currentPassword?: unknown;
+      newPassword?: unknown;
+    };
+  }>("/change-password", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    const currentTime = now();
+    const rateLimitKey = buildLoginRateLimitKey({
+      surface: "admin",
+      identifier: `password-change:${admin.id}`,
+      ipAddress: request.ip || null,
+    });
+
+    const failureEntry: RateLimitEntry = {
+      count: 0,
+      resetAt: currentTime + loginRateLimitWindowMs,
+    };
+    let canUseRateLimitStore = true;
+
+    try {
+      const existingEntry = await getOrCreateRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        loginRateLimitWindowMs,
+        currentTime,
+      );
+
+      failureEntry.count = existingEntry.count;
+      failureEntry.resetAt = existingEntry.resetAt;
+    } catch (error) {
+      canUseRateLimitStore = false;
+      request.log.error(
+        {
+          err: error,
+          code: "ADMIN_PASSWORD_CHANGE_RATE_LIMIT_GET_FAILED",
+          route: "/api/admin/auth/change-password",
+        },
+        "No se pudo leer el rate limit de cambio de contraseña admin",
+      );
+    }
+
+    if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+        includeRetryAfter: true,
+      });
+
+      return reply.code(429).send(
+        buildLoginRateLimitResponse({
+          resetAt: failureEntry.resetAt,
+          now: currentTime,
+        }),
+      );
+    }
+
+    const markFailure = async () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
+      try {
+        const updatedEntry = await incrementRateLimitEntry(
+          loginRateLimitStore,
+          rateLimitKey,
+          failureEntry,
+          currentTime,
+        );
+
+        failureEntry.count = updatedEntry.count;
+        failureEntry.resetAt = updatedEntry.resetAt;
+
+        setLoginRateLimitHeaders(reply, {
+          max: loginRateLimitMaxAttempts,
+          windowMs: loginRateLimitWindowMs,
+          failedCount: failureEntry.count,
+          resetAt: failureEntry.resetAt,
+          now: currentTime,
+        });
+      } catch (error) {
+        canUseRateLimitStore = false;
+        request.log.error(
+          {
+            err: error,
+            code: "ADMIN_PASSWORD_CHANGE_RATE_LIMIT_INCREMENT_FAILED",
+            route: "/api/admin/auth/change-password",
+          },
+          "No se pudo actualizar el rate limit de cambio de contraseña admin",
+        );
+      }
+    };
+
+    const markSuccess = async () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
+      if (loginRateLimitStore.delete) {
+        try {
+          await loginRateLimitStore.delete(rateLimitKey);
+        } catch (error) {
+          request.log.warn(
+            {
+              err: error,
+              code: "ADMIN_PASSWORD_CHANGE_RATE_LIMIT_RESET_FAILED",
+              route: "/api/admin/auth/change-password",
+            },
+            "No se pudo limpiar el rate limit tras cambio de contraseña admin",
+          );
+        }
+      }
+
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: 0,
+        resetAt: currentTime + loginRateLimitWindowMs,
+        now: currentTime,
+      });
+    };
+
+    if (!isPasswordChangeBody(request.body)) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const adminUser = await deps.getAdminUserForPasswordChange(admin.id);
+
+    if (!adminUser || adminUser.id !== admin.id || !adminUser.passwordHash) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const currentPasswordCheck = await deps.verifyPassword(
+      request.body.currentPassword,
+      adminUser.passwordHash,
+    );
+
+    if (!currentPasswordCheck.valid) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const newPasswordMatchesCurrent =
+      request.body.newPassword === request.body.currentPassword ||
+      (
+        await deps.verifyPassword(request.body.newPassword, adminUser.passwordHash)
+      ).valid;
+
+    if (newPasswordMatchesCurrent) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const newPasswordHash = await deps.hashPassword(request.body.newPassword);
+
+    await deps.updateAdminPasswordHash(admin.id, newPasswordHash);
+
+    await deps.writeAuditLog(createAuditRequestLike(request, admin), {
+      event: ADMIN_PASSWORD_CHANGED_AUDIT_EVENT,
+      targetAdminUserId: admin.id,
+      metadata: {
+        username: admin.username,
+        selfService: true,
+        sessionMaintained: true,
+      },
+      actor: {
+        type: "admin_user",
+        adminUserId: admin.id,
+      },
+    });
+
+    await markSuccess();
+
+    return reply.code(200).send({
+      success: true,
     });
   });
 

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -55,6 +55,7 @@ type SessionClinicUserRecord = {
   id: number;
   clinicId: number;
   username: string;
+  passwordHash?: string;
   authProId?: string | null;
   role: unknown;
 };
@@ -87,6 +88,7 @@ type AuthenticatedClinicUser = {
   permissions: ReturnType<typeof getClinicPermissions>;
   canUploadReports: boolean;
   canManageClinicUsers: boolean;
+  passwordHash?: string;
   sessionToken: string;
 };
 
@@ -229,6 +231,8 @@ export type AuthNativeRoutesOptions = {
 
 const REQUEST_TIMER_KEY = "__clinicAuthRequestTimer";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const PASSWORD_CHANGE_MIN_LENGTH = 8;
+const PASSWORD_CHANGE_ERROR_MESSAGE = "No se pudo actualizar la credencial.";
 
 type AuthFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -580,6 +584,34 @@ function setLoginRateLimitHeaders(
   }
 }
 
+function isPasswordChangeBody(
+  body: unknown,
+): body is { currentPassword: string; newPassword: string } {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const candidate = body as {
+    currentPassword?: unknown;
+    newPassword?: unknown;
+  };
+
+  return (
+    typeof candidate.currentPassword === "string" &&
+    candidate.currentPassword.length > 0 &&
+    typeof candidate.newPassword === "string" &&
+    candidate.newPassword.length >= PASSWORD_CHANGE_MIN_LENGTH &&
+    candidate.newPassword.trim().length >= PASSWORD_CHANGE_MIN_LENGTH
+  );
+}
+
+function sendPasswordChangeRejected(reply: FastifyReply) {
+  return reply.code(400).send({
+    success: false,
+    error: PASSWORD_CHANGE_ERROR_MESSAGE,
+  });
+}
+
 function getUserAgent(request: FastifyRequest) {
   const value = request.headers["user-agent"];
 
@@ -870,6 +902,7 @@ async function authenticateClinicUser(
     permissions,
     canUploadReports: permissions.canUploadReports,
     canManageClinicUsers: permissions.canManageClinicUsers,
+    passwordHash: clinicUser.passwordHash,
     sessionToken: token,
   };
 }
@@ -1022,6 +1055,7 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
   app.options("/login", optionsHandler);
   app.options("/me", optionsHandler);
   app.options("/logout", optionsHandler);
+  app.options("/change-password", optionsHandler);
 
   app.post<{
     Body: {
@@ -1348,6 +1382,208 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
         role: auth.role,
       },
       permissions: auth.permissions,
+    });
+  });
+
+  app.post<{
+    Body: {
+      currentPassword?: unknown;
+      newPassword?: unknown;
+    };
+  }>("/change-password", async (request, reply) => {
+    if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
+      return reply;
+    }
+
+    const auth = await authenticateClinicUser(request, reply, deps, now);
+
+    if (!auth) {
+      return reply;
+    }
+
+    const currentTime = now();
+    const rateLimitKey = buildLoginRateLimitKey({
+      surface: "clinic",
+      identifier: `password-change:${auth.id}`,
+      ipAddress: request.ip || null,
+    });
+
+    const failureEntry: RateLimitEntry = {
+      count: 0,
+      resetAt: currentTime + loginRateLimitWindowMs,
+    };
+    let canUseRateLimitStore = true;
+
+    try {
+      const existingEntry = await getOrCreateRateLimitEntry(
+        loginRateLimitStore,
+        rateLimitKey,
+        loginRateLimitWindowMs,
+        currentTime,
+      );
+
+      failureEntry.count = existingEntry.count;
+      failureEntry.resetAt = existingEntry.resetAt;
+    } catch (error) {
+      canUseRateLimitStore = false;
+      request.log.error(
+        {
+          err: error,
+          code: "AUTH_PASSWORD_CHANGE_RATE_LIMIT_GET_FAILED",
+          route: "/api/auth/change-password",
+        },
+        "No se pudo leer el rate limit de cambio de contraseña clinic",
+      );
+    }
+
+    if (canUseRateLimitStore && failureEntry.count >= loginRateLimitMaxAttempts) {
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: failureEntry.count,
+        resetAt: failureEntry.resetAt,
+        now: currentTime,
+        includeRetryAfter: true,
+      });
+
+      return reply.code(429).send(
+        buildLoginRateLimitResponse({
+          resetAt: failureEntry.resetAt,
+          now: currentTime,
+        }),
+      );
+    }
+
+    const markFailure = async () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
+      try {
+        const updatedEntry = await incrementRateLimitEntry(
+          loginRateLimitStore,
+          rateLimitKey,
+          failureEntry,
+          currentTime,
+        );
+
+        failureEntry.count = updatedEntry.count;
+        failureEntry.resetAt = updatedEntry.resetAt;
+
+        setLoginRateLimitHeaders(reply, {
+          max: loginRateLimitMaxAttempts,
+          windowMs: loginRateLimitWindowMs,
+          failedCount: failureEntry.count,
+          resetAt: failureEntry.resetAt,
+          now: currentTime,
+        });
+      } catch (error) {
+        canUseRateLimitStore = false;
+        request.log.error(
+          {
+            err: error,
+            code: "AUTH_PASSWORD_CHANGE_RATE_LIMIT_INCREMENT_FAILED",
+            route: "/api/auth/change-password",
+          },
+          "No se pudo actualizar el rate limit de cambio de contraseña clinic",
+        );
+      }
+    };
+
+    const markSuccess = async () => {
+      if (!canUseRateLimitStore) {
+        return;
+      }
+
+      if (loginRateLimitStore.delete) {
+        try {
+          await loginRateLimitStore.delete(rateLimitKey);
+        } catch (error) {
+          request.log.warn(
+            {
+              err: error,
+              code: "AUTH_PASSWORD_CHANGE_RATE_LIMIT_RESET_FAILED",
+              route: "/api/auth/change-password",
+            },
+            "No se pudo limpiar el rate limit tras cambio de contraseña clinic",
+          );
+        }
+      }
+
+      setLoginRateLimitHeaders(reply, {
+        max: loginRateLimitMaxAttempts,
+        windowMs: loginRateLimitWindowMs,
+        failedCount: 0,
+        resetAt: currentTime + loginRateLimitWindowMs,
+        now: currentTime,
+      });
+    };
+
+    if (!isPasswordChangeBody(request.body)) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    if (!auth.passwordHash) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const currentPasswordCheck = await deps.verifyPassword(
+      request.body.currentPassword,
+      auth.passwordHash,
+    );
+
+    if (!currentPasswordCheck.valid) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const newPasswordMatchesCurrent =
+      request.body.newPassword === request.body.currentPassword ||
+      (
+        await deps.verifyPassword(request.body.newPassword, auth.passwordHash)
+      ).valid;
+
+    if (newPasswordMatchesCurrent) {
+      await markFailure();
+
+      return sendPasswordChangeRejected(reply);
+    }
+
+    const newPasswordHash = await deps.hashPassword(request.body.newPassword);
+
+    await deps.upsertClinicUser({
+      clinicId: auth.clinicId,
+      username: auth.username,
+      passwordHash: newPasswordHash,
+      authProId: auth.authProId,
+      role: auth.role,
+    });
+
+    await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+      event: AUDIT_EVENTS.CLINIC_USER_CREDENTIALS_UPDATED,
+      clinicId: auth.clinicId,
+      targetClinicUserId: auth.id,
+      metadata: {
+        username: auth.username,
+        role: auth.role,
+        selfService: true,
+        sessionMaintained: true,
+      },
+      actor: {
+        type: "clinic_user",
+        clinicUserId: auth.id,
+      },
+    });
+
+    await markSuccess();
+
+    return reply.code(200).send({
+      success: true,
     });
   });
 

--- a/test/auth-password-change.test.ts
+++ b/test/auth-password-change.test.ts
@@ -1,0 +1,469 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Fastify from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../server/lib/env.ts");
+const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const { LOGIN_RATE_LIMIT_CODE } = await import(
+  "../server/lib/login-rate-limit.ts"
+);
+const { createMemoryRateLimitStore } = await import(
+  "../server/lib/rate-limit-store.ts"
+);
+const { adminAuthNativeRoutes } = await import(
+  "../server/routes/admin-auth.fastify.ts"
+);
+const { clinicAuthNativeRoutes } = await import(
+  "../server/routes/auth.fastify.ts"
+);
+
+const ALLOWED_ORIGIN = "http://localhost:3000";
+const PASSWORD_CHANGE_ERROR = "No se pudo actualizar la credencial.";
+const NOW = Date.UTC(2026, 5, 16, 12, 0, 0);
+const FUTURE = new Date("2099-01-01T00:00:00.000Z");
+
+type AuditCall = {
+  event?: unknown;
+  targetAdminUserId?: unknown;
+  targetClinicUserId?: unknown;
+  metadata?: Record<string, unknown>;
+};
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+function assertSecretNotPresent(value: unknown, secret: string): void {
+  assert.equal(
+    JSON.stringify(value).includes(secret),
+    false,
+    `response/audit payload must not contain secret: ${secret}`,
+  );
+}
+
+function createPasswordHarness(input: {
+  initialPassword: string;
+  initialHash: string;
+}) {
+  const passwordByHash = new Map<string, string>([
+    [input.initialHash, input.initialPassword],
+  ]);
+  let storedHash = input.initialHash;
+
+  return {
+    get storedHash() {
+      return storedHash;
+    },
+    setStoredHash(hash: string) {
+      storedHash = hash;
+    },
+    hashPassword: async (password: string) => {
+      const hash = `argon:${password}`;
+      passwordByHash.set(hash, password);
+      return hash;
+    },
+    verifyPassword: async (password: string, passwordHash: string) => ({
+      valid: passwordByHash.get(passwordHash) === password,
+      needsRehash: passwordHash.startsWith("legacy:"),
+    }),
+  };
+}
+
+async function createClinicPasswordChangeApp(input?: {
+  initialPassword?: string;
+  initialHash?: string;
+  maxAttempts?: number;
+}) {
+  const initialPassword = input?.initialPassword ?? "old-clinic-password";
+  const passwords = createPasswordHarness({
+    initialPassword,
+    initialHash: input?.initialHash ?? "legacy:clinic-password",
+  });
+  const auditCalls: AuditCall[] = [];
+  const upserts: Array<Record<string, unknown>> = [];
+  const createdSessions: Array<Record<string, unknown>> = [];
+  const deletedSessions: string[] = [];
+  const app = Fastify();
+
+  const clinicUser = () => ({
+    id: 7,
+    clinicId: 3,
+    username: "vetneb",
+    passwordHash: passwords.storedHash,
+    authProId: null,
+    role: "clinic_owner",
+  });
+
+  await app.register(clinicAuthNativeRoutes as any, {
+    prefix: "/api/auth",
+    now: () => NOW,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: input?.maxAttempts ?? 10,
+    loginRateLimitStore: createMemoryRateLimitStore(),
+    createActiveSession: async (session: Record<string, unknown>) => {
+      createdSessions.push(session);
+    },
+    deleteActiveSession: async (tokenHash: string) => {
+      deletedSessions.push(tokenHash);
+    },
+    getActiveSessionByToken: async (tokenHash: string) =>
+      tokenHash === "hash:clinic-session"
+        ? { clinicUserId: 7, expiresAt: FUTURE }
+        : null,
+    getClinicUserById: async (clinicUserId: number) =>
+      clinicUserId === 7 ? clinicUser() : null,
+    getClinicUserByUsername: async (username: string) =>
+      username.trim() === "vetneb" ? clinicUser() : null,
+    getClinicUserByIdentifier: async (identifier: string) =>
+      identifier.trim() === "vetneb" ? clinicUser() : null,
+    updateSessionLastAccess: async () => {},
+    upsertClinicUser: async (nextUser: Record<string, unknown>) => {
+      upserts.push(nextUser);
+      passwords.setStoredHash(String(nextUser.passwordHash));
+    },
+    generateSessionToken: () => "new-clinic-session",
+    hashPassword: passwords.hashPassword,
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: passwords.verifyPassword,
+    writeAuditLog: async (_req: unknown, input: AuditCall) => {
+      auditCalls.push(input);
+    },
+    recordLoginFailedAttempt: async () => {},
+  });
+
+  return {
+    app,
+    auditCalls,
+    upserts,
+    createdSessions,
+    deletedSessions,
+    getStoredHash: () => passwords.storedHash,
+  };
+}
+
+async function createAdminPasswordChangeApp(input?: {
+  initialPassword?: string;
+  initialHash?: string;
+  maxAttempts?: number;
+}) {
+  const initialPassword = input?.initialPassword ?? "old-admin-password";
+  const passwords = createPasswordHarness({
+    initialPassword,
+    initialHash: input?.initialHash ?? "legacy:admin-password",
+  });
+  const auditCalls: AuditCall[] = [];
+  const updates: Array<Record<string, unknown>> = [];
+  const createdSessions: Array<Record<string, unknown>> = [];
+  const deletedSessions: string[] = [];
+  const app = Fastify();
+
+  const adminUser = () => ({
+    id: 1,
+    username: "VETNEB",
+    passwordHash: passwords.storedHash,
+  });
+
+  await app.register(adminAuthNativeRoutes as any, {
+    prefix: "/api/admin/auth",
+    now: () => NOW,
+    loginRateLimitWindowMs: 60_000,
+    loginRateLimitMaxAttempts: input?.maxAttempts ?? 10,
+    loginRateLimitStore: createMemoryRateLimitStore(),
+    createAdminSession: async (session: Record<string, unknown>) => {
+      createdSessions.push(session);
+    },
+    deleteAdminSession: async (tokenHash: string) => {
+      deletedSessions.push(tokenHash);
+    },
+    getAdminSessionByToken: async (tokenHash: string) =>
+      tokenHash === "hash:admin-session"
+        ? { adminUserId: 1, expiresAt: FUTURE }
+        : null,
+    getAdminUserById: async (adminUserId: number) =>
+      adminUserId === 1 ? { id: 1, username: "VETNEB" } : null,
+    getAdminUserByUsername: async (username: string) =>
+      username.trim() === "VETNEB" ? adminUser() : null,
+    getAdminUserForPasswordChange: async (adminUserId: number) =>
+      adminUserId === 1 ? adminUser() : null,
+    updateAdminSessionLastAccess: async () => {},
+    updateAdminPasswordHash: async (
+      adminUserId: number,
+      passwordHash: string,
+    ) => {
+      updates.push({ adminUserId, passwordHash });
+      passwords.setStoredHash(passwordHash);
+    },
+    generateSessionToken: () => "new-admin-session",
+    hashPassword: passwords.hashPassword,
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: passwords.verifyPassword,
+    writeAuditLog: async (_req: unknown, input: AuditCall) => {
+      auditCalls.push(input);
+    },
+    recordLoginFailedAttempt: async () => {},
+  });
+
+  return {
+    app,
+    auditCalls,
+    updates,
+    createdSessions,
+    deletedSessions,
+    getStoredHash: () => passwords.storedHash,
+  };
+}
+
+test("clinic password change updates hash, keeps session, and allows login with new password", async () => {
+  const oldPassword = "old-clinic-password";
+  const newPassword = "new-clinic-password";
+  const harness = await createClinicPasswordChangeApp({
+    initialPassword: oldPassword,
+    initialHash: "legacy:clinic-password",
+  });
+
+  try {
+    const response = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/change-password",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+        cookie: `${ENV.cookieName}=clinic-session`,
+      },
+      payload: {
+        currentPassword: oldPassword,
+        newPassword,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), { success: true });
+    assert.equal(response.headers["set-cookie"], undefined);
+    assert.equal(harness.deletedSessions.length, 0);
+    assert.equal(harness.getStoredHash(), `argon:${newPassword}`);
+
+    assert.equal(harness.upserts.length, 1);
+    assert.equal(harness.upserts[0].passwordHash, `argon:${newPassword}`);
+    assert.equal(harness.upserts[0].role, "clinic_owner");
+
+    assert.equal(harness.auditCalls.length, 1);
+    assert.equal(
+      harness.auditCalls[0].event,
+      AUDIT_EVENTS.CLINIC_USER_CREDENTIALS_UPDATED,
+    );
+    assert.equal(harness.auditCalls[0].targetClinicUserId, 7);
+    assert.equal(harness.auditCalls[0].metadata?.selfService, true);
+    assert.equal(harness.auditCalls[0].metadata?.sessionMaintained, true);
+    assertSecretNotPresent(harness.auditCalls, oldPassword);
+    assertSecretNotPresent(harness.auditCalls, newPassword);
+
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+      },
+      payload: {
+        username: "vetneb",
+        password: newPassword,
+      },
+    });
+
+    assert.equal(login.statusCode, 200);
+    assert.equal(JSON.parse(login.body).success, true);
+    assert.equal(harness.createdSessions.length, 1);
+  } finally {
+    await harness.app.close();
+  }
+});
+
+test("admin password change updates hash, keeps session, and allows login with new password", async () => {
+  const oldPassword = "old-admin-password";
+  const newPassword = "new-admin-password";
+  const harness = await createAdminPasswordChangeApp({
+    initialPassword: oldPassword,
+    initialHash: "legacy:admin-password",
+  });
+
+  try {
+    const response = await harness.app.inject({
+      method: "POST",
+      url: "/api/admin/auth/change-password",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+        cookie: `${ENV.adminCookieName}=admin-session`,
+      },
+      payload: {
+        currentPassword: oldPassword,
+        newPassword,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), { success: true });
+    assert.equal(response.headers["set-cookie"], undefined);
+    assert.equal(harness.deletedSessions.length, 0);
+    assert.equal(harness.getStoredHash(), `argon:${newPassword}`);
+
+    assert.deepEqual(harness.updates, [
+      {
+        adminUserId: 1,
+        passwordHash: `argon:${newPassword}`,
+      },
+    ]);
+    assert.equal(harness.auditCalls.length, 1);
+    assert.equal(harness.auditCalls[0].event, "auth.admin.password.changed");
+    assert.equal(harness.auditCalls[0].targetAdminUserId, 1);
+    assert.equal(harness.auditCalls[0].metadata?.selfService, true);
+    assert.equal(harness.auditCalls[0].metadata?.sessionMaintained, true);
+    assertSecretNotPresent(harness.auditCalls, oldPassword);
+    assertSecretNotPresent(harness.auditCalls, newPassword);
+
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/admin/auth/login",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+      },
+      payload: {
+        username: "VETNEB",
+        password: newPassword,
+      },
+    });
+
+    assert.equal(login.statusCode, 200);
+    assert.equal(JSON.parse(login.body).success, true);
+    assert.equal(harness.createdSessions.length, 1);
+  } finally {
+    await harness.app.close();
+  }
+});
+
+test("password change failures use generic responses and never update hashes", async () => {
+  const oldPassword = "old-clinic-password";
+  const harness = await createClinicPasswordChangeApp({
+    initialPassword: oldPassword,
+  });
+  const expectedBody = {
+    success: false,
+    error: PASSWORD_CHANGE_ERROR,
+  };
+
+  try {
+    const payloads = [
+      {},
+      { currentPassword: 123, newPassword: "new-clinic-password" },
+      { currentPassword: oldPassword, newPassword: "short" },
+      { currentPassword: "wrong-clinic-password", newPassword: "new-clinic-password" },
+      { currentPassword: oldPassword, newPassword: oldPassword },
+    ];
+
+    for (const payload of payloads) {
+      const response = await harness.app.inject({
+        method: "POST",
+        url: "/api/auth/change-password",
+        headers: {
+          origin: ALLOWED_ORIGIN,
+          cookie: `${ENV.cookieName}=clinic-session`,
+        },
+        payload,
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(JSON.parse(response.body), expectedBody);
+      assertSecretNotPresent(response.body, oldPassword);
+    }
+
+    assert.equal(harness.upserts.length, 0);
+    assert.equal(harness.auditCalls.length, 0);
+  } finally {
+    await harness.app.close();
+  }
+});
+
+test("password change endpoint requires authenticated session", async () => {
+  const harness = await createClinicPasswordChangeApp();
+
+  try {
+    const response = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/change-password",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+      },
+      payload: {
+        currentPassword: "old-clinic-password",
+        newPassword: "new-clinic-password",
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.equal(harness.upserts.length, 0);
+    assert.equal(harness.auditCalls.length, 0);
+  } finally {
+    await harness.app.close();
+  }
+});
+
+test("password change reuses auth rate limit store for failed attempts", async () => {
+  const harness = await createClinicPasswordChangeApp({
+    maxAttempts: 1,
+  });
+
+  try {
+    const first = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/change-password",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+        cookie: `${ENV.cookieName}=clinic-session`,
+      },
+      payload: {
+        currentPassword: "wrong-clinic-password",
+        newPassword: "new-clinic-password",
+      },
+    });
+
+    assert.equal(first.statusCode, 400);
+    assert.equal(first.headers["ratelimit-limit"], "1");
+    assert.equal(first.headers["ratelimit-remaining"], "0");
+
+    const second = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/change-password",
+      headers: {
+        origin: ALLOWED_ORIGIN,
+        cookie: `${ENV.cookieName}=clinic-session`,
+      },
+      payload: {
+        currentPassword: "wrong-clinic-password",
+        newPassword: "new-clinic-password",
+      },
+    });
+
+    assert.equal(second.statusCode, 429);
+    assert.equal(JSON.parse(second.body).code, LOGIN_RATE_LIMIT_CODE);
+    assert.equal(harness.upserts.length, 0);
+    assert.equal(harness.auditCalls.length, 0);
+  } finally {
+    await harness.app.close();
+  }
+});
+
+test("particular auth remains token-backed and has no password change endpoint", () => {
+  const source = readSource("server/routes/particular-auth.fastify.ts");
+
+  assert.equal(source.includes("change-password"), false);
+  assert.equal(source.includes("passwordHash"), false);
+  assert.equal(source.includes("verifyPassword"), false);
+  assert.equal(source.includes("getParticularTokenByTokenHash"), true);
+});

--- a/test/backend-api-no-store-cache-contract.test.ts
+++ b/test/backend-api-no-store-cache-contract.test.ts
@@ -19,6 +19,11 @@ test("sensitive response cache helper clasifica API no publica para no-store", (
   assert.equal(SENSITIVE_API_CACHE_CONTROL, "no-store");
   assert.equal(shouldApplySensitiveApiNoStore("/api/admin/auth/me"), true);
   assert.equal(
+    shouldApplySensitiveApiNoStore("/api/admin/auth/change-password"),
+    true,
+  );
+  assert.equal(shouldApplySensitiveApiNoStore("/api/auth/change-password"), true);
+  assert.equal(
     shouldApplySensitiveApiNoStore("/api/admin/failed-login-alerts?limit=5"),
     true,
   );

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -232,6 +232,7 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           'app.options("/login"',
           'app.options("/me"',
           'app.options("/logout"',
+          'app.options("/change-password"',
         ],
       },
       {
@@ -240,6 +241,7 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
           'app.options("/login"',
           'app.options("/me"',
           'app.options("/logout"',
+          'app.options("/change-password"',
         ],
       },
       {

--- a/test/security-csrf-mutating-route-coverage.test.ts
+++ b/test/security-csrf-mutating-route-coverage.test.ts
@@ -70,7 +70,7 @@ type MutatingRouteFile = {
 
 const MUTATING_ROUTE_FILES: readonly MutatingRouteFile[] = [
   // Admin — clase A (operaciones autenticadas con admin_session_id)
-  { file: "server/routes/admin-auth.fastify.ts", expectedMutations: 2, class: "B" },
+  { file: "server/routes/admin-auth.fastify.ts", expectedMutations: 3, class: "B" },
   { file: "server/routes/admin-clinics.fastify.ts", expectedMutations: 3, class: "A" },
   { file: "server/routes/admin-particular-tokens.fastify.ts", expectedMutations: 4, class: "A" },
   { file: "server/routes/admin-pricing.fastify.ts", expectedMutations: 1, class: "A" },
@@ -82,7 +82,7 @@ const MUTATING_ROUTE_FILES: readonly MutatingRouteFile[] = [
   { file: "server/routes/admin-system-maintenance.fastify.ts", expectedMutations: 1, class: "A" },
   { file: "server/routes/admin-users-roles.fastify.ts", expectedMutations: 2, class: "A" },
   // Clínica — clase A/B (operaciones autenticadas con app_session_id)
-  { file: "server/routes/auth.fastify.ts", expectedMutations: 2, class: "B" },
+  { file: "server/routes/auth.fastify.ts", expectedMutations: 3, class: "B" },
   { file: "server/routes/clinic-public-profile.fastify.ts", expectedMutations: 3, class: "A" },
   { file: "server/routes/report-access-tokens.fastify.ts", expectedMutations: 2, class: "A" },
   { file: "server/routes/reports-status.fastify.ts", expectedMutations: 1, class: "A" },
@@ -651,6 +651,5 @@ test("rutas de preview y download pasan por deps.createSignedReport* (no storage
     );
   }
 });
-
 
 

--- a/test/security-trusted-origin-cors-boundaries.test.ts
+++ b/test/security-trusted-origin-cors-boundaries.test.ts
@@ -209,6 +209,7 @@ test("auth login y mutations bloquean Origin no permitido antes de tocar depende
       createApp: createClinicAuthApp,
       loginUrl: "/api/auth/login",
       logoutUrl: "/api/auth/logout",
+      changePasswordUrl: "/api/auth/change-password",
       cookie: `${ENV.cookieName}=session-token`,
       payload: {
         username: "vetneb",
@@ -220,6 +221,7 @@ test("auth login y mutations bloquean Origin no permitido antes de tocar depende
       createApp: createAdminAuthApp,
       loginUrl: "/api/admin/auth/login",
       logoutUrl: "/api/admin/auth/logout",
+      changePasswordUrl: "/api/admin/auth/change-password",
       cookie: `${ENV.adminCookieName}=admin-session-token`,
       payload: {
         username: "VETNEB",
@@ -231,6 +233,7 @@ test("auth login y mutations bloquean Origin no permitido antes de tocar depende
       createApp: createParticularAuthApp,
       loginUrl: "/api/particular/auth/login",
       logoutUrl: "/api/particular/auth/logout",
+      changePasswordUrl: null,
       cookie: `${ENV.particularCookieName}=particular-session-token`,
       payload: {
         token: "PARTICULAR-RAW-TOKEN",
@@ -263,6 +266,23 @@ test("auth login y mutations bloquean Origin no permitido antes de tocar depende
       });
 
       assertForbiddenOriginResponse(logoutResponse);
+
+      if (scenario.changePasswordUrl) {
+        const changePasswordResponse = await app.inject({
+          method: "POST",
+          url: scenario.changePasswordUrl,
+          headers: {
+            origin: BLOCKED_ORIGIN,
+            cookie: scenario.cookie,
+          },
+          payload: {
+            currentPassword: "secret",
+            newPassword: "new-secret",
+          },
+        });
+
+        assertForbiddenOriginResponse(changePasswordResponse);
+      }
     } finally {
       await app.close();
     }
@@ -274,7 +294,12 @@ test("auth preflight OPTIONS solo expone CORS con origins confiables y sin wildc
     {
       name: "clinic auth",
       createApp: createClinicAuthApp,
-      urls: ["/api/auth/login", "/api/auth/me", "/api/auth/logout"],
+      urls: [
+        "/api/auth/login",
+        "/api/auth/me",
+        "/api/auth/logout",
+        "/api/auth/change-password",
+      ],
     },
     {
       name: "admin auth",
@@ -283,6 +308,7 @@ test("auth preflight OPTIONS solo expone CORS con origins confiables y sin wildc
         "/api/admin/auth/login",
         "/api/admin/auth/me",
         "/api/admin/auth/logout",
+        "/api/admin/auth/change-password",
       ],
     },
     {


### PR DESCRIPTION
# feat(auth): authenticated password change endpoints

## Scope

- Added `POST /api/auth/change-password` for authenticated clinic users.
- Added `POST /api/admin/auth/change-password` for authenticated admin users.
- Request body: `{ currentPassword, newPassword }`.
- Success body: `{ success: true }`.
- Particular auth remains excluded because it is token-backed and has no password hash contract.

## Security contracts

- Both endpoints require the existing cookie-backed authenticated session.
- Both endpoints enforce the existing trusted-origin/CORS boundary before auth deps are touched.
- `currentPassword` is verified with the existing `verifyPassword` helper.
- `newPassword` is hashed with the existing `hashPassword` helper.
- Legacy/current hashes that return `needsRehash` do not block the flow; changing the password writes a fresh hash.
- New passwords follow the existing backend minimum: at least 8 characters and at least 8 non-whitespace-trimmed characters.
- New password equal to the current credential is rejected after the current password has been verified.
- Public failure responses for invalid body/current password/policy/same-password use the same generic error.
- No password/hash is returned in responses or included in audit metadata.
- Sensitive response no-store remains delegated to the global `/api/*` backend hook.

## Rate limit

The endpoints reuse the existing auth rate-limit store with keys scoped as
`password-change:<userId>` plus IP and the current auth surface (`clinic` or
`admin`). This avoids schema or migration changes while preserving per-user/IP
throttling. Failed attempts increment the store; success clears the endpoint key
when the store supports delete.

## Audit and session behavior

- Clinic self-service changes write `clinic_user.credentials.updated` with actor,
  target clinic user, username, role, `selfService`, and `sessionMaintained`.
- Admin self-service changes write `auth.admin.password.changed` with actor,
  target admin user, username, `selfService`, and `sessionMaintained`.
- The current session is maintained. Invalidating other active sessions remains
  a future hardening step because this PR intentionally avoids session schema or
  broad DB helper changes.
- The admin event is written to the existing varchar audit table without adding
  a schema/migration/catalog change; formal catalog inclusion can be handled in
  a later audit taxonomy PR.

## Test coverage

- `test/auth-password-change.test.ts` covers clinic/admin success, login with the
  new password, generic failures, auth requirement, rate limit behavior, audit
  secret boundaries, and particular exclusion.
- CSRF mutation counts were updated for `auth.fastify.ts` and
  `admin-auth.fastify.ts`; particular remains unchanged.
- Trusted-origin/preflight coverage now includes both change-password endpoints.
- Backend no-store cache contract includes both endpoints.
