### PR TITLE
fix(admin): guard audit hydration boundary

### DIFF
--- a/docs/implementation/admin-audit-hydration-guard.md
+++ b/docs/implementation/admin-audit-hydration-guard.md
@@ -1,0 +1,158 @@
+# PR fix/admin-audit-hydration-guard — Entrega Codex
+
+## Base
+
+- Rama: `fix/admin-audit-hydration-guard`.
+- HEAD inicial: `bf011ab docs(protocol): add VETNEB AI working protocol (#1049)`.
+- Working tree inicial: limpio.
+- Entorno: Windows, PowerShell y PNPM.
+
+## Scope incluido
+
+- Diagnóstico del hydration mismatch reproducible en Admin Audit.
+- Corrección mínima de la frontera SSR/CSR del filtro mobile de auditoría.
+- Guard E2E contra `pageerror` y errores de consola de hidratación.
+- Validación en Chromium a 1366×768, 1440×900 y mobile 390×844.
+
+## Scope excluido
+
+- Backend, DB, Drizzle, migraciones, endpoints, auth, cookies, CORS, CSP y rate limits.
+- Dependencias, `package.json`, `pnpm-lock.yaml`, CI, workflows y Dependabot.
+- Rediseño visual, cambios de layout y refactors compartidos de `ModuleDialog`.
+- Cobertura E2E poblada de Overview, Tokens, Reports, Audit y Users/Roles.
+- Visibilidad de contraseñas de Clínica y contrato UI uniforme para 401/403.
+- `.env`, secretos, tokens, cookies reales y datos sensibles.
+
+## Auditoría previa
+
+### Archivos revisados
+
+- `frontend/src/app/dashboard/admin/page.tsx`.
+- `frontend/src/app/dashboard/admin/AdminAuditCard.tsx`.
+- `frontend/src/app/dashboard/admin/AdminAuditDenseTable.tsx`.
+- `frontend/src/app/dashboard/admin/AdminAuditDetailDialog.tsx`.
+- `frontend/src/app/dashboard/admin/AdminAuditFilterBar.tsx`.
+- `frontend/src/components/dashboard/ModuleDialog.tsx`.
+- `frontend/src/components/ui/button.tsx`.
+- `frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts`.
+- `frontend/e2e/contacto-hydration.spec.ts`.
+- `frontend/e2e/login-hydration.spec.ts`.
+- `test/admin-audit-enterprise-density.test.ts`.
+- `docs/audit/admin-enterprise-density-completion-audit.md`.
+- `docs/implementation/admin-audit-enterprise-density.md`.
+
+### Causa raíz encontrada
+
+`AdminAuditFilterBar` era un Server Component que construía un `Button` y lo
+entregaba como prop `trigger` a `ModuleDialog`, un Client Component. Radix
+`Dialog.Trigger asChild` clona ese nodo para agregar `aria-controls`,
+`data-state`, handler y ref. En la ruta Audit, el HTML SSR no contenía el
+`button`, mientras la primera renderización cliente sí lo agregaba. React
+detectaba una divergencia estructural y regeneraba el árbol en cliente.
+
+La captura del `pageerror` ubicó la cadena exacta:
+
+`AdminAuditFilterBar` → `ModuleDialog` → `DialogTrigger` → `SlotClone` →
+`Button`.
+
+No se encontraron como causa `Date.now`, `Math.random`, browser APIs durante
+render, locale dependiente ni IDs generados manualmente en la superficie Audit.
+
+## Solución implementada
+
+- `AdminAuditFilterBar.tsx` se declaró Client Component con `"use client"`.
+- El trigger y `ModuleDialog` ahora se construyen dentro de la misma frontera
+  cliente y producen markup inicial estable.
+- No se cambió markup, copy, clases, filtros, navegación, datos ni contrato
+  responsive.
+- `ModuleDialog` permaneció intacto para no ampliar el riesgo a otros módulos.
+- El E2E no-scroll captura errores antes de navegar a Admin Audit, espera la
+  finalización de la hidratación y falla ante cualquier `pageerror` o mensaje
+  de consola compatible con hydration/server-render mismatch.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/AdminAuditFilterBar.tsx`.
+- `frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts`.
+- `docs/implementation/admin-audit-hydration-guard.md`.
+
+## Tests y validaciones
+
+### Reproducción previa
+
+- `pnpm exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --grep "admin audit log"`, desde `frontend`:
+  - Antes del guard: 2/2 asserts de overflow aprobaban aunque React emitía el
+    hydration mismatch.
+  - Fase roja con guard: 0/2; ambos viewports fallaron por el `pageerror`
+    esperado en `AdminAuditFilterBar`.
+  - Fase verde tras el fix: 2/2 aprobados, sin `pageerror` ni warning de
+    hidratación.
+- `pnpm exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --grep "admin audit"`, desde `frontend`:
+  - Resultado final: 3/3 aprobados.
+  - Incluye 1366×768, 1440×900 y 390×844.
+  - En mobile, el filtro abre con Enter, cierra con Escape y devuelve el foco al
+    trigger sin error de hidratación.
+
+### Validación obligatoria
+
+- `pnpm test`: aprobado, 2806/2806 tests.
+- `pnpm build`: aprobado.
+- `pnpm security:public-surface`: aprobado, sin exposición pública detectada;
+  conserva dos hallazgos informativos `server-only` preexistentes en
+  `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint`: aprobado.
+- `pnpm --dir frontend typecheck`: aprobado.
+- `pnpm --dir frontend build`: aprobado; `/dashboard/admin` continúa como ruta
+  dinámica.
+
+### Incidencia de validación controlada
+
+Playwright/Next dev cambió temporalmente `frontend/next-env.d.ts` para apuntar
+a `.next/dev/types/routes.d.ts`. La primera ejecución de `pnpm test` falló
+9/2806 por contratos que prohíben ese artefacto. Se restauró exclusivamente la
+línea generada; la repetición completa pasó 2806/2806 y el archivo no integra
+el diff final.
+
+## QA y resultado
+
+- Chromium 1366×768: Admin Audit sin overflow y sin hydration mismatch.
+- Chromium 1440×900: Admin Audit sin overflow y sin hydration mismatch.
+- Chromium 390×844: filtro mobile operativo por teclado y sin hydration
+  mismatch.
+- El contrato visual y funcional permanece sin cambios.
+- Los 404 de `getAuditEntries` y `getAdminSystemHealth` continúan como limitación
+  conocida del web server E2E local; no producen el error de hidratación y no
+  se ocultaron con mocks nuevos.
+
+## Riesgo residual
+
+- Bajo: el cambio productivo se limita a la frontera cliente del filtro Audit.
+- El E2E local sigue validando Audit con superficie vacía por ausencia del
+  endpoint admin real en ese servidor; la cobertura poblada pertenece al PR
+  separado definido por Nico.
+- Al abrir el filtro, Radix emite en desarrollo avisos internos de título y
+  descripción por el contrato de IDs custom de `ModuleDialog`; el diálogo
+  conserva nombre accesible verificado por rol. Corregir ese helper compartido
+  afectaría otros módulos y queda fuera de este fix aislado.
+
+## Estado final
+
+- Sin cambios en backend, DB, auth, seguridad, dependencias, configuración
+  productiva ni módulos fuera del scope.
+- Sin `git add`, `git commit`, `git push`, comandos `gh` ni instalación de
+  paquetes.
+- Archivos dejados en working tree para revisión manual de Nico.
+
+## Comandos manuales pendientes para Nico
+
+```powershell
+Set-Location C:\PORTAL-VETNEB
+git status --short --untracked-files=all
+git diff --check
+git diff --stat
+git diff --name-only
+git add frontend/src/app/dashboard/admin/AdminAuditFilterBar.tsx frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts docs/implementation/admin-audit-hydration-guard.md
+git commit -m "fix(admin): guard audit hydration boundary"
+git push
+gh pr checks --watch
+```

--- a/frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
+++ b/frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
@@ -133,6 +133,34 @@ function json(route: Route, body: unknown) {
   });
 }
 
+function collectHydrationFailures(page: Page) {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  return {
+    async assertClean() {
+      await page.waitForTimeout(500);
+
+      const hydrationConsoleErrors = consoleErrors.filter((message) =>
+        /hydration|server rendered html|text content does not match/i.test(message),
+      );
+
+      expect(pageErrors).toEqual([]);
+      expect(hydrationConsoleErrors).toEqual([]);
+    },
+  };
+}
+
 function denseClinicsSnapshot(limit: number) {
   const usersPerClinic = 3;
   const clinics = Array.from({ length: limit }, (_, i) => {
@@ -442,6 +470,11 @@ for (const viewport of VIEWPORTS) {
       test(`${routeCase.label} fits without external or internal scroll`, async ({
         page,
       }, testInfo) => {
+        const hydrationFailures =
+          routeCase.label === "admin audit log"
+            ? collectHydrationFailures(page)
+            : null;
+
         await page.setViewportSize({
           width: viewport.width,
           height: viewport.height,
@@ -471,6 +504,7 @@ for (const viewport of VIEWPORTS) {
           `${viewport.name}-${routeCase.label}`,
           routeCase.ready.includes("workspace"),
         );
+        await hydrationFailures?.assertClean();
       });
     }
 
@@ -504,3 +538,35 @@ for (const viewport of VIEWPORTS) {
     });
   });
 }
+
+test("admin audit mobile filter keeps keyboard interaction hydration-safe", async ({
+  page,
+}) => {
+  const hydrationFailures = collectHydrationFailures(page);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await setAdminSession(page);
+  await mockBrowserApis(page);
+  await page.goto("/dashboard/admin?module=audit-log");
+
+  await expect(
+    page.locator('[data-dashboard-module-workspace="audit-log"]'),
+  ).toBeVisible({ timeout: 12_000 });
+
+  const filterTrigger = page.getByRole("button", {
+    name: "Filtros",
+    exact: true,
+  });
+  await expect(filterTrigger).toBeVisible();
+  await filterTrigger.focus();
+  await filterTrigger.press("Enter");
+
+  const filterDialog = page.getByRole("dialog", {
+    name: "Filtrar auditoría",
+  });
+  await expect(filterDialog).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(filterDialog).toBeHidden();
+  await expect(filterTrigger).toBeFocused();
+  await hydrationFailures.assertClean();
+});

--- a/frontend/src/app/dashboard/admin/AdminAuditFilterBar.tsx
+++ b/frontend/src/app/dashboard/admin/AdminAuditFilterBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Filter } from "lucide-react";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";


### PR DESCRIPTION
## Summary
- Fix Admin Audit hydration mismatch by moving the audit filter bar into a stable client boundary.
- Add focused E2E regression coverage for Admin Audit hydration/page errors.
- Validate mobile audit filter keyboard interaction with Enter/Escape and focus return.
- Document implementation evidence, exclusions, validation results, and residual risks.

## Tests
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- pnpm exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --grep "admin audit"

## Notes
- No backend, database, auth, dependency, CI, secret, or visual redesign changes.
- Residual Radix development warnings in shared ModuleDialog remain documented and out of scope.