### PR TITLE
feat(dashboard): apply global masked master detail workspaces

### DIFF
--- a/docs/implementation/dashboard-global-masked-master-detail.md
+++ b/docs/implementation/dashboard-global-masked-master-detail.md
@@ -1,0 +1,218 @@
+# Dashboard global — Navegación Jerárquica Enmascarada + Master-Detail en Cascada (sin scroll)
+
+- **Rama:** `feat/dashboard-global-masked-master-detail`
+- **Base:** `main` @ `bf4785b` (test(dashboard): enforce internal no-scroll contract, #1014)
+- **Fecha:** 2026-06-17
+- **Tipo:** Implementación + tests. No es auditoría ni rediseño libre.
+
+## 1. Objetivo del PR
+
+Llevar **ambos dashboards** (Clínica y Administración) al mismo modelo operativo de
+**workspace administrativo fijo**: pantalla fija, sin scroll externo ni scroll
+interno operativo, navegación por estados, Master-Detail en Cascada, listas
+limitadas, detalle dinámico y formularios en capa dedicada. Completa los módulos
+que la auditoría marcó como rezagados (PR-B/C/D/E) sin reintroducir scroll y sin
+degradar el contrato anti-scroll mergeado en #1014 (PR-A).
+
+## 2. Documentos rectores usados
+
+- `docs/audit/dashboard-masked-master-detail-no-scroll-audit.md` — §2 (diagnóstico
+  por módulo), §3 (mapa de arquitectura), §4 (decisión por módulo), §5 (reglas
+  visuales), §6 (plan PR-B/C/D/E), §7 (criterios de aceptación medibles).
+- `docs/implementation/dashboard-internal-no-scroll-contract.md` — PR-A: `main`
+  no es scroll container (`overflow: hidden`); módulos deben **caber**, no scrollear.
+
+## 3. Estado de reanudación tras interrupción
+
+La reanudación encontró la rama `feat/dashboard-global-masked-master-detail`
+ya creada sobre `bf4785b test(dashboard): enforce internal no-scroll contract
+(#1014)`, con cambios parciales en Tokens clínica, Informes clínica, Logística
+clínica, `admin/page.tsx`, este documento y un E2E global nuevo. No había PRs
+abiertos ni ramas remotas no mergeadas reportadas por `git branch -r --no-merged
+origin/main`. Se continuó en la rama existente, sin crear otra rama y sin
+descartar cambios.
+
+Los cambios parciales se corrigieron antes de cerrar la implementación:
+el alta de Tokens ya estaba en `ModuleDialog`, pero dependía de
+`overflow-y-auto` interno; se convirtió a flujo por pasos. El token generado
+seguía como bloque inline dentro del card; se movió a una capa dialog controlada.
+También quedaban spacers móviles `h-24 md:hidden`; se eliminaron.
+
+## 4. Problema global corregido
+
+El shell ya era de pantalla fija con primitivas maduras (`ModuleSurface`,
+`ModuleTabs`, `ModuleDialog`, `MasterDetailWorkspace`, `usePagedRows`,
+`CompactPager`), pero **módulos rezagados no las consumían**:
+
+- **Clínica · Tokens particulares (🔴, peor ofensor):** un único card apilaba
+  verticalmente **formulario de 13 campos + panel de token generado + lista de
+  hasta 10 tokens, cada uno con 6 bandas de detalle**. Con `main` en
+  `overflow: hidden` (PR-A) ese contenido **recortaba** con datos reales.
+- **Clínica · Informes/Logística (🟡, bifurcación):** resúmenes teaser que
+  empujaban al usuario fuera del shell hacia rutas full-page (`/dashboard/informes`,
+  `/dashboard/logistica`), rompiendo el enmascaramiento.
+- **Admin · Resumen / Mantenimiento / Roles (🟡):** slots con `space-y-6` /
+  `space-y-4` / `section` plano, sin cadena de altura ni tabs.
+
+## 5. Arquitectura aplicada (sin inventar primitivas)
+
+```
+DashboardShell (h-dvh overflow-hidden)                 [existente]
+└─ main.dashboard-main (overflow-hidden, no scroll)    [PR-A]
+   └─ Controller (Hub ↔ Module, ?module=, "Volver")    [existente]
+      └─ Module
+         ├─ Lista master  → usePagedRows + CompactPager (≤4 visibles)
+         ├─ Detalle       → panel dedicado (desktop split) / capa de reemplazo (mobile)
+         ├─ Tabs          → ModuleTabs (navegación por estado same-card)
+         └─ Alta/edición  → ModuleDialog por pasos (capa flotante; nunca apila)
+```
+
+Estados estandarizados por módulo: `selected<Entity>Id`, `isMobileDetailOpen`
+(capa de reemplazo mobile), `isCreateDialogOpen` (alta en capa dedicada),
+`page` (paginación compacta).
+
+## 6. Cambios en Dashboard Clínica
+
+| Módulo | Antes | Ahora |
+|---|---|---|
+| **Operaciones** (`ClinicCommandCenter.tsx`) | banner + métricas + listas apiladas | `ModuleSurface` + `ModuleTabs` [Métricas \| Recientes]; el banner queda en toolbar fija y las listas recientes no conviven verticalmente con métricas |
+| **Tokens particulares** (`ClinicParticularTokensCard.tsx`) | 🔴 form + token + lista + 6 bandas apilados | Master-Detail: lista `usePagedRows` (≤4) + `CompactPager` · detalle en panel dedicado con las 6 bandas (incl. Seguimiento + alerta de tinción) · **alta en `ModuleDialog` por 3 pasos** · token generado en `ModuleDialog` controlado · mobile = capa de reemplazo con "Volver a la lista" |
+| **Informes** (`ClinicInformesWorkspaceSummary.tsx`) | teaser + botón a ruta | `ModuleSurface` in-shell con master-detail seleccionable (lista de informes recientes + detalle) · deep-link `/dashboard/informes` preservado como módulo completo · mobile = reemplazo con "Volver" |
+| **Logística** (`ClinicLogisticaWorkspaceSummary.tsx`) | teaser + botón a ruta | igual patrón in-shell (visitas recientes → detalle) · deep-link `/dashboard/logistica` preservado · mobile = reemplazo |
+| **Perfil público** | 🟢 ya conforme | preservado sin degradar |
+
+## 7. Cambios en Dashboard Administración
+
+| Slot | Antes | Ahora |
+|---|---|---|
+| **Resumen (admin)** | `div.space-y-6` (command center + alertas apilados) | `ModuleTabs` [Resumen \| Alertas]; cada tab cabe en un viewport. Orden y strings de contrato preservados (`AdminCommandCenter` → `AdminFailedLoginAlertsReadOnlyCard`) |
+| **Alertas críticas** | tabla client-side con 25 visibles | `PAGE_SIZE=5`, card `flex min-h-0 flex-1`, tabla en cuerpo acotado y paginación visible |
+| **Mantenimiento** | `div.space-y-4` (schema + dry-run) | `ModuleTabs` [Esquema \| Dry-run] (`id="admin-maintenance"` preservado); candidatos dry-run paginados de a 4 con `CompactPager` |
+| **Roles clínica** | `section` plano + 25 visibles | `section` con cadena `flex min-h-0 flex-1 flex-col`; tabla roles `PAGE_SIZE=5` |
+| **Subir informe / Tokens admin / Precios** | wrappers sin `min-h-0 flex-1` | wrappers reforzados para preservar el alto de sus componentes internos |
+| Clínicas / Precios / Auditoría / Sesiones / Estado / Tokens admin | 🟢 referencias ya conformes | preservados; sirven de modelo |
+| **Hub mobile admin/clínica** | el hub inicial podía exceder el alto fijo en 390×844 | hero/launcher compactos en mobile, descripciones largas ocultas antes de `sm`, launcher admin denso en 3 columnas |
+
+## 8. Módulos cubiertos
+
+Clínica: Operaciones, Tokens, Informes, Logística (migrados); Perfil (preservado).
+Admin: Resumen, Mantenimiento, Roles (migrados); Clínicas, Precios, Auditoría,
+Sesiones, Estado del sistema, Tokens particulares admin, Subir informe (preservados).
+
+## 9. Módulos que ya estaban correctos y se preservaron
+
+`AdminClinicsManagementCard` (Master-Detail + Dialog, PAGE_SIZE=5),
+`AdminPricingEditorCard` (ModuleTabs + usePagedRows ITEMS_PER_PAGE=1),
+`AdminAuditLogTable` (usePagedRows PAGE_SIZE=8 + CompactPager),
+`AdminSessionsReadOnlyCard` (+ ModuleDialog), `AdminParticularTokensCard`
+(state machine + split), `healthWorkspaceSlot` (ModuleTabs) y el `perfil`
+clínica (`ModuleTabs`). No se degradó ninguno.
+
+## 10. Lista máxima visible por módulo
+
+| Módulo | Máximo visible | Mecanismo |
+|---|---|---|
+| Operaciones clínica · informes recientes | 3 | datos ya acotados + tab [Recientes] |
+| Operaciones clínica · visitas de campo | 3 | datos ya acotados + tab [Recientes] |
+| Tokens clínica | 4 | `usePagedRows(4)` + `CompactPager` |
+| Informes clínica (in-shell) | 3 (recientes) | lista acotada + deep-link a módulo completo |
+| Logística clínica (in-shell) | 3 (recientes) | lista acotada + deep-link a módulo completo |
+| Admin intentos fallidos | 5 / pág | paginación client/API existente (`PAGE_SIZE=5`) |
+| Admin roles | 5 / pág | paginación client/API existente (`PAGE_SIZE=5`) |
+| Admin mantenimiento dry-run | 4 / pág | `usePagedRows(4)` + `CompactPager` |
+
+## 11. Comportamiento desktop
+
+- **Tokens clínica:** split fijo `xl:grid-cols-[0.82fr_1.46fr]` (lista master a la
+  izquierda, detalle a la derecha). Seleccionar un token llena el detalle sin
+  cambiar la altura del card. Alta vía botón → `ModuleDialog` por pasos.
+- **Informes/Logística:** split `xl:grid-cols-[0.85fr_1.15fr]` dentro de
+  `ModuleSurface`; toolbar fijo con el deep-link al módulo completo.
+- **Admin:** tabs conmutan contenido en el mismo viewport.
+
+## 12. Comportamiento tablet/mobile
+
+- Por debajo de `xl` los módulos master-detail usan **capa de reemplazo**: se ve la
+  lista; al seleccionar, el detalle **reemplaza** la lista (`hidden xl:flex` /
+  `hidden xl:block`) con botón **"Volver a la lista"**. No se apilan lista + detalle.
+- El alta de Tokens vive en `ModuleDialog` con **3 pasos compactos** (Vínculo,
+  Paciente, Muestra), sin scroll vertical interno del formulario y sin apilar bajo
+  la lista.
+- Se eliminaron los spacers `h-24 md:hidden` de clínica, admin y logística.
+
+## 13. Resolución de formularios
+
+El alta de Tokens clínica se movió de un bloque vertical permanente a un
+**`ModuleDialog` por pasos** (capa dedicada). Preserva validaciones (`validateFormState`,
+`required`, `parseOptionalReportId`), loading/error, submit/cancel y el invariante
+"token completo visible una sola vez". El token generado también vive en una capa
+dialog controlada y no empuja el card; el cierre exige confirmar que el token fue
+registrado o que no se necesita copia.
+
+## 14. Resolución de detalle
+
+El detalle ya no se expande inline empujando la lista. Desktop: panel dedicado en
+el split. Mobile: capa de reemplazo con "Volver". En Tokens el detalle muestra las
+6 bandas (Paciente, Muestra, Fechas, Publicación, Vínculo, Seguimiento con alerta
+de tinción especial) del token seleccionado, no por cada fila de la lista.
+
+## 15. Tests agregados/modificados
+
+- **Nuevo E2E:** `frontend/e2e/dashboard-global-masked-master-detail.spec.ts` —
+  no-scroll de `main`/`body`/`html` para Tokens/Informes/Logística clínica y
+  Resumen/Mantenimiento/Roles admin a 1366×768 y 390×844; Tokens clínica con
+  mock de 6 registros para verificar lista visible ≤4, selección de detalle,
+  alerta de tinción especial, volver mobile y pasos del `ModuleDialog`.
+- **Source-contract alineados (sin bajar cobertura):** los contratos existentes
+  `frontend-dashboard-clinic-tokens`, `frontend-dashboard-admin`,
+  `frontend-dashboard-home`, `frontend-dashboard-clinic-command-center`,
+  `frontend-admin-failed-login-alerts-card`,
+  `frontend-admin-users-roles-card`,
+  `frontend-admin-maintenance-dry-run-card`,
+  `frontend-dashboard-mobile-polish-bottom-actions` y
+  `progress-production-invariants` se alinearon al contrato nuevo.
+- **E2E existentes alineados:** `dashboard-workspace-layout-polish.spec.ts`
+  ahora valida las regiones reales del nuevo `/dashboard/informes`
+  (`Lista de informes` + `Detalle del informe`).
+
+## 16. Viewports cubiertos
+
+- **Desktop:** 1366×768 (mínimo del producto).
+- **Mobile:** 390×844 (viewport mobile estándar de la suite).
+
+## 17. Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend lint` | ✓ OK |
+| `pnpm --dir frontend typecheck` | ✓ OK |
+| `pnpm test` (nativos) | ✓ OK — 2760/2760 |
+| `pnpm --dir frontend build` | ✓ OK |
+| `pnpm build` (backend) | ✓ OK |
+| `pnpm security:public-surface` | ✓ PASS — sólo notas esperadas `server-only` para `CLINIC_SESSION_COOKIE_NAME` / `ADMIN_SESSION_COOKIE_NAME` |
+| `pnpm --dir frontend e2e -- e2e/dashboard-global-masked-master-detail.spec.ts --reporter=line` | ✓ OK — 16/16 |
+| `pnpm --dir frontend e2e -- e2e/dashboard-accessibility-keyboard.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts e2e/dashboard-auth-redirect.spec.ts e2e/dashboard-card-navigation-shell.spec.ts e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-interaction-foundation.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-master-detail-state-polish.spec.ts e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-single-viewport-app-shell.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts --reporter=line` | ✓ OK — 172/172 |
+
+## 18. Riesgos
+
+- **Datos server-side de Informes/Logística:** el E2E del módulo in-shell cubre el
+  frame no-scroll con los datos que entregue la app; la selección con datos reales
+  queda reforzada por contratos de fuente. Tokens sí usa mock browser-side con 6
+  registros porque su carga es client-side.
+- **Sin cambios de API/seguridad:** el refactor es de composición/UI. No toca
+  payloads, endpoints, separación de sesión (`app_session_id`/`admin_session_id`),
+  ni el invariante "token visible una sola vez".
+- **CSS compartido:** se mantiene el contrato PR-A/#1014 (`main.dashboard-main`
+  sigue `overflow-hidden`, nunca `auto/scroll`). Se compactó sólo la densidad
+  mobile del shell/hub (`dashboard-main`, hero y launcher denso admin) para que
+  los hubs iniciales también quepan en 390×844, sin mover scroll a otro wrapper.
+
+## 19. Resultado final
+
+Ambos dashboards operan bajo el mismo modelo: pantalla fija, listas limitadas,
+detalle por estado/panel/capa, formularios en capa dedicada y mobile por capas de
+reemplazo. El peor ofensor (Tokens clínica) deja de apilar lista + detalle +
+formulario; los módulos de Informes/Logística tienen master-detail in-shell; los
+slots admin rezagados pasan a tabs/cadena de altura/listas acotadas. No se
+reintrodujo scroll operativo, no se movió el scroll a otro wrapper, no se debilitó
+el contrato de #1014 y no se bajaron tests.

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -1,0 +1,400 @@
+import { expect, test } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global masked Master-Detail / no-scroll contract for BOTH dashboards.
+//
+// Governing audit: docs/audit/dashboard-masked-master-detail-no-scroll-audit.md
+// Governing contract: docs/implementation/dashboard-internal-no-scroll-contract.md
+//
+// PR-A blindó that the shell `main.dashboard-main` is never an operational
+// scroll container, but explicitly DEFERRED the heavy in-card modules (clinic
+// Tokens particulares — PR-B, Informes/Logística density — PR-C/E). This spec
+// closes that gap: it asserts the migrated modules (clinic Tokens / Informes /
+// Logística in-shell, admin resumen / mantenimiento / roles) keep main/body/html
+// free of operational scroll on desktop and mobile, and — critically — that
+// opening the Tokens "alta" form (now a dedicated ModuleDialog layer) does NOT
+// turn `main` into a scroll container even though the form is long.
+//
+// The e2e server runs with NEXT_PUBLIC_API_URL="" so the modules render their
+// degraded/empty frame; the fixed composition must still hold without scroll.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Page = import("@playwright/test").Page;
+
+// Small tolerance for sub-pixel rounding only. Real scroll is far larger.
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "desktop-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+type Surface = "clinic" | "admin";
+
+type ModuleCase = {
+  label: string;
+  surface: Surface;
+  path: string;
+  moduleId: string;
+};
+
+const MODULES: ModuleCase[] = [
+  {
+    label: "clinic Tokens particulares (master-detail + dialog alta)",
+    surface: "clinic",
+    path: "/dashboard?module=tokens",
+    moduleId: "tokens",
+  },
+  {
+    label: "clinic Informes (in-shell master-detail)",
+    surface: "clinic",
+    path: "/dashboard?module=informes",
+    moduleId: "informes",
+  },
+  {
+    label: "clinic Logística (in-shell master-detail)",
+    surface: "clinic",
+    path: "/dashboard?module=logistica",
+    moduleId: "logistica",
+  },
+  {
+    label: "admin Resumen/Alertas (tabs)",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin",
+    moduleId: "admin",
+  },
+  {
+    label: "admin Mantenimiento (tabs)",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin-maintenance",
+    moduleId: "admin-maintenance",
+  },
+  {
+    label: "admin Roles clínica",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin-users-roles",
+    moduleId: "admin-users-roles",
+  },
+];
+
+const MOCK_TOKENS = Array.from({ length: 6 }, (_, index) => {
+  const id = index + 1;
+  return {
+    id,
+    clinicId: 10,
+    reportId: id % 2 === 0 ? 200 + id : null,
+    tokenLast4: String(9000 + id).slice(-4),
+    tutorLastName: `Tutor ${id}`,
+    petName: `Paciente ${id}`,
+    petAge: `${id + 1} años`,
+    petBreed: "Mestizo",
+    petSex: id % 2 === 0 ? "Hembra" : "Macho",
+    petSpecies: id % 2 === 0 ? "Felinos" : "Caninos",
+    sampleLocation: "Piel",
+    sampleEvolution: "Subaguda",
+    detailsLesion: "Lesión nodular compatible con seguimiento.",
+    extractionDate: "2026-06-01T00:00:00.000Z",
+    shippingDate: "2026-06-02T00:00:00.000Z",
+    isActive: true,
+    lastLoginAt: null,
+    createdAt: "2026-06-03T00:00:00.000Z",
+    updatedAt: "2026-06-03T00:00:00.000Z",
+    createdByAdminId: null,
+    createdByClinicUserId: 77,
+    hasLinkedReport: id % 2 === 0,
+  };
+});
+
+async function mockClinicTokens(page: Page) {
+  await page.route(
+    (url) => url.pathname === "/api/particular-tokens",
+    async (route) => {
+    const request = route.request();
+
+    if (request.method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "Token particular generado.",
+          token: "VETNEB-MOCK-TOKEN-1234",
+          particularToken: MOCK_TOKENS[0],
+        }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        count: MOCK_TOKENS.length,
+        particularTokens: MOCK_TOKENS,
+        pagination: { limit: 10, offset: 0 },
+        filters: { clinicId: null },
+      }),
+    });
+    },
+  );
+
+  await page.route(
+    (url) => url.pathname === "/api/study-tracking",
+    async (route) => {
+    const url = new URL(route.request().url());
+    const particularTokenId = Number(url.searchParams.get("particularTokenId") ?? "0");
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        count: 1,
+        trackingCases: [
+          {
+            id: 500 + particularTokenId,
+            clinicId: 10,
+            reportId: null,
+            particularTokenId,
+            createdByAdminId: null,
+            createdByClinicUserId: 77,
+            labReceivedAt: "2026-06-03T00:00:00.000Z",
+            receptionAt: "2026-06-03T00:00:00.000Z",
+            estimatedDeliveryAt: "2026-06-08T00:00:00.000Z",
+            estimatedDeliveryAutoCalculatedAt: "2026-06-03T00:00:00.000Z",
+            estimatedDeliveryWasManuallyAdjusted: false,
+            currentStage: "processing",
+            processingAt: "2026-06-04T00:00:00.000Z",
+            evaluationAt: null,
+            reportDevelopmentAt: null,
+            deliveredAt: null,
+            specialStainRequired: particularTokenId === 2,
+            specialStainNotifiedAt: null,
+            paymentUrl: null,
+            adminContactEmail: null,
+            adminContactPhone: null,
+            notes: null,
+            createdAt: "2026-06-03T00:00:00.000Z",
+            updatedAt: "2026-06-04T00:00:00.000Z",
+          },
+        ],
+        pagination: { limit: 1, offset: 0 },
+      }),
+    });
+    },
+  );
+}
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function applySession(page: Page, surface: Surface) {
+  if (surface === "clinic") {
+    await setClinicSession(page);
+  } else {
+    await setAdminSession(page);
+  }
+}
+
+type ScrollContract = {
+  htmlScrollHeight: number;
+  htmlClientHeight: number;
+  bodyScrollHeight: number;
+  bodyClientHeight: number;
+  mainScrollHeight: number;
+  mainClientHeight: number;
+  mainOverflowY: string;
+  mainClassName: string;
+  hasMain: boolean;
+};
+
+async function readScrollContract(page: Page): Promise<ScrollContract> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector(
+      "main.dashboard-main",
+    ) as HTMLElement | null;
+
+    return {
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+      mainScrollHeight: main?.scrollHeight ?? 0,
+      mainClientHeight: main?.clientHeight ?? 0,
+      mainOverflowY: main ? window.getComputedStyle(main).overflowY : "none",
+      mainClassName: typeof main?.className === "string" ? main.className : "",
+      hasMain: main !== null,
+    };
+  });
+}
+
+function assertNoInternalScroll(metrics: ScrollContract, label: string) {
+  expect(metrics.hasMain, `${label}: main.dashboard-main present`).toBe(true);
+
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main must not be a scroll container (overflow-y=${metrics.mainOverflowY}, class="${metrics.mainClassName}")`,
+  ).not.toBe("auto");
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main must not be a scroll container (overflow-y=${metrics.mainOverflowY})`,
+  ).not.toBe("scroll");
+
+  expect(
+    metrics.mainScrollHeight,
+    `${label}: main scrolled (${metrics.mainScrollHeight} > ${metrics.mainClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.mainClientHeight + TOLERANCE);
+  expect(
+    metrics.bodyScrollHeight,
+    `${label}: body scrolled (${metrics.bodyScrollHeight} > ${metrics.bodyClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+  expect(
+    metrics.htmlScrollHeight,
+    `${label}: documentElement scrolled (${metrics.htmlScrollHeight} > ${metrics.htmlClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+}
+
+for (const viewport of VIEWPORTS) {
+  test.describe(`global masked master-detail no-scroll — ${viewport.name}`, () => {
+    for (const moduleCase of MODULES) {
+      test(`${moduleCase.label} keeps main/body/html free of operational scroll`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await applySession(page, moduleCase.surface);
+        if (moduleCase.moduleId === "tokens") {
+          await mockClinicTokens(page);
+        }
+
+        await page.goto(moduleCase.path);
+        await expect(
+          page
+            .locator(
+              `[data-dashboard-module-workspace="${moduleCase.moduleId}"]`,
+            )
+            .first(),
+        ).toBeVisible({ timeout: 12_000 });
+
+        await expect(async () => {
+          const metrics = await readScrollContract(page);
+          assertNoInternalScroll(metrics, `${viewport.name} ${moduleCase.label}`);
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+
+    // The Tokens "alta" form lives in a dedicated ModuleDialog layer. Opening it
+    // must NOT turn `main` into a scroll container, even though the 13-field form
+    // is long — the dialog floats (fixed/portaled) and never grows the shell.
+    test(`clinic Tokens alta dialog opens without turning main into a scroll container`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      });
+      await setClinicSession(page);
+      await mockClinicTokens(page);
+
+      await page.goto("/dashboard?module=tokens");
+      await expect(
+        page.locator('[data-dashboard-module-workspace="tokens"]').first(),
+      ).toBeVisible({ timeout: 12_000 });
+
+      await page
+        .getByRole("button", { name: "Generar token particular" })
+        .first()
+        .click();
+
+      await expect(
+        page.locator('[data-module-dialog="true"]').first(),
+      ).toBeVisible({ timeout: 5_000 });
+      await expect(page.getByText("Paso 1 de 3: Vínculo")).toBeVisible();
+      await page.locator("#clinic-token-particular-email").fill("particular@example.com");
+      await page.locator("#clinic-token-tutor-last-name").fill("Tutor Demo");
+      await page.getByRole("button", { name: "Siguiente" }).click();
+      await expect(page.getByText("Paso 2 de 3: Paciente")).toBeVisible();
+      await page.locator("#clinic-token-pet-name").fill("Paciente Demo");
+      await page.locator("#clinic-token-pet-age").fill("4 años");
+      await page.locator("#clinic-token-pet-breed").fill("Mestizo");
+      await page.getByRole("button", { name: "Siguiente" }).click();
+      await expect(page.getByText("Paso 3 de 3: Muestra")).toBeVisible();
+
+      await expect(async () => {
+        const metrics = await readScrollContract(page);
+        assertNoInternalScroll(
+          metrics,
+          `${viewport.name} clinic Tokens alta dialog`,
+        );
+      }).toPass({ timeout: 10_000 });
+    });
+  });
+}
+
+test("clinic Tokens desktop limits the master list and selects detail without scroll", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  await setClinicSession(page);
+  await mockClinicTokens(page);
+
+  await page.goto("/dashboard?module=tokens");
+  await expect(page.locator('[data-dashboard-module-workspace="tokens"]').first()).toBeVisible({
+    timeout: 12_000,
+  });
+  await expect(page.locator('[id^="clinic-particular-token-"]')).toHaveCount(4);
+  await expect(page.getByText(/1.4 de 6 tokens/)).toBeVisible();
+
+  await page.locator("#clinic-particular-token-2").click();
+  await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeVisible();
+  await expect(page.getByText("Alerta: Solicitud de tinción especial")).toBeVisible();
+
+  const metrics = await readScrollContract(page);
+  assertNoInternalScroll(metrics, "desktop clinic Tokens selected detail");
+});
+
+test("clinic Tokens mobile replaces list with detail and internal back returns", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await setClinicSession(page);
+  await mockClinicTokens(page);
+
+  await page.goto("/dashboard?module=tokens");
+  await expect(page.locator('[data-dashboard-module-workspace="tokens"]').first()).toBeVisible({
+    timeout: 12_000,
+  });
+  await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
+
+  await page.locator("#clinic-particular-token-2").click();
+  await expect(page.locator("#clinic-particular-token-1")).toBeHidden();
+  await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Volver a la lista" }).click();
+  await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeHidden();
+
+  const metrics = await readScrollContract(page);
+  assertNoInternalScroll(metrics, "mobile clinic Tokens detail back");
+});

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -70,7 +70,10 @@ test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
       timeout: 8_000,
     });
     await expect(
-      page.getByRole("region", { name: "Informes del dashboard" }),
+      page.getByRole("region", { name: "Lista de informes" }),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.getByRole("region", { name: "Detalle del informe" }),
     ).toBeVisible({ timeout: 8_000 });
   });
 

--- a/frontend/src/app/dashboard/ClinicCommandCenter.tsx
+++ b/frontend/src/app/dashboard/ClinicCommandCenter.tsx
@@ -2,6 +2,8 @@ import type { Report, FieldVisit, DashboardStats } from "@/types";
 import { StatsCards } from "@/components/dashboard/StatsCards";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
+import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
+import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ClipboardList, Route } from "lucide-react";
 import { formatDate } from "@/lib/utils";
@@ -24,155 +26,178 @@ export function ClinicCommandCenter({
   visitsLoadError,
 }: ClinicCommandCenterProps) {
   return (
-    <section
-      className="flex h-full min-h-0 flex-col gap-3"
-      aria-labelledby="clinic-command-center-heading"
+    <ModuleSurface
+      ariaLabel="Centro de operaciones clínica"
+      toolbar={
+        <section className="surface-note-info w-full" aria-labelledby="dashboard-operational-priority">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="min-w-0 max-w-3xl">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-vetneb-navy/80">
+                Estado operativo clínica
+              </p>
+              <p
+                id="dashboard-operational-priority"
+                className="mt-1 text-sm font-medium text-vetneb-navy"
+              >
+                Priorice informes pendientes y visitas activas para sostener continuidad diagnóstica.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:min-w-[20rem]">
+              <div className="dashboard-kpi-pill" data-tone="critical">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                  Informes pendientes
+                </p>
+                <p className="mt-1 text-lg font-bold leading-none">
+                  {stats?.pendingReports ?? "—"}
+                </p>
+              </div>
+              <div className="dashboard-kpi-pill" data-tone="focus">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                  Visitas activas
+                </p>
+                <p className="mt-1 text-lg font-bold leading-none">
+                  {stats?.activeVisits ?? "—"}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+      }
     >
-      <section className="surface-note-info" aria-labelledby="dashboard-operational-priority">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-vetneb-navy/80">
-              Estado operativo clínica
-            </p>
-            <p
-              id="dashboard-operational-priority"
-              className="mt-1 text-sm font-medium text-vetneb-navy"
-            >
-              Priorice informes pendientes y visitas activas para sostener continuidad diagnóstica.
-            </p>
-          </div>
-          <div className="grid grid-cols-2 gap-2 sm:min-w-[20rem]">
-            <div className="dashboard-kpi-pill" data-tone="critical">
-              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
-                Informes pendientes
-              </p>
-              <p className="mt-1 text-lg font-bold leading-none">
-                {stats?.pendingReports ?? "—"}
-              </p>
-            </div>
-            <div className="dashboard-kpi-pill" data-tone="focus">
-              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
-                Visitas activas
-              </p>
-              <p className="mt-1 text-lg font-bold leading-none">
-                {stats?.activeVisits ?? "—"}
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <div>
-        <h2
-          id="clinic-command-center-heading"
-          className="dashboard-section-heading"
-        >
-          Métricas operativas
-        </h2>
-        <p className="dashboard-section-description">
-          Vista rápida de informes, pendientes y actividad logística del día.
+      {statsLoadError ? (
+        <p role="alert" className="clinical-alert-warning shrink-0">
+          No se pudieron cargar las métricas operativas. Intente nuevamente.
         </p>
-        {statsLoadError ? (
-          <p role="alert" className="mt-3 clinical-alert-warning">
-            No se pudieron cargar las métricas operativas. Intente nuevamente.
-          </p>
-        ) : null}
-        <div className="mt-4">
-          <StatsCards stats={stats} />
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card className="dashboard-surface">
-          <CardHeader className="flex flex-row items-start justify-between pb-3">
-            <div>
-              <CardTitle className="text-base">Informes recientes</CardTitle>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Últimos estudios cargados y su estado actual.
-              </p>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-1.5">
-            {reportsLoadError ? (
-              <p role="alert" className="clinical-alert-warning">
-                No se pudieron cargar los informes recientes. Intente nuevamente.
-              </p>
-            ) : recentReports.length ? (
-              recentReports.map((report) => (
-                <div
-                  key={report.id}
-                  className="dashboard-list-row"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-vetneb-ink">
-                      {report.patientName ?? "Sin nombre"}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {report.studyType} · {formatDate(report.uploadDate)}
-                    </p>
-                  </div>
-                  <StatusBadge
-                    status={report.status}
-                    size="sm"
-                    className="ml-2 shrink-0"
-                  />
+      ) : null}
+      <ModuleTabs
+        ariaLabel="Secciones del centro operativo clínica"
+        tabs={[
+          {
+            id: "metricas",
+            label: "Métricas",
+            content: (
+              <section
+                className="flex min-h-0 flex-1 flex-col gap-3"
+                aria-labelledby="clinic-command-center-heading"
+              >
+                <div>
+                  <h2
+                    id="clinic-command-center-heading"
+                    className="dashboard-section-heading"
+                  >
+                    Métricas operativas
+                  </h2>
+                  <p className="dashboard-section-description">
+                    Vista rápida de informes, pendientes y actividad logística del día.
+                  </p>
                 </div>
-              ))
-            ) : (
-              <EmptyState
-                title="Sin informes recientes"
-                description="No hay informes recientes disponibles."
-                icon={ClipboardList}
-              />
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="dashboard-surface">
-          <CardHeader className="flex flex-row items-start justify-between pb-3">
-            <div>
-              <CardTitle className="text-base">Visitas de campo</CardTitle>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Programación logística con seguimiento en curso.
-              </p>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-1.5">
-            {visitsLoadError ? (
-              <p role="alert" className="clinical-alert-warning">
-                No se pudieron cargar las visitas de campo recientes. Intente nuevamente.
-              </p>
-            ) : recentVisits.length ? (
-              recentVisits.map((visit) => (
-                <div
-                  key={visit.id}
-                  className="dashboard-list-row"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-vetneb-ink">
-                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {formatDate(visit.scheduledAt)}
-                    </p>
-                  </div>
-                  <StatusBadge
-                    status={visit.status}
-                    size="sm"
-                    className="ml-2 shrink-0"
-                  />
+                <div className="min-h-0 flex-1">
+                  <StatsCards stats={stats} />
                 </div>
-              ))
-            ) : (
-              <EmptyState
-                title="Sin visitas recientes"
-                description="No hay visitas de campo recientes disponibles."
-                icon={Route}
-              />
-            )}
-          </CardContent>
-        </Card>
-      </div>
-    </section>
+              </section>
+            ),
+          },
+          {
+            id: "recientes",
+            label: "Recientes",
+            content: (
+              <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 lg:grid-cols-2">
+                <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
+                  <CardHeader className="shrink-0 pb-3">
+                    <div>
+                      <CardTitle className="text-base">Informes recientes</CardTitle>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Últimos estudios cargados y su estado actual.
+                      </p>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="min-h-0 flex-1 space-y-1.5">
+                    {reportsLoadError ? (
+                      <p role="alert" className="clinical-alert-warning">
+                        No se pudieron cargar los informes recientes. Intente nuevamente.
+                      </p>
+                    ) : recentReports.length ? (
+                      recentReports.map((report) => (
+                        <div
+                          key={report.id}
+                          className="dashboard-list-row"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-vetneb-ink">
+                              {report.patientName ?? "Sin nombre"}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {report.studyType} · {formatDate(report.uploadDate)}
+                            </p>
+                          </div>
+                          <StatusBadge
+                            status={report.status}
+                            size="sm"
+                            className="ml-2 shrink-0"
+                          />
+                        </div>
+                      ))
+                    ) : (
+                      <EmptyState
+                        title="Sin informes recientes"
+                        description="No hay informes recientes disponibles."
+                        icon={ClipboardList}
+                        size="sm"
+                      />
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
+                  <CardHeader className="shrink-0 pb-3">
+                    <div>
+                      <CardTitle className="text-base">Visitas de campo</CardTitle>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Programación logística con seguimiento en curso.
+                      </p>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="min-h-0 flex-1 space-y-1.5">
+                    {visitsLoadError ? (
+                      <p role="alert" className="clinical-alert-warning">
+                        No se pudieron cargar las visitas de campo recientes. Intente nuevamente.
+                      </p>
+                    ) : recentVisits.length ? (
+                      recentVisits.map((visit) => (
+                        <div
+                          key={visit.id}
+                          className="dashboard-list-row"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-vetneb-ink">
+                              {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {formatDate(visit.scheduledAt)}
+                            </p>
+                          </div>
+                          <StatusBadge
+                            status={visit.status}
+                            size="sm"
+                            className="ml-2 shrink-0"
+                          />
+                        </div>
+                      ))
+                    ) : (
+                      <EmptyState
+                        title="Sin visitas recientes"
+                        description="No hay visitas de campo recientes disponibles."
+                        icon={Route}
+                        size="sm"
+                      />
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            ),
+          },
+        ]}
+      />
+    </ModuleSurface>
   );
 }

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -1,11 +1,15 @@
+"use client";
+
+import { useState } from "react";
 import type { Report } from "@/types";
-import { ClipboardList, ExternalLink } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft, ClipboardList, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
+import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 type Props = {
   recentReports: Report[];
@@ -16,57 +20,174 @@ export function ClinicInformesWorkspaceSummary({
   recentReports,
   reportsLoadError,
 }: Props) {
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(
+    recentReports[0]?.id ?? null,
+  );
+  // Mobile/tablet replacement layer: detail covers the list (no vertical stack).
+  const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
+
+  const selectedReport =
+    recentReports.find((report) => report.id === selectedReportId) ??
+    recentReports[0] ??
+    null;
+
+  function selectReport(reportId: number) {
+    setSelectedReportId(reportId);
+    setIsMobileDetailOpen(true);
+  }
+
+  const fullModuleLink = (
+    <PublicRouteControl
+      href={ROUTES.dashboardInformes}
+      variant="bare"
+      className="inline-flex h-9 items-center gap-2 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-3 text-sm font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+      aria-label="Abrir módulo completo de informes"
+    >
+      <ExternalLink className="h-4 w-4" aria-hidden="true" />
+      Ver módulo de informes completo
+    </PublicRouteControl>
+  );
+
   return (
-    <div className="space-y-4">
-      <Card className="dashboard-surface">
-        <CardHeader className="flex flex-row items-start justify-between pb-3">
-          <div>
-            <CardTitle className="text-base">Informes recientes</CardTitle>
-            <p className="mt-1 text-xs text-muted-foreground">
+    <ModuleSurface
+      ariaLabel="Informes recientes de la clínica"
+      toolbar={
+        <div className="flex w-full flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-vetneb-ink">
+              Informes recientes
+            </h3>
+            <p className="text-xs text-muted-foreground">
               Últimos estudios cargados. Para acceso completo use el módulo de informes.
             </p>
           </div>
-        </CardHeader>
-        <CardContent className="space-y-1.5">
-          {reportsLoadError ? (
-            <p role="alert" className="clinical-alert-warning">
-              No se pudieron cargar los informes recientes. Intente nuevamente.
-            </p>
-          ) : recentReports.length ? (
-            recentReports.map((report) => (
-              <div key={report.id} className="dashboard-list-row">
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-vetneb-ink">
-                    {report.patientName ?? "Sin nombre"}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {report.studyType} · {formatDate(report.uploadDate)}
-                  </p>
-                </div>
-                <StatusBadge status={report.status} size="sm" className="ml-2 shrink-0" />
-              </div>
-            ))
-          ) : (
-            <EmptyState
-              title="Sin informes recientes"
-              description="No hay informes recientes disponibles."
-              icon={ClipboardList}
-            />
-          )}
-        </CardContent>
-      </Card>
+          {fullModuleLink}
+        </div>
+      }
+    >
+      {reportsLoadError ? (
+        <p role="alert" className="clinical-alert-warning">
+          No se pudieron cargar los informes recientes. Intente nuevamente.
+        </p>
+      ) : recentReports.length ? (
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 xl:grid-cols-[0.85fr_1.15fr]">
+          <div
+            className={cn(
+              "flex min-h-0 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82",
+              isMobileDetailOpen && "hidden xl:flex",
+            )}
+          >
+            <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden">
+              {recentReports.map((report) => {
+                const isSelected = selectedReport?.id === report.id;
 
-      <div className="flex justify-start">
-        <PublicRouteControl
-          href={ROUTES.dashboardInformes}
-          variant="bare"
-          className="inline-flex h-10 items-center gap-2 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-4 text-sm font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-          aria-label="Abrir módulo completo de informes"
-        >
-          <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          Ver módulo de informes completo
-        </PublicRouteControl>
-      </div>
-    </div>
+                return (
+                  <button
+                    key={report.id}
+                    type="button"
+                    onClick={() => selectReport(report.id)}
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                      isSelected && "bg-vetneb-cyan/12",
+                    )}
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-vetneb-ink">
+                        {report.patientName ?? "Sin nombre"}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {report.studyType} · {formatDate(report.uploadDate)}
+                      </p>
+                    </div>
+                    <StatusBadge status={report.status} size="sm" className="ml-2 shrink-0" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "min-h-0 overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82 p-4",
+              !isMobileDetailOpen && "hidden xl:block",
+            )}
+          >
+            {selectedReport ? (
+              <div className="space-y-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="xl:hidden"
+                  onClick={() => setIsMobileDetailOpen(false)}
+                >
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                  Volver a la lista
+                </Button>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                      Detalle del informe
+                    </p>
+                    <h4 className="mt-1 truncate text-lg font-semibold text-vetneb-ink">
+                      {selectedReport.patientName ?? "Sin nombre"}
+                    </h4>
+                  </div>
+                  <StatusBadge status={selectedReport.status} size="sm" className="shrink-0" />
+                </div>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Estudio
+                    </p>
+                    <p className="mt-1 text-xs text-vetneb-ink">
+                      {selectedReport.studyType ?? "—"}
+                    </p>
+                  </div>
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Carga
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {formatDate(selectedReport.uploadDate)}
+                    </p>
+                  </div>
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Informe
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      #{selectedReport.id} · {selectedReport.hasFile ? "Con archivo" : "Sin archivo"}
+                    </p>
+                  </div>
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Acción
+                    </p>
+                    <PublicRouteControl
+                      href={`${ROUTES.dashboardInformes}?reportId=${selectedReport.id}`}
+                      variant="textLink"
+                      className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                      aria-label={`Abrir informe ${selectedReport.id} en el módulo completo`}
+                    >
+                      Abrir en módulo completo
+                    </PublicRouteControl>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="surface-empty">Seleccione un informe para ver el detalle.</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <EmptyState
+          title="Sin informes recientes"
+          description="No hay informes recientes disponibles."
+          icon={ClipboardList}
+        />
+      )}
+    </ModuleSurface>
   );
 }

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -1,11 +1,15 @@
+"use client";
+
+import { useState } from "react";
 import type { FieldVisit } from "@/types";
-import { Route as RouteIcon, ExternalLink } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft, Route as RouteIcon, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
+import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 type Props = {
   recentVisits: FieldVisit[];
@@ -16,57 +20,174 @@ export function ClinicLogisticaWorkspaceSummary({
   recentVisits,
   visitsLoadError,
 }: Props) {
+  const [selectedVisitId, setSelectedVisitId] = useState<number | null>(
+    recentVisits[0]?.id ?? null,
+  );
+  // Mobile/tablet replacement layer: detail covers the list (no vertical stack).
+  const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
+
+  const selectedVisit =
+    recentVisits.find((visit) => visit.id === selectedVisitId) ??
+    recentVisits[0] ??
+    null;
+
+  function selectVisit(visitId: number) {
+    setSelectedVisitId(visitId);
+    setIsMobileDetailOpen(true);
+  }
+
+  const fullModuleLink = (
+    <PublicRouteControl
+      href={ROUTES.dashboardLogistica}
+      variant="bare"
+      className="inline-flex h-9 items-center gap-2 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-3 text-sm font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+      aria-label="Abrir módulo completo de logística"
+    >
+      <ExternalLink className="h-4 w-4" aria-hidden="true" />
+      Ver módulo de logística completo
+    </PublicRouteControl>
+  );
+
   return (
-    <div className="space-y-4">
-      <Card className="dashboard-surface">
-        <CardHeader className="flex flex-row items-start justify-between pb-3">
-          <div>
-            <CardTitle className="text-base">Visitas de campo recientes</CardTitle>
-            <p className="mt-1 text-xs text-muted-foreground">
+    <ModuleSurface
+      ariaLabel="Visitas de campo recientes de la clínica"
+      toolbar={
+        <div className="flex w-full flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-vetneb-ink">
+              Visitas de campo recientes
+            </h3>
+            <p className="text-xs text-muted-foreground">
               Programación logística activa. Para gestión completa use el módulo de logística.
             </p>
           </div>
-        </CardHeader>
-        <CardContent className="space-y-1.5">
-          {visitsLoadError ? (
-            <p role="alert" className="clinical-alert-warning">
-              No se pudieron cargar las visitas de campo. Intente nuevamente.
-            </p>
-          ) : recentVisits.length ? (
-            recentVisits.map((visit) => (
-              <div key={visit.id} className="dashboard-list-row">
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-vetneb-ink">
-                    {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {formatDate(visit.scheduledAt)}
-                  </p>
-                </div>
-                <StatusBadge status={visit.status} size="sm" className="ml-2 shrink-0" />
-              </div>
-            ))
-          ) : (
-            <EmptyState
-              title="Sin visitas recientes"
-              description="No hay visitas de campo recientes disponibles."
-              icon={RouteIcon}
-            />
-          )}
-        </CardContent>
-      </Card>
+          {fullModuleLink}
+        </div>
+      }
+    >
+      {visitsLoadError ? (
+        <p role="alert" className="clinical-alert-warning">
+          No se pudieron cargar las visitas de campo. Intente nuevamente.
+        </p>
+      ) : recentVisits.length ? (
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 xl:grid-cols-[0.85fr_1.15fr]">
+          <div
+            className={cn(
+              "flex min-h-0 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82",
+              isMobileDetailOpen && "hidden xl:flex",
+            )}
+          >
+            <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden">
+              {recentVisits.map((visit) => {
+                const isSelected = selectedVisit?.id === visit.id;
 
-      <div className="flex justify-start">
-        <PublicRouteControl
-          href={ROUTES.dashboardLogistica}
-          variant="bare"
-          className="inline-flex h-10 items-center gap-2 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-4 text-sm font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
-          aria-label="Abrir módulo completo de logística"
-        >
-          <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          Ver módulo de logística completo
-        </PublicRouteControl>
-      </div>
-    </div>
+                return (
+                  <button
+                    key={visit.id}
+                    type="button"
+                    onClick={() => selectVisit(visit.id)}
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                      isSelected && "bg-vetneb-cyan/12",
+                    )}
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-vetneb-ink">
+                        {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatDate(visit.scheduledAt)}
+                      </p>
+                    </div>
+                    <StatusBadge status={visit.status} size="sm" className="ml-2 shrink-0" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "min-h-0 overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82 p-4",
+              !isMobileDetailOpen && "hidden xl:block",
+            )}
+          >
+            {selectedVisit ? (
+              <div className="space-y-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="xl:hidden"
+                  onClick={() => setIsMobileDetailOpen(false)}
+                >
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                  Volver a la lista
+                </Button>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                      Detalle de la visita
+                    </p>
+                    <h4 className="mt-1 truncate text-lg font-semibold text-vetneb-ink">
+                      {selectedVisit.clinicName ?? `Clínica #${selectedVisit.clinicId}`}
+                    </h4>
+                  </div>
+                  <StatusBadge status={selectedVisit.status} size="sm" className="shrink-0" />
+                </div>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Programada
+                    </p>
+                    <p className="mt-1 text-xs text-vetneb-ink">
+                      {formatDate(selectedVisit.scheduledAt)}
+                    </p>
+                  </div>
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Completada
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {selectedVisit.completedAt ? formatDate(selectedVisit.completedAt) : "—"}
+                    </p>
+                  </div>
+                  <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Dirección
+                    </p>
+                    <p className="mt-1 truncate text-xs text-muted-foreground">
+                      {selectedVisit.address ?? "Sin dirección registrada"}
+                    </p>
+                  </div>
+                  <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Acción
+                    </p>
+                    <PublicRouteControl
+                      href={ROUTES.dashboardLogisticaVisitas}
+                      variant="textLink"
+                      className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                      aria-label="Abrir visitas de campo en el módulo completo"
+                    >
+                      Abrir visitas en módulo completo
+                    </PublicRouteControl>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="surface-empty">Seleccione una visita para ver el detalle.</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <EmptyState
+          title="Sin visitas recientes"
+          description="No hay visitas de campo recientes disponibles."
+          icon={RouteIcon}
+        />
+      )}
+    </ModuleSurface>
   );
 }

