### PR TITLE
feat(auth): add password change API clients

### DIFF
--- a/IMPLEMENTATION_NOTES/feat-auth-password-change-api-clients.md
+++ b/IMPLEMENTATION_NOTES/feat-auth-password-change-api-clients.md
@@ -1,0 +1,71 @@
+# feat(auth): add password change API clients
+
+## Summary
+- Added frontend API client `changeClinicPassword` for the authenticated clinic
+  password change endpoint.
+- Added frontend API client `changeAdminPassword` for the authenticated admin
+  password change endpoint.
+- Added a shared `ChangePasswordInput` / `ChangePasswordResponse` contract and
+  static test contracts for endpoint, method, payload, credentials, error
+  pattern and surface scope.
+- No UI was added. This PR is API-client wrappers + tests + note only.
+
+## Scope
+Files changed:
+- `frontend/src/lib/api.ts` — new `ChangePasswordInput`, `ChangePasswordResponse`
+  types and `changeClinicPassword` / `changeAdminPassword` clients.
+
+Files added:
+- `test/frontend-api-password-change.test.ts` — contract tests for both clients.
+- `IMPLEMENTATION_NOTES/feat-auth-password-change-api-clients.md` — this note.
+
+Out of scope (intentionally untouched):
+- UI / forms / dashboard / profile / settings components.
+- Backend routes, `server/**`, drizzle / database / migrations.
+- Reset password flow.
+- Particular auth (token-backed, no password-hash contract — `change-password`
+  intentionally absent for the particular surface).
+- `package.json` / `pnpm-lock.yaml` / dependencies.
+- PWA / service worker / FlexSearch.
+
+## Implementation
+- Both clients delegate to the existing shared `apiFetch<T>` helper, inheriting:
+  - `credentials: "include"` (cookie-backed session, same as other auth clients).
+  - `Content-Type: application/json` (auto-set by `apiFetch` for JSON bodies).
+  - The existing `ApiResponseError` / generic-message error path (429 rate-limit
+    handling, `BACKEND_OPERATION_ERROR_MESSAGE` for 5xx, etc.).
+- Endpoints:
+  - clinic: `POST /api/auth/change-password`
+  - admin:  `POST /api/admin/auth/change-password`
+- Body is built explicitly as `{ currentPassword, newPassword }` so only those
+  two fields are serialized (no incidental field leakage).
+- Response type mirrors the backend success body `{ success: true }`.
+
+## Security
+- No `localStorage` / `sessionStorage` / `document.cookie` writes; verified for
+  the new clients and for the whole API client module.
+- No frontend logging of password material (no `console.*` in the clients).
+- Error handling follows the existing `apiFetch` pattern; no new enumerative
+  failure messages were introduced.
+- No tokens or hashes are exposed; only the generic `{ success: true }` is read.
+- Particular surface is not touched; no `/api/particular/auth/change-password`
+  client exists.
+
+## Validation
+Commands run on branch `feat/auth-password-change-api-clients` (results):
+- `pnpm --dir frontend lint` -> PASS (exit 0)
+- `pnpm --dir frontend typecheck` -> PASS (exit 0)
+- `pnpm --dir frontend build` -> PASS (exit 0)
+- `pnpm test` -> PASS (2735 passed, 0 failed)
+- `pnpm typecheck:test` -> PASS (exit 0)
+- `pnpm security:public-surface` -> PASS (no public devtools exposure findings;
+  only pre-existing `server-only` markers in `frontend/src/proxy.ts`)
+- Isolated `test/frontend-api-password-change.test.ts` -> 8 passed, 0 failed
+- `git diff --check` -> clean (exit 0)
+
+## Risk
+Low. API-client wrappers and static contract tests only. No runtime backend,
+schema, dependency or UI changes.
+
+## Rollback
+Revert this PR.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -329,6 +329,39 @@ export async function logout(): Promise<void> {
   await apiFetch<void>("/api/auth/logout", { method: "POST" });
 }
 
