### PR TITLE
fix(admin): hide clinic passwords by default

### DIFF
--- a/docs/implementation/admin-clinic-password-visibility.md
+++ b/docs/implementation/admin-clinic-password-visibility.md
@@ -1,0 +1,143 @@
+# Admin clinic password visibility
+
+## Base
+
+- Rama: `fix/admin-clinic-password-visibility`.
+- HEAD inicial: `a6ec736 test(admin): add populated admin e2e coverage (#1051)`.
+- `main` local inicial: `a6ec736 test(admin): add populated admin e2e coverage (#1051)`.
+- Working tree inicial: limpio.
+
+## Objetivo
+
+Ocultar por defecto las contraseñas nuevas ingresadas por Administración al
+crear una Clínica o reemplazar la credencial de un usuario de Clínica. La
+revelación debe ser explícita, accesible y reversible, sin cambiar los contratos
+de API ni persistencia.
+
+## Scope incluido
+
+- Alta de Clínica en `AdminClinicsManagementCard`.
+- Reemplazo de credenciales en `ClinicEditDrawer`.
+- Contratos estáticos y E2E de estado inicial, reveal y hide.
+- Runbook de staging y checklist de release relacionados.
+- Documento de implementación y trazabilidad.
+
+## Scope excluido
+
+- Backend, endpoints, DB, Drizzle, schema y migraciones.
+- Auth, cookies, sesiones, roles, permisos y manejo uniforme de 401/403.
+- Dependencias, `package.json`, lockfile, CI, workflows y Dependabot.
+- Rediseño del dashboard, App Shell y módulos Admin no relacionados.
+- `.env`, secretos, tokens y datos reales.
+
+## Auditoría previa
+
+- Rama, HEAD, `main` local y working tree coincidían con la base esperada.
+- `AdminClinicsManagementCard.tsx` renderizaba la contraseña inicial con
+  `type="text"`.
+- `ClinicEditDrawer.tsx` renderizaba cada nueva contraseña de recuperación con
+  `type="text"`.
+- `frontend-admin-clinics-management-card.test.ts` exigía expresamente que esos
+  inputs no usaran `type="password"`.
+- `docs/staging-smoke-runbook.md` y `docs/release-readiness.md` documentaban la
+  visibilidad durante la carga.
+- Los tipos de listado `AdminClinicManagementSummary` y las respuestas de
+  clínicas no contienen password ni hash. El dato sensible es el valor nuevo
+  ingresado localmente por el Admin; no proviene del listado backend.
+- No existía acción de copiar en estas dos superficies.
+
+## Comportamiento anterior
+
+- El valor nuevo quedaba visible mientras se escribía.
+- No existía interacción de reveal/hide.
+- El riesgo P2 era exposición visual, captura accidental y shoulder surfing.
+
+## Comportamiento corregido
+
+- Ambos inputs usan `type="password"` en su estado inicial.
+- Cada campo incorpora un botón `type="button"` con iconos `Eye`/`EyeOff`, foco
+  visible, `aria-label`, `aria-pressed` y `aria-controls`.
+- Reveal solo ocurre por click o activación de teclado del botón.
+- La segunda activación vuelve a ocultar el valor.
+- La visibilidad del alta se resetea al cerrar o completar el diálogo.
+- La visibilidad de recuperación se mantiene por usuario y se resetea al
+  cambiar de Clínica o guardar la credencial.
+- Se conservan `autocomplete="new-password"`, la confirmación antes de
+  reemplazar, el payload y las acciones existentes.
+- El botón se ubica dentro del campo con padding derecho, sin agregar altura ni
+  scroll regional; el patrón es neutro para desktop, laptop, tablet y móvil.
+
+## Tests agregados o ajustados
+
+- Contrato estático para estado inicial oculto en alta y recuperación.
+- Contrato de interacción accesible para reveal/hide.
+- E2E de alta con valor sintético: oculto, ausente como texto visible, reveal y
+  hide.
+- E2E de recuperación con el mismo contrato.
+- Contrato documental para eliminar las instrucciones legacy de visibilidad.
+- Contrato de iconos del botón Actualizar ajustado para incluir `Eye`/`EyeOff`.
+
+## Archivos modificados
+
+- `frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx`.
+- `frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx`.
+- `frontend/e2e/admin-clinic-edit-drawer.spec.ts`.
+- `test/frontend-admin-clinics-management-card.test.ts`.
+- `test/frontend-dashboard-action-feedback-focus-polish.test.ts`.
+- `test/admin-docs-operational-contract.test.ts`.
+- `docs/staging-smoke-runbook.md`.
+- `docs/release-readiness.md`.
+- `docs/implementation/admin-clinic-password-visibility.md`.
+
+## Validaciones
+
+- TDD focal inicial de UI y docs: 11/15; cuatro fallos esperados por el contrato
+  inseguro previo.
+- Contratos focales de UI y docs después del cambio: 15/15.
+- Contrato focal de feedback/iconos: 19/19.
+- E2E focal inicial: 0/2 por selector ambiguo del test; el DOM ya informaba
+  `type="password"`. Se seleccionó explícitamente el textbox.
+- E2E focal final:
+  `pnpm --dir frontend exec playwright test e2e/admin-clinic-edit-drawer.spec.ts --grep "password starts hidden"`
+  — 2/2.
+- `pnpm --dir frontend lint` — pasó.
+- `pnpm --dir frontend typecheck` — pasó.
+- Primera ejecución de `pnpm test` — 2806/2807; un contrato estático esperaba
+  la lista anterior exacta de imports de Lucide.
+- `pnpm test` final — 2807/2807.
+- `pnpm build` — pasó.
+- `pnpm security:public-surface` — pasó sin exposición pública; conservó dos
+  notas server-only esperadas para nombres de cookies en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend build` — pasó; 25/25 páginas generadas.
+
+Playwright regeneró temporalmente `frontend/next-env.d.ts` con la ruta de tipos
+de desarrollo. El cambio incidental fue revertido mediante parche y el archivo
+quedó fuera del diff.
+
+## Resultado
+
+- Contraseña visible por defecto: no.
+- Contraseña como texto inicial: no.
+- Contraseña en `title`, `aria-label`, `placeholder` o `data-*`: no.
+- Reveal/hide: explícito, accesible y reversible.
+- Copia: no aplica; la superficie no tenía acción de copiar.
+- Secretos reales: no se leyeron, imprimieron ni incorporaron.
+
+## Riesgo residual y QA humana
+
+- Playwright ejecutó Chromium desktop. El patrón no cambia altura ni ancho del
+  formulario, pero Nico debe completar QA visual en desktop, laptop, tablet y
+  móvil, además de teclado, foco y temas soportados.
+- El E2E mostró advertencias Radix preexistentes de `DialogTitle`/`Description`
+  en superficies del dashboard. No se modificaron porque no pertenecen a este
+  P2 y los dos tests focales pasaron.
+- La contraseña nueva permanece necesariamente en el estado controlado del
+  formulario hasta guardar o cerrar; no se renderiza como texto ni atributo
+  accesible.
+
+## Estado final y acciones manuales
+
+- Los cambios quedan en working tree, sin stage, commit ni push.
+- Nico debe revisar el diff y ejecutar la QA humana responsive.
+- Stage, commit, push y creación del PR quedan a cargo de Nico.
+- Después del push y creación del PR: `gh pr checks --watch`.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -407,9 +407,10 @@ Remove-Item Env:\SMOKE_PASSWORD
 - [ ] `[BLOCKER]` Panel admin carga health, sesiones, audit log, usuarios/roles,
   pricing, mantenimiento y tokens particulares con datos reales.
 - [ ] `[BLOCKER]` Panel admin permite crear clinica sin seleccionar rol,
-  crear usuario/contraseña inicial visible durante la carga, editar
-  nombre/email/telefono, cambiar username (email real de clínica) y reemplazar contraseña visible
-  durante la carga sin exponer passwords, hashes ni secretos.
+  crear usuario con contraseña inicial enmascarada por defecto, con reveal explícito y reversible,
+  editar nombre/email/telefono, cambiar username (email
+  real de clínica) y reemplazar contraseña con el mismo comportamiento seguro
+  sin exponer passwords, hashes ni secretos.
 - [ ] `[BLOCKER]` Panel admin permite eliminar clínicas desde UI con confirmación
   exacta por nombre y advertencia destructiva explícita.
 - [ ] `[BLOCKER]` Audit log admin registra `clinic.created`,

--- a/docs/staging-smoke-runbook.md
+++ b/docs/staging-smoke-runbook.md
@@ -391,14 +391,16 @@ habilitar operaciones admin desde frontend con `credentials: "include"`.
    - email de contacto,
    - telefono opcional,
    - usuario de acceso (usar email real de la clínica),
-   - contraseña inicial visible mientras se ingresa.
+   - contraseña inicial enmascarada por defecto; revelarla de forma explícita
+     solo durante la verificación y volver a ocultarla.
 6. Confirmar que la respuesta visual no muestra contraseña, hashes ni secretos.
 7. En la misma seccion, cambiar nombre/email/telefono de la clinica y guardar.
 8. Cambiar el username del usuario de clinica y confirmar que el listado se
    actualiza.
-9. Para recuperacion de contraseña, asignar una nueva contraseña visible y
-   guardar. La contraseña anterior no se consulta ni se recupera. Confirmar el
-   dialogo: `Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?`
+9. Para recuperacion de contraseña, asignar una nueva contraseña enmascarada por
+   defecto. Verificar que reveal/hide requiere una acción explícita, volver a
+   ocultarla y guardar. La contraseña anterior no se consulta ni se recupera.
+   Confirmar el dialogo: `Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?`
 10. Confirmar que `Clínicas` no muestra selector, columna ni acciones de rol.
    Los roles se gestionan aparte en `Roles clínica`, si aplica.
 11. Revisar `Log de auditoría` y confirmar eventos sanitizados:

--- a/frontend/e2e/admin-clinic-edit-drawer.spec.ts
+++ b/frontend/e2e/admin-clinic-edit-drawer.spec.ts
@@ -165,6 +165,43 @@ test.describe("admin clinic edit drawer — component behavior", () => {
     await expect(editButton).toBeEnabled();
   });
 
+  test("new clinic password starts hidden and only reveals by explicit reversible action", async ({
+    page,
+  }) => {
+    const syntheticPassword = "ClaveInicialSintetica42";
+
+    await page.goto("/dashboard/admin");
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+
+    await page.getByRole("button", { name: "Nueva clínica" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Nueva clínica" });
+    const passwordInput = dialog.getByRole("textbox", {
+      name: "Contraseña inicial",
+    });
+    await passwordInput.fill(syntheticPassword);
+
+    await expect(passwordInput).toHaveAttribute("type", "password");
+    await expect(dialog.getByText(syntheticPassword, { exact: true })).toHaveCount(0);
+
+    const revealButton = dialog.getByRole("button", {
+      name: "Mostrar contraseña inicial",
+    });
+    await expect(revealButton).toHaveAttribute("aria-pressed", "false");
+    await revealButton.click();
+
+    await expect(passwordInput).toHaveAttribute("type", "text");
+    await expect(
+      dialog.getByRole("button", { name: "Ocultar contraseña inicial" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await dialog
+      .getByRole("button", { name: "Ocultar contraseña inicial" })
+      .click();
+    await expect(passwordInput).toHaveAttribute("type", "password");
+  });
+
   test("clicking Edit opens the drawer with clinic data", async ({ page }) => {
     await page.goto("/dashboard/admin");
     await navigateToGestionTab(page);
@@ -186,6 +223,44 @@ test.describe("admin clinic edit drawer — component behavior", () => {
 
     // Drawer should show the clinic ID
     await expect(drawer.getByText(/clínica #1/i)).toBeVisible();
+  });
+
+  test("replacement password starts hidden and only reveals by explicit reversible action", async ({
+    page,
+  }) => {
+    const syntheticPassword = "ClaveReemplazoSintetica42";
+
+    await page.goto("/dashboard/admin");
+    await navigateToGestionTab(page);
+    await waitForClinicList(page);
+    await page
+      .getByRole("button", { name: /editar clínica clínica test/i })
+      .click();
+
+    const drawer = page.getByRole("dialog", { name: /editar clínica/i });
+    const passwordInput = drawer.getByRole("textbox", {
+      name: "Nueva contraseña",
+    });
+    await passwordInput.fill(syntheticPassword);
+
+    await expect(passwordInput).toHaveAttribute("type", "password");
+    await expect(drawer.getByText(syntheticPassword, { exact: true })).toHaveCount(0);
+
+    const revealButton = drawer.getByRole("button", {
+      name: "Mostrar nueva contraseña",
+    });
+    await expect(revealButton).toHaveAttribute("aria-pressed", "false");
+    await revealButton.click();
+
+    await expect(passwordInput).toHaveAttribute("type", "text");
+    await expect(
+      drawer.getByRole("button", { name: "Ocultar nueva contraseña" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await drawer
+      .getByRole("button", { name: "Ocultar nueva contraseña" })
+      .click();
+    await expect(passwordInput).toHaveAttribute("type", "password");
   });
 
   test("drawer has accessible close button and title", async ({ page }) => {

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
-import { ChevronLeft, ChevronRight, Loader2, Pencil, Plus, RefreshCw, Search } from "lucide-react";
+import { ChevronLeft, ChevronRight, Eye, EyeOff, Loader2, Pencil, Plus, RefreshCw, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
@@ -111,6 +111,7 @@ export function AdminClinicsManagementCard() {
   const [createForm, setCreateForm] = useState<CreateClinicForm>(getInitialCreateForm);
   const [editingClinic, setEditingClinic] = useState<AdminClinicManagementSummary | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isCreatePasswordVisible, setIsCreatePasswordVisible] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeActionKey, setActiveActionKey] = useState<string | null>(null);
@@ -156,6 +157,11 @@ export function AdminClinicsManagementCard() {
     setCreateForm((current) => ({ ...current, [key]: value }));
   }
 
+  function handleCreateDialogOpenChange(open: boolean) {
+    setIsCreateOpen(open);
+    if (!open) setIsCreatePasswordVisible(false);
+  }
+
   async function handleCreateClinic(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -178,6 +184,7 @@ export function AdminClinicsManagementCard() {
       setSuccessMessage(
         `Clínica creada: ${result.clinic.clinicName} con usuario ${result.user.username}.`,
       );
+      setIsCreatePasswordVisible(false);
       setIsCreateOpen(false);
       loadClinics(0);
     } catch (err) {
@@ -273,7 +280,7 @@ export function AdminClinicsManagementCard() {
       <CardContent className="flex min-h-0 flex-1 flex-col gap-2 px-4 pb-4 pt-3">
         <ModuleDialog
           open={isCreateOpen}
-          onOpenChange={setIsCreateOpen}
+          onOpenChange={handleCreateDialogOpenChange}
           title="Nueva clínica"
           description="Alta de clínica con su usuario de acceso inicial."
           busy={activeActionKey === "create-clinic"}
@@ -335,26 +342,50 @@ export function AdminClinicsManagementCard() {
             />
           </label>
 
-          <label className="space-y-1.5">
-            <span className="text-xs text-muted-foreground">Contraseña inicial</span>
-            <Input
-              type="text"
-              value={createForm.password}
-              disabled={isBusy}
-              minLength={8}
-              required
-              autoComplete="new-password"
-              aria-describedby="create-clinic-password-hint"
-              onChange={(event) =>
-                updateCreateField("password", event.target.value)
-              }
-            />
-          </label>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="create-clinic-password"
+              className="text-xs text-muted-foreground"
+            >
+              Contraseña inicial
+            </label>
+            <div className="relative">
+              <Input
+                id="create-clinic-password"
+                type={isCreatePasswordVisible ? "text" : "password"}
+                value={createForm.password}
+                disabled={isBusy}
+                minLength={8}
+                required
+                autoComplete="new-password"
+                aria-describedby="create-clinic-password-hint"
+                className="pr-10"
+                onChange={(event) =>
+                  updateCreateField("password", event.target.value)
+                }
+              />
+              <button
+                type="button"
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
+                onClick={() => setIsCreatePasswordVisible((current) => !current)}
+                disabled={isBusy}
+                aria-label={isCreatePasswordVisible ? "Ocultar contraseña inicial" : "Mostrar contraseña inicial"}
+                aria-pressed={isCreatePasswordVisible}
+                aria-controls="create-clinic-password"
+              >
+                {isCreatePasswordVisible ? (
+                  <EyeOff className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Eye className="h-4 w-4" aria-hidden="true" />
+                )}
+              </button>
+            </div>
+          </div>
 
           <div className="md:col-span-2">
             <p id="create-clinic-password-hint" className="text-xs text-muted-foreground">
               La contraseña anterior no se puede consultar. Para recuperación,
-              cargue una nueva contraseña visible y guárdela.
+              cargue una nueva contraseña y guárdela.
             </p>
           </div>
 

--- a/frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx
+++ b/frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useEffect, useId, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { KeyRound, Loader2, Save, X } from "lucide-react";
+import { Eye, EyeOff, KeyRound, Loader2, Save, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { AdminClinicManagementSummary } from "@/types";
@@ -58,6 +58,9 @@ export function ClinicEditDrawer({
   const [userDrafts, setUserDrafts] = useState<
     Record<number, { username: string; password: string }>
   >({});
+  const [visiblePasswordUserIds, setVisiblePasswordUserIds] = useState<
+    Record<number, boolean>
+  >({});
   const [clinicSaving, setClinicSaving] = useState(false);
   const [credentialsSaving, setCredentialsSaving] = useState<number | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -73,6 +76,7 @@ export function ClinicEditDrawer({
     if (!clinic) return;
     setClinicDraft(getInitialClinicDraft(clinic));
     setUserDrafts(getInitialUserDrafts(clinic));
+    setVisiblePasswordUserIds({});
     setClinicError(null);
     setCredentialsErrors({});
     setDeleteError(null);
@@ -144,6 +148,7 @@ export function ClinicEditDrawer({
         ...prev,
         [userId]: { ...prev[userId]!, password: "" },
       }));
+      setVisiblePasswordUserIds((prev) => ({ ...prev, [userId]: false }));
     } catch (err) {
       setCredentialsErrors((prev) => ({
         ...prev,
@@ -154,6 +159,13 @@ export function ClinicEditDrawer({
     } finally {
       setCredentialsSaving(null);
     }
+  }
+
+  function togglePasswordVisibility(userId: number) {
+    setVisiblePasswordUserIds((prev) => ({
+      ...prev,
+      [userId]: !prev[userId],
+    }));
   }
 
   async function handleDelete() {
@@ -306,6 +318,9 @@ export function ClinicEditDrawer({
               };
               const credError = credentialsErrors[user.userId];
               const isSavingThis = credentialsSaving === user.userId;
+              const passwordInputId = `clinic-user-${user.userId}-password`;
+              const isPasswordVisible =
+                visiblePasswordUserIds[user.userId] ?? false;
 
               return (
                 <section
@@ -343,27 +358,48 @@ export function ClinicEditDrawer({
                           }
                         />
                       </label>
-                      <label className="block space-y-1">
-                        <span className="text-xs text-muted-foreground">
+                      <div className="block space-y-1">
+                        <label
+                          htmlFor={passwordInputId}
+                          className="text-xs text-muted-foreground"
+                        >
                           Nueva contraseña
-                        </span>
-                        <Input
-                          type="text"
-                          value={draft.password}
-                          minLength={8}
-                          autoComplete="new-password"
-                          placeholder="Dejar vacío para no cambiar"
-                          onChange={(e) =>
-                            setUserDrafts((prev) => ({
-                              ...prev,
-                              [user.userId]: {
-                                ...prev[user.userId]!,
-                                password: e.target.value,
-                              },
-                            }))
-                          }
-                        />
-                      </label>
+                        </label>
+                        <div className="relative">
+                          <Input
+                            id={passwordInputId}
+                            type={isPasswordVisible ? "text" : "password"}
+                            value={draft.password}
+                            minLength={8}
+                            autoComplete="new-password"
+                            placeholder="Dejar vacío para no cambiar"
+                            className="pr-10"
+                            onChange={(e) =>
+                              setUserDrafts((prev) => ({
+                                ...prev,
+                                [user.userId]: {
+                                  ...prev[user.userId]!,
+                                  password: e.target.value,
+                                },
+                              }))
+                            }
+                          />
+                          <button
+                            type="button"
+                            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:opacity-55"
+                            onClick={() => togglePasswordVisibility(user.userId)}
+                            aria-label={isPasswordVisible ? "Ocultar nueva contraseña" : "Mostrar nueva contraseña"}
+                            aria-pressed={isPasswordVisible}
+                            aria-controls={passwordInputId}
+                          >
+                            {isPasswordVisible ? (
+                              <EyeOff className="h-4 w-4" aria-hidden="true" />
+                            ) : (
+                              <Eye className="h-4 w-4" aria-hidden="true" />
+                            )}
+                          </button>
+                        </div>
+                      </div>
                       <p className="text-xs text-muted-foreground">
                         La contraseña anterior no se puede consultar.
                       </p>

--- a/test/admin-docs-operational-contract.test.ts
+++ b/test/admin-docs-operational-contract.test.ts
@@ -21,7 +21,8 @@ test("staging smoke runbook enforces real admin operation without demo/smoke flo
     "Transporte de correo",
     "Gmail API HTTPS",
     "usuario de acceso (usar email real de la clínica)",
-    "contraseña inicial visible mientras se ingresa",
+    "contraseña inicial enmascarada por defecto",
+    "revelarla de forma explícita",
   ]) {
     assert.ok(
       source.includes(marker),
@@ -40,6 +41,8 @@ test("release readiness tracks full admin sections and safe delete policy", () =
     "`Auditoría`, `Mantenimiento`",
     "eliminar clínicas desde UI con confirmación",
     "exacta por nombre",
+    "contraseña inicial enmascarada por defecto",
+    "reveal explícito y reversible",
     "No se usa demo/smoke/smock como operación real",
     "clinic.deleted",
     "Gmail API HTTPS",

--- a/test/frontend-admin-clinics-management-card.test.ts
+++ b/test/frontend-admin-clinics-management-card.test.ts
@@ -69,18 +69,34 @@ test("admin clinics management card lists clinics users and editable actions wit
   assert.equal(source.includes("ShieldCheck"), false);
 });
 
-test("admin clinics management card keeps admin-entered passwords visible and avoids hashes", () => {
+test("admin clinics management card hides admin-entered passwords by default and avoids hashes", () => {
   const source = read(ADMIN_CLINICS_CARD_PATH);
-  // Password confirmation and new-password fields live in the drawer (PR3C)
   const drawerSource = read(ADMIN_CLINICS_DRAWER_PATH);
 
   assert.ok(drawerSource.includes("window.confirm("));
   assert.ok(drawerSource.includes("Se reemplazará la contraseña de acceso de esta clínica. ¿Confirmás el cambio?"));
   assert.ok(source.includes("La contraseña anterior no se puede consultar. Para recuperación,"));
   assert.ok(drawerSource.includes("Nueva contraseña"));
-  assert.equal(source.includes('type="password"'), false);
-  assert.equal(drawerSource.includes('type="password"'), false);
-  assert.ok(source.includes('type="text"'));
+  assert.ok(
+    source.includes(
+      "const [isCreatePasswordVisible, setIsCreatePasswordVisible] = useState(false)",
+    ),
+  );
+  assert.ok(
+    source.includes(
+      'type={isCreatePasswordVisible ? "text" : "password"}',
+    ),
+  );
+  assert.ok(
+    drawerSource.includes(
+      "const [visiblePasswordUserIds, setVisiblePasswordUserIds] = useState<",
+    ),
+  );
+  assert.ok(
+    drawerSource.includes('type={isPasswordVisible ? "text" : "password"}'),
+  );
+  assert.equal(source.includes('type="text"'), false);
+  assert.equal(drawerSource.includes('type="text"'), false);
   assert.equal(source.includes("passwordHash"), false);
   assert.equal(drawerSource.includes("passwordHash"), false);
   assert.equal(source.includes("password_hash"), false);
@@ -89,6 +105,39 @@ test("admin clinics management card keeps admin-entered passwords visible and av
   assert.equal(drawerSource.includes("hash"), false);
   assert.equal(source.includes("contraseña actual"), false);
   assert.equal(drawerSource.includes("contraseña actual"), false);
+});
+
+test("admin clinic password reveal controls require explicit accessible interaction", () => {
+  const source = read(ADMIN_CLINICS_CARD_PATH);
+  const drawerSource = read(ADMIN_CLINICS_DRAWER_PATH);
+
+  assert.ok(source.includes('type="button"'));
+  assert.ok(
+    source.includes(
+      'aria-label={isCreatePasswordVisible ? "Ocultar contraseña inicial" : "Mostrar contraseña inicial"}',
+    ),
+  );
+  assert.ok(source.includes("aria-pressed={isCreatePasswordVisible}"));
+  assert.ok(source.includes('aria-controls="create-clinic-password"'));
+  assert.ok(
+    source.includes(
+      "onClick={() => setIsCreatePasswordVisible((current) => !current)}",
+    ),
+  );
+
+  assert.ok(drawerSource.includes('type="button"'));
+  assert.ok(
+    drawerSource.includes(
+      'aria-label={isPasswordVisible ? "Ocultar nueva contraseña" : "Mostrar nueva contraseña"}',
+    ),
+  );
+  assert.ok(drawerSource.includes("aria-pressed={isPasswordVisible}"));
+  assert.ok(drawerSource.includes("aria-controls={passwordInputId}"));
+  assert.ok(
+    drawerSource.includes(
+      "onClick={() => togglePasswordVisibility(user.userId)}",
+    ),
+  );
 });
 
 test("admin clinics management card maps fetch failures to an operational backend message", () => {

--- a/test/frontend-dashboard-action-feedback-focus-polish.test.ts
+++ b/test/frontend-dashboard-action-feedback-focus-polish.test.ts
@@ -98,7 +98,7 @@ test("PR-4 globals.css defines dashboard-option-row for listbox focus", () => {
 test("PR-4 AdminClinicsManagementCard Actualizar button has aria-busy when loading", () => {
   const source = read(ADMIN_CLINICS_CARD_PATH);
   assert.ok(source.includes("aria-busy={isPending ? true : undefined}"));
-  assert.ok(source.includes('import { ChevronLeft, ChevronRight, Loader2, Pencil, Plus, RefreshCw, Search } from "lucide-react";'));
+  assert.ok(source.includes('import { ChevronLeft, ChevronRight, Eye, EyeOff, Loader2, Pencil, Plus, RefreshCw, Search } from "lucide-react";'));
 });
 
 test("PR-4 AdminFailedLoginAlertsReadOnlyCard Actualizar button has aria-busy and spinner", () => {


### PR DESCRIPTION
## Summary
- Hide Admin Clinic passwords by default in clinic creation and credential recovery.
- Add explicit accessible reveal/hide controls with reversible state.
- Preserve API payloads, confirmation flow, autocomplete, and existing credential workflows.
- Update focused contracts, E2E reveal/hide coverage, and operational documentation.

## Tests
- pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-clinics-management-card.test.ts test/admin-docs-operational-contract.test.ts
- pnpm --dir frontend exec playwright test e2e/admin-clinic-edit-drawer.spec.ts --grep "password starts hidden"
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Notes
- No backend, database, migrations, auth, sessions, dependencies, lockfile, CI, Dependabot, or 401/403 changes.
- frontend/next-env.d.ts was restored after Playwright regenerated it and is not part of the diff.