### PR TITLE
feat(admin): enterprise density for sessions module

### DIFF
--- a/docs/implementation/admin-sessions-enterprise-density.md
+++ b/docs/implementation/admin-sessions-enterprise-density.md
@@ -44,23 +44,23 @@ No se modificaron API, backend, base de datos, migraciones ni dependencias.
   badges de 20 px (`h-5 text-[11px]`) y acciones de 28 px (`h-7 px-2 text-xs`).
 - Lista mobile priorizada (`md:hidden`); tabla solo desde `md:block`.
 - Paginación compacta con rango `start–end de total` y controles anterior/siguiente.
+- Ajuste CI no-scroll: header `min-h-11 py-1`, métricas `min-h-10`, filtros
+  `min-h-11 py-1`, cuerpo `py-1` y paginación `min-h-9 py-1`.
 - Errores de carga en `role="alert"` y bloque `clinical-alert-error`; no se
   convierten en empty state silencioso.
 
 ### PAGE_SIZE final
 
-Se eligió **`PAGE_SIZE = 9`**, alineado con PR-3, PR-4, PR-6 y PR-7A.
+Se eligió **`PAGE_SIZE = 8`** como fallback final del contrato no-scroll.
 
 Justificación:
 
-- Nueve filas densas + header + métricas + filtros + paginación caben en el
-  presupuesto del App Shell con columnas progresivamente ocultas en breakpoints
-  (`lg`/`xl`).
-- La fila superior de cambio de contraseña vive en `page.tsx` fuera del card;
-  el card usa `overflow-hidden`, `p-0` y alturas mínimas compactas para
-  compensar ese costo vertical.
-- Fallback documentado: si E2E no-scroll en 1366×768 regresara, reducir a
-  `PAGE_SIZE = 8` sin tocar backend.
+- Frontend CI no-scroll en 1366×768 falló con nueve filas: `Expected <= 521` /
+  `Received 586`, un exceso vertical de 65 px.
+- Ocho filas conservan la paginación server-side y reducen el alto de la tabla
+  sin introducir scroll regional ni tocar backend.
+- La fila superior “Cambiar contraseña” vive en `page.tsx` fuera del card y
+  consume altura adicional dentro del mismo presupuesto del App Shell.
 
 ### Seguridad de sesiones
 
@@ -76,19 +76,30 @@ Justificación:
 - No se agrega `overflow-y-auto`, `overflow-y-scroll` ni
   `data-dashboard-scroll-region`.
 - El card mantiene `flex min-h-0 flex-1 flex-col overflow-hidden`.
-- Nueve filas densas + paginación fija dentro del presupuesto de viewport.
+- Ocho filas densas + paginación fija dentro del presupuesto de viewport.
 
 ## Tests y validaciones
 
-Resultados finales (Terminal 1):
+Resultados finales del parche (Terminal 1 / Terminal 2):
 
-- Focal sesiones + polish: OK (incluye `admin-sessions-enterprise-density`, card, API, responsive, password UI, tables-cards polish).
-- `pnpm test`: OK — **2806** aprobados, **0** fallos.
-- `pnpm build`: OK — `dist/index.js` generado.
-- `pnpm security:public-surface`: OK — PASS (notas server-only preexistentes en proxy).
+- Tests focales solicitados mediante `pnpm test ...`: OK — el script nativo
+  ejecutó la suite completa, **2806** aprobados y **0** fallos.
+- E2E `admin sessions populated`: OK — **2/2** en Chromium; pasan 1366×768 y
+  1440×900 sin scroll externo ni interno.
 - `pnpm --dir frontend lint`: OK.
 - `pnpm --dir frontend typecheck`: OK.
 - `pnpm --dir frontend build`: OK — Next.js 16.2.7 compilación exitosa.
+- `pnpm build`: OK — `dist/index.js` generado.
+- `pnpm security:public-surface`: OK — PASS, sin exposición pública.
+
+Trazabilidad de incidencias durante la validación:
+
+- Con `PAGE_SIZE = 8` antes de compactar contenedores, 1366×768 todavía falló
+  con `Expected <= 521` / `Received 544`; 1440×900 pasó.
+- Una ejecución concurrente de Playwright y tests hizo que Next reescribiera
+  temporalmente `frontend/next-env.d.ts` a la ruta de tipos de desarrollo y
+  activó nueve guardrails de scope. Se restituyó exactamente el archivo base y
+  la suite aislada final pasó 2806/2806; el archivo quedó fuera del diff.
 
 ## No alcance
 
@@ -107,8 +118,9 @@ Resultados finales (Terminal 1):
 2. `total` backend puede estar acotado por merge in-memory en cargas muy grandes
    (deuda preexistente en `db-admin-sessions.ts`).
 3. Confirmación de revocación sigue usando diálogo nativo del navegador.
-4. El fit final depende de mantener nueve filas y métricas compactas; ampliar a
-   25/50/100 requiere PR de scroll regional.
+4. El fit final depende de mantener ocho filas y métricas compactas; la fila
+   “Cambiar contraseña” consume altura adicional. Ampliar a 25/50/100 requiere
+   PR de scroll regional.
 
 ## Exclusiones explícitas
 