+export type ChangePasswordInput = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+export type ChangePasswordResponse = {
+  success: true;
+};
+
+export async function changeClinicPassword(
+  input: ChangePasswordInput,
+): Promise<ChangePasswordResponse> {
+  return apiFetch<ChangePasswordResponse>("/api/auth/change-password", {
+    method: "POST",
+    body: JSON.stringify({
+      currentPassword: input.currentPassword,
+      newPassword: input.newPassword,
+    }),
+  });
+}
+
+export async function changeAdminPassword(
+  input: ChangePasswordInput,
+): Promise<ChangePasswordResponse> {
+  return apiFetch<ChangePasswordResponse>("/api/admin/auth/change-password", {
+    method: "POST",
+    body: JSON.stringify({
+      currentPassword: input.currentPassword,
+      newPassword: input.newPassword,
+    }),
+  });
+}
+
 export async function loginParticular(
   credentials: ParticularLoginCredentials,
 ): Promise<ParticularAuthResponse> {

--- a/test/frontend-api-password-change.test.ts
+++ b/test/frontend-api-password-change.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function getFunctionSource(source: string, functionName: string): string {
+  const signature = `export async function ${functionName}`;
+  const start = source.indexOf(signature);
+
+  if (start === -1) {
+    return "";
+  }
+
+  const nextFunction = source.indexOf(
+    "\nexport async function ",
+    start + signature.length,
+  );
+
+  return nextFunction === -1
+    ? source.slice(start)
+    : source.slice(start, nextFunction);
+}
+
+test("frontend API client exposes a shared change-password input contract", () => {
+  const source = read(API_CLIENT_PATH);
+
+  assert.ok(source.includes("export type ChangePasswordInput = {"));
+  assert.ok(source.includes("currentPassword: string;"));
+  assert.ok(source.includes("newPassword: string;"));
+  assert.ok(source.includes("export type ChangePasswordResponse = {"));
+  assert.ok(source.includes("success: true;"));
+});
+
+test("frontend API client changes clinic password against authenticated auth endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = getFunctionSource(source, "changeClinicPassword");
+
+  assert.ok(
+    functionSource.includes(
+      "export async function changeClinicPassword(",
+    ),
+  );
+  assert.ok(functionSource.includes("input: ChangePasswordInput,"));
+  assert.ok(functionSource.includes("): Promise<ChangePasswordResponse>"));
+  assert.ok(
+    functionSource.includes(
+      'return apiFetch<ChangePasswordResponse>("/api/auth/change-password", {',
+    ),
+  );
+  assert.ok(functionSource.includes('method: "POST",'));
+});
+
+test("frontend API client changes admin password against admin auth endpoint", () => {
+  const source = read(API_CLIENT_PATH);
+  const functionSource = getFunctionSource(source, "changeAdminPassword");
+
+  assert.ok(
+    functionSource.includes(
+      "export async function changeAdminPassword(",
+    ),
+  );
+  assert.ok(functionSource.includes("input: ChangePasswordInput,"));
+  assert.ok(functionSource.includes("): Promise<ChangePasswordResponse>"));
+  assert.ok(
+    functionSource.includes(
+      'return apiFetch<ChangePasswordResponse>("/api/admin/auth/change-password", {',
+    ),
+  );
+  assert.ok(functionSource.includes('method: "POST",'));
+});
+
+test("change-password clients send exactly currentPassword and newPassword", () => {
+  const source = read(API_CLIENT_PATH);
+
+  for (const functionName of [
+    "changeClinicPassword",
+    "changeAdminPassword",
+  ]) {
+    const functionSource = getFunctionSource(source, functionName);
+
+    assert.ok(
+      functionSource.includes("body: JSON.stringify({"),
+      `${functionName} must serialize a JSON body`,
+    );
+    assert.ok(
+      functionSource.includes("currentPassword: input.currentPassword,"),
+      `${functionName} must forward currentPassword`,
+    );
+    assert.ok(
+      functionSource.includes("newPassword: input.newPassword,"),
+      `${functionName} must forward newPassword`,
+    );
+  }
+});
+
+test("change-password clients reuse the shared apiFetch credentials and JSON contract", () => {
+  const source = read(API_CLIENT_PATH);
+
+  // apiFetch centralizes credentials: "include" and Content-Type: application/json,
+  // so the clients must not re-implement fetch nor override those defaults.
+  for (const functionName of [
+    "changeClinicPassword",
+    "changeAdminPassword",
+  ]) {
+    const functionSource = getFunctionSource(source, functionName);
+
+    assert.ok(
+      functionSource.includes("apiFetch<ChangePasswordResponse>("),
+      `${functionName} must delegate to the shared apiFetch helper`,
+    );
+    assert.equal(
+      functionSource.includes("await fetch("),
+      false,
+      `${functionName} must not bypass apiFetch with a raw fetch`,
+    );
+    assert.equal(
+      functionSource.includes("credentials:"),
+      false,
+      `${functionName} must inherit the shared include-credentials default`,
+    );
+  }
+});
+
+test("change-password clients defer error handling to the shared API pattern", () => {
+  const source = read(API_CLIENT_PATH);
+
+  // No bespoke try/catch and no enumerative messages: failures propagate through
+  // the existing ApiResponseError / generic-message path in apiFetch.
+  for (const functionName of [
+    "changeClinicPassword",
+    "changeAdminPassword",
+  ]) {
+    const functionSource = getFunctionSource(source, functionName);
+
+    assert.equal(
+      functionSource.includes("try {"),
+      false,
+      `${functionName} must not wrap apiFetch in a bespoke try/catch`,
+    );
+    assert.equal(
+      functionSource.includes("catch"),
+      false,
+      `${functionName} must not swallow or re-map backend errors`,
+    );
+  }
+});
+
+test("change-password clients never persist or log password material", () => {
+  const source = read(API_CLIENT_PATH);
+
+  for (const functionName of [
+    "changeClinicPassword",
+    "changeAdminPassword",
+  ]) {
+    const functionSource = getFunctionSource(source, functionName);
+
+    assert.equal(
+      functionSource.includes("localStorage"),
+      false,
+      `${functionName} must not touch localStorage`,
+    );
+    assert.equal(
+      functionSource.includes("sessionStorage"),
+      false,
+      `${functionName} must not touch sessionStorage`,
+    );
+    assert.equal(
+      functionSource.includes("document.cookie"),
+      false,
+      `${functionName} must not write cookies directly`,
+    );
+    assert.equal(
+      /console\.(log|warn|error|info)/.test(functionSource),
+      false,
+      `${functionName} must not log password material`,
+    );
+  }
+
+  // Defense in depth: the whole API client never reaches for web storage.
+  assert.equal(source.includes("localStorage"), false);
+  assert.equal(source.includes("sessionStorage"), false);
+});
+
+test("change-password clients stay scoped to clinic and admin surfaces only", () => {
+  const source = read(API_CLIENT_PATH);
+
+  for (const functionName of [
+    "changeClinicPassword",
+    "changeAdminPassword",
+  ]) {
+    const functionSource = getFunctionSource(source, functionName);
+
+    assert.equal(
+      functionSource.toLowerCase().includes("particular"),
+      false,
+      `${functionName} must not touch the particular surface`,
+    );
+  }
+
+  // Only the two authenticated change-password endpoints are wired from the client.
+  assert.ok(source.includes('"/api/auth/change-password"'));
+  assert.ok(source.includes('"/api/admin/auth/change-password"'));
+  assert.equal(
+    source.includes("/api/particular/auth/change-password"),
+    false,
+  );
+});


