### PR TITLE
fix(dashboard): make global details inline and responsive

### DIFF
--- a/docs/implementation/dashboard-global-inline-details-responsive.md
+++ b/docs/implementation/dashboard-global-inline-details-responsive.md
@@ -1,0 +1,117 @@
+# Dashboard global: detalles inline y adaptación responsive
+
+## 1. Resumen ejecutivo
+
+Se unifica el patrón visual de Dashboard Administración y Dashboard Clínica: las superficies master-detail dejan de depender de paneles laterales rígidos y muestran el detalle dentro del ítem seleccionado. La solución conserva datos, acciones y lógica; cambia únicamente la composición visual y los contenedores.
+
+Además, una capa CSS acotada al App Shell impide desbordes horizontales, permite que flex/grid encojan correctamente, compacta elementos secundarios en viewports efectivos reducidos y mantiene tablas/paginadores dentro de sus cards.
+
+## 2. Rama creada
+
+`fix/dashboard-global-inline-details-responsive`, basada en `a7f4761` (`main` y `origin/main` en paridad al iniciar).
+
+## 3. Objetivo del PR
+
+- Aplicar detalle inline en todas las superficies master-detail de ambos dashboards.
+- Evitar solapamientos, contenido fuera de página y scroll horizontal global ante cambios de viewport o zoom.
+- Mantener una densidad institucional compacta y consistente.
+- Preservar contratos API, contenido interno y lógica de negocio.
+
+## 4. Problema visual observado
+
+- Tokens Admin e Informes Clínica completos usaban grids laterales que reducían el ancho útil y podían dejar el detalle fuera del área visible.
+- Tokens Clínica y los summaries de Informes/Logística sustituían la lista por un panel de detalle en móvil y mantenían dos columnas en desktop; el comportamiento no era equivalente al detalle inline solicitado.
+- La tabla de Auditoría podía crecer verticalmente por contenido largo y competir con el paginador.
+- Flex/grid, tablas, chips y medios necesitaban un guard común de `min-width: 0`, wrapping y límites de ancho.
+
+## 5. Superficies revisadas
+
+- Administración: hub, resumen/alertas, clínicas, precios, sesiones, roles, estado, mantenimiento, reportes, Tokens particulares y Auditoría.
+- Clínica: hub, operaciones, perfil, Tokens particulares, summaries de Informes y Logística, Informes completos, visitas y rutas.
+- Componentes compartidos: App Shell, cards, tabs, badges/chips, paginadores, tablas y primitivas master-detail.
+
+## 6. Decisión técnica aplicada
+
+- Primitivas reutilizables `dashboard-inline-list`, `dashboard-inline-scroll` y `dashboard-inline-detail`.
+- Lista de una sola columna; cada selector expone `aria-expanded` y el detalle se renderiza inmediatamente debajo del ítem activo.
+- Cadena `flex min-h-0 flex-1` para limitar la superficie al espacio disponible; el scroll queda localizado en la lista, no en la página.
+- Guard responsive scoped a `.dashboard-app-shell` para ancho máximo, shrink de hijos, wrapping y densidad.
+- Tablas dentro de wrappers acotados; el paginador permanece como bloque `shrink-0` y puede envolver sus controles en anchos reducidos.
+
+## 7. Cambios implementados
+
+- Tokens Administración: panel lateral eliminado; detalle completo inline dentro del token activo.
+- Tokens Clínica: patrón lateral/cover eliminado; lista y detalle inline equivalentes a Administración en desktop y móvil.
+- Informes Clínica (ruta completa): panel lateral eliminado; cabecera, datos, acciones, archivo y timeline conservados inline.
+- Summaries Clínica de Informes y Logística: paneles laterales/cover eliminados; detalle inline en el ítem seleccionado.
+- Auditoría Administración: filas más compactas, wrapping en actor/objetivo/detalle/fecha, padding responsive, tabla acotada y paginador protegido.
+- Capa global: anti-desborde horizontal, densidad de chips y paginadores adaptativos.
+- E2E: contratos actualizados para selección inline y ausencia de panel persistente.
+
+## 8. Archivos modificados
+
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/app/dashboard/informes/page.tsx`
+- `frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx`
+- `frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx`
+- `frontend/src/app/dashboard/admin/AdminAuditLogTable.tsx`
+- `frontend/src/app/globals.css`
+- `frontend/e2e/dashboard-accessibility-keyboard.spec.ts`
+- `frontend/e2e/dashboard-global-masked-master-detail.spec.ts`
+- `frontend/e2e/dashboard-master-detail-state-polish.spec.ts`
+- `frontend/e2e/dashboard-workspace-layout-polish.spec.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `test/frontend-dashboard-home.test.ts`
+- `docs/implementation/dashboard-global-inline-details-responsive.md`
+
+## 9. Validaciones ejecutadas
+
+Terminal 1, Windows/PowerShell y PNPM:
+
+```text
+pnpm --dir frontend lint
+pnpm --dir frontend typecheck
+pnpm --dir frontend build
+pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-master-detail-state-polish.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts e2e/dashboard-accessibility-keyboard.spec.ts
+pnpm --dir frontend exec playwright test e2e/dashboard-viewport-zoom-adaptability.spec.ts e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts
+pnpm validate:local
+git diff --check
+```
+
+## 10. Resultado de validaciones
+
+- Lint frontend: OK.
+- Typecheck frontend: OK.
+- E2E afectados: 44/44 OK.
+- Contratos estáticos actualizados de Tokens/Summaries: 22/22 OK.
+- Matriz viewport/zoom y no-scroll: 88/88 OK; incluye 1920×1080, 1600×900, 1536×864, 1366×768, 1280×720, 768×1024 y 390×844.
+- Build frontend: OK; rutas `/dashboard`, `/dashboard/admin` y `/dashboard/informes` compiladas.
+- `pnpm validate:local`: OK; typecheck backend, typecheck tests, 2760/2760 tests y build backend.
+- `git diff --check`: OK.
+
+Los avisos 404 de endpoints durante E2E corresponden al frame degradado/mocks del entorno de pruebas y no se ocultaron.
+
+## 11. Riesgos residuales
+
+- Los E2E de Informes completos usan el frame sin datos para fetch server-side; el contenido real del detalle requiere una sesión con datos disponibles.
+- La validación visual local puede quedar limitada por autenticación o ausencia de backend/datos; cualquier superficie no observable se registra explícitamente abajo.
+- Las tablas anchas conservan scroll local deliberado dentro de la card para no ocultar columnas críticas.
+
+## 12. Pantallas que requieren validación manual de Nico
+
+**NO CONFIRMADO — requiere validación manual de Nico con sesión y datos reales:**
+
+- Administración: Tokens particulares y Auditoría con registros reales.
+- Clínica: Tokens particulares, summary de Informes, summary de Logística e Informes completos con archivo/timeline real.
+- Zoom de página real del navegador en 100%, menor y mayor.
+
+Motivo: el navegador local redirige correctamente al login y no se usaron credenciales ni cookies reales. La automatización E2E sí validó estructura, interacción inline, ausencia de desborde/scroll global y viewports equivalentes con cookies ficticias, pero no sustituye la inspección estética de datos productivos por Nico.
+
+## 13. Confirmación de no-alcance
+
+- Sin cambios en backend, base de datos, migraciones, autenticación, seguridad ni contratos API.
+- Sin dependencias nuevas ni cambios en lockfiles.
+- Sin cambios en web pública, branding o producción.
+- Sin secretos, cookies reales, tokens, passwords, hashes ni `.env` reales.
+- No se ejecutaron `git add`, `git commit`, `git push`, `gh pr create`, `gh pr checks --watch` ni `gh pr merge`.

--- a/frontend/e2e/dashboard-accessibility-keyboard.spec.ts
+++ b/frontend/e2e/dashboard-accessibility-keyboard.spec.ts
@@ -201,11 +201,14 @@ test.describe("Informes — accessible profile-layout actions", () => {
     }
   });
 
-  test("reports list and detail are visible", async ({ page }) => {
+  test("reports list renders with inline detail contract", async ({ page }) => {
     await expect(page.locator("#reports-master-list")).toBeVisible({
       timeout: 4_000,
     });
-    await expect(page.locator("#report-detail")).toBeVisible();
+    // Inline master-detail: the detail expands inside the selected report row,
+    // so there is no persistent lateral detail panel. With the e2e empty-API
+    // frame there is no selected report, hence no #report-detail node.
+    await expect(page.locator("#report-detail")).toHaveCount(0);
   });
 });
 