--- a/frontend/src/app/dashboard/admin/AdminCommandCenter.tsx
+++ b/frontend/src/app/dashboard/admin/AdminCommandCenter.tsx
@@ -1,11 +1,6 @@
 import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
+import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
 import { cn } from "@/lib/utils";
 
 type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
@@ -29,97 +24,105 @@ export function AdminCommandCenter({
   systemStatusDetail,
   hasSystemHealthFetchError,
 }: AdminCommandCenterProps) {
-  return (
-    <section
-      className="space-y-4"
-      aria-labelledby="admin-command-center-heading"
+  const metricsPanel = (
+    <div
+      className="overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-[0_12px_34px_rgba(15,45,62,0.08)] ring-1 ring-white/55 transition-[border-color,box-shadow,background-color] duration-200 hover:border-vetneb-teal/35"
+      role="region"
+      aria-label="Métricas de auditoría"
     >
-      <div>
-        <h2
-          id="admin-command-center-heading"
-          className="dashboard-section-heading"
-        >
-          Resumen operativo
-        </h2>
-        <p className="dashboard-section-description">
-          Lectura inmediata de auditoría, variedad de eventos y salud del sistema.
-        </p>
-      </div>
+      <div className="grid grid-cols-1 divide-y divide-vetneb-line/60 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+        <div className="px-5 py-3.5">
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            Eventos de auditoría
+          </p>
+          <p className="mt-1.5 text-2xl font-bold tracking-tight text-vetneb-ink">
+            {auditEntriesCount}
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">Registros totales</p>
+        </div>
 
-      <div
-        className="overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-[0_12px_34px_rgba(15,45,62,0.08)] ring-1 ring-white/55 transition-[border-color,box-shadow,background-color] duration-200 hover:border-vetneb-teal/35"
-        role="region"
-        aria-label="Métricas de auditoría"
-      >
-        <div className="grid grid-cols-1 divide-y divide-vetneb-line/60 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-          <div className="px-5 py-3.5">
-            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Eventos de auditoría
-            </p>
-            <p className="mt-1.5 text-2xl font-bold tracking-tight text-vetneb-ink">
-              {auditEntriesCount}
-            </p>
-            <p className="mt-0.5 text-xs text-muted-foreground">Registros totales</p>
-          </div>
+        <div className="px-5 py-3.5">
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            Tipos de evento
+          </p>
+          <p className="mt-1.5 text-2xl font-bold tracking-tight text-vetneb-ink">
+            {eventTypesCount}
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">Categorías distintas</p>
+        </div>
 
-          <div className="px-5 py-3.5">
-            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Tipos de evento
-            </p>
-            <p className="mt-1.5 text-2xl font-bold tracking-tight text-vetneb-ink">
-              {eventTypesCount}
-            </p>
-            <p className="mt-0.5 text-xs text-muted-foreground">Categorías distintas</p>
+        <div className="px-5 py-3.5">
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            Estado del sistema
+          </p>
+          <div className="mt-1.5 flex items-center gap-2">
+            <span
+              className={cn("h-2.5 w-2.5 rounded-full", systemStatusIndicatorClass)}
+              aria-hidden="true"
+            />
+            <Badge variant={systemStatusVariant}>
+              {systemStatusLabel}
+            </Badge>
           </div>
-
-          <div className="px-5 py-3.5">
-            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Estado del sistema
-            </p>
-            <div className="mt-1.5 flex items-center gap-2">
-              <span
-                className={cn("h-2.5 w-2.5 rounded-full", systemStatusIndicatorClass)}
-                aria-hidden="true"
-              />
-              <Badge variant={systemStatusVariant}>
-                {systemStatusLabel}
-              </Badge>
-            </div>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {hasSystemHealthFetchError
-                ? "No se pudo consultar el estado del sistema."
-                : systemStatusDetail}
-            </p>
-          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {hasSystemHealthFetchError
+              ? "No se pudo consultar el estado del sistema."
+              : systemStatusDetail}
+          </p>
         </div>
       </div>
+    </div>
+  );
 
-      <Card className="dashboard-surface">
-        <CardHeader className="pb-2 pt-4">
-          <CardTitle className="text-base">Alertas</CardTitle>
-          <CardDescription>
-            Seguridad y salud operativa quedan priorizadas antes de las secciones secundarias.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-2 pb-4 md:grid-cols-2">
-          <div className="surface-soft">
-            <p className="text-sm font-semibold text-vetneb-ink">
-              Intentos fallidos de login
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Revisar actividad de acceso antes de cambios administrativos.
+  const alertsPanel = (
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 md:grid-cols-2">
+      <div className="surface-soft">
+        <p className="text-sm font-semibold text-vetneb-ink">
+          Intentos fallidos de login
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Revisar actividad de acceso antes de cambios administrativos.
+        </p>
+      </div>
+      <div className="surface-soft">
+        <p className="text-sm font-semibold text-vetneb-ink">
+          Sistema
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Consultar salud, esquema y mantenimiento agrupados.
+        </p>
+      </div>
+    </div>
+  );
+
+  return (
+    <section
+      className="flex min-h-0 flex-1 flex-col"
+      aria-labelledby="admin-command-center-heading"
+    >
+      <ModuleSurface
+        toolbar={
+          <div className="min-w-0">
+            <h2
+              id="admin-command-center-heading"
+              className="dashboard-section-heading"
+            >
+              Resumen operativo
+            </h2>
+            <p className="dashboard-section-description hidden sm:block">
+              Lectura inmediata de auditoría, variedad de eventos y salud del sistema.
             </p>
           </div>
-          <div className="surface-soft">
-            <p className="text-sm font-semibold text-vetneb-ink">
-              Sistema
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Consultar salud, esquema y mantenimiento agrupados.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+        }
+      >
+        <ModuleTabs
+          ariaLabel="Resumen operativo"
+          tabs={[
+            { id: "metricas", label: "Métricas", content: metricsPanel },
+            { id: "alertas", label: "Alertas", content: alertsPanel },
+          ]}
+        />
+      </ModuleSurface>
     </section>
   );
 }

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -32,7 +32,7 @@ import type {
   AdminFailedLoginAlertSurface,
 } from "@/types";
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 5;
 
 function formatSurface(value: AdminFailedLoginAlertSurface) {
   if (value === "admin") return "Admin";
@@ -134,7 +134,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
     : false;
 
   return (
-    <Card id="failed-login-alerts" className="dashboard-surface">
+    <Card id="failed-login-alerts" className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
       <CardHeader className="flex flex-col gap-3 border-b border-vetneb-line/70 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <CardTitle className="text-base">
@@ -170,7 +170,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4 pt-6">
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
         <div className="dashboard-filter-stats-grid">
           <div className="surface-soft">
             <p className="text-xs text-muted-foreground">Total filtrado</p>
@@ -236,7 +236,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           </div>
         ) : null}
 
-        <div className="dashboard-table-responsive">
+        <div className="dashboard-table-responsive min-h-0 flex-1">
           <Table>
             <TableHeader>
               <TableRow>
@@ -311,7 +311,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           </Table>
         </div>
 
-        <div className="dashboard-table-pagination">
+        <div className="dashboard-table-pagination shrink-0">
           <div className="dashboard-table-pagination-controls">
             <Button
               type="button"

--- a/frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx
@@ -11,6 +11,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { CompactPager } from "@/components/dashboard/CompactPager";
+import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import { getAdminMaintenancePurgeDryRun } from "@/lib/api";
 import type {
   MaintenancePurgeCandidateGroup,
@@ -85,6 +87,7 @@ export function AdminMaintenanceDryRunCard() {
     useState<MaintenancePurgeDryRunSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const pagedCandidates = usePagedRows(snapshot?.candidates ?? [], 4);
 
   function handleAnalyze() {
     setError(null);
@@ -106,7 +109,7 @@ export function AdminMaintenanceDryRunCard() {
   }
 
   return (
-    <Card className="dashboard-surface">
+    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
       <CardHeader className="flex flex-col gap-3 border-b border-vetneb-line/70 md:flex-row md:items-start md:justify-between">
         <div>
           <CardTitle className="text-base">
@@ -122,7 +125,7 @@ export function AdminMaintenanceDryRunCard() {
         </Button>
       </CardHeader>
 
-      <CardContent className="space-y-4 pt-6">
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
         {error ? (
           <div className="clinical-alert-error">
             {error}
@@ -174,14 +177,26 @@ export function AdminMaintenanceDryRunCard() {
               ) : null}
             </div>
 
-            <div className="space-y-3">
-              {snapshot.candidates.map((candidate) => (
+            <div className="min-h-0 flex-1 space-y-2 overflow-hidden">
+              {pagedCandidates.pageItems.map((candidate) => (
                 <MaintenanceCandidateRow
                   key={candidate.category}
                   candidate={candidate}
                 />
               ))}
             </div>
+            <CompactPager
+              page={pagedCandidates.page}
+              pageCount={pagedCandidates.pageCount}
+              rangeStart={pagedCandidates.rangeStart}
+              rangeEnd={pagedCandidates.rangeEnd}
+              total={pagedCandidates.total}
+              hasPrev={pagedCandidates.hasPrev}
+              hasNext={pagedCandidates.hasNext}
+              onPrev={pagedCandidates.goPrev}
+              onNext={pagedCandidates.goNext}
+              itemLabel="grupos"
+            />
           </>
         )}
       </CardContent>

--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -31,7 +31,7 @@ import type {
   ClinicUserRole,
 } from "@/types";
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 5;
 
 function formatUserType(value: AdminRoleUserType) {
   return value === "admin" ? "Admin" : "Clínica";
@@ -208,7 +208,7 @@ export function AdminUsersRolesReadOnlyCard() {
     : false;
 
   return (
-    <Card className="dashboard-surface">
+    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
       <CardHeader className="flex flex-col gap-3 border-b border-vetneb-line/70 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <CardTitle className="text-base">Usuarios y roles</CardTitle>
@@ -225,7 +225,7 @@ export function AdminUsersRolesReadOnlyCard() {
         </Button>
       </CardHeader>
 
-      <CardContent className="space-y-4 pt-6">
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
         <div className="dashboard-filter-stats-grid-5">
           <div className="surface-soft">
             <p className="text-xs text-muted-foreground">Total filtrado</p>
@@ -298,7 +298,7 @@ export function AdminUsersRolesReadOnlyCard() {
           </div>
         ) : null}
 
-        <div className="dashboard-table-responsive">
+        <div className="dashboard-table-responsive min-h-0 flex-1">
           <Table>
             <TableHeader>
               <TableRow>
@@ -394,7 +394,7 @@ export function AdminUsersRolesReadOnlyCard() {
           </Table>
         </div>
 
-        <div className="dashboard-table-pagination">
+        <div className="dashboard-table-pagination shrink-0">
           <div className="dashboard-table-pagination-controls">
             <Button
               type="button"

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -399,38 +399,62 @@ export default async function AdminPage({
   }));
 
   // ── Administración workspace: command center + critical alerts ──────────────
+  // Single-viewport App Shell: split the resumen command center and the critical
+  // alerts table into tabs so each fits one desktop viewport without scroll
+  // (previously stacked via space-y-6, growing past the viewport).
   const adminWorkspaceSlot = (
-    <div className="space-y-6">
-      <div id="admin-command-center">
-        <AdminCommandCenter
-          auditEntriesCount={auditEntries.length}
-          eventTypesCount={Object.keys(eventCounts).length}
-          systemStatusLabel={formatSystemStatus(systemStatus)}
-          systemStatusVariant={getSystemStatusVariant(systemStatus)}
-          systemStatusIndicatorClass={getSystemStatusIndicatorClass(systemStatus)}
-          systemStatusDetail={formatSystemStatusDetail(serviceChecks)}
-          hasSystemHealthFetchError={hasSystemHealthFetchError}
-        />
-      </div>
-      <section className="space-y-4" aria-labelledby="admin-alertas-heading">
-        <div>
-          <h2 id="admin-alertas-heading" className="dashboard-section-heading">
-            Alertas críticas
-          </h2>
-          <p className="dashboard-section-description">
-            Intentos fallidos y señales de acceso se revisan antes de las tareas secundarias.
-          </p>
-        </div>
-        <AdminFailedLoginAlertsReadOnlyCard />
-      </section>
-    </div>
+    <ModuleTabs
+      ariaLabel="Resumen y alertas"
+      tabs={[
+        {
+          id: "resumen",
+          label: "Resumen",
+          content: (
+            <div
+              id="admin-command-center"
+              className="flex min-h-0 flex-1 flex-col"
+            >
+              <AdminCommandCenter
+                auditEntriesCount={auditEntries.length}
+                eventTypesCount={Object.keys(eventCounts).length}
+                systemStatusLabel={formatSystemStatus(systemStatus)}
+                systemStatusVariant={getSystemStatusVariant(systemStatus)}
+                systemStatusIndicatorClass={getSystemStatusIndicatorClass(systemStatus)}
+                systemStatusDetail={formatSystemStatusDetail(serviceChecks)}
+                hasSystemHealthFetchError={hasSystemHealthFetchError}
+              />
+            </div>
+          ),
+        },
+        {
+          id: "alertas",
+          label: "Alertas",
+          content: (
+            <section
+              className="flex min-h-0 flex-1 flex-col gap-4"
+              aria-labelledby="admin-alertas-heading"
+            >
+              <div>
+                <h2 id="admin-alertas-heading" className="dashboard-section-heading">
+                  Alertas críticas
+                </h2>
+                <p className="dashboard-section-description">
+                  Intentos fallidos y señales de acceso se revisan antes de las tareas secundarias.
+                </p>
+              </div>
+              <AdminFailedLoginAlertsReadOnlyCard />
+            </section>
+          ),
+        },
+      ]}
+    />
   );
 
   // ── Subir informe workspace ─────────────────────────────────────────────────
   const reportUploadWorkspaceSlot = (
     <section
       id="admin-report-upload"
-      className="dashboard-surface overflow-hidden p-0"
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden p-0"
     >
       <div className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between">
         <div className="min-w-0">
@@ -593,14 +617,14 @@ export default async function AdminPage({
 
   // ── Tokens particulares workspace ───────────────────────────────────────────
   const tokensWorkspaceSlot = (
-    <section id="admin-particular-tokens">
+    <section id="admin-particular-tokens" className="flex min-h-0 flex-1 flex-col">
       <AdminParticularTokensCard />
     </section>
   );
 
   // ── Precios workspace ───────────────────────────────────────────────────────
   const pricingWorkspaceSlot = (
-    <section id="admin-pricing">
+    <section id="admin-pricing" className="flex min-h-0 flex-1 flex-col">
       <AdminPricingEditorCard />
     </section>
   );
@@ -629,8 +653,9 @@ export default async function AdminPage({
   );
 
   // ── Roles clínica workspace ─────────────────────────────────────────────────
+  // Height chain so the read-only roles card owns the viewport without scroll.
   const usersRolesWorkspaceSlot = (
-    <section id="admin-users-roles">
+    <section id="admin-users-roles" className="flex min-h-0 flex-1 flex-col">
       <AdminUsersRolesReadOnlyCard />
     </section>
   );
@@ -776,13 +801,28 @@ export default async function AdminPage({
   );
 
   // ── Mantenimiento workspace ─────────────────────────────────────────────────
+  // Single-viewport App Shell: schema health and the dry-run card switch via tabs
+  // so each owns the viewport without the previous space-y-4 vertical stack.
   const maintenanceWorkspaceSlot = (
-    <div className="space-y-4">
-      <AdminSchemaHealthStatusCard />
-      <section id="admin-maintenance">
-        <AdminMaintenanceDryRunCard />
-      </section>
-    </div>
+    <ModuleTabs
+      ariaLabel="Mantenimiento del sistema"
+      tabs={[
+        {
+          id: "esquema",
+          label: "Esquema",
+          content: <AdminSchemaHealthStatusCard />,
+        },
+        {
+          id: "dry-run",
+          label: "Dry-run",
+          content: (
+            <section id="admin-maintenance">
+              <AdminMaintenanceDryRunCard />
+            </section>
+          ),
+        },
+      ]}
+    />
   );
 
   return (
@@ -826,7 +866,6 @@ export default async function AdminPage({
             eventTypesCount={Object.keys(eventCounts).length}
           />
         </Suspense>
-        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/frontend/src/app/dashboard/logistica/page.tsx
+++ b/frontend/src/app/dashboard/logistica/page.tsx
@@ -112,7 +112,6 @@ export default async function LogisticaPage() {
           fieldVisitsLoadError={fieldVisitsLoadError}
           routePlansLoadError={routePlansLoadError}
         />
-        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -167,7 +167,6 @@ export default async function DashboardPage({
             }}
           />
         </Suspense>
-        <div className="h-24 md:hidden" aria-hidden="true" />
       </main>
     </>
   );

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -220,7 +220,7 @@
      primitives (ModuleSurface/ModuleTabs/usePagedRows/MasterDetail), never by
      scrolling `main`. Replaces the legacy `overflow-y-auto` escape hatch. */
   .dashboard-main {
-    @apply flex min-h-0 flex-1 flex-col space-y-6 overflow-hidden px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6;
+    @apply flex min-h-0 flex-1 flex-col space-y-4 overflow-hidden px-3 py-3 sm:space-y-6 sm:px-6 sm:py-5 lg:px-8 lg:py-6;
   }
 
   .surface-note-info {
@@ -260,7 +260,7 @@
   }
 
   .clinical-modal {
-    @apply rounded-lg border border-vetneb-line/85 bg-card text-card-foreground shadow-[0_24px_72px_rgba(8,35,50,0.22)];
+    @apply overflow-hidden rounded-lg border border-vetneb-line/85 bg-card text-card-foreground shadow-[0_24px_72px_rgba(8,35,50,0.22)];
   }
 
   .clinical-progress {
@@ -1779,6 +1779,16 @@
     min-height: 0;
   }
 
+  .dashboard-cockpit-launcher-dense {
+    gap: 0.65rem;
+    padding: 0.75rem;
+  }
+
+  .dashboard-cockpit-grid-dense {
+    gap: 0.45rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   /* Premium module tile: compact, dense, no fixed height so rows can stretch
      (auto-rows: 1fr) to fit the viewport without scrolling. */
   .dashboard-cockpit-tile {
@@ -1864,6 +1874,17 @@
     min-width: 0;
     flex: 1 1 auto;
     gap: 0.75rem;
+    overflow: hidden;
+  }
+
+  .dashboard-cockpit-launcher-dense .dashboard-cockpit-tile {
+    gap: 0.25rem;
+    padding: 0.5rem 0.55rem;
+  }
+
+  .dashboard-cockpit-launcher-dense .dashboard-cockpit-tile-icon {
+    height: 1.55rem;
+    width: 1.55rem;
   }
 
   /* Fixed (non-growing) toolbar row: filters, search, primary actions. */
@@ -1883,6 +1904,7 @@
     min-height: 0;
     min-width: 0;
     flex: 1 1 auto;
+    overflow: hidden;
   }
 
   /* Segmented tab control (no new dependency; reuses native buttons). */

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+import { ArrowLeft } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { CompactPager } from "@/components/dashboard/CompactPager";
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import {
   createClinicParticularToken,
   getClinicStudyTrackingCases,
@@ -14,7 +18,7 @@ import {
   type ClinicParticularTokenCreatePayload,
   type ClinicParticularTokenSummary,
 } from "@/lib/api";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 type ClinicParticularTokenFormState = {
   reportId: string;
@@ -35,6 +39,18 @@ type ClinicParticularTokenFormState = {
 type GeneratedTokenDetails = {
   petName: string;
   tutorLastName: string;
+};
+
+/** Maximum tokens visible per page in the master list (rest via CompactPager). */
+const TOKENS_PAGE_SIZE = 4;
+
+const CREATE_TOKEN_STEP_ORDER = ["contact", "patient", "sample"] as const;
+type CreateTokenStep = (typeof CREATE_TOKEN_STEP_ORDER)[number];
+
+const CREATE_TOKEN_STEP_LABELS: Record<CreateTokenStep, string> = {
+  contact: "Vínculo",
+  patient: "Paciente",
+  sample: "Muestra",
 };
 
 const INITIAL_FORM_STATE: ClinicParticularTokenFormState = {
@@ -73,6 +89,22 @@ const REQUIRED_FIELD_LABELS: Array<{
   { key: "extractionDate", label: "Fecha de extracción" },
   { key: "shippingDate", label: "Fecha de envío" },
 ];
+
+const FORM_FIELD_STEPS: Record<keyof ClinicParticularTokenFormState, CreateTokenStep> = {
+  reportId: "contact",
+  particularEmail: "contact",
+  tutorLastName: "contact",
+  petName: "patient",
+  petAge: "patient",
+  petBreed: "patient",
+  petSex: "patient",
+  petSpecies: "patient",
+  sampleLocation: "sample",
+  sampleEvolution: "sample",
+  detailsLesion: "sample",
+  extractionDate: "sample",
+  shippingDate: "sample",
+};
 
 const PET_SEX_OPTIONS = [
   { value: "Macho", label: "Macho" },
@@ -129,6 +161,16 @@ function validateFormState(formState: ClinicParticularTokenFormState): void {
   }
 }
 
+function getFirstMissingFieldStep(
+  formState: ClinicParticularTokenFormState,
+): CreateTokenStep | null {
+  const missingField = REQUIRED_FIELD_LABELS.find(
+    (field) => !String(formState[field.key]).trim(),
+  );
+
+  return missingField ? FORM_FIELD_STEPS[missingField.key] : null;
+}
+
 function buildPayload(
   formState: ClinicParticularTokenFormState,
 ): ClinicParticularTokenCreatePayload {
@@ -177,10 +219,20 @@ function getTrackingStageLabel(
   return TRACKING_STAGE_LABELS[stage] ?? stage;
 }
 
+function getCreateStepIndex(step: CreateTokenStep): number {
+  return CREATE_TOKEN_STEP_ORDER.indexOf(step);
+}
+
 export function ClinicParticularTokensCard() {
+  // Alta in a dedicated dialog layer (audit §4): the form never grows `main`.
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [createStep, setCreateStep] = useState<CreateTokenStep>("contact");
   const [formState, setFormState] =
     useState<ClinicParticularTokenFormState>(INITIAL_FORM_STATE);
   const [tokens, setTokens] = useState<ClinicParticularTokenSummary[]>([]);
+  const [selectedTokenId, setSelectedTokenId] = useState<number | null>(null);
+  // Mobile/tablet replacement layer: detail covers the list (no vertical stack).
+  const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
   const [trackingCasesByTokenId, setTrackingCasesByTokenId] = useState<
     Record<number, ClinicStudyTrackingCaseSummary>
   >({});
@@ -201,22 +253,42 @@ export function ClinicParticularTokensCard() {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  const pagedTokens = usePagedRows(tokens, TOKENS_PAGE_SIZE);
+  const selectedToken =
+    selectedTokenId === null
+      ? (tokens[0] ?? null)
+      : (tokens.find((token) => token.id === selectedTokenId) ?? tokens[0] ?? null);
+  const selectedTrackingCase = selectedToken
+    ? trackingCasesByTokenId[selectedToken.id]
+    : undefined;
+
+  const activeTokensCount = tokens.filter((token) => token.isActive).length;
+  const linkedReportsCount = tokens.filter((token) => token.hasLinkedReport).length;
+  const createStepIndex = getCreateStepIndex(createStep);
+  const isLastCreateStep = createStep === "sample";
+
   async function loadTokens() {
     setIsLoadingTokens(true);
     setTrackingLoadError(null);
 
     try {
       const snapshot = await getClinicParticularTokens({ limit: 10, offset: 0 });
-      setTokens(snapshot.particularTokens);
+      const nextTokens = snapshot.particularTokens;
+      setTokens(nextTokens);
+      setSelectedTokenId((current) =>
+        current && nextTokens.some((token) => token.id === current)
+          ? current
+          : nextTokens[0]?.id ?? null,
+      );
 
-      if (snapshot.particularTokens.length === 0) {
+      if (nextTokens.length === 0) {
         setTrackingCasesByTokenId({});
         return;
       }
 
       try {
         const trackingEntries = await Promise.all(
-          snapshot.particularTokens.map(async (token) => {
+          nextTokens.map(async (token) => {
             const trackingSnapshot = await getClinicStudyTrackingCases({
               particularTokenId: token.id,
               limit: 1,
@@ -269,6 +341,35 @@ export function ClinicParticularTokensCard() {
     setStatusMessage(null);
   }
 
+  function selectToken(tokenId: number) {
+    setSelectedTokenId(tokenId);
+    setIsMobileDetailOpen(true);
+  }
+
+  function handleCreateDialogOpenChange(open: boolean) {
+    setIsCreateDialogOpen(open);
+    if (!open) {
+      setCreateStep("contact");
+    }
+  }
+
+  function goToPreviousCreateStep() {
+    setCreateStep((current) => {
+      const previousIndex = Math.max(0, getCreateStepIndex(current) - 1);
+      return CREATE_TOKEN_STEP_ORDER[previousIndex];
+    });
+  }
+
+  function goToNextCreateStep() {
+    setCreateStep((current) => {
+      const nextIndex = Math.min(
+        CREATE_TOKEN_STEP_ORDER.length - 1,
+        getCreateStepIndex(current) + 1,
+      );
+      return CREATE_TOKEN_STEP_ORDER[nextIndex];
+    });
+  }
+
   function clearGeneratedTokenState() {
     setGeneratedToken(null);
     setGeneratedTokenRecipientEmail(null);
@@ -315,6 +416,7 @@ export function ClinicParticularTokensCard() {
 
   function resetForm() {
     setFormState(INITIAL_FORM_STATE);
+    setCreateStep("contact");
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -334,11 +436,22 @@ export function ClinicParticularTokensCard() {
       return;
     }
 
+    if (!isLastCreateStep) {
+      goToNextCreateStep();
+      return;
+    }
+
     let payload: ClinicParticularTokenCreatePayload;
 
     try {
       payload = buildPayload(formState);
     } catch (error) {
+      const missingStep = getFirstMissingFieldStep(formState);
+      if (missingStep) {
+        setCreateStep(missingStep);
+      } else if (formState.reportId.trim()) {
+        setCreateStep("contact");
+      }
       setErrorMessage(
         error instanceof Error
           ? error.message
@@ -367,6 +480,7 @@ export function ClinicParticularTokensCard() {
       setStatusMessage(response.message);
       resetForm();
       await loadTokens();
+      setIsCreateDialogOpen(false);
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -379,503 +493,711 @@ export function ClinicParticularTokensCard() {
   }
 
   return (
-    <Card id="clinic-particular-tokens" className="dashboard-surface">
-      <CardHeader className="border-b border-vetneb-line/70">
-        <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
+    <Card
+      id="clinic-particular-tokens"
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <CardHeader className="shrink-0 border-b border-vetneb-line/70">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0">
+            <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Gestión compacta: generar token en una capa dedicada, seleccionar de la
+              lista y revisar el seguimiento solo desde el detalle.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-sm xl:min-w-[20rem]">
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Tokens</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">{tokens.length}</p>
+            </div>
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Activos</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">
+                {activeTokensCount}
+              </p>
+            </div>
+            <div className="surface-soft px-3 py-2">
+              <p className="text-xs text-muted-foreground">Informes</p>
+              <p className="mt-0.5 font-semibold text-vetneb-ink">
+                {linkedReportsCount}
+              </p>
+            </div>
+          </div>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-6 pt-6">
-        <form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            <div>
-              <label htmlFor="clinic-token-report-id" className="field-label">
-                ID informe vinculado
-              </label>
-              <Input
-                id="clinic-token-report-id"
-                name="reportId"
-                type="number"
-                autoComplete="off"
-                min="1"
-                inputMode="numeric"
-                placeholder="Opcional"
-                value={formState.reportId}
-                onChange={(event) => updateField("reportId", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
 
-            <div>
-              <label htmlFor="clinic-token-particular-email" className="field-label">
-                Email del particular
-              </label>
-              <Input
-                id="clinic-token-particular-email"
-                name="particularEmail"
-                type="email"
-                autoComplete="off"
-                placeholder="email@ejemplo.com"
-                required
-                value={formState.particularEmail}
-                onChange={(event) =>
-                  updateField("particularEmail", event.target.value)
-                }
-                disabled={isSubmitting}
-                aria-describedby="clinic-token-particular-email-help"
-              />
-              <p
-                id="clinic-token-particular-email-help"
-                className="mt-1 text-xs text-muted-foreground"
-              >
-                Obligatorio. El backend enviará el token a este email usando la
-                configuración de correo de VETNEB.
-              </p>
-            </div>
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-4 pt-4">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">
+            Lista limitada con paginación compacta. La generación abre una capa
+            dedicada y no apila el formulario sobre la lista.
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setIsCreateDialogOpen(true)}
+            disabled={generatedToken !== null}
+          >
+            Generar token particular
+          </Button>
+        </div>
 
-            <div>
-              <label htmlFor="clinic-token-tutor-last-name" className="field-label">
-                Apellido del tutor
-              </label>
-              <Input
-                id="clinic-token-tutor-last-name"
-                name="tutorLastName"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.tutorLastName}
-                onChange={(event) =>
-                  updateField("tutorLastName", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
+        {errorMessage ? (
+          <p className="clinical-alert-error shrink-0 px-3 py-2" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
 
-            <div>
-              <label htmlFor="clinic-token-pet-name" className="field-label">
-                Nombre del paciente
-              </label>
-              <Input
-                id="clinic-token-pet-name"
-                name="petName"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.petName}
-                onChange={(event) => updateField("petName", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
+        {statusMessage ? (
+          <p className="clinical-alert-success shrink-0 px-3 py-2">
+            {statusMessage}
+          </p>
+        ) : null}
 
-            <div>
-              <label htmlFor="clinic-token-pet-age" className="field-label">
-                Edad
-              </label>
-              <Input
-                id="clinic-token-pet-age"
-                name="petAge"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.petAge}
-                onChange={(event) => updateField("petAge", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-pet-breed" className="field-label">
-                Raza
-              </label>
-              <Input
-                id="clinic-token-pet-breed"
-                name="petBreed"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.petBreed}
-                onChange={(event) => updateField("petBreed", event.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-pet-sex" className="field-label">
-                Sexo
-              </label>
-              <select
-                id="clinic-token-pet-sex"
-                name="petSex"
-                className="field-select"
-                required
-                value={formState.petSex}
-                onChange={(event) => updateField("petSex", event.target.value)}
-                disabled={isSubmitting}
-              >
-                {PET_SEX_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-pet-species" className="field-label">
-                Especie
-              </label>
-              <select
-                id="clinic-token-pet-species"
-                name="petSpecies"
-                className="field-select"
-                required
-                value={formState.petSpecies}
-                onChange={(event) =>
-                  updateField("petSpecies", event.target.value)
-                }
-                disabled={isSubmitting}
-              >
-                {PET_SPECIES_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-sample-location" className="field-label">
-                Ubicación de la muestra
-              </label>
-              <Input
-                id="clinic-token-sample-location"
-                name="sampleLocation"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.sampleLocation}
-                onChange={(event) =>
-                  updateField("sampleLocation", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-sample-evolution" className="field-label">
-                Evolución
-              </label>
-              <Input
-                id="clinic-token-sample-evolution"
-                name="sampleEvolution"
-                type="text"
-                autoComplete="off"
-                required
-                value={formState.sampleEvolution}
-                onChange={(event) =>
-                  updateField("sampleEvolution", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-extraction-date" className="field-label">
-                Fecha de extracción
-              </label>
-              <Input
-                id="clinic-token-extraction-date"
-                name="extractionDate"
-                type="date"
-                autoComplete="off"
-                required
-                value={formState.extractionDate}
-                onChange={(event) =>
-                  updateField("extractionDate", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="clinic-token-shipping-date" className="field-label">
-                Fecha de envío
-              </label>
-              <Input
-                id="clinic-token-shipping-date"
-                name="shippingDate"
-                type="date"
-                autoComplete="off"
-                required
-                value={formState.shippingDate}
-                onChange={(event) =>
-                  updateField("shippingDate", event.target.value)
-                }
-                disabled={isSubmitting}
-              />
-            </div>
-          </div>
-
-          <div>
-            <label htmlFor="clinic-token-details-lesion" className="field-label">
-              Detalle de lesión
-            </label>
-            <textarea
-              id="clinic-token-details-lesion"
-              name="detailsLesion"
-              className="field-textarea"
-              autoComplete="off"
-              required
-              value={formState.detailsLesion}
-              onChange={(event) =>
-                updateField("detailsLesion", event.target.value)
-              }
-              disabled={isSubmitting}
-            />
-          </div>
-
-          {errorMessage ? (
-            <p
-              className="clinical-alert-error px-3 py-2"
-              role="alert"
-            >
-              {errorMessage}
-            </p>
-          ) : null}
-
-          {statusMessage ? (
-            <p className="clinical-alert-success px-3 py-2">
-              {statusMessage}
-            </p>
-          ) : null}
-
-          {generatedToken ? (
-            <div className="clinical-muted-band space-y-3 rounded-lg p-4">
-              <p className="text-sm font-semibold text-vetneb-navy">
-                Token generado
-              </p>
-              <Input
-                className="mt-2 font-mono text-sm"
-                readOnly
-                value={generatedToken}
-                aria-label="Token particular generado"
-              />
-              <p className="mt-2 text-xs text-muted-foreground">
-                Copiar ahora. El token completo solo se muestra una vez.
-              </p>
-              <div className="clinical-alert-error px-3 py-2">
-                <p className="text-sm font-semibold">
-                  IMPORTANTE: el token completo solo se muestra una vez.
-                </p>
-                <p className="mt-1 text-sm">
-                  Antes de cerrar este bloque, verificá que el token haya sido
-                  copiado si necesitás respaldo operativo.
+        <section
+          aria-label="Tokens particulares de la clínica"
+          className="grid min-h-0 flex-1 grid-cols-1 gap-4 xl:grid-cols-[0.82fr_1.46fr]"
+        >
+          <div
+            className={cn(
+              "flex min-h-0 flex-col overflow-hidden rounded-xl border border-vetneb-line/75 bg-card/82",
+              isMobileDetailOpen && "hidden xl:flex",
+            )}
+          >
+            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-4 py-3">
+              <div>
+                <h3 className="text-sm font-semibold text-vetneb-ink">
+                  Últimos tokens de la clínica
+                </h3>
+                <p className="dashboard-section-description">
+                  Seleccionar un token abre el detalle.
                 </p>
               </div>
-              <p className="text-sm text-vetneb-ink">
-                {generatedTokenRecipientEmail
-                  ? `Email enviado a: ${generatedTokenRecipientEmail}`
-                  : "El backend informó envío correcto del email."}
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void handleCopyManualMessage()}
-                >
-                  Copiar mensaje para enviar
-                </Button>
-              </div>
-              {copyStatusMessage ? (
-                <p className="clinical-alert-success px-3 py-2 text-sm">
-                  {copyStatusMessage}
-                </p>
-              ) : null}
-              {copyErrorMessage ? (
-                <p className="clinical-alert-error px-3 py-2 text-sm" role="alert">
-                  {copyErrorMessage}
-                </p>
-              ) : null}
-              <label className="flex items-start gap-2 text-sm text-vetneb-ink">
-                <input
-                  type="checkbox"
-                  className="mt-1"
-                  checked={isGeneratedTokenConfirmed}
-                  onChange={(event) =>
-                    setIsGeneratedTokenConfirmed(event.target.checked)
-                  }
-                />
-                <span>
-                  Confirmo que registré el token visible o que no necesito copia
-                  adicional.
-                </span>
-              </label>
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={handleCloseGeneratedToken}
-                disabled={!isGeneratedTokenConfirmed}
+                onClick={() => void loadTokens()}
+                disabled={isLoadingTokens}
               >
-                Cerrar token visible
+                {isLoadingTokens ? "Actualizando..." : "Actualizar"}
               </Button>
             </div>
+
+            {trackingLoadError ? (
+              <p className="clinical-alert-warning m-3 px-3 py-2 text-sm" role="alert">
+                {trackingLoadError}
+              </p>
+            ) : null}
+
+            {tokens.length ? (
+              <>
+                <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden">
+                  {pagedTokens.pageItems.map((token) => {
+                    const isSelected = selectedToken?.id === token.id;
+                    const trackingCase = trackingCasesByTokenId[token.id];
+
+                    return (
+                      <button
+                        key={token.id}
+                        type="button"
+                        id={`clinic-particular-token-${token.id}`}
+                        onClick={() => selectToken(token.id)}
+                        aria-pressed={isSelected}
+                        className={cn(
+                          "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                          isSelected && "bg-vetneb-cyan/12",
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-vetneb-ink">
+                              {token.petName} · {token.tutorLastName}
+                            </p>
+                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              Token ****{token.tokenLast4}
+                            </p>
+                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              {trackingCase
+                                ? getTrackingStageLabel(trackingCase.currentStage)
+                                : "Sin seguimiento vinculado"}
+                            </p>
+                          </div>
+                          <div className="flex shrink-0 flex-col items-end gap-1">
+                            <Badge variant={token.isActive ? "default" : "outline"}>
+                              {token.isActive ? "Activo" : "Inactivo"}
+                            </Badge>
+                            <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
+                              {token.hasLinkedReport ? "Informe" : "Sin informe"}
+                            </Badge>
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+                <CompactPager
+                  className="shrink-0"
+                  page={pagedTokens.page}
+                  pageCount={pagedTokens.pageCount}
+                  rangeStart={pagedTokens.rangeStart}
+                  rangeEnd={pagedTokens.rangeEnd}
+                  total={pagedTokens.total}
+                  hasPrev={pagedTokens.hasPrev}
+                  hasNext={pagedTokens.hasNext}
+                  onPrev={pagedTokens.goPrev}
+                  onNext={pagedTokens.goNext}
+                  itemLabel="tokens"
+                />
+              </>
+            ) : (
+              <p className="surface-empty m-4">
+                {isLoadingTokens
+                  ? "Cargando tokens particulares..."
+                  : "No hay tokens particulares generados por esta clínica."}
+              </p>
+            )}
+          </div>
+
+          <div
+            className={cn(
+              "min-h-0 overflow-hidden rounded-xl border border-vetneb-line/75 bg-card/82",
+              !isMobileDetailOpen && "hidden xl:block",
+            )}
+          >
+            {selectedToken ? (
+              <div className="space-y-3 p-4">
+                <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="mb-2 xl:hidden"
+                      onClick={() => setIsMobileDetailOpen(false)}
+                    >
+                      <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                      Volver a la lista
+                    </Button>
+                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                      Detalle del token
+                    </p>
+                    <h3 className="mt-1 text-lg font-semibold text-vetneb-ink">
+                      {selectedToken.petName} · {selectedToken.tutorLastName}
+                    </h3>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Token ****{selectedToken.tokenLast4}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant={selectedToken.isActive ? "default" : "outline"}>
+                      {selectedToken.isActive ? "Activo" : "Inactivo"}
+                    </Badge>
+                    <Badge variant={selectedToken.hasLinkedReport ? "default" : "outline"}>
+                      {selectedToken.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
+                    </Badge>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Paciente
+                    </p>
+                    <p className="mt-1 text-xs text-vetneb-ink">
+                      {selectedToken.petSpecies} · {selectedToken.petBreed} · {selectedToken.petSex}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">Edad: {selectedToken.petAge}</p>
+                  </div>
+
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Muestra
+                    </p>
+                    <p className="mt-1 text-xs text-vetneb-ink">{selectedToken.sampleLocation}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Evolución: {selectedToken.sampleEvolution}
+                    </p>
+                  </div>
+
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Fechas
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Extracción: {formatDate(selectedToken.extractionDate)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Envío: {formatDate(selectedToken.shippingDate)}
+                    </p>
+                  </div>
+
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Publicación
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Informe: {selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Último acceso: {selectedToken.lastLoginAt ? formatDate(selectedToken.lastLoginAt) : "—"}
+                    </p>
+                  </div>
+
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Vínculo
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Tutor: {selectedToken.tutorLastName}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Origen: {formatTokenSource(selectedToken)}
+                    </p>
+                  </div>
+
+                  <div className="clinical-muted-band rounded-lg px-3 py-2">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                      Seguimiento
+                    </p>
+                    {selectedTrackingCase ? (
+                      <>
+                        <p className="mt-1 text-xs text-vetneb-ink">
+                          Etapa: {getTrackingStageLabel(selectedTrackingCase.currentStage)}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {selectedTrackingCase.specialStainRequired
+                            ? "Alerta: Solicitud de tinción especial"
+                            : "Sin alerta de tinción especial"}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Sin seguimiento vinculado.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <p className="surface-empty m-4">
+                Seleccione un token para abrir el detalle.
+              </p>
+            )}
+          </div>
+        </section>
+      </CardContent>
+
+      <ModuleDialog
+        open={isCreateDialogOpen}
+        onOpenChange={handleCreateDialogOpenChange}
+        busy={isSubmitting}
+        title="Generar token particular"
+        description={`Paso ${createStepIndex + 1} de ${CREATE_TOKEN_STEP_ORDER.length}: ${CREATE_TOKEN_STEP_LABELS[createStep]}`}
+      >
+        <form
+          className="flex min-h-0 flex-col gap-4"
+          onSubmit={handleSubmit}
+          autoComplete="off"
+        >
+          <div className="flex shrink-0 flex-wrap gap-2" aria-label="Pasos del alta de token">
+            {CREATE_TOKEN_STEP_ORDER.map((step, index) => (
+              <button
+                key={step}
+                type="button"
+                onClick={() => setCreateStep(step)}
+                className={cn(
+                  "clinical-pill px-3 py-1 text-[0.68rem] tracking-normal",
+                  step === createStep && "border-vetneb-teal bg-vetneb-teal/15",
+                )}
+                aria-current={step === createStep ? "step" : undefined}
+              >
+                {index + 1}. {CREATE_TOKEN_STEP_LABELS[step]}
+              </button>
+            ))}
+          </div>
+
+          <div className="min-h-0">
+            {createStep === "contact" ? (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div>
+                <label htmlFor="clinic-token-report-id" className="field-label">
+                  ID informe vinculado
+                </label>
+                <Input
+                  id="clinic-token-report-id"
+                  name="reportId"
+                  type="number"
+                  autoComplete="off"
+                  min="1"
+                  inputMode="numeric"
+                  placeholder="Opcional"
+                  value={formState.reportId}
+                  onChange={(event) => updateField("reportId", event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-particular-email" className="field-label">
+                  Email del particular
+                </label>
+                <Input
+                  id="clinic-token-particular-email"
+                  name="particularEmail"
+                  type="email"
+                  autoComplete="off"
+                  placeholder="email@ejemplo.com"
+                  required
+                  value={formState.particularEmail}
+                  onChange={(event) =>
+                    updateField("particularEmail", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                  aria-describedby="clinic-token-particular-email-help"
+                />
+                <p
+                  id="clinic-token-particular-email-help"
+                  className="mt-1 text-xs text-muted-foreground"
+                >
+                  Obligatorio. El backend enviará el token a este email usando la
+                  configuración de correo de VETNEB.
+                </p>
+              </div>
+
+              <div className="md:col-span-2">
+                <label htmlFor="clinic-token-tutor-last-name" className="field-label">
+                  Apellido del tutor
+                </label>
+                <Input
+                  id="clinic-token-tutor-last-name"
+                  name="tutorLastName"
+                  type="text"
+                  autoComplete="off"
+                  required
+                  value={formState.tutorLastName}
+                  onChange={(event) =>
+                    updateField("tutorLastName", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                />
+              </div>
+            </div>
+            ) : null}
+
+            {createStep === "patient" ? (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div>
+                <label htmlFor="clinic-token-pet-name" className="field-label">
+                  Nombre del paciente
+                </label>
+                <Input
+                  id="clinic-token-pet-name"
+                  name="petName"
+                  type="text"
+                  autoComplete="off"
+                  required
+                  value={formState.petName}
+                  onChange={(event) => updateField("petName", event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-pet-age" className="field-label">
+                  Edad
+                </label>
+                <Input
+                  id="clinic-token-pet-age"
+                  name="petAge"
+                  type="text"
+                  autoComplete="off"
+                  required
+                  value={formState.petAge}
+                  onChange={(event) => updateField("petAge", event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-pet-breed" className="field-label">
+                  Raza
+                </label>
+                <Input
+                  id="clinic-token-pet-breed"
+                  name="petBreed"
+                  type="text"
+                  autoComplete="off"
+                  required
+                  value={formState.petBreed}
+                  onChange={(event) => updateField("petBreed", event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-pet-sex" className="field-label">
+                  Sexo
+                </label>
+                <select
+                  id="clinic-token-pet-sex"
+                  name="petSex"
+                  className="field-select"
+                  required
+                  value={formState.petSex}
+                  onChange={(event) => updateField("petSex", event.target.value)}
+                  disabled={isSubmitting}
+                >
+                  {PET_SEX_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-pet-species" className="field-label">
+                  Especie
+                </label>
+                <select
+                  id="clinic-token-pet-species"
+                  name="petSpecies"
+                  className="field-select"
+                  required
+                  value={formState.petSpecies}
+                  onChange={(event) =>
+                    updateField("petSpecies", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                >
+                  {PET_SPECIES_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            ) : null}
+
+            {createStep === "sample" ? (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div>
+                <label htmlFor="clinic-token-sample-location" className="field-label">
+                  Ubicación de la muestra
+                </label>
+                <Input
+                  id="clinic-token-sample-location"
+                  name="sampleLocation"
+                  type="text"
+                  autoComplete="off"
+                  required
+                  value={formState.sampleLocation}
+                  onChange={(event) =>
+                    updateField("sampleLocation", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-sample-evolution" className="field-label">
+                  Evolución
+                </label>
+                <Input
+                  id="clinic-token-sample-evolution"
+                  name="sampleEvolution"
+                  type="text"
+                  autoComplete="off"
+                  required
+                  value={formState.sampleEvolution}
+                  onChange={(event) =>
+                    updateField("sampleEvolution", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-extraction-date" className="field-label">
+                  Fecha de extracción
+                </label>
+                <Input
+                  id="clinic-token-extraction-date"
+                  name="extractionDate"
+                  type="date"
+                  autoComplete="off"
+                  required
+                  value={formState.extractionDate}
+                  onChange={(event) =>
+                    updateField("extractionDate", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="clinic-token-shipping-date" className="field-label">
+                  Fecha de envío
+                </label>
+                <Input
+                  id="clinic-token-shipping-date"
+                  name="shippingDate"
+                  type="date"
+                  autoComplete="off"
+                  required
+                  value={formState.shippingDate}
+                  onChange={(event) =>
+                    updateField("shippingDate", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="md:col-span-2">
+                <label htmlFor="clinic-token-details-lesion" className="field-label">
+                  Detalle de lesión
+                </label>
+                <textarea
+                  id="clinic-token-details-lesion"
+                  name="detailsLesion"
+                  className="field-textarea"
+                  autoComplete="off"
+                  required
+                  value={formState.detailsLesion}
+                  onChange={(event) =>
+                    updateField("detailsLesion", event.target.value)
+                  }
+                  disabled={isSubmitting}
+                  rows={3}
+                />
+              </div>
+            </div>
+            ) : null}
+          </div>
+
+          {errorMessage ? (
+            <p className="clinical-alert-error px-3 py-2 text-sm" role="alert">
+              {errorMessage}
+            </p>
           ) : null}
 
-          <Button type="submit" disabled={isSubmitting || generatedToken !== null}>
-            {isSubmitting ? "Generando token..." : "Generar token particular"}
-          </Button>
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-vetneb-line/70 pt-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleCreateDialogOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+            <div className="flex flex-wrap gap-2">
+              {createStepIndex > 0 ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={goToPreviousCreateStep}
+                  disabled={isSubmitting}
+                >
+                  Anterior
+                </Button>
+              ) : null}
+              {isLastCreateStep ? (
+                <Button type="submit" disabled={isSubmitting || generatedToken !== null}>
+                  {isSubmitting ? "Generando token..." : "Generar token particular"}
+                </Button>
+              ) : (
+                <Button type="submit" disabled={isSubmitting}>
+                  Siguiente
+                </Button>
+              )}
+            </div>
+          </div>
         </form>
+      </ModuleDialog>
 
-        <div className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h3 className="text-sm font-semibold text-vetneb-ink">
-              Últimos tokens de la clínica
-            </h3>
+      <ModuleDialog
+        open={generatedToken !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleCloseGeneratedToken();
+          }
+        }}
+        busy={!isGeneratedTokenConfirmed}
+        title="Token generado"
+        description="Copiar ahora. El token completo solo se muestra una vez."
+      >
+        <div className="flex min-h-0 flex-col gap-3">
+          <Input
+            className="font-mono text-sm"
+            readOnly
+            value={generatedToken ?? ""}
+            aria-label="Token particular generado"
+          />
+          <div className="clinical-alert-error px-3 py-2">
+            <p className="text-sm font-semibold">
+              IMPORTANTE: el token completo solo se muestra una vez.
+            </p>
+            <p className="mt-1 text-sm">
+              Antes de cerrar este bloque, verificá que el token haya sido
+              copiado si necesitás respaldo operativo.
+            </p>
+          </div>
+          <p className="text-sm text-vetneb-ink">
+            {generatedTokenRecipientEmail
+              ? `Email enviado a: ${generatedTokenRecipientEmail}`
+              : "El backend informó envío correcto del email."}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => void loadTokens()}
-              disabled={isLoadingTokens}
+              onClick={() => void handleCopyManualMessage()}
             >
-              {isLoadingTokens ? "Actualizando..." : "Actualizar"}
+              Copiar mensaje para enviar
             </Button>
           </div>
-
-          {trackingLoadError ? (
-            <p className="clinical-alert-warning px-3 py-2 text-sm" role="alert">
-              {trackingLoadError}
+          {copyStatusMessage ? (
+            <p className="clinical-alert-success px-3 py-2 text-sm">
+              {copyStatusMessage}
             </p>
           ) : null}
-
-          {tokens.length ? (
-            <div className="space-y-2">
-              {tokens.map((token) => {
-                const trackingCase = trackingCasesByTokenId[token.id];
-
-                return (
-                  <div
-                    key={token.id}
-                    id={`clinic-particular-token-${token.id}`}
-                    className="rounded-lg border border-vetneb-line/75 bg-vetneb-surface-raised/74 px-4 py-3 shadow-[0_8px_20px_rgba(15,45,62,0.06)]"
-                  >
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <div className="space-y-1">
-                      <p className="text-sm font-semibold text-vetneb-ink">
-                        {token.petName} · {token.tutorLastName}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Token ****{token.tokenLast4}
-                      </p>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span
-                        className={
-                          token.isActive
-                            ? "clinical-pill shrink-0 px-2.5 py-0.5 text-[0.68rem] tracking-[0.08em]"
-                            : "inline-flex shrink-0 items-center rounded-full border border-vetneb-line/90 bg-card/80 px-2.5 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground"
-                        }
-                      >
-                        {token.isActive ? "Activo" : "Inactivo"}
-                      </span>
-                      <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
-                        {token.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
-                      </Badge>
-                    </div>
-                  </div>
-
-                  <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-6">
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Paciente
-                      </p>
-                      <p className="mt-1 text-xs text-vetneb-ink">
-                        {token.petSpecies} · {token.petBreed} · {token.petSex}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">Edad: {token.petAge}</p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Muestra
-                      </p>
-                      <p className="mt-1 text-xs text-vetneb-ink">{token.sampleLocation}</p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Evolución: {token.sampleEvolution}
-                      </p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Fechas
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Extracción: {formatDate(token.extractionDate)}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Envío: {formatDate(token.shippingDate)}
-                      </p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Publicación
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Informe: {token.reportId ? `#${token.reportId}` : "—"}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Último acceso: {token.lastLoginAt ? formatDate(token.lastLoginAt) : "—"}
-                      </p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Vínculo
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Tutor: {token.tutorLastName}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Origen: {formatTokenSource(token)}
-                      </p>
-                    </div>
-
-                    <div className="clinical-muted-band rounded-lg px-3 py-2">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                        Seguimiento
-                      </p>
-                      {trackingCase ? (
-                        <>
-                          <p className="mt-1 text-xs text-vetneb-ink">
-                            Etapa: {getTrackingStageLabel(trackingCase.currentStage)}
-                          </p>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {trackingCase.specialStainRequired
-                              ? "Alerta: Solicitud de tinción especial"
-                              : "Sin alerta de tinción especial"}
-                          </p>
-                        </>
-                      ) : (
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          Sin seguimiento vinculado.
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <p className="surface-empty">
-              {isLoadingTokens
-                ? "Cargando tokens particulares..."
-                : "No hay tokens particulares generados por esta clínica."}
+          {copyErrorMessage ? (
+            <p className="clinical-alert-error px-3 py-2 text-sm" role="alert">
+              {copyErrorMessage}
             </p>
-          )}
+          ) : null}
+          <label className="flex items-start gap-2 text-sm text-vetneb-ink">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={isGeneratedTokenConfirmed}
+              onChange={(event) =>
+                setIsGeneratedTokenConfirmed(event.target.checked)
+              }
+            />
+            <span>
+              Confirmo que registré el token visible o que no necesito copia
+              adicional.
+            </span>
+          </label>
+          <div className="flex justify-end border-t border-vetneb-line/70 pt-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleCloseGeneratedToken}
+              disabled={!isGeneratedTokenConfirmed}
+            >
+              Cerrar token visible
+            </Button>
+          </div>
         </div>
-      </CardContent>
+      </ModuleDialog>
     </Card>
   );
 }

--- a/frontend/src/components/dashboard/DashboardHubHero.tsx
+++ b/frontend/src/components/dashboard/DashboardHubHero.tsx
@@ -47,7 +47,7 @@ export function DashboardHubHero({
     <section
       data-dashboard-hub-hero={variant}
       aria-labelledby="dashboard-hub-hero-title"
-      className="relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-vetneb-navy via-vetneb-navy to-vetneb-teal/80 p-4 text-white shadow-[0_22px_60px_rgba(8,35,50,0.30)] sm:p-5"
+      className="relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-white/10 bg-gradient-to-br from-vetneb-navy via-vetneb-navy to-vetneb-teal/80 p-3 text-white shadow-[0_22px_60px_rgba(8,35,50,0.30)] sm:rounded-2xl sm:p-5"
     >
       <div
         aria-hidden="true"
@@ -59,8 +59,8 @@ export function DashboardHubHero({
       />
 
       <div className="relative flex items-center gap-2.5">
-        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/12 ring-1 ring-white/20">
-          <Icon className="h-5 w-5 text-white" aria-hidden="true" />
+        <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/12 ring-1 ring-white/20 sm:h-9 sm:w-9">
+          <Icon className="h-4 w-4 text-white sm:h-5 sm:w-5" aria-hidden="true" />
         </span>
         <span className="min-w-0 flex-1 truncate text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-white/75">
           {eyebrow}
@@ -68,7 +68,7 @@ export function DashboardHubHero({
       </div>
 
       {statusLabel ? (
-        <span className="relative mt-3 inline-flex w-fit items-center gap-1.5 rounded-full bg-white/12 px-2.5 py-0.5 text-[0.66rem] font-semibold text-white/90 ring-1 ring-white/15">
+        <span className="relative mt-2 inline-flex w-fit items-center gap-1.5 rounded-full bg-white/12 px-2.5 py-0.5 text-[0.66rem] font-semibold text-white/90 ring-1 ring-white/15 sm:mt-3">
           <span
             className={cn("h-1.5 w-1.5 rounded-full", STATUS_DOT_CLASS[statusTone])}
             aria-hidden="true"
@@ -79,27 +79,27 @@ export function DashboardHubHero({
 
       <h2
         id="dashboard-hub-hero-title"
-        className="relative mt-2.5 text-lg font-semibold leading-tight sm:text-xl"
+        className="relative mt-2 text-base font-semibold leading-tight sm:mt-2.5 sm:text-xl"
       >
         {title}
       </h2>
-      <p className="relative mt-1 text-[0.82rem] leading-relaxed text-white/78">
+      <p className="relative mt-1 hidden text-[0.82rem] leading-relaxed text-white/78 sm:block">
         {description}
       </p>
 
-      <div className="relative mt-4 flex min-h-0 flex-1 flex-col justify-center gap-2.5">
+      <div className="relative mt-3 grid min-h-0 grid-cols-2 gap-2 sm:mt-4 sm:flex sm:flex-1 sm:flex-col sm:justify-center sm:gap-2.5">
         {metrics.map((metric) => (
           <div
             key={metric.label}
-            className="rounded-xl border border-white/12 bg-white/[0.08] px-3.5 py-2.5 backdrop-blur-sm"
+            className="rounded-lg border border-white/12 bg-white/[0.08] px-2.5 py-2 backdrop-blur-sm sm:rounded-xl sm:px-3.5 sm:py-2.5"
           >
-            <p className="text-[0.64rem] font-semibold uppercase tracking-wide text-white/70">
+            <p className="line-clamp-1 text-[0.62rem] font-semibold uppercase tracking-wide text-white/70 sm:text-[0.64rem]">
               {metric.label}
             </p>
             <div className="mt-0.5 flex items-baseline justify-between gap-2">
-              <p className="text-2xl font-bold leading-none">{metric.value}</p>
+              <p className="text-xl font-bold leading-none sm:text-2xl">{metric.value}</p>
               {metric.hint ? (
-                <p className="truncate text-[0.64rem] leading-snug text-white/65">
+                <p className="hidden truncate text-[0.64rem] leading-snug text-white/65 sm:block">
                   {metric.hint}
                 </p>
               ) : null}
@@ -112,7 +112,7 @@ export function DashboardHubHero({
         <button
           type="button"
           onClick={onPrimaryAction}
-          className="dashboard-btn-interactive relative mt-4 inline-flex min-h-[2.6rem] items-center justify-center gap-1.5 rounded-md bg-white/95 px-4 text-sm font-semibold text-vetneb-navy shadow-[0_10px_26px_rgba(8,35,50,0.24)] hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/85 focus-visible:ring-offset-2 focus-visible:ring-offset-vetneb-navy"
+          className="dashboard-btn-interactive relative mt-3 inline-flex min-h-[2.35rem] items-center justify-center gap-1.5 rounded-md bg-white/95 px-3 text-xs font-semibold text-vetneb-navy shadow-[0_10px_26px_rgba(8,35,50,0.24)] hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/85 focus-visible:ring-offset-2 focus-visible:ring-offset-vetneb-navy sm:mt-4 sm:min-h-[2.6rem] sm:px-4 sm:text-sm"
         >
           <span>{primaryActionLabel}</span>
           <ChevronRight className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/components/dashboard/DashboardModuleHub.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleHub.tsx
@@ -32,7 +32,8 @@ export function DashboardModuleHub({
 }: DashboardModuleHubProps) {
   // Dense launchers (admin, 10 modules) drop the tile description so every tile
   // fits the viewport height without scroll; sparse launchers (clinic) keep it.
-  const showDescription = cards.length <= 6;
+  const isDenseLauncher = cards.length > 6;
+  const showDescription = !isDenseLauncher;
 
   return (
     <div className={cn("dashboard-cockpit min-h-0 lg:flex-1", className)}>
@@ -44,13 +45,16 @@ export function DashboardModuleHub({
       <section
         aria-label={heading}
         data-dashboard-module-hub="true"
-        className="dashboard-cockpit-launcher"
+        className={cn(
+          "dashboard-cockpit-launcher",
+          isDenseLauncher && "dashboard-cockpit-launcher-dense",
+        )}
       >
         <div className="flex items-baseline justify-between gap-3">
           <div className="min-w-0">
             <h2 className="dashboard-section-heading">{heading}</h2>
             {description ? (
-              <p className="dashboard-section-description line-clamp-1">{description}</p>
+              <p className="dashboard-section-description hidden sm:line-clamp-1">{description}</p>
             ) : null}
           </div>
           <span className="shrink-0 rounded-full border border-vetneb-line/70 bg-vetneb-surface-muted/60 px-2.5 py-0.5 text-[0.66rem] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -58,7 +62,12 @@ export function DashboardModuleHub({
           </span>
         </div>
 
-        <ul className="dashboard-cockpit-grid list-none p-0">
+        <ul
+          className={cn(
+            "dashboard-cockpit-grid list-none p-0",
+            isDenseLauncher && "dashboard-cockpit-grid-dense",
+          )}
+        >
           {cards.map((card) => {
             const key = card.moduleId ?? card.href ?? card.title;
             const ariaLabel = `${card.title}: ${card.description}`;
@@ -77,13 +86,13 @@ export function DashboardModuleHub({
                 </p>
                 <div className="min-h-0 flex-1 overflow-hidden">
                   {showDescription ? (
-                    <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                    <p className="hidden text-xs leading-relaxed text-muted-foreground sm:line-clamp-2">
                       {card.description}
                     </p>
                   ) : null}
                 </div>
-                <div className="flex items-center gap-1 pt-0.5 text-xs font-semibold text-vetneb-teal">
-                  <span>{card.actionLabel ?? "Abrir"}</span>
+                <div className="flex min-w-0 items-center gap-1 pt-0.5 text-xs font-semibold text-vetneb-teal">
+                  <span className="truncate">{card.actionLabel ?? "Abrir"}</span>
                   <ChevronRight
                     className="h-3.5 w-3.5 transition-transform duration-150 group-hover:translate-x-0.5"
                     aria-hidden="true"

--- a/frontend/src/components/dashboard/DashboardPageHeader.tsx
+++ b/frontend/src/components/dashboard/DashboardPageHeader.tsx
@@ -19,7 +19,7 @@ export function DashboardPageHeader({
   return (
     <div
       className={cn(
-        "flex flex-col gap-4 border-b border-vetneb-line/70 pb-5 sm:flex-row sm:items-start sm:justify-between",
+        "flex flex-col gap-3 border-b border-vetneb-line/70 pb-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4 sm:pb-5",
         className,
       )}
     >
@@ -29,7 +29,7 @@ export function DashboardPageHeader({
           {badge ? <div className="shrink-0">{badge}</div> : null}
         </div>
         {description ? (
-          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+          <p className="mt-1 hidden max-w-3xl text-sm text-muted-foreground sm:block">
             {description}
           </p>
         ) : null}

--- a/test/frontend-admin-failed-login-alerts-card.test.ts
+++ b/test/frontend-admin-failed-login-alerts-card.test.ts
@@ -32,7 +32,7 @@ test("admin failed login alerts card keeps typed contracts and pagination size",
   assert.ok(source.includes("AdminFailedLoginAlertReason"));
   assert.ok(source.includes("AdminFailedLoginAlertsSnapshot"));
   assert.ok(source.includes("AdminFailedLoginAlertSurface"));
-  assert.ok(source.includes("const PAGE_SIZE = 25;"));
+  assert.ok(source.includes("const PAGE_SIZE = 5;"));
 });
 
 test("admin failed login alerts card keeps surface reason and nullable formatters", () => {

--- a/test/frontend-admin-maintenance-dry-run-card.test.ts
+++ b/test/frontend-admin-maintenance-dry-run-card.test.ts
@@ -20,6 +20,8 @@ test("admin maintenance dry-run card is client-side and imports required depende
   assert.ok(source.includes('import { useState, useTransition } from "react";'));
   assert.ok(source.includes('import { Badge } from "@/components/ui/badge";'));
   assert.ok(source.includes('import { Button } from "@/components/ui/button";'));
+  assert.ok(source.includes('import { CompactPager } from "@/components/dashboard/CompactPager";'));
+  assert.ok(source.includes('import { usePagedRows } from "@/components/dashboard/usePagedRows";'));
   assert.ok(source.includes('import { getAdminMaintenancePurgeDryRun } from "@/lib/api";'));
   assert.ok(source.includes("MaintenancePurgeCandidateGroup"));
   assert.ok(source.includes("MaintenancePurgeDryRunSnapshot"));
@@ -70,6 +72,7 @@ test("admin maintenance dry-run card keeps state and transition handling", () =>
   assert.ok(source.includes("useState<MaintenancePurgeDryRunSnapshot | null>(null);"));
   assert.ok(source.includes("const [error, setError] = useState<string | null>(null);"));
   assert.ok(source.includes("const [isPending, startTransition] = useTransition();"));
+  assert.ok(source.includes("usePagedRows(snapshot?.candidates ?? [], 4)"));
 });
 
 test("admin maintenance dry-run card calls dry-run API without destructive action", () => {
@@ -126,8 +129,10 @@ test("admin maintenance dry-run card renders dry-run totals and audit context", 
 test("admin maintenance dry-run card renders candidate list from snapshot", () => {
   const source = read(ADMIN_MAINTENANCE_CARD_PATH);
 
-  assert.ok(source.includes("snapshot.candidates.map((candidate) => ("));
+  assert.ok(source.includes("pagedCandidates.pageItems.map((candidate) => ("));
   assert.ok(source.includes("<MaintenanceCandidateRow"));
   assert.ok(source.includes("key={candidate.category}"));
   assert.ok(source.includes("candidate={candidate}"));
+  assert.ok(source.includes("<CompactPager"));
+  assert.ok(source.includes('itemLabel="grupos"'));
 });

--- a/test/frontend-admin-users-roles-card.test.ts
+++ b/test/frontend-admin-users-roles-card.test.ts
@@ -33,7 +33,7 @@ test("admin users roles card keeps typed role contracts and pagination size", ()
   assert.ok(source.includes("AdminRoleUserType"));
   assert.ok(source.includes("AdminUsersRolesSnapshot"));
   assert.ok(source.includes("ClinicUserRole"));
-  assert.ok(source.includes("const PAGE_SIZE = 25;"));
+  assert.ok(source.includes("const PAGE_SIZE = 5;"));
 });
 
 test("admin users roles card keeps user type role and clinic formatters", () => {

--- a/test/frontend-dashboard-admin-command-center.test.ts
+++ b/test/frontend-dashboard-admin-command-center.test.ts
@@ -121,7 +121,7 @@ test("dashboard admin composes module hub, command center, and existing cards", 
   assert.ok(source.includes("<AdminPricingEditorCard />"));
   assert.ok(source.includes("<AdminSessionsReadOnlyCard />"));
   assert.ok(source.includes("<AdminUsersRolesReadOnlyCard />"));
-  assert.ok(source.includes('className="h-24 md:hidden" aria-hidden="true"'));
+  assert.equal(source.includes('className="h-24 md:hidden" aria-hidden="true"'), false);
 
   const mainIndex = source.indexOf('<main className="dashboard-main">');
   const pageHeaderIndex = source.indexOf("<DashboardPageHeader", mainIndex);

--- a/test/frontend-dashboard-clinic-command-center.test.ts
+++ b/test/frontend-dashboard-clinic-command-center.test.ts
@@ -176,7 +176,9 @@ test("ClinicCommandCenter shows visits load error alert", () => {
 test("ClinicCommandCenter uses two-column responsive grid for reports and visits", () => {
   const source = read(CLINIC_COMMAND_CENTER_PATH);
 
-  assert.ok(source.includes("grid grid-cols-1 gap-6 lg:grid-cols-2"));
+  assert.ok(source.includes('import { ModuleSurface } from "@/components/dashboard/ModuleSurface";'));
+  assert.ok(source.includes('import { ModuleTabs } from "@/components/dashboard/ModuleTabs";'));
+  assert.ok(source.includes("grid min-h-0 flex-1 grid-cols-1 gap-3 lg:grid-cols-2"));
   assert.ok(source.includes("dashboard-surface"));
   assert.ok(source.includes("dashboard-list-row"));
 });

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -78,6 +78,26 @@ test("clinic particular tokens card exists and uses clinic helpers", () => {
   assert.equal(source.includes(removedTokenEndpoint), false);
 });
 
+test("clinic tokens uses masked master-detail with paged list and step dialogs", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+
+  assert.ok(source.includes("const TOKENS_PAGE_SIZE = 4;"));
+  assert.ok(source.includes("usePagedRows(tokens, TOKENS_PAGE_SIZE)"));
+  assert.ok(source.includes("<CompactPager"));
+  assert.ok(source.includes("selectedTokenId"));
+  assert.ok(source.includes("isMobileDetailOpen"));
+  assert.ok(source.includes("Volver a la lista"));
+  assert.ok(source.includes('hidden xl:flex'));
+  assert.ok(source.includes('hidden xl:block'));
+  assert.ok(source.includes("CREATE_TOKEN_STEP_ORDER"));
+  assert.ok(source.includes("createStep"));
+  assert.ok(source.includes("Siguiente"));
+  assert.ok(source.includes("Anterior"));
+  assert.ok(source.includes('title="Generar token particular"'));
+  assert.ok(source.includes('title="Token generado"'));
+  assert.equal(source.includes("overflow-y-auto"), false);
+});
+
 test("clinic token generation requires all programmed data fields", () => {
   const source = read(CLINIC_TOKENS_CARD_PATH);
 

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -5,6 +5,10 @@ import test from "node:test";
 
 const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
 const CLINIC_COMMAND_CENTER_PATH = "frontend/src/app/dashboard/ClinicCommandCenter.tsx";
+const CLINIC_INFORMES_SUMMARY_PATH =
+  "frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx";
+const CLINIC_LOGISTICA_SUMMARY_PATH =
+  "frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -124,6 +128,8 @@ test("dashboard home clinic command center receives all required data props", ()
 test("dashboard home clinic command center presentational props contain operational section strings", () => {
   const source = read(CLINIC_COMMAND_CENTER_PATH);
 
+  assert.ok(source.includes("ModuleSurface"));
+  assert.ok(source.includes("ModuleTabs"));
   assert.ok(source.includes("Estado operativo clínica"));
   assert.ok(source.includes("Priorice informes pendientes y visitas activas"));
   assert.ok(source.includes("<StatsCards stats={stats} />"));
@@ -136,6 +142,24 @@ test("dashboard home clinic command center presentational props contain operatio
   assert.ok(source.includes('role="alert"'));
   assert.ok(source.includes("No hay informes recientes disponibles."));
   assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
+});
+
+test("clinic informes and logistica summaries use in-shell master-detail layers", () => {
+  for (const [context, path] of [
+    ["informes", CLINIC_INFORMES_SUMMARY_PATH],
+    ["logistica", CLINIC_LOGISTICA_SUMMARY_PATH],
+  ] as const) {
+    const source = read(path);
+
+    assert.ok(source.includes('"use client";'), `${context} summary must own state`);
+    assert.ok(source.includes("ModuleSurface"), `${context} summary must use ModuleSurface`);
+    assert.ok(source.includes("useState"), `${context} summary must use selection state`);
+    assert.ok(source.includes("isMobileDetailOpen"), `${context} summary must use mobile replacement layer`);
+    assert.ok(source.includes("Volver a la lista"), `${context} summary must expose internal back action`);
+    assert.ok(source.includes("hidden xl:flex"), `${context} master must hide under detail on mobile`);
+    assert.ok(source.includes("hidden xl:block"), `${context} detail must replace list on mobile`);
+    assert.equal(source.includes("space-y-4"), false, `${context} summary must not stack teaser blocks`);
+  }
 });
 
 test("dashboard home keeps status badge and date formatting in clinic command center", () => {

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -116,7 +116,7 @@ test("PR-9 MasterDetailWorkspace and AdminSectionTabs avoid horizontal page over
   assertNoForbiddenSurfaceImports(tabsSource, "AdminSectionTabs");
 });
 
-test("PR-9 private dashboard pages leave bottom space for mobile fixed actions", () => {
+test("dashboard pages do not use mobile bottom spacers as layout compensation", () => {
   const dashboardSource = read(DASHBOARD_HOME_PATH);
   const adminSource = read(ADMIN_PAGE_PATH);
   const informesSource = read(INFORMES_PAGE_PATH);
@@ -128,9 +128,10 @@ test("PR-9 private dashboard pages leave bottom space for mobile fixed actions",
   assert.ok(informesSource.includes("Detalle del informe"));
 
   assert.ok(logisticaSource.includes("<StickyActionBar"), "logistica uses StickyActionBar");
-  assert.ok(
+  assert.equal(
     logisticaSource.includes('className="h-24 md:hidden" aria-hidden="true"'),
-    "logistica keeps mobile bottom spacer",
+    false,
+    "logistica must not keep mobile bottom spacer",
   );
 
   for (const [context, source] of [
@@ -143,9 +144,10 @@ test("PR-9 private dashboard pages leave bottom space for mobile fixed actions",
       source.includes("<AdminDashboardWorkspaceController") ||
       source.includes("<DashboardModuleHub");
     assert.ok(usesHubPattern, `${context} uses DashboardModuleHub card hub`);
-    assert.ok(
+    assert.equal(
       source.includes('className="h-24 md:hidden" aria-hidden="true"'),
-      `${context} keeps mobile bottom spacer`,
+      false,
+      `${context} must not keep mobile bottom spacer`,
     );
   }
 });

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -419,7 +419,9 @@ test("dashboard home keeps visual dashboard states and card spacing conventions"
   assertContainsAll(
     commandCenterSource,
     [
-      '<section className="surface-note-info" aria-labelledby="dashboard-operational-priority">',
+      '<ModuleSurface',
+      '<ModuleTabs',
+      '<section className="surface-note-info w-full" aria-labelledby="dashboard-operational-priority">',
       "<StatsCards stats={stats} />",
       "recentReports.map((report) =>",
       "recentVisits.map((visit) =>",
@@ -430,7 +432,7 @@ test("dashboard home keeps visual dashboard states and card spacing conventions"
   assertMatchesAll(
     combinedSource,
     [
-      /className="grid grid-cols-1 gap-6 lg:grid-cols-2"/,
+      /className="grid min-h-0 flex-1 grid-cols-1 gap-3 lg:grid-cols-2"/,
       /className="dashboard-list-row"/,
       /className="truncate text-sm font-semibold text-vetneb-ink"/,
       /className="text-xs text-muted-foreground"/,

--- a/test/progress-production-invariants.test.ts
+++ b/test/progress-production-invariants.test.ts
@@ -343,7 +343,7 @@ test("particular token invariants: hard delete, legacy revoke hard-delete, casca
 
   assertIncludes(
     clinicCardSource,
-    '<form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">',
+    '<form\n          className="flex min-h-0 flex-col gap-4"',
     clinicCardFile,
   );
   assertNotIncludes(clinicCardSource, 'autoComplete="on"', clinicCardFile);


### PR DESCRIPTION
## Summary
- Apply masked Master-Detail dashboard architecture globally to clinic and admin workspaces
- Limit dashboard lists, move forms to dedicated layers/dialogs, and preserve fixed viewport behavior
- Extend no-scroll and interaction coverage for clinic/admin dashboards

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm test
- pnpm --dir frontend build
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend e2e -- e2e/dashboard-global-masked-master-detail.spec.ts --reporter=line
- pnpm --dir frontend e2e -- e2e/dashboard-accessibility-keyboard.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts e2e/dashboard-auth-redirect.spec.ts e2e/dashboard-card-navigation-shell.spec.ts e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-interaction-foundation.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-master-detail-state-polish.spec.ts e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-single-viewport-app-shell.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts --reporter=line