### PR TITLE
feat(admin): compact overview and clinics dashboard density

### DIFF
--- a/docs/implementation/admin-overview-clinics-enterprise-density.md
+++ b/docs/implementation/admin-overview-clinics-enterprise-density.md
@@ -10,10 +10,11 @@ continúa con `overflow-hidden`; no se agrega scroll global ni una región verti
 interna. Resumen y Clínicas se ajustan al viewport mediante densidad, paginación
 acotada y superficies flex existentes.
 
-Clínicas usa un page size fijo de **10 filas**. Es el primer valor dentro del
-objetivo de 10–14/15 filas que permite conservar filas de aproximadamente 40 px,
-header de 36 px, filtros y acciones dentro del viewport mínimo de 1366×768 sin
-convertir `main` ni el body de tabla en un contenedor de scroll.
+Clínicas usa un page size fijo de **9 filas**. El valor inicial de 10 filas
+producía 12 px de scroll vertical interno en `.dashboard-table-responsive` en
+el E2E de CI a 1366×768. Nueve filas conservan la densidad de aproximadamente
+40 px por fila y dejan un margen estable sin convertir `main` ni el body de
+tabla en un contenedor de scroll.
 
 ## Deuda técnica explícita
 
@@ -37,7 +38,7 @@ Esta deuda no se implementa en PR-3.
 - Header, acciones y buscador compactos.
 - Padding de panel limitado a 8–16 px.
 - Tabla de 13 px, headers de 12 px semibold y filas de aproximadamente 40 px.
-- Paginación server-side existente elevada de 5 a 10 filas.
+- Paginación server-side existente elevada de 5 a 9 filas.
 - Alta en diálogo y edición en drawer se conservan; no hay detalle inline grande.
 - No se agrega selector 25/50/100 ni scroll vertical al body de tabla.
 
@@ -55,7 +56,7 @@ Esta deuda no se implementa en PR-3.
 ## Tests y validaciones
 
 Se validan los contratos de densidad, los cuatro paneles del Resumen, la
-navegación `?module=admin-clinics`, el page size 10, la ausencia de scroll
+navegación `?module=admin-clinics`, el page size 9, la ausencia de scroll
 vertical nuevo y la continuidad del shell horizontal sin sidebar.
 
 Resultados finales:
@@ -64,8 +65,9 @@ Resultados finales:
 - `pnpm --dir frontend typecheck`: OK, sin errores.
 - `pnpm --dir frontend build`: OK, build de producción completo.
 - `pnpm test`: OK, 2777 tests aprobados, 0 fallos.
-- E2E local: no ejecutado; queda para CI porque el servidor de Playwright puede
-  regenerar `next-env.d.ts` y ensuciar el worktree.
+- E2E específico `admin clinics populated fits without external or internal
+  scroll`: OK, 2/2 casos en Chromium (1366×768 y 1440×900). El web server local
+  regeneró `next-env.d.ts`; se restauró al contenido previo y no integra el diff.
 
 ## No alcance
 
@@ -78,8 +80,8 @@ Resultados finales:
 
 ## Riesgos residuales
 
-- El fit real con 10 filas depende de la validación visual/E2E de CI en
-  1366×768 y de que el contenido truncado conserve sus límites actuales.
+- El fit con 9 filas se valida en 1366×768 mediante el contrato E2E específico;
+  el contenido truncado debe conservar sus límites actuales.
 - Mensajes transitorios de error o éxito agregan altura; el shell mantiene el
   contrato no-scroll y puede recortarlos en viewports excepcionalmente bajos.
 - La ampliación a 25/50/100 continúa bloqueada hasta implementar y aprobar la