@@ -217,10 +220,12 @@ test.describe("ReportFileActions — aria-busy (PR-8)", () => {
   }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator("#report-detail")).toBeVisible({
+    await expect(page.locator("#reports-master-list")).toBeVisible({
       timeout: 8_000,
     });
 
+    // Action buttons live inside the selected report's inline detail; under the
+    // empty-API frame there is no selection, so the assertions stay conditional.
     const actionButtons = page.locator(
       'button[aria-label="Ver informe"], button[aria-label="Archivo no disponible."], button[aria-label="Descargar informe"]',
     );

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Global masked Master-Detail / no-scroll contract for BOTH dashboards.
+// Global inline/masked Master-Detail / no-scroll contract for BOTH dashboards.
 //
 // Governing audit: docs/audit/dashboard-masked-master-detail-no-scroll-audit.md
 // Governing contract: docs/implementation/dashboard-internal-no-scroll-contract.md
@@ -40,7 +40,7 @@ type ModuleCase = {
 
 const MODULES: ModuleCase[] = [
   {
-    label: "clinic Tokens particulares (master-detail + dialog alta)",
+    label: "clinic Tokens particulares (inline detail + dialog alta)",
     surface: "clinic",
     path: "/dashboard?module=tokens",
     moduleId: "tokens",
@@ -352,7 +352,7 @@ for (const viewport of VIEWPORTS) {
   });
 }
 
-test("clinic Tokens desktop limits the master list and selects detail without scroll", async ({
+test("clinic Tokens desktop limits the list and expands detail inline without shell scroll", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1366, height: 768 });
@@ -367,6 +367,11 @@ test("clinic Tokens desktop limits the master list and selects detail without sc
   await expect(page.getByText(/1.4 de 6 tokens/)).toBeVisible();
 
   await page.locator("#clinic-particular-token-2").click();
+  await expect(page.locator("#clinic-particular-token-2")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(page.locator('[data-detail-state="selected"]')).toHaveCount(1);
   await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeVisible();
   await expect(page.getByText("Alerta: Solicitud de tinción especial")).toBeVisible();
 
@@ -374,7 +379,7 @@ test("clinic Tokens desktop limits the master list and selects detail without sc
   assertNoInternalScroll(metrics, "desktop clinic Tokens selected detail");
 });
 
-test("clinic Tokens mobile replaces list with detail and internal back returns", async ({
+test("clinic Tokens mobile keeps the list and expands the selected detail inline", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -388,13 +393,14 @@ test("clinic Tokens mobile replaces list with detail and internal back returns",
   await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
 
   await page.locator("#clinic-particular-token-2").click();
-  await expect(page.locator("#clinic-particular-token-1")).toBeHidden();
+  await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
+  await expect(page.locator("#clinic-particular-token-2")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(page.locator('[data-detail-state="selected"]')).toHaveCount(1);
   await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeVisible();
 
-  await page.getByRole("button", { name: "Volver a la lista" }).click();
-  await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeHidden();
-
   const metrics = await readScrollContract(page);
-  assertNoInternalScroll(metrics, "mobile clinic Tokens detail back");
+  assertNoInternalScroll(metrics, "mobile clinic Tokens inline detail");
 });

--- a/frontend/e2e/dashboard-master-detail-state-polish.spec.ts
+++ b/frontend/e2e/dashboard-master-detail-state-polish.spec.ts
@@ -22,13 +22,18 @@ test.describe("dashboard reports profile-layout state polish — smoke", () => {
     await expect(page.getByText("Lista de informes")).toBeVisible();
   });
 
-  test("informes: selected report detail panel renders", async ({ page }) => {
+  test("informes: detail is inline, not a standalone lateral panel", async ({
+    page,
+  }) => {
     await setClinicSession(page);
     await page.goto("/dashboard/informes");
-    await expect(page.locator("#report-detail")).toBeVisible({
+    await expect(page.locator("#reports-master-list")).toBeVisible({
       timeout: 8_000,
     });
-    await expect(page.getByText("Detalle del informe")).toBeVisible();
+    // Inline master-detail: the detail expands inside the selected list item, so
+    // there is no persistent lateral detail panel. With the e2e empty-API frame
+    // there is no selected report, hence no #report-detail node is rendered.
+    await expect(page.locator("#report-detail")).toHaveCount(0);
   });
 
   test("informes: compact filter search region visible", async ({ page }) => {

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -72,9 +72,9 @@ test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
     await expect(
       page.getByRole("region", { name: "Lista de informes" }),
     ).toBeVisible({ timeout: 8_000 });
-    await expect(
-      page.getByRole("region", { name: "Detalle del informe" }),
-    ).toBeVisible({ timeout: 8_000 });
+    // Inline master-detail: the detail expands inside the selected report row,
+    // so there is no standalone "Detalle del informe" region without a selection.
+    await expect(page.locator("#report-detail")).toHaveCount(0);
   });
 
   test("workspace Volver button keeps dashboard-btn-interactive (PR-1 contract preserved)", async ({

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -2,12 +2,11 @@
 
 import { useState } from "react";
 import type { Report } from "@/types";
-import { ArrowLeft, ClipboardList, ExternalLink } from "lucide-react";
+import { ClipboardList, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
 import { cn, formatDate } from "@/lib/utils";
 
@@ -23,18 +22,10 @@ export function ClinicInformesWorkspaceSummary({
   const [selectedReportId, setSelectedReportId] = useState<number | null>(
     recentReports[0]?.id ?? null,
   );
-  // Mobile/tablet replacement layer: detail covers the list (no vertical stack).
-  const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
-
   const selectedReport =
     recentReports.find((report) => report.id === selectedReportId) ??
     recentReports[0] ??
     null;
-
-  function selectReport(reportId: number) {
-    setSelectedReportId(reportId);
-    setIsMobileDetailOpen(true);
-  }
 
   const fullModuleLink = (
     <PublicRouteControl
@@ -70,116 +61,97 @@ export function ClinicInformesWorkspaceSummary({
           No se pudieron cargar los informes recientes. Intente nuevamente.
         </p>
       ) : recentReports.length ? (
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 xl:grid-cols-[0.85fr_1.15fr]">
-          <div
-            className={cn(
-              "flex min-h-0 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82",
-              isMobileDetailOpen && "hidden xl:flex",
-            )}
-          >
-            <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden">
+        <div className="dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82">
+            <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
               {recentReports.map((report) => {
                 const isSelected = selectedReport?.id === report.id;
 
                 return (
-                  <button
-                    key={report.id}
-                    type="button"
-                    onClick={() => selectReport(report.id)}
-                    aria-pressed={isSelected}
-                    className={cn(
-                      "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                      isSelected && "bg-vetneb-cyan/12",
-                    )}
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-vetneb-ink">
-                        {report.patientName ?? "Sin nombre"}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {report.studyType} · {formatDate(report.uploadDate)}
-                      </p>
-                    </div>
-                    <StatusBadge status={report.status} size="sm" className="ml-2 shrink-0" />
-                  </button>
+                  <div key={report.id} className="min-w-0">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedReportId(report.id)}
+                      aria-pressed={isSelected}
+                      aria-expanded={isSelected}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                        isSelected && "bg-vetneb-cyan/12",
+                      )}
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-vetneb-ink">
+                          {report.patientName ?? "Sin nombre"}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {report.studyType} · {formatDate(report.uploadDate)}
+                        </p>
+                      </div>
+                      <StatusBadge status={report.status} size="sm" className="ml-2 shrink-0" />
+                    </button>
+
+                    {isSelected && selectedReport ? (
+                      <div
+                        data-detail-state="selected"
+                        className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40 p-4"
+                      >
+                        <div className="space-y-3">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                Detalle del informe
+                              </p>
+                              <h4 className="mt-1 break-words text-lg font-semibold text-vetneb-ink">
+                                {selectedReport.patientName ?? "Sin nombre"}
+                              </h4>
+                            </div>
+                            <StatusBadge status={selectedReport.status} size="sm" className="shrink-0" />
+                          </div>
+                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            <div className="clinical-muted-band rounded-lg px-3 py-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Estudio
+                              </p>
+                              <p className="mt-1 text-xs text-vetneb-ink">
+                                {selectedReport.studyType ?? "—"}
+                              </p>
+                            </div>
+                            <div className="clinical-muted-band rounded-lg px-3 py-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Carga
+                              </p>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {formatDate(selectedReport.uploadDate)}
+                              </p>
+                            </div>
+                            <div className="clinical-muted-band rounded-lg px-3 py-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Informe
+                              </p>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                #{selectedReport.id} · {selectedReport.hasFile ? "Con archivo" : "Sin archivo"}
+                              </p>
+                            </div>
+                            <div className="clinical-muted-band rounded-lg px-3 py-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Acción
+                              </p>
+                              <PublicRouteControl
+                                href={`${ROUTES.dashboardInformes}?reportId=${selectedReport.id}`}
+                                variant="textLink"
+                                className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                                aria-label={`Abrir informe ${selectedReport.id} en el módulo completo`}
+                              >
+                                Abrir en módulo completo
+                              </PublicRouteControl>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
                 );
               })}
             </div>
-          </div>
-
-          <div
-            className={cn(
-              "min-h-0 overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82 p-4",
-              !isMobileDetailOpen && "hidden xl:block",
-            )}
-          >
-            {selectedReport ? (
-              <div className="space-y-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="xl:hidden"
-                  onClick={() => setIsMobileDetailOpen(false)}
-                >
-                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-                  Volver a la lista
-                </Button>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                      Detalle del informe
-                    </p>
-                    <h4 className="mt-1 truncate text-lg font-semibold text-vetneb-ink">
-                      {selectedReport.patientName ?? "Sin nombre"}
-                    </h4>
-                  </div>
-                  <StatusBadge status={selectedReport.status} size="sm" className="shrink-0" />
-                </div>
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Estudio
-                    </p>
-                    <p className="mt-1 text-xs text-vetneb-ink">
-                      {selectedReport.studyType ?? "—"}
-                    </p>
-                  </div>
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Carga
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {formatDate(selectedReport.uploadDate)}
-                    </p>
-                  </div>
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Informe
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      #{selectedReport.id} · {selectedReport.hasFile ? "Con archivo" : "Sin archivo"}
-                    </p>
-                  </div>
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Acción
-                    </p>
-                    <PublicRouteControl
-                      href={`${ROUTES.dashboardInformes}?reportId=${selectedReport.id}`}
-                      variant="textLink"
-                      className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                      aria-label={`Abrir informe ${selectedReport.id} en el módulo completo`}
-                    >
-                      Abrir en módulo completo
-                    </PublicRouteControl>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <p className="surface-empty">Seleccione un informe para ver el detalle.</p>
-            )}
-          </div>
         </div>
       ) : (
         <EmptyState

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -2,12 +2,11 @@
 
 import { useState } from "react";
 import type { FieldVisit } from "@/types";
-import { ArrowLeft, Route as RouteIcon, ExternalLink } from "lucide-react";
+import { Route as RouteIcon, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { Button } from "@/components/ui/button";
 import { ROUTES } from "@/lib/routes";
 import { cn, formatDate } from "@/lib/utils";
 
@@ -23,18 +22,10 @@ export function ClinicLogisticaWorkspaceSummary({
   const [selectedVisitId, setSelectedVisitId] = useState<number | null>(
     recentVisits[0]?.id ?? null,
   );
-  // Mobile/tablet replacement layer: detail covers the list (no vertical stack).
-  const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
-
   const selectedVisit =
     recentVisits.find((visit) => visit.id === selectedVisitId) ??
     recentVisits[0] ??
     null;
-
-  function selectVisit(visitId: number) {
-    setSelectedVisitId(visitId);
-    setIsMobileDetailOpen(true);
-  }
 
   const fullModuleLink = (
     <PublicRouteControl
@@ -70,116 +61,97 @@ export function ClinicLogisticaWorkspaceSummary({
           No se pudieron cargar las visitas de campo. Intente nuevamente.
         </p>
       ) : recentVisits.length ? (
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 xl:grid-cols-[0.85fr_1.15fr]">
-          <div
-            className={cn(
-              "flex min-h-0 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82",
-              isMobileDetailOpen && "hidden xl:flex",
-            )}
-          >
-            <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden">
+        <div className="dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82">
+            <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
               {recentVisits.map((visit) => {
                 const isSelected = selectedVisit?.id === visit.id;
 
                 return (
-                  <button
-                    key={visit.id}
-                    type="button"
-                    onClick={() => selectVisit(visit.id)}
-                    aria-pressed={isSelected}
-                    className={cn(
-                      "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                      isSelected && "bg-vetneb-cyan/12",
-                    )}
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-vetneb-ink">
-                        {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {formatDate(visit.scheduledAt)}
-                      </p>
-                    </div>
-                    <StatusBadge status={visit.status} size="sm" className="ml-2 shrink-0" />
-                  </button>
+                  <div key={visit.id} className="min-w-0">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedVisitId(visit.id)}
+                      aria-pressed={isSelected}
+                      aria-expanded={isSelected}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                        isSelected && "bg-vetneb-cyan/12",
+                      )}
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-vetneb-ink">
+                          {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDate(visit.scheduledAt)}
+                        </p>
+                      </div>
+                      <StatusBadge status={visit.status} size="sm" className="ml-2 shrink-0" />
+                    </button>
+
+                    {isSelected && selectedVisit ? (
+                      <div
+                        data-detail-state="selected"
+                        className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40 p-4"
+                      >
+                        <div className="space-y-3">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                Detalle de la visita
+                              </p>
+                              <h4 className="mt-1 break-words text-lg font-semibold text-vetneb-ink">
+                                {selectedVisit.clinicName ?? `Clínica #${selectedVisit.clinicId}`}
+                              </h4>
+                            </div>
+                            <StatusBadge status={selectedVisit.status} size="sm" className="shrink-0" />
+                          </div>
+                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            <div className="clinical-muted-band rounded-lg px-3 py-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Programada
+                              </p>
+                              <p className="mt-1 text-xs text-vetneb-ink">
+                                {formatDate(selectedVisit.scheduledAt)}
+                              </p>
+                            </div>
+                            <div className="clinical-muted-band rounded-lg px-3 py-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Completada
+                              </p>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {selectedVisit.completedAt ? formatDate(selectedVisit.completedAt) : "—"}
+                              </p>
+                            </div>
+                            <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Dirección
+                              </p>
+                              <p className="mt-1 break-words text-xs text-muted-foreground">
+                                {selectedVisit.address ?? "Sin dirección registrada"}
+                              </p>
+                            </div>
+                            <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
+                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                Acción
+                              </p>
+                              <PublicRouteControl
+                                href={ROUTES.dashboardLogisticaVisitas}
+                                variant="textLink"
+                                className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
+                                aria-label="Abrir visitas de campo en el módulo completo"
+                              >
+                                Abrir visitas en módulo completo
+                              </PublicRouteControl>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
                 );
               })}
             </div>
-          </div>
-
-          <div
-            className={cn(
-              "min-h-0 overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82 p-4",
-              !isMobileDetailOpen && "hidden xl:block",
-            )}
-          >
-            {selectedVisit ? (
-              <div className="space-y-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="xl:hidden"
-                  onClick={() => setIsMobileDetailOpen(false)}
-                >
-                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-                  Volver a la lista
-                </Button>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                      Detalle de la visita
-                    </p>
-                    <h4 className="mt-1 truncate text-lg font-semibold text-vetneb-ink">
-                      {selectedVisit.clinicName ?? `Clínica #${selectedVisit.clinicId}`}
-                    </h4>
-                  </div>
-                  <StatusBadge status={selectedVisit.status} size="sm" className="shrink-0" />
-                </div>
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Programada
-                    </p>
-                    <p className="mt-1 text-xs text-vetneb-ink">
-                      {formatDate(selectedVisit.scheduledAt)}
-                    </p>
-                  </div>
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Completada
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {selectedVisit.completedAt ? formatDate(selectedVisit.completedAt) : "—"}
-                    </p>
-                  </div>
-                  <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Dirección
-                    </p>
-                    <p className="mt-1 truncate text-xs text-muted-foreground">
-                      {selectedVisit.address ?? "Sin dirección registrada"}
-                    </p>
-                  </div>
-                  <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Acción
-                    </p>
-                    <PublicRouteControl
-                      href={ROUTES.dashboardLogisticaVisitas}
-                      variant="textLink"
-                      className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                      aria-label="Abrir visitas de campo en el módulo completo"
-                    >
-                      Abrir visitas en módulo completo
-                    </PublicRouteControl>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <p className="surface-empty">Seleccione una visita para ver el detalle.</p>
-            )}
-          </div>
         </div>
       ) : (
         <EmptyState

--- a/frontend/src/app/dashboard/admin/AdminAuditLogTable.tsx
+++ b/frontend/src/app/dashboard/admin/AdminAuditLogTable.tsx
@@ -79,8 +79,8 @@ export function AdminAuditLogTable({
           </div>
         ) : null}
 
-        <div className="dashboard-fitted-table px-6">
-          <Table>
+        <div className="dashboard-fitted-table px-3 sm:px-6">
+          <Table className="[&_td]:py-2 [&_th]:h-9">
             <TableHeader>
               <TableRow>
                 <TableHead>ID</TableHead>
@@ -112,19 +112,19 @@ export function AdminAuditLogTable({
                     <TableCell>
                       <Badge variant={entry.eventVariant}>{entry.eventLabel}</Badge>
                     </TableCell>
-                    <TableCell className="text-sm text-vetneb-ink/88">
+                    <TableCell className="whitespace-normal wrap-break-word text-sm text-vetneb-ink/88">
                       {entry.actor}
                     </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
+                    <TableCell className="whitespace-normal wrap-break-word text-sm text-muted-foreground">
                       {entry.actorTypeLabel}
                     </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
+                    <TableCell className="whitespace-normal wrap-break-word text-sm text-muted-foreground">
                       {entry.target}
                     </TableCell>
                     <TableCell className="max-w-md whitespace-normal wrap-break-word text-xs text-muted-foreground">
                       {entry.detail}
                     </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
+                    <TableCell className="whitespace-normal text-xs text-muted-foreground">
                       {entry.date}
                     </TableCell>
                   </TableRow>
@@ -142,7 +142,7 @@ export function AdminAuditLogTable({
           </Table>
         </div>
 
-        <div className="px-6 pb-4">
+        <div className="shrink-0 px-3 pb-4 sm:px-6">
           <CompactPager
             page={paged.page}
             pageCount={paged.pageCount}

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -917,8 +917,8 @@ export function AdminParticularTokensCard() {
   }
 
   return (
-    <Card className="dashboard-surface overflow-hidden">
-      <CardHeader className="border-b border-vetneb-line/70">
+    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
+      <CardHeader className="shrink-0 border-b border-vetneb-line/70">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
           <div>
             <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
@@ -955,11 +955,11 @@ export function AdminParticularTokensCard() {
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4 pt-4">
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-4 pt-4">
         <div
           role="tablist"
           aria-label="Secciones de tokens particulares"
-          className="flex flex-wrap gap-2 rounded-xl border border-vetneb-line/75 bg-card/78 p-1"
+          className="flex shrink-0 flex-wrap gap-2 rounded-xl border border-vetneb-line/75 bg-card/78 p-1"
         >
           <Button
             type="button"
@@ -986,7 +986,7 @@ export function AdminParticularTokensCard() {
         {generatedToken ? (
           <section
             aria-labelledby="generated-token-heading"
-            className="rounded-xl border border-vetneb-cyan/45 bg-vetneb-cyan/10 p-4 shadow-[0_10px_32px_rgba(14,116,144,0.08)]"
+            className="shrink-0 rounded-xl border border-vetneb-cyan/45 bg-vetneb-cyan/10 p-4 shadow-[0_10px_32px_rgba(14,116,144,0.08)]"
           >
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div className="min-w-0">
@@ -1070,20 +1070,20 @@ export function AdminParticularTokensCard() {
         ) : null}
 
         {errorMessage ? (
-          <p className="clinical-alert-error px-3 py-2" role="alert">
+          <p className="clinical-alert-error shrink-0 px-3 py-2" role="alert">
             {errorMessage}
           </p>
         ) : null}
 
         {statusMessage ? (
-          <p className="clinical-alert-success px-3 py-2">{statusMessage}</p>
+          <p className="clinical-alert-success shrink-0 px-3 py-2">{statusMessage}</p>
         ) : null}
 
         {activePanel === "create" ? (
           <section
             role="tabpanel"
             aria-label="Generar token particular"
-            className="rounded-xl border border-vetneb-line/75 bg-card/82 p-4"
+            className="dashboard-inline-scroll rounded-xl border border-vetneb-line/75 bg-card/82 p-4"
           >
             <div className="mb-4">
               <h3 className="dashboard-section-heading">Nuevo token particular</h3>
@@ -1423,16 +1423,16 @@ export function AdminParticularTokensCard() {
           <section
             role="tabpanel"
             aria-label="Tokens particulares administrados"
-            className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[0.82fr_1.46fr]"
+            className="flex min-h-0 flex-1 flex-col"
           >
-            <div className="rounded-xl border border-vetneb-line/75 bg-card/82">
-              <div className="flex items-center justify-between gap-3 border-b border-vetneb-line/70 px-4 py-3">
+            <div className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82">
+              <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-4 py-3">
                 <div>
                   <h3 className="dashboard-section-heading">
                     Últimos tokens administrados
                   </h3>
                   <p className="dashboard-section-description">
-                    Seleccionar un token abre el detalle.
+                    Seleccionar un token despliega el detalle dentro del propio token.
                   </p>
                 </div>
                 <Button
@@ -1447,29 +1447,30 @@ export function AdminParticularTokensCard() {
               </div>
 
               {trackingLoadError ? (
-                <p className="clinical-alert-warning m-3 px-3 py-2 text-sm" role="alert">
+                <p className="clinical-alert-warning m-3 shrink-0 px-3 py-2 text-sm" role="alert">
                   {trackingLoadError}
                 </p>
               ) : null}
 
               {tokens.length ? (
-                <div className="divide-y divide-vetneb-line/60">
+                <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
                   {tokens.map((token) => {
                     const isSelected = selectedToken?.id === token.id;
                     const trackingCase = trackingCasesByTokenId[token.id];
 
                     return (
-                      <button
-                        key={token.id}
-                        type="button"
-                        onClick={() => setSelectedTokenId(token.id)}
-                        aria-pressed={isSelected}
-                        className={cn(
-                          "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                          isSelected && "bg-vetneb-cyan/12",
-                        )}
-                      >
-                        <div className="flex items-start justify-between gap-3">
+                      <div key={token.id} className="min-w-0">
+                        <button
+                          type="button"
+                          onClick={() => setSelectedTokenId(token.id)}
+                          aria-pressed={isSelected}
+                          aria-expanded={isSelected}
+                          className={cn(
+                            "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                            isSelected && "bg-vetneb-cyan/12",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
                           <div className="min-w-0">
                             <p className="truncate text-sm font-semibold text-vetneb-ink">
                               {formatTokenTitle(clinicOptions, token)}
@@ -1493,21 +1494,13 @@ export function AdminParticularTokensCard() {
                             </Badge>
                           </div>
                         </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              ) : (
-                <p className="surface-empty m-4">
-                  {isLoadingTokens
-                    ? "Cargando tokens particulares..."
-                    : "No hay tokens particulares administrados."}
-                </p>
-              )}
-            </div>
+                        </button>
 
-            <div className="rounded-xl border border-vetneb-line/75 bg-card/82">
-              {selectedToken ? (
+                        {isSelected && selectedToken ? (
+                          <div
+                            data-detail-state="selected"
+                            className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
+                          >
                 <div className="space-y-4 p-4">
                   <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
                     <div className="min-w-0">
@@ -1767,9 +1760,17 @@ export function AdminParticularTokensCard() {
                     </Button>
                   </div>
                 </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
               ) : (
                 <p className="surface-empty m-4">
-                  Seleccione un token para abrir el detalle.
+                  {isLoadingTokens
+                    ? "Cargando tokens particulares..."
+                    : "No hay tokens particulares administrados."}
                 </p>
               )}
             </div>

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -299,8 +299,8 @@ export default async function InformesPage({
           }
         />
 
-        <Card className="dashboard-surface overflow-hidden">
-          <CardHeader className="border-b border-vetneb-line/70">
+        <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
+          <CardHeader className="shrink-0 border-b border-vetneb-line/70">
             <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
               <div>
                 <CardTitle className="text-base">Informes disponibles</CardTitle>
@@ -336,12 +336,12 @@ export default async function InformesPage({
             </div>
           </CardHeader>
 
-          <CardContent className="space-y-4 pt-4">
+          <CardContent className="flex min-h-0 flex-1 flex-col gap-4 pt-4">
             <form
               method="get"
               role="search"
               aria-label="Filtros compactos de informes"
-              className="rounded-xl border border-vetneb-line/75 bg-card/78 p-3 shadow-[0_8px_28px_rgba(15,45,62,0.04)]"
+              className="shrink-0 rounded-xl border border-vetneb-line/75 bg-card/78 p-3 shadow-[0_8px_28px_rgba(15,45,62,0.04)]"
             >
               <div className="grid grid-cols-1 gap-3 lg:grid-cols-[1.4fr_0.8fr_1fr_auto] lg:items-end">
                 <label className="block">
@@ -397,13 +397,13 @@ export default async function InformesPage({
             </form>
 
             {reportsLoadError || reports.length === 0 ? (
-              <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[0.86fr_1.44fr]">
+              <div className="flex min-h-0 flex-1 flex-col">
                 <section
                   id="reports-master-list"
                   aria-labelledby="reports-list-heading"
-                  className="dashboard-master-panel rounded-xl border border-vetneb-line/75 bg-card/82"
+                  className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
                 >
-                  <div className="border-b border-vetneb-line/70 px-4 py-3">
+                  <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
                     <h2
                       id="reports-list-heading"
                       className="dashboard-section-heading"
@@ -415,7 +415,7 @@ export default async function InformesPage({
                     </p>
                   </div>
 
-                  <div className="p-4">
+                  <div className="dashboard-inline-scroll p-4">
                     {reportsLoadError ? (
                       <div role="alert">
                         <ErrorState
@@ -431,36 +431,17 @@ export default async function InformesPage({
                     )}
                   </div>
                 </section>
-
-                <section
-                  id="report-detail"
-                  aria-labelledby="report-detail-heading"
-                  className="dashboard-detail-panel rounded-xl border border-vetneb-line/75 bg-card/82"
-                >
-                  <div className="p-4">
-                    <h2
-                      id="report-detail-heading"
-                      className="sr-only"
-                    >
-                      Detalle del informe
-                    </h2>
-                    <EmptyState
-                      title="No hay informe seleccionado"
-                      description="Seleccione un informe de la lista para ver el detalle operativo."
-                    />
-                  </div>
-                </section>
               </div>
             ) : null}
 
             {!reportsLoadError && reports.length > 0 ? (
-              <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[0.86fr_1.44fr]">
+              <div className="flex min-h-0 flex-1 flex-col">
                 <section
                   id="reports-master-list"
                   aria-labelledby="reports-list-heading"
-                  className="dashboard-master-panel rounded-xl border border-vetneb-line/75 bg-card/82"
+                  className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
                 >
-                  <div className="border-b border-vetneb-line/70 px-4 py-3">
+                  <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
                     <h2
                       id="reports-list-heading"
                       className="dashboard-section-heading"
@@ -468,60 +449,177 @@ export default async function InformesPage({
                       Lista de informes
                     </h2>
                     <p className="dashboard-section-description">
-                      Click en un informe para ver detalles y acciones.
+                      Click en un informe para ver el detalle desplegado dentro del propio informe.
                     </p>
                   </div>
 
-                  <div className="divide-y divide-vetneb-line/60">
+                  <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
                     {reports.map((report) => {
                       const isSelected = selectedReport?.id === report.id;
 
                       return (
-                        <PublicRouteControl
-                          key={report.id}
-                          id={`report-${report.id}`}
-                          href={buildInformesHref({
-                            query,
-                            status,
-                            studyType,
-                            reportId: report.id,
-                            page,
-                          })}
-                          replace
-                          prefetch={false}
-                          variant="bare"
-                          aria-current={isSelected ? "true" : undefined}
-                          aria-label={
-                            isSelected
-                              ? `Informe seleccionado: ${getReportTitle(report)}`
-                              : `Seleccionar informe: ${getReportTitle(report)}`
-                          }
-                          className={cn(
-                            "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                            isSelected && "bg-vetneb-cyan/12",
-                          )}
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                Informe #{report.id}
-                              </p>
-                              <p className="mt-1 truncate text-sm font-semibold text-vetneb-ink">
-                                {report.patientName ?? "Paciente sin nombre"}
-                              </p>
-                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                                {report.studyType ?? "Tipo sin registrar"} ·{" "}
-                                {formatDate(report.uploadDate)}
-                              </p>
+                        <div key={report.id} className="min-w-0">
+                          <PublicRouteControl
+                            id={`report-${report.id}`}
+                            href={buildInformesHref({
+                              query,
+                              status,
+                              studyType,
+                              reportId: report.id,
+                              page,
+                            })}
+                            replace
+                            prefetch={false}
+                            variant="bare"
+                            aria-current={isSelected ? "true" : undefined}
+                            aria-expanded={isSelected}
+                            aria-label={
+                              isSelected
+                                ? `Informe seleccionado: ${getReportTitle(report)}`
+                                : `Seleccionar informe: ${getReportTitle(report)}`
+                            }
+                            className={cn(
+                              "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                              isSelected && "bg-vetneb-cyan/12",
+                            )}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                  Informe #{report.id}
+                                </p>
+                                <p className="mt-1 truncate text-sm font-semibold text-vetneb-ink">
+                                  {report.patientName ?? "Paciente sin nombre"}
+                                </p>
+                                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                  {report.studyType ?? "Tipo sin registrar"} ·{" "}
+                                  {formatDate(report.uploadDate)}
+                                </p>
+                              </div>
+                              <Badge
+                                variant={getReportStatusVariant(report.status)}
+                                className="shrink-0"
+                              >
+                                {getReportStatusLabel(report.status)}
+                              </Badge>
                             </div>
-                            <Badge
-                              variant={getReportStatusVariant(report.status)}
-                              className="shrink-0"
+                          </PublicRouteControl>
+
+                          {isSelected && selectedReport ? (
+                            <div
+                              id="report-detail"
+                              aria-labelledby="report-detail-heading"
+                              data-detail-state="selected"
+                              className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
                             >
-                              {getReportStatusLabel(report.status)}
-                            </Badge>
-                          </div>
-                        </PublicRouteControl>
+                              <div className="space-y-4 p-4">
+                                <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
+                                  <div className="min-w-0">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                      Detalle del informe
+                                    </p>
+                                    <h2
+                                      id="report-detail-heading"
+                                      className="mt-1 text-xl font-semibold text-vetneb-ink"
+                                    >
+                                      {getReportTitle(selectedReport)}
+                                    </h2>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                      Clínica{" "}
+                                      {selectedReport.clinicName ??
+                                        `#${selectedReport.clinicId}`}
+                                    </p>
+                                  </div>
+                                  <StatusBadge
+                                    status={selectedReport.status}
+                                    label={getReportStatusLabel(selectedReport.status)}
+                                  />
+                                </div>
+
+                                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                                  <div className="surface-soft">
+                                    <p className="text-xs text-muted-foreground">Paciente</p>
+                                    <p className="mt-1 font-semibold text-vetneb-ink">
+                                      {selectedReport.patientName ?? "—"}
+                                    </p>
+                                  </div>
+                                  <div className="surface-soft">
+                                    <p className="text-xs text-muted-foreground">
+                                      Tipo de estudio
+                                    </p>
+                                    <p className="mt-1 font-semibold text-vetneb-ink">
+                                      {selectedReport.studyType ?? "—"}
+                                    </p>
+                                  </div>
+                                  <div className="surface-soft">
+                                    <p className="text-xs text-muted-foreground">Fecha</p>
+                                    <p className="mt-1 font-semibold text-vetneb-ink">
+                                      {formatDate(selectedReport.uploadDate)}
+                                    </p>
+                                  </div>
+                                  <div className="surface-soft">
+                                    <p className="text-xs text-muted-foreground">Creado</p>
+                                    <p className="mt-1 font-semibold text-vetneb-ink">
+                                      {formatDate(selectedReport.createdAt)}
+                                    </p>
+                                  </div>
+                                  <div className="surface-soft">
+                                    <p className="text-xs text-muted-foreground">
+                                      Actualizado
+                                    </p>
+                                    <p className="mt-1 font-semibold text-vetneb-ink">
+                                      {formatDate(selectedReport.updatedAt)}
+                                    </p>
+                                  </div>
+                                  <div className="surface-soft">
+                                    <p className="text-xs text-muted-foreground">Archivo</p>
+                                    <p className="mt-1 font-semibold text-vetneb-ink">
+                                      {selectedReport.fileName ??
+                                        (selectedReport.hasFile ? "Disponible" : "—")}
+                                    </p>
+                                  </div>
+                                </div>
+
+                                <section className="space-y-3" aria-labelledby="report-actions-heading">
+                                  <div>
+                                    <h3
+                                      id="report-actions-heading"
+                                      className="text-base font-semibold text-vetneb-ink"
+                                    >
+                                      Acciones
+                                    </h3>
+                                    <p className="text-sm text-muted-foreground">
+                                      Visualización y descarga del archivo disponible.
+                                    </p>
+                                  </div>
+                                  <ReportFileActions
+                                    reportId={selectedReport.id}
+                                    hasFile={selectedReport.hasFile}
+                                    align="start"
+                                  />
+                                </section>
+
+                                <section
+                                  className="space-y-3"
+                                  aria-labelledby="study-timeline-heading"
+                                >
+                                  <div>
+                                    <h3
+                                      id="study-timeline-heading"
+                                      className="text-base font-semibold text-vetneb-ink"
+                                    >
+                                      Línea de tiempo del estudio
+                                    </h3>
+                                    <p className="text-sm text-muted-foreground">
+                                      Pasos derivados del estado y fechas ya disponibles.
+                                    </p>
+                                  </div>
+                                  <StudyTimeline steps={selectedReportTimelineSteps} />
+                                </section>
+                              </div>
+                            </div>
+                          ) : null}
+                        </div>
                       );
                     })}
                   </div>
@@ -529,7 +627,7 @@ export default async function InformesPage({
                   {reportsTotalPages > 1 ? (
                     <nav
                       aria-label="Paginación de informes"
-                      className="flex items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+                      className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
                     >
                       <PublicRouteControl
                         href={buildInformesHref({
@@ -570,126 +668,6 @@ export default async function InformesPage({
                       </PublicRouteControl>
                     </nav>
                   ) : null}
-                </section>
-
-                <section
-                  id="report-detail"
-                  aria-labelledby="report-detail-heading"
-                  className="dashboard-master-panel rounded-xl border border-vetneb-line/75 bg-card/82"
-                >
-                  {selectedReport ? (
-                    <div className="space-y-4 p-4">
-                      <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
-                        <div className="min-w-0">
-                          <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                            Detalle del informe
-                          </p>
-                          <h2
-                            id="report-detail-heading"
-                            className="mt-1 text-xl font-semibold text-vetneb-ink"
-                          >
-                            {getReportTitle(selectedReport)}
-                          </h2>
-                          <p className="mt-1 text-sm text-muted-foreground">
-                            Clínica{" "}
-                            {selectedReport.clinicName ??
-                              `#${selectedReport.clinicId}`}
-                          </p>
-                        </div>
-                        <StatusBadge
-                          status={selectedReport.status}
-                          label={getReportStatusLabel(selectedReport.status)}
-                        />
-                      </div>
-
-                      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-                        <div className="surface-soft">
-                          <p className="text-xs text-muted-foreground">Paciente</p>
-                          <p className="mt-1 font-semibold text-vetneb-ink">
-                            {selectedReport.patientName ?? "—"}
-                          </p>
-                        </div>
-                        <div className="surface-soft">
-                          <p className="text-xs text-muted-foreground">
-                            Tipo de estudio
-                          </p>
-                          <p className="mt-1 font-semibold text-vetneb-ink">
-                            {selectedReport.studyType ?? "—"}
-                          </p>
-                        </div>
-                        <div className="surface-soft">
-                          <p className="text-xs text-muted-foreground">Fecha</p>
-                          <p className="mt-1 font-semibold text-vetneb-ink">
-                            {formatDate(selectedReport.uploadDate)}
-                          </p>
-                        </div>
-                        <div className="surface-soft">
-                          <p className="text-xs text-muted-foreground">Creado</p>
-                          <p className="mt-1 font-semibold text-vetneb-ink">
-                            {formatDate(selectedReport.createdAt)}
-                          </p>
-                        </div>
-                        <div className="surface-soft">
-                          <p className="text-xs text-muted-foreground">
-                            Actualizado
-                          </p>
-                          <p className="mt-1 font-semibold text-vetneb-ink">
-                            {formatDate(selectedReport.updatedAt)}
-                          </p>
-                        </div>
-                        <div className="surface-soft">
-                          <p className="text-xs text-muted-foreground">Archivo</p>
-                          <p className="mt-1 font-semibold text-vetneb-ink">
-                            {selectedReport.fileName ??
-                              (selectedReport.hasFile ? "Disponible" : "—")}
-                          </p>
-                        </div>
-                      </div>
-
-                      <section className="space-y-3" aria-labelledby="report-actions-heading">
-                        <div>
-                          <h3
-                            id="report-actions-heading"
-                            className="text-base font-semibold text-vetneb-ink"
-                          >
-                            Acciones
-                          </h3>
-                          <p className="text-sm text-muted-foreground">
-                            Visualización y descarga del archivo disponible.
-                          </p>
-                        </div>
-                        <ReportFileActions
-                          reportId={selectedReport.id}
-                          hasFile={selectedReport.hasFile}
-                          align="start"
-                        />
-                      </section>
-
-                      <section
-                        className="space-y-3"
-                        aria-labelledby="study-timeline-heading"
-                      >
-                        <div>
-                          <h3
-                            id="study-timeline-heading"
-                            className="text-base font-semibold text-vetneb-ink"
-                          >
-                            Línea de tiempo del estudio
-                          </h3>
-                          <p className="text-sm text-muted-foreground">
-                            Pasos derivados del estado y fechas ya disponibles.
-                          </p>
-                        </div>
-                        <StudyTimeline steps={selectedReportTimelineSteps} />
-                      </section>
-                    </div>
-                  ) : (
-                    <EmptyState
-                      title="No hay informe seleccionado"
-                      description="Seleccione un informe de la lista para ver el detalle operativo."
-                      className="m-5"
-                    />
-                  )}
                 </section>
               </div>
             ) : null}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2196,3 +2196,93 @@
   }
 }
 /* dashboard-viewport-zoom-adaptability:end */
+/* dashboard-global-inline-adaptive:start */
+/*
+  Global inline master-detail + adaptive overflow guard for BOTH dashboards
+  (Administración + Clínica).
+
+  Builds on the no-scroll App Shell (PR-A/#1014) and the density layer
+  (#1017 / dashboard-viewport-zoom-adaptability). Goal: the detail opens INLINE
+  inside the selected list item (no rigid lateral panel) and every dashboard
+  surface adapts to the effective viewport/zoom without overlapping, without
+  horizontal overflow and without leaving the page. Reusable classes scoped to
+  `.dashboard-app-shell`; the pinned className/@apply contracts are not edited,
+  so the no-scroll contract is preserved — every rule only helps content fit.
+*/
+@layer components {
+  /* Inline master-detail list: the list is the only column; the selected item
+     expands its detail within the list flow. The list body is bounded and
+     internally scrollable so the expanded detail is always reachable while the
+     shell stays no-scroll (an inner scroll never grows `main`). */
+  .dashboard-inline-list {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+
+  .dashboard-inline-scroll {
+    min-height: 0;
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+  }
+
+  /* Inline detail card: expands under the selected row, fluid to the available
+     width; long values wrap instead of forcing a horizontal scroll. */
+  .dashboard-inline-detail {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+    overflow-wrap: break-word;
+  }
+
+  /* ── Global no-horizontal-overflow guard (both dashboards) ───────────────── */
+  /* Cards/surfaces shrink in flex/grid instead of forcing width; media and
+     tables never exceed their container. */
+  .dashboard-app-shell :is(.dashboard-surface, .surface-soft, .clinical-muted-band) {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .dashboard-app-shell :is(img, svg, video, table, pre) {
+    max-width: 100%;
+  }
+
+  /* Opt-in wrapper: a wide table scrolls inside its own card, never the page. */
+  .dashboard-table-scroll {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  /* Data tables own the remaining card height. Their existing table wrapper
+     handles local overflow, so long audit values cannot grow over pagination. */
+  .dashboard-app-shell .dashboard-fitted-table {
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .dashboard-app-shell .dashboard-fitted-table > div {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .dashboard-app-shell .dashboard-compact-pager {
+    min-width: 0;
+    max-width: 100%;
+    flex-wrap: wrap;
+  }
+
+  /* Chips compact with the effective viewport (browser zoom) so estados/etiquetas
+     never overflow their row. Scoped to dashboards only. */
+  @media (max-height: 760px), (max-width: 1280px) {
+    .dashboard-app-shell .clinical-pill {
+      font-size: var(--dash-secondary-font);
+    }
+  }
+}
+/* dashboard-global-inline-adaptive:end */

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
-import { ArrowLeft } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -231,8 +230,6 @@ export function ClinicParticularTokensCard() {
     useState<ClinicParticularTokenFormState>(INITIAL_FORM_STATE);
   const [tokens, setTokens] = useState<ClinicParticularTokenSummary[]>([]);
   const [selectedTokenId, setSelectedTokenId] = useState<number | null>(null);
-  // Mobile/tablet replacement layer: detail covers the list (no vertical stack).
-  const [isMobileDetailOpen, setIsMobileDetailOpen] = useState(false);
   const [trackingCasesByTokenId, setTrackingCasesByTokenId] = useState<
     Record<number, ClinicStudyTrackingCaseSummary>
   >({});
@@ -339,11 +336,6 @@ export function ClinicParticularTokensCard() {
     setFormState((current) => ({ ...current, [field]: value }));
     setErrorMessage(null);
     setStatusMessage(null);
-  }
-
-  function selectToken(tokenId: number) {
-    setSelectedTokenId(tokenId);
-    setIsMobileDetailOpen(true);
   }
 
   function handleCreateDialogOpenChange(open: boolean) {
@@ -558,21 +550,16 @@ export function ClinicParticularTokensCard() {
 
         <section
           aria-label="Tokens particulares de la clínica"
-          className="grid min-h-0 flex-1 grid-cols-1 gap-4 xl:grid-cols-[0.82fr_1.46fr]"
+          className="flex min-h-0 flex-1 flex-col"
         >
-          <div
-            className={cn(
-              "flex min-h-0 flex-col overflow-hidden rounded-xl border border-vetneb-line/75 bg-card/82",
-              isMobileDetailOpen && "hidden xl:flex",
-            )}
-          >
+          <div className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82">
             <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-4 py-3">
               <div>
                 <h3 className="text-sm font-semibold text-vetneb-ink">
                   Últimos tokens de la clínica
                 </h3>
                 <p className="dashboard-section-description">
-                  Seleccionar un token abre el detalle.
+                  Seleccionar un token despliega el detalle dentro del propio token.
                 </p>
               </div>
               <Button
@@ -594,47 +581,160 @@ export function ClinicParticularTokensCard() {
 
             {tokens.length ? (
               <>
-                <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden">
+                <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
                   {pagedTokens.pageItems.map((token) => {
                     const isSelected = selectedToken?.id === token.id;
                     const trackingCase = trackingCasesByTokenId[token.id];
 
                     return (
-                      <button
-                        key={token.id}
-                        type="button"
-                        id={`clinic-particular-token-${token.id}`}
-                        onClick={() => selectToken(token.id)}
-                        aria-pressed={isSelected}
-                        className={cn(
-                          "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                          isSelected && "bg-vetneb-cyan/12",
-                        )}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-sm font-semibold text-vetneb-ink">
-                              {token.petName} · {token.tutorLastName}
-                            </p>
-                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                              Token ****{token.tokenLast4}
-                            </p>
-                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                              {trackingCase
-                                ? getTrackingStageLabel(trackingCase.currentStage)
-                                : "Sin seguimiento vinculado"}
-                            </p>
+                      <div key={token.id} className="min-w-0">
+                        <button
+                          type="button"
+                          id={`clinic-particular-token-${token.id}`}
+                          onClick={() => setSelectedTokenId(token.id)}
+                          aria-pressed={isSelected}
+                          aria-expanded={isSelected}
+                          className={cn(
+                            "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                            isSelected && "bg-vetneb-cyan/12",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-semibold text-vetneb-ink">
+                                {token.petName} · {token.tutorLastName}
+                              </p>
+                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                Token ****{token.tokenLast4}
+                              </p>
+                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                {trackingCase
+                                  ? getTrackingStageLabel(trackingCase.currentStage)
+                                  : "Sin seguimiento vinculado"}
+                              </p>
+                            </div>
+                            <div className="flex shrink-0 flex-col items-end gap-1">
+                              <Badge variant={token.isActive ? "default" : "outline"}>
+                                {token.isActive ? "Activo" : "Inactivo"}
+                              </Badge>
+                              <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
+                                {token.hasLinkedReport ? "Informe" : "Sin informe"}
+                              </Badge>
+                            </div>
                           </div>
-                          <div className="flex shrink-0 flex-col items-end gap-1">
-                            <Badge variant={token.isActive ? "default" : "outline"}>
-                              {token.isActive ? "Activo" : "Inactivo"}
-                            </Badge>
-                            <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
-                              {token.hasLinkedReport ? "Informe" : "Sin informe"}
-                            </Badge>
+                        </button>
+
+                        {isSelected && selectedToken ? (
+                          <div
+                            data-detail-state="selected"
+                            className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
+                          >
+                            <div className="space-y-3 p-4">
+                              <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-3 lg:flex-row lg:items-start lg:justify-between">
+                                <div className="min-w-0">
+                                  <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                    Detalle del token
+                                  </p>
+                                  <h3 className="mt-1 text-lg font-semibold text-vetneb-ink">
+                                    {selectedToken.petName} · {selectedToken.tutorLastName}
+                                  </h3>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Token ****{selectedToken.tokenLast4}
+                                  </p>
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  <Badge variant={selectedToken.isActive ? "default" : "outline"}>
+                                    {selectedToken.isActive ? "Activo" : "Inactivo"}
+                                  </Badge>
+                                  <Badge variant={selectedToken.hasLinkedReport ? "default" : "outline"}>
+                                    {selectedToken.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
+                                  </Badge>
+                                </div>
+                              </div>
+
+                              <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+                                <div className="clinical-muted-band rounded-lg px-3 py-2">
+                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                    Paciente
+                                  </p>
+                                  <p className="mt-1 text-xs text-vetneb-ink">
+                                    {selectedToken.petSpecies} · {selectedToken.petBreed} · {selectedToken.petSex}
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">Edad: {selectedToken.petAge}</p>
+                                </div>
+
+                                <div className="clinical-muted-band rounded-lg px-3 py-2">
+                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                    Muestra
+                                  </p>
+                                  <p className="mt-1 text-xs text-vetneb-ink">{selectedToken.sampleLocation}</p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Evolución: {selectedToken.sampleEvolution}
+                                  </p>
+                                </div>
+
+                                <div className="clinical-muted-band rounded-lg px-3 py-2">
+                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                    Fechas
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Extracción: {formatDate(selectedToken.extractionDate)}
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Envío: {formatDate(selectedToken.shippingDate)}
+                                  </p>
+                                </div>
+
+                                <div className="clinical-muted-band rounded-lg px-3 py-2">
+                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                    Publicación
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Informe: {selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Último acceso: {selectedToken.lastLoginAt ? formatDate(selectedToken.lastLoginAt) : "—"}
+                                  </p>
+                                </div>
+
+                                <div className="clinical-muted-band rounded-lg px-3 py-2">
+                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                    Vínculo
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Tutor: {selectedToken.tutorLastName}
+                                  </p>
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Origen: {formatTokenSource(selectedToken)}
+                                  </p>
+                                </div>
+
+                                <div className="clinical-muted-band rounded-lg px-3 py-2">
+                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                                    Seguimiento
+                                  </p>
+                                  {selectedTrackingCase ? (
+                                    <>
+                                      <p className="mt-1 text-xs text-vetneb-ink">
+                                        Etapa: {getTrackingStageLabel(selectedTrackingCase.currentStage)}
+                                      </p>
+                                      <p className="mt-1 text-xs text-muted-foreground">
+                                        {selectedTrackingCase.specialStainRequired
+                                          ? "Alerta: Solicitud de tinción especial"
+                                          : "Sin alerta de tinción especial"}
+                                      </p>
+                                    </>
+                                  ) : (
+                                    <p className="mt-1 text-xs text-muted-foreground">
+                                      Sin seguimiento vinculado.
+                                    </p>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </button>
+                        ) : null}
+                      </div>
                     );
                   })}
                 </div>
@@ -657,135 +757,8 @@ export function ClinicParticularTokensCard() {
                 {isLoadingTokens
                   ? "Cargando tokens particulares..."
                   : "No hay tokens particulares generados por esta clínica."}
-              </p>
-            )}
-          </div>
-
-          <div
-            className={cn(
-              "min-h-0 overflow-hidden rounded-xl border border-vetneb-line/75 bg-card/82",
-              !isMobileDetailOpen && "hidden xl:block",
-            )}
-          >
-            {selectedToken ? (
-              <div className="space-y-3 p-4">
-                <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-3 lg:flex-row lg:items-start lg:justify-between">
-                  <div className="min-w-0">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="mb-2 xl:hidden"
-                      onClick={() => setIsMobileDetailOpen(false)}
-                    >
-                      <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-                      Volver a la lista
-                    </Button>
-                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                      Detalle del token
-                    </p>
-                    <h3 className="mt-1 text-lg font-semibold text-vetneb-ink">
-                      {selectedToken.petName} · {selectedToken.tutorLastName}
-                    </h3>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Token ****{selectedToken.tokenLast4}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Badge variant={selectedToken.isActive ? "default" : "outline"}>
-                      {selectedToken.isActive ? "Activo" : "Inactivo"}
-                    </Badge>
-                    <Badge variant={selectedToken.hasLinkedReport ? "default" : "outline"}>
-                      {selectedToken.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
-                    </Badge>
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Paciente
-                    </p>
-                    <p className="mt-1 text-xs text-vetneb-ink">
-                      {selectedToken.petSpecies} · {selectedToken.petBreed} · {selectedToken.petSex}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">Edad: {selectedToken.petAge}</p>
-                  </div>
-
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Muestra
-                    </p>
-                    <p className="mt-1 text-xs text-vetneb-ink">{selectedToken.sampleLocation}</p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Evolución: {selectedToken.sampleEvolution}
-                    </p>
-                  </div>
-
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Fechas
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Extracción: {formatDate(selectedToken.extractionDate)}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Envío: {formatDate(selectedToken.shippingDate)}
-                    </p>
-                  </div>
-
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Publicación
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Informe: {selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Último acceso: {selectedToken.lastLoginAt ? formatDate(selectedToken.lastLoginAt) : "—"}
-                    </p>
-                  </div>
-
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Vínculo
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Tutor: {selectedToken.tutorLastName}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Origen: {formatTokenSource(selectedToken)}
-                    </p>
-                  </div>
-
-                  <div className="clinical-muted-band rounded-lg px-3 py-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                      Seguimiento
-                    </p>
-                    {selectedTrackingCase ? (
-                      <>
-                        <p className="mt-1 text-xs text-vetneb-ink">
-                          Etapa: {getTrackingStageLabel(selectedTrackingCase.currentStage)}
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {selectedTrackingCase.specialStainRequired
-                            ? "Alerta: Solicitud de tinción especial"
-                            : "Sin alerta de tinción especial"}
-                        </p>
-                      </>
-                    ) : (
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Sin seguimiento vinculado.
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <p className="surface-empty m-4">
-                Seleccione un token para abrir el detalle.
-              </p>
-            )}
+                </p>
+              )}
           </div>
         </section>
       </CardContent>

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -78,17 +78,21 @@ test("clinic particular tokens card exists and uses clinic helpers", () => {
   assert.equal(source.includes(removedTokenEndpoint), false);
 });
 
-test("clinic tokens uses masked master-detail with paged list and step dialogs", () => {
+test("clinic tokens uses inline master-detail with paged list and step dialogs", () => {
   const source = read(CLINIC_TOKENS_CARD_PATH);
 
   assert.ok(source.includes("const TOKENS_PAGE_SIZE = 4;"));
   assert.ok(source.includes("usePagedRows(tokens, TOKENS_PAGE_SIZE)"));
   assert.ok(source.includes("<CompactPager"));
   assert.ok(source.includes("selectedTokenId"));
-  assert.ok(source.includes("isMobileDetailOpen"));
-  assert.ok(source.includes("Volver a la lista"));
-  assert.ok(source.includes('hidden xl:flex'));
-  assert.ok(source.includes('hidden xl:block'));
+  assert.ok(source.includes("dashboard-inline-list"));
+  assert.ok(source.includes("dashboard-inline-scroll"));
+  assert.ok(source.includes("dashboard-inline-detail"));
+  assert.ok(source.includes("aria-expanded={isSelected}"));
+  assert.ok(source.includes('data-detail-state="selected"'));
+  assert.equal(source.includes("isMobileDetailOpen"), false);
+  assert.equal(source.includes("Volver a la lista"), false);
+  assert.equal(source.includes('xl:grid-cols-[0.82fr_1.46fr]'), false);
   assert.ok(source.includes("CREATE_TOKEN_STEP_ORDER"));
   assert.ok(source.includes("createStep"));
   assert.ok(source.includes("Siguiente"));

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -144,7 +144,7 @@ test("dashboard home clinic command center presentational props contain operatio
   assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
 });
 
-test("clinic informes and logistica summaries use in-shell master-detail layers", () => {
+test("clinic informes and logistica summaries use inline master-detail layers", () => {
   for (const [context, path] of [
     ["informes", CLINIC_INFORMES_SUMMARY_PATH],
     ["logistica", CLINIC_LOGISTICA_SUMMARY_PATH],
@@ -154,10 +154,14 @@ test("clinic informes and logistica summaries use in-shell master-detail layers"
     assert.ok(source.includes('"use client";'), `${context} summary must own state`);
     assert.ok(source.includes("ModuleSurface"), `${context} summary must use ModuleSurface`);
     assert.ok(source.includes("useState"), `${context} summary must use selection state`);
-    assert.ok(source.includes("isMobileDetailOpen"), `${context} summary must use mobile replacement layer`);
-    assert.ok(source.includes("Volver a la lista"), `${context} summary must expose internal back action`);
-    assert.ok(source.includes("hidden xl:flex"), `${context} master must hide under detail on mobile`);
-    assert.ok(source.includes("hidden xl:block"), `${context} detail must replace list on mobile`);
+    assert.ok(source.includes("dashboard-inline-list"), `${context} summary must use inline list`);
+    assert.ok(source.includes("dashboard-inline-scroll"), `${context} summary must bound list overflow`);
+    assert.ok(source.includes("dashboard-inline-detail"), `${context} summary must render inline detail`);
+    assert.ok(source.includes("aria-expanded={isSelected}"), `${context} selection must expose expanded state`);
+    assert.ok(source.includes('data-detail-state="selected"'), `${context} detail must remain inside the selected row`);
+    assert.equal(source.includes("isMobileDetailOpen"), false, `${context} summary must not use a replacement layer`);
+    assert.equal(source.includes("Volver a la lista"), false, `${context} summary must keep list and detail together`);
+    assert.equal(source.includes('xl:grid-cols-[0.85fr_1.15fr]'), false, `${context} summary must not use a lateral grid`);
     assert.equal(source.includes("space-y-4"), false, `${context} summary must not stack teaser blocks`);
   }
 });


### PR DESCRIPTION
## Summary
- Convert dashboard master-detail surfaces to inline responsive details
- Align Tokens Admin, Tokens Clínica, Informes Clínica, Informes summary and Logística summary under the same adaptive pattern
- Compact Admin Audit table density and protect pagination from overlap
- Add/adjust responsive anti-overflow contracts for dashboard cards, lists, details and fitted tables
- Preserve business logic, data, actions, backend, DB, auth and API contracts

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- E2E affected dashboard matrix: 132/132
- pnpm validate:local: 2760/2760
- git diff --check

## Manual validation pending
- Visual authenticated review with real session/data by Nico at 100% zoom, zoom menor and zoom mayor