### PR TITLE
fix(dashboard): surface password change panel in workspaces

### DIFF
--- a/IMPLEMENTATION_NOTES/fix-dashboard-surface-password-change-panel.md
+++ b/IMPLEMENTATION_NOTES/fix-dashboard-surface-password-change-panel.md
@@ -1,0 +1,58 @@
+# fix(dashboard): surface password change panel in workspaces
+
+## Summary
+- Moved the password change security panel above existing workspace content.
+- Clinic: security panel now appears before the public profile card.
+- Admin: security panel now appears before the sessions card.
+
+## Reason
+The PR #1004 UI existed but was too hidden inside existing workspaces, below
+other cards. On opening the workspace the user saw the pre-existing card first
+and the "Seguridad" panel sat below the fold, so the change looked absent from
+the dashboard. Reordering the JSX surfaces the panel immediately, without adding
+any new module, navigation, route or behavior.
+
+## Scope
+Changed:
+- `frontend/src/app/dashboard/page.tsx` — clinic `perfil` workspace renders
+  `<PasswordChangePanel variant="clinic" />` before `<ClinicPublicProfileCard />`.
+- `frontend/src/app/dashboard/admin/page.tsx` — admin `admin-sessions` workspace
+  renders `<PasswordChangePanel variant="admin" />` before
+  `<AdminSessionsReadOnlyCard />`. The `id="admin-sessions"` anchor and the
+  sessions card are preserved.
+- `test/frontend-dashboard-password-change-ui.test.ts` — added static order
+  contracts (panel before the existing card on each surface) and a guard that no
+  new "Seguridad" module is introduced.
+- `IMPLEMENTATION_NOTES/fix-dashboard-surface-password-change-panel.md` (new) —
+  this note.
+
+Out of scope (intentionally untouched):
+- backend / `server/**`
+- API clients (`changeClinicPassword` / `changeAdminPassword` unchanged)
+- routes / workspace controllers / module routing
+- new dashboard module ("Seguridad")
+- sidebar / hub / cards navigation
+- particular auth
+- dependencies / `package.json` / `pnpm-lock.yaml`
+- PWA / service worker / public pages / GitHub workflows
+
+## Behavior preserved
+- Same imports, same `variant` props, same API clients, same copy, same module,
+  same validation, success and error states. Only JSX order changed.
+
+## Validation
+Commands run on branch `fix/dashboard-surface-password-change-panel` (results):
+- `pnpm --dir frontend lint` -> PASS (exit 0)
+- `pnpm --dir frontend typecheck` -> PASS (exit 0)
+- `pnpm --dir frontend build` -> PASS (exit 0)
+- `pnpm test` -> PASS (2749 passed, 0 failed)
+- `pnpm typecheck:test` -> PASS (exit 0)
+- `pnpm security:public-surface` -> PASS (no public devtools exposure findings;
+  only the pre-existing `server-only` markers in `frontend/src/proxy.ts`)
+- `git diff --check` -> clean (exit 0)
+
+## Risk
+Low. JSX order only, no behavior, copy or routing changes.
+
+## Rollback
+Revert this PR.

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -589,8 +589,8 @@ export default async function AdminPage({
   // ── Sesiones workspace ──────────────────────────────────────────────────────
   const sessionsWorkspaceSlot = (
     <section id="admin-sessions" className="space-y-6">
-      <AdminSessionsReadOnlyCard />
       <PasswordChangePanel variant="admin" />
+      <AdminSessionsReadOnlyCard />
     </section>
   );
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -145,8 +145,8 @@ export default async function DashboardPage({
               ),
               perfil: (
                 <div className="space-y-6">
-                  <ClinicPublicProfileCard />
                   <PasswordChangePanel variant="clinic" />
+                  <ClinicPublicProfileCard />
                 </div>
               ),
               tokens: <ClinicParticularTokensCard />,

--- a/test/frontend-dashboard-password-change-ui.test.ts
+++ b/test/frontend-dashboard-password-change-ui.test.ts
@@ -70,6 +70,18 @@ test("clinic dashboard wires the panel with the clinic variant", () => {
   assert.ok(source.includes('<PasswordChangePanel variant="clinic" />'));
   // The existing public profile card is preserved in the same workspace.
   assert.ok(source.includes("<ClinicPublicProfileCard />"));
+
+  // PR #1005: the security panel is surfaced above the public profile card so
+  // it is visible immediately when the perfil workspace opens.
+  assert.ok(
+    source.indexOf('<PasswordChangePanel variant="clinic" />') <
+      source.indexOf("<ClinicPublicProfileCard />"),
+    "clinic password panel must render before the public profile card",
+  );
+
+  // No new "Seguridad" module/navigation is introduced; the panel stays inside
+  // the existing perfil workspace.
+  assert.equal(source.toLowerCase().includes('"seguridad"'), false);
 });
 
 test("admin dashboard wires the panel with the admin variant", () => {
@@ -84,6 +96,18 @@ test("admin dashboard wires the panel with the admin variant", () => {
   // The existing sessions card and its anchor are preserved.
   assert.ok(source.includes("<AdminSessionsReadOnlyCard />"));
   assert.ok(source.includes('id="admin-sessions"'));
+
+  // PR #1005: the security panel is surfaced above the sessions card so it is
+  // visible immediately when the admin-sessions workspace opens.
+  assert.ok(
+    source.indexOf('<PasswordChangePanel variant="admin" />') <
+      source.indexOf("<AdminSessionsReadOnlyCard />"),
+    "admin password panel must render before the sessions card",
+  );
+
+  // No new "Seguridad" admin module/navigation is introduced; the panel stays
+  // inside the existing admin-sessions workspace.
+  assert.equal(source.toLowerCase().includes('"seguridad"'), false);
 });
 
 test("no clinic, admin or particular password change leaks to public/particular surfaces", () => {


### PR DESCRIPTION
# fix(dashboard): surface password change panel in workspaces

## Summary
- Moved the password change security panel above existing workspace content.
- Clinic: security panel now appears before the public profile card.
- Admin: security panel now appears before the sessions card.

## Reason
The PR #1004 UI existed but was too hidden inside existing workspaces, below
other cards. On opening the workspace the user saw the pre-existing card first
and the "Seguridad" panel sat below the fold, so the change looked absent from
the dashboard. Reordering the JSX surfaces the panel immediately, without adding
any new module, navigation, route or behavior.

## Scope
Changed:
- `frontend/src/app/dashboard/page.tsx` — clinic `perfil` workspace renders
  `<PasswordChangePanel variant="clinic" />` before `<ClinicPublicProfileCard />`.
- `frontend/src/app/dashboard/admin/page.tsx` — admin `admin-sessions` workspace
  renders `<PasswordChangePanel variant="admin" />` before
  `<AdminSessionsReadOnlyCard />`. The `id="admin-sessions"` anchor and the
  sessions card are preserved.
- `test/frontend-dashboard-password-change-ui.test.ts` — added static order
  contracts (panel before the existing card on each surface) and a guard that no
  new "Seguridad" module is introduced.
- `IMPLEMENTATION_NOTES/fix-dashboard-surface-password-change-panel.md` (new) —
  this note.

Out of scope (intentionally untouched):
- backend / `server/**`
- API clients (`changeClinicPassword` / `changeAdminPassword` unchanged)
- routes / workspace controllers / module routing
- new dashboard module ("Seguridad")
- sidebar / hub / cards navigation
- particular auth
- dependencies / `package.json` / `pnpm-lock.yaml`
- PWA / service worker / public pages / GitHub workflows

## Behavior preserved
- Same imports, same `variant` props, same API clients, same copy, same module,
  same validation, success and error states. Only JSX order changed.

## Validation
Commands run on branch `fix/dashboard-surface-password-change-panel` (results):
- `pnpm --dir frontend lint` -> PASS (exit 0)
- `pnpm --dir frontend typecheck` -> PASS (exit 0)
- `pnpm --dir frontend build` -> PASS (exit 0)
- `pnpm test` -> PASS (2749 passed, 0 failed)
- `pnpm typecheck:test` -> PASS (exit 0)
- `pnpm security:public-surface` -> PASS (no public devtools exposure findings;
  only the pre-existing `server-only` markers in `frontend/src/proxy.ts`)
- `git diff --check` -> clean (exit 0)

## Risk
Low. JSX order only, no behavior, copy or routing changes.

## Rollback
Revert this PR.
