### PR TITLE
feat(admin): compact users roles dashboard density

### DIFF
--- a/docs/implementation/admin-users-roles-enterprise-density.md
+++ b/docs/implementation/admin-users-roles-enterprise-density.md
@@ -1,0 +1,102 @@
+# PR-7A — Admin Usuarios y Roles con densidad enterprise
+
+## Objetivo
+
+Convertir Usuarios y Roles del Dashboard Administración en una consola compacta,
+sobria y segura, manteniendo el contrato funcional existente y el App Shell sin
+scroll global.
+
+## Superficie real y frontera de alcance
+
+- Identificador real de navegación: `admin-users-roles`.
+- Superficie frontend: `AdminUsersRolesReadOnlyCard` dentro de
+  `/dashboard/admin?module=admin-users-roles`.
+- La navegación horizontal conserva la etiqueta `Usuarios`.
+- PR-7A incluye exclusivamente lectura de usuarios administrativos y de clínica,
+  filtros existentes y cambio de rol de usuarios de clínica.
+- Sesiones, revocación, dispositivos y datos de sesión quedan fuera de alcance y
+  se reservan para PR-7B.
+
+## Estado previo detectado
+
+La superficie ya consumía `GET /api/admin/users-roles` con filtros `userType` y
+`role`, además de `limit/offset`. Usaba paginación server-side de cinco filas,
+cinco bloques altos para métricas y filtros, una tabla espaciosa y botones de
+cambio de rol que elevaban la altura de cada fila. El cambio de rol ya requería
+confirmación y utilizaba el contrato backend auditado existente.
+
+No se detectó carga masiva ni N+1: cada página requiere una consulta y cada cambio
+de rol una mutación puntual. Tampoco existe búsqueda textual server-side en el
+contrato actual.
+
+## Implementación
+
+- Page size final: `9`, server-side mediante `limit/offset`.
+- Header de 48 px aproximados, acción secundaria de 32 px y subtítulo breve.
+- Franja única de tres métricas con valores de 20 px.
+- Filtros de tipo y rol en una barra compacta; no se agregaron filtros sin dato.
+- Tabla desktop con header de 32 px y filas de 36 px.
+- Lista mobile priorizada con usuario, rol, clínica e identificación secundaria.
+- Paginación compacta con rango, página actual y controles anterior/siguiente.
+- IDs internos permanecen como metadata secundaria; no son contenido principal.
+- No se muestran emails porque el contrato no los entrega ni eran necesarios.
+- Se mantienen usuario, tipo, rol, clínica, alta y actualización, que son los
+  únicos datos reales disponibles para esta superficie.
+
+## Seguridad y trazabilidad
+
+- Los usuarios admin continúan sin ser editables desde esta consola.
+- Solo los dos roles de clínica existentes pueden alternarse.
+- Cada cambio conserva confirmación explícita, bloqueo durante la mutación,
+  protección contra degradar al último Owner y feedback controlado.
+- El contrato backend existente registra `clinic_user.role.changed`; PR-7A no
+  modifica autorización, validación ni auditoría.
+- No se muestran ni trasladan passwords, hashes, tokens, cookies, session IDs o
+  datos de sesión.
+- No se agregan logs de consola, HTML inseguro, fetch público ni endpoint nuevo.
+
+## No-scroll y responsive
+
+`dashboard-main` conserva `overflow-hidden`. La tabla no agrega scroll vertical
+regional ni `data-dashboard-scroll-region`; nueve filas densas caben en el
+viewport de referencia 1366×768. Desktop usa tabla ajustada, mientras mobile usa
+una lista priorizada para evitar una tabla horizontal ilegible.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx`
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx`
+- `test/frontend-admin-users-roles-card.test.ts`
+- `test/frontend-dashboard-tables-cards-consistency-polish.test.ts`
+- `test/admin-users-roles-enterprise-density.test.ts`
+- `docs/implementation/admin-users-roles-enterprise-density.md`
+
+## Tests y validaciones
+
+- Tests focalizados de Usuarios/Roles y regresión PR-2 a PR-6: 99/99.
+- `pnpm --dir frontend lint`: OK.
+- `pnpm --dir frontend typecheck`: OK.
+- `pnpm --dir frontend build`: OK.
+- `pnpm test`: 2799/2799.
+- `dashboard-real-app-shell-no-scroll-contract.spec.ts` en Chromium: 28/28
+  para 1440×900 y 1366×768.
+- No existe E2E específico para `admin-users-roles`; el E2E ejecutado cubre el
+  contrato global real del App Shell, y los contratos estáticos focalizados
+  cubren esta superficie.
+
+## Deuda técnica y riesgos residuales
+
+- El backend no ofrece búsqueda textual, estado ni última actividad para esta
+  superficie; no se implementa filtrado client-side parcial ni se inventan datos.
+- No existe selector 25/50/100 porque el contrato de scroll regional se difiere.
+- La confirmación sensible continúa usando el diálogo nativo existente; un
+  diálogo de producto exigiría una modificación funcional adicional.
+- La semántica histórica del componente conserva `ReadOnlyCard`, aunque permite
+  la mutación de rol ya existente; se mantiene para evitar renombrados amplios.
+
+## No alcance y próximos PRs
+
+No se modifica Dashboard Clínica, Sesiones, auth, login, cookies, backend, base
+de datos, migraciones, dependencias, web pública, Tokens, Clínicas, Resumen,
+Informes, Auditoría ni ramas Dependabot. PR-7B podrá abordar Sesiones de forma
+independiente.

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -744,7 +744,7 @@ test.describe("admin dashboard — per-module workspace activation", () => {
     { cardTitle: "Clínicas", workspaceId: "admin-clinics" },
     { cardTitle: "Precios", workspaceId: "admin-pricing" },
     { cardTitle: "Sesiones", workspaceId: "admin-sessions" },
-    { cardTitle: "Roles clínica", workspaceId: "admin-users-roles" },
+    { cardTitle: "Usuarios y roles", workspaceId: "admin-users-roles" },
     { cardTitle: "Estado del sistema", workspaceId: "admin-health" },
     { cardTitle: "Tokens particulares", workspaceId: "admin-particular-tokens" },
     { cardTitle: "Mantenimiento", workspaceId: "admin-maintenance" },

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -128,8 +128,8 @@ const ADMIN_MODULE_META: Record<AdminModule, { title: string; description: strin
     description: "Consultar y revocar sesiones activas de clínicas.",
   },
   "admin-users-roles": {
-    title: "Roles clínica",
-    description: "Auditoría de cambios de rol en usuarios de clínicas.",
+    title: "Usuarios y roles",
+    description: "Permisos administrativos y de clínica con trazabilidad.",
   },
   "audit-log": {
     title: "Auditoría",
@@ -283,11 +283,11 @@ export function AdminDashboardWorkspaceController({
     },
     {
       icon: UsersRound,
-      title: "Roles clínica",
-      description: "Auditoría de cambios de rol en usuarios de clínicas.",
+      title: "Usuarios y roles",
+      description: "Permisos administrativos y de clínica con trazabilidad.",
       moduleId: "admin-users-roles" as AdminModule,
       onClick: () => activateModule("admin-users-roles"),
-      actionLabel: "Ver roles",
+      actionLabel: "Ver usuarios",
     },
     {
       icon: ScrollText,

--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -4,12 +4,7 @@ import { useEffect, useMemo, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -18,10 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  changeAdminClinicUserRole,
-  getAdminUsersRoles,
-} from "@/lib/api";
+import { changeAdminClinicUserRole, getAdminUsersRoles } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
 import type {
   AdminRoleUserRole,
@@ -31,7 +23,9 @@ import type {
   ClinicUserRole,
 } from "@/types";
 
-const PAGE_SIZE = 5;
+// Nine compact rows are the viewport-safe contract established for the admin
+// modules while dashboard-main intentionally remains non-scrollable.
+const PAGE_SIZE = 9;
 
 function formatUserType(value: AdminRoleUserType) {
   return value === "admin" ? "Admin" : "Clínica";
@@ -61,6 +55,17 @@ function formatClinic(user: AdminRoleUserSummary) {
   if (user.userType === "admin") return "—";
 
   return user.clinicName ? `${user.clinicName} #${user.clinicId}` : `#${user.clinicId}`;
+}
+
+function getClinicMetadata(user: AdminRoleUserSummary) {
+  if (user.userType === "admin") return null;
+
+  return [
+    `Clínica #${user.clinicId}`,
+    user.clinicLocality?.trim() || null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function getNextClinicRole(role: ClinicUserRole): ClinicUserRole {
@@ -94,6 +99,36 @@ function formatRoleChangeError(error: unknown) {
   }
 
   return message;
+}
+
+type RoleBadgeProps = {
+  role: AdminRoleUserRole;
+};
+
+function AdminRoleBadge({ role }: RoleBadgeProps) {
+  return (
+    <Badge
+      variant={getRoleVariant(role)}
+      className="h-5 max-w-full truncate px-1.5 text-[11px] font-medium"
+    >
+      {formatRole(role)}
+    </Badge>
+  );
+}
+
+type UserTypeBadgeProps = {
+  userType: AdminRoleUserType;
+};
+
+function AdminUserTypeBadge({ userType }: UserTypeBadgeProps) {
+  return (
+    <Badge
+      variant={getUserTypeVariant(userType)}
+      className="h-5 px-1.5 text-[11px] font-medium"
+    >
+      {formatUserType(userType)}
+    </Badge>
+  );
 }
 
 export function AdminUsersRolesReadOnlyCard() {
@@ -154,7 +189,7 @@ export function AdminUsersRolesReadOnlyCard() {
 
     const nextRole = getNextClinicRole(user.role);
     const confirmed = window.confirm(
-      `¿Cambiar el rol de ${user.username} de ${formatRole(user.role)} a ${formatRole(nextRole)}?`,
+      `¿Cambiar el rol de ${user.username} de ${formatRole(user.role)} a ${formatRole(nextRole)}? El cambio quedará registrado en auditoría.`,
     );
 
     if (!confirmed) {
@@ -202,20 +237,42 @@ export function AdminUsersRolesReadOnlyCard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
+  const users = snapshot?.users ?? [];
   const hasPreviousPage = offset > 0;
   const hasNextPage = snapshot
     ? offset + snapshot.users.length < snapshot.total
     : false;
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const pageCount = snapshot ? Math.max(1, Math.ceil(snapshot.total / PAGE_SIZE)) : 1;
+  const rangeStart = users.length ? offset + 1 : 0;
+  const rangeEnd = offset + users.length;
 
   return (
-    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
-      <CardHeader className="flex flex-col gap-3 border-b border-vetneb-line/70 lg:flex-row lg:items-start lg:justify-between">
-        <div>
+    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none">
+      <CardHeader className="flex min-h-12 shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-3 py-2 sm:px-4">
+        <div className="min-w-0">
           <CardTitle className="text-base">Usuarios y roles</CardTitle>
+          <p
+            className={`line-clamp-2 text-xs sm:truncate ${
+              error
+                ? "text-destructive"
+                : roleChangeMessage
+                  ? "text-vetneb-teal"
+                  : "text-muted-foreground"
+            }`}
+            role={error ? "alert" : roleChangeMessage ? "status" : undefined}
+            title={error ?? roleChangeMessage ?? undefined}
+          >
+            {error ??
+              roleChangeMessage ??
+              "Permisos administrativos y de clínica con cambios auditados."}
+          </p>
         </div>
-
         <Button
           type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 px-2.5 text-xs"
           onClick={loadUsersRoles}
           disabled={isPending || isMutatingRole}
           aria-busy={isPending ? true : undefined}
@@ -225,33 +282,42 @@ export function AdminUsersRolesReadOnlyCard() {
         </Button>
       </CardHeader>
 
-      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
-        <div className="dashboard-filter-stats-grid-5">
-          <div className="surface-soft">
-            <p className="text-xs text-muted-foreground">Total filtrado</p>
-            <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+      <CardContent className="flex min-h-0 flex-1 flex-col p-0">
+        <div className="grid min-h-11 shrink-0 grid-cols-3 border-b border-vetneb-line/70">
+          <div className="flex items-center justify-between gap-2 px-3 py-1 sm:px-4">
+            <span className="truncate text-[11px] text-muted-foreground sm:text-xs">
+              Total filtrado
+            </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
               {snapshot?.total ?? "—"}
-            </p>
+            </strong>
           </div>
-
-          <div className="surface-soft">
-            <p className="text-xs text-muted-foreground">Admins</p>
-            <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+          <div className="flex items-center justify-between gap-2 border-x border-vetneb-line/70 px-3 py-1 sm:px-4">
+            <span className="truncate text-[11px] text-muted-foreground sm:text-xs">
+              Admins
+            </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
               {snapshot?.totals.adminUsers ?? "—"}
-            </p>
+            </strong>
           </div>
-
-          <div className="surface-soft">
-            <p className="text-xs text-muted-foreground">Clínicas</p>
-            <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+          <div className="flex items-center justify-between gap-2 px-3 py-1 sm:px-4">
+            <span className="truncate text-[11px] text-muted-foreground sm:text-xs">
+              Clínicas
+            </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
               {snapshot?.totals.clinicUsers ?? "—"}
-            </p>
+            </strong>
           </div>
+        </div>
 
-          <label className="surface-soft">
-            <span className="text-xs text-muted-foreground">Tipo usuario</span>
+        <div
+          className="flex min-h-12 shrink-0 items-end gap-2 border-b border-vetneb-line/70 bg-muted/15 px-3 py-2 sm:px-4"
+          aria-label="Filtros de usuarios y roles"
+        >
+          <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48">
+            Tipo usuario
             <select
-              className="field-select mt-2"
+              className="field-select h-8 text-xs"
               value={userType}
               disabled={disableUserActions}
               onChange={(event) => {
@@ -266,10 +332,10 @@ export function AdminUsersRolesReadOnlyCard() {
             </select>
           </label>
 
-          <label className="surface-soft">
-            <span className="text-xs text-muted-foreground">Rol</span>
+          <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48">
+            Rol
             <select
-              className="field-select mt-2"
+              className="field-select h-8 text-xs"
               value={role}
               disabled={disableUserActions}
               onChange={(event) => {
@@ -284,127 +350,165 @@ export function AdminUsersRolesReadOnlyCard() {
               <option value="clinic_staff">Staff clínica</option>
             </select>
           </label>
+
+          <span className="ml-auto hidden pb-2 text-[11px] text-muted-foreground md:inline">
+            {PAGE_SIZE} por página
+          </span>
         </div>
 
-        {error ? (
-          <div className="clinical-alert-error">
-            {error}
-          </div>
-        ) : null}
+        <div className="min-h-0 flex-1 py-2">
+          {users.length ? (
+            <>
+              <div className="dashboard-table-responsive dashboard-fitted-table hidden px-3 md:block sm:px-4">
+                <Table
+                  className="table-fixed text-[13px] [&_td]:h-9 [&_td]:px-2 [&_td]:py-1 [&_th]:h-8 [&_th]:px-2 [&_th]:text-xs [&_th]:font-semibold"
+                  aria-label="Tabla de usuarios y roles administrativos"
+                >
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[18%]">Usuario</TableHead>
+                      <TableHead className="w-[10%]">Tipo</TableHead>
+                      <TableHead className="w-[14%]">Rol</TableHead>
+                      <TableHead>Clínica</TableHead>
+                      <TableHead className="hidden w-[9.5rem] xl:table-cell">Creado</TableHead>
+                      <TableHead className="w-[9.5rem]">Actualizado</TableHead>
+                      <TableHead className="w-[8.5rem] text-right">Acción</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {users.map((user) => {
+                      const userKey = getUserKey(user);
+                      const isChanging = changingUserKey === userKey;
+                      const wasChanged = changedUserKey === userKey;
 
-        {roleChangeMessage ? (
-          <div className="clinical-alert-success">
-            {roleChangeMessage}
-          </div>
-        ) : null}
+                      return (
+                        <TableRow
+                          key={userKey}
+                          className={wasChanged ? "bg-vetneb-teal/10" : undefined}
+                        >
+                          <TableCell>
+                            <p className="truncate font-semibold text-vetneb-ink/90">
+                              {user.username}
+                            </p>
+                            <p className="truncate font-mono text-[11px] text-muted-foreground">
+                              ID {user.userId}{wasChanged ? " · Actualizado" : ""}
+                            </p>
+                          </TableCell>
+                          <TableCell>
+                            <AdminUserTypeBadge userType={user.userType} />
+                          </TableCell>
+                          <TableCell>
+                            <AdminRoleBadge role={user.role} />
+                          </TableCell>
+                          <TableCell>
+                            <p className="truncate text-xs text-vetneb-ink/85">
+                              {user.userType === "clinic"
+                                ? user.clinicName || `Clínica #${user.clinicId}`
+                                : "Administración VETNEB"}
+                            </p>
+                            {getClinicMetadata(user) ? (
+                              <p className="truncate text-[11px] text-muted-foreground">
+                                {getClinicMetadata(user)}
+                              </p>
+                            ) : null}
+                          </TableCell>
+                          <TableCell className="hidden truncate text-xs text-muted-foreground xl:table-cell">
+                            {formatDateTime(user.createdAt)}
+                          </TableCell>
+                          <TableCell className="truncate text-xs text-muted-foreground">
+                            {formatDateTime(user.updatedAt)}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {user.userType === "clinic" ? (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                disabled={disableUserActions}
+                                aria-busy={isChanging ? true : undefined}
+                                onClick={() => void handleChangeClinicRole(user)}
+                              >
+                                {isChanging ? "Cambiando..." : "Cambiar rol"}
+                              </Button>
+                            ) : (
+                              <span className="text-[11px] text-muted-foreground">
+                                No editable
+                              </span>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
 
-        <div className="dashboard-table-responsive min-h-0 flex-1">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Usuario</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead>Rol</TableHead>
-                <TableHead>Clínica</TableHead>
-                <TableHead>Creado</TableHead>
-                <TableHead>Actualizado</TableHead>
-                <TableHead className="text-right">Acción</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {snapshot?.users.length ? (
-                snapshot.users.map((user) => {
+              <div className="divide-y divide-vetneb-line/70 border-y border-vetneb-line/70 md:hidden">
+                {users.map((user) => {
                   const userKey = getUserKey(user);
                   const isChanging = changingUserKey === userKey;
-                  const wasChanged = changedUserKey === userKey;
 
                   return (
-                    <TableRow
-                      key={userKey}
-                      className={wasChanged ? "bg-vetneb-teal/10" : undefined}
-                    >
-                      <TableCell>
-                        <div className="flex flex-col gap-1">
-                          <span className="text-sm font-semibold text-vetneb-ink/88">
+                    <div key={userKey} className="flex min-h-10 items-center gap-2 px-3 py-1">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5">
+                          <p className="truncate text-xs font-semibold text-vetneb-ink">
                             {user.username}
-                          </span>
-                          <span className="font-mono text-xs text-muted-foreground">
-                            #{user.userId}
-                          </span>
-                          {wasChanged ? (
-                            <span className="text-xs font-medium text-vetneb-teal">
-                              Actualizado
-                            </span>
-                          ) : null}
+                          </p>
+                          <AdminRoleBadge role={user.role} />
                         </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={getUserTypeVariant(user.userType)}>
-                          {formatUserType(user.userType)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={getRoleVariant(user.role)}>
-                          {formatRole(user.role)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {formatClinic(user)}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {formatDateTime(user.createdAt)}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {formatDateTime(user.updatedAt)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {user.userType === "clinic" ? (
-                          <Button
-                            type="button"
-                            variant="outline"
-                            disabled={disableUserActions}
-                            onClick={() => void handleChangeClinicRole(user)}
-                          >
-                            {isChanging
-                              ? "Cambiando..."
-                              : `Cambiar a ${formatRole(getNextClinicRole(user.role))}`}
-                          </Button>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">
-                            No editable
-                          </span>
-                        )}
-                      </TableCell>
-                    </TableRow>
+                        <p className="truncate text-[11px] text-muted-foreground">
+                          ID {user.userId} · {formatClinic(user)}
+                        </p>
+                      </div>
+                      {user.userType === "clinic" ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-7 shrink-0 px-2 text-xs"
+                          disabled={disableUserActions}
+                          aria-busy={isChanging ? true : undefined}
+                          onClick={() => void handleChangeClinicRole(user)}
+                        >
+                          {isChanging ? "Cambiando..." : "Cambiar"}
+                        </Button>
+                      ) : (
+                        <AdminUserTypeBadge userType={user.userType} />
+                      )}
+                    </div>
                   );
-                })
-              ) : (
-                <TableRow>
-                  <TableCell
-                    colSpan={7}
-                    className="clinical-table-state"
-                  >
-                    {isPending
-                      ? "Cargando usuarios y roles..."
-                      : "No hay usuarios para los filtros seleccionados."}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                })}
+              </div>
+            </>
+          ) : (
+            <div className="mx-3 flex min-h-20 items-center justify-center rounded-md border border-vetneb-line/70 bg-muted/20 px-4 text-center text-xs text-muted-foreground sm:mx-4">
+              {isPending
+                ? "Cargando usuarios y roles..."
+                : "No hay usuarios para los filtros seleccionados."}
+            </div>
+          )}
         </div>
 
-        <div className="dashboard-table-pagination shrink-0">
+        <footer
+          className="dashboard-table-pagination min-h-10 shrink-0 border-t border-vetneb-line/70 px-3 py-1.5 text-xs text-muted-foreground sm:px-4"
+          aria-label="Paginación de usuarios y roles"
+        >
+          <span aria-live="polite">
+            {users.length ? `${rangeStart}–${rangeEnd} de ${snapshot?.total ?? 0}` : "Sin usuarios"}
+          </span>
           <div className="dashboard-table-pagination-controls">
             <Button
               type="button"
               variant="outline"
+              size="sm"
               disabled={!hasPreviousPage || disableUserActions}
               onClick={() => {
                 resetFiltersFeedback();
                 setOffset(Math.max(offset - PAGE_SIZE, 0));
               }}
-              className="flex-1 sm:flex-none"
+              className="h-7 px-2 text-xs flex-1 sm:flex-none"
             >
               Anterior
             </Button>
@@ -413,23 +517,23 @@ export function AdminUsersRolesReadOnlyCard() {
               aria-live="polite"
               aria-atomic="true"
             >
-              Pág.&nbsp;{Math.floor(offset / PAGE_SIZE) + 1}
-              {snapshot ? ` / ${Math.max(1, Math.ceil(snapshot.total / PAGE_SIZE))}` : null}
+              Pág. {page} / {pageCount}
             </span>
             <Button
               type="button"
               variant="outline"
+              size="sm"
               disabled={!hasNextPage || disableUserActions}
               onClick={() => {
                 resetFiltersFeedback();
                 setOffset(offset + PAGE_SIZE);
               }}
-              className="flex-1 sm:flex-none"
+              className="h-7 px-2 text-xs flex-1 sm:flex-none"
             >
               Siguiente
             </Button>
           </div>
-        </div>
+        </footer>
       </CardContent>
     </Card>
   );

--- a/test/admin-users-roles-enterprise-density.test.ts
+++ b/test/admin-users-roles-enterprise-density.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx";
+const PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const CONTROLLER_PATH =
+  "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
+const NAV_PATH = "frontend/src/components/dashboard/DashboardHorizontalNav.tsx";
+const API_PATH = "frontend/src/lib/api.ts";
+const GLOBALS_PATH = "frontend/src/app/globals.css";
+
+function read(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("PR-7A preserves the real admin-users-roles navigation surface", () => {
+  const page = read(PAGE_PATH);
+  const controller = read(CONTROLLER_PATH);
+  const nav = read(NAV_PATH);
+
+  assert.ok(page.includes('id="admin-users-roles"'));
+  assert.ok(page.includes('"admin-users-roles": usersRolesWorkspaceSlot'));
+  assert.ok(page.includes("<AdminUsersRolesReadOnlyCard />"));
+  assert.ok(controller.includes('"admin-users-roles": {'));
+  assert.ok(controller.includes('title: "Usuarios y roles"'));
+  assert.ok(nav.includes("?module=admin-users-roles"));
+});
+
+test("PR-7A uses viewport-safe server pagination with nine rows", () => {
+  const card = read(CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes("const PAGE_SIZE = 9;"));
+  assert.ok(card.includes("limit: PAGE_SIZE"));
+  assert.ok(card.includes("offset"));
+  assert.ok(card.includes("getAdminUsersRoles(query)"));
+  assert.equal(card.includes("slice("), false);
+  assert.equal(card.includes("PAGE_SIZE_OPTIONS"), false);
+  assert.ok(api.includes('query.set("limit", String(params.limit))'));
+  assert.ok(api.includes('query.set("offset", String(params.offset))'));
+});
+
+test("PR-7A renders a compact desktop table and prioritized mobile list", () => {
+  const card = read(CARD_PATH);
+
+  for (const marker of [
+    "Total filtrado",
+    "Tipo usuario",
+    "Rol",
+    'aria-label="Tabla de usuarios y roles administrativos"',
+    "[&_td]:h-9",
+    "[&_th]:h-8",
+    "text-[13px]",
+    "md:block",
+    "md:hidden",
+    'aria-label="Paginación de usuarios y roles"',
+  ]) {
+    assert.ok(card.includes(marker), `missing compact marker: ${marker}`);
+  }
+});
+
+test("PR-7A keeps role changes constrained, confirmed and auditable", () => {
+  const card = read(CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes("window.confirm("));
+  assert.ok(card.includes("El cambio quedará registrado en auditoría."));
+  assert.ok(card.includes("changeAdminClinicUserRole(user.userId, nextRole)"));
+  assert.ok(card.includes('user.userType === "clinic"'));
+  assert.ok(card.includes("No se puede degradar el último Owner clínica."));
+  assert.ok(api.includes('method: "PATCH"'));
+  assert.ok(api.includes("body: JSON.stringify({ role })"));
+});
+
+test("PR-7A does not expose sensitive fields or expand network surface", () => {
+  const card = read(CARD_PATH);
+
+  for (const forbidden of [
+    "dangerouslySetInnerHTML",
+    "console.log",
+    "console.info",
+    "passwordHash",
+    "authProId",
+    "sessionId",
+    "tokenHash",
+    "fetch(",
+    "/api/public",
+    "Promise.all",
+  ]) {
+    assert.equal(card.includes(forbidden), false, `sensitive marker: ${forbidden}`);
+  }
+});
+
+test("PR-7A respects density and global no-scroll contracts", () => {
+  const card = read(CARD_PATH);
+
+  for (const forbidden of [
+    "text-2xl",
+    "text-3xl",
+    "p-6",
+    "p-8",
+    "gap-6",
+    "gap-8",
+    "h-14",
+    "h-16",
+    "overflow-y-auto",
+    "overflow-y-scroll",
+    "data-dashboard-scroll-region",
+  ]) {
+    assert.equal(card.includes(forbidden), false, `forbidden density token: ${forbidden}`);
+  }
+
+  const globals = read(GLOBALS_PATH);
+  assert.match(
+    globals,
+    /\.dashboard-main\s*\{[\s\S]*?@apply[^;]*overflow-hidden[^;]*;[\s\S]*?\}/,
+  );
+});

--- a/test/frontend-admin-users-roles-card.test.ts
+++ b/test/frontend-admin-users-roles-card.test.ts
@@ -33,7 +33,7 @@ test("admin users roles card keeps typed role contracts and pagination size", ()
   assert.ok(source.includes("AdminRoleUserType"));
   assert.ok(source.includes("AdminUsersRolesSnapshot"));
   assert.ok(source.includes("ClinicUserRole"));
-  assert.ok(source.includes("const PAGE_SIZE = 5;"));
+  assert.ok(source.includes("const PAGE_SIZE = 9;"));
 });
 
 test("admin users roles card keeps user type role and clinic formatters", () => {
@@ -152,28 +152,28 @@ test("admin users roles card renders title counters filters and table columns", 
   assert.ok(source.includes("Clínicas"));
   assert.ok(source.includes("Tipo usuario"));
   assert.ok(source.includes("Rol"));
-  assert.ok(source.includes("<TableHead>Usuario</TableHead>"));
-  assert.ok(source.includes("<TableHead>Tipo</TableHead>"));
-  assert.ok(source.includes("<TableHead>Rol</TableHead>"));
-  assert.ok(source.includes("<TableHead>Clínica</TableHead>"));
-  assert.ok(source.includes("<TableHead>Creado</TableHead>"));
-  assert.ok(source.includes("<TableHead>Actualizado</TableHead>"));
-  assert.ok(source.includes('<TableHead className="text-right">Acción</TableHead>'));
+  assert.ok(source.includes(">Usuario</TableHead>"));
+  assert.ok(source.includes(">Tipo</TableHead>"));
+  assert.ok(source.includes(">Rol</TableHead>"));
+  assert.ok(source.includes(">Clínica</TableHead>"));
+  assert.ok(source.includes(">Creado</TableHead>"));
+  assert.ok(source.includes(">Actualizado</TableHead>"));
+  assert.ok(source.includes(">Acción</TableHead>"));
 });
 
 test("admin users roles card renders rows editable clinic actions and admin non-editable state", () => {
   const source = read(ADMIN_USERS_ROLES_CARD_PATH);
 
-  assert.ok(source.includes("snapshot.users.map((user) => {"));
+  assert.ok(source.includes("users.map((user) => {"));
   assert.ok(source.includes("const userKey = getUserKey(user);"));
   assert.ok(source.includes("const isChanging = changingUserKey === userKey;"));
   assert.ok(source.includes("const wasChanged = changedUserKey === userKey;"));
   assert.ok(source.includes('className={wasChanged ? "bg-vetneb-teal/10" : undefined}'));
   assert.ok(source.includes("{user.username}"));
-  assert.ok(source.includes("#{user.userId}"));
+  assert.ok(source.includes("ID {user.userId}"));
   assert.ok(source.includes("Actualizado"));
-  assert.ok(source.includes("formatUserType(user.userType)"));
-  assert.ok(source.includes("formatRole(user.role)"));
+  assert.ok(source.includes("<AdminUserTypeBadge userType={user.userType} />"));
+  assert.ok(source.includes("<AdminRoleBadge role={user.role} />"));
   assert.ok(source.includes("formatClinic(user)"));
   assert.ok(source.includes("formatDateTime(user.createdAt)"));
   assert.ok(source.includes("formatDateTime(user.updatedAt)"));

--- a/test/frontend-dashboard-tables-cards-consistency-polish.test.ts
+++ b/test/frontend-dashboard-tables-cards-consistency-polish.test.ts
@@ -120,16 +120,16 @@ test("PR-7 AdminFailedLoginAlertsReadOnlyCard uses dashboard-filter-stats-grid f
   );
 });
 
-test("PR-7 AdminUsersRolesReadOnlyCard uses dashboard-filter-stats-grid-5 for stats bar", () => {
+test("PR-7A AdminUsersRolesReadOnlyCard uses a compact three-metric strip", () => {
   const source = read(USERS_ROLES_CARD_PATH);
   assert.ok(
-    source.includes("dashboard-filter-stats-grid-5"),
-    "AdminUsersRolesReadOnlyCard must use dashboard-filter-stats-grid-5 class",
+    source.includes("grid min-h-11 shrink-0 grid-cols-3"),
+    "AdminUsersRolesReadOnlyCard must keep its metrics in one compact row",
   );
   assert.equal(
-    source.includes('className="grid grid-cols-1 gap-3 md:grid-cols-5"'),
+    source.includes("dashboard-filter-stats-grid-5"),
     false,
-    "AdminUsersRolesReadOnlyCard must not hardcode 5-col grid",
+    "AdminUsersRolesReadOnlyCard must not use the former stacked five-card grid",
   );
 });
 


### PR DESCRIPTION
## Summary
- Compact Admin Users/Roles into an enterprise-density operational console
- Preserve the real module identifier admin-users-roles
- Use server-side pagination with PAGE_SIZE = 9
- Keep clinic role edits behind existing confirmation/audit flow
- Keep IDs as secondary metadata and avoid emails, credentials, tokens or sessions
- Preserve no-scroll contract and avoid backend, DB or dependency changes

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm test
- Focused regression PR-2 through PR-6: 99/99
- Playwright App Shell no-scroll E2E: 28/28
- git diff --check

## Scope
Admin Users/Roles only.
No Dashboard Clínica, Sesiones, revocation, auth, login, public web, backend, DB, dependencies, migrations, SEO or Dependabot changes.
No E2E contract relaxation.