### PR TITLE
refactor(dashboard): align token and reports workspaces to profile layout

### DIFF
--- a/frontend/e2e/dashboard-accessibility-keyboard.spec.ts
+++ b/frontend/e2e/dashboard-accessibility-keyboard.spec.ts
@@ -114,98 +114,30 @@ async function mockParticularTokensApi(page: Page) {
 
 // ─── FilterDrawer ─────────────────────────────────────────────────────────────
 
-test.describe("FilterDrawer — keyboard & a11y (PR-8)", () => {
+test.describe("Informes compact filters — keyboard & a11y", () => {
   test.beforeEach(async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator('[data-sticky-filter-bar="true"]')).toBeVisible({
-      timeout: 8_000,
-    });
+    await expect(
+      page.getByRole("search", { name: "Filtros compactos de informes" }),
+    ).toBeVisible({ timeout: 8_000 });
   });
 
-  // Use the FilterDrawer trigger's aria-label to distinguish it from
-  // DashboardNotificationsBell which also carries aria-haspopup="dialog".
-  test("filter drawer trigger has aria-haspopup=dialog", async ({ page }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await expect(trigger).toBeVisible();
-    const haspopup = await trigger.getAttribute("aria-haspopup");
-    expect(haspopup).toBe("dialog");
+  test("compact filter search region is accessible", async ({ page }) => {
+    await expect(
+      page.getByRole("search", { name: "Filtros compactos de informes" }),
+    ).toBeVisible();
   });
 
-  test("filter drawer trigger has aria-expanded=false when closed", async ({
-    page,
-  }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await expect(trigger).toBeVisible();
-    const expanded = await trigger.getAttribute("aria-expanded");
-    expect(expanded).toBe("false");
+  test("filter fields expose accessible labels", async ({ page }) => {
+    await expect(page.getByLabel("Buscar informes")).toBeVisible();
+    await expect(page.getByLabel("Filtrar por estado")).toBeVisible();
+    await expect(page.getByLabel("Filtrar por tipo de estudio")).toBeVisible();
   });
 
-  test("filter drawer opens when trigger is clicked", async ({ page }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await trigger.click();
-    await expect(page.locator('[data-filter-drawer-open="true"]')).toBeVisible({
-      timeout: 3_000,
-    });
-  });
-
-  test("filter drawer closes on Escape and returns focus to trigger", async ({
-    page,
-  }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await trigger.click();
-    await expect(page.locator('[data-filter-drawer-open="true"]')).toBeVisible({
-      timeout: 3_000,
-    });
-
-    await page.keyboard.press("Escape");
-
-    await expect(page.locator('[data-filter-drawer-open="true"]')).not.toBeVisible({
-      timeout: 3_000,
-    });
-
-    // Focus should return to the FilterDrawer trigger (not the notifications bell)
-    const focusedAriaLabel = await page.evaluate(
-      () => document.activeElement?.getAttribute("aria-label"),
-    );
-    expect(focusedAriaLabel).toMatch(/filtrar informes/i);
-  });
-
-  test("filter drawer closes on backdrop click", async ({ page }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await trigger.click();
-    await expect(page.locator('[data-filter-drawer-open="true"]')).toBeVisible({
-      timeout: 3_000,
-    });
-
-    // Click the backdrop overlay directly.
-    // force: true is needed because isolation:isolate on .dashboard-main limits
-    // the effective z-index of the non-portal FilterDrawer overlay, making the
-    // backdrop unreachable via raw mouse coordinates in Playwright.
-    await page
-      .locator('[data-filter-backdrop="true"]')
-      .click({ force: true });
-
-    await expect(page.locator('[data-filter-drawer-open="true"]')).not.toBeVisible({
-      timeout: 3_000,
-    });
-  });
-
-  test("filter drawer panel has role=dialog and aria-modal=true", async ({
-    page,
-  }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await trigger.click();
-    const panel = page.getByRole("dialog", { name: /filtros de informes/i });
-    await expect(panel).toHaveAttribute("aria-modal", "true");
-    await expect(panel).toBeVisible({ timeout: 3_000 });
-  });
-
-  test("filter drawer close button has aria-label", async ({ page }) => {
-    const trigger = page.getByRole("button", { name: /filtrar informes/i });
-    await trigger.click();
-    const closeBtn = page.getByRole("button", { name: /cerrar panel de filtros/i });
-    await expect(closeBtn).toBeVisible({ timeout: 3_000 });
+  test("filter form exposes submit and clear actions", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "Filtrar" })).toBeVisible();
+    await expect(page.getByText("Limpiar")).toBeVisible();
   });
 });
 
@@ -214,150 +146,86 @@ test.describe("FilterDrawer — keyboard & a11y (PR-8)", () => {
 // which lives in the admin-particular-tokens workspace (not admin-report-upload).
 // The tokens API is mocked so the test runs without a backend.
 
-test.describe("UploadReportModal — keyboard & a11y (PR-8)", () => {
+test.describe("Admin token workspace — upload removed from token list", () => {
   test.beforeEach(async ({ page }) => {
     await mockParticularTokensApi(page);
     await setAdminSession(page);
     await page.goto("/dashboard/admin?module=admin-particular-tokens");
-    await expect(
-      page.locator('[data-dashboard-module-workspace="admin-particular-tokens"]'),
-    ).toBeVisible({ timeout: 8_000 });
-    // Wait for token to render (mock returns one token with no linked report)
-    await expect(
-      page
-        .getByRole("button", { name: /subir informe para este token/i })
-        .first(),
-    ).toBeVisible({ timeout: 8_000 });
+    await expect(page.locator("main.dashboard-main")).toBeVisible({
+      timeout: 8_000,
+    });
   });
 
-  test("upload report modal trigger button is visible", async ({ page }) => {
-    const trigger = page
-      .getByRole("button", { name: /subir informe para este token/i })
-      .first();
-    await expect(trigger).toBeVisible();
-  });
-
-  test("upload report modal opens on trigger click", async ({ page }) => {
-    const trigger = page
-      .getByRole("button", { name: /subir informe para este token/i })
-      .first();
-    await trigger.click();
-    const modal = page.getByRole("dialog", { name: /subir informe/i });
-    await expect(modal).toBeVisible({ timeout: 3_000 });
-  });
-
-  test("upload report modal has aria-modal=true", async ({ page }) => {
-    const trigger = page
-      .getByRole("button", { name: /subir informe para este token/i })
-      .first();
-    await trigger.click();
-    const modal = page.locator('[role="dialog"][aria-modal="true"]');
-    await expect(modal).toBeVisible({ timeout: 3_000 });
-  });
-
-  test("upload report modal closes on Escape and returns focus to trigger", async ({
+  test("token workspace no longer exposes upload report trigger", async ({
     page,
   }) => {
-    const trigger = page
-      .getByRole("button", { name: /subir informe para este token/i })
-      .first();
-    await trigger.click();
-    const modal = page.getByRole("dialog", { name: /subir informe/i });
-    await expect(modal).toBeVisible({ timeout: 3_000 });
-
-    await page.keyboard.press("Escape");
-
-    await expect(modal).not.toBeVisible({ timeout: 3_000 });
-
-    const focused = await page.evaluate(
-      () => (document.activeElement as HTMLElement)?.textContent?.trim(),
-    );
-    expect(focused).toMatch(/subir informe para este token/i);
-  });
-
-  test("upload report modal closes on backdrop click", async ({ page }) => {
-    const trigger = page
-      .getByRole("button", { name: /subir informe para este token/i })
-      .first();
-    await trigger.click();
-    const modal = page.getByRole("dialog", { name: /subir informe/i });
-    await expect(modal).toBeVisible({ timeout: 3_000 });
-
-    // Click the backdrop area far outside the modal dialog (top-left corner)
-    await page.mouse.click(10, 10);
-
-    await expect(modal).not.toBeVisible({ timeout: 3_000 });
-  });
-
-  test("upload report modal close button has descriptive aria-label", async ({
-    page,
-  }) => {
-    const trigger = page
-      .getByRole("button", { name: /subir informe para este token/i })
-      .first();
-    await trigger.click();
     await expect(
-      page.getByRole("button", { name: /cerrar modal de subir informe/i }),
-    ).toBeVisible({ timeout: 3_000 });
+      page.getByRole("button", { name: /subir informe para este token/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /reemplazar informe/i }),
+    ).toHaveCount(0);
+  });
+
+  test("token workspace exposes list/create profile tabs", async ({ page }) => {
+    await expect(
+      page.getByRole("tab", { name: "Tokens administrados" }),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByRole("tab", { name: "Generar token" })).toBeVisible();
   });
 });
 
 // ─── Informes table — accessible select buttons ───────────────────────────────
 
-test.describe("Informes — accessible row actions (PR-8)", () => {
+test.describe("Informes — accessible profile-layout actions", () => {
   test.beforeEach(async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator(".dashboard-master-panel")).toBeVisible({
+    await expect(page.locator("#reports-master-list")).toBeVisible({
       timeout: 8_000,
     });
   });
 
-  test("filter bar region is accessible", async ({ page }) => {
+  test("compact filter region is accessible", async ({ page }) => {
     await expect(
-      page.getByRole("region", { name: "Filtros del dashboard" }),
+      page.getByRole("search", { name: "Filtros compactos de informes" }),
     ).toBeVisible({ timeout: 3_000 });
   });
 
-  test("pagination nav has aria-label", async ({ page }) => {
-    // If there is pagination, validate its aria attributes
+  test("pagination nav keeps aria-label when rendered", async ({ page }) => {
     const paginationNav = page.locator('[aria-label="Paginación de informes"]');
-    // Nav may not render if there is only 1 page — skip if absent
     const count = await paginationNav.count();
+
     if (count > 0) {
-      const prevBtn = page.getByRole("button", { name: "Página anterior" });
-      await expect(prevBtn).toBeVisible();
+      await expect(paginationNav.first()).toBeVisible();
     }
   });
 
-  test("master panel table is visible and has thead", async ({ page }) => {
-    const masterPanel = page.locator(".dashboard-master-panel");
-    await expect(masterPanel.locator("table")).toBeVisible({ timeout: 4_000 });
-    await expect(masterPanel.locator("thead")).toBeVisible();
+  test("reports list and detail are visible", async ({ page }) => {
+    await expect(page.locator("#reports-master-list")).toBeVisible({
+      timeout: 4_000,
+    });
+    await expect(page.locator("#report-detail")).toBeVisible();
   });
 });
 
 // ─── ReportFileActions — aria-busy ───────────────────────────────────────────
 
 test.describe("ReportFileActions — aria-busy (PR-8)", () => {
-  test("ver informe button has aria-label when file not available", async ({
+  test("selected report action buttons keep accessible labels when rendered", async ({
     page,
   }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator(".dashboard-master-panel")).toBeVisible({
+    await expect(page.locator("#report-detail")).toBeVisible({
       timeout: 8_000,
     });
 
-    // The ReportFileActions buttons are rendered in the table rows.
-    // When no file is available, the button label reflects "Archivo no disponible."
-    // When file exists, label is "Ver informe" or "Descargar informe".
-    // Validate at least one button with a known aria-label pattern exists.
     const actionButtons = page.locator(
-      'button[aria-label="Ver informe"], button[aria-label="Archivo no disponible."]',
+      'button[aria-label="Ver informe"], button[aria-label="Archivo no disponible."], button[aria-label="Descargar informe"]',
     );
     const count = await actionButtons.count();
-    // Only validate if there are rows in the table
+
     if (count > 0) {
       await expect(actionButtons.first()).toBeVisible();
     }

--- a/frontend/e2e/dashboard-master-detail-state-polish.spec.ts
+++ b/frontend/e2e/dashboard-master-detail-state-polish.spec.ts
@@ -12,64 +12,60 @@ async function setClinicSession(page: Page) {
   ]);
 }
 
-test.describe("dashboard master-detail state polish — smoke (PR-3)", () => {
-  test("informes: master panel renders (dashboard-master-panel)", async ({
-    page,
-  }) => {
+test.describe("dashboard reports profile-layout state polish — smoke", () => {
+  test("informes: reports list panel renders", async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator(".dashboard-master-panel")).toBeVisible({
+    await expect(page.locator("#reports-master-list")).toBeVisible({
       timeout: 8_000,
     });
+    await expect(page.getByText("Lista de informes")).toBeVisible();
   });
 
-  test("informes: detail panel renders with data-detail-state attribute", async ({
-    page,
-  }) => {
+  test("informes: selected report detail panel renders", async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    const detailPanel = page.locator(".dashboard-detail-panel");
-    await expect(detailPanel).toBeVisible({ timeout: 8_000 });
-    const state = await detailPanel.getAttribute("data-detail-state");
-    expect(["empty", "selected"]).toContain(state);
+    await expect(page.locator("#report-detail")).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.getByText("Detalle del informe")).toBeVisible();
   });
 
-  test("informes: workspace has data-master-detail-workspace attribute", async ({
-    page,
-  }) => {
+  test("informes: compact filter search region visible", async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
     await expect(
-      page.locator('[data-master-detail-workspace="true"]'),
+      page.getByRole("search", { name: "Filtros compactos de informes" }),
     ).toBeVisible({ timeout: 8_000 });
   });
 
-  test("informes: master panel contains table element", async ({ page }) => {
-    await setClinicSession(page);
-    await page.goto("/dashboard/informes");
-    const masterPanel = page.locator(".dashboard-master-panel");
-    await expect(masterPanel).toBeVisible({ timeout: 8_000 });
-    await expect(masterPanel.locator("table")).toBeVisible({ timeout: 4_000 });
-  });
-
-  test("informes: no horizontal overflow at 768px (tablet)", async ({
+  test("informes: no table-based master-detail workspace is required", async ({
     page,
   }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard/informes");
+    await expect(page.locator("#reports-master-list")).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.locator("#reports-master-list table")).toHaveCount(0);
+  });
+
+  test("informes: no horizontal overflow at 768px tablet", async ({ page }) => {
     await setClinicSession(page);
     await page.setViewportSize({ width: 768, height: 1024 });
     await page.goto("/dashboard/informes");
-    await expect(page.locator(".dashboard-master-panel")).toBeVisible({
+    await expect(page.locator("#reports-master-list")).toBeVisible({
       timeout: 8_000,
     });
-    const overflow = await page
-      .locator(".dashboard-master-panel")
-      .evaluate((el) => el.scrollWidth - el.clientWidth);
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
     expect(overflow).toBeLessThanOrEqual(2);
   });
 
-  test("informes: no horizontal overflow at 375px (mobile)", async ({
-    page,
-  }) => {
+  test("informes: no horizontal overflow at 375px mobile", async ({ page }) => {
     await setClinicSession(page);
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/dashboard/informes");
@@ -82,15 +78,5 @@ test.describe("dashboard master-detail state polish — smoke (PR-3)", () => {
         document.documentElement.clientWidth,
     );
     expect(overflow).toBeLessThanOrEqual(2);
-  });
-
-  test("informes: PR-2 contract preserved — filter bar region visible", async ({
-    page,
-  }) => {
-    await setClinicSession(page);
-    await page.goto("/dashboard/informes");
-    await expect(
-      page.getByRole("region", { name: "Filtros del dashboard" }),
-    ).toBeVisible({ timeout: 8_000 });
   });
 });

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -5,7 +5,6 @@ import { FormEvent, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
-import { UploadReportModal } from "@/components/dashboard/UploadReportModal";
 import {
   Card,
   CardContent,
@@ -25,7 +24,7 @@ import {
   type AdminParticularTokenCreatePayload,
   type AdminParticularTokenSummary,
 } from "@/lib/api";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 type AdminParticularTokenFormState = {
   clinicId: string;
@@ -56,6 +55,8 @@ type GeneratedTokenDetails = {
   petName: string;
   tutorLastName: string;
 };
+
+type WorkspacePanel = "tokens" | "create";
 
 const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
   clinicId: "",
@@ -110,6 +111,28 @@ const PET_SPECIES_OPTIONS = [
   { value: "Ovinos", label: "Ovinos" },
   { value: "Caprinos", label: "Caprinos" },
   { value: "Aves", label: "Aves" },
+];
+
+const TRACKING_STAGE_LABELS: Record<
+  AdminStudyTrackingCaseSummary["currentStage"],
+  string
+> = {
+  reception: "Recepción de muestra",
+  processing: "Procesamiento",
+  evaluation: "Evaluación",
+  report_development: "Desarrollo de informe",
+  delivered: "Informe disponible / Publicado",
+};
+
+const TRACKING_STAGE_OPTIONS: Array<{
+  value: AdminStudyTrackingStage;
+  label: string;
+}> = [
+  { value: "reception", label: "Recepción de muestra" },
+  { value: "processing", label: "Procesamiento" },
+  { value: "evaluation", label: "Evaluación" },
+  { value: "report_development", label: "Desarrollo de informe" },
+  { value: "delivered", label: "Informe disponible / Publicado" },
 ];
 
 function normalizeSearchText(value: string | number): string {
@@ -283,25 +306,6 @@ function getTrackingLabReceivedAt(
   return trackingCase.labReceivedAt ?? trackingCase.receptionAt;
 }
 
-const TRACKING_STAGE_LABELS: Record<AdminStudyTrackingCaseSummary["currentStage"], string> = {
-  reception: "Recepción de muestra",
-  processing: "Procesamiento",
-  evaluation: "Evaluación",
-  report_development: "Desarrollo de informe",
-  delivered: "Informe disponible / Publicado",
-};
-
-const TRACKING_STAGE_OPTIONS: Array<{
-  value: AdminStudyTrackingStage;
-  label: string;
-}> = [
-  { value: "reception", label: "Recepción de muestra" },
-  { value: "processing", label: "Procesamiento" },
-  { value: "evaluation", label: "Evaluación" },
-  { value: "report_development", label: "Desarrollo de informe" },
-  { value: "delivered", label: "Informe disponible / Publicado" },
-];
-
 function getTrackingStageLabel(
   stage: AdminStudyTrackingCaseSummary["currentStage"],
 ): string {
@@ -337,19 +341,8 @@ function formatTokenClinicLink(
     : `Clínica #${clinicId}`;
 }
 
-function buildTokenPresetClinic(
-  clinicOptions: ClinicOption[],
-  token: AdminParticularTokenSummary,
-) {
-  const clinicName = resolveClinicName(clinicOptions, token.clinicId);
-
-  return {
-    id: token.clinicId,
-    name: clinicName ?? `Clínica #${token.clinicId}`,
-  };
-}
-
 export function AdminParticularTokensCard() {
+  const [activePanel, setActivePanel] = useState<WorkspacePanel>("tokens");
   const [formState, setFormState] =
     useState<AdminParticularTokenFormState>(INITIAL_FORM_STATE);
   const [clinicSearch, setClinicSearch] = useState("");
@@ -357,6 +350,7 @@ export function AdminParticularTokensCard() {
   const [isLoadingClinics, setIsLoadingClinics] = useState(false);
   const [clinicLoadError, setClinicLoadError] = useState<string | null>(null);
   const [tokens, setTokens] = useState<AdminParticularTokenSummary[]>([]);
+  const [selectedTokenId, setSelectedTokenId] = useState<number | null>(null);
   const [trackingCasesByTokenId, setTrackingCasesByTokenId] = useState<
     Record<number, AdminStudyTrackingCaseSummary>
   >({});
@@ -393,20 +387,56 @@ export function AdminParticularTokensCard() {
   const filteredClinicOptions = hasClinicQuery
     ? clinicOptions
         .filter((option) => matchClinicOption(option, clinicSearch))
-        .slice(0, 20)
+        .slice(0, 8)
     : selectedClinic
       ? [selectedClinic]
       : [];
+
+  const selectedToken =
+    selectedTokenId === null
+      ? (tokens[0] ?? null)
+      : (tokens.find((token) => token.id === selectedTokenId) ?? tokens[0] ?? null);
+  const selectedTrackingCase = selectedToken
+    ? trackingCasesByTokenId[selectedToken.id]
+    : null;
+  const selectedTrackingStageDraft = selectedTrackingCase
+    ? trackingStageDraftsByCaseId[selectedTrackingCase.id] ??
+      selectedTrackingCase.currentStage
+    : null;
+  const selectedLabReceivedDraft = selectedTrackingCase
+    ? labReceivedDraftsByCaseId[selectedTrackingCase.id] ??
+      toDateInputValue(getTrackingLabReceivedAt(selectedTrackingCase))
+    : "";
+  const selectedHasTrackingStageChange = selectedTrackingCase
+    ? selectedTrackingStageDraft !== selectedTrackingCase.currentStage
+    : false;
+  const selectedHasLabReceivedChange = selectedTrackingCase
+    ? selectedLabReceivedDraft !==
+      toDateInputValue(getTrackingLabReceivedAt(selectedTrackingCase))
+    : false;
+  const isSelectedTrackingUpdating = selectedTrackingCase
+    ? Boolean(updatingTrackingCaseIds[selectedTrackingCase.id])
+    : false;
+
+  const activeTokensCount = tokens.filter((token) => token.isActive).length;
+  const linkedReportsCount = tokens.filter((token) => token.hasLinkedReport).length;
+  const trackingCount = Object.keys(trackingCasesByTokenId).length;
 
   async function loadTokens() {
     setIsLoadingTokens(true);
     setTrackingLoadError(null);
 
     try {
-      const snapshot = await getAdminParticularTokens({ limit: 10, offset: 0 });
-      setTokens(snapshot.particularTokens);
+      const snapshot = await getAdminParticularTokens({ limit: 8, offset: 0 });
+      const nextTokens = snapshot.particularTokens;
+      setTokens(nextTokens);
+      setSelectedTokenId((current) =>
+        current && nextTokens.some((token) => token.id === current)
+          ? current
+          : nextTokens[0]?.id ?? null,
+      );
 
-      if (snapshot.particularTokens.length === 0) {
+      if (nextTokens.length === 0) {
         setTrackingCasesByTokenId({});
         setTrackingStageDraftsByCaseId({});
         setLabReceivedDraftsByCaseId({});
@@ -415,7 +445,7 @@ export function AdminParticularTokensCard() {
 
       try {
         const trackingEntries = await Promise.all(
-          snapshot.particularTokens.map(async (token) => {
+          nextTokens.map(async (token) => {
             const trackingSnapshot = await getAdminStudyTrackingCases({
               particularTokenId: token.id,
               limit: 1,
@@ -665,6 +695,7 @@ export function AdminParticularTokensCard() {
       setStatusMessage(response.message);
       resetForm();
       await loadTokens();
+      setActivePanel("tokens");
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -696,7 +727,16 @@ export function AdminParticularTokensCard() {
     try {
       const response = await deleteAdminParticularToken(token.id);
       setStatusMessage(response.message);
-      setTokens((current) => current.filter((t) => t.id !== token.id));
+      setTokens((current) => {
+        const nextTokens = current.filter((t) => t.id !== token.id);
+        setSelectedTokenId((currentSelectedId) =>
+          currentSelectedId === token.id
+            ? nextTokens[0]?.id ?? null
+            : currentSelectedId,
+        );
+
+        return nextTokens;
+      });
       setTrackingCasesByTokenId((current) => {
         const next = { ...current };
         delete next[token.id];
@@ -877,422 +917,131 @@ export function AdminParticularTokensCard() {
   }
 
   return (
-    <Card className="dashboard-surface">
+    <Card className="dashboard-surface overflow-hidden">
       <CardHeader className="border-b border-vetneb-line/70">
-        <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6 pt-6">
-        <form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            <div className="md:col-span-2">
-              <label htmlFor="admin-token-clinic-search" className="field-label">
-                Clínica
-              </label>
-              <Input
-                id="admin-token-clinic-search"
-                name="clinicSearch"
-                type="text"
-                placeholder="Buscar clínica por nombre, localidad, usuario o ID..."
-                autoComplete="off"
-                required
-                value={clinicSearch}
-                onChange={(event) => handleClinicSearchChange(event.target.value)}
-                disabled={isSubmitting}
-                aria-describedby="admin-token-clinic-help"
-              />
-              <input
-                id="admin-token-clinic-id"
-                name="clinicId"
-                type="hidden"
-                value={formState.clinicId}
-                readOnly
-              />
-              <p
-                id="admin-token-clinic-help"
-                className="mt-1 text-xs text-muted-foreground"
-              >
-                Seleccione una clínica del listado. La búsqueda admite texto
-                parcial, acentos, localidad, ID y usuarios asociados.
-              </p>
-
-              {clinicLoadError ? (
-                <p
-                  className="mt-2 clinical-alert-error px-3 py-2"
-                  role="alert"
-                >
-                  {clinicLoadError}
-                </p>
-              ) : null}
-
-              <div
-                className="mt-2 max-h-44 overflow-y-auto rounded-lg border border-vetneb-line/80 bg-card/92"
-                role="listbox"
-                aria-label="Clínicas registradas"
-              >
-                {isLoadingClinics ? (
-                  <p className="surface-empty m-2 py-3">
-                    Cargando clínicas registradas...
-                  </p>
-                ) : null}
-
-                {!isLoadingClinics &&
-                hasClinicQuery &&
-                filteredClinicOptions.length === 0 ? (
-                  <p className="surface-empty m-2 py-3">
-                    No hay clínicas registradas que coincidan con la búsqueda.
-                  </p>
-                ) : null}
-
-                {!isLoadingClinics
-                  ? filteredClinicOptions.map((option) => (
-                      <button
-                        key={option.id}
-                        type="button"
-                        className={`dashboard-option-row clinical-hover-row flex w-full items-center justify-between gap-2 border-b border-vetneb-line/35 px-3 py-2 text-left text-sm last:border-b-0 ${
-                          String(option.id) === formState.clinicId
-                            ? "bg-vetneb-teal/12 text-vetneb-navy shadow-[inset_0_0_0_1px_rgba(16,60,96,0.28)]"
-                            : "text-vetneb-ink/88"
-                        }`}
-                        onClick={() => selectClinic(option)}
-                        disabled={isSubmitting}
-                        role="option"
-                        aria-selected={String(option.id) === formState.clinicId}
-                      >
-                        <span className="min-w-0">
-                          <span className="block truncate font-medium">
-                            {option.name}
-                          </span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            ID #{option.id} · Localidad:{" "}
-                            {option.locality ?? "No informada"}
-                          </span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            Usuarios:{" "}
-                            {option.usernames.length
-                              ? option.usernames.join(", ")
-                              : "Sin usuarios asociados"}
-                          </span>
-                        </span>
-                        {String(option.id) === formState.clinicId ? (
-                          <span className="clinical-pill shrink-0 px-2 py-0.5 text-xs tracking-normal">
-                            Seleccionada
-                          </span>
-                        ) : null}
-                      </button>
-                    ))
-                  : null}
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-report-id" className="field-label">
-                ID informe vinculado
-              </label>
-              <Input
-                id="admin-token-report-id"
-                name="reportId"
-                type="number"
-                min="1"
-                inputMode="numeric"
-                placeholder="Opcional"
-                autoComplete="off"
-                value={formState.reportId}
-                onChange={(event) => updateField("reportId", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-particular-email" className="field-label">
-                Email del particular
-              </label>
-              <Input
-                id="admin-token-particular-email"
-                name="particularEmail"
-                type="email"
-                placeholder="email@ejemplo.com"
-                autoComplete="off"
-                required
-                value={formState.particularEmail}
-                onChange={(event) =>
-                  updateField("particularEmail", event.target.value)
-                }
-                disabled={isSubmitting}
-                aria-describedby="admin-token-particular-email-help"
-              />
-              <p
-                id="admin-token-particular-email-help"
-                className="mt-1 text-xs text-muted-foreground"
-              >
-                Obligatorio. El backend enviará el token a este email usando la
-                configuración de correo de VETNEB.
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-tutor-last-name" className="field-label">
-                Apellido del tutor
-              </label>
-              <Input
-                id="admin-token-tutor-last-name"
-                name="tutorLastName"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.tutorLastName}
-                onChange={(event) =>
-                  updateField("tutorLastName", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-pet-name" className="field-label">
-                Nombre del paciente
-              </label>
-              <Input
-                id="admin-token-pet-name"
-                name="petName"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.petName}
-                onChange={(event) => updateField("petName", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-pet-age" className="field-label">
-                Edad
-              </label>
-              <Input
-                id="admin-token-pet-age"
-                name="petAge"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.petAge}
-                onChange={(event) => updateField("petAge", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-pet-breed" className="field-label">
-                Raza
-              </label>
-              <Input
-                id="admin-token-pet-breed"
-                name="petBreed"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.petBreed}
-                onChange={(event) => updateField("petBreed", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-pet-sex" className="field-label">
-                Sexo
-              </label>
-              <select
-                id="admin-token-pet-sex"
-                name="petSex"
-                className="field-select"
-                required
-                value={formState.petSex}
-                onChange={(event) => updateField("petSex", event.target.value)}
-                disabled={isSubmitting}
-              >
-                {PET_SEX_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-pet-species" className="field-label">
-                Especie
-              </label>
-              <select
-                id="admin-token-pet-species"
-                name="petSpecies"
-                className="field-select"
-                required
-                value={formState.petSpecies}
-                onChange={(event) =>
-                  updateField("petSpecies", event.target.value)
-                }
-                disabled={isSubmitting}
-              >
-                {PET_SPECIES_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-sample-location" className="field-label">
-                Ubicación de la muestra
-              </label>
-              <Input
-                id="admin-token-sample-location"
-                name="sampleLocation"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.sampleLocation}
-                onChange={(event) =>
-                  updateField("sampleLocation", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-sample-evolution" className="field-label">
-                Evolución
-              </label>
-              <Input
-                id="admin-token-sample-evolution"
-                name="sampleEvolution"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.sampleEvolution}
-                onChange={(event) =>
-                  updateField("sampleEvolution", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-extraction-date" className="field-label">
-                Fecha de extracción
-              </label>
-              <Input
-                id="admin-token-extraction-date"
-                name="extractionDate"
-                type="date"
-                autoComplete="off"
-                required
-                value={formState.extractionDate}
-                onChange={(event) =>
-                  updateField("extractionDate", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="admin-token-shipping-date" className="field-label">
-                Fecha de envío
-              </label>
-              <Input
-                id="admin-token-shipping-date"
-                name="shippingDate"
-                type="date"
-                autoComplete="off"
-                required
-                value={formState.shippingDate}
-                onChange={(event) =>
-                  updateField("shippingDate", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-          </div>
-
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
           <div>
-            <label htmlFor="admin-token-details-lesion" className="field-label">
-              Detalle de lesión
-            </label>
-            <textarea
-              id="admin-token-details-lesion"
-              name="detailsLesion"
-              className="field-textarea"
-              autoComplete="off"
-              required
-              value={formState.detailsLesion}
-              onChange={(event) =>
-                updateField("detailsLesion", event.target.value)
-              }
-              disabled={isSubmitting}
-            />
+            <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Gestión compacta: generar token, seleccionar de la lista y editar el
+              seguimiento solo desde el detalle.
+            </p>
           </div>
 
-          {errorMessage ? (
-            <p
-              className="clinical-alert-error px-3 py-2"
-              role="alert"
-            >
-              {errorMessage}
-            </p>
-          ) : null}
+          <div className="grid grid-cols-2 gap-2 text-sm sm:grid-cols-4 xl:min-w-[34rem]">
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Tokens</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">{tokens.length}</p>
+            </div>
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Activos</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">
+                {activeTokensCount}
+              </p>
+            </div>
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Informes</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">
+                {linkedReportsCount}
+              </p>
+            </div>
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Seguimientos</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">
+                {trackingCount}
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
 
-          {statusMessage ? (
-            <p className="clinical-alert-success px-3 py-2">
-              {statusMessage}
-            </p>
-          ) : null}
+      <CardContent className="space-y-4 pt-4">
+        <div
+          role="tablist"
+          aria-label="Secciones de tokens particulares"
+          className="flex flex-wrap gap-2 rounded-xl border border-vetneb-line/75 bg-card/78 p-1"
+        >
+          <Button
+            type="button"
+            variant={activePanel === "tokens" ? "default" : "ghost"}
+            size="sm"
+            role="tab"
+            aria-selected={activePanel === "tokens"}
+            onClick={() => setActivePanel("tokens")}
+          >
+            Tokens administrados
+          </Button>
+          <Button
+            type="button"
+            variant={activePanel === "create" ? "default" : "ghost"}
+            size="sm"
+            role="tab"
+            aria-selected={activePanel === "create"}
+            onClick={() => setActivePanel("create")}
+          >
+            Generar token
+          </Button>
+        </div>
 
-          {generatedToken ? (
-            <div className="clinical-muted-band space-y-3 rounded-lg p-4">
-              <p className="text-sm font-semibold text-vetneb-navy">
-                Token generado
-              </p>
-              <Input
-                className="mt-2 font-mono text-sm"
-                readOnly
-                value={generatedToken}
-                aria-label="Token particular generado por admin"
-              />
-              <p className="mt-2 text-xs text-muted-foreground">
-                Copiar ahora. El token completo solo se muestra una vez.
-              </p>
-              <div className="clinical-alert-error px-3 py-2">
-                <p className="text-sm font-semibold">
-                  IMPORTANTE: el token completo solo se muestra una vez.
-                </p>
-                <p className="mt-1 text-sm">
-                  Antes de cerrar este bloque, verificá que el token haya sido
-                  copiado si necesitás respaldo operativo.
-                </p>
-              </div>
-              <p className="text-sm text-vetneb-ink">
-                {generatedTokenRecipientEmail
-                  ? `Email enviado a: ${generatedTokenRecipientEmail}`
-                  : "El backend informó envío correcto del email."}
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void handleCopyManualMessage()}
+        {generatedToken ? (
+          <section
+            aria-labelledby="generated-token-heading"
+            className="rounded-xl border border-vetneb-cyan/45 bg-vetneb-cyan/10 p-4 shadow-[0_10px_32px_rgba(14,116,144,0.08)]"
+          >
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <h3
+                  id="generated-token-heading"
+                  className="text-sm font-semibold text-vetneb-navy"
                 >
-                  Copiar mensaje para enviar
-                </Button>
+                  Token generado recientemente
+                </h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  IMPORTANTE: el token completo solo se muestra una vez. Antes de cerrar este bloque, verificá que el token haya sido copiado si necesitás respaldo operativo.
+                </p>
               </div>
-              {copyStatusMessage ? (
-                <p className="clinical-alert-success px-3 py-2 text-sm">
-                  {copyStatusMessage}
-                </p>
-              ) : null}
-              {copyErrorMessage ? (
-                <p className="clinical-alert-error px-3 py-2 text-sm" role="alert">
-                  {copyErrorMessage}
-                </p>
-              ) : null}
+              <Badge variant="default">Visible una vez</Badge>
+            </div>
+
+            <div className="mt-3 grid grid-cols-1 gap-3 xl:grid-cols-[1fr_auto] xl:items-end">
+              <label className="block">
+                <span className="field-label">Token completo</span>
+                <Input
+                  className="font-mono text-sm"
+                  readOnly
+                  value={generatedToken}
+                  aria-label="Token particular generado por admin"
+                />
+              </label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void handleCopyManualMessage()}
+              >
+                Copiar mensaje para enviar
+              </Button>
+            </div>
+
+            <p className="mt-3 text-sm text-vetneb-ink">
+              {generatedTokenRecipientEmail
+                ? `Email enviado a: ${generatedTokenRecipientEmail}`
+                : "El backend informó envío correcto del email."}
+            </p>
+
+            {copyStatusMessage ? (
+              <p className="clinical-alert-success mt-3 px-3 py-2 text-sm">
+                {copyStatusMessage}
+              </p>
+            ) : null}
+
+            {copyErrorMessage ? (
+              <p className="clinical-alert-error mt-3 px-3 py-2 text-sm" role="alert">
+                {copyErrorMessage}
+              </p>
+            ) : null}
+
+            <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <label className="flex items-start gap-2 text-sm text-vetneb-ink">
                 <input
                   type="checkbox"
@@ -1317,230 +1066,636 @@ export function AdminParticularTokensCard() {
                 Cerrar token visible
               </Button>
             </div>
-          ) : null}
+          </section>
+        ) : null}
 
-          <Button type="submit" disabled={isSubmitting || generatedToken !== null}>
-            {isSubmitting ? "Generando token..." : "Generar token particular"}
-          </Button>
-        </form>
+        {errorMessage ? (
+          <p className="clinical-alert-error px-3 py-2" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
 
-        <div className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h3 className="text-sm font-semibold text-vetneb-ink">
-              Últimos tokens administrados
-            </h3>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void loadTokens()}
-              disabled={isLoadingTokens}
-            >
-              {isLoadingTokens ? "Actualizando..." : "Actualizar"}
-            </Button>
-          </div>
+        {statusMessage ? (
+          <p className="clinical-alert-success px-3 py-2">{statusMessage}</p>
+        ) : null}
 
-          {trackingLoadError ? (
-            <p className="clinical-alert-warning px-3 py-2 text-sm" role="alert">
-              {trackingLoadError}
-            </p>
-          ) : null}
+        {activePanel === "create" ? (
+          <section
+            role="tabpanel"
+            aria-label="Generar token particular"
+            className="rounded-xl border border-vetneb-line/75 bg-card/82 p-4"
+          >
+            <div className="mb-4">
+              <h3 className="dashboard-section-heading">Nuevo token particular</h3>
+              <p className="dashboard-section-description">
+                Formulario compacto para crear el acceso. El informe se vincula por
+                ID si ya existe en el circuito del token.
+              </p>
+            </div>
 
-          {tokens.length ? (
-            <div className="space-y-2">
-              {tokens.map((token) => {
-                const trackingCase = trackingCasesByTokenId[token.id];
-                const isUpdatingTrackingCase = trackingCase
-                  ? Boolean(updatingTrackingCaseIds[trackingCase.id])
-                  : false;
-                const trackingStageDraft = trackingCase
-                  ? trackingStageDraftsByCaseId[trackingCase.id] ??
-                    trackingCase.currentStage
-                  : null;
-                const hasTrackingStageChange = trackingCase
-                  ? trackingStageDraft !== trackingCase.currentStage
-                  : false;
-                const labReceivedDraft = trackingCase
-                  ? labReceivedDraftsByCaseId[trackingCase.id] ??
-                    toDateInputValue(getTrackingLabReceivedAt(trackingCase))
-                  : "";
-                const hasLabReceivedChange = trackingCase
-                  ? labReceivedDraft !==
-                    toDateInputValue(getTrackingLabReceivedAt(trackingCase))
-                  : false;
-
-                return (
-                  <div
-                    key={token.id}
-                    className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
+            <form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-4">
+                <div className="lg:col-span-2">
+                  <label htmlFor="admin-token-clinic-search" className="field-label">
+                    Clínica
+                  </label>
+                  <Input
+                    id="admin-token-clinic-search"
+                    name="clinicSearch"
+                    type="text"
+                    placeholder="Buscar clínica por nombre, localidad, usuario o ID..."
+                    autoComplete="off"
+                    required
+                    value={clinicSearch}
+                    onChange={(event) => handleClinicSearchChange(event.target.value)}
+                    disabled={isSubmitting}
+                    aria-describedby="admin-token-clinic-help"
+                  />
+                  <input
+                    id="admin-token-clinic-id"
+                    name="clinicId"
+                    type="hidden"
+                    value={formState.clinicId}
+                    readOnly
+                  />
+                  <p
+                    id="admin-token-clinic-help"
+                    className="mt-1 text-xs text-muted-foreground"
                   >
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <div className="space-y-1">
-                      <p className="text-sm font-semibold text-vetneb-ink">
-                        {formatTokenTitle(clinicOptions, token)}
+                    Seleccione una clínica registrada.
+                  </p>
+
+                  {clinicLoadError ? (
+                    <p className="clinical-alert-error mt-2 px-3 py-2" role="alert">
+                      {clinicLoadError}
+                    </p>
+                  ) : null}
+
+                  <div
+                    className="mt-2 rounded-lg border border-vetneb-line/80 bg-card/92"
+                    role="listbox"
+                    aria-label="Clínicas registradas"
+                  >
+                    {isLoadingClinics ? (
+                      <p className="surface-empty m-2 py-3">
+                        Cargando clínicas registradas...
                       </p>
-                      <p className="text-xs text-muted-foreground">
-                        Tutor: {token.tutorLastName} · Token ****{token.tokenLast4}
+                    ) : null}
+
+                    {!isLoadingClinics &&
+                    hasClinicQuery &&
+                    filteredClinicOptions.length === 0 ? (
+                      <p className="surface-empty m-2 py-3">
+                        No hay clínicas registradas que coincidan.
+                      </p>
+                    ) : null}
+
+                    {!isLoadingClinics
+                      ? filteredClinicOptions.map((option) => (
+                          <button
+                            key={option.id}
+                            type="button"
+                            className={cn(
+                              "dashboard-option-row clinical-hover-row flex w-full items-center justify-between gap-2 border-b border-vetneb-line/35 px-3 py-2 text-left text-sm last:border-b-0",
+                              String(option.id) === formState.clinicId
+                                ? "bg-vetneb-teal/12 text-vetneb-navy shadow-[inset_0_0_0_1px_rgba(16,60,96,0.28)]"
+                                : "text-vetneb-ink/88",
+                            )}
+                            onClick={() => selectClinic(option)}
+                            disabled={isSubmitting}
+                            role="option"
+                            aria-selected={String(option.id) === formState.clinicId}
+                          >
+                            <span className="min-w-0">
+                              <span className="block truncate font-medium">
+                                {option.name}
+                              </span>
+                              <span className="block truncate text-xs text-muted-foreground">
+                                ID #{option.id} · Localidad: {option.locality ?? "No informada"} · Usuarios: {option.usernames.join(", ")}
+                              </span>
+                            </span>
+                            {String(option.id) === formState.clinicId ? (
+                              <span className="clinical-pill shrink-0 px-2 py-0.5 text-xs tracking-normal">
+                                Seleccionada
+                              </span>
+                            ) : null}
+                          </button>
+                        ))
+                      : null}
+                  </div>
+                </div>
+
+                <label className="block">
+                  <span className="field-label">ID informe vinculado</span>
+                  <Input
+                    id="admin-token-report-id"
+                    name="reportId"
+                    type="number"
+                    min="1"
+                    inputMode="numeric"
+                    placeholder="Opcional"
+                    autoComplete="off"
+                    value={formState.reportId}
+                    onChange={(event) => updateField("reportId", event.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Email particular</span>
+                  <Input
+                    id="admin-token-particular-email"
+                    name="particularEmail"
+                    type="email"
+                    placeholder="email@ejemplo.com"
+                    autoComplete="off"
+                    required
+                    value={formState.particularEmail}
+                    onChange={(event) =>
+                      updateField("particularEmail", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Obligatorio. El backend enviará el token a este email usando la
+                    configuración de correo de VETNEB.
+                  </p>
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Apellido tutor</span>
+                  <Input
+                    id="admin-token-tutor-last-name"
+                    name="tutorLastName"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    value={formState.tutorLastName}
+                    onChange={(event) =>
+                      updateField("tutorLastName", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Paciente</span>
+                  <Input
+                    id="admin-token-pet-name"
+                    name="petName"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    value={formState.petName}
+                    onChange={(event) => updateField("petName", event.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Edad</span>
+                  <Input
+                    id="admin-token-pet-age"
+                    name="petAge"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    value={formState.petAge}
+                    onChange={(event) => updateField("petAge", event.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Raza</span>
+                  <Input
+                    id="admin-token-pet-breed"
+                    name="petBreed"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    value={formState.petBreed}
+                    onChange={(event) => updateField("petBreed", event.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Sexo</span>
+                  <select
+                    id="admin-token-pet-sex"
+                    name="petSex"
+                    className="field-select"
+                    required
+                    value={formState.petSex}
+                    onChange={(event) => updateField("petSex", event.target.value)}
+                    disabled={isSubmitting}
+                  >
+                    {PET_SEX_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Especie</span>
+                  <select
+                    id="admin-token-pet-species"
+                    name="petSpecies"
+                    className="field-select"
+                    required
+                    value={formState.petSpecies}
+                    onChange={(event) =>
+                      updateField("petSpecies", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  >
+                    {PET_SPECIES_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Ubicación muestra</span>
+                  <Input
+                    id="admin-token-sample-location"
+                    name="sampleLocation"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    value={formState.sampleLocation}
+                    onChange={(event) =>
+                      updateField("sampleLocation", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Evolución</span>
+                  <Input
+                    id="admin-token-sample-evolution"
+                    name="sampleEvolution"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    value={formState.sampleEvolution}
+                    onChange={(event) =>
+                      updateField("sampleEvolution", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Extracción</span>
+                  <Input
+                    id="admin-token-extraction-date"
+                    name="extractionDate"
+                    type="date"
+                    autoComplete="off"
+                    required
+                    value={formState.extractionDate}
+                    onChange={(event) =>
+                      updateField("extractionDate", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="field-label">Envío</span>
+                  <Input
+                    id="admin-token-shipping-date"
+                    name="shippingDate"
+                    type="date"
+                    autoComplete="off"
+                    required
+                    value={formState.shippingDate}
+                    onChange={(event) =>
+                      updateField("shippingDate", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                </label>
+
+                <label className="block lg:col-span-4">
+                  <span className="field-label">Detalle de lesión</span>
+                  <textarea
+                    id="admin-token-details-lesion"
+                    name="detailsLesion"
+                    className="field-textarea"
+                    autoComplete="off"
+                    required
+                    value={formState.detailsLesion}
+                    onChange={(event) =>
+                      updateField("detailsLesion", event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                </label>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="submit"
+                  disabled={isSubmitting || generatedToken !== null}
+                >
+                  {isSubmitting ? "Generando token..." : "Generar token particular"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={resetForm}
+                  disabled={isSubmitting}
+                >
+                  Limpiar formulario
+                </Button>
+              </div>
+            </form>
+          </section>
+        ) : (
+          <section
+            role="tabpanel"
+            aria-label="Tokens particulares administrados"
+            className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[0.82fr_1.46fr]"
+          >
+            <div className="rounded-xl border border-vetneb-line/75 bg-card/82">
+              <div className="flex items-center justify-between gap-3 border-b border-vetneb-line/70 px-4 py-3">
+                <div>
+                  <h3 className="dashboard-section-heading">
+                    Últimos tokens administrados
+                  </h3>
+                  <p className="dashboard-section-description">
+                    Seleccionar un token abre el detalle.
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void loadTokens()}
+                  disabled={isLoadingTokens}
+                >
+                  {isLoadingTokens ? "Actualizando..." : "Actualizar"}
+                </Button>
+              </div>
+
+              {trackingLoadError ? (
+                <p className="clinical-alert-warning m-3 px-3 py-2 text-sm" role="alert">
+                  {trackingLoadError}
+                </p>
+              ) : null}
+
+              {tokens.length ? (
+                <div className="divide-y divide-vetneb-line/60">
+                  {tokens.map((token) => {
+                    const isSelected = selectedToken?.id === token.id;
+                    const trackingCase = trackingCasesByTokenId[token.id];
+
+                    return (
+                      <button
+                        key={token.id}
+                        type="button"
+                        onClick={() => setSelectedTokenId(token.id)}
+                        aria-pressed={isSelected}
+                        className={cn(
+                          "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                          isSelected && "bg-vetneb-cyan/12",
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-vetneb-ink">
+                              {formatTokenTitle(clinicOptions, token)}
+                            </p>
+                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              Tutor: {token.tutorLastName} · Token ****
+                              {token.tokenLast4}
+                            </p>
+                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              {trackingCase
+                                ? getTrackingStageLabel(trackingCase.currentStage)
+                                : "Sin seguimiento vinculado"}
+                            </p>
+                          </div>
+                          <div className="flex shrink-0 flex-col items-end gap-1">
+                            <Badge variant={token.isActive ? "default" : "outline"}>
+                              {token.isActive ? "Activo" : "Inactivo"}
+                            </Badge>
+                            <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
+                              {token.hasLinkedReport ? "Informe" : "Sin informe"}
+                            </Badge>
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="surface-empty m-4">
+                  {isLoadingTokens
+                    ? "Cargando tokens particulares..."
+                    : "No hay tokens particulares administrados."}
+                </p>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-vetneb-line/75 bg-card/82">
+              {selectedToken ? (
+                <div className="space-y-4 p-4">
+                  <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0">
+                      <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                        Detalle del token
+                      </p>
+                      <h3 className="mt-1 text-xl font-semibold text-vetneb-ink">
+                        {formatTokenTitle(clinicOptions, selectedToken)}
+                      </h3>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {formatTokenClinicLink(clinicOptions, selectedToken.clinicId)}
                       </p>
                     </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span
-                        className={
-                          token.isActive
-                            ? "clinical-pill shrink-0 px-2.5 py-0.5 text-[0.68rem] tracking-[0.08em]"
-                            : "inline-flex shrink-0 items-center rounded-full border border-vetneb-line/90 bg-card/80 px-2.5 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground"
-                        }
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant={selectedToken.isActive ? "default" : "outline"}>
+                        {selectedToken.isActive ? "Activo" : "Inactivo"}
+                      </Badge>
+                      <Badge
+                        variant={selectedToken.hasLinkedReport ? "default" : "outline"}
                       >
-                        {token.isActive ? "Activo" : "Inactivo"}
-                      </span>
-                      <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
-                        {token.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
+                        {selectedToken.hasLinkedReport
+                          ? "Informe vinculado"
+                          : "Sin informe"}
                       </Badge>
                     </div>
                   </div>
 
-                  <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-6">
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Paciente
+                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    <div className="surface-soft">
+                      <p className="text-xs text-muted-foreground">Paciente</p>
+                      <p className="mt-1 font-semibold text-vetneb-ink">
+                        {selectedToken.petName}
                       </p>
-                      <p className="mt-1 text-xs text-vetneb-ink">
-                        {token.petSpecies} · {token.petBreed} · {token.petSex}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">Edad: {token.petAge}</p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Muestra
-                      </p>
-                      <p className="mt-1 text-xs text-vetneb-ink">{token.sampleLocation}</p>
                       <p className="mt-1 text-xs text-muted-foreground">
-                        Evolución: {token.sampleEvolution}
+                        {selectedToken.petSpecies} · {selectedToken.petBreed} ·{" "}
+                        {selectedToken.petSex} · {selectedToken.petAge}
                       </p>
                     </div>
+                    <div className="surface-soft">
+                      <p className="text-xs text-muted-foreground">Tutor</p>
+                      <p className="mt-1 font-semibold text-vetneb-ink">
+                        {selectedToken.tutorLastName}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Token ****{selectedToken.tokenLast4}
+                      </p>
+                    </div>
+                    <div className="surface-soft">
+                      <p className="text-xs text-muted-foreground">Muestra</p>
+                      <p className="mt-1 font-semibold text-vetneb-ink">
+                        {selectedToken.sampleLocation}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Evolución: {selectedToken.sampleEvolution}
+                      </p>
+                    </div>
+                    <div className="surface-soft">
+                      <p className="text-xs text-muted-foreground">Fechas</p>
+                      <p className="mt-1 text-sm text-vetneb-ink">
+                        Extracción: {formatDate(selectedToken.extractionDate)}
+                      </p>
+                      <p className="mt-1 text-sm text-vetneb-ink">
+                        Envío: {formatDate(selectedToken.shippingDate)}
+                      </p>
+                    </div>
+                    <div className="surface-soft">
+                      <p className="text-xs text-muted-foreground">Publicación</p>
+                      <p className="mt-1 font-semibold text-vetneb-ink">
+                        {selectedToken.reportId ? `Informe #${selectedToken.reportId}` : "—"}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Último acceso:{" "}
+                        {selectedToken.lastLoginAt
+                          ? formatDate(selectedToken.lastLoginAt)
+                          : "—"}
+                      </p>
+                    </div>
+                    <div className="surface-soft">
+                      <p className="text-xs text-muted-foreground">Origen</p>
+                      <p className="mt-1 font-semibold text-vetneb-ink">
+                        {formatTokenSource(selectedToken)}
+                      </p>
+                    </div>
+                  </div>
 
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Fechas
+                  <section className="space-y-3">
+                    <div>
+                      <h4 className="text-base font-semibold text-vetneb-ink">
+                        Detalle de lesión
+                      </h4>
+                      <p className="text-sm text-muted-foreground">
+                        {selectedToken.detailsLesion}
                       </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Extracción: {formatDate(token.extractionDate)}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Envío: {formatDate(token.shippingDate)}
+                    </div>
+                  </section>
+
+                  {selectedToken.hasLinkedReport && selectedToken.reportId ? (
+                    <section className="space-y-2">
+                      <h4 className="text-base font-semibold text-vetneb-ink">
+                        Informe vinculado
+                      </h4>
+                      <ReportFileActions
+                        reportId={selectedToken.reportId}
+                        scope="admin"
+                        align="start"
+                      />
+                    </section>
+                  ) : null}
+
+                  <section className="space-y-3 rounded-xl border border-vetneb-line/75 bg-vetneb-surface-raised/60 p-3">
+                    <div>
+                      <h4 className="text-base font-semibold text-vetneb-ink">
+                        Seguimiento y modificaciones
+                      </h4>
+                      <p className="text-sm text-muted-foreground">
+                        Las modificaciones se realizan solo sobre el token seleccionado.
                       </p>
                     </div>
 
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Publicación
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Informe: {token.reportId ? `#${token.reportId}` : "—"}
-                      </p>
-                      {token.hasLinkedReport && token.reportId ? (
-                        <div className="mt-2">
-                          <p className="mb-1 text-xs font-semibold text-vetneb-navy">
-                            Acciones
+                    {selectedTrackingCase ? (
+                      <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">Etapa actual</p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {getTrackingStageLabel(selectedTrackingCase.currentStage)}
                           </p>
-                          <ReportFileActions
-                            reportId={token.reportId}
-                            scope="admin"
-                            align="start"
-                          />
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Impacta la estimación del informe. Estimación informe:{" "}
+                            {formatDate(selectedTrackingCase.estimatedDeliveryAt)}
+                          </p>
                         </div>
-                      ) : null}
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Último acceso: {token.lastLoginAt ? formatDate(token.lastLoginAt) : "—"}
-                      </p>
-                    </div>
 
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Vínculo
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {formatTokenClinicLink(clinicOptions, token.clinicId)}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Origen: {formatTokenSource(token)}
-                      </p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Seguimiento
-                      </p>
-                      {trackingCase ? (
-                        <>
-                          <p className="mt-1 text-xs text-vetneb-ink">
-                            Etapa: {getTrackingStageLabel(trackingCase.currentStage)}
-                          </p>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            Entrega en laboratorio:{" "}
-                            {formatDate(getTrackingLabReceivedAt(trackingCase))}
-                          </p>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            Estimación informe:{" "}
-                            {formatDate(trackingCase.estimatedDeliveryAt)}
-                          </p>
-                          <label
-                            htmlFor={`admin-tracking-lab-received-${trackingCase.id}`}
-                            className="mt-2 block text-xs font-semibold text-vetneb-navy"
-                          >
-                            Entrega en laboratorio
-                          </label>
+                        <label className="block">
+                          <span className="field-label">Entrega en laboratorio</span>
                           <Input
-                            id={`admin-tracking-lab-received-${trackingCase.id}`}
+                            id={`admin-tracking-lab-received-${selectedTrackingCase.id}`}
                             type="date"
-                            className="mt-1 text-xs"
-                            value={labReceivedDraft}
+                            value={selectedLabReceivedDraft}
                             onChange={(event) =>
                               handleLabReceivedDraftChange(
-                                trackingCase,
+                                selectedTrackingCase,
                                 event.target.value,
                               )
                             }
-                            disabled={isUpdatingTrackingCase}
+                            disabled={isSelectedTrackingUpdating}
                           />
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            Impacta la estimación del informe.
-                          </p>
                           <Button
                             type="button"
                             variant="outline"
                             size="sm"
                             className="mt-2 w-full"
                             onClick={() =>
-                              void handleLabReceivedAtUpdate(token.id, trackingCase)
+                              void handleLabReceivedAtUpdate(
+                                selectedToken.id,
+                                selectedTrackingCase,
+                              )
                             }
                             disabled={
-                              !hasLabReceivedChange || isUpdatingTrackingCase
+                              !selectedHasLabReceivedChange ||
+                              isSelectedTrackingUpdating
                             }
                           >
                             Actualizar entrega
                           </Button>
-                          <label
-                            htmlFor={`admin-tracking-stage-${trackingCase.id}`}
-                            className="mt-2 block text-xs font-semibold text-vetneb-navy"
-                          >
-                            Cambiar etapa del seguimiento
-                          </label>
+                        </label>
+
+                        <label className="block">
+                          <span className="field-label">Etapa</span>
                           <select
-                            id={`admin-tracking-stage-${trackingCase.id}`}
-                            className="field-select mt-1 text-xs"
-                            value={trackingStageDraft ?? trackingCase.currentStage}
+                            id={`admin-tracking-stage-${selectedTrackingCase.id}`}
+                            className="field-select"
+                            value={
+                              selectedTrackingStageDraft ??
+                              selectedTrackingCase.currentStage
+                            }
                             onChange={(event) =>
                               handleTrackingStageDraftChange(
-                                trackingCase,
+                                selectedTrackingCase,
                                 event.target.value as AdminStudyTrackingStage,
                               )
                             }
-                            disabled={isUpdatingTrackingCase}
+                            disabled={isSelectedTrackingUpdating}
                           >
                             {TRACKING_STAGE_OPTIONS.map((stageOption) => (
-                              <option key={stageOption.value} value={stageOption.value}>
+                              <option
+                                key={stageOption.value}
+                                value={stageOption.value}
+                              >
                                 {stageOption.label}
                               </option>
                             ))}
@@ -1551,78 +1706,75 @@ export function AdminParticularTokensCard() {
                             size="sm"
                             className="mt-2 w-full"
                             onClick={() =>
-                              void handleTrackingStageUpdate(token.id, trackingCase)
+                              void handleTrackingStageUpdate(
+                                selectedToken.id,
+                                selectedTrackingCase,
+                              )
                             }
                             disabled={
-                              !hasTrackingStageChange || isUpdatingTrackingCase
+                              !selectedHasTrackingStageChange ||
+                              isSelectedTrackingUpdating
                             }
                           >
-                            {isUpdatingTrackingCase
+                            {isSelectedTrackingUpdating
                               ? "Actualizando..."
                               : "Actualizar estado"}
                           </Button>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {trackingCase.specialStainRequired
-                              ? "Alerta: Solicitud de tinción especial"
-                              : "Sin alerta de tinción especial"}
-                          </p>
+                        </label>
+
+                        <div className="lg:col-span-3 flex flex-wrap gap-2">
                           <Button
                             type="button"
                             variant="outline"
                             size="sm"
-                            className="mt-2 w-full"
                             onClick={() =>
-                              void handleSpecialStainChange(token.id, trackingCase)
+                              void handleSpecialStainChange(
+                                selectedToken.id,
+                                selectedTrackingCase,
+                              )
                             }
-                            disabled={isUpdatingTrackingCase}
+                            disabled={isSelectedTrackingUpdating}
                           >
-                            {trackingCase.specialStainRequired
+                            {selectedTrackingCase.specialStainRequired
                               ? "Resolver tinción especial"
                               : "Solicitar tinción especial"}
                           </Button>
-                        </>
-                      ) : (
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          Sin seguimiento vinculado.
-                        </p>
-                      )}
-                    </div>
-                  </div>
+                          <span className="inline-flex items-center text-sm text-muted-foreground">
+                            {selectedTrackingCase.specialStainRequired
+                              ? "Alerta: Solicitud de tinción especial"
+                              : "Sin alerta de tinción especial."}
+                          </span>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="surface-empty">
+                        Sin seguimiento vinculado para este token.
+                      </p>
+                    )}
+                  </section>
 
-                  <div className="mt-3 flex flex-wrap justify-end gap-2">
-                    <UploadReportModal
-                      triggerLabel={
-                        token.hasLinkedReport && token.reportId
-                          ? "Reemplazar informe"
-                          : "Subir informe para este token"
-                      }
-                      presetClinic={buildTokenPresetClinic(clinicOptions, token)}
-                      presetParticularToken={token}
-                      onUploaded={loadTokens}
-                    />
+                  <div className="flex justify-end">
                     <Button
                       type="button"
                       variant="destructive"
                       size="sm"
-                      disabled={revokingTokenId === token.id}
-                      onClick={() => void handleDeleteToken(token)}
-                      className="min-h-[2.75rem]"
+                      disabled={revokingTokenId === selectedToken.id}
+                      onClick={() => void handleDeleteToken(selectedToken)}
                     >
-                      {revokingTokenId === token.id ? "Eliminando..." : "Eliminar token"}
+                      {revokingTokenId === selectedToken.id
+                        ? "Eliminando..."
+                        : "Eliminar token"}
                     </Button>
                   </div>
-                  </div>
-                );
-              })}
+                </div>
+              ) : (
+                <p className="surface-empty m-4">
+                  Seleccione un token para abrir el detalle.
+                </p>
+              )}
             </div>
-          ) : (
-            <p className="surface-empty">
-              {isLoadingTokens
-                ? "Cargando tokens particulares..."
-                : "No hay tokens particulares administrados."}
-            </p>
-          )}
-        </div>
+          </section>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -339,6 +339,8 @@ export default async function InformesPage({
           <CardContent className="space-y-4 pt-4">
             <form
               method="get"
+              role="search"
+              aria-label="Filtros compactos de informes"
               className="rounded-xl border border-vetneb-line/75 bg-card/78 p-3 shadow-[0_8px_28px_rgba(15,45,62,0.04)]"
             >
               <div className="grid grid-cols-1 gap-3 lg:grid-cols-[1.4fr_0.8fr_1fr_auto] lg:items-end">
@@ -415,7 +417,7 @@ export default async function InformesPage({
                 <section
                   id="reports-master-list"
                   aria-labelledby="reports-list-heading"
-                  className="rounded-xl border border-vetneb-line/75 bg-card/82"
+                  className="dashboard-master-panel rounded-xl border border-vetneb-line/75 bg-card/82"
                 >
                   <div className="border-b border-vetneb-line/70 px-4 py-3">
                     <h2
@@ -532,7 +534,7 @@ export default async function InformesPage({
                 <section
                   id="report-detail"
                   aria-labelledby="report-detail-heading"
-                  className="rounded-xl border border-vetneb-line/75 bg-card/82"
+                  className="dashboard-master-panel rounded-xl border border-vetneb-line/75 bg-card/82"
                 >
                   {selectedReport ? (
                     <div className="space-y-4 p-4">

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -1,39 +1,26 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import { FileText, ListChecks } from "lucide-react";
 
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ErrorState } from "@/components/dashboard/ErrorState";
-import { FilterDrawer } from "@/components/dashboard/FilterDrawer";
-import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
-  StickyFilterBar,
-  type ActiveFilter,
-} from "@/components/dashboard/StickyFilterBar";
-import {
-  StickyActionBar,
-  type StickyActionBarAction,
-} from "@/components/dashboard/StickyActionBar";
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
   StudyTimeline,
   type StudyTimelineStep,
 } from "@/components/dashboard/StudyTimeline";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   getReportsPaginated,
   searchReportsPaginated,
@@ -54,7 +41,7 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-const REPORTS_PAGE_SIZE = 20;
+const REPORTS_PAGE_SIZE = 6;
 
 const statusOptions = [
   { value: "", label: "Todos los estados" },
@@ -96,36 +83,8 @@ function normalizeReportIdFilter(value: string) {
 
 function normalizePageParam(value: string): number {
   const n = Number(value);
+
   return Number.isInteger(n) && n > 0 ? n : 1;
-}
-
-function getStatusFilterLabel(value: string) {
-  return statusOptions.find((option) => option.value === value)?.label ?? value;
-}
-
-function buildActiveFilters(input: {
-  query: string;
-  status: string;
-  studyType: string;
-}): ActiveFilter[] {
-  const activeFilters: ActiveFilter[] = [];
-
-  if (input.query) {
-    activeFilters.push({ label: "Búsqueda", value: input.query });
-  }
-
-  if (input.status) {
-    activeFilters.push({
-      label: "Estado",
-      value: getStatusFilterLabel(input.status),
-    });
-  }
-
-  if (input.studyType) {
-    activeFilters.push({ label: "Tipo de estudio", value: input.studyType });
-  }
-
-  return activeFilters;
 }
 
 function buildInformesHref(input: {
@@ -134,7 +93,6 @@ function buildInformesHref(input: {
   studyType?: string;
   reportId?: number | null;
   page?: number;
-  hash?: string;
 }) {
   const params = new URLSearchParams();
 
@@ -159,13 +117,14 @@ function buildInformesHref(input: {
   }
 
   const qs = params.toString();
-  const hash = input.hash ? `#${input.hash}` : "";
 
-  return `/dashboard/informes${qs ? `?${qs}` : ""}${hash}`;
+  return `/dashboard/informes${qs ? `?${qs}` : ""}`;
 }
 
 function getReportTitle(report: Report) {
-  return report.patientName ? `${report.patientName} · Informe #${report.id}` : `Informe #${report.id}`;
+  return report.patientName
+    ? `${report.patientName} · Informe #${report.id}`
+    : `Informe #${report.id}`;
 }
 
 const REPORT_STATUS_ORDER = {
@@ -301,30 +260,12 @@ export default async function InformesPage({
     selectedReportId === null
       ? (reports[0] ?? null)
       : (reports.find((report) => report.id === selectedReportId) ?? null);
-  const selectedReportIdValue = selectedReport ? String(selectedReport.id) : null;
+
   const selectedReportTimelineSteps = selectedReport
     ? buildStudyTimelineSteps(selectedReport)
     : [];
-  const activeFilters = buildActiveFilters({ query, status, studyType });
-  const stickyActions = [
-    {
-      label: "Lista",
-      href: "#reports-master-list",
-      variant: "outline",
-      icon: <ListChecks className="h-4 w-4" aria-hidden="true" />,
-      "aria-label": "Ir a lista de informes",
-    },
-    {
-      label: "Detalle",
-      href: "#report-detail",
-      variant: "default",
-      disabled: !selectedReport,
-      icon: <FileText className="h-4 w-4" aria-hidden="true" />,
-      "aria-label": selectedReport
-        ? `Ir al detalle del informe ${selectedReport.id}`
-        : "Detalle de informe no disponible",
-    },
-  ] satisfies StickyActionBarAction[];
+
+  const hasActiveFilters = Boolean(query || status || studyType);
 
   return (
     <>
@@ -336,7 +277,7 @@ export default async function InformesPage({
       <main className="dashboard-main">
         <DashboardPageHeader
           title="Informes"
-          description="Workspace operativo para revisar informes clinic-scoped, abrir detalle y consultar el avance del estudio sin salir de la lista."
+          description="Consulta compacta de informes: lista operativa, selección directa y detalle separado sin superponer filtros."
           badge={
             selectedReport ? (
               <StatusBadge
@@ -358,359 +299,359 @@ export default async function InformesPage({
           }
         />
 
-        <StickyActionBar
-          context={selectedReport ? `Informe #${selectedReport.id}` : "Informes"}
-          actions={stickyActions}
-        >
-          {selectedReport ? (
-            <ReportFileActions
-              reportId={selectedReport.id}
-              hasFile={selectedReport.hasFile}
-              align="start"
-            />
-          ) : null}
-        </StickyActionBar>
+        <Card className="dashboard-surface overflow-hidden">
+          <CardHeader className="border-b border-vetneb-line/70">
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+              <div>
+                <CardTitle className="text-base">Informes disponibles</CardTitle>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Seleccione un informe de la lista para abrir el detalle operativo.
+                </p>
+              </div>
 
-        <StickyFilterBar
-          title="Filtros"
-          activeFilters={activeFilters}
-          drawer={
-            <FilterDrawer
-              title="Filtros de informes"
-              description="Búsqueda por paciente o tipo de estudio, y estado operativo."
-              triggerLabel="Filtrar informes"
-              activeCount={activeFilters.length}
+              <div className="grid grid-cols-2 gap-2 text-sm sm:grid-cols-4 xl:min-w-[34rem]">
+                <div className="surface-soft px-3 py-2">
+                  <p className="text-xs text-muted-foreground">Total</p>
+                  <p className="mt-0.5 font-semibold text-vetneb-ink">{reportsTotal}</p>
+                </div>
+                <div className="surface-soft px-3 py-2">
+                  <p className="text-xs text-muted-foreground">Mostrando</p>
+                  <p className="mt-0.5 font-semibold text-vetneb-ink">
+                    {reportsTotal > 0 ? `${pageStart}-${pageEnd}` : "0"}
+                  </p>
+                </div>
+                <div className="surface-soft px-3 py-2">
+                  <p className="text-xs text-muted-foreground">Página</p>
+                  <p className="mt-0.5 font-semibold text-vetneb-ink">
+                    {Math.max(page, 1)} / {Math.max(reportsTotalPages, 1)}
+                  </p>
+                </div>
+                <div className="surface-soft px-3 py-2">
+                  <p className="text-xs text-muted-foreground">Filtros</p>
+                  <p className="mt-0.5 font-semibold text-vetneb-ink">
+                    {hasActiveFilters ? "Activos" : "Sin filtros"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent className="space-y-4 pt-4">
+            <form
+              method="get"
+              className="rounded-xl border border-vetneb-line/75 bg-card/78 p-3 shadow-[0_8px_28px_rgba(15,45,62,0.04)]"
             >
-              <form method="get" className="space-y-4">
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-[1.4fr_0.8fr_1fr_auto] lg:items-end">
                 <label className="block">
-                  <span className="text-sm font-semibold text-vetneb-ink">
-                    Buscar
-                  </span>
+                  <span className="field-label">Buscar</span>
                   <Input
                     name="query"
                     defaultValue={query}
                     placeholder="Buscar por paciente o tipo de estudio..."
-                    className="mt-1.5 min-w-0"
                     aria-label="Buscar informes"
                   />
                 </label>
 
                 <label className="block">
-                  <span className="text-sm font-semibold text-vetneb-ink">
-                    Estado
-                  </span>
+                  <span className="field-label">Estado</span>
                   <select
                     name="status"
                     defaultValue={status}
-                    className="field-select mt-1.5"
+                    className="field-select"
                     aria-label="Filtrar por estado"
                   >
-                    {statusOptions.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
+                    {statusOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
                       </option>
                     ))}
                   </select>
                 </label>
 
                 <label className="block">
-                  <span className="text-sm font-semibold text-vetneb-ink">
-                    Tipo de estudio
-                  </span>
+                  <span className="field-label">Tipo de estudio</span>
                   <Input
                     name="studyType"
                     defaultValue={studyType}
                     placeholder="Filtrar por tipo de estudio..."
-                    className="mt-1.5 min-w-0"
                     aria-label="Filtrar por tipo de estudio"
                   />
                 </label>
 
-                <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
+                <div className="flex flex-wrap gap-2">
+                  <Button type="submit" size="sm">
+                    Filtrar
+                  </Button>
                   <PublicRouteControl
                     href="/dashboard/informes"
                     replace
                     variant="bare"
-                    className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-semibold text-foreground/80 transition-[background-color,color] duration-150 hover:bg-accent/70 hover:text-accent-foreground"
+                    className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70"
                   >
                     Limpiar
                   </PublicRouteControl>
-                  <Button type="submit" size="sm">
-                    Filtrar
-                  </Button>
                 </div>
-              </form>
-            </FilterDrawer>
-          }
-        />
-
-        <MasterDetailWorkspace
-          selectedId={selectedReportIdValue}
-          master={
-            <div id="reports-master-list" className="space-y-4 p-4">
-              <div>
-                <h2 className="dashboard-section-heading">Informes</h2>
-                <p className="dashboard-section-description">
-                  {reportsTotal > 0
-                    ? `Mostrando ${pageStart}–${pageEnd} de ${reportsTotal}`
-                    : "Lista clinic-scoped con selección de detalle."}
-                </p>
               </div>
+            </form>
 
-              <div className="min-w-0 overflow-x-auto rounded-lg border border-vetneb-line/70">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>ID</TableHead>
-                      <TableHead>Paciente</TableHead>
-                      <TableHead>Tipo de estudio</TableHead>
-                      <TableHead className="hidden lg:table-cell">Clínica</TableHead>
-                      <TableHead>Fecha</TableHead>
-                      <TableHead>Estado</TableHead>
-                      <TableHead className="text-right">Acciones</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {reportsLoadError ? (
-                      <TableRow>
-                        <TableCell
-                          colSpan={7}
-                          role="alert"
-                          className="clinical-table-state"
-                        >
-                          <ErrorState
-                            title="No se pudieron cargar los informes"
-                            message="No se pudieron cargar los informes. Intente nuevamente."
-                            className="text-left"
-                          />
-                        </TableCell>
-                      </TableRow>
-                    ) : reports.length ? (
-                      reports.map((report) => {
-                        const isSelected = selectedReport?.id === report.id;
-
-                        return (
-                          <TableRow
-                            key={report.id}
-                            id={`report-${report.id}`}
-                            className={cn("dashboard-row-interactive", isSelected && "bg-vetneb-cyan/10 dashboard-table-row-selected")}
-                          >
-                            <TableCell className="font-mono text-xs text-muted-foreground">
-                              #{report.id}
-                            </TableCell>
-                            <TableCell className="font-medium">
-                              {report.patientName ?? "—"}
-                            </TableCell>
-                            <TableCell className="text-vetneb-ink/75">
-                              {report.studyType ?? "—"}
-                            </TableCell>
-                            <TableCell className="hidden text-sm text-vetneb-ink/75 lg:table-cell">
-                              {report.clinicName ?? `Clínica #${report.clinicId}`}
-                            </TableCell>
-                            <TableCell className="text-sm text-muted-foreground">
-                              {formatDate(report.uploadDate)}
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant={getReportStatusVariant(report.status)}>
-                                {getReportStatusLabel(report.status)}
-                              </Badge>
-                            </TableCell>
-                            <TableCell className="text-right">
-                              <div className="flex flex-col items-end gap-2">
-                                <PublicRouteControl
-                                  href={buildInformesHref({
-                                    query,
-                                    status,
-                                    studyType,
-                                    reportId: report.id,
-                                    page,
-                                    hash: "report-detail",
-                                  })}
-                                  replace
-                                  prefetch={false}
-                                  variant="bare"
-                                  aria-current={isSelected ? "true" : undefined}
-                                  aria-label={
-                                    isSelected
-                                      ? `Informe seleccionado: ${getReportTitle(report)}`
-                                      : `Seleccionar informe: ${getReportTitle(report)}`
-                                  }
-                                  className="inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-2 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70"
-                                >
-                                  {isSelected ? "Seleccionado" : "Seleccionar"}
-                                </PublicRouteControl>
-                                <ReportFileActions
-                                  reportId={report.id}
-                                  hasFile={report.hasFile}
-                                />
-                              </div>
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })
-                    ) : (
-                      <TableRow>
-                        <TableCell
-                          colSpan={7}
-                          className="clinical-table-state"
-                        >
-                          <EmptyState
-                            title="No hay informes disponibles."
-                            description="Cuando haya informes para los filtros actuales, aparecerán en este panel."
-                            className="border-0 bg-transparent"
-                          />
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
+            {reportsLoadError ? (
+              <div role="alert">
+                <ErrorState
+                  title="No se pudieron cargar los informes"
+                  message="No se pudieron cargar los informes. Intente nuevamente."
+                />
               </div>
+            ) : null}
 
-              {reportsTotalPages > 1 && (
-                <nav
-                  aria-label="Paginación de informes"
-                  className="flex items-center justify-between gap-2 pt-1"
-                >
-                  <PublicRouteControl
-                    href={buildInformesHref({ query, status, studyType, page: page - 1 })}
-                    replace
-                    prefetch={false}
-                    variant="bare"
-                    disabled={page <= 1}
-                    aria-label="Página anterior"
-                    aria-disabled={page <= 1 ? "true" : undefined}
-                    className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    Anterior
-                  </PublicRouteControl>
-                  <span className="dashboard-pagination-context">
-                    Página {page} de {reportsTotalPages}
-                  </span>
-                  <PublicRouteControl
-                    href={buildInformesHref({ query, status, studyType, page: page + 1 })}
-                    replace
-                    prefetch={false}
-                    variant="bare"
-                    disabled={page >= reportsTotalPages}
-                    aria-label="Página siguiente"
-                    aria-disabled={page >= reportsTotalPages ? "true" : undefined}
-                    className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    Siguiente
-                  </PublicRouteControl>
-                </nav>
-              )}
-            </div>
-          }
-          detail={
-            selectedReport ? (
-              <div id="report-detail" className="space-y-6 p-5">
-                <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 md:flex-row md:items-start md:justify-between">
-                  <div className="min-w-0">
-                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                      Detalle del informe
-                    </p>
-                    <h2 className="mt-1 text-xl font-semibold text-vetneb-ink">
-                      {getReportTitle(selectedReport)}
-                    </h2>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      Clínica {selectedReport.clinicName ?? `#${selectedReport.clinicId}`}
-                    </p>
-                  </div>
-                  <StatusBadge
-                    status={selectedReport.status}
-                    label={getReportStatusLabel(selectedReport.status)}
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-                  <div className="surface-soft">
-                    <p className="text-xs text-muted-foreground">Paciente</p>
-                    <p className="mt-1 font-semibold text-vetneb-ink">
-                      {selectedReport.patientName ?? "—"}
-                    </p>
-                  </div>
-                  <div className="surface-soft">
-                    <p className="text-xs text-muted-foreground">Tipo de estudio</p>
-                    <p className="mt-1 font-semibold text-vetneb-ink">
-                      {selectedReport.studyType ?? "—"}
-                    </p>
-                  </div>
-                  <div className="surface-soft">
-                    <p className="text-xs text-muted-foreground">Fecha</p>
-                    <p className="mt-1 font-semibold text-vetneb-ink">
-                      {formatDate(selectedReport.uploadDate)}
-                    </p>
-                  </div>
-                  <div className="surface-soft">
-                    <p className="text-xs text-muted-foreground">Creado</p>
-                    <p className="mt-1 font-semibold text-vetneb-ink">
-                      {formatDate(selectedReport.createdAt)}
-                    </p>
-                  </div>
-                  <div className="surface-soft">
-                    <p className="text-xs text-muted-foreground">Actualizado</p>
-                    <p className="mt-1 font-semibold text-vetneb-ink">
-                      {formatDate(selectedReport.updatedAt)}
-                    </p>
-                  </div>
-                  <div className="surface-soft">
-                    <p className="text-xs text-muted-foreground">Archivo</p>
-                    <p className="mt-1 font-semibold text-vetneb-ink">
-                      {selectedReport.fileName ?? (selectedReport.hasFile ? "Disponible" : "—")}
-                    </p>
-                  </div>
-                </div>
-
-                <section id="report-actions" className="space-y-3">
-                  <div>
-                    <h3 className="text-base font-semibold text-vetneb-ink">
-                      Acciones
-                    </h3>
-                    <p className="text-sm text-muted-foreground">
-                      Acciones reales existentes para visualizar o descargar el archivo.
-                    </p>
-                  </div>
-                  <ReportFileActions
-                    reportId={selectedReport.id}
-                    hasFile={selectedReport.hasFile}
-                    align="start"
-                  />
-                </section>
-
-                <section className="space-y-3" aria-labelledby="study-timeline-heading">
-                  <div>
-                    <h3
-                      id="study-timeline-heading"
-                      className="text-base font-semibold text-vetneb-ink"
-                    >
-                      Línea de tiempo del estudio
-                    </h3>
-                    <p className="text-sm text-muted-foreground">
-                      Pasos derivados del estado y fechas ya disponibles del informe.
-                    </p>
-                  </div>
-                  <StudyTimeline steps={selectedReportTimelineSteps} />
-                </section>
-              </div>
-            ) : (
+            {!reportsLoadError && reports.length === 0 ? (
               <EmptyState
-                title="No hay informe seleccionado"
-                description="Seleccione un informe de la lista para ver el detalle operativo."
-                className="m-5"
+                title="No hay informes disponibles."
+                description="Cuando haya informes para los filtros actuales, aparecerán en esta lista."
               />
-            )
-          }
-          emptyDetail={
-            <EmptyState
-              title="No hay informe seleccionado"
-              description="Seleccione un informe de la lista para ver el detalle operativo."
-              className="m-5"
-            />
-          }
-        />
+            ) : null}
 
-        <div className="h-24 md:hidden" aria-hidden="true" />
+            {!reportsLoadError && reports.length > 0 ? (
+              <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[0.86fr_1.44fr]">
+                <section
+                  id="reports-master-list"
+                  aria-labelledby="reports-list-heading"
+                  className="rounded-xl border border-vetneb-line/75 bg-card/82"
+                >
+                  <div className="border-b border-vetneb-line/70 px-4 py-3">
+                    <h2
+                      id="reports-list-heading"
+                      className="dashboard-section-heading"
+                    >
+                      Lista de informes
+                    </h2>
+                    <p className="dashboard-section-description">
+                      Click en un informe para ver detalles y acciones.
+                    </p>
+                  </div>
+
+                  <div className="divide-y divide-vetneb-line/60">
+                    {reports.map((report) => {
+                      const isSelected = selectedReport?.id === report.id;
+
+                      return (
+                        <PublicRouteControl
+                          key={report.id}
+                          id={`report-${report.id}`}
+                          href={buildInformesHref({
+                            query,
+                            status,
+                            studyType,
+                            reportId: report.id,
+                            page,
+                          })}
+                          replace
+                          prefetch={false}
+                          variant="bare"
+                          aria-current={isSelected ? "true" : undefined}
+                          aria-label={
+                            isSelected
+                              ? `Informe seleccionado: ${getReportTitle(report)}`
+                              : `Seleccionar informe: ${getReportTitle(report)}`
+                          }
+                          className={cn(
+                            "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                            isSelected && "bg-vetneb-cyan/12",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                Informe #{report.id}
+                              </p>
+                              <p className="mt-1 truncate text-sm font-semibold text-vetneb-ink">
+                                {report.patientName ?? "Paciente sin nombre"}
+                              </p>
+                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                {report.studyType ?? "Tipo sin registrar"} ·{" "}
+                                {formatDate(report.uploadDate)}
+                              </p>
+                            </div>
+                            <Badge
+                              variant={getReportStatusVariant(report.status)}
+                              className="shrink-0"
+                            >
+                              {getReportStatusLabel(report.status)}
+                            </Badge>
+                          </div>
+                        </PublicRouteControl>
+                      );
+                    })}
+                  </div>
+
+                  {reportsTotalPages > 1 ? (
+                    <nav
+                      aria-label="Paginación de informes"
+                      className="flex items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+                    >
+                      <PublicRouteControl
+                        href={buildInformesHref({
+                          query,
+                          status,
+                          studyType,
+                          page: page - 1,
+                        })}
+                        replace
+                        prefetch={false}
+                        variant="bare"
+                        disabled={page <= 1}
+                        aria-label="Página anterior"
+                        aria-disabled={page <= 1 ? "true" : undefined}
+                        className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Anterior
+                      </PublicRouteControl>
+                      <span className="dashboard-pagination-context">
+                        Página {page} de {reportsTotalPages}
+                      </span>
+                      <PublicRouteControl
+                        href={buildInformesHref({
+                          query,
+                          status,
+                          studyType,
+                          page: page + 1,
+                        })}
+                        replace
+                        prefetch={false}
+                        variant="bare"
+                        disabled={page >= reportsTotalPages}
+                        aria-label="Página siguiente"
+                        aria-disabled={page >= reportsTotalPages ? "true" : undefined}
+                        className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Siguiente
+                      </PublicRouteControl>
+                    </nav>
+                  ) : null}
+                </section>
+
+                <section
+                  id="report-detail"
+                  aria-labelledby="report-detail-heading"
+                  className="rounded-xl border border-vetneb-line/75 bg-card/82"
+                >
+                  {selectedReport ? (
+                    <div className="space-y-4 p-4">
+                      <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div className="min-w-0">
+                          <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                            Detalle del informe
+                          </p>
+                          <h2
+                            id="report-detail-heading"
+                            className="mt-1 text-xl font-semibold text-vetneb-ink"
+                          >
+                            {getReportTitle(selectedReport)}
+                          </h2>
+                          <p className="mt-1 text-sm text-muted-foreground">
+                            Clínica{" "}
+                            {selectedReport.clinicName ??
+                              `#${selectedReport.clinicId}`}
+                          </p>
+                        </div>
+                        <StatusBadge
+                          status={selectedReport.status}
+                          label={getReportStatusLabel(selectedReport.status)}
+                        />
+                      </div>
+
+                      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">Paciente</p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {selectedReport.patientName ?? "—"}
+                          </p>
+                        </div>
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">
+                            Tipo de estudio
+                          </p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {selectedReport.studyType ?? "—"}
+                          </p>
+                        </div>
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">Fecha</p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {formatDate(selectedReport.uploadDate)}
+                          </p>
+                        </div>
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">Creado</p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {formatDate(selectedReport.createdAt)}
+                          </p>
+                        </div>
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">
+                            Actualizado
+                          </p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {formatDate(selectedReport.updatedAt)}
+                          </p>
+                        </div>
+                        <div className="surface-soft">
+                          <p className="text-xs text-muted-foreground">Archivo</p>
+                          <p className="mt-1 font-semibold text-vetneb-ink">
+                            {selectedReport.fileName ??
+                              (selectedReport.hasFile ? "Disponible" : "—")}
+                          </p>
+                        </div>
+                      </div>
+
+                      <section className="space-y-3" aria-labelledby="report-actions-heading">
+                        <div>
+                          <h3
+                            id="report-actions-heading"
+                            className="text-base font-semibold text-vetneb-ink"
+                          >
+                            Acciones
+                          </h3>
+                          <p className="text-sm text-muted-foreground">
+                            Visualización y descarga del archivo disponible.
+                          </p>
+                        </div>
+                        <ReportFileActions
+                          reportId={selectedReport.id}
+                          hasFile={selectedReport.hasFile}
+                          align="start"
+                        />
+                      </section>
+
+                      <section
+                        className="space-y-3"
+                        aria-labelledby="study-timeline-heading"
+                      >
+                        <div>
+                          <h3
+                            id="study-timeline-heading"
+                            className="text-base font-semibold text-vetneb-ink"
+                          >
+                            Línea de tiempo del estudio
+                          </h3>
+                          <p className="text-sm text-muted-foreground">
+                            Pasos derivados del estado y fechas ya disponibles.
+                          </p>
+                        </div>
+                        <StudyTimeline steps={selectedReportTimelineSteps} />
+                      </section>
+                    </div>
+                  ) : (
+                    <EmptyState
+                      title="No hay informe seleccionado"
+                      description="Seleccione un informe de la lista para ver el detalle operativo."
+                      className="m-5"
+                    />
+                  )}
+                </section>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
       </main>
     </>
   );

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -396,20 +396,61 @@ export default async function InformesPage({
               </div>
             </form>
 
-            {reportsLoadError ? (
-              <div role="alert">
-                <ErrorState
-                  title="No se pudieron cargar los informes"
-                  message="No se pudieron cargar los informes. Intente nuevamente."
-                />
-              </div>
-            ) : null}
+            {reportsLoadError || reports.length === 0 ? (
+              <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[0.86fr_1.44fr]">
+                <section
+                  id="reports-master-list"
+                  aria-labelledby="reports-list-heading"
+                  className="dashboard-master-panel rounded-xl border border-vetneb-line/75 bg-card/82"
+                >
+                  <div className="border-b border-vetneb-line/70 px-4 py-3">
+                    <h2
+                      id="reports-list-heading"
+                      className="dashboard-section-heading"
+                    >
+                      Lista de informes
+                    </h2>
+                    <p className="dashboard-section-description">
+                      Click en un informe para ver detalles y acciones.
+                    </p>
+                  </div>
 
-            {!reportsLoadError && reports.length === 0 ? (
-              <EmptyState
-                title="No hay informes disponibles."
-                description="Cuando haya informes para los filtros actuales, aparecerán en esta lista."
-              />
+                  <div className="p-4">
+                    {reportsLoadError ? (
+                      <div role="alert">
+                        <ErrorState
+                          title="No se pudieron cargar los informes"
+                          message="No se pudieron cargar los informes. Intente nuevamente."
+                        />
+                      </div>
+                    ) : (
+                      <EmptyState
+                        title="No hay informes disponibles."
+                        description="Cuando haya informes para los filtros actuales, aparecerán en esta lista."
+                      />
+                    )}
+                  </div>
+                </section>
+
+                <section
+                  id="report-detail"
+                  aria-labelledby="report-detail-heading"
+                  className="dashboard-detail-panel rounded-xl border border-vetneb-line/75 bg-card/82"
+                >
+                  <div className="p-4">
+                    <h2
+                      id="report-detail-heading"
+                      className="sr-only"
+                    >
+                      Detalle del informe
+                    </h2>
+                    <EmptyState
+                      title="No hay informe seleccionado"
+                      description="Seleccione un informe de la lista para ver el detalle operativo."
+                    />
+                  </div>
+                </section>
+              </div>
             ) : null}
 
             {!reportsLoadError && reports.length > 0 ? (

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -449,41 +449,39 @@ test("admin token card consume seguimiento por token desde study-tracking", () =
   assert.ok(api.includes("export async function getAdminStudyTrackingCases("));
 });
 
-test("admin token card exposes report upload action scoped to each token", () => {
+test("admin token card removes report upload action from token workspace", () => {
   const card = read(ADMIN_CARD_PATH);
   const uploadModal = read("frontend/src/components/dashboard/UploadReportModal.tsx");
 
-  assert.ok(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
-  assert.ok(card.includes("triggerLabel={"));
-  assert.ok(card.includes('"Subir informe para este token"'));
-  assert.ok(card.includes('"Reemplazar informe"'));
-  assert.ok(card.includes("presetClinic={buildTokenPresetClinic(clinicOptions, token)}"));
-  assert.ok(card.includes("presetParticularToken={token}"));
-  assert.ok(card.includes("onUploaded={loadTokens}"));
+  assert.equal(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'), false);
+  assert.equal(card.includes("triggerLabel={"), false);
+  assert.equal(card.includes('"Subir informe para este token"'), false);
+  assert.equal(card.includes('"Reemplazar informe"'), false);
+  assert.equal(card.includes("presetClinic={buildTokenPresetClinic(clinicOptions, token)}"), false);
+  assert.equal(card.includes("presetParticularToken={token}"), false);
+  assert.equal(card.includes("onUploaded={loadTokens}"), false);
   assert.ok(uploadModal.includes("presetParticularToken?: AdminParticularTokenSummary;"));
-  assert.ok(uploadModal.includes('formData.append("clinicId", String(presetClinic.id));'));
   assert.ok(uploadModal.includes('formData.append("particularTokenId", String(presetParticularToken.id));'));
   assert.equal(card.includes("tokenHash"), false);
-  assert.ok(card.includes("Token ****{token.tokenLast4}"));
+  assert.ok(card.includes("Token ****{selectedToken.tokenLast4}"));
 });
 
-test("admin token card shows linked report preview and download actions without exposing token", () => {
+test("admin token card shows selected linked report preview and download actions without exposing token", () => {
   const card = read(ADMIN_CARD_PATH);
 
   assert.ok(card.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
-  assert.ok(card.includes("token.hasLinkedReport && token.reportId ? ("));
-  assert.ok(card.includes("Informe: {token.reportId ? `#${token.reportId}` : \"—\"}"));
+  assert.ok(card.includes("selectedToken.hasLinkedReport && selectedToken.reportId ? ("));
   assert.ok(card.includes("<ReportFileActions"));
-  assert.ok(card.includes("reportId={token.reportId}"));
+  assert.ok(card.includes("reportId={selectedToken.reportId}"));
   assert.ok(card.includes('scope="admin"'));
   assert.ok(card.includes('align="start"'));
-  assert.ok(card.includes("Acciones"));
-  assert.ok(card.includes('"Reemplazar informe"'));
+  assert.ok(card.includes("Informe vinculado"));
+  assert.equal(card.includes('"Reemplazar informe"'), false);
   assert.equal(card.includes("tokenHash"), false);
   assert.equal(card.includes("storagePath"), false);
 });
 
-test("admin token card renders clinic name in title and vínculo with fallback", () => {
+test("admin token card renders clinic name in list and selected detail with fallback", () => {
   const card = read(ADMIN_CARD_PATH);
 
   assert.ok(card.includes("hasResolvedName: boolean;"));
@@ -496,21 +494,22 @@ test("admin token card renders clinic name in title and vínculo with fallback",
   assert.ok(card.includes("`Clínica: ${clinicName} (#${clinicId})`"));
   assert.ok(card.includes("`Clínica #${clinicId}`"));
   assert.ok(card.includes("{formatTokenTitle(clinicOptions, token)}"));
-  assert.ok(card.includes("{formatTokenClinicLink(clinicOptions, token.clinicId)}"));
+  assert.ok(card.includes("{formatTokenClinicLink(clinicOptions, selectedToken.clinicId)}"));
 });
 
-test("admin token tracking stage uses local draft and explicit update button", () => {
+test("admin token tracking stage uses selected local draft and explicit update button", () => {
   const card = read(ADMIN_CARD_PATH);
 
   assert.ok(card.includes("trackingStageDraftsByCaseId"));
   assert.ok(card.includes("function handleTrackingStageDraftChange("));
   assert.ok(card.includes("function handleTrackingStageUpdate("));
   assert.ok(card.includes("currentStage: nextStage"));
-  assert.ok(card.includes("value={trackingStageDraft ?? trackingCase.currentStage}"));
+  assert.ok(card.includes("selectedTrackingStageDraft"));
+  assert.ok(card.includes("selectedHasTrackingStageChange"));
   assert.ok(card.includes("handleTrackingStageDraftChange("));
-  assert.ok(card.includes("void handleTrackingStageUpdate(token.id, trackingCase)"));
+  assert.ok(card.includes("void handleTrackingStageUpdate("));
   assert.ok(card.includes("disabled={"));
-  assert.ok(card.includes("!hasTrackingStageChange || isUpdatingTrackingCase"));
+  assert.ok(card.includes("!selectedHasTrackingStageChange"));
   assert.ok(card.includes('"Actualizar estado"'));
   assert.ok(card.includes('"Actualizando..."'));
 });

--- a/test/frontend-admin-report-workflow.test.ts
+++ b/test/frontend-admin-report-workflow.test.ts
@@ -20,7 +20,7 @@ function read(relativePath: string): string {
   );
 }
 
-test("dashboard admin elimina seguimiento redundante y mueve carga de informes al token", () => {
+test("dashboard admin elimina seguimiento redundante y quita carga de informes del token workspace", () => {
   const page = read(PAGE_PATH);
   const card = read(ADMIN_PARTICULAR_TOKENS_CARD_PATH);
 
@@ -39,15 +39,17 @@ test("dashboard admin elimina seguimiento redundante y mueve carga de informes a
     false,
   );
   assert.equal(page.includes("<UploadReportModal />"), false);
-  assert.ok(
+  assert.equal(
     card.includes(
       'import { UploadReportModal } from "@/components/dashboard/UploadReportModal";',
     ),
+    false,
   );
-  assert.ok(card.includes("triggerLabel={"));
-  assert.ok(card.includes('"Subir informe para este token"'));
-  assert.ok(card.includes('"Reemplazar informe"'));
-  assert.ok(card.includes("presetParticularToken={token}"));
+  assert.equal(card.includes('"Subir informe para este token"'), false);
+  assert.equal(card.includes('"Reemplazar informe"'), false);
+  assert.equal(card.includes("presetParticularToken={token}"), false);
+  assert.ok(card.includes("Informe vinculado"));
+  assert.ok(card.includes("<ReportFileActions"));
 });
 
 test("sidebar admin no muestra seguimiento de informes y conserva anclas operativas", () => {

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -51,11 +51,11 @@ test("dashboard informes page shows empty state when reports are unavailable", (
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("reportsLoadError ?"));
-  assert.ok(source.includes("reports.length ?"));
+  assert.ok(source.includes("reports.length > 0 ?"));
   assert.ok(source.includes("No se pudieron cargar los informes. Intente nuevamente."));
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay informes disponibles."));
-  assert.ok(source.includes("colSpan={7}"));
+  assert.ok(source.includes("<EmptyState"));
   assert.ok(source.includes("reports.map((report)"));
 });
 

--- a/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
+++ b/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
@@ -123,27 +123,16 @@ test("StickyFilterBar renders sticky active-filter summary and action slots", ()
   assert.equal(source.includes("shadow-xl"), false);
 });
 
-test("dashboard informes integrates drawer and sticky filter bar without changing reports behavior", () => {
+test("dashboard informes uses compact inline filters without drawer sticky overlap", () => {
   const source = read(INFORMES_PAGE_PATH);
-  const mainSource = source.slice(source.indexOf('<main className="dashboard-main">'));
 
-  assert.ok(source.includes('import { FilterDrawer } from "@/components/dashboard/FilterDrawer";'));
-  assert.ok(source.includes('} from "@/components/dashboard/StickyFilterBar";'));
-  assert.ok(source.includes("type ActiveFilter,"));
-  assert.ok(source.includes("function buildActiveFilters(input: {"));
-  assert.ok(source.includes("query: string;"));
-  assert.ok(source.includes("status: string;"));
-  assert.ok(source.includes("studyType: string;"));
-  assert.ok(source.includes('activeFilters.push({ label: "Búsqueda", value: input.query });'));
-  assert.ok(source.includes('label: "Estado"'));
-  assert.ok(source.includes('label: "Tipo de estudio"'));
-  assert.ok(source.includes("const activeFilters = buildActiveFilters({ query, status, studyType });"));
-  assert.ok(source.includes("<StickyFilterBar"));
-  assert.ok(source.includes("activeFilters={activeFilters}"));
-  assert.ok(source.includes("<FilterDrawer"));
-  assert.ok(source.includes('triggerLabel="Filtrar informes"'));
-  assert.ok(source.includes("activeCount={activeFilters.length}"));
-  assert.ok(source.includes('<form method="get"'));
+  assert.equal(source.includes('import { FilterDrawer } from "@/components/dashboard/FilterDrawer";'), false);
+  assert.equal(source.includes('} from "@/components/dashboard/StickyFilterBar";'), false);
+  assert.equal(source.includes("<StickyFilterBar"), false);
+  assert.equal(source.includes("<FilterDrawer"), false);
+  assert.equal(source.includes('triggerLabel="Filtrar informes"'), false);
+  assert.ok(source.includes('<form'));
+  assert.ok(source.includes('method="get"'));
   assert.ok(source.includes('name="query"'));
   assert.ok(source.includes("defaultValue={query}"));
   assert.ok(source.includes('name="status"'));
@@ -159,21 +148,13 @@ test("dashboard informes integrates drawer and sticky filter bar without changin
   assert.ok(source.includes("studyType: studyType || undefined,"));
   assert.ok(source.includes(": await getReportsPaginated("));
   assert.ok(source.includes("requestOptions,"));
-  assert.ok(source.includes("<MasterDetailWorkspace"));
+  assert.equal(source.includes("<MasterDetailWorkspace"), false);
   assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
-  assert.ok(source.includes("<StickyActionBar"));
+  assert.equal(source.includes("<StickyActionBar"), false);
   assert.ok(source.includes("<ReportFileActions"));
   assert.equal(source.includes('from "next/link"'), false);
   assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("<a"), false);
-
-  const stickyActionIndex = mainSource.indexOf("<StickyActionBar");
-  const stickyFilterIndex = mainSource.indexOf("<StickyFilterBar");
-  const workspaceIndex = mainSource.indexOf("<MasterDetailWorkspace");
-
-  assert.ok(stickyActionIndex >= 0);
-  assert.ok(stickyFilterIndex > stickyActionIndex);
-  assert.ok(workspaceIndex > stickyFilterIndex);
 });
 
 test("PR-6 scope leaves backend auth API middleware SEO and dependencies untouched", () => {

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -25,9 +25,9 @@ test("dashboard informes defines non-indexable metadata and clinic read dependen
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
   assert.ok(source.includes('import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";'));
-  assert.ok(source.includes('import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";'));
+  assert.equal(source.includes('import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";'), false);
   assert.ok(source.includes('import { StatusBadge } from "@/components/dashboard/StatusBadge";'));
-  assert.ok(source.includes('} from "@/components/dashboard/StickyActionBar";'));
+  assert.equal(source.includes('} from "@/components/dashboard/StickyActionBar";'), false);
   assert.ok(source.includes('} from "@/components/dashboard/StudyTimeline";'));
   assert.ok(source.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
   assert.equal(source.includes("UploadReportModal"), false);
@@ -75,7 +75,7 @@ test("dashboard informes keeps status filter options aligned to report statuses"
   assert.ok(source.includes('{ value: "delivered", label: "Entregado" }'));
 });
 
-test("dashboard informes renders clinic reports surface without technical source copy", () => {
+test("dashboard informes renders profile-layout clinic reports surface without technical source copy", () => {
   const source = read(INFORMES_PAGE_PATH);
   const removedSourceCopy = "Lectura clinic-" + "scoped conectada a";
   const removedReportsEndpoint = "GET " + "/api/reports";
@@ -84,8 +84,10 @@ test("dashboard informes renders clinic reports surface without technical source
   assert.ok(source.includes('subtitle="Consulta de informes médicos veterinarios"'));
   assert.ok(source.includes('notifications="clinic"'));
   assert.ok(source.includes("<DashboardPageHeader"));
-  assert.ok(source.includes("<StickyActionBar"));
-  assert.ok(source.includes("<MasterDetailWorkspace"));
+  assert.equal(source.includes("<StickyActionBar"), false);
+  assert.equal(source.includes("<MasterDetailWorkspace"), false);
+  assert.ok(source.includes("Lista de informes"));
+  assert.ok(source.includes("Detalle del informe"));
   assert.ok(source.includes("<StudyTimeline"));
   assert.equal(source.includes("<UploadReportModal />"), false);
   assert.equal(source.includes("/api/admin"), false);
@@ -93,10 +95,11 @@ test("dashboard informes renders clinic reports surface without technical source
   assert.equal(source.includes(removedReportsEndpoint), false);
 });
 
-test("dashboard informes renders filters and reports table columns", () => {
+test("dashboard informes renders compact inline filters and profile-layout list/detail columns", () => {
   const source = read(INFORMES_PAGE_PATH);
 
-  assert.ok(source.includes('<form method="get"'));
+  assert.ok(source.includes('<form'));
+  assert.ok(source.includes('method="get"'));
   assert.ok(source.includes('placeholder="Buscar por paciente o tipo de estudio..."'));
   assert.ok(source.includes('name="query"'));
   assert.ok(source.includes("defaultValue={query}"));
@@ -110,29 +113,23 @@ test("dashboard informes renders filters and reports table columns", () => {
   assert.ok(source.includes("Limpiar"));
   assert.ok(source.includes('id="reports-master-list"'));
   assert.ok(source.includes('id="report-detail"'));
-  assert.ok(source.includes("<TableHead>ID</TableHead>"));
-  assert.ok(source.includes("<TableHead>Paciente</TableHead>"));
-  assert.ok(source.includes("<TableHead>Tipo de estudio</TableHead>"));
-  assert.ok(source.includes(">Clínica</TableHead>"));
-  assert.ok(source.includes("<TableHead>Fecha</TableHead>"));
-  assert.ok(source.includes("<TableHead>Estado</TableHead>"));
-  assert.ok(source.includes('<TableHead className="text-right">Acciones</TableHead>'));
+  assert.ok(source.includes("Lista de informes"));
+  assert.ok(source.includes("Detalle del informe"));
+  assert.equal(source.includes("<TableHead>"), false);
 });
 
-test("dashboard informes keeps row rendering badges dates and report actions", () => {
+test("dashboard informes keeps list rendering badges dates and selected report actions", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("reports.map((report) =>"));
   assert.ok(source.includes("const isSelected = selectedReport?.id === report.id;"));
-  assert.ok(source.includes('report.patientName ?? "—"'));
-  assert.ok(source.includes('report.studyType ?? "—"'));
-  assert.ok(source.includes("report.clinicName ?? `Clínica #${report.clinicId}`"));
+  assert.ok(source.includes('report.patientName ?? "Paciente sin nombre"'));
+  assert.ok(source.includes('report.studyType ?? "Tipo sin registrar"'));
   assert.ok(source.includes("formatDate(report.uploadDate)"));
   assert.ok(source.includes("getReportStatusVariant(report.status)"));
   assert.ok(source.includes("getReportStatusLabel(report.status)"));
+  assert.ok(source.includes("id={`report-${report.id}`}"));
   assert.ok(source.includes("<ReportFileActions"));
-  assert.ok(source.includes("reportId={report.id}"));
-  assert.ok(source.includes("hasFile={report.hasFile}"));
   assert.ok(source.includes("reportId={selectedReport.id}"));
   assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
   assert.equal(source.includes("storagePath"), false);
@@ -143,7 +140,7 @@ test("dashboard informes keeps empty state and avoids client-side fetch literals
 
   assert.ok(source.includes("No hay informes disponibles."));
   assert.ok(source.includes("<EmptyState"));
-  assert.ok(source.includes("colSpan={7}"));
+  assert.equal(source.includes("colSpan={7}"), false);
   assert.equal(source.includes("fetch("), false);
   assert.equal(source.includes("mock"), false);
 });
@@ -156,9 +153,9 @@ test("dashboard informes separates fetch failures from real empty report lists",
   assert.ok(source.includes("try {"));
   assert.ok(source.includes("reportsLoadError = true;"));
   assert.ok(source.includes("reportsLoadError ?"));
-  assert.ok(source.includes("No se pudieron cargar los informes. Intente nuevamente."));
-  assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes(": reports.length ?"));
+  assert.ok(source.includes("No se pudieron cargar los informes"));
+  assert.ok(source.includes("<ErrorState"));
+  assert.ok(source.includes("reports.length > 0 ?"));
   assert.ok(source.includes("No hay informes disponibles."));
 });
 

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -122,18 +122,16 @@ test("PR-9 private dashboard pages leave bottom space for mobile fixed actions",
   const informesSource = read(INFORMES_PAGE_PATH);
   const logisticaSource = read(LOGISTICA_PAGE_PATH);
 
-  // PR5: dashboard and admin use DashboardModuleHub (card hub) instead of StickyActionBar.
-  // Informes and logistica retain StickyActionBar for their page-level quick actions.
-  for (const [context, source] of [
-    ["informes", informesSource],
-    ["logistica", logisticaSource],
-  ] as const) {
-    assert.ok(source.includes("<StickyActionBar"), `${context} uses StickyActionBar`);
-    assert.ok(
-      source.includes('className="h-24 md:hidden" aria-hidden="true"'),
-      `${context} keeps mobile bottom spacer`,
-    );
-  }
+  // PR5: dashboard/admin use hubs; PR1012 makes informes profile-layout without StickyActionBar.
+  assert.equal(informesSource.includes("<StickyActionBar"), false);
+  assert.ok(informesSource.includes("Lista de informes"));
+  assert.ok(informesSource.includes("Detalle del informe"));
+
+  assert.ok(logisticaSource.includes("<StickyActionBar"), "logistica uses StickyActionBar");
+  assert.ok(
+    logisticaSource.includes('className="h-24 md:hidden" aria-hidden="true"'),
+    "logistica keeps mobile bottom spacer",
+  );
 
   for (const [context, source] of [
     ["dashboard", dashboardSource],

--- a/test/frontend-dashboard-reports-master-detail.test.ts
+++ b/test/frontend-dashboard-reports-master-detail.test.ts
@@ -108,32 +108,26 @@ test("StudyTimeline supports ordered visual states without business calculations
   assert.equal(source.includes("fetch("), false);
 });
 
-test("dashboard informes composes master-detail, selected report detail, timeline, and sticky actions", () => {
+test("dashboard informes composes profile-layout list, selected report detail, timeline, and actions", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("<DashboardPageHeader"));
-  assert.ok(source.includes("<StickyActionBar"));
-  assert.ok(source.includes("<MasterDetailWorkspace"));
+  assert.equal(source.includes("<StickyActionBar"), false);
+  assert.equal(source.includes("<MasterDetailWorkspace"), false);
+  assert.ok(source.includes("Lista de informes"));
+  assert.ok(source.includes("Detalle del informe"));
   assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
   assert.ok(source.includes("buildStudyTimelineSteps(selectedReport)"));
   assert.ok(source.includes("const selectedReport ="));
   assert.ok(source.includes("selectedReportId === null"));
   assert.ok(source.includes("? (reports[0] ?? null)"));
   assert.ok(source.includes(": (reports.find((report) => report.id === selectedReportId) ?? null)"));
-  assert.ok(source.includes("const stickyActions = ["));
-  assert.ok(source.includes('label: "Lista"'));
-  assert.ok(source.includes('href: "#reports-master-list"'));
-  assert.ok(source.includes('label: "Detalle"'));
-  assert.ok(source.includes('href: "#report-detail"'));
   assert.ok(source.includes('id="reports-master-list"'));
   assert.ok(source.includes('id="report-detail"'));
-  assert.ok(source.includes('id="report-actions"'));
   assert.ok(source.includes("Línea de tiempo del estudio"));
-  assert.ok(source.includes("Pasos derivados del estado y fechas ya disponibles del informe."));
+  assert.ok(source.includes("Pasos derivados del estado y fechas ya disponibles."));
   assert.ok(source.includes("reportId={selectedReport.id}"));
   assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
-  assert.ok(source.includes("reportId={report.id}"));
-  assert.ok(source.includes("hasFile={report.hasFile}"));
 });
 
 test("dashboard informes derives timeline steps from existing report fields only", () => {
@@ -153,7 +147,7 @@ test("dashboard informes derives timeline steps from existing report fields only
   assert.equal(source.includes("new Date("), false);
 });
 
-test("dashboard informes server-side pagination controls and summary", () => {
+test("dashboard informes server-side pagination controls and compact summary", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(source.includes("reportsTotalPages > 1"));
@@ -161,9 +155,8 @@ test("dashboard informes server-side pagination controls and summary", () => {
   assert.ok(source.includes('aria-label="Página anterior"'));
   assert.ok(source.includes('aria-label="Página siguiente"'));
   assert.ok(source.includes("Página {page} de {reportsTotalPages}"));
-  assert.ok(source.includes("Mostrando ${pageStart}"));
-  assert.ok(source.includes("de ${reportsTotal}"));
-  assert.ok(source.includes("const REPORTS_PAGE_SIZE = 20"));
+  assert.ok(source.includes("{reportsTotal > 0 ? `${pageStart}-${pageEnd}` : \"0\"}"));
+  assert.ok(source.includes("const REPORTS_PAGE_SIZE = 6"));
   assert.ok(source.includes("page: page - 1"));
   assert.ok(source.includes("page: page + 1"));
   assert.ok(source.includes("disabled={page <= 1}"));

--- a/test/frontend-report-download-action.test.ts
+++ b/test/frontend-report-download-action.test.ts
@@ -44,7 +44,7 @@ test("frontend report actions handles unavailable loading and error states", () 
   assert.equal(source.includes("No autorizado"), false);
 });
 
-test("frontend informes page uses report file actions", () => {
+test("frontend informes page uses selected report file actions", () => {
   const source = read(INFORMES_PAGE_PATH);
 
   assert.ok(
@@ -53,8 +53,8 @@ test("frontend informes page uses report file actions", () => {
     ),
   );
   assert.ok(source.includes("<ReportFileActions"));
-  assert.ok(source.includes("reportId={report.id}"));
-  assert.ok(source.includes("hasFile={report.hasFile}"));
+  assert.ok(source.includes("reportId={selectedReport.id}"));
+  assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
   assert.equal(source.includes("storagePath"), false);
   assert.equal(source.includes("<button"), false);
 });

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -74,7 +74,7 @@ test("frontend informes page does not expose admin upload modal in clinic dashbo
   assert.equal(source.includes("dashboard administrador"), false);
 });
 
-test("frontend admin dashboard routes upload report modal through token cards", () => {
+test("frontend admin token workspace does not mount upload report modal", () => {
   const page = read(ADMIN_PAGE_PATH);
   const card = read(ADMIN_CARD_PATH);
 
@@ -82,12 +82,11 @@ test("frontend admin dashboard routes upload report modal through token cards", 
   assert.ok(page.includes('id="admin-report-upload"'));
   assert.equal(page.includes("<UploadReportModal />"), false);
   assert.ok(page.includes("Carga de informes"));
-  assert.ok(page.includes("cada token administrado"));
-  assert.ok(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'));
-  assert.ok(card.includes("triggerLabel={"));
-  assert.ok(card.includes('"Subir informe para este token"'));
-  assert.ok(card.includes('"Reemplazar informe"'));
-  assert.ok(card.includes("presetParticularToken={token}"));
+  assert.equal(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'), false);
+  assert.equal(card.includes("triggerLabel={"), false);
+  assert.equal(card.includes('"Subir informe para este token"'), false);
+  assert.equal(card.includes('"Reemplazar informe"'), false);
+  assert.equal(card.includes("presetParticularToken={token}"), false);
 });
 
 test("frontend upload report modal supports preset particular token uploads", () => {


### PR DESCRIPTION
## Summary
- Align clinic reports dashboard to the profile-public layout pattern: compact inline filters, report list, and selected detail panel
- Align admin particular tokens dashboard to the same operational pattern: separate create panel, compact token list, and selected token detail/modification panel
- Remove report upload actions from the admin token workspace because report upload belongs to the token/report flow
- Remove sticky/drawer/master-detail legacy report UI from clinic reports to avoid filter overlap and selection bugs
- Update native frontend contracts to lock the new profile-layout dashboard behavior

## Validation
- pnpm test
- pnpm build
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm security:public-surface