### PR TITLE
feat(auth): add dashboard password change UI

### DIFF
--- a/IMPLEMENTATION_NOTES/feat-auth-dashboard-password-change-ui.md
+++ b/IMPLEMENTATION_NOTES/feat-auth-dashboard-password-change-ui.md
@@ -1,0 +1,90 @@
+# feat(auth): add dashboard password change UI
+
+## Summary
+- Added dashboard UI for clinic password change.
+- Added dashboard UI for admin password change.
+- Reused the frontend API clients merged in PR #1003
+  (`changeClinicPassword` / `changeAdminPassword`).
+- Single reusable client component selected by a serializable `variant` prop, so
+  the server pages stay free of function props and direct `fetch`.
+
+## Scope
+Files changed:
+- `frontend/src/components/dashboard/PasswordChangePanel.tsx` (new) — reusable
+  "Seguridad" card with the password-change form and all client state.
+- `frontend/src/app/dashboard/page.tsx` — renders `<PasswordChangePanel
+  variant="clinic" />` inside the existing `perfil` (account) workspace, next to
+  the public-profile card. No new module/navigation added.
+- `frontend/src/app/dashboard/admin/page.tsx` — renders `<PasswordChangePanel
+  variant="admin" />` inside the existing `admin-sessions` (access) workspace,
+  next to the sessions card.
+- `test/frontend-dashboard-password-change-ui.test.ts` (new) — static contract
+  tests for both surfaces.
+- `IMPLEMENTATION_NOTES/feat-auth-dashboard-password-change-ui.md` (new) — this
+  note.
+
+Out of scope (intentionally untouched):
+- Backend endpoints / `server/**` (endpoints exist since PR #1002).
+- Reset password / email-password recovery.
+- Particular auth (token-backed, no password-change contract).
+- Dependencies / `package.json` / `pnpm-lock.yaml`.
+- Broad dashboard redesign, new navigation, new modules, layout changes.
+- PWA / service worker / FlexSearch / public pages / GitHub workflows.
+
+## Placement decision
+The dashboard uses a module/workspace hub. Rather than adding a new module
+(which would mean new navigation across controllers, hubs and sidebars), the
+security card is embedded in the most natural existing workspace per role:
+- clinic → `perfil` (the account/profile area),
+- admin → `admin-sessions` (the access/security area).
+The clinic `<ClinicPublicProfileCard />` and admin `<AdminSessionsReadOnlyCard />`
+and `id="admin-sessions"` anchor are preserved, so existing dashboard contracts
+remain green.
+
+## UX
+- "Seguridad" card titled per the suggested copy, subtitle "Actualizá tu
+  contraseña de acceso sin cerrar tu sesión actual."
+- Three labelled password fields: current, new, confirmation.
+- States: idle, submitting ("Actualizando..."), success, validation error,
+  generic server error.
+- Submit button "Actualizar contraseña", disabled while submitting.
+- Success keeps the current session active (no logout) and clears the fields.
+- Success/error are exposed through accessible live regions
+  (`aria-live="polite"` + `role="status"` for success; `aria-live="assertive"` +
+  `role="alert"` for errors).
+
+## Validation rules (client-side, aligned to backend)
+- Required: current, new and confirmation must be present.
+- New password minimum 8 characters (backend minimum).
+- Confirmation must match the new password.
+- New password must differ from the current one.
+- Only `{ currentPassword, newPassword }` is sent; `confirmPassword` never leaves
+  the component.
+
+## Security
+- No `localStorage` / `sessionStorage` / `document.cookie`; passwords live only in
+  component state during interaction.
+- No password logging (no `console.*` in the component or touched pages).
+- No password in query params or URLs; submission goes through the shared
+  `apiFetch` POST body via the existing clients.
+- Backend failures collapse to one generic, non-enumerative message; the catch
+  does not branch on backend error details.
+- No tokens/hashes exposed; particular auth remains excluded (no UI, no client).
+
+## Validation
+Commands run on branch `feat/auth-dashboard-password-change-ui` (results):
+- `pnpm --dir frontend lint` -> PASS (exit 0)
+- `pnpm --dir frontend typecheck` -> PASS (exit 0)
+- `pnpm --dir frontend build` -> PASS (exit 0)
+- `pnpm test` -> PASS (2749 passed, 0 failed)
+- `pnpm typecheck:test` -> PASS (exit 0)
+- `pnpm security:public-surface` -> PASS (no public devtools exposure findings;
+  only pre-existing `server-only` markers in `frontend/src/proxy.ts`)
+- `git diff --check` -> clean (exit 0)
+
+## Risk
+Low/medium. UI only, using existing API clients. No backend, schema, dependency
+or navigation changes.
+
+## Rollback
+Revert this PR.

--- a/IMPLEMENTATION_NOTES/feat-auth-dashboard-password-change-ui.md
+++ b/IMPLEMENTATION_NOTES/feat-auth-dashboard-password-change-ui.md
@@ -88,3 +88,33 @@ or navigation changes.
 
 ## Rollback
 Revert this PR.
+
+## CI follow-up
+- Investigated the Frontend CI failure in `frontend/e2e/public-routes.spec.ts`
+  ("unknown route renders the branded not-found page ..."), which is unrelated to
+  the password-change scope (the PR diff does not touch the not-found page or any
+  public navigation).
+- Root cause: the branded not-found CTAs navigate via an `onClick` handler
+  (`PublicRouteControl` → `router.push`), which only runs after React hydrates.
+  The test clicked "Contactar"/"Volver al inicio" immediately after a
+  `domcontentloaded` navigation, so the click raced hydration and was lost
+  (URL stayed on the unknown route). "Ver servicios" passed only because many
+  awaited assertions preceded it, giving hydration time.
+- The repo intentionally forbids `next/link` and `<a>` in frontend source
+  (public navigation hardening contract), so the product stays on the
+  button + `router.push` pattern. Fix is test-only: wrap the not-found CTA
+  navigations in the suite's established hydration-safe `toPass` retry
+  (mirrors `frontend/e2e/contacto-hydration.spec.ts`).
+- No backend, dependency, product or password-flow scope changes.
+
+### CI follow-up validation
+- `pnpm --dir frontend lint` -> PASS
+- `pnpm --dir frontend typecheck` -> PASS
+- `pnpm --dir frontend build` -> PASS
+- `pnpm --dir frontend exec playwright test e2e/public-routes.spec.ts
+  --project=chromium` -> PASS (9/9, including the previously failing not-found
+  test)
+- `pnpm test` -> PASS (2749 passed, 0 failed; navigation-hardening contracts
+  stay green)
+- `pnpm typecheck:test` -> PASS
+- `pnpm security:public-surface` -> PASS

--- a/frontend/e2e/public-routes.spec.ts
+++ b/frontend/e2e/public-routes.spec.ts
@@ -1,4 +1,28 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+// The branded not-found CTAs navigate through an onClick handler (router.push),
+// which only runs after React hydrates. Right after a `domcontentloaded`
+// navigation the handler may not be attached yet, so the first click can be a
+// no-op and the URL stays put. Retry the click until the navigation actually
+// happens, mirroring the hydration-probe pattern used elsewhere in the suite
+// (see contacto-hydration.spec.ts).
+async function clickAndExpectNavigation(
+  page: Page,
+  name: string,
+  expectedUrl: string,
+): Promise<void> {
+  const control = page.getByRole("button", { name });
+
+  await expect(control).toBeVisible();
+  await expect(control).toBeEnabled();
+  await expect(async () => {
+    await control.click();
+    await expect(page).toHaveURL(expectedUrl, { timeout: 500 });
+  }).toPass({
+    intervals: [50, 100, 250],
+    timeout: 5_000,
+  });
+}
 
 const routes = [
   { path: "/", text: /VETNEB/i },
@@ -80,20 +104,17 @@ test("unknown route renders the branded not-found page without mobile overflow",
   );
   expect(overflow).toBeLessThanOrEqual(0);
 
-  await page.getByRole("button", { name: "Ver servicios" }).click();
-  await expect(page).toHaveURL("/servicios");
+  await clickAndExpectNavigation(page, "Ver servicios", "/servicios");
 
   await page.goto("/ruta-institucional-inexistente", {
     waitUntil: "domcontentloaded",
   });
-  await page.getByRole("button", { name: "Contactar" }).click();
-  await expect(page).toHaveURL("/contacto");
+  await clickAndExpectNavigation(page, "Contactar", "/contacto");
 
   await page.goto("/ruta-institucional-inexistente", {
     waitUntil: "domcontentloaded",
   });
-  await page.getByRole("button", { name: "Volver al inicio" }).click();
-  await expect(page).toHaveURL("/");
+  await clickAndExpectNavigation(page, "Volver al inicio", "/");
 });
 
 test("global metadata publishes one dedicated OpenGraph and Twitter image", async ({

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -29,6 +29,7 @@ import { AdminPricingEditorCard } from "./AdminPricingEditorCard";
 import { AdminSchemaHealthStatusCard } from "./AdminSchemaHealthStatusCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
+import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";
 import { AdminDashboardWorkspaceController } from "./AdminDashboardWorkspaceController";
 import type { AdminModule } from "./AdminDashboardWorkspaceController";
 import { getAdminSystemHealth, getAuditEntries } from "@/lib/api";
@@ -587,8 +588,9 @@ export default async function AdminPage({
 
   // ── Sesiones workspace ──────────────────────────────────────────────────────
   const sessionsWorkspaceSlot = (
-    <section id="admin-sessions">
+    <section id="admin-sessions" className="space-y-6">
       <AdminSessionsReadOnlyCard />
+      <PasswordChangePanel variant="admin" />
     </section>
   );
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import type { ClinicModule } from "@/components/dashboard/ClinicDashboardWorkspa
 import { ClinicCommandCenter } from "./ClinicCommandCenter";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
+import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";
 import { ClinicInformesWorkspaceSummary } from "./ClinicInformesWorkspaceSummary";
 import { ClinicLogisticaWorkspaceSummary } from "./ClinicLogisticaWorkspaceSummary";
 import {
@@ -142,7 +143,12 @@ export default async function DashboardPage({
                   visitsLoadError={visitsLoadError}
                 />
               ),
-              perfil: <ClinicPublicProfileCard />,
+              perfil: (
+                <div className="space-y-6">
+                  <ClinicPublicProfileCard />
+                  <PasswordChangePanel variant="clinic" />
+                </div>
+              ),
               tokens: <ClinicParticularTokensCard />,
             }}
           />

--- a/frontend/src/components/dashboard/PasswordChangePanel.tsx
+++ b/frontend/src/components/dashboard/PasswordChangePanel.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { type FormEvent, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  changeAdminPassword,
+  changeClinicPassword,
+  type ChangePasswordInput,
+  type ChangePasswordResponse,
+} from "@/lib/api";
+
+export type PasswordChangeVariant = "clinic" | "admin";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+const DEFAULT_TITLE = "Seguridad";
+const DEFAULT_DESCRIPTION =
+  "Actualizá tu contraseña de acceso sin cerrar tu sesión actual.";
+
+const SUCCESS_MESSAGE = "Contraseña actualizada correctamente.";
+const GENERIC_ERROR_MESSAGE =
+  "No pudimos cambiar la contraseña. Verificá los datos e intentá nuevamente.";
+
+const REQUIRED_FIELDS_MESSAGE =
+  "Completá la contraseña actual, la nueva y su confirmación.";
+const MIN_LENGTH_MESSAGE =
+  "La nueva contraseña debe tener al menos 8 caracteres.";
+const MISMATCH_MESSAGE =
+  "La nueva contraseña y su confirmación no coinciden.";
+const SAME_AS_CURRENT_MESSAGE =
+  "La nueva contraseña debe ser distinta de la actual.";
+
+// Both authenticated surfaces reuse the API clients merged in PR #1003. The
+// variant maps to the matching client; the token-backed surface is
+// intentionally absent because it has no password-change contract.
+const PASSWORD_CHANGE_HANDLERS: Record<
+  PasswordChangeVariant,
+  (input: ChangePasswordInput) => Promise<ChangePasswordResponse>
+> = {
+  clinic: changeClinicPassword,
+  admin: changeAdminPassword,
+};
+
+type PasswordChangePanelProps = {
+  variant: PasswordChangeVariant;
+  title?: string;
+  description?: string;
+};
+
+type PasswordFormState = {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+};
+
+const INITIAL_FORM_STATE: PasswordFormState = {
+  currentPassword: "",
+  newPassword: "",
+  confirmPassword: "",
+};
+
+function getValidationError(state: PasswordFormState): string | null {
+  if (
+    !state.currentPassword ||
+    !state.newPassword ||
+    !state.confirmPassword
+  ) {
+    return REQUIRED_FIELDS_MESSAGE;
+  }
+
+  if (state.newPassword.length < MIN_PASSWORD_LENGTH) {
+    return MIN_LENGTH_MESSAGE;
+  }
+
+  if (state.newPassword !== state.confirmPassword) {
+    return MISMATCH_MESSAGE;
+  }
+
+  if (state.newPassword === state.currentPassword) {
+    return SAME_AS_CURRENT_MESSAGE;
+  }
+
+  return null;
+}
+
+export function PasswordChangePanel({
+  variant,
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+}: PasswordChangePanelProps) {
+  const fieldId = useId();
+  const currentPasswordId = `${fieldId}-current-password`;
+  const newPasswordId = `${fieldId}-new-password`;
+  const confirmPasswordId = `${fieldId}-confirm-password`;
+
+  const [formState, setFormState] =
+    useState<PasswordFormState>(INITIAL_FORM_STATE);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function updateField(field: keyof PasswordFormState, value: string) {
+    setFormState((current) => ({ ...current, [field]: value }));
+    setStatusMessage(null);
+    setErrorMessage(null);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const validationError = getValidationError(formState);
+
+    if (validationError) {
+      setStatusMessage(null);
+      setErrorMessage(validationError);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      // Only the two backend-required fields leave the component; the
+      // confirmation stays local and is never transmitted.
+      await PASSWORD_CHANGE_HANDLERS[variant]({
+        currentPassword: formState.currentPassword,
+        newPassword: formState.newPassword,
+      });
+
+      // Success keeps the current session active and clears the sensitive
+      // fields from component state.
+      setFormState(INITIAL_FORM_STATE);
+      setStatusMessage(SUCCESS_MESSAGE);
+    } catch {
+      // Backend failures collapse to a single generic, non-enumerative message.
+      setErrorMessage(GENERIC_ERROR_MESSAGE);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Card id={`${variant}-password-change`} className="dashboard-surface">
+      <CardHeader className="border-b border-vetneb-line/70">
+        <CardTitle className="text-base">{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="pt-6">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor={currentPasswordId} className="field-label">
+              Contraseña actual
+            </label>
+            <Input
+              id={currentPasswordId}
+              name="currentPassword"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={formState.currentPassword}
+              onChange={(event) =>
+                updateField("currentPassword", event.target.value)
+              }
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div>
+            <label htmlFor={newPasswordId} className="field-label">
+              Nueva contraseña
+            </label>
+            <Input
+              id={newPasswordId}
+              name="newPassword"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              value={formState.newPassword}
+              onChange={(event) =>
+                updateField("newPassword", event.target.value)
+              }
+              disabled={isSubmitting}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Mínimo 8 caracteres.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor={confirmPasswordId} className="field-label">
+              Confirmar nueva contraseña
+            </label>
+            <Input
+              id={confirmPasswordId}
+              name="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              value={formState.confirmPassword}
+              onChange={(event) =>
+                updateField("confirmPassword", event.target.value)
+              }
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div aria-live="polite" role="status">
+            {statusMessage ? (
+              <p className="clinical-alert-success px-3 py-2">
+                {statusMessage}
+              </p>
+            ) : null}
+          </div>
+
+          <div aria-live="assertive">
+            {errorMessage ? (
+              <p className="clinical-alert-error px-3 py-2" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
+          </div>
+
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Actualizando..." : "Actualizar contraseña"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/test/frontend-dashboard-password-change-ui.test.ts
+++ b/test/frontend-dashboard-password-change-ui.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PANEL_PATH =
+  "frontend/src/components/dashboard/PasswordChangePanel.tsx";
+const CLINIC_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function countOccurrences(source: string, marker: string): number {
+  return source.split(marker).length - 1;
+}
+
+function getFunctionBody(source: string, signature: string): string {
+  const start = source.indexOf(signature);
+
+  if (start === -1) {
+    return "";
+  }
+
+  const braceStart = source.indexOf("{", start);
+  let depth = 0;
+
+  for (let index = braceStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(braceStart, index + 1);
+      }
+    }
+  }
+
+  return source.slice(braceStart);
+}
+
+test("password change panel reuses both merged API clients mapped by variant", () => {
+  const source = read(PANEL_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("changeAdminPassword,"));
+  assert.ok(source.includes("changeClinicPassword,"));
+  assert.ok(source.includes("type ChangePasswordInput,"));
+  assert.ok(source.includes("type ChangePasswordResponse,"));
+  assert.ok(source.includes('} from "@/lib/api";'));
+
+  // Variant maps to the matching authenticated client.
+  assert.ok(source.includes("clinic: changeClinicPassword,"));
+  assert.ok(source.includes("admin: changeAdminPassword,"));
+});
+
+test("clinic dashboard wires the panel with the clinic variant", () => {
+  const source = read(CLINIC_PAGE_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";',
+    ),
+  );
+  assert.ok(source.includes('<PasswordChangePanel variant="clinic" />'));
+  // The existing public profile card is preserved in the same workspace.
+  assert.ok(source.includes("<ClinicPublicProfileCard />"));
+});
+
+test("admin dashboard wires the panel with the admin variant", () => {
+  const source = read(ADMIN_PAGE_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";',
+    ),
+  );
+  assert.ok(source.includes('<PasswordChangePanel variant="admin" />'));
+  // The existing sessions card and its anchor are preserved.
+  assert.ok(source.includes("<AdminSessionsReadOnlyCard />"));
+  assert.ok(source.includes('id="admin-sessions"'));
+});
+
+test("no clinic, admin or particular password change leaks to public/particular surfaces", () => {
+  const panel = read(PANEL_PATH);
+  const apiClient = read(API_CLIENT_PATH);
+
+  // No particular password-change UI surface exists.
+  assert.equal(panel.toLowerCase().includes("particular"), false);
+  assert.equal(panel.includes("changeParticularPassword"), false);
+
+  // No particular password-change client exists in the API layer.
+  assert.equal(apiClient.includes("changeParticularPassword"), false);
+  assert.equal(
+    apiClient.includes("/api/particular/auth/change-password"),
+    false,
+  );
+});
+
+test("password change form exposes the three required password fields", () => {
+  const source = read(PANEL_PATH);
+
+  assert.ok(source.includes("Contraseña actual"));
+  assert.ok(source.includes("Nueva contraseña"));
+  assert.ok(source.includes("Confirmar nueva contraseña"));
+
+  assert.ok(source.includes('name="currentPassword"'));
+  assert.ok(source.includes('name="newPassword"'));
+  assert.ok(source.includes('name="confirmPassword"'));
+
+  // Exactly three password inputs, no more.
+  assert.equal(countOccurrences(source, 'type="password"'), 3);
+});
+
+test("password fields use the correct autocomplete tokens", () => {
+  const source = read(PANEL_PATH);
+
+  assert.ok(source.includes('autoComplete="current-password"'));
+  // Both the new password and its confirmation use the new-password token.
+  assert.equal(countOccurrences(source, 'autoComplete="new-password"'), 2);
+});
+
+test("submit sends only currentPassword and newPassword, never the confirmation", () => {
+  const source = read(PANEL_PATH);
+  const handlerBody = getFunctionBody(
+    source,
+    "async function handleSubmit(",
+  );
+
+  assert.ok(handlerBody.includes("PASSWORD_CHANGE_HANDLERS[variant]({"));
+  assert.ok(
+    handlerBody.includes("currentPassword: formState.currentPassword,"),
+  );
+  assert.ok(handlerBody.includes("newPassword: formState.newPassword,"));
+
+  // The confirmation never leaves the component (no payload field for it).
+  assert.equal(
+    handlerBody.includes("confirmPassword: formState.confirmPassword"),
+    false,
+  );
+  assert.equal(handlerBody.includes("confirmPassword:"), false);
+});
+
+test("password change enforces the required, length, match and difference rules", () => {
+  const source = read(PANEL_PATH);
+  const validationBody = getFunctionBody(
+    source,
+    "function getValidationError(",
+  );
+
+  assert.ok(validationBody.includes("!state.currentPassword"));
+  assert.ok(validationBody.includes("!state.newPassword"));
+  assert.ok(validationBody.includes("!state.confirmPassword"));
+  assert.ok(validationBody.includes("state.newPassword.length < MIN_PASSWORD_LENGTH"));
+  assert.ok(validationBody.includes("state.newPassword !== state.confirmPassword"));
+  assert.ok(validationBody.includes("state.newPassword === state.currentPassword"));
+  assert.ok(source.includes("const MIN_PASSWORD_LENGTH = 8;"));
+});
+
+test("success keeps the session, resets fields and shows the non-sensitive message", () => {
+  const source = read(PANEL_PATH);
+  const handlerBody = getFunctionBody(
+    source,
+    "async function handleSubmit(",
+  );
+
+  assert.ok(source.includes('"Contraseña actualizada correctamente."'));
+  assert.ok(handlerBody.includes("setFormState(INITIAL_FORM_STATE);"));
+  assert.ok(handlerBody.includes("setStatusMessage(SUCCESS_MESSAGE);"));
+
+  // No logout / session teardown on success.
+  assert.equal(source.includes("logout"), false);
+  assert.equal(source.includes("setUser(null)"), false);
+});
+
+test("backend errors collapse to a single generic non-enumerative message", () => {
+  const source = read(PANEL_PATH);
+  const handlerBody = getFunctionBody(
+    source,
+    "async function handleSubmit(",
+  );
+
+  assert.ok(
+    source.includes(
+      '"No pudimos cambiar la contraseña. Verificá los datos e intentá nuevamente."',
+    ),
+  );
+  assert.ok(handlerBody.includes("} catch {"));
+  assert.ok(handlerBody.includes("setErrorMessage(GENERIC_ERROR_MESSAGE);"));
+
+  // The catch must not branch on backend error details (no enumeration).
+  assert.equal(handlerBody.includes("error.message"), false);
+  assert.equal(handlerBody.includes("instanceof"), false);
+});
+
+test("success and error regions are accessible live regions", () => {
+  const source = read(PANEL_PATH);
+
+  assert.ok(source.includes('aria-live="polite"'));
+  assert.ok(source.includes('role="status"'));
+  assert.ok(source.includes('aria-live="assertive"'));
+  assert.ok(source.includes('role="alert"'));
+});
+
+test("submit button reflects loading and disabled states", () => {
+  const source = read(PANEL_PATH);
+
+  assert.ok(source.includes('type="submit"'));
+  assert.ok(source.includes("disabled={isSubmitting}"));
+  assert.ok(source.includes("Actualizando..."));
+  assert.ok(source.includes("Actualizar contraseña"));
+});
+
+test("password change UI never persists or logs sensitive material", () => {
+  for (const path of [PANEL_PATH, CLINIC_PAGE_PATH, ADMIN_PAGE_PATH]) {
+    const source = read(path);
+
+    assert.equal(source.includes("localStorage"), false, `${path} localStorage`);
+    assert.equal(
+      source.includes("sessionStorage"),
+      false,
+      `${path} sessionStorage`,
+    );
+    assert.equal(
+      source.includes("document.cookie"),
+      false,
+      `${path} document.cookie`,
+    );
+    assert.equal(
+      /console\.(log|warn|error|info)/.test(source),
+      false,
+      `${path} console logging`,
+    );
+  }
+});
+
+test("password change UI stays frontend-only with no backend or dependency reach", () => {
+  const panel = read(PANEL_PATH);
+
+  for (const forbidden of ["server/", "/api/auth", "/api/admin", "fetch("]) {
+    assert.equal(
+      panel.includes(forbidden),
+      false,
+      `panel must not reach ${forbidden} directly`,
+    );
+  }
+});


### PR DESCRIPTION
# feat(auth): add dashboard password change UI

## Summary
- Added dashboard UI for clinic password change.
- Added dashboard UI for admin password change.
- Reused the frontend API clients merged in PR #1003
  (`changeClinicPassword` / `changeAdminPassword`).
- Single reusable client component selected by a serializable `variant` prop, so
  the server pages stay free of function props and direct `fetch`.

## Scope
Files changed:
- `frontend/src/components/dashboard/PasswordChangePanel.tsx` (new) — reusable
  "Seguridad" card with the password-change form and all client state.
- `frontend/src/app/dashboard/page.tsx` — renders `<PasswordChangePanel
  variant="clinic" />` inside the existing `perfil` (account) workspace, next to
  the public-profile card. No new module/navigation added.
- `frontend/src/app/dashboard/admin/page.tsx` — renders `<PasswordChangePanel
  variant="admin" />` inside the existing `admin-sessions` (access) workspace,
  next to the sessions card.
- `test/frontend-dashboard-password-change-ui.test.ts` (new) — static contract
  tests for both surfaces.
- `IMPLEMENTATION_NOTES/feat-auth-dashboard-password-change-ui.md` (new) — this
  note.

Out of scope (intentionally untouched):
- Backend endpoints / `server/**` (endpoints exist since PR #1002).
- Reset password / email-password recovery.
- Particular auth (token-backed, no password-change contract).
- Dependencies / `package.json` / `pnpm-lock.yaml`.
- Broad dashboard redesign, new navigation, new modules, layout changes.
- PWA / service worker / FlexSearch / public pages / GitHub workflows.

## Placement decision
The dashboard uses a module/workspace hub. Rather than adding a new module
(which would mean new navigation across controllers, hubs and sidebars), the
security card is embedded in the most natural existing workspace per role:
- clinic → `perfil` (the account/profile area),
- admin → `admin-sessions` (the access/security area).
The clinic `<ClinicPublicProfileCard />` and admin `<AdminSessionsReadOnlyCard />`
and `id="admin-sessions"` anchor are preserved, so existing dashboard contracts
remain green.

## UX
- "Seguridad" card titled per the suggested copy, subtitle "Actualizá tu
  contraseña de acceso sin cerrar tu sesión actual."
- Three labelled password fields: current, new, confirmation.
- States: idle, submitting ("Actualizando..."), success, validation error,
  generic server error.
- Submit button "Actualizar contraseña", disabled while submitting.
- Success keeps the current session active (no logout) and clears the fields.
- Success/error are exposed through accessible live regions
  (`aria-live="polite"` + `role="status"` for success; `aria-live="assertive"` +
  `role="alert"` for errors).

## Validation rules (client-side, aligned to backend)
- Required: current, new and confirmation must be present.
- New password minimum 8 characters (backend minimum).
- Confirmation must match the new password.
- New password must differ from the current one.
- Only `{ currentPassword, newPassword }` is sent; `confirmPassword` never leaves
  the component.

## Security
- No `localStorage` / `sessionStorage` / `document.cookie`; passwords live only in
  component state during interaction.
- No password logging (no `console.*` in the component or touched pages).
- No password in query params or URLs; submission goes through the shared
  `apiFetch` POST body via the existing clients.
- Backend failures collapse to one generic, non-enumerative message; the catch
  does not branch on backend error details.
- No tokens/hashes exposed; particular auth remains excluded (no UI, no client).

## Validation
Commands run on branch `feat/auth-dashboard-password-change-ui` (results):
- `pnpm --dir frontend lint` -> PASS (exit 0)
- `pnpm --dir frontend typecheck` -> PASS (exit 0)
- `pnpm --dir frontend build` -> PASS (exit 0)
- `pnpm test` -> PASS (2749 passed, 0 failed)
- `pnpm typecheck:test` -> PASS (exit 0)
- `pnpm security:public-surface` -> PASS (no public devtools exposure findings;
  only pre-existing `server-only` markers in `frontend/src/proxy.ts`)
- `git diff --check` -> clean (exit 0)

## Risk
Low/medium. UI only, using existing API clients. No backend, schema, dependency
or navigation changes.

## Rollback
Revert this PR.