### PR DESCRIPTION
# feat(auth): add password change API clients

## Summary
- Added frontend API client `changeClinicPassword` for the authenticated clinic
  password change endpoint.
- Added frontend API client `changeAdminPassword` for the authenticated admin
  password change endpoint.
- Added a shared `ChangePasswordInput` / `ChangePasswordResponse` contract and
  static test contracts for endpoint, method, payload, credentials, error
  pattern and surface scope.
- No UI was added. This PR is API-client wrappers + tests + note only.

## Scope
Files changed:
- `frontend/src/lib/api.ts` — new `ChangePasswordInput`, `ChangePasswordResponse`
  types and `changeClinicPassword` / `changeAdminPassword` clients.

Files added:
- `test/frontend-api-password-change.test.ts` — contract tests for both clients.
- `IMPLEMENTATION_NOTES/feat-auth-password-change-api-clients.md` — this note.

Out of scope (intentionally untouched):
- UI / forms / dashboard / profile / settings components.
- Backend routes, `server/**`, drizzle / database / migrations.
- Reset password flow.
- Particular auth (token-backed, no password-hash contract — `change-password`
  intentionally absent for the particular surface).
- `package.json` / `pnpm-lock.yaml` / dependencies.
- PWA / service worker / FlexSearch.

## Implementation
- Both clients delegate to the existing shared `apiFetch<T>` helper, inheriting:
  - `credentials: "include"` (cookie-backed session, same as other auth clients).
  - `Content-Type: application/json` (auto-set by `apiFetch` for JSON bodies).
  - The existing `ApiResponseError` / generic-message error path (429 rate-limit
    handling, `BACKEND_OPERATION_ERROR_MESSAGE` for 5xx, etc.).
- Endpoints:
  - clinic: `POST /api/auth/change-password`
  - admin:  `POST /api/admin/auth/change-password`
- Body is built explicitly as `{ currentPassword, newPassword }` so only those
  two fields are serialized (no incidental field leakage).
- Response type mirrors the backend success body `{ success: true }`.

## Security
- No `localStorage` / `sessionStorage` / `document.cookie` writes; verified for
  the new clients and for the whole API client module.
- No frontend logging of password material (no `console.*` in the clients).
- Error handling follows the existing `apiFetch` pattern; no new enumerative
  failure messages were introduced.
- No tokens or hashes are exposed; only the generic `{ success: true }` is read.
- Particular surface is not touched; no `/api/particular/auth/change-password`
  client exists.

## Validation
Commands run on branch `feat/auth-password-change-api-clients` (results):
- `pnpm --dir frontend lint` -> PASS (exit 0)
- `pnpm --dir frontend typecheck` -> PASS (exit 0)
- `pnpm --dir frontend build` -> PASS (exit 0)
- `pnpm test` -> PASS (2735 passed, 0 failed)
- `pnpm typecheck:test` -> PASS (exit 0)
- `pnpm security:public-surface` -> PASS (no public devtools exposure findings;
  only pre-existing `server-only` markers in `frontend/src/proxy.ts`)
- Isolated `test/frontend-api-password-change.test.ts` -> 8 passed, 0 failed
- `git diff --check` -> clean (exit 0)

## Risk
Low. API-client wrappers and static contract tests only. No runtime backend,
schema, dependency or UI changes.

## Rollback
Revert this PR.
