### PR TITLE
test(dashboard): enforce internal no-scroll contract

### DIFF
--- a/docs/implementation/dashboard-internal-no-scroll-contract.md
+++ b/docs/implementation/dashboard-internal-no-scroll-contract.md
@@ -1,0 +1,134 @@
+# PR-A — Contrato no-scroll interno del Dashboard App Shell
+
+- **Rama:** `fix/dashboard-internal-no-scroll-contract`
+- **Base:** `main` @ `d2c6d26` (audit masked master detail no scroll contract, #1013)
+- **Fecha:** 2026-06-17
+- **Tipo:** Implementación + tests (contrato). No es rediseño de módulos.
+
+## Objetivo del PR
+
+Blindar por contrato que `main.dashboard-main` **deja de ser un scroll container operativo**. El shell ya era de pantalla fija (`h-dvh overflow-hidden`), pero `main` reintroducía scroll vertical operativo vía `overflow-y: auto`, y dos tests E2E **exigían** ese comportamiento incorrecto. Este PR corrige el CSS, reemplaza los contratos E2E incorrectos por el contrato correcto y agrega una suite de medición anti-scroll para `html` / `body` / `main` en desktop y mobile.
+
+No se rediseñan Tokens ni Informes (eso es PR-B / PR-C). El alcance es exclusivamente el contrato del shell/main.
+
+## Auditoría rectora usada
+
+`docs/audit/dashboard-masked-master-detail-no-scroll-audit.md` — §1.2 (distinción body vs `main` interno), §2.1 (escape hatch `overflow-y-auto`), §5 regla 2 (“`main` no debe scrollear; su `overflow-y-auto` es red de seguridad, no mecanismo de navegación”), §6 PR-A.
+
+## Problema corregido
+
+- `main.dashboard-main` tenía `overflow-y: auto`: cuando un módulo excedía el alto disponible, `main` scrolleaba internamente — la “página vertical” que el usuario percibía, pese a que el `body`/`html` nunca crecían.
+- Los tests sólo blindaban que el `body` no creciera; **no** prohibían el scroll interno de `main`. Peor: dos specs **exigían** `overflow-y: auto` en `main`, protegiendo el comportamiento incorrecto.
+
+Evidencia empírica (medición e2e con `NEXT_PUBLIC_API_URL=""`, antes y después del cambio): en los shells cubiertos `main.scrollHeight === main.clientHeight` (overflow real = 0) en todos los viewports probados — el `overflow-y: auto` era **inerte** en esas superficies, por lo que cambiarlo a `overflow: hidden` no introduce recorte:
+
+| Superficie | Viewport | main scroll/client | main overflow |
+|---|---|---|---|
+| Clínica hub | 1366×768 | 675 / 675 | 0 |
+| Clínica hub | 390×844 | 772 / 772 | 0 |
+| Admin hub | 1366×768 | 675 / 675 | 0 |
+| Admin hub | 390×844 | 772 / 772 | 0 |
+
+## Contrato anterior (incorrecto)
+
+```css
+/* globals.css */
+.dashboard-main { @apply ... overflow-y-auto ... overflow-x-hidden; }
+```
+
+```ts
+// dashboard-card-navigation-shell.spec.ts (viejo)
+expect(mainHasOverflowAuto).toBe(true);            // exigía overflow-y:auto
+
+// dashboard-app-shell-visibility-contract.spec.ts (viejo)
+expect(metrics.mainOverflowMode).toBe("auto");     // exigía overflow-y:auto
+```
+
+## Contrato nuevo (correcto)
+
+```css
+/* globals.css */
+.dashboard-main { @apply ... overflow-hidden ...; }   /* NO es scroll container */
+```
+
+- `main.dashboard-main`: `overflow-y` computado **nunca** `auto` ni `scroll`.
+- `main`, `body` y `documentElement`: `scrollHeight ≤ clientHeight` (tolerancia subpíxel 2px).
+- Mensajes de error indican qué contenedor scrolleó y su `overflow-y`/clase.
+
+```ts
+// nuevo contrato (3 specs)
+expect(mainOverflowY).not.toBe("auto");
+expect(mainOverflowY).not.toBe("scroll");
+expect(main.scrollHeight).toBeLessThanOrEqual(main.clientHeight + 2);
+expect(body.scrollHeight).toBeLessThanOrEqual(body.clientHeight + 2);
+expect(html.scrollHeight).toBeLessThanOrEqual(html.clientHeight + 2);
+```
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/app/globals.css` | `.dashboard-main`: `overflow-y-auto`+`overflow-x-hidden` → `overflow-hidden`. Comentario de contrato. |
+| `frontend/e2e/dashboard-card-navigation-shell.spec.ts` | Reemplaza el test “main is scroll container (overflow-y-auto)” por “main is NOT an operational scroll container” (assert NOT auto/scroll). |
+| `frontend/e2e/dashboard-app-shell-visibility-contract.spec.ts` | Reemplaza `mainOverflowMode === "auto"` por `not auto / not scroll`. (No agrega bound de fit: ese spec corre a 650px de alto sólo para validar chrome del shell.) |
+| `frontend/e2e/dashboard-single-viewport-app-shell.spec.ts` | Sólo comentarios (el contrato `scrollHeight ≤ clientHeight` ya era correcto). |
+
+## Tests agregados
+
+| Archivo | Cobertura |
+|---|---|
+| `frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts` (**nuevo**) | Helper `readScrollContract` (html/body/main: scrollHeight, clientHeight, overflow-y computado, className) + `assertNoInternalScroll`. Mide shells admin y clínica. |
+
+## Viewports cubiertos
+
+- **Desktop:** 1366×768 (mínimo aceptable del producto).
+- **Mobile:** 390×844 (viewport mobile estándar de la suite, ver `visual-smoke.spec.ts`).
+
+(El contrato de fit a 1440×900 y 1366×768 sobre todos los módulos sigue cubierto por los specs existentes `dashboard-single-viewport-app-shell` y `dashboard-real-app-shell-no-scroll-contract`, que ahora también validan que `main` no es scroll container.)
+
+## Módulos cubiertos (verde)
+
+- Shell global (clínica y admin).
+- Hub clínica `/dashboard` y hub admin `/dashboard/admin` (desktop + mobile).
+- Módulos ya conformes vía specs existentes: operaciones, informes (summary in-shell), logística (summary in-shell), perfil; admin clinics, audit-log, pricing, sessions, health, maintenance, upload (1366×768 / 1440×900).
+
+## Módulos pendientes (NO maquillados en este PR)
+
+- **PR-B — Tokens particulares (clínica):** `ClinicParticularTokensCard` (formulario de 13 campos + lista + 6 bandas por token) puede exceder `main` con datos reales → con `overflow: hidden` recortaría en vez de scrollear. Se resuelve con Master-Detail en Cascada + `ModuleDialog` (no en este PR).
+- **PR-C — Informes (clínica):** la ruta `/dashboard/informes` apila header + filtros + grid master-detail con paneles `min-height: 18rem`; densidad a resolver con lista limitada + detail pane + overlay mobile.
+
+> A viewports ultracompactos (650px de alto) el módulo operaciones aún excede; queda dentro de la densidad de módulos (PR-B/C). El spec de visibilidad a 650px valida sólo el chrome del shell, no el fit del módulo.
+
+## Riesgos
+
+- **Bajo–medio.** El cambio CSS es una sola propiedad sobre una clase del shell. Empíricamente `main` no desbordaba en las superficies cubiertas (overflow real = 0), por lo que no se introduce recorte en lo cubierto.
+- **Módulos diferidos:** con datos reales, Tokens/Informes pasarán de scrollear a **recortar** hasta PR-B/PR-C. Es intencional (no maquillar) y está documentado; el contrato E2E los excluye explícitamente.
+- **Contrato CSS pin:** `frontend-visual-consistency.test.ts` fija el bloque `.dashboard-main` por `space-y-6 / sm:px-6 / lg:px-8` (no por `overflow-y-auto`); el cambio los preserva → verde.
+- **Pin de sidebar:** `frontend-dashboard-shell.test.ts` exige `overflow-y-auto` en el **sidebar frame** (no en `main`); intacto.
+
+## Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend lint` | ✓ OK |
+| `pnpm --dir frontend typecheck` | ✓ OK |
+| `pnpm test` (nativos) | ✓ 2758 / 2758 |
+| `pnpm --dir frontend build` | ✓ OK |
+| `pnpm build` (backend) | ✓ OK |
+| `pnpm security:public-surface` | ✓ PASS |
+| E2E contratos no-scroll (5 specs) | ✓ 119 / 119 |
+
+**E2E afectados (verde):** `dashboard-internal-no-scroll-contract` (nuevo, 8), `dashboard-card-navigation-shell`, `dashboard-app-shell-visibility-contract`, `dashboard-single-viewport-app-shell`, `dashboard-real-app-shell-no-scroll-contract`.
+
+### Hallazgo fuera de scope (no introducido por este PR)
+
+`dashboard-workspace-layout-polish.spec.ts › "/dashboard/informes layout loads"` falla por un `aria-label` obsoleto: espera `region` con nombre **"Informes del dashboard"** que **no existe** en la ruta Informes actual. **Verificado con `git stash`: falla idéntico en la base `d2c6d26` sin mis cambios** → preexistente, independiente del contrato no-scroll. No se modifica aquí (la ruta Informes es PR-C); se recomienda corregir el `aria-label`/expectativa en PR-C.
+
+## Resultado final
+
+Contrato no-scroll interno implementado y blindado:
+- `main.dashboard-main` ya **no** es scroll container operativo (`overflow: hidden`).
+- Tests dejan de exigir `overflow-y-auto`; ahora fallan si `main` scrollea (auto/scroll) o si `main`/`body`/`html` exceden el viewport.
+- Desktop (1366×768) y mobile (390×844) cubiertos para shells admin y clínica.
+- Sin scroll interno como parche; sin scroll movido a otro wrapper; sin rediseño de módulos.
+- Validaciones nativas, builds, seguridad y E2E de contrato en verde.

--- a/frontend/e2e/dashboard-app-shell-visibility-contract.spec.ts
+++ b/frontend/e2e/dashboard-app-shell-visibility-contract.spec.ts
@@ -200,15 +200,18 @@ async function expectAppShellVisible(page: Page, expectedSurface: "clinic" | "ad
     `${expectedSurface} body vertical overflow`,
   ).toBeLessThanOrEqual(TOLERANCE);
 
+  // App Shell contract: `main` is not an operational scroll container. Module
+  // fit (`scrollHeight ≤ clientHeight`) is asserted by the dedicated no-scroll
+  // specs at the supported viewports (≥768px height); this visibility spec runs
+  // at intentionally short 650px viewports to verify shell chrome only.
   expect(
     metrics.mainOverflowMode,
-    `${expectedSurface} main must remain the controlled dashboard scroll container`,
-  ).toBe("auto");
-
+    `${expectedSurface} main must NOT be an operational scroll container`,
+  ).not.toBe("auto");
   expect(
-    metrics.mainOverflowY,
-    `${expectedSurface} main overflow must stay bounded for compact viewport`,
-  ).toBeGreaterThanOrEqual(0);
+    metrics.mainOverflowMode,
+    `${expectedSurface} main must NOT be an operational scroll container`,
+  ).not.toBe("scroll");
 
   expect(metrics.shellBeforeBorder, `${expectedSurface} shell visual border`).not.toBe("0px");
   expect(metrics.shellAfterHeight, `${expectedSurface} shell top rail`).not.toBe("0px");

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -431,19 +431,23 @@ test.describe("dashboard shell — no global scroll", () => {
     expect(shellClass).toContain("overflow-hidden");
   });
 