--- a/docs/implementation/admin-sessions-enterprise-density.md
+++ b/docs/implementation/admin-sessions-enterprise-density.md
@@ -1,0 +1,118 @@
+# PR-7B — Densidad enterprise en Admin Sesiones
+
+> Rama: `feat/admin-sessions-enterprise-density`  
+> Base: `2c7d505 chore(dev): add Cursor VETNEB protocol rules (#1046)`
+
+## Objetivo
+
+Convertir exclusivamente el módulo **Sesiones** del Dashboard Administración en
+una consola compacta para consultar y revocar sesiones Admin, clínica y
+particulares. El rediseño continúa los contratos visuales de PR-4 a PR-7A sin
+modificar backend, base de datos, dependencias, login, web pública ni Dashboard
+Clínica.
+
+## Estado previo detectado
+
+- `AdminSessionsReadOnlyCard` usaba `PAGE_SIZE = 3` para encajar en viewport con
+  tabla de siete columnas.
+- Header con `CardDescription` larga consumía altura vertical.
+- Solo tabla responsive; mobile arrastraba siete columnas comprimidas.
+- Paginación, filtros y revocación ya eran server-side y seguros.
+- El endpoint `GET /api/admin/sessions` ya devuelve `total`, `limit`, `offset` y
+  `currentAdminSessionId`.
+- El workspace en `page.tsx` incluye un control compacto de cambio de contraseña
+  encima del card, reduciendo presupuesto vertical respecto a Usuarios/Roles.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx`
+- `test/admin-sessions-enterprise-density.test.ts`
+- `test/frontend-admin-sessions-card.test.ts`
+- `docs/implementation/admin-sessions-enterprise-density.md`
+
+No se modificaron API, backend, base de datos, migraciones ni dependencias.
+
+## Implementación
+
+### Consola y densidad
+
+- Header compacto de ~48 px con subtítulo de 12 px (sin `CardDescription`).
+- Franja de cuatro métricas: total filtrado (`snapshot.total`), activas y
+  expiradas visibles en la página actual, número de página.
+- Barra de filtros de una línea: tipo de sesión, estado y actualización manual.
+- Tabla desktop de 13 px, header de 32 px (`h-8`), filas de 36 px (`h-9`),
+  badges de 20 px (`h-5 text-[11px]`) y acciones de 28 px (`h-7 px-2 text-xs`).
+- Lista mobile priorizada (`md:hidden`); tabla solo desde `md:block`.
+- Paginación compacta con rango `start–end de total` y controles anterior/siguiente.
+- Errores de carga en `role="alert"` y bloque `clinical-alert-error`; no se
+  convierten en empty state silencioso.
+
+### PAGE_SIZE final
+
+Se eligió **`PAGE_SIZE = 9`**, alineado con PR-3, PR-4, PR-6 y PR-7A.
+
+Justificación:
+
+- Nueve filas densas + header + métricas + filtros + paginación caben en el
+  presupuesto del App Shell con columnas progresivamente ocultas en breakpoints
+  (`lg`/`xl`).
+- La fila superior de cambio de contraseña vive en `page.tsx` fuera del card;
+  el card usa `overflow-hidden`, `p-0` y alturas mínimas compactas para
+  compensar ese costo vertical.
+- Fallback documentado: si E2E no-scroll en 1366×768 regresara, reducir a
+  `PAGE_SIZE = 8` sin tocar backend.
+
+### Seguridad de sesiones
+
+- No se muestran tokens, hashes, cookies ni passwords.
+- Revocación conserva `window.confirm` explícito y mensaje de auditoría.
+- `currentAdminSessionId` bloquea revocar la sesión admin propia.
+- IDs de sesión y actor permanecen como metadata operativa secundaria.
+- Sin `console.log`, `dangerouslySetInnerHTML` ni fetch público nuevo.
+
+## Contrato no-scroll
+
+- `dashboard-main` conserva `overflow-hidden` sin cambios.
+- No se agrega `overflow-y-auto`, `overflow-y-scroll` ni
+  `data-dashboard-scroll-region`.
+- El card mantiene `flex min-h-0 flex-1 flex-col overflow-hidden`.
+- Nueve filas densas + paginación fija dentro del presupuesto de viewport.
+
+## Tests y validaciones
+
+Resultados finales (Terminal 1):
+
+- Focal sesiones + polish: OK (incluye `admin-sessions-enterprise-density`, card, API, responsive, password UI, tables-cards polish).
+- `pnpm test`: OK — **2806** aprobados, **0** fallos.
+- `pnpm build`: OK — `dist/index.js` generado.
+- `pnpm security:public-surface`: OK — PASS (notas server-only preexistentes en proxy).
+- `pnpm --dir frontend lint`: OK.
+- `pnpm --dir frontend typecheck`: OK.
+- `pnpm --dir frontend build`: OK — Next.js 16.2.7 compilación exitosa.
+
+## No alcance
+
+- Dashboard Clínica.
+- Admin Usuarios/Roles (PR-7A).
+- Login/auth estructural, cookies, middleware.
+- Backend, DB, migraciones, secretos, `.env` y dependencias.
+- Scroll regional y selector 25/50/100.
+- Dependabot y otros módulos admin cerrados.
+- Cambios en `page.tsx` salvo necesidad futura de reubicar cambio de contraseña.
+
+## Riesgos residuales
+
+1. Contadores Activas/Expiradas reflejan la página visible, no totales globales
+   (el snapshot no expone desglose server-side).
+2. `total` backend puede estar acotado por merge in-memory en cargas muy grandes
+   (deuda preexistente en `db-admin-sessions.ts`).
+3. Confirmación de revocación sigue usando diálogo nativo del navegador.
+4. El fit final depende de mantener nueve filas y métricas compactas; ampliar a
+   25/50/100 requiere PR de scroll regional.
+
+## Exclusiones explícitas
+
+- Sin cambios en `server/routes/admin-sessions.fastify.ts`.
+- Sin cambios en `server/db-admin-sessions.ts`.
+- Sin cambios en `frontend/src/lib/api.ts` ni `frontend/src/types/index.ts`.
+- Sin instalación de dependencias ni modificación de `.env`.

--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -22,10 +22,9 @@ import type {
   AdminSessionsSnapshot,
 } from "@/types";
 
-// Nine rows match the viewport-safe contract used across admin enterprise modules.
-// The admin-sessions workspace also renders a compact credential-change control above
-// this card; if no-scroll regressions appear at 1366×768, reduce to 8 and document.
-const PAGE_SIZE = 9;
+// Eight rows preserve the 1366×768 no-scroll contract because the workspace also
+// renders the credential-change control above this card.
+const PAGE_SIZE = 8;
 
 function formatOptionalDate(value: string | null) {
   return value ? formatDateTime(value) : "—";
@@ -192,7 +191,7 @@ export function AdminSessionsReadOnlyCard() {
 
   return (
     <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none">
-      <CardHeader className="flex min-h-12 shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-3 py-2 sm:px-4">
+      <CardHeader className="flex min-h-11 shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-3 py-1 sm:px-4">
         <div className="min-w-0">
           <CardTitle className="text-base">Sesiones activas y expiradas</CardTitle>
           <p
@@ -221,7 +220,7 @@ export function AdminSessionsReadOnlyCard() {
       </CardHeader>
 
       <CardContent className="flex min-h-0 flex-1 flex-col p-0">
-        <div className="dashboard-filter-stats-grid min-h-11 shrink-0 border-b border-vetneb-line/70">
+        <div className="dashboard-filter-stats-grid min-h-10 shrink-0 border-b border-vetneb-line/70">
           <div className="flex items-center justify-between gap-2 px-1 py-1">
             <span className="truncate text-[11px] text-muted-foreground sm:text-xs">
               Total filtrado
@@ -263,7 +262,7 @@ export function AdminSessionsReadOnlyCard() {
         </div>
 
         <div
-          className="flex min-h-12 shrink-0 items-end gap-2 border-b border-vetneb-line/70 bg-muted/15 px-3 py-2 sm:px-4"
+          className="flex min-h-11 shrink-0 items-end gap-2 border-b border-vetneb-line/70 bg-muted/15 px-3 py-1 sm:px-4"
           aria-label="Filtros de sesiones"
         >
           <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48">
@@ -308,7 +307,7 @@ export function AdminSessionsReadOnlyCard() {
           </span>
         </div>
 
-        <div className="min-h-0 flex-1 py-2">
+        <div className="min-h-0 flex-1 py-1">
           {sessions.length ? (
             <>
               <div className="dashboard-table-responsive dashboard-fitted-table hidden px-3 md:block sm:px-4">
@@ -475,7 +474,7 @@ export function AdminSessionsReadOnlyCard() {
         </div>
 
         <footer
-          className="dashboard-table-pagination min-h-10 shrink-0 border-t border-vetneb-line/70 px-3 py-1.5 text-xs text-muted-foreground sm:px-4"
+          className="dashboard-table-pagination min-h-9 shrink-0 border-t border-vetneb-line/70 px-3 py-1 text-xs text-muted-foreground sm:px-4"
           aria-label="Paginación de sesiones"
         >
           <span aria-live="polite">

--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -4,13 +4,7 @@ import { useEffect, useMemo, useState, useTransition } from "react";
 import { Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -21,8 +15,6 @@ import {
 } from "@/components/ui/table";
 import { getAdminSessions, revokeAdminSession } from "@/lib/api";
 import { formatDateTime } from "@/lib/utils";
-import { EmptyState } from "@/components/dashboard/EmptyState";
-import { LoadingState } from "@/components/dashboard/LoadingState";
 import type {
   AdminSessionStatus,
   AdminSessionSummary,
@@ -30,10 +22,10 @@ import type {
   AdminSessionsSnapshot,
 } from "@/types";
 
-// Single-viewport App Shell: a full page must fit the desktop viewport (1366×768)
-// without scroll. With the fixed filter-stats bar + 7-column table, the server
-// page size is bounded to what the compact table shows.
-const PAGE_SIZE = 3;
+// Nine rows match the viewport-safe contract used across admin enterprise modules.
+// The admin-sessions workspace also renders a compact credential-change control above
+// this card; if no-scroll regressions appear at 1366×768, reduce to 8 and document.
+const PAGE_SIZE = 9;
 
 function formatOptionalDate(value: string | null) {
   return value ? formatDateTime(value) : "—";
@@ -67,6 +59,40 @@ function getStatusVariant(
 
 function formatStatus(value: AdminSessionStatus) {
   return value === "active" ? "Activa" : "Expirada";
+}
+
+function getSessionKey(session: AdminSessionSummary) {
+  return `${session.sessionType}-${session.sessionId}`;
+}
+
+type SessionTypeBadgeProps = {
+  sessionType: AdminSessionType;
+};
+
+function SessionTypeBadge({ sessionType }: SessionTypeBadgeProps) {
+  return (
+    <Badge
+      variant={getSessionTypeVariant(sessionType)}
+      className="h-5 px-1.5 text-[11px] font-medium"
+    >
+      {formatSessionType(sessionType)}
+    </Badge>
+  );
+}
+
+type SessionStatusBadgeProps = {
+  status: AdminSessionStatus;
+};
+
+function SessionStatusBadge({ status }: SessionStatusBadgeProps) {
+  return (
+    <Badge
+      variant={getStatusVariant(status)}
+      className="h-5 px-1.5 text-[11px] font-medium"
+    >
+      {formatStatus(status)}
+    </Badge>
+  );
 }
 
 export function AdminSessionsReadOnlyCard() {
@@ -112,7 +138,7 @@ export function AdminSessionsReadOnlyCard() {
   }
 
   async function handleRevokeSession(session: AdminSessionSummary) {
-    const sessionKey = `${session.sessionType}-${session.sessionId}`;
+    const sessionKey = getSessionKey(session);
     const confirmed = window.confirm(
       `¿Revocar la sesión ${formatSessionType(session.sessionType)} #${
         session.sessionId
