### PR TITLE
feat(dashboard): introduce premium workspace visual shell

### DIFF
--- a/IMPLEMENTATION_NOTES/feat-dashboard-premium-visual-shell.md
+++ b/IMPLEMENTATION_NOTES/feat-dashboard-premium-visual-shell.md
@@ -3,6 +3,8 @@
 Rama: `feat/dashboard-premium-visual-shell` · Base: `main` @ `e262643`
 Normas: ISO/IEC 25010 (usabilidad/mantenibilidad), ISO/IEC 25000 SQuaRE, ISO 9001, ISO/IEC 5055, ISO/IEC 15504 SPICE, ISO 27001, ISO/IEC 14598.
 
+> **Addendum (PR #1007 — fix CI E2E).** El run Frontend CI falló en `e2e/dashboard-card-navigation-shell.spec.ts` (2 tests de accesibilidad de cards). Causa raíz: el spec selecciona las cards del hub con `hub.locator("button")` dentro de `[data-dashboard-module-hub="true"]` y exige `aria-label` en **todo** `<button>`; el hero quedaba **dentro** de esa sección y su CTA (botón con texto, sin `aria-label`) contaminaba la colección de cards. Fix quirúrgico: en `DashboardModuleHub` el hero se renderiza ahora en un slot `data-dashboard-hub-hero-slot="true"` **fuera** (antes) de la sección de cards. Sin cambios visuales, sin perder el hero, cero dependencias. Validado: el spec pasa 65/65 (incluidos los 2 tests antes en rojo). Detalle en §“Addendum — fix CI E2E”.
+
 ## Resumen
 
 El primer viewport de `/dashboard` y `/dashboard/admin` (landing del hub, sin `?module=`) era una grilla plana de tarjetas sin datos vivos: el contenido operativo (KPIs, estado del sistema) vivía una capa adentro, dentro de los módulos. Los PRs #1004/#1005 sumaron funcionalidad **dentro** de módulos, por eso el landing seguía igual.
@@ -108,5 +110,47 @@ git add frontend/src/components/dashboard/DashboardHubHero.tsx `
 git commit -m "feat(dashboard): introduce premium workspace visual shell"
 git push -u origin feat/dashboard-premium-visual-shell
 gh pr create --fill
+gh pr checks --watch
+```
+
+---
+
+## Addendum — fix CI E2E (PR #1007)
+
+### Diagnóstico
+- **Síntoma**: Frontend CI/validate-frontend rojo en `e2e/dashboard-card-navigation-shell.spec.ts` (2 failed / 248 passed):
+  - `clinic dashboard — module hub initial state › clinic hub cards have accessible names with descriptions` → `card 0 should have aria-label` (Received: null).
+  - `admin dashboard — module hub initial state › admin hub cards have accessible names` → `admin card 0 should have aria-label` (Received: null).
+- **Causa raíz**: ambos tests recogen las cards con `const cards = hub.locator("button")` dentro de `[data-dashboard-module-hub="true"]` y validan que **cada** `<button>` tenga `aria-label`. El `DashboardHubHero` se renderizaba **dentro** de esa sección y su CTA es un `<button>` con texto visible pero sin `aria-label`, por lo que entraba en la colección de cards y rompía el aserto. No es un defecto de accesibilidad real (el botón tiene nombre accesible por su texto); es contaminación del selector de cards.
+
+### Cambio aplicado (mínimo)
+- `frontend/src/components/dashboard/DashboardModuleHub.tsx`: el hero pasa a un slot envolvente `data-dashboard-hub-hero-slot="true"` ubicado **fuera** (antes) de la `<section data-dashboard-module-hub="true">`. Se conservan todos los contratos de cards (`data-dashboard-module-card`, `dashboard-card-interactive`, focus rings) y el `aria-label` de la sección.
+- `test/frontend-dashboard-hub-hero.test.ts`: el contrato del slot ahora exige `data-dashboard-hub-hero-slot="true"` y que el hero se renderice **antes** de la sección de cards (guardia de regresión que reproduce el invariante del E2E a nivel unitario).
+
+### Archivos modificados (relativo al commit del PR)
+- `frontend/src/components/dashboard/DashboardModuleHub.tsx`
+- `test/frontend-dashboard-hub-hero.test.ts`
+- `IMPLEMENTATION_NOTES/feat-dashboard-premium-visual-shell.md` (esta nota)
+
+### Validaciones ejecutadas (Terminal 1)
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend e2e -- e2e/dashboard-card-navigation-shell.spec.ts` | ✅ **65 passed** (incluye los 2 tests antes en rojo) |
+| `pnpm --dir frontend typecheck` | ✅ PASS |
+| `pnpm --dir frontend lint` | ✅ PASS |
+| `pnpm --dir frontend build` | ✅ PASS |
+| `pnpm test` (contratos) | ✅ **2758 pass / 0 fail** (incluye hub-hero, shell, interaction-foundation, last-module, visual-consistency, password-change-ui) |
+| `git diff --check` | ✅ sin errores |
+
+> Nota: el webServer de Playwright corre `next dev`, que reescribe `frontend/next-env.d.ts` al path dev. Se restauró con `git checkout -- frontend/next-env.d.ts` y `next build` lo deja en el path de producción. Working tree final: sólo los 3 archivos del fix.
+
+### Dependencias
+Cero dependencias nuevas (`package.json` / `pnpm-lock.yaml` sin cambios).
+
+### Comandos para Nico (Git manual)
+```powershell
+git add -A
+git commit -m "fix(dashboard): keep hero outside hub card selectors"
+git push
 gh pr checks --watch
 ```

--- a/IMPLEMENTATION_NOTES/feat-dashboard-premium-visual-shell.md
+++ b/IMPLEMENTATION_NOTES/feat-dashboard-premium-visual-shell.md
@@ -1,0 +1,112 @@
+# feat(dashboard): introduce premium workspace visual shell
+
+Rama: `feat/dashboard-premium-visual-shell` · Base: `main` @ `e262643`
+Normas: ISO/IEC 25010 (usabilidad/mantenibilidad), ISO/IEC 25000 SQuaRE, ISO 9001, ISO/IEC 5055, ISO/IEC 15504 SPICE, ISO 27001, ISO/IEC 14598.
+
+## Resumen
+
+El primer viewport de `/dashboard` y `/dashboard/admin` (landing del hub, sin `?module=`) era una grilla plana de tarjetas sin datos vivos: el contenido operativo (KPIs, estado del sistema) vivía una capa adentro, dentro de los módulos. Los PRs #1004/#1005 sumaron funcionalidad **dentro** de módulos, por eso el landing seguía igual.
+
+Este PR introduce una **shell visual premium en el landing del hub**: una banda **hero operativo** ancha, con gradiente institucional navy→teal, datos vivos ya disponibles, status chip y CTA principal — renderizada **antes** de navegar a ningún módulo. El cambio es evidente al entrar, en la primera pantalla, en ambos roles.
+
+## Alcance
+
+- Sólo frontend dashboard clínica (`/dashboard`) y admin (`/dashboard/admin`).
+- Cambio **aditivo**: no se elimina ninguna estructura existente.
+- Sin backend, DB, migrations, auth, contratos API ni producción.
+- Conserva navegación, sidebar, `PasswordChangePanel`, persistencia de último módulo, dark-gray theme mode y separación admin/clínica.
+
+## Archivos tocados
+
+Nuevos:
+- `frontend/src/components/dashboard/DashboardHubHero.tsx` — hero presentacional reutilizable (`variant: "clinic" | "admin"`, eyebrow, título, descripción, status chip, métricas[], CTA). Sin fetch, sin imports de api/headers/public/middleware, theme-independiente (texto blanco sobre gradiente de marca).
+- `test/frontend-dashboard-hub-hero.test.ts` — contrato del hero y su wiring.
+- `docs/audits/DASHBOARD_PREMIUM_VISUAL_REDESIGN_PLAN.md` — auditoría Fase 1.
+
+Modificados:
+- `frontend/src/components/dashboard/DashboardModuleHub.tsx` — nuevo prop opcional `hero?: ReactNode`, renderizado arriba del heading + grilla; se conservan `data-dashboard-module-hub`, `data-dashboard-module-card`, `dashboard-card-interactive` y focus rings.
+- `frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx` — construye `clinicHero` con `pendingReports`/`activeVisits` (datos que ya recibía) y CTA → módulo `operaciones`.
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx` — construye `adminHero` con estado del sistema + `auditEntriesCount`/`eventTypesCount`; CTA → módulo `admin`.
+- `frontend/src/app/dashboard/admin/page.tsx` — pasa `auditEntriesCount={auditEntries.length}` y `eventTypesCount={Object.keys(eventCounts).length}` (2 líneas aditivas).
+
+`git diff --stat`: 4 archivos modificados, 74 inserciones, 1 eliminación.
+
+## Decisión de dependencias
+
+**No se agregaron dependencias.** El hero se construye con Tailwind (ya presente) + clases de componente existentes + íconos `lucide-react` (ya instalado). `package.json` y `pnpm-lock.yaml` sin cambios (verificado por test y por `git status`). Alternativa evitada: librerías de UI/animación/charts/themes — innecesarias para una banda hero, sumarían peso y riesgo. Impacto en bundle: nulo (sólo un componente React nuevo).
+
+## Cambios visuales concretos
+
+Primer viewport del hub (antes: header genérico + grilla plana de tarjetas):
+
+- **Clínica — workspace operativo de laboratorio**: banda hero con eyebrow “Workspace operativo · Clínica”, título “Centro de operaciones clínica”, status chip (“Operación al día” / “Atención requerida”), tiles vivos **Informes pendientes** y **Visitas activas**, y CTA “Abrir centro de operaciones”.
+- **Admin — centro de control**: banda hero con eyebrow “Centro de control · Administración”, estado del sistema prominente (status chip con tono ok/warn/down), tiles vivos **Eventos de auditoría** y **Tipos de evento**, y CTA “Abrir administración”.
+- Jerarquía visual: hero (nivel 1, gradiente + sombra + glow) → métricas → grilla de módulos (conservada).
+- Mejor uso del espacio horizontal: en `lg+` el bloque de copy queda a la izquierda y los tiles de KPI a la derecha (reduce sensación de página plana y de scroll).
+- Responsive: hero apila en columna `< lg`; tiles en grilla 2-col en móvil; CTA táctil (`min-h`).
+- Accesibilidad: `<section>` con `data-dashboard-hub-hero`, `aria-labelledby`/`id` de heading, botón con foco visible (`focus-visible:ring-2`), decorativos con `aria-hidden`.
+
+## Tests ejecutados (Terminal 1)
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend typecheck` | ✅ PASS (tsc --noEmit) |
+| `pnpm --dir frontend lint` | ✅ PASS (eslint) |
+| `pnpm test` | ✅ 2758 pass / 0 fail (incluye el nuevo `frontend-dashboard-hub-hero.test.ts` y todos los contratos de dashboard/admin/last-module/visual-consistency) |
+| `pnpm --dir frontend build` | ✅ PASS (next build; `/dashboard` y `/dashboard/admin` dinámicas) |
+| `pnpm build` | ✅ PASS (backend esbuild, no afectado) |
+| `pnpm security:public-surface` | ✅ PASS (sin hallazgos de exposición pública) |
+| `git diff --check` | ✅ sin errores de whitespace |
+
+> `pnpm --dir frontend test:e2e` **no existe**; el script real es `pnpm --dir frontend e2e` (Playwright, requiere navegadores/servidor). Los E2E de dashboard existentes no se modificaron. No se ejecutó E2E en este entorno.
+
+## Riesgos remanentes y mitigaciones
+
+| Riesgo | Estado |
+|---|---|
+| Romper responsive | Mitigado: `flex-col` → `lg:flex-row`, tiles en grilla; build OK. |
+| Ocultar acciones existentes | No: cambio aditivo, grilla de módulos intacta. |
+| Duplicar contenido | No: el hero usa datos del landing (no presentes antes); los command centers siguen en sus módulos. |
+| Aumentar scroll | Mitigado: hero usa ancho horizontal, altura acotada. |
+| Tocar seguridad por accidente | No: sin auth/middleware/api/cookies; test anti-sensibles del hero. |
+| Dependencia innecesaria | No: cero dependencias nuevas. |
+| Romper contratos string-exact | No: 2758/2758 verde. |
+| Guardrails `PR-N scope` por diff | Sin impacto: archivos tocados no están en blocklist (verificado en §2.6 de la auditoría). |
+
+## Rollback plan
+
+Cambio puramente frontend y aditivo. Rollback lógico:
+- Revertir los 4 archivos modificados y eliminar los 3 nuevos (`DashboardHubHero.tsx`, `test/frontend-dashboard-hub-hero.test.ts`, auditoría). El hub vuelve a su grilla previa sin más efectos (el prop `hero` es opcional).
+- No hay migraciones, datos ni contratos que revertir.
+
+## Criterios de aceptación cumplidos
+
+- [x] Antes/después evidente en la **primera pantalla** de ambos dashboards.
+- [x] Cambio visible **sin** navegar a módulos profundos.
+- [x] No depende de texto nuevo masivo (copy mínimo, foco en diseño/datos).
+- [x] No rompe acciones existentes (tarjetas, navegación, last-module): tests verde.
+- [x] No expone secretos/tokens/hashes/cookies: test anti-sensibles + `security:public-surface` PASS.
+- [x] No cambia contratos API ni rutas; sin `fetch` en componentes.
+- [x] Mantiene separación admin/clínica (heroes con `variant` distinto, sin import cruzado).
+- [x] `PasswordChangePanel` intacto (no se tocó su slot).
+- [x] Conserva dark-gray theme mode y sidebar.
+- [x] build/typecheck/lint pasan; cero dependencias nuevas.
+
+## Recomendaciones para commit/PR (Git manual lo hace Nico)
+
+Rama ya creada: `feat/dashboard-premium-visual-shell`. Sugerido:
+
+```powershell
+git add frontend/src/components/dashboard/DashboardHubHero.tsx `
+        frontend/src/components/dashboard/DashboardModuleHub.tsx `
+        frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx `
+        frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx `
+        frontend/src/app/dashboard/admin/page.tsx `
+        test/frontend-dashboard-hub-hero.test.ts `
+        docs/audits/DASHBOARD_PREMIUM_VISUAL_REDESIGN_PLAN.md `
+        IMPLEMENTATION_NOTES/feat-dashboard-premium-visual-shell.md
+git commit -m "feat(dashboard): introduce premium workspace visual shell"
+git push -u origin feat/dashboard-premium-visual-shell
+gh pr create --fill
+gh pr checks --watch
+```

--- a/docs/audits/DASHBOARD_PREMIUM_VISUAL_REDESIGN_PLAN.md
+++ b/docs/audits/DASHBOARD_PREMIUM_VISUAL_REDESIGN_PLAN.md
@@ -1,0 +1,211 @@
+# Dashboard Premium Visual Redesign — Plan de auditoría e implementación
+
+Rama: `feat/dashboard-premium-visual-shell`
+Base: `main` @ `e262643`
+Alcance: Frontend dashboard clínica (`/dashboard`) y admin (`/dashboard/admin`).
+Normas de referencia: ISO/IEC 25010 (usabilidad, mantenibilidad), ISO/IEC 25000 SQuaRE, ISO 9001, ISO/IEC 5055, ISO/IEC 15504 SPICE, ISO 27001, ISO/IEC 14598.
+
+---
+
+## 1. Diagnóstico honesto
+
+### 1.1 Por qué el dashboard se ve igual
+
+El primer viewport real al entrar a `/dashboard` y `/dashboard/admin` (sin `?module=`) está compuesto por:
+
+1. `DashboardTopbar` (header sticky) — ya tiene polish.
+2. `main.dashboard-main` →
+   - `DashboardPageHeader` — título + descripción genérica (“Seleccione un módulo para acceder a sus funciones.”).
+   - `*DashboardWorkspaceController` que, **sin módulo activo, renderiza `DashboardModuleHub`**: una grilla plana de tarjetas genéricas (icono + título + descripción + “acción →”).
+
+El contenido operativo real (KPIs, informes recientes, estado del sistema) **no está en el landing**: vive una capa adentro, dentro de los módulos:
+
+- Clínica: `ClinicCommandCenter` (KPIs, informes/visitas) está dentro del módulo `operaciones`.
+- Admin: `AdminCommandCenter` (eventos, tipos de evento, estado) está dentro del módulo `admin`.
+
+Resultado: la **primera pantalla es una grilla de tarjetas sin datos vivos**, idéntica conceptualmente desde hace varios PRs. Es “plana que sube y baja” porque no hay banda de resumen con jerarquía ni señal operativa inmediata.
+
+### 1.2 Qué componentes/layouts limitan el salto visual
+
+| Superficie | Limitación |
+|---|---|
+| `DashboardModuleHub` | Grilla uniforme 1/2/3 columnas, todas las tarjetas con el mismo peso visual. Sin hero, sin métricas, sin jerarquía. |
+| `*WorkspaceController` | Ya reciben datos vivos (`pendingReports`, `activeVisits`, `systemStatus`) pero los usan **solo como badges minúsculos** en tarjetas. |
+| `DashboardPageHeader` | Repite el título del topbar y aporta una descripción genérica; consume altura sin densidad útil. |
+| Datos vivos | Existen en `page.tsx` (stats, auditoría, health) pero no se exponen en el landing. |
+
+### 1.3 Qué cambios anteriores no generaron impacto visible
+
+- **#1004** agregó `PasswordChangePanel` dentro de `perfil` / `admin-sessions` (módulos profundos) → invisible en el landing.
+- **#1005** subió ese panel dentro de los workspaces existentes → sigue siendo invisible hasta navegar a un módulo.
+- **#1006** sólo reorganizó documentación.
+
+Ninguno tocó el **primer viewport** del hub.
+
+### 1.4 Qué debe cambiar para que el primer viewport sea claramente distinto
+
+Introducir una **shell visual premium en el landing del hub** (no dentro de módulos):
+
+- Un **hero operativo** ancho con datos vivos ya disponibles (clínica: informes pendientes + visitas activas; admin: estado del sistema + volumen de auditoría + tipos de evento), CTA principal y jerarquía visual fuerte.
+- Reutilizar la grilla de módulos existente debajo del hero, sin perder ninguna tarjeta.
+
+Esto cambia el landing **antes de navegar a ningún módulo**, que es exactamente lo que faltaba.
+
+---
+
+## 2. Mapa de superficies reales
+
+### 2.1 Dashboard clínica (`/dashboard`)
+- `frontend/src/app/dashboard/page.tsx` (server; carga stats/reports/visitas; arma slots).
+- `frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx` (client; hub ↔ workspace, last-module).
+- `frontend/src/app/dashboard/ClinicCommandCenter.tsx` (presentacional módulo `operaciones`).
+
+### 2.2 Dashboard admin (`/dashboard/admin`)
+- `frontend/src/app/dashboard/admin/page.tsx` (server; auditoría + health; arma slots).
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx` (client; hub ↔ workspace, last-module).
+- `frontend/src/app/dashboard/admin/AdminCommandCenter.tsx` (presentacional módulo `admin`).
+
+### 2.3 Componentes compartidos
+- `frontend/src/components/dashboard/DashboardModuleHub.tsx` (grilla de tarjetas del landing). **Superficie clave del cambio.**
+- `frontend/src/components/dashboard/DashboardModuleWorkspace.tsx` (wrapper de módulo con “Volver”).
+- `frontend/src/components/dashboard/DashboardTopbar.tsx`, `DashboardPageHeader.tsx`.
+- `frontend/src/components/dashboard/DashboardSidebarFrame.tsx` + `Clinic/AdminDashboardSidebar.tsx`.
+- `frontend/src/app/globals.css` (tokens `dashboard-*`, `surface-*`, `dashboard-kpi-pill`, `dashboard-card-interactive`).
+
+### 2.4 Tests existentes relevantes (contratos string-exact)
+- `test/frontend-dashboard-home.test.ts`, `test/frontend-dashboard-clinic-command-center.test.ts`
+- `test/frontend-dashboard-admin.test.ts`, `test/frontend-dashboard-admin-command-center.test.ts`
+- `test/frontend-dashboard-shell.test.ts`, `test/frontend-dashboard-private-shell-foundation.test.ts`
+- `test/frontend-dashboard-interaction-foundation.test.ts` (contratos de `DashboardModuleHub`)
+- `test/frontend-dashboard-last-module.test.ts` (lógica de controllers)
+- `test/frontend-visual-consistency.test.ts` (clases/grids existentes)
+- `test/frontend-dashboard-accessibility-focus-aria.test.ts`, `test/frontend-dashboard-workspace-layout-polish.test.ts`
+
+### 2.5 Tests faltantes (a agregar)
+- Contrato del nuevo hero del hub: presencia, datos vivos, CTA, separación clínica/admin, sin fetch, sin secretos. → `test/frontend-dashboard-hub-hero.test.ts`.
+
+### 2.6 Restricciones de los guardrails de scope (verificado en repo)
+Los tests `PR-N ... stays within allowed file scope` ejecutan `git diff --name-only` y bloquean (prefijos) `server/`, `drizzle/`, `shared/`, `frontend/src/app/api/`, `frontend/src/middleware`; (exactos) `package.json`, `pnpm-lock.yaml`, `frontend/package.json`, `frontend/pnpm-lock.yaml`, `frontend/next-env.d.ts`, `frontend/tsconfig.json`, `frontend/src/app/layout.tsx`, `frontend/src/lib/auth.ts`, `frontend/src/lib/seo.ts`, `frontend/src/middleware.ts`.
+
+**`frontend/src/app/globals.css` NO está bloqueado** (sólo se lee para asserts). Los archivos objetivo de este PR (hub, controllers, nuevos componentes, `page.tsx`) **no** están bloqueados. Estos guardrails se evalúan sobre el working tree: pueden “fallar” localmente con árbol sucio y pasan en CI (diff vacío post-commit) — comportamiento documentado del repo.
+
+---
+
+## 3. Propuesta visual premium
+
+Estrategia: **aditiva**. No se elimina ninguna estructura contractual existente; se inyecta una banda hero en el landing del hub y se enriquece la jerarquía. La decisión de no tocar `globals.css` es deliberada (ver §8): el hero se construye con utilidades Tailwind + clases de componente ya existentes.
+
+### 3.1 Dashboard clínica — workspace operativo de laboratorio
+- **Layout**: hero ancho full-width arriba del hub; debajo, la grilla de módulos existente.
+- **Header**: se conserva `DashboardTopbar` + `DashboardPageHeader`. El hero añade jerarquía sin duplicar copy.
+- **Hero**: gradiente institucional navy→teal (marca, theme-aware), eyebrow “Workspace operativo · Clínica”, título, subtítulo, **tiles de KPI vivos** (Informes pendientes / Visitas activas) y **CTA primaria** “Abrir centro de operaciones” → módulo `operaciones`.
+- **Grid de cards**: se conserva (`operaciones`, `informes`, `logística`, `perfil`, `tokens`) con sus badges.
+- **Jerarquía visual**: hero (nivel 1) → métricas (nivel 2) → módulos (nivel 3).
+- **Estados**: si stats no cargó, KPIs muestran 0 (consistente con badges actuales); sin datos sensibles.
+- **Módulo hero/resumen**: el hero es el resumen accionable del landing.
+- **Responsive**: hero apila en columna < `lg`, fila a `lg+`; tiles en grilla 2-col en móvil.
+- **Reducir scroll**: el hero usa espacio horizontal (tiles a la derecha) en escritorio.
+- **Qué NO cambiar**: lógica de URL/last-module, slots de workspace, `ClinicCommandCenter`, `PasswordChangePanel`, navegación, sidebar.
+
+### 3.2 Dashboard admin — centro de control
+- **Layout**: idéntico patrón; hero arriba del hub admin.
+- **Hero**: gradiente navy profundo, eyebrow “Centro de control · Administración”, **estado del sistema prominente** (punto de estado + label), tiles vivos (Eventos de auditoría / Tipos de evento), CTA “Abrir administración” → módulo `admin`.
+- **Grid de cards**: se conservan las 10 tarjetas admin.
+- **Jerarquía**: estado/seguridad first (consistente con la prioridad de “Alertas críticas”).
+- **Estados**: si `systemHealth` falló, el estado se muestra como tal (variant outline / label), sin inventar datos.
+- **Responsive**: igual al clínico.
+- **Qué NO cambiar**: auditoría, health, contratos de `page.tsx`, `AdminCommandCenter`, sesiones, `PasswordChangePanel`, sidebar.
+
+### 3.3 Componentes compartidos
+- **Nuevo** `DashboardHubHero.tsx`: hero presentacional reutilizable (eyebrow, título, descripción, status chip opcional, métricas[], CTA opcional, `variant: "clinic" | "admin"`). Sin fetch, sin imports de api/middleware/public, theme-aware.
+- **Modificado** `DashboardModuleHub.tsx`: nuevo prop opcional `hero?: ReactNode`, renderizado arriba del heading + grilla. Se conservan `data-dashboard-module-hub`, `data-dashboard-module-card`, `dashboard-card-interactive`, focus rings.
+- **Modificados** controllers: construyen el hero con datos que ya reciben y lo pasan a `DashboardModuleHub`.
+
+---
+
+## 4. Criterios de aceptación visual (verificables)
+
+1. Antes/después evidente en la **primera pantalla** de `/dashboard` y `/dashboard/admin` sin navegar a módulos: aparece una banda hero con datos vivos y CTA. ✔ verificable visualmente + por test de presencia.
+2. El cambio es visible **sin entrar a módulos profundos**. ✔
+3. No depende de texto nuevo masivo (copy mínimo, foco en diseño/datos). ✔
+4. No rompe acciones existentes (tarjetas, navegación, last-module). ✔ tests.
+5. No expone secretos/tokens/hashes/cookies. ✔ test anti-sensibles.
+6. No cambia contratos API ni rutas. ✔ sin tocar `lib/api`, sin fetch en componentes.
+7. Mantiene rutas actuales (`/dashboard`, `/dashboard/admin`, `?module=`). ✔
+8. Mantiene separación admin/clínica (heroes distintos, sin import cruzado). ✔
+9. `PasswordChangePanel` sigue visible donde corresponde (`perfil` / `admin-sessions`). ✔ no se toca.
+10. Conserva dark-gray theme mode (hero usa tokens de marca theme-aware). ✔
+11. Conserva sidebar y persistencia de último módulo. ✔
+
+---
+
+## 5. Plan de implementación del PR
+
+**Título sugerido:** `feat(dashboard): introduce premium workspace visual shell`
+
+**Scope:** sólo frontend dashboard clínica/admin. Sin backend, DB, migrations, auth, contratos API ni producción.
+
+Archivos:
+- `frontend/src/components/dashboard/DashboardHubHero.tsx` (nuevo)
+- `frontend/src/components/dashboard/DashboardModuleHub.tsx` (prop `hero`)
+- `frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx` (hero clínica)
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx` (hero admin + recibe counts)
+- `frontend/src/app/dashboard/admin/page.tsx` (pasa `auditEntriesCount`, `eventTypesCount` — aditivo)
+- `test/frontend-dashboard-hub-hero.test.ts` (nuevo, contrato)
+
+No se toca: `page.tsx` clínica, command centers, sidebars, layout, `globals.css`, `lib/*`, backend.
+
+---
+
+## 6. Tests y validación
+
+Comandos PNPM reales del repo:
+
+```powershell
+pnpm test                       # root: node --test test/**/*.test.ts (contratos)
+pnpm --dir frontend lint        # eslint
+pnpm --dir frontend typecheck   # tsc --noEmit
+pnpm --dir frontend build       # next build
+pnpm build                      # backend esbuild (no afectado)
+pnpm security:public-surface    # auditoría devtools superficie pública
+```
+
+> `pnpm --dir frontend test:e2e` **no existe**; el script real es `pnpm --dir frontend e2e` (Playlist Playwright, requiere navegadores). E2E existentes de dashboard (`frontend/e2e/dashboard-*.spec.ts`) no se modifican.
+
+Tests mínimos a asegurar:
+- Rutas dashboard siguen protegidas (sin tocar middleware/auth → contratos existentes intactos).
+- Módulos existentes siguen visibles (tarjetas en controllers → tests `frontend-dashboard-admin`/`home`).
+- `PasswordChangePanel` no desaparece (no se toca `page.tsx` clínica ni slot sessions).
+- Separación admin/clínica (test nuevo: heroes con variant correcto, sin import cruzado).
+- Sin secretos/datos sensibles (test nuevo).
+- build/typecheck/lint pasan.
+- Theme mode intacto (no se toca `globals.css` ni toggles).
+- Sidebar intacto (no se toca).
+- Persistencia de último módulo intacta (no se toca la lógica; `frontend-dashboard-last-module`).
+
+---
+
+## 7. Riesgos y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| Romper responsive | Hero con `flex-col` → `lg:flex-row`; tiles en grilla; probado en build. |
+| Ocultar acciones existentes | Cambio aditivo; grilla de módulos intacta. |
+| Duplicar contenido | Hero usa datos del landing (no presentes antes); no repite los command centers (que viven en módulos). |
+| Aumentar scroll | Hero usa ancho horizontal en escritorio; altura acotada. |
+| Tocar seguridad por accidente | No se toca auth/middleware/api/cookies; test anti-sensibles en el hero. |
+| Dependencia innecesaria | Cero dependencias nuevas (ver §8). |
+| Maquillar sin cambiar percepción | El cambio está en el **primer viewport** del hub, no dentro de módulos. |
+| Romper contratos string-exact | Cambios aditivos; se preservan todas las cadenas/orden/atributos verificados; se corre `pnpm test`. |
+
+---
+
+## 8. Decisión sobre dependencias
+
+**No se agregan dependencias.** Justificación:
+- El hero se construye con **Tailwind** (ya presente) y clases de componente existentes (`dashboard-kpi-pill`, `dashboard-card-interactive`, gradientes de marca navy/teal ya usados en `DashboardModuleHub`).
+- Íconos vía `lucide-react` (ya instalado).
+- No se requieren librerías de UI/animación/charts/themes.
+- Evita impacto en bundle y respeta el guardrail `package.json`/`pnpm-lock.yaml` sin cambios.
+
+Alternativa evitada: librerías de dashboard/animación (p. ej. framer-motion, una UI kit) — innecesarias para una banda hero con grilla; sumarían peso y riesgo sin beneficio.

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -15,6 +15,8 @@ import {
   UsersRound,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { DashboardHubHero } from "@/components/dashboard/DashboardHubHero";
+import type { DashboardHubHeroStatusTone } from "@/components/dashboard/DashboardHubHero";
 import { DashboardModuleHub } from "@/components/dashboard/DashboardModuleHub";
 import { DashboardModuleWorkspace } from "@/components/dashboard/DashboardModuleWorkspace";
 import {
@@ -74,7 +76,16 @@ type AdminDashboardWorkspaceControllerProps = {
   systemStatus: string;
   systemStatusLabel: string;
   systemStatusVariant: "default" | "secondary" | "destructive" | "outline";
+  auditEntriesCount: number;
+  eventTypesCount: number;
 };
+
+function getHeroStatusTone(systemStatus: string): DashboardHubHeroStatusTone {
+  if (systemStatus === "ok") return "ok";
+  if (systemStatus === "degraded") return "warn";
+  if (systemStatus === "down") return "down";
+  return "neutral";
+}
 
 const ADMIN_MODULE_META: Record<AdminModule, { title: string; description: string }> = {
   admin: {
@@ -125,6 +136,8 @@ export function AdminDashboardWorkspaceController({
   systemStatus,
   systemStatusLabel,
   systemStatusVariant,
+  auditEntriesCount,
+  eventTypesCount,
 }: AdminDashboardWorkspaceControllerProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -168,6 +181,32 @@ export function AdminDashboardWorkspaceController({
     setHasManuallyReturnedToHub(true);
     router.replace("/dashboard/admin", { scroll: false });
   }, [router]);
+
+  const adminHero = (
+    <DashboardHubHero
+      variant="admin"
+      icon={ShieldCheck}
+      eyebrow="Centro de control · Administración"
+      title="Centro de control operativo"
+      description="Estado del sistema, seguridad y auditoría en una sola lectura antes de abrir cada módulo."
+      statusLabel={systemStatusLabel}
+      statusTone={getHeroStatusTone(systemStatus)}
+      metrics={[
+        {
+          label: "Eventos de auditoría",
+          value: auditEntriesCount,
+          hint: "Registros totales",
+        },
+        {
+          label: "Tipos de evento",
+          value: eventTypesCount,
+          hint: "Categorías distintas",
+        },
+      ]}
+      primaryActionLabel="Abrir administración"
+      onPrimaryAction={() => activateModule("admin")}
+    />
+  );
 
   const adminCards = [
     {
@@ -275,6 +314,7 @@ export function AdminDashboardWorkspaceController({
       heading="Módulos de administración"
       description="Acceso a clínicas, precios, sesiones, auditoría y estado del sistema."
       cards={adminCards}
+      hero={adminHero}
     />
   );
 }

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -870,6 +870,8 @@ export default async function AdminPage({
             systemStatus={systemStatus}
             systemStatusLabel={formatSystemStatus(systemStatus)}
             systemStatusVariant={getSystemStatusVariant(systemStatus)}
+            auditEntriesCount={auditEntries.length}
+            eventTypesCount={Object.keys(eventCounts).length}
           />
         </Suspense>
         <div className="h-24 md:hidden" aria-hidden="true" />

--- a/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
+++ b/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
@@ -9,6 +9,7 @@ import {
   LayoutDashboard,
   Route,
 } from "lucide-react";
+import { DashboardHubHero } from "./DashboardHubHero";
 import { DashboardModuleHub } from "./DashboardModuleHub";
 import { DashboardModuleWorkspace } from "./DashboardModuleWorkspace";
 import { ROUTES } from "@/lib/routes";
@@ -132,6 +133,32 @@ export function ClinicDashboardWorkspaceController({
     router.replace(ROUTES.dashboard, { scroll: false });
   }, [router]);
 
+  const clinicHero = (
+    <DashboardHubHero
+      variant="clinic"
+      icon={LayoutDashboard}
+      eyebrow="Workspace operativo · Clínica"
+      title="Centro de operaciones clínica"
+      description="Resumen accionable de informes y logística antes de abrir cada módulo."
+      statusLabel={pendingReports > 0 ? "Atención requerida" : "Operación al día"}
+      statusTone={pendingReports > 0 ? "warn" : "ok"}
+      metrics={[
+        {
+          label: "Informes pendientes",
+          value: pendingReports,
+          hint: pendingReports > 0 ? "Requieren atención" : "Sin pendientes",
+        },
+        {
+          label: "Visitas activas",
+          value: activeVisits,
+          hint: activeVisits > 0 ? "En curso o programadas" : "Sin visitas activas",
+        },
+      ]}
+      primaryActionLabel="Abrir centro de operaciones"
+      onPrimaryAction={() => activateModule("operaciones")}
+    />
+  );
+
   const clinicCards = [
     {
       icon: LayoutDashboard,
@@ -212,6 +239,7 @@ export function ClinicDashboardWorkspaceController({
       heading="Módulos operativos"
       description="Acceso rápido a informes, logística, perfil público y tokens de la clínica."
       cards={clinicCards}
+      hero={clinicHero}
     />
   );
 }

--- a/frontend/src/components/dashboard/DashboardHubHero.tsx
+++ b/frontend/src/components/dashboard/DashboardHubHero.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type DashboardHubHeroMetric = {
+  label: string;
+  value: ReactNode;
+  hint?: string;
+};
+
+export type DashboardHubHeroStatusTone = "ok" | "warn" | "down" | "neutral";
+
+export type DashboardHubHeroProps = {
+  variant: "clinic" | "admin";
+  icon: LucideIcon;
+  eyebrow: string;
+  title: string;
+  description: string;
+  metrics: DashboardHubHeroMetric[];
+  statusLabel?: string;
+  statusTone?: DashboardHubHeroStatusTone;
+  primaryActionLabel?: string;
+  onPrimaryAction?: () => void;
+};
+
+const STATUS_DOT_CLASS: Record<DashboardHubHeroStatusTone, string> = {
+  ok: "bg-emerald-300",
+  warn: "bg-amber-300",
+  down: "bg-rose-300",
+  neutral: "bg-white/70",
+};
+
+export function DashboardHubHero({
+  variant,
+  icon: Icon,
+  eyebrow,
+  title,
+  description,
+  metrics,
+  statusLabel,
+  statusTone = "neutral",
+  primaryActionLabel,
+  onPrimaryAction,
+}: DashboardHubHeroProps) {
+  return (
+    <section
+      data-dashboard-hub-hero={variant}
+      aria-labelledby="dashboard-hub-hero-title"
+      className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-vetneb-navy via-vetneb-navy to-vetneb-teal/80 px-5 py-5 text-white shadow-[0_22px_60px_rgba(8,35,50,0.30)] sm:px-7 sm:py-6"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-12 -top-20 h-52 w-52 rounded-full bg-vetneb-cyan/25 blur-3xl"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-24 left-8 h-56 w-56 rounded-full bg-vetneb-teal/20 blur-3xl"
+      />
+
+      <div className="relative flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 lg:max-w-2xl">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/12 ring-1 ring-white/20">
+              <Icon className="h-5 w-5 text-white" aria-hidden="true" />
+            </span>
+            <span className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-white/75">
+              {eyebrow}
+            </span>
+            {statusLabel ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-white/12 px-2.5 py-0.5 text-[0.66rem] font-semibold text-white/90 ring-1 ring-white/15">
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full",
+                    STATUS_DOT_CLASS[statusTone],
+                  )}
+                  aria-hidden="true"
+                />
+                {statusLabel}
+              </span>
+            ) : null}
+          </div>
+
+          <h2
+            id="dashboard-hub-hero-title"
+            className="mt-3 text-xl font-semibold leading-tight sm:text-2xl"
+          >
+            {title}
+          </h2>
+          <p className="mt-1.5 text-sm leading-relaxed text-white/80">
+            {description}
+          </p>
+
+          {primaryActionLabel && onPrimaryAction ? (
+            <button
+              type="button"
+              onClick={onPrimaryAction}
+              className="dashboard-btn-interactive mt-4 inline-flex min-h-[2.5rem] items-center gap-1.5 rounded-md bg-white/95 px-4 text-sm font-semibold text-vetneb-navy shadow-[0_10px_26px_rgba(8,35,50,0.24)] hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/85 focus-visible:ring-offset-2 focus-visible:ring-offset-vetneb-navy"
+            >
+              <span>{primaryActionLabel}</span>
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+
+        <div className="grid w-full grid-cols-2 gap-2.5 sm:max-w-md lg:w-auto lg:min-w-[20rem]">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="rounded-xl border border-white/12 bg-white/[0.08] px-3.5 py-3 backdrop-blur-sm"
+            >
+              <p className="text-[0.66rem] font-semibold uppercase tracking-wide text-white/70">
+                {metric.label}
+              </p>
+              <p className="mt-1 text-2xl font-bold leading-none">
+                {metric.value}
+              </p>
+              {metric.hint ? (
+                <p className="mt-1 text-[0.66rem] leading-snug text-white/65">
+                  {metric.hint}
+                </p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardModuleHub.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleHub.tsx
@@ -31,18 +31,21 @@ export function DashboardModuleHub({
   className,
 }: DashboardModuleHubProps) {
   return (
-    <section
-      aria-label={heading}
-      data-dashboard-module-hub="true"
-      className={cn("space-y-5", className)}
-    >
-      {hero ? <div>{hero}</div> : null}
-      <div>
-        <h2 className="dashboard-section-heading">{heading}</h2>
-        {description ? (
-          <p className="dashboard-section-description">{description}</p>
-        ) : null}
-      </div>
+    <div className={cn("space-y-5", className)}>
+      {hero ? (
+        <div data-dashboard-hub-hero-slot="true">{hero}</div>
+      ) : null}
+      <section
+        aria-label={heading}
+        data-dashboard-module-hub="true"
+        className="space-y-5"
+      >
+        <div>
+          <h2 className="dashboard-section-heading">{heading}</h2>
+          {description ? (
+            <p className="dashboard-section-description">{description}</p>
+          ) : null}
+        </div>
       <ul className="grid list-none grid-cols-1 gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
         {cards.map((card) => {
           const key = card.moduleId ?? card.href ?? card.title;
@@ -108,6 +111,7 @@ export function DashboardModuleHub({
           );
         })}
       </ul>
-    </section>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/components/dashboard/DashboardModuleHub.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleHub.tsx
@@ -19,6 +19,7 @@ type DashboardModuleHubProps = {
   heading: string;
   description?: string;
   cards: DashboardModuleCard[];
+  hero?: ReactNode;
   className?: string;
 };
 
@@ -26,14 +27,16 @@ export function DashboardModuleHub({
   heading,
   description,
   cards,
+  hero,
   className,
 }: DashboardModuleHubProps) {
   return (
     <section
       aria-label={heading}
       data-dashboard-module-hub="true"
-      className={cn("space-y-4", className)}
+      className={cn("space-y-5", className)}
     >
+      {hero ? <div>{hero}</div> : null}
       <div>
         <h2 className="dashboard-section-heading">{heading}</h2>
         {description ? (

--- a/test/frontend-dashboard-hub-hero.test.ts
+++ b/test/frontend-dashboard-hub-hero.test.ts
@@ -77,14 +77,26 @@ test("DashboardHubHero stores or renders no sensitive identifiers", () => {
 
 // ── Module hub: optional hero slot above cards ───────────────────────────────
 
-test("DashboardModuleHub accepts an optional hero slot and keeps module-card contracts", () => {
+test("DashboardModuleHub renders the hero slot outside the module-card section", () => {
   const source = read(HUB_PATH);
 
   assert.ok(source.includes("hero?: ReactNode;"));
   assert.ok(source.includes("hero,"));
-  assert.ok(source.includes("{hero ? <div>{hero}</div> : null}"));
+  assert.ok(source.includes('data-dashboard-hub-hero-slot="true"'));
   assert.ok(source.includes('data-dashboard-module-hub="true"'));
   assert.ok(source.includes("data-dashboard-module-card={card.moduleId}"));
+
+  // Regression guard for the E2E `hub.locator("button")` selector: the hero
+  // (with its CTA button) must render BEFORE/OUTSIDE the module-card section so
+  // it is never counted among the hub's accessible module cards.
+  const heroSlotIndex = source.indexOf('data-dashboard-hub-hero-slot="true"');
+  const moduleHubIndex = source.indexOf('data-dashboard-module-hub="true"');
+  assert.ok(heroSlotIndex >= 0);
+  assert.ok(moduleHubIndex >= 0);
+  assert.ok(
+    heroSlotIndex < moduleHubIndex,
+    "hero slot must render before (outside) the module-card section",
+  );
 });
 
 // ── Clinic controller wiring ─────────────────────────────────────────────────

--- a/test/frontend-dashboard-hub-hero.test.ts
+++ b/test/frontend-dashboard-hub-hero.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const HERO_PATH = "frontend/src/components/dashboard/DashboardHubHero.tsx";
+const HUB_PATH = "frontend/src/components/dashboard/DashboardModuleHub.tsx";
+const CLINIC_CONTROLLER_PATH =
+  "frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx";
+const ADMIN_CONTROLLER_PATH =
+  "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+// ── Hero component: presentational and accessible ────────────────────────────
+
+test("DashboardHubHero exports a typed presentational hero component", () => {
+  const source = read(HERO_PATH);
+
+  assert.ok(source.includes("export type DashboardHubHeroProps"));
+  assert.ok(source.includes("export type DashboardHubHeroMetric"));
+  assert.ok(source.includes("export type DashboardHubHeroStatusTone"));
+  assert.ok(source.includes("export function DashboardHubHero("));
+  assert.ok(source.includes('variant: "clinic" | "admin";'));
+  assert.ok(source.includes("metrics: DashboardHubHeroMetric[];"));
+});
+
+test("DashboardHubHero keeps hub-hero landmark, heading id and metric/action contracts", () => {
+  const source = read(HERO_PATH);
+
+  assert.ok(source.includes("data-dashboard-hub-hero={variant}"));
+  assert.ok(source.includes('aria-labelledby="dashboard-hub-hero-title"'));
+  assert.ok(source.includes('id="dashboard-hub-hero-title"'));
+  assert.ok(source.includes("metrics.map((metric) =>"));
+  assert.ok(source.includes("onClick={onPrimaryAction}"));
+  assert.ok(source.includes("focus-visible:ring-2"));
+});
+
+test("DashboardHubHero does not fetch data or import server/public surfaces", () => {
+  const source = read(HERO_PATH);
+
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes('from "@/lib/api"'), false);
+  assert.equal(source.includes('from "@/app/api'), false);
+  assert.equal(source.includes('from "next/headers"'), false);
+  assert.equal(source.includes("@/components/public/"), false);
+  assert.equal(source.toLowerCase().includes("middleware"), false);
+});
+
+test("DashboardHubHero stores or renders no sensitive identifiers", () => {
+  const source = read(HERO_PATH).toLowerCase();
+
+  for (const forbidden of [
+    "session",
+    "auth",
+    "cookie",
+    "token",
+    "password",
+    "secret",
+    "jwt",
+    "bearer",
+    "hash",
+  ]) {
+    assert.equal(
+      source.includes(forbidden),
+      false,
+      `hero must not reference ${forbidden}`,
+    );
+  }
+});
+
+// ── Module hub: optional hero slot above cards ───────────────────────────────
+
+test("DashboardModuleHub accepts an optional hero slot and keeps module-card contracts", () => {
+  const source = read(HUB_PATH);
+
+  assert.ok(source.includes("hero?: ReactNode;"));
+  assert.ok(source.includes("hero,"));
+  assert.ok(source.includes("{hero ? <div>{hero}</div> : null}"));
+  assert.ok(source.includes('data-dashboard-module-hub="true"'));
+  assert.ok(source.includes("data-dashboard-module-card={card.moduleId}"));
+});
+
+// ── Clinic controller wiring ─────────────────────────────────────────────────
+
+test("clinic controller renders a clinic hero with live operational metrics", () => {
+  const source = read(CLINIC_CONTROLLER_PATH);
+
+  assert.ok(source.includes('import { DashboardHubHero } from "./DashboardHubHero";'));
+  assert.ok(source.includes('variant="clinic"'));
+  assert.ok(source.includes("value: pendingReports,"));
+  assert.ok(source.includes("value: activeVisits,"));
+  assert.ok(source.includes('onPrimaryAction={() => activateModule("operaciones")}'));
+  assert.ok(source.includes("hero={clinicHero}"));
+  assert.equal(source.includes('variant="admin"'), false);
+});
+
+// ── Admin controller wiring ──────────────────────────────────────────────────
+
+test("admin controller renders an admin control hero with audit metrics and system status", () => {
+  const source = read(ADMIN_CONTROLLER_PATH);
+
+  assert.ok(source.includes('import { DashboardHubHero } from "@/components/dashboard/DashboardHubHero";'));
+  assert.ok(source.includes('variant="admin"'));
+  assert.ok(source.includes("auditEntriesCount: number;"));
+  assert.ok(source.includes("eventTypesCount: number;"));
+  assert.ok(source.includes("value: auditEntriesCount,"));
+  assert.ok(source.includes("value: eventTypesCount,"));
+  assert.ok(source.includes("statusLabel={systemStatusLabel}"));
+  assert.ok(source.includes('onPrimaryAction={() => activateModule("admin")}'));
+  assert.ok(source.includes("hero={adminHero}"));
+  assert.equal(source.includes('variant="clinic"'), false);
+});
+
+test("admin page forwards live audit counts to the workspace controller", () => {
+  const source = read(ADMIN_PAGE_PATH);
+
+  assert.ok(source.includes("auditEntriesCount={auditEntries.length}"));
+  assert.ok(source.includes("eventTypesCount={Object.keys(eventCounts).length}"));
+});
+
+// ── Scope invariant: no new dependency surfaced by this feature ──────────────
+
+test("hero feature does not register itself as a dependency", () => {
+  const rootPkg = readFileSync(resolve(process.cwd(), "package.json"), "utf8");
+  const frontendPkg = readFileSync(
+    resolve(process.cwd(), "frontend/package.json"),
+    "utf8",
+  );
+
+  assert.equal(rootPkg.includes("DashboardHubHero"), false);
+  assert.equal(frontendPkg.includes("DashboardHubHero"), false);
+});


### PR DESCRIPTION
﻿## Summary
- Introduce a premium dashboard workspace hero for clinic and admin dashboards
- Add shared DashboardHubHero component and additive DashboardModuleHub hero slot
- Surface live operational/admin data in the first viewport
- Preserve existing modules, navigation, PasswordChangePanel, dark gray theme and API/auth contracts
- Add dashboard hero contract coverage
- Document audit and implementation notes

## Visual impact
- Clinic dashboard now opens as an operational laboratory workspace
- Admin dashboard now opens as a control center
- First viewport changes immediately without entering deep modules
- Existing dashboard module grid remains preserved below the hero

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm test
- pnpm --dir frontend build
- pnpm build
- pnpm security:public-surface
- git diff --check

## Test result
- pnpm test: 2758 pass / 0 fail

## Scope
- Frontend dashboard clinic/admin only
- No backend changes
- No DB changes
- No migrations
- No auth/session changes
- No API contract changes
- No production configuration changes
- No new dependencies

## Notes
- E2E was not run locally because the available script is pnpm --dir frontend e2e and requires browser/server environment.
- package.json and pnpm-lock.yaml were not modified.
