### PR TITLE
feat(admin): compact reports dashboard density

### DIFF
--- a/docs/implementation/admin-reports-enterprise-density.md
+++ b/docs/implementation/admin-reports-enterprise-density.md
@@ -1,0 +1,159 @@
+# PR-5 — Densidad enterprise en Informes Admin
+
+> Rama: `feat/admin-reports-enterprise-density`  
+> Base: `919d8e1 feat(admin): compact tokens dashboard density (#1042)`
+
+## Objetivo
+
+Convertir exclusivamente **Informes** del Dashboard Administración en una
+consola compacta para carga, lectura de estado, trazabilidad y acceso seguro al
+documento. El cambio continúa los contratos visuales de PR-2, PR-3 y PR-4 sin
+modificar backend, base de datos, dependencias ni el Dashboard Clínica.
+
+## Estado previo detectado
+
+- El identificador real y conservado del módulo es `admin-report-upload`.
+- La superficie solo mostraba texto indicando que la carga debía realizarse
+  desde Tokens, pero Tokens ya no montaba el modal de carga. No había una acción
+  operativa disponible en Informes.
+- No había listado ni cola conectada dentro del módulo.
+- Ya existía el contrato frontend/backend admin
+  `getAdminReportWorkflow({ limit, offset })`, con `pagination.hasMore` y datos
+  reales de clínica, paciente, estudio, archivo, etapa y tinción especial.
+- Ya existían mutaciones para etapa y tinción, además de preview/descarga por URL
+  firmada solicitada bajo scope admin.
+- El modal legacy recorría todas las páginas de usuarios clínica para construir
+  su selector. También recorría los tokens de la clínica seleccionada. No había
+  un N+1 por informe en la pantalla vacía, pero sí carga masiva de catálogo al
+  abrir el modal.
+
+## Implementación
+
+### Consola y listado
+
+- Header de 20 px, descripción corta y acciones de 32 px.
+- Franja operativa compacta con conteos de la página actual: registros,
+  entregados y solicitudes de tinción.
+- Tabla desktop densa y lista mobile priorizada.
+- Columnas basadas exclusivamente en datos existentes: caso/paciente, clínica,
+  estudio, estado, fecha, archivo y acción.
+- Estados loading, error, success y empty compactos.
+- Detalle en `ModuleDialog`, no inline. Permite actualizar la etapa, solicitar o
+  resolver tinción y acceder al documento.
+
+### Subida de informe
+
+- Flujo en `ModuleDialog` dividido en dos pasos para no consumir altura del App
+  Shell: asignación y documento.
+- Búsqueda de clínica explícita y server-side mediante `getAdminClinics`, con un
+  máximo de nueve resultados. Ya no se descarga el catálogo completo de
+  usuarios clínica.
+- Los tokens se cargan solo después de seleccionar una clínica. Se preserva el
+  vínculo opcional y el reemplazo de informe existente.
+- Se conservan archivo PDF, paciente, tipo de estudio y fecha de carga.
+- Controles y botones de 28–32 px, sin dropzone ni formulario tipo landing.
+
+## Paginación y page size
+
+Se usa `PAGE_SIZE = 9`, con:
+
+- `limit: PAGE_SIZE`;
+- `offset: page * PAGE_SIZE`;
+- anterior desde la segunda página;
+- siguiente según `pagination.hasMore` real del endpoint.
+
+Nueve filas es el límite viewport-safe validado en PR-3 para 1366×768. No se
+agrega selector 25/50/100 ni se simula un total global que el contrato no
+entrega.
+
+## Contrato no-scroll
+
+- `dashboard-main` conserva `overflow-hidden` sin cambios.
+- No se agrega `overflow-y-auto`, `overflow-y-scroll` ni
+  `data-dashboard-scroll-region`.
+- La tabla usa nueve filas densas y paginación fija.
+- Subida y detalle viven en diálogos compactos.
+- El marcador `.dashboard-surface` se conserva para el contrato E2E del App
+  Shell.
+
+## Seguridad de informes y archivos
+
+- El listado no recibe ni renderiza URLs privadas.
+- Preview y descarga reutilizan `ReportFileActions` con `scope="admin"`; la URL
+  firmada se solicita solo al ejecutar la acción.
+- No se agregan logs, `dangerouslySetInnerHTML`, fetch público ni previews
+  embebidas.
+- La carga mantiene `FormData`, `accept="application/pdf"` y las validaciones
+  backend existentes. No se relajan políticas de storage.
+- El token particular continúa mostrándose enmascarado con sus últimos cuatro
+  caracteres.
+
+## N+1 y carga pesada
+
+No existía un N+1 por fila en el módulo previo porque no había listado. La nueva
+tabla hace una única consulta paginada y ninguna consulta adicional por fila.
+
+La carga masiva de usuarios clínica del modal legacy se elimina de esta
+superficie utilizando la búsqueda server-side existente. Los tokens siguen
+leyéndose por páginas solo para la clínica elegida y bajo demanda. No existe un
+endpoint de búsqueda de tokens más específico; conservar este recorrido
+on-demand evita perder tokens sin agregar backend.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx`
+- `frontend/src/app/dashboard/admin/AdminReportsCard.tsx`
+- `frontend/src/app/dashboard/admin/AdminReportsUploadPanel.tsx`
+- `frontend/src/app/dashboard/admin/AdminReportStatusBadge.tsx`
+- `test/admin-reports-enterprise-density.test.ts`
+- `test/frontend-dashboard-admin.test.ts`
+- `test/frontend-report-upload-modal.test.ts`
+- `docs/implementation/admin-reports-enterprise-density.md`
+
+## Tests y validaciones
+
+- `pnpm --dir frontend lint`: OK.
+- `pnpm --dir frontend typecheck`: OK.
+- `pnpm --dir frontend build`: OK.
+- `pnpm test`: OK, 2788 tests aprobados y 0 fallos.
+- Tests focales Informes + shell horizontal + Resumen/Clínicas + Tokens: 57
+  aprobados y 0 fallos.
+- E2E
+  `dashboard-real-app-shell-no-scroll-contract.spec.ts --grep "admin upload report alias fits without external or internal scroll"`:
+  2 aprobados en Chromium, 1440×900 y 1366×768.
+- La primera ejecución E2E detectó la ausencia del marcador estructural
+  `.dashboard-surface`; se restauró y la repetición final pasó en ambos
+  viewports.
+- Playwright modificó `frontend/next-env.d.ts`; se restauró y no forma parte del
+  diff.
+
+## Deuda técnica y riesgos residuales
+
+1. El workflow paginado expone `hasMore`, pero no `total`; la interfaz no inventa
+   un total global.
+2. Una clínica con más de cien tokens requiere varias páginas bajo demanda para
+   completar el selector. Un endpoint de búsqueda de tokens permitiría evitar
+   ese recorrido sin recortar funcionalidad.
+3. El E2E no-scroll usa la superficie vacía porque sus mocks actuales no
+   incluyen `admin/report-workflow`; la densidad de nueve filas queda protegida
+   por contratos de fuente y por el precedente E2E poblado de PR-3.
+4. El modal legacy `UploadReportModal` permanece sin cambios para conservar sus
+   contratos históricos; Informes Admin usa el nuevo panel específico.
+
+## No alcance
+
+- Dashboard Clínica e Informes Clínica.
+- Tokens, Clínicas, Resumen, Auditoría, Usuarios y Sesiones Admin, salvo el
+  título mínimo del workspace activo de Informes.
+- Login, web pública, Home, Pricing y SEO.
+- Backend, DB, migraciones, storage, secretos, `.env` y dependencias.
+- Scroll regional, selector 25/50/100 y PR-6 o posteriores.
+- Dependabot.
+
+## Próximos PRs
+
+- Infraestructura aprobada de scroll regional para page sizes 25/50/100.
+- Total global o cursor estable en el contrato de workflow.
+- Búsqueda server-side paginada de tokens particulares por clínica.
+- Fixture E2E poblado específico para la cola de Informes Admin.

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -104,8 +104,8 @@ const ADMIN_MODULE_META: Record<AdminModule, { title: string; description: strin
     description: "Resumen operativo, alertas críticas y métricas del sistema.",
   },
   "admin-report-upload": {
-    title: "Subir informe",
-    description: "Cargar nuevos informes vinculados a tokens de clínica.",
+    title: "Informes",
+    description: "Carga, estado y trazabilidad de informes administrados.",
   },
   "admin-health": {
     title: "Estado del sistema",

--- a/frontend/src/app/dashboard/admin/AdminReportStatusBadge.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportStatusBadge.tsx
@@ -1,0 +1,49 @@
+import type { AdminReportWorkflowStage } from "@/lib/api";
+
+const STATUS_META: Record<
+  AdminReportWorkflowStage,
+  { label: string; className: string }
+> = {
+  sample_received: {
+    label: "Muestra recibida",
+    className: "border-slate-300 bg-slate-50 text-slate-700",
+  },
+  processing: {
+    label: "Procesamiento",
+    className: "border-sky-200 bg-sky-50 text-sky-800",
+  },
+  evaluation: {
+    label: "Evaluación",
+    className: "border-amber-200 bg-amber-50 text-amber-800",
+  },
+  report_development: {
+    label: "Desarrollo",
+    className: "border-violet-200 bg-violet-50 text-violet-800",
+  },
+  delivered: {
+    label: "Entregado",
+    className: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  },
+};
+
+export const ADMIN_REPORT_STAGE_OPTIONS = (
+  Object.entries(STATUS_META) as Array<
+    [AdminReportWorkflowStage, (typeof STATUS_META)[AdminReportWorkflowStage]]
+  >
+).map(([value, meta]) => ({ value, label: meta.label }));
+
+type AdminReportStatusBadgeProps = {
+  stage: AdminReportWorkflowStage;
+};
+
+export function AdminReportStatusBadge({ stage }: AdminReportStatusBadgeProps) {
+  const meta = STATUS_META[stage];
+
+  return (
+    <span
+      className={`inline-flex h-5 items-center rounded-md border px-1.5 text-[0.6875rem] font-semibold ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  FilePlus2,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  getAdminReportWorkflow,
+  updateAdminReportSpecialStain,
+  updateAdminReportWorkflowStage,
+  type AdminReportWorkflowItem,
+  type AdminReportWorkflowStage,
+} from "@/lib/api";
+import {
+  ADMIN_REPORT_STAGE_OPTIONS,
+  AdminReportStatusBadge,
+} from "./AdminReportStatusBadge";
+import { AdminReportsUploadPanel } from "./AdminReportsUploadPanel";
+
+// PR-3 established nine dense rows as the safe 1366x768 limit while the App
+// Shell intentionally has no vertical scroll region.
+const PAGE_SIZE = 9;
+
+const STUDY_LABELS: Record<string, string> = {
+  histopatologia: "Histopatología",
+  citologia: "Citología",
+  hemoparasitos: "Hemoparásitos",
+};
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("es-AR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "2-digit",
+  }).format(date);
+}
+
+function studyLabel(value: string | null) {
+  if (!value) return "Sin tipo";
+  return STUDY_LABELS[value] ?? value;
+}
+
+export function AdminReportsCard() {
+  const [reports, setReports] = useState<AdminReportWorkflowItem[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyReportId, setBusyReportId] = useState<number | null>(null);
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
+  const [isUploadOpen, setIsUploadOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const selectedReport = useMemo(
+    () => reports.find((report) => report.id === selectedReportId) ?? null,
+    [reports, selectedReportId],
+  );
+
+  const deliveredCount = reports.filter(
+    (report) => report.workflowStage === "delivered",
+  ).length;
+  const specialStainCount = reports.filter(
+    (report) => report.specialStainRequested,
+  ).length;
+  const rangeStart = reports.length ? page * PAGE_SIZE + 1 : 0;
+  const rangeEnd = page * PAGE_SIZE + reports.length;
+
+  const loadReports = useCallback(async (nextPage: number) => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const snapshot = await getAdminReportWorkflow({
+        limit: PAGE_SIZE,
+        offset: nextPage * PAGE_SIZE,
+      });
+      setReports(snapshot.reports);
+      setHasMore(snapshot.pagination.hasMore);
+      setSelectedReportId((current) =>
+        snapshot.reports.some((report) => report.id === current) ? current : null,
+      );
+    } catch (error) {
+      setReports([]);
+      setHasMore(false);
+      setSelectedReportId(null);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo cargar la cola de informes.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadReports(page);
+  }, [loadReports, page]);
+
+  function replaceReport(updated: AdminReportWorkflowItem) {
+    setReports((current) =>
+      current.map((report) => (report.id === updated.id ? updated : report)),
+    );
+  }
+
+  async function handleStageChange(
+    report: AdminReportWorkflowItem,
+    stage: AdminReportWorkflowStage,
+  ) {
+    if (stage === report.workflowStage || busyReportId !== null) return;
+    setBusyReportId(report.id);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const response = await updateAdminReportWorkflowStage(report.id, stage);
+      replaceReport(response.report);
+      setStatusMessage(`Etapa del informe #${report.id} actualizada.`);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo actualizar la etapa del informe.",
+      );
+    } finally {
+      setBusyReportId(null);
+    }
+  }
+
+  async function handleSpecialStainChange(report: AdminReportWorkflowItem) {
+    if (busyReportId !== null) return;
+    setBusyReportId(report.id);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      const response = await updateAdminReportSpecialStain(
+        report.id,
+        !report.specialStainRequested,
+      );
+      replaceReport(response.report);
+      setStatusMessage(
+        report.specialStainRequested
+          ? `Solicitud de tinción del informe #${report.id} resuelta.`
+          : `Tinción especial solicitada para el informe #${report.id}.`,
+      );
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo actualizar la tinción especial.",
+      );
+    } finally {
+      setBusyReportId(null);
+    }
+  }
+
+  async function handleUploaded(message: string) {
+    setStatusMessage(message);
+    setErrorMessage(null);
+    if (page === 0) {
+      await loadReports(0);
+    } else {
+      setPage(0);
+    }
+  }
+
+  return (
+    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden shadow-none">
+      <CardHeader className="flex-row items-start justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-4 py-3">
+        <div className="min-w-0">
+          <CardTitle className="text-xl leading-tight">Informes</CardTitle>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Cola administrativa, trazabilidad y documentos en una sola vista.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 px-2.5 text-xs"
+            onClick={() => void loadReports(page)}
+            disabled={isLoading || busyReportId !== null}
+          >
+            {isLoading ? (
+              <Loader2 className="animate-spin" aria-hidden="true" />
+            ) : (
+              <RefreshCw aria-hidden="true" />
+            )}
+            <span className="hidden sm:inline">Actualizar</span>
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 px-2.5 text-xs"
+            onClick={() => setIsUploadOpen(true)}
+          >
+            <FilePlus2 aria-hidden="true" />
+            Subir informe
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-2 px-4 pb-3 pt-2">
+        <div className="flex min-h-8 flex-wrap items-center justify-between gap-2 rounded-md border border-vetneb-line/65 bg-vetneb-surface-raised/45 px-2.5 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span>
+              <strong className="font-semibold text-vetneb-ink">{reports.length}</strong> en página
+            </span>
+            <span>
+              <strong className="font-semibold text-vetneb-ink">{deliveredCount}</strong> entregados
+            </span>
+            <span>
+              <strong className="font-semibold text-vetneb-ink">{specialStainCount}</strong> con tinción
+            </span>
+          </div>
+          <span className="tabular-nums">Página {page + 1}</span>
+        </div>
+
+        {errorMessage ? (
+          <p className="clinical-alert-error shrink-0 px-3 py-1.5 text-xs" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+        {statusMessage ? (
+          <p className="clinical-alert-success shrink-0 px-3 py-1.5 text-xs" role="status">
+            {statusMessage}
+          </p>
+        ) : null}
+
+        <section
+          aria-label="Cola administrativa de informes"
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          {reports.length ? (
+            <>
+              <div className="dashboard-table-responsive hidden min-h-0 flex-1 md:block">
+                <Table className="table-fixed text-[0.8125rem] [&_th]:h-9 [&_th]:px-2.5 [&_td]:px-2.5">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[20%]">Caso / paciente</TableHead>
+                      <TableHead className="w-[18%]">Clínica</TableHead>
+                      <TableHead className="w-[14%]">Estudio</TableHead>
+                      <TableHead className="w-[15%]">Estado</TableHead>
+                      <TableHead className="hidden w-[12%] lg:table-cell">Fecha</TableHead>
+                      <TableHead className="hidden w-[13%] xl:table-cell">Archivo</TableHead>
+                      <TableHead className="w-[8%] text-right">Acción</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {reports.map((report) => (
+                      <TableRow key={report.id}>
+                        <TableCell className="py-1">
+                          <p className="truncate font-medium text-vetneb-ink">
+                            {report.patientName || "Paciente sin registrar"}
+                          </p>
+                          <p className="font-mono text-[0.6875rem] text-muted-foreground">
+                            Informe #{report.id}
+                          </p>
+                        </TableCell>
+                        <TableCell className="py-1">
+                          <p className="truncate">
+                            {report.clinicName || `Clínica #${report.clinicId}`}
+                          </p>
+                        </TableCell>
+                        <TableCell className="py-1">
+                          <span className="block truncate">{studyLabel(report.studyType)}</span>
+                        </TableCell>
+                        <TableCell className="py-1">
+                          <AdminReportStatusBadge stage={report.workflowStage} />
+                          {report.specialStainRequested ? (
+                            <span className="ml-1 text-[0.6875rem] font-semibold text-amber-700">
+                              Tinción
+                            </span>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="hidden py-1 text-xs lg:table-cell">
+                          {formatDate(report.uploadDate ?? report.createdAt)}
+                        </TableCell>
+                        <TableCell className="hidden py-1 xl:table-cell">
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {report.fileName || "Sin archivo"}
+                          </span>
+                        </TableCell>
+                        <TableCell className="py-1 text-right">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-7 px-2 text-xs"
+                            onClick={() => setSelectedReportId(report.id)}
+                          >
+                            Ver
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div className="divide-y divide-vetneb-line/60 rounded-md border border-vetneb-line/75 md:hidden">
+                {reports.map((report) => (
+                  <div
+                    key={report.id}
+                    className="flex min-h-10 items-center gap-2 px-2.5 py-1.5"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-semibold">
+                        #{report.id} · {report.patientName || "Sin paciente"}
+                      </p>
+                      <p className="truncate text-[0.6875rem] text-muted-foreground">
+                        {report.clinicName || `Clínica #${report.clinicId}`} · {studyLabel(report.studyType)}
+                      </p>
+                    </div>
+                    <AdminReportStatusBadge stage={report.workflowStage} />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => setSelectedReportId(report.id)}
+                    >
+                      Ver
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : (
+            <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
+              {isLoading ? "Cargando informes…" : "No hay informes en esta página."}
+            </p>
+          )}
+
+          <nav
+            className="mt-2 flex min-h-10 shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 px-1 pt-2 text-xs text-muted-foreground"
+            aria-label="Paginación de informes admin"
+          >
+            <span>
+              {reports.length ? `${rangeStart}–${rangeEnd}` : "0 resultados"} · {PAGE_SIZE} por página
+            </span>
+            <div className="flex items-center gap-1.5">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 w-8 p-0"
+                disabled={page === 0 || isLoading}
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+                aria-label="Página anterior"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              </Button>
+              <span className="min-w-16 text-center">Página {page + 1}</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 w-8 p-0"
+                disabled={!hasMore || isLoading}
+                onClick={() => setPage((current) => current + 1)}
+                aria-label="Página siguiente"
+              >
+                <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+              </Button>
+            </div>
+          </nav>
+        </section>
+      </CardContent>
+
+      <AdminReportsUploadPanel
+        open={isUploadOpen}
+        onOpenChange={setIsUploadOpen}
+        onUploaded={handleUploaded}
+      />
+
+      {selectedReport ? (
+        <ModuleDialog
+          open={selectedReportId !== null}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setSelectedReportId(null);
+          }}
+          busy={busyReportId === selectedReport.id}
+          title={`Informe #${selectedReport.id}`}
+          description={
+            selectedReport.clinicName || `Clínica #${selectedReport.clinicId}`
+          }
+        >
+          <div className="space-y-3 text-[0.8125rem]">
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2 rounded-md border border-vetneb-line/70 px-3 py-2">
+              <div>
+                <p className="text-[0.6875rem] text-muted-foreground">Paciente</p>
+                <p className="truncate font-medium">
+                  {selectedReport.patientName || "Sin registrar"}
+                </p>
+              </div>
+              <div>
+                <p className="text-[0.6875rem] text-muted-foreground">Estudio</p>
+                <p className="truncate font-medium">{studyLabel(selectedReport.studyType)}</p>
+              </div>
+              <div>
+                <p className="text-[0.6875rem] text-muted-foreground">Carga</p>
+                <p>{formatDate(selectedReport.uploadDate ?? selectedReport.createdAt)}</p>
+              </div>
+              <div>
+                <p className="text-[0.6875rem] text-muted-foreground">Última actualización</p>
+                <p>{formatDate(selectedReport.workflowUpdatedAt)}</p>
+              </div>
+              <div className="col-span-2 min-w-0">
+                <p className="text-[0.6875rem] text-muted-foreground">Archivo</p>
+                <p className="truncate">{selectedReport.fileName || "Sin archivo disponible"}</p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <label className="space-y-1">
+                <span className="text-xs font-medium">Etapa operativa</span>
+                <select
+                  className="field-select h-8 text-xs"
+                  value={selectedReport.workflowStage}
+                  disabled={busyReportId !== null}
+                  onChange={(event) =>
+                    void handleStageChange(
+                      selectedReport,
+                      event.target.value as AdminReportWorkflowStage,
+                    )
+                  }
+                >
+                  {ADMIN_REPORT_STAGE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="space-y-1">
+                <span className="block text-xs font-medium">Tinción especial</span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-full text-xs"
+                  disabled={busyReportId !== null}
+                  onClick={() => void handleSpecialStainChange(selectedReport)}
+                >
+                  {busyReportId === selectedReport.id ? (
+                    <Loader2 className="animate-spin" aria-hidden="true" />
+                  ) : null}
+                  {selectedReport.specialStainRequested ? "Marcar resuelta" : "Solicitar tinción"}
+                </Button>
+              </div>
+            </div>
+
+            <div className="border-t border-vetneb-line/65 pt-2">
+              <p className="mb-1 text-xs font-medium">Documento seguro</p>
+              <ReportFileActions
+                reportId={selectedReport.id}
+                hasFile={Boolean(selectedReport.fileName)}
+                scope="admin"
+                align="start"
+              />
+            </div>
+          </div>
+        </ModuleDialog>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminReportsUploadPanel.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsUploadPanel.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import { FormEvent, useRef, useState } from "react";
+import { Check, FileUp, Loader2, Search } from "lucide-react";
+
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  getAdminClinics,
+  getAdminParticularTokens,
+  uploadAdminReport,
+  type AdminParticularTokenSummary,
+} from "@/lib/api";
+import type { AdminClinicManagementSummary } from "@/types";
+
+const CLINIC_RESULT_LIMIT = 9;
+const TOKEN_PAGE_SIZE = 100;
+
+const STUDY_TYPE_OPTIONS = [
+  { value: "histopatologia", label: "Histopatología" },
+  { value: "citologia", label: "Citología" },
+  { value: "hemoparasitos", label: "Hemoparásitos" },
+] as const;
+
+type UploadStep = "assignment" | "document";
+
+type AdminReportsUploadPanelProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUploaded: (message: string) => void | Promise<void>;
+};
+
+function tokenLabel(token: AdminParticularTokenSummary) {
+  const reportState = token.hasLinkedReport ? "reemplaza informe" : "sin informe";
+  return `****${token.tokenLast4} · ${token.petName} · ${token.tutorLastName} · ${reportState}`;
+}
+
+export function AdminReportsUploadPanel({
+  open,
+  onOpenChange,
+  onUploaded,
+}: AdminReportsUploadPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const clinicRequestId = useRef(0);
+  const tokenRequestId = useRef(0);
+  const [step, setStep] = useState<UploadStep>("assignment");
+  const [clinicQuery, setClinicQuery] = useState("");
+  const [clinics, setClinics] = useState<AdminClinicManagementSummary[]>([]);
+  const [selectedClinic, setSelectedClinic] =
+    useState<AdminClinicManagementSummary | null>(null);
+  const [isSearchingClinics, setIsSearchingClinics] = useState(false);
+  const [particularTokens, setParticularTokens] = useState<
+    AdminParticularTokenSummary[]
+  >([]);
+  const [particularTokenId, setParticularTokenId] = useState("");
+  const [isLoadingTokens, setIsLoadingTokens] = useState(false);
+  const [selectedFileName, setSelectedFileName] = useState("");
+  const [patientName, setPatientName] = useState("");
+  const [studyType, setStudyType] = useState<string>(STUDY_TYPE_OPTIONS[0].value);
+  const [uploadDate, setUploadDate] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function resetForm() {
+    setStep("assignment");
+    setClinicQuery("");
+    setClinics([]);
+    setSelectedClinic(null);
+    setParticularTokens([]);
+    setParticularTokenId("");
+    setSelectedFileName("");
+    setPatientName("");
+    setStudyType(STUDY_TYPE_OPTIONS[0].value);
+    setUploadDate("");
+    setErrorMessage(null);
+    setIsSearchingClinics(false);
+    setIsLoadingTokens(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && !isSubmitting) {
+      clinicRequestId.current += 1;
+      tokenRequestId.current += 1;
+      resetForm();
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleClinicSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const query = clinicQuery.trim();
+
+    if (!query) {
+      setClinics([]);
+      setErrorMessage("Ingrese nombre, email, usuario o ID de clínica.");
+      return;
+    }
+
+    const requestId = clinicRequestId.current + 1;
+    clinicRequestId.current = requestId;
+    setIsSearchingClinics(true);
+    setErrorMessage(null);
+    setSelectedClinic(null);
+    setParticularTokens([]);
+    setParticularTokenId("");
+
+    try {
+      const snapshot = await getAdminClinics({
+        search: query,
+        limit: CLINIC_RESULT_LIMIT,
+        offset: 0,
+      });
+      if (clinicRequestId.current !== requestId) return;
+      setClinics(snapshot.clinics);
+      if (!snapshot.clinics.length) {
+        setErrorMessage("No se encontraron clínicas con ese criterio.");
+      }
+    } catch (error) {
+      if (clinicRequestId.current !== requestId) return;
+      setClinics([]);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudieron buscar las clínicas.",
+      );
+    } finally {
+      if (clinicRequestId.current === requestId) setIsSearchingClinics(false);
+    }
+  }
+
+  function handleClinicQueryChange(value: string) {
+    clinicRequestId.current += 1;
+    tokenRequestId.current += 1;
+    setClinicQuery(value);
+    setClinics([]);
+    setSelectedClinic(null);
+    setParticularTokens([]);
+    setParticularTokenId("");
+    setIsSearchingClinics(false);
+    setIsLoadingTokens(false);
+    setErrorMessage(null);
+  }
+
+  async function selectClinic(clinic: AdminClinicManagementSummary) {
+    const requestId = tokenRequestId.current + 1;
+    tokenRequestId.current = requestId;
+    setSelectedClinic(clinic);
+    setClinicQuery(clinic.clinicName);
+    setClinics([clinic]);
+    setParticularTokens([]);
+    setParticularTokenId("");
+    setIsLoadingTokens(true);
+    setErrorMessage(null);
+
+    try {
+      let offset = 0;
+      let count = Number.POSITIVE_INFINITY;
+      const tokens: AdminParticularTokenSummary[] = [];
+
+      while (offset < count) {
+        const snapshot = await getAdminParticularTokens({
+          clinicId: clinic.clinicId,
+          limit: TOKEN_PAGE_SIZE,
+          offset,
+        });
+        count = snapshot.count;
+        tokens.push(...snapshot.particularTokens);
+        offset += snapshot.particularTokens.length;
+        if (!snapshot.particularTokens.length) break;
+      }
+
+      if (tokenRequestId.current === requestId) {
+        setParticularTokens(tokens);
+      }
+    } catch (error) {
+      if (tokenRequestId.current === requestId) {
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "No se pudieron cargar los tokens de la clínica.",
+        );
+      }
+    } finally {
+      if (tokenRequestId.current === requestId) setIsLoadingTokens(false);
+    }
+  }
+
+  function continueToDocument() {
+    if (!selectedClinic) {
+      setErrorMessage("Seleccione una clínica registrada.");
+      return;
+    }
+    setErrorMessage(null);
+    setStep("document");
+  }
+
+  async function handleUpload(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedClinic || isSubmitting) return;
+
+    const file = fileInputRef.current?.files?.[0];
+    if (!file) {
+      setErrorMessage("Seleccione un archivo PDF para subir.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("clinicId", String(selectedClinic.clinicId));
+    formData.append("file", file);
+    if (patientName.trim()) formData.append("patientName", patientName.trim());
+    formData.append("studyType", studyType);
+    if (uploadDate) formData.append("uploadDate", uploadDate);
+    if (particularTokenId) {
+      formData.append("particularTokenId", particularTokenId);
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await uploadAdminReport(formData);
+      resetForm();
+      onOpenChange(false);
+      await onUploaded(response.message);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudo subir el informe. Intente nuevamente.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <ModuleDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      busy={isSubmitting}
+      title="Subir informe"
+      description={
+        step === "assignment"
+          ? "Paso 1 de 2 · clínica y vínculo opcional."
+          : "Paso 2 de 2 · documento y datos del estudio."
+      }
+    >
+      {step === "assignment" ? (
+        <div className="space-y-3">
+          <form
+            className="flex items-end gap-2"
+            role="search"
+            aria-label="Buscar clínica para el informe"
+            onSubmit={(event) => void handleClinicSearch(event)}
+          >
+            <label className="min-w-0 flex-1 space-y-1">
+              <span className="text-xs font-medium text-vetneb-ink">Clínica</span>
+              <Input
+                className="h-8 text-[0.8125rem]"
+                value={clinicQuery}
+                onChange={(event) => handleClinicQueryChange(event.target.value)}
+                placeholder="Nombre, email, usuario o ID"
+                disabled={isSearchingClinics || isSubmitting}
+                aria-label="Buscar clínica registrada"
+              />
+            </label>
+            <Button
+              type="submit"
+              variant="outline"
+              size="sm"
+              className="h-8 px-3 text-xs"
+              disabled={isSearchingClinics || isSubmitting}
+            >
+              {isSearchingClinics ? (
+                <Loader2 className="animate-spin" aria-hidden="true" />
+              ) : (
+                <Search aria-hidden="true" />
+              )}
+              Buscar
+            </Button>
+          </form>
+
+          {clinics.length ? (
+            <div className="divide-y divide-vetneb-line/60 rounded-md border border-vetneb-line/75">
+              {clinics.map((clinic) => {
+                const selected = selectedClinic?.clinicId === clinic.clinicId;
+                return (
+                  <button
+                    key={clinic.clinicId}
+                    type="button"
+                    className="flex min-h-8 w-full items-center gap-2 px-2.5 py-1 text-left text-xs hover:bg-accent/55"
+                    onClick={() => void selectClinic(clinic)}
+                    aria-pressed={selected}
+                  >
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {clinic.clinicName}
+                    </span>
+                    <span className="shrink-0 font-mono text-[0.6875rem] text-muted-foreground">
+                      #{clinic.clinicId}
+                    </span>
+                    {selected ? (
+                      <Check className="h-3.5 w-3.5 text-emerald-700" aria-hidden="true" />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {selectedClinic ? (
+            <label className="block space-y-1">
+              <span className="text-xs font-medium text-vetneb-ink">
+                Token particular <span className="font-normal text-muted-foreground">(opcional)</span>
+              </span>
+              <select
+                className="field-select h-8 text-[0.8125rem]"
+                value={particularTokenId}
+                onChange={(event) => {
+                  setParticularTokenId(event.target.value);
+                  const token = particularTokens.find(
+                    (item) => String(item.id) === event.target.value,
+                  );
+                  if (token && !patientName.trim()) {
+                    setPatientName(`${token.petName} / ${token.tutorLastName}`);
+                  }
+                }}
+                disabled={isLoadingTokens || isSubmitting}
+              >
+                <option value="">
+                  {isLoadingTokens ? "Cargando tokens…" : "Sin token vinculado"}
+                </option>
+                {particularTokens.map((token) => (
+                  <option key={token.id} value={token.id}>
+                    {tokenLabel(token)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+
+          {errorMessage ? (
+            <p className="clinical-alert-error px-3 py-1.5 text-xs" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+
+          <div className="flex justify-end gap-2 border-t border-vetneb-line/65 pt-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={() => handleOpenChange(false)}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={continueToDocument}
+              disabled={!selectedClinic || isLoadingTokens}
+            >
+              Continuar
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <form className="space-y-3" onSubmit={(event) => void handleUpload(event)}>
+          <div className="rounded-md border border-vetneb-line/70 bg-vetneb-surface-raised/55 px-3 py-2 text-xs">
+            <span className="font-semibold">{selectedClinic?.clinicName}</span>
+            <span className="text-muted-foreground">
+              {particularTokenId ? " · token vinculado" : " · sin token particular"}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <span className="text-xs font-medium text-vetneb-ink">Archivo PDF</span>
+              <Input
+                ref={fileInputRef}
+                id="admin-report-file"
+                type="file"
+                accept="application/pdf"
+                required
+                disabled={isSubmitting}
+                className="sr-only"
+                onChange={(event) => {
+                  setSelectedFileName(event.target.files?.[0]?.name ?? "");
+                  setErrorMessage(null);
+                }}
+              />
+              <div className="mt-1 flex h-8 items-center gap-2 rounded-md border border-vetneb-line/80 px-2.5">
+                <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                  {selectedFileName || "Sin archivo seleccionado"}
+                </span>
+                <label
+                  htmlFor="admin-report-file"
+                  className="inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md border border-vetneb-line/80 px-2 text-xs font-semibold hover:bg-accent/60"
+                >
+                  <FileUp className="h-3.5 w-3.5" aria-hidden="true" />
+                  Seleccionar
+                </label>
+              </div>
+            </div>
+
+            <label className="space-y-1">
+              <span className="text-xs font-medium text-vetneb-ink">Paciente</span>
+              <Input
+                className="h-8 text-[0.8125rem]"
+                value={patientName}
+                onChange={(event) => setPatientName(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className="text-xs font-medium text-vetneb-ink">Tipo de estudio</span>
+              <select
+                className="field-select h-8 text-[0.8125rem]"
+                value={studyType}
+                onChange={(event) => setStudyType(event.target.value)}
+                disabled={isSubmitting}
+                required
+              >
+                {STUDY_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1 sm:col-span-2">
+              <span className="text-xs font-medium text-vetneb-ink">Fecha de carga</span>
+              <Input
+                className="h-8 text-[0.8125rem]"
+                type="date"
+                value={uploadDate}
+                onChange={(event) => setUploadDate(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </label>
+          </div>
+
+          {errorMessage ? (
+            <p className="clinical-alert-error px-3 py-1.5 text-xs" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+
+          <div className="flex justify-end gap-2 border-t border-vetneb-line/65 pt-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={() => setStep("assignment")}
+              disabled={isSubmitting}
+            >
+              Atrás
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              className="h-8 text-xs"
+              disabled={isSubmitting}
+              aria-busy={isSubmitting}
+            >
+              {isSubmitting ? (
+                <Loader2 className="animate-spin" aria-hidden="true" />
+              ) : (
+                <FileUp aria-hidden="true" />
+              )}
+              {isSubmitting ? "Subiendo…" : "Subir informe"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </ModuleDialog>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -17,6 +17,7 @@ import { AdminClinicsManagementCard } from "./AdminClinicsManagementCard";
 import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMaintenanceDryRunCard } from "./AdminMaintenanceDryRunCard";
 import { AdminParticularTokensCard } from "./AdminParticularTokensCard";
+import { AdminReportsCard } from "./AdminReportsCard";
 import { AdminPricingEditorCard } from "./AdminPricingEditorCard";
 import { AdminSchemaHealthStatusCard } from "./AdminSchemaHealthStatusCard";
 import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
@@ -461,27 +462,13 @@ export default async function AdminPage({
     />
   );
 
-  // ── Subir informe workspace ─────────────────────────────────────────────────
+  // ── Informes workspace ──────────────────────────────────────────────────────
   const reportUploadWorkspaceSlot = (
     <section
       id="admin-report-upload"
-      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden p-0"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
     >
-      <div className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between">
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-widest text-vetneb-navy">
-            Panel administrador
-          </p>
-          <h2 className="mt-2 text-xl font-semibold text-vetneb-ink">
-            Carga de informes
-          </h2>
-          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            La carga de informes se realiza desde cada token administrado
-            en &quot;Últimos tokens administrados&quot;, para vincular clínica y token
-            sin búsqueda manual.
-          </p>
-        </div>
-      </div>
+      <AdminReportsCard />
     </section>
   );
 

--- a/test/admin-reports-enterprise-density.test.ts
+++ b/test/admin-reports-enterprise-density.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const CONTROLLER_PATH =
+  "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
+const CARD_PATH = "frontend/src/app/dashboard/admin/AdminReportsCard.tsx";
+const UPLOAD_PATH =
+  "frontend/src/app/dashboard/admin/AdminReportsUploadPanel.tsx";
+const STATUS_PATH =
+  "frontend/src/app/dashboard/admin/AdminReportStatusBadge.tsx";
+const GLOBALS_PATH = "frontend/src/app/globals.css";
+
+function read(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("Admin Informes preserva el identificador real y monta la consola dedicada", () => {
+  const page = read(PAGE_PATH);
+  const controller = read(CONTROLLER_PATH);
+
+  assert.ok(page.includes('id="admin-report-upload"'));
+  assert.ok(page.includes('import { AdminReportsCard } from "./AdminReportsCard";'));
+  assert.ok(page.includes("<AdminReportsCard />"));
+  assert.ok(controller.includes('"admin-report-upload": {'));
+  assert.ok(controller.includes('title: "Informes"'));
+  assert.ok(
+    controller.includes(
+      'description: "Carga, estado y trazabilidad de informes administrados."',
+    ),
+  );
+});
+
+test("Admin Informes usa paginación server-side viewport-safe de nueve filas", () => {
+  const card = read(CARD_PATH);
+
+  assert.ok(card.includes("const PAGE_SIZE = 9;"));
+  assert.ok(card.includes("getAdminReportWorkflow({"));
+  assert.ok(card.includes("limit: PAGE_SIZE"));
+  assert.ok(card.includes("offset: nextPage * PAGE_SIZE"));
+  assert.ok(card.includes("snapshot.pagination.hasMore"));
+  assert.equal(card.includes("slice("), false);
+  assert.ok(card.includes('aria-label="Paginación de informes admin"'));
+  assert.ok(card.includes("Página anterior"));
+  assert.ok(card.includes("Página siguiente"));
+});
+
+test("Admin Informes presenta tabla y lista mobile densas con detalle en diálogo", () => {
+  const card = read(CARD_PATH);
+
+  for (const marker of [
+    "Caso / paciente",
+    "Clínica",
+    "Estudio",
+    "Estado",
+    "Fecha",
+    "Archivo",
+    "Acción",
+    "dashboard-table-responsive hidden min-h-0 flex-1 md:block",
+    "md:hidden",
+    "<ModuleDialog",
+    "AdminReportStatusBadge",
+  ]) {
+    assert.ok(card.includes(marker), `falta contrato visual: ${marker}`);
+  }
+
+  assert.equal(card.includes("detalle inline"), false);
+  assert.equal(card.includes("dropzone"), false);
+});
+
+test("Admin Informes respeta los límites de densidad y no introduce scroll regional", () => {
+  const source = [read(CARD_PATH), read(UPLOAD_PATH), read(STATUS_PATH)].join("\n");
+
+  for (const forbidden of [
+    "text-2xl",
+    "text-3xl",
+    "p-6",
+    "p-8",
+    "gap-6",
+    "gap-8",
+    "h-14",
+    "h-16",
+    "overflow-y-auto",
+    "overflow-y-scroll",
+    "data-dashboard-scroll-region",
+  ]) {
+    assert.equal(source.includes(forbidden), false, `token prohibido: ${forbidden}`);
+  }
+
+  const globals = read(GLOBALS_PATH);
+  assert.match(
+    globals,
+    /\.dashboard-main\s*\{[\s\S]*?@apply[^;]*overflow-hidden[^;]*;[\s\S]*?\}/,
+  );
+});
+
+test("la subida compacta conserva campos y evita cargar el catálogo global", () => {
+  const upload = read(UPLOAD_PATH);
+
+  assert.ok(upload.includes("<ModuleDialog"));
+  assert.ok(upload.includes('type UploadStep = "assignment" | "document";'));
+  assert.ok(upload.includes("getAdminClinics({"));
+  assert.ok(upload.includes("search: query"));
+  assert.ok(upload.includes("limit: CLINIC_RESULT_LIMIT"));
+  assert.ok(upload.includes("getAdminParticularTokens({"));
+  assert.ok(upload.includes("uploadAdminReport(formData)"));
+  assert.ok(upload.includes('formData.append("clinicId"'));
+  assert.ok(upload.includes('formData.append("file", file)'));
+  assert.ok(upload.includes('formData.append("particularTokenId"'));
+  assert.ok(upload.includes('accept="application/pdf"'));
+  assert.equal(upload.includes("getAdminUsersRoles"), false);
+  assert.equal(upload.includes("Promise.all"), false);
+});
+
+test("seguridad de archivos y trazabilidad permanecen bajo contratos admin", () => {
+  const source = [read(CARD_PATH), read(UPLOAD_PATH)].join("\n");
+
+  assert.ok(source.includes("updateAdminReportWorkflowStage"));
+  assert.ok(source.includes("updateAdminReportSpecialStain"));
+  assert.ok(source.includes("<ReportFileActions"));
+  assert.ok(source.includes('scope="admin"'));
+  assert.equal(source.includes("dangerouslySetInnerHTML"), false);
+  assert.equal(source.includes("console.log"), false);
+  assert.equal(source.includes("console.info"), false);
+  assert.equal(source.includes("downloadUrl"), false);
+  assert.equal(source.includes("previewUrl"), false);
+  assert.equal(source.includes("fetch("), false);
+});

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -151,9 +151,8 @@ test("dashboard admin renders topbar, health, and summary cards", () => {
   assert.ok(combinedSource.includes("Tipos de evento"));
   assert.ok(combinedSource.includes("Estado del sistema"));
   assert.ok(source.includes('id="admin-report-upload"'));
-  assert.ok(source.includes("Panel administrador"));
-  assert.ok(source.includes("cada token administrado"));
-  assert.ok(source.includes("sin búsqueda manual"));
+  assert.ok(source.includes('import { AdminReportsCard } from "./AdminReportsCard";'));
+  assert.ok(source.includes("<AdminReportsCard />"));
   assert.equal(source.includes("<UploadReportModal />"), false);
   assert.ok(source.includes('id="admin-health"'));
   assert.ok(source.includes("<AdminClinicsManagementCard />"));
@@ -198,8 +197,7 @@ test("dashboard admin keeps module hub cards and preserves admin sections", () =
   assert.ok(controllerSource.includes('"admin-health"'));
   assert.ok(source.includes('<AdminDashboardWorkspaceController'));
   assert.ok(source.includes('id="admin-report-upload"'));
-  assert.ok(source.includes("Carga de informes"));
-  assert.ok(source.includes("cada token administrado"));
+  assert.ok(source.includes("<AdminReportsCard />"));
   assert.ok(source.includes("Alertas críticas"));
   assert.ok(source.includes("Sistema"));
   assert.ok(source.includes("Auditoría"));
@@ -219,20 +217,20 @@ test("dashboard admin keeps module hub cards and preserves admin sections", () =
   // PR5B: slot vars defined before <main> in render order (commandCenter → alerts → tabs).
   const commandCenterIndex = source.indexOf("<AdminCommandCenter");
   const alertsCardIndex = source.indexOf("<AdminFailedLoginAlertsReadOnlyCard />");
-  const reportUploadTitleIndex = source.indexOf("Carga de informes");
+  const reportsCardIndex = source.indexOf("<AdminReportsCard />");
 
   assert.ok(mainIndex >= 0);
   assert.ok(pageHeaderIndex >= 0);
   assert.ok(workspaceControllerIndex >= 0);
   assert.ok(commandCenterIndex >= 0);
   assert.ok(alertsCardIndex >= 0);
-  assert.ok(reportUploadTitleIndex >= 0);
+  assert.ok(reportsCardIndex >= 0);
   assert.ok(mainIndex < workspaceControllerIndex);
   // App Shell: page header is a controller prop, rendered hub-only after the
   // controller opening tag.
   assert.ok(workspaceControllerIndex < pageHeaderIndex);
   assert.ok(commandCenterIndex < alertsCardIndex);
-  assert.ok(alertsCardIndex < reportUploadTitleIndex);
+  assert.ok(alertsCardIndex < reportsCardIndex);
   assert.equal(source.includes(`xl:grid-cols-${7}`), false);
 });
 

--- a/test/frontend-report-upload-modal.test.ts
+++ b/test/frontend-report-upload-modal.test.ts
@@ -81,7 +81,7 @@ test("frontend admin token workspace does not mount upload report modal", () => 
   assert.equal(page.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'), false);
   assert.ok(page.includes('id="admin-report-upload"'));
   assert.equal(page.includes("<UploadReportModal />"), false);
-  assert.ok(page.includes("Carga de informes"));
+  assert.ok(page.includes("<AdminReportsCard />"));
   assert.equal(card.includes('import { UploadReportModal } from "@/components/dashboard/UploadReportModal";'), false);
   assert.equal(card.includes("triggerLabel={"), false);
   assert.equal(card.includes('"Subir informe para este token"'), false);


### PR DESCRIPTION
## Summary
- Compact Admin Reports into an enterprise-density operational console
- Preserve the real module identifier admin-report-upload
- Add dense paginated report workflow table with PAGE_SIZE = 9
- Add compact upload flow with server-side clinic search and token loading on demand
- Preserve secure report download/actions without exposing private URLs
- Preserve no-scroll contract and avoid backend, DB or dependency changes

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm test
- Playwright no-scroll E2E Chromium: admin upload report alias, 2/2 at 1366x768 and 1440x900
- git diff --check

## Scope
Admin Reports only.
No Dashboard Clínica, Informes Clínica, Tokens, Clínicas, Resumen, Auditoría, Usuarios, Sesiones, login, public web, backend, DB, dependencies, migrations, SEO or Dependabot changes.
No E2E contract relaxation.