@@ -146,45 +172,108 @@ export function AdminSessionsReadOnlyCard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
+  const sessions = snapshot?.sessions ?? [];
   const hasPreviousPage = offset > 0;
   const hasNextPage = snapshot
     ? offset + snapshot.sessions.length < snapshot.total
     : false;
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const pageCount = snapshot
+    ? Math.max(1, Math.ceil(snapshot.total / PAGE_SIZE))
+    : 1;
+  const rangeStart = sessions.length ? offset + 1 : 0;
+  const rangeEnd = offset + sessions.length;
+  const activeOnPage = sessions.filter((session) => session.status === "active")
+    .length;
+  const expiredOnPage = sessions.filter(
+    (session) => session.status === "expired",
+  ).length;
+  const disableActions = isPending || revokingSessionKey !== null;
 
   return (
-    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col">
-      <CardHeader className="shrink-0 flex flex-col gap-2 border-b border-vetneb-line/70 py-3 lg:flex-row lg:items-start lg:justify-between">
-        <div>
+    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none">
+      <CardHeader className="flex min-h-12 shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-3 py-2 sm:px-4">
+        <div className="min-w-0">
           <CardTitle className="text-base">Sesiones activas y expiradas</CardTitle>
-          <CardDescription>
-            Vista de sesiones Admin, clínica y particulares. No expone tokens,
-            hashes ni cookies. La revocación requiere confirmación explícita.
-          </CardDescription>
+          <p
+            className={`line-clamp-2 text-xs sm:truncate ${
+              error ? "text-destructive" : "text-muted-foreground"
+            }`}
+            role={error ? "alert" : undefined}
+            title={error ?? undefined}
+          >
+            {error ??
+              "Admin, clínica y particulares. Sin tokens ni hashes. Revocación auditada."}
+          </p>
         </div>
-
-        <Button type="button" onClick={loadSessions} disabled={isPending} aria-busy={isPending ? true : undefined}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 px-2.5 text-xs"
+          onClick={loadSessions}
+          disabled={disableActions}
+          aria-busy={isPending ? true : undefined}
+        >
           {isPending ? <Loader2 className="animate-spin" aria-hidden="true" /> : null}
           {isPending ? "Actualizando..." : "Actualizar"}
         </Button>
       </CardHeader>
 
-      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
-        {/* Compact single-row filter bar (no surface-soft boxes) to keep the
-            sessions card within one desktop viewport. */}
-        <div className="dashboard-filter-stats-grid shrink-0 items-end">
-          <div className="flex items-baseline gap-2">
-            <span className="text-xs text-muted-foreground">Total filtrado</span>
-            <span className="text-lg font-bold text-vetneb-ink">
-              {snapshot?.total ?? "—"}
+      <CardContent className="flex min-h-0 flex-1 flex-col p-0">
+        <div className="dashboard-filter-stats-grid min-h-11 shrink-0 border-b border-vetneb-line/70">
+          <div className="flex items-center justify-between gap-2 px-1 py-1">
+            <span className="truncate text-[11px] text-muted-foreground sm:text-xs">
+              Total filtrado
             </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
+              {snapshot?.total ?? "—"}
+            </strong>
           </div>
+          <div className="flex items-center justify-between gap-2 px-1 py-1">
+            <span
+              className="truncate text-[11px] text-muted-foreground sm:text-xs"
+              title="Activas visibles en la página actual"
+            >
+              Activas
+            </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
+              {snapshot ? activeOnPage : "—"}
+            </strong>
+          </div>
+          <div className="flex items-center justify-between gap-2 px-1 py-1">
+            <span
+              className="truncate text-[11px] text-muted-foreground sm:text-xs"
+              title="Expiradas visibles en la página actual"
+            >
+              Expiradas
+            </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
+              {snapshot ? expiredOnPage : "—"}
+            </strong>
+          </div>
+          <div className="flex items-center justify-between gap-2 px-1 py-1">
+            <span className="truncate text-[11px] text-muted-foreground sm:text-xs">
+              Página
+            </span>
+            <strong className="text-xl font-semibold tabular-nums text-vetneb-ink">
+              {snapshot ? page : "—"}
+            </strong>
+          </div>
+        </div>
 
-          <label className="flex flex-col gap-1">
-            <span className="text-xs text-muted-foreground">Tipo de sesión</span>
+        <div
+          className="flex min-h-12 shrink-0 items-end gap-2 border-b border-vetneb-line/70 bg-muted/15 px-3 py-2 sm:px-4"
+          aria-label="Filtros de sesiones"
+        >
+          <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48">
+            Tipo de sesión
             <select
-              className="field-select"
+              className="field-select h-8 text-xs"
               value={sessionType}
+              disabled={disableActions}
               onChange={(event) => {
+                setError(null);
                 setOffset(0);
                 setSessionType(event.target.value as AdminSessionType | "all");
               }}
@@ -196,12 +285,14 @@ export function AdminSessionsReadOnlyCard() {
             </select>
           </label>
 
-          <label className="flex flex-col gap-1">
-            <span className="text-xs text-muted-foreground">Estado</span>
+          <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48">
+            Estado
             <select
-              className="field-select"
+              className="field-select h-8 text-xs"
               value={status}
+              disabled={disableActions}
               onChange={(event) => {
+                setError(null);
                 setOffset(0);
                 setStatus(event.target.value as AdminSessionStatus | "all");
               }}
@@ -212,142 +303,199 @@ export function AdminSessionsReadOnlyCard() {
             </select>
           </label>
 
-          <div className="flex items-baseline gap-2">
-            <span className="text-xs text-muted-foreground">Página</span>
-            <span className="text-sm font-semibold text-vetneb-ink">
-              {Math.floor(offset / PAGE_SIZE) + 1}
-            </span>
-            <span className="text-xs text-muted-foreground">
-              {snapshot ? `${snapshot.sessions.length} visibles` : "—"}
-            </span>
-          </div>
+          <span className="ml-auto hidden pb-2 text-[11px] text-muted-foreground md:inline">
+            {PAGE_SIZE} por página
+          </span>
         </div>
 
-        {error ? (
-          <div className="clinical-alert-error">
-            {error}
-          </div>
-        ) : null}
+        <div className="min-h-0 flex-1 py-2">
+          {sessions.length ? (
+            <>
+              <div className="dashboard-table-responsive dashboard-fitted-table hidden px-3 md:block sm:px-4">
+                <Table
+                  className="table-fixed text-[13px] [&_td]:h-9 [&_td]:px-2 [&_td]:py-1 [&_th]:h-8 [&_th]:px-2 [&_th]:text-xs [&_th]:font-semibold"
+                  aria-label="Tabla de sesiones administrativas"
+                >
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[14%]">Sesión</TableHead>
+                      <TableHead className="w-[14%]">Actor</TableHead>
+                      <TableHead className="w-[10%]">Estado</TableHead>
+                      <TableHead className="hidden w-[9.5rem] lg:table-cell">
+                        Creada
+                      </TableHead>
+                      <TableHead className="w-[9.5rem]">Último acceso</TableHead>
+                      <TableHead className="hidden w-[9.5rem] xl:table-cell">
+                        Expira
+                      </TableHead>
+                      <TableHead className="w-[8.5rem] text-right">Acción</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sessions.map((session) => {
+                      const sessionKey = getSessionKey(session);
+                      const isRevoking = revokingSessionKey === sessionKey;
+                      const isCurrentAdminSession =
+                        session.sessionType === "admin" &&
+                        typeof snapshot?.currentAdminSessionId === "number" &&
+                        session.sessionId === snapshot.currentAdminSessionId;
 
-        <div className="dashboard-table-responsive min-h-0 flex-1">
-          <Table className="[&_td]:py-1.5 [&_th]:h-9">
-            <TableHeader>
-              <TableRow>
-                <TableHead>Sesión</TableHead>
-                <TableHead>Actor</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead>Creada</TableHead>
-                <TableHead>Último acceso</TableHead>
-                <TableHead>Expira</TableHead>
-                <TableHead className="text-right">Acción</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {snapshot?.sessions.length ? (
-                snapshot.sessions.map((session) => {
-                  const sessionKey = `${session.sessionType}-${session.sessionId}`;
+                      return (
+                        <TableRow key={sessionKey}>
+                          <TableCell>
+                            <div className="flex items-center gap-1.5">
+                              <SessionTypeBadge sessionType={session.sessionType} />
+                              <span className="truncate font-mono text-[11px] text-muted-foreground">
+                                #{session.sessionId}
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <p className="truncate text-xs text-vetneb-ink/88">
+                              {formatActorType(session.actorType)}
+                            </p>
+                            <p className="truncate font-mono text-[11px] text-muted-foreground">
+                              ID {session.actorId}
+                            </p>
+                          </TableCell>
+                          <TableCell>
+                            <SessionStatusBadge status={session.status} />
+                          </TableCell>
+                          <TableCell className="hidden truncate text-xs text-muted-foreground lg:table-cell">
+                            {formatOptionalDate(session.createdAt)}
+                          </TableCell>
+                          <TableCell className="truncate text-xs text-muted-foreground">
+                            {formatOptionalDate(session.lastAccess)}
+                          </TableCell>
+                          <TableCell className="hidden truncate text-xs text-muted-foreground xl:table-cell">
+                            {formatOptionalDate(session.expiresAt)}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-7 px-2 text-xs"
+                              disabled={isRevoking || isCurrentAdminSession}
+                              aria-busy={isRevoking ? true : undefined}
+                              aria-label={
+                                isCurrentAdminSession
+                                  ? `Sesión ${formatSessionType(session.sessionType)} #${session.sessionId} actual, no se puede revocar`
+                                  : `Revocar sesión ${formatSessionType(session.sessionType)} #${session.sessionId}`
+                              }
+                              onClick={() => void handleRevokeSession(session)}
+                            >
+                              {isRevoking ? (
+                                <Loader2 className="animate-spin" aria-hidden="true" />
+                              ) : null}
+                              {isCurrentAdminSession
+                                ? "Sesión actual"
+                                : isRevoking
+                                  ? "Revocando..."
+                                  : "Revocar"}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div
+                className="divide-y divide-vetneb-line/70 border-y border-vetneb-line/70 md:hidden"
+                aria-label="Lista de sesiones"
+              >
+                {sessions.map((session) => {
+                  const sessionKey = getSessionKey(session);
                   const isRevoking = revokingSessionKey === sessionKey;
                   const isCurrentAdminSession =
                     session.sessionType === "admin" &&
-                    typeof snapshot.currentAdminSessionId === "number" &&
+                    typeof snapshot?.currentAdminSessionId === "number" &&
                     session.sessionId === snapshot.currentAdminSessionId;
 
                   return (
-                    <TableRow key={sessionKey}>
-                      <TableCell className="py-1.5">
-                        <div className="flex items-center gap-2">
-                          <Badge
-                            variant={getSessionTypeVariant(session.sessionType)}
-                          >
-                            {formatSessionType(session.sessionType)}
-                          </Badge>
-                          <span className="font-mono text-xs text-muted-foreground">
-                            #{session.sessionId}
-                          </span>
+                    <div
+                      key={sessionKey}
+                      className="flex min-h-10 items-center gap-2 px-3 py-1"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5">
+                          <SessionTypeBadge sessionType={session.sessionType} />
+                          <SessionStatusBadge status={session.status} />
                         </div>
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap py-1.5 text-sm text-vetneb-ink/88">
-                        {formatActorType(session.actorType)} #{session.actorId}
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Badge variant={getStatusVariant(session.status)}>
-                          {formatStatus(session.status)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap py-1.5 text-xs text-muted-foreground">
-                        {formatOptionalDate(session.createdAt)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap py-1.5 text-xs text-muted-foreground">
-                        {formatOptionalDate(session.lastAccess)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap py-1.5 text-xs text-muted-foreground">
-                        {formatOptionalDate(session.expiresAt)}
-                      </TableCell>
-                      <TableCell className="py-1.5 text-right">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="whitespace-nowrap"
-                          disabled={isRevoking || isCurrentAdminSession}
-                          aria-busy={isRevoking ? true : undefined}
-                          aria-label={
-                            isCurrentAdminSession
-                              ? `Sesión ${formatSessionType(session.sessionType)} #${session.sessionId} actual, no se puede revocar`
-                              : `Revocar sesión ${formatSessionType(session.sessionType)} #${session.sessionId}`
-                          }
-                          onClick={() => void handleRevokeSession(session)}
-                        >
-                          {isRevoking ? <Loader2 className="animate-spin" aria-hidden="true" /> : null}
-                          {isCurrentAdminSession
-                            ? "Sesión actual"
-                            : isRevoking
-                              ? "Revocando..."
-                              : "Revocar"}
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-              ) : isPending ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="p-3">
-                    <LoadingState
-                      variant="table"
-                      compact
-                      rows={3}
-                      className="border-0 bg-transparent shadow-none rounded-none"
-                    />
-                  </TableCell>
-                </TableRow>
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={7} className="clinical-table-state">
-                    {error ? (
-                      "No se pudieron cargar las sesiones."
-                    ) : (
-                      <EmptyState
-                        title="Sin sesiones"
-                        description="No hay sesiones para los filtros seleccionados."
+                        <p className="truncate text-[11px] text-muted-foreground">
+                          {formatActorType(session.actorType)} · ID {session.actorId} ·
+                          Sesión #{session.sessionId}
+                        </p>
+                        <p className="truncate text-[11px] text-muted-foreground">
+                          Acceso {formatOptionalDate(session.lastAccess)} · Expira{" "}
+                          {formatOptionalDate(session.expiresAt)}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
                         size="sm"
-                        className="border-0 bg-transparent"
-                      />
-                    )}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                        className="h-7 shrink-0 px-2 text-xs"
+                        disabled={isRevoking || isCurrentAdminSession}
+                        aria-busy={isRevoking ? true : undefined}
+                        aria-label={
+                          isCurrentAdminSession
+                            ? `Sesión ${formatSessionType(session.sessionType)} #${session.sessionId} actual, no se puede revocar`
+                            : `Revocar sesión ${formatSessionType(session.sessionType)} #${session.sessionId}`
+                        }
+                        onClick={() => void handleRevokeSession(session)}
+                      >
+                        {isCurrentAdminSession
+                          ? "Actual"
+                          : isRevoking
+                            ? "Revocando..."
+                            : "Revocar"}
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          ) : error ? (
+            <div
+              className="clinical-alert-error mx-3 sm:mx-4"
+              role="alert"
+            >
+              {error}
+            </div>
+          ) : (
+            <div className="mx-3 flex min-h-20 items-center justify-center rounded-md border border-vetneb-line/70 bg-muted/20 px-4 text-center text-xs text-muted-foreground sm:mx-4">
+              {isPending
+                ? "Cargando sesiones..."
+                : "No hay sesiones para los filtros seleccionados."}
+            </div>
+          )}
         </div>
 
-        <div className="dashboard-table-pagination">
+        <footer
+          className="dashboard-table-pagination min-h-10 shrink-0 border-t border-vetneb-line/70 px-3 py-1.5 text-xs text-muted-foreground sm:px-4"
+          aria-label="Paginación de sesiones"
+        >
+          <span aria-live="polite">
+            {sessions.length
+              ? `${rangeStart}–${rangeEnd} de ${snapshot?.total ?? 0}`
+              : error
+                ? "Error al cargar sesiones"
+                : "Sin sesiones"}
+          </span>
           <div className="dashboard-table-pagination-controls">
             <Button
               type="button"
               variant="outline"
-              disabled={!hasPreviousPage || isPending}
-              onClick={() => setOffset(Math.max(offset - PAGE_SIZE, 0))}
-              className="flex-1 sm:flex-none"
+              size="sm"
+              disabled={!hasPreviousPage || disableActions}
+              onClick={() => {
+                setError(null);
+                setOffset(Math.max(offset - PAGE_SIZE, 0));
+              }}
+              className="h-7 px-2 text-xs flex-1 sm:flex-none"
             >
               Anterior
             </Button>
@@ -356,20 +504,23 @@ export function AdminSessionsReadOnlyCard() {
               aria-live="polite"
               aria-atomic="true"
             >
-              Pág.&nbsp;{Math.floor(offset / PAGE_SIZE) + 1}
-              {snapshot ? ` / ${Math.max(1, Math.ceil(snapshot.total / PAGE_SIZE))}` : null}
+              Pág. {page} / {pageCount}
             </span>
             <Button
               type="button"
               variant="outline"
-              disabled={!hasNextPage || isPending}
-              onClick={() => setOffset(offset + PAGE_SIZE)}
-              className="flex-1 sm:flex-none"
+              size="sm"
+              disabled={!hasNextPage || disableActions}
+              onClick={() => {
+                setError(null);
+                setOffset(offset + PAGE_SIZE);
+              }}
+              className="h-7 px-2 text-xs flex-1 sm:flex-none"
             >
               Siguiente
             </Button>
           </div>
-        </div>
+        </footer>
       </CardContent>
     </Card>
   );

--- a/test/admin-sessions-enterprise-density.test.ts
+++ b/test/admin-sessions-enterprise-density.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx";
+const PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const CONTROLLER_PATH =
+  "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
+const NAV_PATH = "frontend/src/components/dashboard/DashboardHorizontalNav.tsx";
+const API_PATH = "frontend/src/lib/api.ts";
+const GLOBALS_PATH = "frontend/src/app/globals.css";
+
+function read(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("PR-7B preserves the real admin-sessions navigation surface", () => {
+  const page = read(PAGE_PATH);
+  const controller = read(CONTROLLER_PATH);
+  const nav = read(NAV_PATH);
+
+  assert.ok(page.includes('id="admin-sessions"'));
+  assert.ok(page.includes('"admin-sessions": sessionsWorkspaceSlot'));
+  assert.ok(page.includes("<AdminSessionsReadOnlyCard />"));
+  assert.ok(controller.includes('"admin-sessions": {'));
+  assert.ok(controller.includes('title: "Sesiones"'));
+  assert.ok(nav.includes("?module=admin-sessions"));
+});
+
+test("PR-7B uses viewport-safe server pagination with nine rows", () => {
+  const card = read(CARD_PATH);
+  const api = read(API_PATH);
+
+  assert.ok(card.includes("const PAGE_SIZE = 9;"));
+  assert.ok(card.includes("limit: PAGE_SIZE"));
+  assert.ok(card.includes("offset"));
+  assert.ok(card.includes("getAdminSessions(query)"));
+  assert.ok(card.includes("offset + snapshot.sessions.length < snapshot.total"));
+  assert.equal(card.includes("slice("), false);
+  assert.equal(card.includes("PAGE_SIZE_OPTIONS"), false);
+  assert.ok(api.includes('query.set("limit", String(params.limit))'));
+  assert.ok(api.includes('query.set("offset", String(params.offset))'));
+});
+
+test("PR-7B renders a compact desktop table and prioritized mobile list", () => {
+  const card = read(CARD_PATH);
+
+  for (const marker of [
+    "Total filtrado",
+    "Activas",
+    "Expiradas",
+    "Tipo de sesión",
+    "Estado",
+    'aria-label="Tabla de sesiones administrativas"',
+    "[&_td]:h-9",
+    "[&_th]:h-8",
+    "text-[13px]",
+    "md:block",
+    "md:hidden",
+    'aria-label="Paginación de sesiones"',
+    "h-7 px-2 text-xs",
+    "h-5 px-1.5 text-[11px]",
+  ]) {
+    assert.ok(card.includes(marker), `missing compact marker: ${marker}`);
+  }
+
+  assert.equal(card.includes("CardDescription"), false);
+});
+
+test("PR-7B keeps revocation constrained, confirmed and blocks current admin session", () => {
+  const card = read(CARD_PATH);
+
+  assert.ok(card.includes("window.confirm("));
+  assert.ok(card.includes("Esta acción cerrará esa sesión y quedará auditada."));
+  assert.ok(card.includes("await revokeAdminSession(session.sessionType, session.sessionId);"));
+  assert.ok(card.includes("isCurrentAdminSession"));
+  assert.ok(card.includes("snapshot?.currentAdminSessionId"));
+  assert.ok(card.includes("disabled={isRevoking || isCurrentAdminSession}"));
+  assert.ok(card.includes('"Sesión actual"'));
+});
+
+test("PR-7B surfaces load errors explicitly instead of empty success states", () => {
+  const card = read(CARD_PATH);
+
+  assert.ok(card.includes('role="alert"'));
+  assert.ok(card.includes('"No se pudieron cargar las sesiones."'));
+  assert.ok(card.includes("Error al cargar sesiones"));
+  assert.ok(card.includes("clinical-alert-error"));
+});
+
+test("PR-7B does not expose sensitive fields or expand network surface", () => {
+  const card = read(CARD_PATH);
+
+  for (const forbidden of [
+    "dangerouslySetInnerHTML",
+    "console.log",
+    "console.info",
+    "sessionToken",
+    "tokenHash",
+    "passwordHash",
+    "cookie",
+    "fetch(",
+    "/api/public",
+    "Promise.all",
+  ]) {
+    assert.equal(card.includes(forbidden), false, `sensitive marker: ${forbidden}`);
+  }
+});
+
+test("PR-7B respects density and global no-scroll contracts", () => {
+  const card = read(CARD_PATH);
+
+  for (const forbidden of [
+    "text-2xl",
+    "text-3xl",
+    "p-6",
+    "p-8",
+    "gap-6",
+    "gap-8",
+    "h-14",
+    "h-16",
+    "overflow-y-auto",
+    "overflow-y-scroll",
+    "data-dashboard-scroll-region",
+  ]) {
+    assert.equal(card.includes(forbidden), false, `forbidden density token: ${forbidden}`);
+  }
+
+  assert.ok(card.includes("flex min-h-0 flex-1 flex-col"));
+
+  const globals = read(GLOBALS_PATH);
+  assert.match(
+    globals,
+    /\.dashboard-main\s*\{[\s\S]*?@apply[^;]*overflow-hidden[^;]*;[\s\S]*?\}/,
+  );
+});

--- a/test/admin-sessions-enterprise-density.test.ts
+++ b/test/admin-sessions-enterprise-density.test.ts
@@ -32,11 +32,11 @@ test("PR-7B preserves the real admin-sessions navigation surface", () => {
   assert.ok(nav.includes("?module=admin-sessions"));
 });
 
-test("PR-7B uses viewport-safe server pagination with nine rows", () => {
+test("PR-7B uses viewport-safe server pagination with eight rows", () => {
   const card = read(CARD_PATH);
   const api = read(API_PATH);
 
-  assert.ok(card.includes("const PAGE_SIZE = 9;"));
+  assert.ok(card.includes("const PAGE_SIZE = 8;"));
   assert.ok(card.includes("limit: PAGE_SIZE"));
   assert.ok(card.includes("offset"));
   assert.ok(card.includes("getAdminSessions(query)"));

--- a/test/frontend-admin-sessions-card.test.ts
+++ b/test/frontend-admin-sessions-card.test.ts
@@ -31,7 +31,7 @@ test("admin sessions card keeps typed session contracts", () => {
   assert.ok(source.includes("AdminSessionSummary"));
   assert.ok(source.includes("AdminSessionType"));
   assert.ok(source.includes("AdminSessionsSnapshot"));
-  assert.ok(source.includes("const PAGE_SIZE = 3;"));
+  assert.ok(source.includes("const PAGE_SIZE = 9;"));
 });
 
 test("admin sessions card keeps formatters and badge variants", () => {
@@ -90,7 +90,7 @@ test("admin sessions card revokes sessions only after explicit confirmation", ()
   const source = read(ADMIN_SESSIONS_CARD_PATH);
 
   assert.ok(source.includes("async function handleRevokeSession(session: AdminSessionSummary)"));
-  assert.ok(source.includes("const sessionKey = `${session.sessionType}-${session.sessionId}`;"));
+  assert.ok(source.includes("const sessionKey = getSessionKey(session);"));
   assert.ok(source.includes("const confirmed = window.confirm("));
   assert.ok(source.includes("Esta acción cerrará esa sesión y quedará auditada."));
   assert.ok(source.includes("if (!confirmed) {"));
@@ -105,28 +105,33 @@ test("admin sessions card renders safe description filters and table columns", (
   const source = read(ADMIN_SESSIONS_CARD_PATH);
 
   assert.ok(source.includes("Sesiones activas y expiradas"));
-  assert.ok(source.includes("Vista de sesiones Admin, clínica y particulares. No expone tokens,"));
-  assert.ok(source.includes("hashes ni cookies. La revocación requiere confirmación explícita."));
+  assert.ok(source.includes("Sin tokens ni hashes. Revocación auditada."));
   assert.ok(source.includes("Total filtrado"));
+  assert.ok(source.includes("Activas"));
+  assert.ok(source.includes("Expiradas"));
   assert.ok(source.includes("Tipo de sesión"));
   assert.ok(source.includes("Estado"));
+  assert.ok(source.includes("dashboard-filter-stats-grid"));
   assert.ok(source.includes("Página"));
-  assert.ok(source.includes("<TableHead>Sesión</TableHead>"));
-  assert.ok(source.includes("<TableHead>Actor</TableHead>"));
-  assert.ok(source.includes("<TableHead>Estado</TableHead>"));
-  assert.ok(source.includes("<TableHead>Creada</TableHead>"));
-  assert.ok(source.includes("<TableHead>Último acceso</TableHead>"));
-  assert.ok(source.includes("<TableHead>Expira</TableHead>"));
-  assert.ok(source.includes('<TableHead className="text-right">Acción</TableHead>'));
+  assert.ok(source.includes(">Sesión</TableHead>"));
+  assert.ok(source.includes(">Actor</TableHead>"));
+  assert.ok(source.includes(">Estado</TableHead>"));
+  assert.ok(source.includes("Creada"));
+  assert.ok(source.includes("Último acceso"));
+  assert.ok(source.includes("Expira"));
+  assert.ok(source.includes("Acción</TableHead>"));
+  assert.ok(source.includes('aria-label="Tabla de sesiones administrativas"'));
+  assert.ok(source.includes("text-[13px]"));
+  assert.ok(source.includes("md:hidden"));
 });
 
 test("admin sessions card renders rows actions empty state and pagination", () => {
   const source = read(ADMIN_SESSIONS_CARD_PATH);
 
-  assert.ok(source.includes("snapshot.sessions.map((session) => {"));
+  assert.ok(source.includes("sessions.map((session) => {"));
   assert.ok(source.includes("formatSessionType(session.sessionType)"));
   assert.ok(source.includes("formatActorType(session.actorType)"));
-  assert.ok(source.includes("formatStatus(session.status)"));
+  assert.ok(source.includes("SessionStatusBadge"));
   assert.ok(source.includes("formatOptionalDate(session.createdAt)"));
   assert.ok(source.includes("formatOptionalDate(session.lastAccess)"));
   assert.ok(source.includes("formatOptionalDate(session.expiresAt)"));
@@ -134,8 +139,9 @@ test("admin sessions card renders rows actions empty state and pagination", () =
   assert.ok(source.includes('"Revocando..."'));
   assert.ok(source.includes('"Revocar"'));
   assert.ok(source.includes("isPending ?"));
-  assert.ok(source.includes("LoadingState"));
+  assert.ok(source.includes("Cargando sesiones..."));
   assert.ok(source.includes('"No se pudieron cargar las sesiones."'));
+  assert.ok(source.includes("clinical-alert-error"));
   assert.ok(source.includes("No hay sesiones para los filtros seleccionados."));
   assert.ok(source.includes("const hasPreviousPage = offset > 0;"));
   assert.ok(source.includes("const hasNextPage = snapshot"));
@@ -165,6 +171,7 @@ test("admin sessions card detecta sesión actual via currentAdminSessionId y des
   assert.ok(source.includes('session.sessionType === "admin"'));
   assert.ok(source.includes("snapshot.currentAdminSessionId"));
   assert.ok(source.includes("session.sessionId === snapshot.currentAdminSessionId"));
+  assert.ok(source.includes("snapshot?.currentAdminSessionId"));
   assert.ok(source.includes("disabled={isRevoking || isCurrentAdminSession}"));
 });
 

--- a/test/frontend-admin-sessions-card.test.ts
+++ b/test/frontend-admin-sessions-card.test.ts
@@ -31,7 +31,7 @@ test("admin sessions card keeps typed session contracts", () => {
   assert.ok(source.includes("AdminSessionSummary"));
   assert.ok(source.includes("AdminSessionType"));
   assert.ok(source.includes("AdminSessionsSnapshot"));
-  assert.ok(source.includes("const PAGE_SIZE = 9;"));
+  assert.ok(source.includes("const PAGE_SIZE = 8;"));
 });
 
 test("admin sessions card keeps formatters and badge variants", () => {


### PR DESCRIPTION
## Summary
- Redesign Admin Sesiones with enterprise-density layout for high-density operations
- Increase sessions pagination target to PAGE_SIZE = 9 while preserving server-side limit/offset
- Add compact metrics row, dense desktop table, and prioritized mobile card list
- Preserve revoke safety, current admin session protection, explicit error states, and no sensitive leakage
- Add PR-7B implementation documentation and density contract tests

## Scope
- frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
- test/admin-sessions-enterprise-density.test.ts
- test/frontend-admin-sessions-card.test.ts
- docs/implementation/admin-sessions-enterprise-density.md

## Validation
- pnpm test test/admin-sessions-enterprise-density.test.ts test/frontend-admin-sessions-card.test.ts test/frontend-admin-sessions-api.test.ts test/admin-dashboard-responsive-touch.test.ts test/frontend-dashboard-password-change-ui.test.ts
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Notes
- PAGE_SIZE final: 9
- No backend, DB, migrations, api.ts, types, page.tsx, dependencies, .env, CI, Dashboard Clínica, or other admin modules touched
- No overflow-y-auto or regional vertical scroll added
- Known debts preserved: visible-page active/expired counters, native window.confirm, backend total behavior on very large merged session sets