--- a/docs/implementation/admin-overview-clinics-enterprise-density.md
+++ b/docs/implementation/admin-overview-clinics-enterprise-density.md
@@ -1,0 +1,86 @@
+# PR-3 — Densidad enterprise en Resumen y Clínicas Admin
+
+> Rama: `feat/admin-overview-clinics-enterprise-density`
+> Base: `3950834 feat(dashboard): replace sidebar shell with horizontal navigation (#1040)`
+
+## Decisión de layout
+
+Este PR respeta el contrato global no-scroll vigente. `main.dashboard-main`
+continúa con `overflow-hidden`; no se agrega scroll global ni una región vertical
+interna. Resumen y Clínicas se ajustan al viewport mediante densidad, paginación
+acotada y superficies flex existentes.
+
+Clínicas usa un page size fijo de **10 filas**. Es el primer valor dentro del
+objetivo de 10–14/15 filas que permite conservar filas de aproximadamente 40 px,
+header de 36 px, filtros y acciones dentro del viewport mínimo de 1366×768 sin
+convertir `main` ni el body de tabla en un contenedor de scroll.
+
+## Deuda técnica explícita
+
+Para 25/50/100 filas reales se requiere un PR dedicado que introduzca scroll regional acotado al body de tabla mediante una región explícita tipo `data-dashboard-scroll-region`, actualizando el contrato no-scroll para permitir solo ese scroll interno designado.
+
+Esta deuda no se implementa en PR-3.
+
+## Cambios en Resumen Admin
+
+- Header operativo existente, compacto y sin hero dentro del módulo Resumen.
+- Strip de tres KPI con valores de 20 px: eventos, tipos de evento y estado.
+- Cuatro paneles densos: atención requerida, actividad reciente real, módulos
+  operativos y alertas/estados.
+- Actividad reciente derivada del audit log ya cargado por la página; no agrega
+  requests ni contratos backend.
+- Accesos compactos que preservan la navegación existente por `?module=`,
+  incluida Clínicas mediante `?module=admin-clinics`.
+
+## Cambios en Clínicas Admin
+
+- Header, acciones y buscador compactos.
+- Padding de panel limitado a 8–16 px.
+- Tabla de 13 px, headers de 12 px semibold y filas de aproximadamente 40 px.
+- Paginación server-side existente elevada de 5 a 10 filas.
+- Alta en diálogo y edición en drawer se conservan; no hay detalle inline grande.
+- No se agrega selector 25/50/100 ni scroll vertical al body de tabla.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/AdminCommandCenter.tsx`
+- `frontend/src/app/dashboard/admin/AdminOverviewQuickLinks.tsx`
+- `frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx`
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `test/admin-overview-clinics-enterprise-density.test.ts`
+- `test/frontend-dashboard-admin-command-center.test.ts`
+- `test/frontend-visual-consistency.test.ts`
+- `docs/implementation/admin-overview-clinics-enterprise-density.md`
+
+## Tests y validaciones
+
+Se validan los contratos de densidad, los cuatro paneles del Resumen, la
+navegación `?module=admin-clinics`, el page size 10, la ausencia de scroll
+vertical nuevo y la continuidad del shell horizontal sin sidebar.
+
+Resultados finales:
+
+- `pnpm --dir frontend lint`: OK, sin errores.
+- `pnpm --dir frontend typecheck`: OK, sin errores.
+- `pnpm --dir frontend build`: OK, build de producción completo.
+- `pnpm test`: OK, 2777 tests aprobados, 0 fallos.
+- E2E local: no ejecutado; queda para CI porque el servidor de Playwright puede
+  regenerar `next-env.d.ts` y ensuciar el worktree.
+
+## No alcance
+
+- Dashboard Clínica y los módulos Admin de Tokens, Informes, Auditoría,
+  Usuarios y Sesiones.
+- Login, web pública, Home, Pricing y SEO.
+- Backend, base de datos, migraciones, dependencias y Dependabot.
+- Contrato global no-scroll y specs E2E generales.
+- Infraestructura regional de scroll y selector 25/50/100.
+
+## Riesgos residuales
+
+- El fit real con 10 filas depende de la validación visual/E2E de CI en
+  1366×768 y de que el contenido truncado conserve sus límites actuales.
+- Mensajes transitorios de error o éxito agregan altura; el shell mantiene el
+  contrato no-scroll y puede recortarlos en viewports excepcionalmente bajos.
+- La ampliación a 25/50/100 continúa bloqueada hasta implementar y aprobar la
+  región de scroll explícita descrita como deuda técnica.

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -47,10 +47,12 @@ const ClinicEditDrawer = dynamic(
   { ssr: false },
 );
 
-// Single-viewport App Shell: a full page of clinics must fit the desktop
-// viewport (1366×768) without scroll, so the server page size is bounded to the
-// compact table height and clinic creation moves into a dialog.
-const PAGE_SIZE = 5;
+// Enterprise density without breaking the App Shell no-scroll contract: denser
+// rows/header let a full page fit the 1366×768 minimum viewport, so the server
+// page size is raised from 5 to a value that fills the dense viewport without
+// internal scroll. True 25/50/100 needs the no-scroll contract relaxation
+// (audit §3) and is deferred. CI must confirm this fits 1366×768.
+const PAGE_SIZE = 10;
 
 type CreateClinicForm = {
   clinicName: string;
@@ -235,26 +237,40 @@ export function AdminClinicsManagementCard() {
 
   return (
     <Card id="admin-clinics" className="dashboard-surface flex min-h-0 flex-1 flex-col">
-      <CardHeader className="shrink-0 flex flex-col gap-2 border-b border-vetneb-line/70 py-3 lg:flex-row lg:items-center lg:justify-between">
-        <CardTitle className="text-base">Clínicas</CardTitle>
+      <CardHeader className="shrink-0 flex flex-col gap-2 border-b border-vetneb-line/70 px-4 py-2 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0">
+          <CardTitle className="text-[0.95rem] leading-tight">Clínicas</CardTitle>
+          <p className="text-[0.72rem] text-muted-foreground">
+            Administración de clínicas registradas · alto volumen.
+          </p>
+        </div>
         <div className="flex flex-wrap items-center gap-2">
           <Button
             type="button"
             variant="outline"
+            size="sm"
+            className="h-8"
             onClick={() => setIsCreateOpen(true)}
             disabled={isBusy}
           >
             <Plus aria-hidden="true" />
             Nueva clínica
           </Button>
-          <Button type="button" onClick={() => loadClinics()} disabled={isBusy} aria-busy={isPending ? true : undefined}>
+          <Button
+            type="button"
+            size="sm"
+            className="h-8"
+            onClick={() => loadClinics()}
+            disabled={isBusy}
+            aria-busy={isPending ? true : undefined}
+          >
             {isPending ? <Loader2 className="animate-spin" aria-hidden="true" /> : <RefreshCw aria-hidden="true" />}
             {isPending ? "Actualizando..." : "Actualizar"}
           </Button>
         </div>
       </CardHeader>
 
-      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-2 px-4 pb-4 pt-3">
         <ModuleDialog
           open={isCreateOpen}
           onOpenChange={setIsCreateOpen}
@@ -378,14 +394,14 @@ export function AdminClinicsManagementCard() {
           </div>
           {totalClinics > 0 ? (
             <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-              <span>
+              <span className="tabular-nums">
                 {pageStart}–{pageEnd} de {totalClinics}
               </span>
               <Button
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-9 w-9 p-0 sm:h-7 sm:w-7"
+                className="h-8 w-8 p-0"
                 onClick={() => loadClinics(currentOffset - PAGE_SIZE)}
                 disabled={isBusy || !hasPrev}
                 aria-label="Página anterior"
@@ -396,7 +412,7 @@ export function AdminClinicsManagementCard() {
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-9 w-9 p-0 sm:h-7 sm:w-7"
+                className="h-8 w-8 p-0"
                 onClick={() => loadClinics(currentOffset + PAGE_SIZE)}
                 disabled={isBusy || !hasNext}
                 aria-label="Página siguiente"
@@ -408,7 +424,7 @@ export function AdminClinicsManagementCard() {
         </div>
 
         <div className="dashboard-table-responsive">
-          <Table>
+          <Table className="text-[0.8125rem] [&_th]:h-9 [&_th]:px-3 [&_td]:px-3">
             <TableHeader>
               <TableRow>
                 <TableHead>Clínica</TableHead>
@@ -424,9 +440,9 @@ export function AdminClinicsManagementCard() {
                   <TableRow
                     key={`${clinic.clinicId}-${user?.userId ?? "empty"}`}
                   >
-                    <TableCell className="py-1.5">
+                    <TableCell className="py-1">
                       <span className="flex items-center gap-1.5">
-                        <span className="max-w-[13rem] truncate text-sm font-medium">
+                        <span className="max-w-[13rem] truncate font-medium">
                           {clinic.clinicName}
                         </span>
                         <span className="shrink-0 font-mono text-[0.62rem] text-muted-foreground">
@@ -435,13 +451,13 @@ export function AdminClinicsManagementCard() {
                       </span>
                     </TableCell>
 
-                    <TableCell className="py-1.5 text-sm">
+                    <TableCell className="py-1">
                       <span className="block max-w-[14rem] truncate">
                         {clinic.contactEmail ?? "—"}
                       </span>
                     </TableCell>
 
-                    <TableCell className="py-1.5 text-sm">
+                    <TableCell className="py-1">
                       {user ? (
                         <span className="inline-flex max-w-[12rem] items-center gap-1">
                           <span className="truncate">{user.username}</span>
@@ -452,20 +468,20 @@ export function AdminClinicsManagementCard() {
                           ) : null}
                         </span>
                       ) : (
-                        <span className="text-sm text-muted-foreground">
+                        <span className="text-muted-foreground">
                           Sin usuario
                         </span>
                       )}
                     </TableCell>
 
                     <TableCell
-                      className="whitespace-nowrap py-1.5 text-[0.66rem] text-muted-foreground"
+                      className="whitespace-nowrap py-1 text-xs text-muted-foreground"
                       title={`Creada: ${formatDateTime(clinic.createdAt)} · Actualizada: ${formatDateTime(clinic.updatedAt)}`}
                     >
                       {formatDateTime(clinic.updatedAt)}
                     </TableCell>
 
-                    <TableCell className="py-1.5 text-right">
+                    <TableCell className="py-1 text-right">
                       <Button
                         type="button"
                         variant="outline"
@@ -473,7 +489,7 @@ export function AdminClinicsManagementCard() {
                         disabled={isBusy || editingClinic !== null}
                         onClick={() => setEditingClinic(clinic)}
                         aria-label={`Editar clínica ${clinic.clinicName}`}
-                        className="min-h-[2.75rem]"
+                        className="h-8"
                       >
                         <Pencil aria-hidden="true" />
                         Editar

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -49,10 +49,10 @@ const ClinicEditDrawer = dynamic(
 
 // Enterprise density without breaking the App Shell no-scroll contract: denser
 // rows/header let a full page fit the 1366×768 minimum viewport, so the server
-// page size is raised from 5 to a value that fills the dense viewport without
-// internal scroll. True 25/50/100 needs the no-scroll contract relaxation
-// (audit §3) and is deferred. CI must confirm this fits 1366×768.
-const PAGE_SIZE = 10;
+// page size is raised from 5 to a conservative value that leaves one dense-row
+// margin in the 1366×768 viewport without internal scroll. True 25/50/100 needs
+// the no-scroll contract relaxation (audit §3) and is deferred.
+const PAGE_SIZE = 9;
 
 type CreateClinicForm = {
   clinicName: string;

--- a/frontend/src/app/dashboard/admin/AdminCommandCenter.tsx
+++ b/frontend/src/app/dashboard/admin/AdminCommandCenter.tsx
@@ -1,9 +1,15 @@
 import { Badge } from "@/components/ui/badge";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
-import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
+import { AdminOverviewQuickLinks } from "./AdminOverviewQuickLinks";
 import { cn } from "@/lib/utils";
 
 type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
+
+type RecentAdminActivity = {
+  event: string;
+  actor: string;
+  date: string;
+};
 
 type AdminCommandCenterProps = {
   auditEntriesCount: number;
@@ -13,6 +19,7 @@ type AdminCommandCenterProps = {
   systemStatusIndicatorClass: string;
   systemStatusDetail: string;
   hasSystemHealthFetchError: boolean;
+  recentActivity: RecentAdminActivity | null;
 };
 
 export function AdminCommandCenter({
@@ -23,78 +30,8 @@ export function AdminCommandCenter({
   systemStatusIndicatorClass,
   systemStatusDetail,
   hasSystemHealthFetchError,
+  recentActivity,
 }: AdminCommandCenterProps) {
-  const metricsPanel = (
-    <div
-      className="overflow-hidden rounded-lg border border-vetneb-line/80 bg-card/95 shadow-[0_12px_34px_rgba(15,45,62,0.08)] ring-1 ring-white/55 transition-[border-color,box-shadow,background-color] duration-200 hover:border-vetneb-teal/35"
-      role="region"
-      aria-label="Métricas de auditoría"
-    >
-      <div className="grid grid-cols-1 divide-y divide-vetneb-line/60 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-        <div className="px-5 py-3.5">
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-            Eventos de auditoría
-          </p>
-          <p className="mt-1.5 text-2xl font-bold tracking-tight text-vetneb-ink">
-            {auditEntriesCount}
-          </p>
-          <p className="mt-0.5 text-xs text-muted-foreground">Registros totales</p>
-        </div>
-
-        <div className="px-5 py-3.5">
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-            Tipos de evento
-          </p>
-          <p className="mt-1.5 text-2xl font-bold tracking-tight text-vetneb-ink">
-            {eventTypesCount}
-          </p>
-          <p className="mt-0.5 text-xs text-muted-foreground">Categorías distintas</p>
-        </div>
-
-        <div className="px-5 py-3.5">
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-            Estado del sistema
-          </p>
-          <div className="mt-1.5 flex items-center gap-2">
-            <span
-              className={cn("h-2.5 w-2.5 rounded-full", systemStatusIndicatorClass)}
-              aria-hidden="true"
-            />
-            <Badge variant={systemStatusVariant}>
-              {systemStatusLabel}
-            </Badge>
-          </div>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {hasSystemHealthFetchError
-              ? "No se pudo consultar el estado del sistema."
-              : systemStatusDetail}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-
-  const alertsPanel = (
-    <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 md:grid-cols-2">
-      <div className="surface-soft">
-        <p className="text-sm font-semibold text-vetneb-ink">
-          Intentos fallidos de login
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Revisar actividad de acceso antes de cambios administrativos.
-        </p>
-      </div>
-      <div className="surface-soft">
-        <p className="text-sm font-semibold text-vetneb-ink">
-          Sistema
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Consultar salud, esquema y mantenimiento agrupados.
-        </p>
-      </div>
-    </div>
-  );
-
   return (
     <section
       className="flex min-h-0 flex-1 flex-col"
@@ -115,13 +52,94 @@ export function AdminCommandCenter({
           </div>
         }
       >
-        <ModuleTabs
-          ariaLabel="Resumen operativo"
-          tabs={[
-            { id: "metricas", label: "Métricas", content: metricsPanel },
-            { id: "alertas", label: "Alertas", content: alertsPanel },
-          ]}
-        />
+        <div className="flex min-h-0 flex-1 flex-col gap-3">
+          <div
+            className="grid grid-cols-2 gap-2 lg:grid-cols-3"
+            role="group"
+            aria-label="Métricas operativas"
+          >
+            <div className="rounded-md border border-vetneb-line/70 bg-card/95 px-3 py-1.5">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                Eventos de auditoría
+              </p>
+              <p className="mt-0.5 text-xl font-semibold leading-tight tracking-tight text-vetneb-ink">
+                {auditEntriesCount}
+              </p>
+              <p className="text-[0.7rem] text-muted-foreground">Registros totales</p>
+            </div>
+
+            <div className="rounded-md border border-vetneb-line/70 bg-card/95 px-3 py-1.5">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                Tipos de evento
+              </p>
+              <p className="mt-0.5 text-xl font-semibold leading-tight tracking-tight text-vetneb-ink">
+                {eventTypesCount}
+              </p>
+              <p className="text-[0.7rem] text-muted-foreground">Categorías distintas</p>
+            </div>
+
+            <div className="col-span-2 rounded-md border border-vetneb-line/70 bg-card/95 px-3 py-1.5 lg:col-span-1">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                Estado del sistema
+              </p>
+              <div className="mt-0.5 flex items-center gap-2">
+                <span
+                  className={cn("h-2 w-2 rounded-full", systemStatusIndicatorClass)}
+                  aria-hidden="true"
+                />
+                <Badge variant={systemStatusVariant}>{systemStatusLabel}</Badge>
+              </div>
+              <p className="mt-0.5 line-clamp-1 text-[0.7rem] text-muted-foreground">
+                {hasSystemHealthFetchError
+                  ? "No se pudo consultar el estado del sistema."
+                  : systemStatusDetail}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 sm:grid-cols-2">
+            <div className="surface-soft">
+              <p className="text-[0.8rem] font-semibold text-vetneb-ink">
+                Atención requerida
+              </p>
+              <p className="mt-1 text-[0.72rem] text-muted-foreground">
+                Revisar intentos fallidos de login y salud del sistema antes de
+                cambios administrativos.
+              </p>
+            </div>
+
+            <div className="surface-soft min-h-0">
+              <p className="text-[0.8rem] font-semibold text-vetneb-ink">
+                Actividad reciente
+              </p>
+              {recentActivity ? (
+                <p className="mt-1 line-clamp-2 text-[0.72rem] text-muted-foreground">
+                  <span className="font-semibold text-foreground/85">
+                    {recentActivity.event}
+                  </span>{" "}
+                  · {recentActivity.actor} · {recentActivity.date}
+                </p>
+              ) : (
+                <p className="mt-1 text-[0.72rem] text-muted-foreground">
+                  Sin actividad de auditoría disponible.
+                </p>
+              )}
+            </div>
+
+            <AdminOverviewQuickLinks />
+
+            <div className="surface-soft min-h-0">
+              <p className="text-[0.8rem] font-semibold text-vetneb-ink">
+                Alertas y estados
+              </p>
+              <p className="mt-1 line-clamp-2 text-[0.72rem] text-muted-foreground">
+                {hasSystemHealthFetchError
+                  ? "Estado no disponible; revisar conectividad del servicio."
+                  : `${systemStatusLabel}: ${systemStatusDetail}`}
+              </p>
+            </div>
+          </div>
+        </div>
       </ModuleSurface>
     </section>
   );

--- a/frontend/src/app/dashboard/admin/AdminOverviewQuickLinks.tsx
+++ b/frontend/src/app/dashboard/admin/AdminOverviewQuickLinks.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { ROUTES } from "@/lib/routes";
+
+const QUICK_LINKS: Array<{ label: string; module: string }> = [
+  { label: "Clínicas", module: "admin-clinics" },
+  { label: "Informes", module: "admin-report-upload" },
+  { label: "Tokens", module: "admin-particular-tokens" },
+  { label: "Auditoría", module: "audit-log" },
+  { label: "Usuarios", module: "admin-users-roles" },
+  { label: "Sesiones", module: "admin-sessions" },
+];
+
+export function AdminOverviewQuickLinks() {
+  return (
+    <nav className="surface-soft min-h-0" aria-label="Módulos operativos">
+      <p className="text-[0.8rem] font-semibold text-vetneb-ink">Módulos operativos</p>
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
+        {QUICK_LINKS.map((link) => (
+          <PublicRouteControl
+            key={link.module}
+            href={`${ROUTES.dashboardAdmin}?module=${link.module}`}
+            prefetch={false}
+            variant="bare"
+            aria-label={`Ir a ${link.label}`}
+            className="inline-flex items-center rounded-md border border-input bg-background px-2.5 py-1 text-[0.72rem] font-semibold text-foreground dashboard-nav-interactive hover:bg-accent/60 focus-visible:ring-offset-2"
+          >
+            {link.label}
+          </PublicRouteControl>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -397,6 +397,16 @@ export default async function AdminPage({
     detail: getAuditMetadataSummary(entry),
     date: formatDateTime(entry.createdAt),
   }));
+  const latestAuditEntry = auditEntries[0];
+  const recentAdminActivity = latestAuditEntry
+    ? {
+        event: EVENT_LABELS[latestAuditEntry.event] ?? latestAuditEntry.event,
+        actor: `${ACTOR_LABELS[latestAuditEntry.actorType] ?? latestAuditEntry.actorType}${
+          latestAuditEntry.actorId ? ` #${latestAuditEntry.actorId}` : ""
+        }`,
+        date: formatDateTime(latestAuditEntry.createdAt),
+      }
+    : null;
 
   // ── Administración workspace: command center + critical alerts ──────────────
   // Single-viewport App Shell: split the resumen command center and the critical
@@ -422,6 +432,7 @@ export default async function AdminPage({
                 systemStatusIndicatorClass={getSystemStatusIndicatorClass(systemStatus)}
                 systemStatusDetail={formatSystemStatusDetail(serviceChecks)}
                 hasSystemHealthFetchError={hasSystemHealthFetchError}
+                recentActivity={recentAdminActivity}
               />
             </div>
           ),

--- a/test/admin-overview-clinics-enterprise-density.test.ts
+++ b/test/admin-overview-clinics-enterprise-density.test.ts
@@ -69,8 +69,8 @@ test("admin overview keeps the four compact operational panels", () => {
 test("admin clinics console raises the server page size while respecting no-scroll", () => {
   const source = read(CLINICS_CARD_PATH);
 
-  // Denser rows let a full page fit the minimum viewport without internal scroll.
-  assert.ok(source.includes("const PAGE_SIZE = 10;"));
+  // Nine dense rows preserve a full-row margin in the minimum viewport.
+  assert.ok(source.includes("const PAGE_SIZE = 9;"));
   assert.ok(source.includes("limit: PAGE_SIZE"));
   assert.ok(source.includes("snapshot?.total"));
 

--- a/test/admin-overview-clinics-enterprise-density.test.ts
+++ b/test/admin-overview-clinics-enterprise-density.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const COMMAND_CENTER_PATH =
+  "frontend/src/app/dashboard/admin/AdminCommandCenter.tsx";
+const QUICK_LINKS_PATH =
+  "frontend/src/app/dashboard/admin/AdminOverviewQuickLinks.tsx";
+const CLINICS_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx";
+const GLOBALS_PATH = "frontend/src/app/globals.css";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+const FORBIDDEN_OVERSIZED = [
+  "text-2xl",
+  "text-3xl",
+  "p-6",
+  "p-8",
+  "gap-6",
+  "gap-8",
+  "h-14",
+  "h-16",
+];
+
+for (const path of [COMMAND_CENTER_PATH, QUICK_LINKS_PATH, CLINICS_CARD_PATH]) {
+  test(`enterprise density: ${path} avoids oversized landing-style classes`, () => {
+    const source = read(path);
+    for (const forbidden of FORBIDDEN_OVERSIZED) {
+      assert.equal(
+        source.includes(forbidden),
+        false,
+        `${path} must not use oversized class ${forbidden}`,
+      );
+    }
+  });
+}
+
+test("admin overview module exposes a compact KPI strip without a gradient hero", () => {
+  const source = read(COMMAND_CENTER_PATH);
+
+  assert.ok(source.includes("Métricas operativas"));
+  assert.ok(source.includes("text-xl"));
+  assert.equal(source.includes("DashboardHubHero"), false);
+  assert.equal(source.includes("bg-gradient-to-br"), false);
+});
+
+test("admin overview keeps the four compact operational panels", () => {
+  const overviewSource = read(COMMAND_CENTER_PATH);
+  const linksSource = read(QUICK_LINKS_PATH);
+
+  for (const panel of [
+    "Atención requerida",
+    "Actividad reciente",
+    "Alertas y estados",
+  ]) {
+    assert.ok(overviewSource.includes(panel), `missing compact panel ${panel}`);
+  }
+  assert.ok(linksSource.includes("Módulos operativos"));
+  assert.ok(linksSource.includes('module: "admin-clinics"'));
+});
+
+test("admin clinics console raises the server page size while respecting no-scroll", () => {
+  const source = read(CLINICS_CARD_PATH);
+
+  // Denser rows let a full page fit the minimum viewport without internal scroll.
+  assert.ok(source.includes("const PAGE_SIZE = 10;"));
+  assert.ok(source.includes("limit: PAGE_SIZE"));
+  assert.ok(source.includes("snapshot?.total"));
+
+  // No-scroll contract: the table body must NOT become an internal scroll region
+  // (true 25/50/100 needs the contract relaxation, deferred).
+  assert.equal(source.includes("overflow-y-auto"), false);
+  assert.equal(source.includes("overflow-y-scroll"), false);
+
+  // Server-side pagination drives results (no client-side slicing).
+  assert.equal(source.includes("filteredRows"), false);
+  assert.equal(source.includes("PAGE_SIZE_OPTIONS"), false);
+  assert.equal(source.includes("<Select"), false);
+});
+
+test("PR-3 leaves the global dashboard main no-scroll contract intact", () => {
+  const source = read(GLOBALS_PATH);
+  const mainStart = source.indexOf("  .dashboard-main {");
+  const mainEnd = source.indexOf("  }", mainStart);
+  const mainBlock = source.slice(mainStart, mainEnd);
+
+  assert.ok(mainStart >= 0, "dashboard-main contract must exist");
+  assert.ok(mainBlock.includes("overflow-hidden"));
+  assert.equal(mainBlock.includes("overflow-y-auto"), false);
+  assert.equal(mainBlock.includes("overflow-y-scroll"), false);
+});
+
+test("admin clinics console keeps a dense table header and rows", () => {
+  const source = read(CLINICS_CARD_PATH);
+
+  assert.ok(source.includes("[&_th]:h-9"));
+  assert.ok(source.includes("text-[0.8125rem]"));
+  assert.ok(source.includes('className="py-1 text-right"'));
+  // Edit action is a compact control, not a 44px+ row driver.
+  assert.equal(source.includes("min-h-[2.75rem]"), false);
+  assert.equal(source.includes("py-1.5"), false);
+});

--- a/test/frontend-dashboard-admin-command-center.test.ts
+++ b/test/frontend-dashboard-admin-command-center.test.ts
@@ -72,7 +72,7 @@ test("StickyActionBar keeps reusable fixed and sticky action contracts", () => {
   assert.equal(source.includes("fetch("), false);
 });
 
-test("AdminCommandCenter keeps real KPI summary and alert shortcuts", () => {
+test("AdminCommandCenter keeps a compact KPI summary and module access", () => {
   const source = read(ADMIN_COMMAND_CENTER_PATH);
 
   assert.ok(source.includes("type AdminCommandCenterProps = {"));
@@ -80,6 +80,7 @@ test("AdminCommandCenter keeps real KPI summary and alert shortcuts", () => {
   assert.ok(source.includes("eventTypesCount: number;"));
   assert.ok(source.includes("systemStatusLabel: string;"));
   assert.ok(source.includes("hasSystemHealthFetchError: boolean;"));
+  assert.ok(source.includes("recentActivity: RecentAdminActivity | null;"));
   assert.ok(source.includes('aria-labelledby="admin-command-center-heading"'));
   assert.ok(source.includes("Resumen operativo"));
   assert.ok(source.includes("Eventos de auditoría"));
@@ -88,11 +89,34 @@ test("AdminCommandCenter keeps real KPI summary and alert shortcuts", () => {
   assert.ok(source.includes("Registros totales"));
   assert.ok(source.includes("Categorías distintas"));
   assert.ok(source.includes("No se pudo consultar el estado del sistema."));
-  assert.ok(source.includes("Alertas"));
-  assert.ok(source.includes("Intentos fallidos de login"));
-  assert.ok(source.includes("Consultar salud, esquema y mantenimiento agrupados."));
+  assert.ok(source.includes("Atención requerida"));
+  assert.ok(source.includes("Actividad reciente"));
+  assert.ok(source.includes("Alertas y estados"));
+  assert.ok(source.includes("<AdminOverviewQuickLinks"));
   assert.ok(source.includes('className="surface-soft"'));
+
+  // Enterprise density: no oversized KPI typography in the overview module.
+  assert.equal(source.includes("text-2xl"), false);
+  assert.equal(source.includes("text-3xl"), false);
   assert.equal(source.includes("<a"), false);
+  assert.equal(source.includes("fetch("), false);
+});
+
+test("AdminOverviewQuickLinks preserves admin ?module= navigation", () => {
+  const source = read(
+    "frontend/src/app/dashboard/admin/AdminOverviewQuickLinks.tsx",
+  );
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(
+    source.includes(
+      'import { PublicRouteControl } from "@/components/public/PublicRouteControl";',
+    ),
+  );
+  assert.ok(source.includes("`${ROUTES.dashboardAdmin}?module=${link.module}`"));
+  assert.ok(source.includes('module: "admin-clinics"'));
+  assert.ok(source.includes('module: "admin-report-upload"'));
+  assert.ok(source.includes('aria-label="Módulos operativos"'));
   assert.equal(source.includes("fetch("), false);
 });
 
@@ -104,6 +128,7 @@ test("dashboard admin composes module hub, command center, and existing cards", 
   // PR5B: DashboardModuleHub and adminCards are inside AdminDashboardWorkspaceController.
   assert.ok(source.includes("<AdminDashboardWorkspaceController"));
   assert.ok(source.includes("<AdminCommandCenter"));
+  assert.ok(source.includes("recentActivity={recentAdminActivity}"));
   assert.ok(controllerSource.includes("const adminCards = ["));
   assert.ok(controllerSource.includes('title: "Subir informe"'));
   assert.ok(controllerSource.includes('"admin-report-upload"'));

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -484,7 +484,7 @@ test("dashboard admin keeps dense professional layout and visual state surfaces"
   assertMatchesAll(
     combinedSource,
     [
-      /className="grid grid-cols-1 divide-y divide-vetneb-line\/60 sm:grid-cols-3 sm:divide-x sm:divide-y-0"/,
+      /className="grid grid-cols-2 gap-2 lg:grid-cols-3"/,
       /className="dashboard-surface"/,
       /className="grid grid-cols-1 md:grid-cols-5 gap-3"/,
       /className="surface-soft"/,


### PR DESCRIPTION
## Summary
- Compact Admin overview into an enterprise-density operational console
- Add real recent activity, attention, operational modules and status panels
- Compact Admin clinics header, filters, table typography, rows and controls
- Preserve the global no-scroll app shell contract
- Keep clinics page size at 9 as the CI-verified viewport-safe limit for 1366x768
- Document 25/50/100 pagination as a future regional table-body scroll PR

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm test
- Playwright targeted no-scroll E2E: admin clinics populated fits without external or internal scroll
- git diff --check

## Scope
Admin Overview and Admin Clinics only.
No Dashboard Clínica, Tokens, Informes, Auditoría, Usuarios, Sesiones, login, public web, backend, DB, dependencies, migrations, SEO or Dependabot changes.
No E2E contract relaxation.