-  test("dashboard main content area is scroll container (overflow-y-auto)", async ({ page }) => {
+  test("dashboard main content area is NOT an operational scroll container", async ({ page }) => {
     await page.goto("/dashboard");
 
-    await page.waitForSelector("main", { timeout: 8_000 });
+    await page.waitForSelector("main.dashboard-main", { timeout: 8_000 });
 
-    const mainHasOverflowAuto = await page.evaluate(() => {
-      const main = document.querySelector("main");
-      if (!main) return false;
+    const mainOverflow = await page.evaluate(() => {
+      const main = document.querySelector("main.dashboard-main");
+      if (!main) return null;
       const style = window.getComputedStyle(main);
-      return style.overflowY === "auto" || style.overflow === "auto";
+      return { overflowY: style.overflowY, overflowX: style.overflowX };
     });
 
-    expect(mainHasOverflowAuto).toBe(true);
+    // App Shell contract: `main` must not re-enable document-like vertical scroll.
+    // Modules fit the viewport via the no-scroll primitives instead.
+    expect(mainOverflow).not.toBeNull();
+    expect(mainOverflow!.overflowY).not.toBe("auto");
+    expect(mainOverflow!.overflowY).not.toBe("scroll");
   });
 
   test("body does not scroll when clinic dashboard hub fills viewport", async ({ page }) => {

--- a/frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts
+++ b/frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-A — Internal no-scroll contract for the dashboard App Shell.
+//
+// Governing audit: docs/audit/dashboard-masked-master-detail-no-scroll-audit.md
+//
+// The fixed shell (`h-dvh overflow-hidden`) already prevents document/body
+// scroll. The remaining defect was that `main.dashboard-main` re-enabled an
+// operational vertical scroll via `overflow-y: auto`, letting modules behave as
+// a "vertical page". This spec blinda the corrected contract:
+//
+//   1. `main.dashboard-main` is NOT an operational scroll container
+//      (computed overflow-y is neither `auto` nor `scroll`).
+//   2. `main`, `body` and `documentElement` do not scroll (scrollHeight ≤
+//      clientHeight within a small sub-pixel tolerance).
+//
+// Verified on the principal admin and clinic shells at one desktop viewport
+// (1366×768) and one mobile viewport (390×844). The e2e server runs with
+// NEXT_PUBLIC_API_URL="" so the shells render their degraded/empty frame; the
+// fixed composition must still hold without scroll.
+//
+// NOT covered here (deferred): the heavy in-card modules whose OWN content can
+// still overflow with real data — clinic Tokens particulares (PR-B) and the
+// Informes master-detail density (PR-C). This PR does not maquillar those.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Page = import("@playwright/test").Page;
+
+// Small tolerance for sub-pixel rounding only. Real scroll is far larger.
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "desktop-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+type Surface = "clinic" | "admin";
+
+type ShellCase = {
+  label: string;
+  surface: Surface;
+  path: string;
+  ready: string;
+};
+
+const SHELLS: ShellCase[] = [
+  {
+    label: "clinic dashboard shell",
+    surface: "clinic",
+    path: "/dashboard",
+    ready: '[data-dashboard-module-hub="true"]',
+  },
+  {
+    label: "admin dashboard shell",
+    surface: "admin",
+    path: "/dashboard/admin",
+    ready: '[data-dashboard-module-hub="true"]',
+  },
+];
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+type ScrollContract = {
+  htmlScrollHeight: number;
+  htmlClientHeight: number;
+  bodyScrollHeight: number;
+  bodyClientHeight: number;
+  mainScrollHeight: number;
+  mainClientHeight: number;
+  /** Computed `overflow-y` keyword for each element. */
+  htmlOverflowY: string;
+  bodyOverflowY: string;
+  mainOverflowY: string;
+  mainClassName: string;
+  hasMain: boolean;
+};
+
+// Reusable measurement helper: reads scroll geometry + computed overflow modes
+// for documentElement / body / main.dashboard-main in a single page evaluation.
+async function readScrollContract(page: Page): Promise<ScrollContract> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector(
+      "main.dashboard-main",
+    ) as HTMLElement | null;
+
+    return {
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+      mainScrollHeight: main?.scrollHeight ?? 0,
+      mainClientHeight: main?.clientHeight ?? 0,
+      htmlOverflowY: window.getComputedStyle(html).overflowY,
+      bodyOverflowY: window.getComputedStyle(body).overflowY,
+      mainOverflowY: main ? window.getComputedStyle(main).overflowY : "none",
+      mainClassName: typeof main?.className === "string" ? main.className : "",
+      hasMain: main !== null,
+    };
+  });
+}
+
+function assertNoInternalScroll(metrics: ScrollContract, label: string) {
+  expect(metrics.hasMain, `${label}: main.dashboard-main present`).toBe(true);
+
+  // Contract 1: main must NOT be an operational scroll container.
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main.dashboard-main must not enable vertical scroll (overflow-y=${metrics.mainOverflowY}, class="${metrics.mainClassName}")`,
+  ).not.toBe("auto");
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main.dashboard-main must not enable vertical scroll (overflow-y=${metrics.mainOverflowY})`,
+  ).not.toBe("scroll");
+
+  // Contract 2: nothing in the shell chain scrolls (scrollHeight ≤ clientHeight).
+  expect(
+    metrics.mainScrollHeight,
+    `${label}: main scrolled (${metrics.mainScrollHeight} > ${metrics.mainClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.mainClientHeight + TOLERANCE);
+  expect(
+    metrics.bodyScrollHeight,
+    `${label}: body scrolled (${metrics.bodyScrollHeight} > ${metrics.bodyClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+  expect(
+    metrics.htmlScrollHeight,
+    `${label}: documentElement scrolled (${metrics.htmlScrollHeight} > ${metrics.htmlClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+}
+
+for (const viewport of VIEWPORTS) {
+  test.describe(`dashboard internal no-scroll contract — ${viewport.name}`, () => {
+    for (const shell of SHELLS) {
+      test(`${shell.label} keeps main/body/html free of operational scroll`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+
+        if (shell.surface === "clinic") {
+          await setClinicSession(page);
+        } else {
+          await setAdminSession(page);
+        }
+
+        await page.goto(shell.path);
+        await expect(page.locator(shell.ready).first()).toBeVisible({
+          timeout: 12_000,
+        });
+
+        // Poll to absorb hydration/layout settling (fonts, async panels).
+        await expect(async () => {
+          const metrics = await readScrollContract(page);
+          assertNoInternalScroll(metrics, `${viewport.name} ${shell.label}`);
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+  });
+}

--- a/frontend/e2e/dashboard-single-viewport-app-shell.spec.ts
+++ b/frontend/e2e/dashboard-single-viewport-app-shell.spec.ts
@@ -5,8 +5,8 @@ import { expect, test } from "@playwright/test";
 //
 // Desktop dashboard modules must fit one viewport with ZERO operational scroll:
 // no document scroll (vertical or horizontal) and no effective scroll on the
-// `.dashboard-main` container (its `overflow-y: auto` is kept only for the legacy
-// scroll-container contract; the real metric is scrollHeight ≤ clientHeight).
+// `.dashboard-main` container (which is `overflow: hidden` — not a scroll
+// container; the real metric is scrollHeight ≤ clientHeight).
 //
 // Verified at the two mandated desktop viewports: 1440×900 (target) and
 // 1366×768 (minimum acceptable). The e2e server runs with NEXT_PUBLIC_API_URL=""
@@ -192,8 +192,8 @@ for (const viewport of VIEWPORTS) {
             m.bodyClientW + TOLERANCE,
           );
 
-          // The main dashboard container keeps overflow-y:auto for the legacy
-          // contract, but must have no effective scroll.
+          // The main dashboard container is overflow:hidden (not a scroll
+          // container) and must have no effective scroll.
           expect(m.hasMain, "main.dashboard-main present").toBe(true);
           expect(
             m.mainScrollH,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -214,8 +214,13 @@
     background: hsl(var(--vetneb-surface-muted) / 0.52);
     box-shadow: 0 10px 26px rgba(15, 45, 62, 0.07);
   }
+  /* App Shell contract: the dashboard main region is NOT an operational scroll
+     container. The fixed shell (`h-dvh overflow-hidden`) + this `overflow-hidden`
+     keep `main` bounded to the viewport; modules must FIT via the no-scroll
+     primitives (ModuleSurface/ModuleTabs/usePagedRows/MasterDetail), never by
+     scrolling `main`. Replaces the legacy `overflow-y-auto` escape hatch. */
   .dashboard-main {
-    @apply flex min-h-0 flex-1 flex-col space-y-6 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6 overflow-x-hidden;
+    @apply flex min-h-0 flex-1 flex-col space-y-6 overflow-hidden px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6;
   }
 
   .surface-note-info {


### PR DESCRIPTION
## Summary
- Replace outdated dashboard main overflow contract
- Add E2E measurements for body/html/main no-scroll behavior
- Document the internal no-scroll dashboard contract

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm test
- pnpm --dir frontend build
- pnpm build
- pnpm security:public-surface