### PR TITLE
fix(dashboard): adapt app shell density to viewport zoom

### DIFF
--- a/docs/implementation/dashboard-global-viewport-zoom-adaptability.md
+++ b/docs/implementation/dashboard-global-viewport-zoom-adaptability.md
@@ -1,0 +1,128 @@
+# Dashboard global — Viewport-aware Adaptive App Shell (adaptabilidad real a tamaño de pantalla y zoom)
+
+- **Rama:** `fix/dashboard-global-viewport-zoom-adaptability`
+- **Base:** `main` @ `6daae2b fix(ci): restore post-dashboard global validation (#1016)`
+- **Fecha:** 2026-06-17
+- **Tipo:** Implementación frontend/CSS + tests E2E + documentación. Sin cambios de backend, API, payloads, auth ni dependencias.
+
+## 1. Problema observado
+
+En el navegador, ambos dashboards (Clínica y Administración) se veían **proporcionados sólo con Chrome al 50%**. A 80–100% de zoom el layout quedaba **grande/denso**, perdía equilibrio visual y no se adaptaba al viewport efectivo: paddings, gaps, alturas de paneles y listas se sentían sobredimensionados para el alto disponible.
+
+El App Shell ya era de pantalla fija correcta (`h-dvh overflow-hidden` en el shell + `.dashboard-main { overflow-hidden }`, contrato PR-A/#1014) y con master-detail enmascarado en ambos dashboards (#1015). Pero **fijaba la pantalla sin adaptar la densidad**.
+
+## 2. Causa técnica
+
+El shell adaptaba **posición** (pantalla fija, sin scroll global) pero **no densidad**. Toda la métrica interna estaba escrita en unidades `rem` **fijas**:
+
+- `.dashboard-main` con padding `px-3/sm:px-6/lg:px-8` + `py-3/sm:py-5/lg:py-6` y `space-y-4/sm:space-y-6`.
+- `.dashboard-master-panel` / `.dashboard-detail-panel` con `min-height: 18rem` rígido (en single-column forzaba ≥36rem).
+- Cockpit, `ModuleSurface`, `ModuleTabs`, tabs, list-rows, etc. con gaps/paddings/alturas fijos.
+
+**El zoom del navegador cambia el viewport efectivo en píxeles CSS.** Una pantalla 1920×1080 a 150% se comporta como ~1280×720 CSS px; a 50% se comporta como un viewport mucho mayor. Con medidas fijas, a 50% "sobra" altura y todo se ve equilibrado; a 100% la misma métrica fija queda densa para el alto real. El problema no era el App Shell: era que **la densidad no era función del viewport efectivo**.
+
+## 3. Por qué el zoom manual no es solución
+
+Bajar Chrome a 50% sólo **infla artificialmente el viewport efectivo** para que la métrica fija "entre". No es operable (texto minúsculo, dependencia del usuario) y no escala a distintas pantallas. La solución correcta es que el shell **adapte densidad** al viewport efectivo, de modo que a 100% se vea proporcionado por sí mismo. Tampoco se resolvió con:
+
+- `zoom` CSS global (deforma todo y no es adaptativo).
+- Reducción indiscriminada de `font-size` global (degrada legibilidad).
+- Scroll global (rompe el contrato de pantalla fija PR-A/#1014).
+- Parches módulo por módulo sin contrato común.
+
+## 4. Solución: Viewport-aware Adaptive App Shell
+
+Capa **global de densidad** por **variables CSS** scoped a `.dashboard-app-shell` (envuelve TODAS las rutas `/dashboard/**` de ambos dashboards vía `DashboardShellRouter`). Los tokens son **fluidos** con `clamp()` keyed a ancho (`vw`) y al **alto efectivo del viewport** (`vh`), y **escalonan a modo compacto** con `@media (max-height/-width)`.
+
+Como el zoom del navegador cambia el alto del viewport CSS, las media queries por alto hacen que el shell **se compacte automáticamente bajo zoom**, sin zoom manual, sin `zoom` CSS y sin reducir el font global. Los tokens se aplican con selectores de **mayor especificidad** (`.dashboard-app-shell …`), por lo que **no se editan** los strings `@apply`/className pineados por tests, y el contrato no-scroll se preserva (toda reducción sólo ayuda a entrar).
+
+### 4.1. Tokens de densidad (`globals.css`, sección `dashboard-viewport-zoom-adaptability`)
+
+| Token | Rol | Base (fluido) |
+|---|---|---|
+| `--dash-header-h` | alto de header (documentado; chrome ya estable por ancho) | `4.5rem` → `4/3.6rem` compacto |
+| `--dash-sidebar-rail` / `--dash-sidebar-expanded` | ancho de sidebar (rail 4.5rem / expand 15rem, ya adaptativo por ancho 2xl) | `4.5rem` / `15rem` |
+| `--dash-pad-x` | padding horizontal de página | `clamp(0.75rem, 0.45rem + 1vw, 2rem)` |
+| `--dash-pad-y` | padding vertical de página | `clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem)` |
+| `--dash-rhythm` | ritmo vertical entre secciones de `main` | `clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem)` |
+| `--dash-gap` | gap entre paneles/cards | `clamp(0.55rem, 0.35rem + 0.55vh, 1rem)` |
+| `--dash-card-pad` | padding interno de cards | `clamp(0.65rem, 0.45rem + 0.5vw, 1rem)` |
+| `--dash-panel-min` | alto mínimo de paneles master/detail (reemplaza el rígido 18rem) | `clamp(6rem, 1rem + 18vh, 18rem)` |
+| `--dash-control-h` | altura de filtros/controles | `clamp(2rem, 1.75rem + 0.6vh, 2.5rem)` |
+| `--dash-tab-h` | altura de tabs | `clamp(1.9rem, 1.6rem + 0.7vh, 2.25rem)` |
+| `--dash-cockpit-gap` | gap del cockpit (hub) | `clamp(0.5rem, 0.3rem + 0.6vh, 1.15rem)` |
+| `--dash-list-pad-y` | densidad vertical de filas de lista | `clamp(0.4rem, 0.3rem + 0.25vh, 0.65rem)` |
+| `--dash-secondary-font` | densidad tipográfica de texto secundario (sólo modo compacto) | `0.75rem` → `0.7rem` |
+
+### 4.2. Escalones de modo compacto (automáticos por alto)
+
+- `@media (max-height: 860px)` — laptop común a 100% (1366×768 / 1280×720 / 1536×864 efectivo): reduce pad-y, ritmo, gap, card-pad, panel-min, cockpit-gap.
+- `@media (max-height: 760px)` — laptop chico / zoom alto: además header-h, tab-h, list-pad.
+- `@media (max-height: 680px)` — zoom fuerte en panel 1080p (~1280×720 efectivo): valores ultra-compactos + `--dash-secondary-font`.
+- `@media (max-width: 1280px)` — ancho efectivo angosto: padding de página acotado.
+
+### 4.3. Superficies que consumen los tokens (scoped, sin tocar strings pineados)
+
+`.dashboard-main` (padding + ritmo), `.dashboard-cockpit` (gap), `.dashboard-module-surface` / `.dashboard-module-tabs` (gap), `.dashboard-module-tab` (min-height), `.dashboard-master-panel` / `.dashboard-detail-panel` (min-height fluido), `.dashboard-list-row` (padding vertical). En modo compacto (`max-height: 760px`): topbar (vía su hook `[data-dashboard-topbar-polish]`, sin editar className) y `.dashboard-section-description` (texto secundario).
+
+## 5. Contrato visual nuevo
+
+- Sin scroll global en `html`, `body`, shell ni `.dashboard-main` (preservado de PR-A/#1014; verificado en toda la matriz).
+- **No depende de zoom 50%.** A 100% entra proporcionado por densidad adaptativa.
+- Si baja el alto disponible (pantalla chica o zoom alto), **modo compacto automático**: menos padding vertical, gaps, alturas de headers/filtros internos, densidad de cards, badges/timeline secundarios y alto visible de listas.
+- No se oculta información crítica; el chrome (sidebar nav + header) permanece visible en desktop.
+- Sin superposición filtros/lista/detalle; sin re-apilar formulario+lista+detalle (preservado de #1015).
+- Legibilidad mantenida: **no** se reduce el font global; sólo texto secundario en modo ultra-compacto.
+
+## 6. App Shell, no página web
+
+El dashboard se trata como **Adaptive Dashboard App Shell**: navegación lateral fija, header fijo, `main` fijo, densidad adaptativa al viewport efectivo. El chrome ya era estable por ancho (sidebar rail `w-[4.5rem]` → expand `2xl:w-60`; header `min-h-[4.5rem]`); la capa nueva ataca la **densidad del contenido**, que era el origen real del desbalance a 100%.
+
+## 7. Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/app/globals.css` | Nueva sección `dashboard-viewport-zoom-adaptability` (tokens de densidad fluidos + escalones compactos + aplicación scoped). No se editó ningún `@apply`/regla pineada existente. |
+| `frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts` | **Nuevo** E2E de adaptabilidad viewport/zoom (matriz de viewports × ambos dashboards) + pruebas de que la densidad se compacta al achicarse el alto efectivo. |
+| `docs/implementation/dashboard-global-viewport-zoom-adaptability.md` | **Nuevo** este documento. |
+
+No se modificó backend, `frontend/next-env.d.ts`, `package.json`/lock, ni componentes/strings pineados.
+
+## 8. Viewports cubiertos (E2E)
+
+- **Desktop real:** 1920×1080, 1600×900, 1366×768, 1280×720.
+- **Viewport efectivo / zoom:** 1536×864 (≈ zoom alto en 1920×1080), 1280×720 (zoom más exigente).
+- **Tablet / móvil:** 768×1024, 390×844.
+
+Superficies (ambos dashboards): Clínica hub, Informes in-shell, Tokens particulares, Logística in-shell (todas en la matriz completa, incl. móvil); Administración hub, Resumen/Alertas, Mantenimiento, Roles clínica; rutas full-page deep-link (`/dashboard/informes`, `/dashboard/logistica`) en la matriz desktop + zoom efectivo. Pruebas de adaptabilidad: el padding de página y el `min-height` de paneles **disminuyen** al pasar de 1920×1080 a 1280×700.
+
+### Nota de contrato sobre rutas full-page
+
+Las rutas `/dashboard/informes` y `/dashboard/logistica` son los **deep-links de "página completa"**, gemelos de los módulos in-shell `?module=informes` / `?module=logistica`. La garantía de no-scroll estricta a **todo viewport, incluido móvil**, la entregan los **módulos in-shell** (validados a 390×844). Las rutas full-page se validan en la matriz desktop + zoom efectivo (el caso real del reclamo de "100% de zoom"); en móvil 390 px su `LogisticsCommandCenter` (página vertical con `space-y-5`/`gap-6` y dos cards apiladas, patrón heredado) puede exceder marginalmente — es comportamiento de página completa, cubierto operativamente por el módulo in-shell.
+
+## 9. Comportamiento compacto (resumen)
+
+A medida que baja el alto efectivo (pantalla chica o zoom alto): padding de página y ritmo vertical se reducen; el `min-height` de paneles master/detail pasa de fluido (hasta 18rem) a 4–5rem; gaps de módulos/tabs y altura de tabs bajan; filas de lista se densifican; el header se compacta vía su hook; el texto secundario reduce un punto. El contenido crítico y las acciones primarias permanecen visibles.
+
+## 10. Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend lint` | ✓ OK |
+| `pnpm --dir frontend typecheck` | ✓ OK |
+| `pnpm test` (nativos) | ✓ OK |
+| `pnpm --dir frontend build` | ✓ OK |
+| `pnpm build` (backend) | ✓ OK |
+| `pnpm security:public-surface` | ✓ PASS |
+| `pnpm audit --prod` | ✓ OK |
+| E2E `dashboard-viewport-zoom-adaptability.spec.ts` (nuevo) | ✓ 56/56 |
+| E2E suite dashboard (no-scroll, masked master-detail, shell, layout polish, a11y, etc.) | ✓ 170/170 |
+
+`frontend/next-env.d.ts` se restauró tras cada `next dev`/`next build` (sin cambios finales).
+
+## 11. Riesgos / remanentes
+
+- **Riesgo bajo.** Cambio CSS aditivo (nueva sección delimitada) que sólo **reduce** densidad por viewport; no toca overflow del shell ni strings pineados. Toda reducción ayuda al contrato no-scroll.
+- **Datos reales:** los E2E corren en modo degradado (`NEXT_PUBLIC_API_URL=""`). El fit con datos reales sigue acotado por las listas paginadas (`usePagedRows`/`CompactPager`) de #1015; la densidad adaptativa sólo mejora el margen.
+- **Rutas full-page deep-link en móvil:** ver §8. La adaptabilidad estricta móvil vive en los módulos in-shell; las páginas completas heredan el patrón vertical previo (no regresado, sólo más compacto).
+- **Sin cambios de seguridad/API:** no se tocaron payloads, endpoints, separación de sesión (`app_session_id`/`admin_session_id`) ni invariantes; `security:public-surface` y `audit --prod` en verde.

--- a/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
+++ b/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
@@ -1,0 +1,393 @@
+﻿import { expect, test } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global Viewport-aware Adaptive App Shell contract for BOTH dashboards.
+//
+// Governing implementation: docs/implementation/dashboard-global-viewport-zoom-adaptability.md
+// Builds on PR-A/#1014 (main never an operational scroll container) and
+// #1015 (global masked master-detail). This spec proves the *density* layer:
+//
+//   1. No global scroll (html/body/main) across the real screen-size matrix AND
+//      the "effective viewport" sizes produced by browser zoom (a 1920×1080 panel
+//      at high zoom behaves like ~1280×720 / 1536×864 of CSS pixels).
+//   2. The density tokens actually ADAPT: page padding + master/detail panel floor
+//      shrink as the effective viewport height shrinks (so the layout fits at 100%
+//      zoom without the user dropping Chrome to 50%).
+//
+// The e2e server runs with NEXT_PUBLIC_API_URL="" so modules render their
+// degraded/empty frame; the adaptive composition must still hold without scroll.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Page = import("@playwright/test").Page;
+
+const TOLERANCE = 2;
+
+// Real desktop sizes + effective-viewport approximations of browser zoom.
+const ALL_VIEWPORTS = [
+  { name: "desktop-1920x1080", width: 1920, height: 1080 },
+  { name: "desktop-1600x900", width: 1600, height: 900 },
+  { name: "zoom-eff-1536x864", width: 1536, height: 864 },
+  { name: "laptop-1366x768", width: 1366, height: 768 },
+  { name: "zoom-eff-1280x720", width: 1280, height: 720 },
+  { name: "tablet-768x1024", width: 768, height: 1024 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+// The most demanding sizes (low effective height) used for the extra surfaces.
+const DEMANDING_VIEWPORTS = ALL_VIEWPORTS.filter((v) =>
+  ["laptop-1366x768", "zoom-eff-1280x720", "mobile-390x844"].includes(v.name),
+);
+
+// Desktop + effective-zoom sizes (≥1024px wide). This is the matrix that maps to
+// the user's real "100% zoom on a laptop/desktop" complaint. Strict no-scroll on
+// the shell + in-shell modules is asserted at EVERY viewport (incl. tablet/mobile)
+// below; the full-page deep-link routes (the "complete page" twins of the in-shell
+// modules) are asserted across this desktop/zoom matrix, while their strict
+// mobile no-scroll guarantee is delivered by the in-shell `?module=…` surfaces.
+const DESKTOP_ZOOM_VIEWPORTS = ALL_VIEWPORTS.filter((v) => v.width >= 1024);
+
+type Surface = "clinic" | "admin";
+
+type SurfaceCase = {
+  label: string;
+  surface: Surface;
+  path: string;
+  /** Selector that must be visible once the surface is ready. */
+  ready: string;
+  /** Whether the clinic Tokens API must be mocked for this surface. */
+  mockTokens?: boolean;
+};
+
+const CORE_SURFACES: SurfaceCase[] = [
+  {
+    label: "clinic hub (cockpit)",
+    surface: "clinic",
+    path: "/dashboard",
+    ready: "main.dashboard-main",
+  },
+  {
+    label: "clinic Informes (in-shell master-detail)",
+    surface: "clinic",
+    path: "/dashboard?module=informes",
+    ready: '[data-dashboard-module-workspace="informes"]',
+  },
+  {
+    label: "clinic Tokens particulares (master-detail + dialog)",
+    surface: "clinic",
+    path: "/dashboard?module=tokens",
+    ready: '[data-dashboard-module-workspace="tokens"]',
+    mockTokens: true,
+  },
+  {
+    label: "admin hub (launcher)",
+    surface: "admin",
+    path: "/dashboard/admin",
+    ready: "main.dashboard-main",
+  },
+  {
+    label: "admin Resumen/Alertas (tabs)",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin",
+    ready: '[data-dashboard-module-workspace="admin"]',
+  },
+];
+
+const EXTRA_SURFACES: SurfaceCase[] = [
+  {
+    label: "clinic Logística (in-shell master-detail)",
+    surface: "clinic",
+    path: "/dashboard?module=logistica",
+    ready: '[data-dashboard-module-workspace="logistica"]',
+  },
+  {
+    label: "admin Mantenimiento (tabs)",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin-maintenance",
+    ready: '[data-dashboard-module-workspace="admin-maintenance"]',
+  },
+  {
+    label: "admin Roles clínica",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin-users-roles",
+    ready: '[data-dashboard-module-workspace="admin-users-roles"]',
+  },
+];
+
+// Full-page deep-link routes ("complete page" twins of the in-shell modules).
+// Validated across the desktop + effective-zoom matrix.
+const FULL_PAGE_DEEPLINKS: SurfaceCase[] = [
+  {
+    label: "clinic Informes full route",
+    surface: "clinic",
+    path: "/dashboard/informes",
+    ready: "main.dashboard-main",
+  },
+  {
+    label: "clinic Logística full route",
+    surface: "clinic",
+    path: "/dashboard/logistica",
+    ready: "main.dashboard-main",
+  },
+];
+
+const MOCK_TOKENS = Array.from({ length: 6 }, (_, index) => {
+  const id = index + 1;
+  return {
+    id,
+    clinicId: 10,
+    reportId: id % 2 === 0 ? 200 + id : null,
+    tokenLast4: String(9000 + id).slice(-4),
+    tutorLastName: `Tutor ${id}`,
+    petName: `Paciente ${id}`,
+    petAge: `${id + 1} años`,
+    petBreed: "Mestizo",
+    petSex: id % 2 === 0 ? "Hembra" : "Macho",
+    petSpecies: id % 2 === 0 ? "Felinos" : "Caninos",
+    sampleLocation: "Piel",
+    sampleEvolution: "Subaguda",
+    detailsLesion: "Lesión nodular compatible con seguimiento.",
+    extractionDate: "2026-06-01T00:00:00.000Z",
+    shippingDate: "2026-06-02T00:00:00.000Z",
+    isActive: true,
+    lastLoginAt: null,
+    createdAt: "2026-06-03T00:00:00.000Z",
+    updatedAt: "2026-06-03T00:00:00.000Z",
+    createdByAdminId: null,
+    createdByClinicUserId: 77,
+    hasLinkedReport: id % 2 === 0,
+  };
+});
+
+async function mockClinicTokens(page: Page) {
+  await page.route(
+    (url) => url.pathname === "/api/particular-tokens",
+    async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          count: MOCK_TOKENS.length,
+          particularTokens: MOCK_TOKENS,
+          pagination: { limit: 10, offset: 0 },
+          filters: { clinicId: null },
+        }),
+      }),
+  );
+}
+
+async function applySession(page: Page, surface: Surface) {
+  await page.context().addCookies([
+    {
+      name: surface === "clinic" ? "app_session_id" : "admin_session_id",
+      value: surface === "clinic" ? "e2e_test_clinic_session" : "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+type ScrollContract = {
+  htmlScrollHeight: number;
+  htmlClientHeight: number;
+  bodyScrollHeight: number;
+  bodyClientHeight: number;
+  mainScrollHeight: number;
+  mainClientHeight: number;
+  mainOverflowY: string;
+  hasMain: boolean;
+  navVisible: boolean;
+  topbarVisible: boolean;
+};
+
+async function readScrollContract(page: Page): Promise<ScrollContract> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector("main.dashboard-main") as HTMLElement | null;
+    const nav = document.querySelector('[aria-label="Navegación principal"]');
+    const topbar = document.querySelector('[aria-label="Barra superior del dashboard"]');
+
+    const isVisible = (el: Element | null) => {
+      if (!el) return false;
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+
+    return {
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+      mainScrollHeight: main?.scrollHeight ?? 0,
+      mainClientHeight: main?.clientHeight ?? 0,
+      mainOverflowY: main ? window.getComputedStyle(main).overflowY : "none",
+      hasMain: main !== null,
+      navVisible: isVisible(nav),
+      topbarVisible: isVisible(topbar),
+    };
+  });
+}
+
+function assertAdaptiveNoScroll(
+  metrics: ScrollContract,
+  label: string,
+  width: number,
+) {
+  expect(metrics.hasMain, `${label}: main.dashboard-main present`).toBe(true);
+
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main must not be a scroll container (overflow-y=${metrics.mainOverflowY})`,
+  ).not.toBe("auto");
+  expect(metrics.mainOverflowY, `${label}: main overflow not scroll`).not.toBe(
+    "scroll",
+  );
+
+  expect(
+    metrics.mainScrollHeight,
+    `${label}: main scrolled (${metrics.mainScrollHeight} > ${metrics.mainClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.mainClientHeight + TOLERANCE);
+  expect(
+    metrics.bodyScrollHeight,
+    `${label}: body scrolled (${metrics.bodyScrollHeight} > ${metrics.bodyClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+  expect(
+    metrics.htmlScrollHeight,
+    `${label}: documentElement scrolled (${metrics.htmlScrollHeight} > ${metrics.htmlClientHeight})`,
+  ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+
+  // Critical chrome must stay visible (no collapse) on desktop widths.
+  if (width >= 1024) {
+    expect(metrics.navVisible, `${label}: sidebar nav visible`).toBe(true);
+    expect(metrics.topbarVisible, `${label}: dashboard header visible`).toBe(true);
+  }
+}
+
+async function gotoSurface(page: Page, surface: SurfaceCase) {
+  await applySession(page, surface.surface);
+  if (surface.mockTokens) {
+    await mockClinicTokens(page);
+  }
+  await page.goto(surface.path);
+  await expect(page.locator(surface.ready).first()).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+for (const viewport of ALL_VIEWPORTS) {
+  test.describe(`adaptive app shell — ${viewport.name}`, () => {
+    for (const surface of CORE_SURFACES) {
+      test(`${surface.label} fits without global scroll`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await gotoSurface(page, surface);
+
+        await expect(async () => {
+          const metrics = await readScrollContract(page);
+          assertAdaptiveNoScroll(
+            metrics,
+            `${viewport.name} ${surface.label}`,
+            viewport.width,
+          );
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+  });
+}
+
+for (const viewport of DEMANDING_VIEWPORTS) {
+  test.describe(`adaptive app shell extras — ${viewport.name}`, () => {
+    for (const surface of EXTRA_SURFACES) {
+      test(`${surface.label} fits without global scroll`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await gotoSurface(page, surface);
+
+        await expect(async () => {
+          const metrics = await readScrollContract(page);
+          assertAdaptiveNoScroll(
+            metrics,
+            `${viewport.name} ${surface.label}`,
+            viewport.width,
+          );
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+  });
+}
+
+for (const viewport of DESKTOP_ZOOM_VIEWPORTS) {
+  test.describe(`full-page deep-link routes — ${viewport.name}`, () => {
+    for (const surface of FULL_PAGE_DEEPLINKS) {
+      test(`${surface.label} fits without global scroll`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await gotoSurface(page, surface);
+
+        await expect(async () => {
+          const metrics = await readScrollContract(page);
+          assertAdaptiveNoScroll(
+            metrics,
+            `${viewport.name} ${surface.label}`,
+            viewport.width,
+          );
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+  });
+}
+
+// ── Adaptability proof ───────────────────────────────────────────────────────
+// The whole point: the same surface must get DENSER as the effective viewport
+// height shrinks (which is exactly what browser zoom produces). We measure real
+// computed values (clamp() resolves to px) at a tall vs a short viewport.
+
+async function readMainPaddingBottom(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const main = document.querySelector("main.dashboard-main");
+    if (!main) return -1;
+    return parseFloat(window.getComputedStyle(main).paddingBottom);
+  });
+}
+
+test("clinic page padding compacts as the effective viewport height shrinks", async ({
+  page,
+}) => {
+  await applySession(page, "clinic");
+
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.goto("/dashboard");
+  await expect(page.locator("main.dashboard-main")).toBeVisible({ timeout: 15_000 });
+  const tallPadding = await readMainPaddingBottom(page);
+
+  await page.setViewportSize({ width: 1280, height: 700 });
+  await expect(async () => {
+    const shortPadding = await readMainPaddingBottom(page);
+    expect(
+      shortPadding,
+      `compact page padding (${shortPadding}px) < tall padding (${tallPadding}px)`,
+    ).toBeLessThan(tallPadding);
+    expect(shortPadding).toBeGreaterThan(0);
+  }).toPass({ timeout: 5_000 });
+});
+test("master/detail panel floor compacts as the effective viewport height shrinks", async ({
+  page,
+}) => {
+  await applySession(page, "clinic");
+
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.goto("/dashboard/informes");
+  const panel = page.locator(".dashboard-master-panel, .dashboard-detail-panel").first();
+  await expect(panel).toBeVisible({ timeout: 15_000 });
+
+  const readPanelMinHeight = () =>
+    panel.evaluate((el) => parseFloat(window.getComputedStyle(el).minHeight));
+
+  const tallMin = await readPanelMinHeight();
+
+  await page.setViewportSize({ width: 1280, height: 700 });
+  await expect(async () => {
+    const shortMin = await readPanelMinHeight();
+    expect(
+      shortMin,
+      `compact panel min-height (${shortMin}px) < tall min-height (${tallMin}px)`,
+    ).toBeLessThan(tallMin);
+  }).toPass({ timeout: 5_000 });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2049,3 +2049,150 @@
   }
 }
 /* dashboard-app-shell-visibility-contract:end */
+/* dashboard-viewport-zoom-adaptability:start */
+/*
+  Viewport-aware Adaptive App Shell — global density layer for BOTH dashboards
+  (Clínica + Administración).
+
+  PROBLEM: the fixed App Shell (`h-dvh overflow-hidden` + `main overflow-hidden`,
+  contract PR-A/#1014) pins the screen correctly, but every padding/gap/min-height
+  below it was authored in fixed `rem` units. The *effective viewport* shrinks as
+  browser zoom rises (a 1920×1080 panel at 150% behaves like ~1280×720 CSS px), so
+  at 100% zoom those fixed measures looked oversized/dense and the layout only felt
+  balanced when the user manually dropped Chrome to 50% (which inflates the
+  effective viewport). The shell adapted *position*, not *density*.
+
+  FIX: a density-token layer scoped to `.dashboard-app-shell`. Tokens are fluid via
+  `clamp()` keyed to width (`vw`) and to the effective viewport height (`vh`), then
+  step down through `@media (max-height/-width)` compact tiers. Because browser zoom
+  changes the CSS viewport height, the height media queries make the shell
+  auto-compact under zoom WITHOUT manual zoom, `zoom` CSS, or a global font-size
+  shrink. Tokens are applied through higher-specificity `.dashboard-app-shell …`
+  selectors, so the pinned `@apply`/className contracts are never edited and the
+  no-scroll contract is preserved — every reduction only helps content fit.
+*/
+@layer components {
+  .dashboard-app-shell {
+    /* Chrome (documented; already width-adaptive via the pinned sidebar rail /
+       2xl expand and the topbar min-h-[4.5rem] floor). */
+    --dash-header-h: 4.5rem;
+    --dash-sidebar-rail: 4.5rem;
+    --dash-sidebar-expanded: 15rem;
+
+    /* Page frame: outer padding + vertical rhythm between top-level sections. */
+    --dash-pad-x: clamp(0.75rem, 0.45rem + 1vw, 2rem);
+    --dash-pad-y: clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem);
+    --dash-rhythm: clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem);
+
+    /* Panels / cards: gap between panels, internal card padding, master/detail
+       floor (replaces the rigid 18rem that forced 36rem in single-column). */
+    --dash-gap: clamp(0.55rem, 0.35rem + 0.55vh, 1rem);
+    --dash-card-pad: clamp(0.65rem, 0.45rem + 0.5vw, 1rem);
+    --dash-panel-min: clamp(6rem, 1rem + 18vh, 18rem);
+
+    /* Controls: compact filter/toolbar control + tab heights. */
+    --dash-control-h: clamp(2rem, 1.75rem + 0.6vh, 2.5rem);
+    --dash-tab-h: clamp(1.9rem, 1.6rem + 0.7vh, 2.25rem);
+
+    /* Hub + lists density. */
+    --dash-cockpit-gap: clamp(0.5rem, 0.3rem + 0.6vh, 1.15rem);
+    --dash-list-pad-y: clamp(0.4rem, 0.3rem + 0.25vh, 0.65rem);
+
+    /* Secondary text size used only by the compact tiers. */
+    --dash-secondary-font: 0.75rem;
+  }
+
+  /* Compact tier — effective height of a common laptop at 100% zoom
+     (1366×768 / 1280×720 / 1536×864 effective). */
+  @media (max-height: 860px) {
+    .dashboard-app-shell {
+      --dash-pad-y: clamp(0.5rem, 0.3rem + 0.5vh, 1rem);
+      --dash-rhythm: clamp(0.5rem, 0.3rem + 0.5vh, 0.95rem);
+      --dash-gap: clamp(0.5rem, 0.3rem + 0.45vh, 0.85rem);
+      --dash-card-pad: clamp(0.6rem, 0.45rem + 0.4vw, 0.9rem);
+      --dash-panel-min: clamp(5rem, 0.5rem + 16vh, 13rem);
+      --dash-cockpit-gap: clamp(0.5rem, 0.3rem + 0.5vh, 0.9rem);
+    }
+  }
+
+  /* Dense tier — small laptops / higher zoom. */
+  @media (max-height: 760px) {
+    .dashboard-app-shell {
+      --dash-header-h: 4rem;
+      --dash-pad-y: clamp(0.45rem, 0.3rem + 0.4vh, 0.8rem);
+      --dash-rhythm: clamp(0.45rem, 0.3rem + 0.4vh, 0.8rem);
+      --dash-gap: clamp(0.45rem, 0.3rem + 0.4vh, 0.75rem);
+      --dash-panel-min: clamp(4.5rem, 0.5rem + 14vh, 11rem);
+      --dash-tab-h: clamp(1.85rem, 1.6rem + 0.5vh, 2.1rem);
+      --dash-list-pad-y: clamp(0.35rem, 0.25rem + 0.2vh, 0.55rem);
+    }
+  }
+
+  /* Ultra-compact tier — strong zoom on a 1080p panel (~1280×720 effective). */
+  @media (max-height: 680px) {
+    .dashboard-app-shell {
+      --dash-header-h: 3.6rem;
+      --dash-pad-y: 0.4rem;
+      --dash-rhythm: 0.4rem;
+      --dash-gap: 0.4rem;
+      --dash-card-pad: 0.7rem;
+      --dash-panel-min: 4rem;
+      --dash-cockpit-gap: 0.45rem;
+      --dash-secondary-font: 0.7rem;
+    }
+  }
+
+  /* Narrow effective width (high zoom on common laptops) keeps page padding sane. */
+  @media (max-width: 1280px) {
+    .dashboard-app-shell {
+      --dash-pad-x: clamp(0.7rem, 0.4rem + 0.8vw, 1.5rem);
+    }
+  }
+
+  /* ── Apply tokens (higher specificity than the base utility rules) ───────── */
+  .dashboard-app-shell .dashboard-main {
+    padding-inline: var(--dash-pad-x);
+    padding-block: var(--dash-pad-y);
+  }
+
+  .dashboard-app-shell .dashboard-main > :not([hidden]) ~ :not([hidden]) {
+    margin-block-start: var(--dash-rhythm);
+  }
+
+  .dashboard-app-shell .dashboard-cockpit {
+    gap: var(--dash-cockpit-gap);
+  }
+
+  .dashboard-app-shell .dashboard-module-surface,
+  .dashboard-app-shell .dashboard-module-tabs {
+    gap: var(--dash-gap);
+  }
+
+  .dashboard-app-shell .dashboard-module-tab {
+    min-height: var(--dash-tab-h);
+  }
+
+  .dashboard-app-shell .dashboard-master-panel,
+  .dashboard-app-shell .dashboard-detail-panel {
+    min-height: var(--dash-panel-min);
+  }
+
+  .dashboard-app-shell .dashboard-list-row {
+    padding-block: var(--dash-list-pad-y);
+  }
+
+  /* Compact-only chrome + secondary-text density. Targets the topbar via its
+     existing data hook (no className edit) and trims secondary descriptions
+     only — never a global font-size reduction. */
+  @media (max-height: 760px) {
+    .dashboard-app-shell [data-dashboard-topbar-polish="true"] {
+      min-height: var(--dash-header-h);
+      padding-block: 0.4rem;
+    }
+
+    .dashboard-app-shell .dashboard-section-description {
+      font-size: var(--dash-secondary-font);
+    }
+  }
+}
+/* dashboard-viewport-zoom-adaptability:end */


### PR DESCRIPTION
## Summary
- Add viewport-aware density tokens scoped to the Dashboard App Shell
- Adapt Clínica and Administración dashboards to effective viewport/zoom without global scroll
- Add E2E coverage for desktop, tablet, mobile and zoom-equivalent viewports
- Document the adaptive App Shell contract

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend e2e -- e2e/dashboard-viewport-zoom-adaptability.spec.ts --reporter=line
- pnpm --dir frontend lint
- pnpm test
- pnpm --dir frontend build
- pnpm build
- pnpm security:public-surface
- pnpm audit --prod
- dashboard E2E suite: 170/170