### PR TITLE
fix(admin): unify unauthorized UI states

### DIFF
--- a/docs/implementation/admin-unauthorized-ui-consistency.md
+++ b/docs/implementation/admin-unauthorized-ui-consistency.md
@@ -1,0 +1,150 @@
+# PR fix/admin-unauthorized-ui-consistency — Entrega Codex
+
+## Base
+
+- Rama: `fix/admin-unauthorized-ui-consistency`.
+- HEAD inicial: `1a76a2b fix(admin): hide clinic passwords by default (#1052)`.
+- `main` local inicial: `1a76a2b fix(admin): hide clinic passwords by default (#1052)`.
+- Working tree inicial: limpio.
+- Entorno: Windows, PowerShell y PNPM.
+
+## Scope incluido
+
+- Auditoría del manejo frontend de respuestas Admin `401` y `403`.
+- Clasificación tipada y copy seguro para ambos estados.
+- Estado UI local y uniforme dentro del workspace Admin.
+- Preservación de la redirección SSR existente para `401`.
+- Propagación de `403` SSR al módulo que consumió la lectura.
+- Tests contractuales para copy, seguridad, status y exclusión de empty states.
+
+## Scope excluido
+
+- Backend, DB, Drizzle, migraciones, schema y endpoints.
+- Auth, cookies, sesiones, roles, permisos, CSRF, CORS, CSP y rate limits.
+- Dependencias, `package.json`, `pnpm-lock.yaml`, CI, workflows y Dependabot.
+- App Shell global, rediseño del dashboard y cambios visuales fuera de Admin.
+- Contraseñas Clínica, hidratación Audit y E2E poblado ya cerrados.
+- `.env`, secretos y datos reales.
+
+## Auditoría previa
+
+- `apiFetch` ya representaba respuestas fallidas mediante `ApiResponseError`,
+  pero para errores 4xx podía propagar copy recibido del backend.
+- Clínicas, Informes, Tokens, Pricing, Sesiones, Usuarios/Roles, Alertas,
+  Maintenance y Schema usaban mensajes y layouts distintos.
+- Clínicas, Informes y Tokens podían mostrar simultáneamente un error de carga y
+  un empty state de datos inexistentes.
+- Audit conservaba la redirección SSR de `401`, pero un `403` se transformaba en
+  snapshot vacío; sus resúmenes auxiliares podían mostrar cero actividad.
+- System Health absorbía cualquier error como lectura desconocida y Schema
+  Health convertía el `401` en un `Error` sin status HTTP tipado.
+- `ErrorState` no cubría la acción específica de volver a login ni el copy Admin
+  requerido; se eligió un componente local para no ampliar superficies.
+
+## Cambios realizados
+
+### Contrato seguro 401/403
+
+- `api-error.ts` define únicamente dos estados Admin válidos: `401` y `403`.
+- `401` comunica sesión expirada y retorno al login.
+- `403` comunica permisos insuficientes y contacto con Administración.
+- Errores `404`, `429`, `5xx`, errores de red y errores no tipados no se
+  reclasifican como auth.
+
+### Normalización del cliente API
+
+- Las respuestas `401/403` de rutas `/api/admin/*` se clasifican antes de leer
+  el body de error.
+- El `ApiResponseError.status` se conserva y su mensaje usa copy controlado.
+- Schema Health aplica el mismo contrato aunque conserve su lectura especial de
+  respuestas `200/503`.
+- System Health vuelve a propagar solo `401/403`; sus fallos no-auth mantienen el
+  fallback previo a estado desconocido.
+
+### Estado UI uniforme
+
+- `AdminAccessErrorState` reemplaza el contenido del workspace afectado.
+- Usa semántica `role="alert"`, copy breve, layout responsive y acción a login
+  solo para `401`.
+- No renderiza errores técnicos, payloads, empty states ni detalle de roles.
+- El store browser conserva solo el número `401 | 403`, se limpia al cambiar de
+  módulo, volver al hub o salir de Admin y no persiste payloads.
+- Los errores SSR se aplican solo al módulo que depende de la lectura: Audit,
+  System Health u Overview; no bloquean módulos independientes.
+
+## Comportamiento final
+
+- `401` client-side: muestra “Sesión expirada” y “Volver a iniciar sesión”.
+- `401` server-side: conserva la redirección segura existente a login.
+- `403`: muestra “Acceso restringido”, permisos insuficientes y contacto con
+  Administración.
+- Error no-auth: conserva el flujo genérico o específico previo del módulo.
+- Empty state legítimo: se conserva cuando la lectura fue exitosa y no hay datos.
+- Empty state ante `401/403`: no se renderiza porque el workspace se sustituye.
+
+## Tests agregados
+
+- `test/frontend-admin-unauthorized-ui-consistency.test.ts` valida:
+  - clasificación exclusiva de `ApiResponseError(401|403)`;
+  - copy exacto y uniforme;
+  - ausencia de `cookie`, `token`, `stack`, `Supabase`, `JWT`, `role_id`,
+    `permission_id`, `HTTP 401/403`, `Unauthorized` y `Forbidden`;
+  - normalización antes de leer copy del backend;
+  - sustitución del workspace sin `EmptyState`;
+  - preservación del redirect SSR `401` y propagación SSR `403`.
+
+## Archivos modificados
+
+- `frontend/src/lib/api-error.ts`.
+- `frontend/src/lib/admin-access-error.ts`.
+- `frontend/src/lib/api.ts`.
+- `frontend/src/app/dashboard/admin/AdminAccessErrorState.tsx`.
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx`.
+- `frontend/src/app/dashboard/admin/page.tsx`.
+- `test/frontend-admin-unauthorized-ui-consistency.test.ts`.
+- `docs/implementation/admin-unauthorized-ui-consistency.md`.
+
+## Validaciones
+
+- TDD focal inicial: falló por ausencia del nuevo clasificador, como se esperaba.
+- Test focal final: 5/5 aprobados.
+- Contratos Admin colindantes: 36/36 aprobados.
+- Primera ejecución de `pnpm test`: 2805/2812; siete contratos estáticos
+  detectaron el import agrupado, dos firmas textuales cambiadas y el uso de
+  `next/link` no permitido por el contrato global de navegación.
+- Contratos focales después del ajuste a `PublicRouteControl`: 50/50 aprobados.
+- `pnpm test` final: 2812/2812 aprobados.
+- `pnpm build`: aprobado; bundle backend generado correctamente.
+- `pnpm security:public-surface`: aprobado sin exposición pública; informó solo
+  los dos identificadores server-only preexistentes en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint`: aprobado después del cambio final.
+- `pnpm --dir frontend typecheck`: aprobado después del cambio final.
+- `pnpm --dir frontend build`: aprobado; 25/25 páginas generadas y
+  `/dashboard/admin` conserva render dinámico.
+
+## Seguridad
+
+- No se leen ni renderizan bodies de error `401/403` para rutas Admin.
+- No se guardan mensajes, cookies, tokens, headers ni payloads en el store UI.
+- No se modificaron sesiones, cookies, auth, roles ni permisos.
+- No se leyeron, imprimieron ni incorporaron secretos reales.
+
+## Riesgos residuales y QA humana
+
+- El estado uniforme depende de que el servidor responda con status HTTP real;
+  un fallo de red sin respuesta conserva el error genérico, deliberadamente.
+- La normalización se limita a `/api/admin/*`; otras superficies mantienen sus
+  contratos actuales.
+- Nico debe realizar QA visual en desktop, laptop, tablet y móvil, además de
+  teclado, foco, tema soportado, `401`, `403`, empty legítimo y error no-auth.
+
+## Estado final y acciones manuales
+
+- Los cambios quedan en working tree, sin stage, commit ni push.
+- Ocho archivos pertenecen al scope: cuatro modificados y cuatro nuevos.
+- `git diff --check`: aprobado sin errores de whitespace; Git informó avisos de
+  conversión LF/CRLF para dos archivos existentes al volver a tocarlos.
+- No se modificaron backend, DB, auth, dependencias, lockfile, CI ni App Shell.
+- Stage, commit, push, creación del PR, checks remotos y merge quedan a cargo de
+  Nico.
+- Después del push y creación del PR: `gh pr checks --watch`.

--- a/frontend/src/app/dashboard/admin/AdminAccessErrorState.tsx
+++ b/frontend/src/app/dashboard/admin/AdminAccessErrorState.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { LogIn, ShieldAlert } from "lucide-react";
+
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import {
+  getAdminAccessErrorState,
+  type AdminAccessErrorStatus,
+} from "@/lib/api-error";
+import { ROUTES } from "@/lib/routes";
+
+type AdminAccessErrorStateProps = {
+  status: AdminAccessErrorStatus;
+};
+
+export function AdminAccessErrorState({
+  status,
+}: AdminAccessErrorStateProps) {
+  const state = getAdminAccessErrorState(status);
+
+  if (!state) {
+    return null;
+  }
+
+  return (
+    <section
+      role="alert"
+      aria-labelledby="admin-access-error-title"
+      className="dashboard-surface flex min-h-48 flex-1 flex-col items-center justify-center rounded-lg border border-amber-500/25 bg-amber-500/8 px-5 py-8 text-center"
+    >
+      <div
+        className="mb-3 flex h-11 w-11 items-center justify-center rounded-full border border-amber-500/25 bg-card text-amber-700"
+        aria-hidden="true"
+      >
+        <ShieldAlert className="h-5 w-5" />
+      </div>
+      <h2
+        id="admin-access-error-title"
+        className="text-base font-semibold text-vetneb-ink"
+      >
+        {state.title}
+      </h2>
+      <p className="mt-1 max-w-lg text-sm text-muted-foreground">
+        {state.message}
+      </p>
+      {state.supportText ? (
+        <p className="mt-1 max-w-lg text-xs text-muted-foreground">
+          {state.supportText}
+        </p>
+      ) : null}
+      {state.status === 401 ? (
+        <PublicRouteControl
+          href={ROUTES.login}
+          variant="primaryDark"
+          className="mt-4 h-9 w-auto px-4 text-sm"
+          icon={<LogIn className="h-4 w-4" aria-hidden="true" />}
+        >
+          Volver a iniciar sesión
+        </PublicRouteControl>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Activity,
@@ -24,6 +31,14 @@ import {
   readDashboardLastModule,
   writeDashboardLastModule,
 } from "@/lib/dashboard-last-module";
+import {
+  clearAdminAccessError,
+  getAdminAccessErrorServerSnapshot,
+  getAdminAccessErrorSnapshot,
+  subscribeAdminAccessError,
+} from "@/lib/admin-access-error";
+import type { AdminAccessErrorStatus } from "@/lib/api-error";
+import { AdminAccessErrorState } from "./AdminAccessErrorState";
 
 export type AdminModule =
   | "admin"
@@ -81,6 +96,7 @@ type AdminWorkspaceSlots = {
 
 type AdminDashboardWorkspaceControllerProps = {
   initialModule?: AdminModule | null;
+  initialAccessErrorStatus?: AdminAccessErrorStatus | null;
   workspaces: AdminWorkspaceSlots;
   systemStatus: string;
   systemStatusLabel: string;
@@ -143,6 +159,7 @@ const ADMIN_MODULE_META: Record<AdminModule, { title: string; description: strin
 
 export function AdminDashboardWorkspaceController({
   initialModule,
+  initialAccessErrorStatus,
   workspaces,
   systemStatus,
   systemStatusLabel,
@@ -156,13 +173,30 @@ export function AdminDashboardWorkspaceController({
   const [activeModule, setActiveModule] = useState<AdminModule | null>(
     initialModule ?? null,
   );
+  const browserAccessErrorStatus = useSyncExternalStore(
+    subscribeAdminAccessError,
+    getAdminAccessErrorSnapshot,
+    getAdminAccessErrorServerSnapshot,
+  );
+  const accessErrorStatus =
+    browserAccessErrorStatus ?? initialAccessErrorStatus ?? null;
   const hasRestoredLastModule = useRef(false);
+  const previousUrlModule = useRef<AdminModule | null>(initialModule ?? null);
   const [hasManuallyReturnedToHub, setHasManuallyReturnedToHub] =
     useState(false);
 
   useEffect(() => {
+    const nextModule = parseModuleFromUrl(searchParams.get("module"));
+
+    if (previousUrlModule.current !== nextModule) {
+      clearAdminAccessError();
+      previousUrlModule.current = nextModule;
+    }
+
     setActiveModule(parseModuleFromUrl(searchParams.get("module")));
   }, [searchParams]);
+
+  useEffect(() => () => clearAdminAccessError(), []);
 
   useEffect(() => {
     if (!activeModule) return;
@@ -182,6 +216,7 @@ export function AdminDashboardWorkspaceController({
 
   const activateModule = useCallback(
     (moduleId: AdminModule) => {
+      clearAdminAccessError();
       setActiveModule(moduleId);
       router.push(`/dashboard/admin?module=${moduleId}`, { scroll: false });
     },
@@ -189,6 +224,7 @@ export function AdminDashboardWorkspaceController({
   );
 
   const backToHub = useCallback(() => {
+    clearAdminAccessError();
     setActiveModule(null);
     setHasManuallyReturnedToHub(true);
     router.replace("/dashboard/admin", { scroll: false });
@@ -316,8 +352,21 @@ export function AdminDashboardWorkspaceController({
         moduleId={activeModule}
         onBack={backToHub}
       >
-        {workspaces[activeModule]}
+        {accessErrorStatus ? (
+          <AdminAccessErrorState status={accessErrorStatus} />
+        ) : (
+          workspaces[activeModule]
+        )}
       </DashboardModuleWorkspace>
+    );
+  }
+
+  if (accessErrorStatus) {
+    return (
+      <>
+        {pageHeader}
+        <AdminAccessErrorState status={accessErrorStatus} />
+      </>
     );
   }
 

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -40,6 +40,7 @@ import {
   type AdminAuditSnapshot,
 } from "@/lib/api";
 import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
+import { getAdminAccessErrorStatus } from "@/lib/api-error";
 import { formatDateTime } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -356,12 +357,29 @@ async function loadAdminAuditSnapshot(
     return {
       snapshot: await getAuditEntries(query, options, { throwOnError: true }),
       loadError: false,
+      accessErrorStatus: null,
     };
   } catch (error) {
     redirectToLoginOnUnauthorized(error);
     return {
       snapshot: createEmptyAuditSnapshot(query),
       loadError: true,
+      accessErrorStatus: getAdminAccessErrorStatus(error),
+    };
+  }
+}
+
+async function loadAdminSystemHealth(requestOptions: RequestInit) {
+  try {
+    return {
+      snapshot: await getAdminSystemHealth(requestOptions),
+      accessErrorStatus: null,
+    };
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
+    return {
+      snapshot: null,
+      accessErrorStatus: getAdminAccessErrorStatus(error),
     };
   }
 }
@@ -446,7 +464,7 @@ export default async function AdminPage({
     auditOverviewRead,
     roleChangeRead,
     notificationRead,
-    systemHealth,
+    systemHealthRead,
   ] = await Promise.all([
     loadAdminAuditSnapshot(auditQuery, requestOptions),
     loadAdminAuditSnapshot(
@@ -461,13 +479,28 @@ export default async function AdminPage({
       { event: "study_tracking.notification.created", limit: 1, offset: 0 },
       requestOptions,
     ),
-    getAdminSystemHealth(requestOptions),
+    loadAdminSystemHealth(requestOptions),
   ]);
   const auditSnapshot = auditRead.snapshot;
   const auditEntriesLoadError = auditRead.loadError;
   const auditOverviewSnapshot = auditOverviewRead.snapshot;
   const roleChangeSnapshot = roleChangeRead.snapshot;
   const notificationSnapshot = notificationRead.snapshot;
+  const systemHealth = systemHealthRead.snapshot;
+  const initialAccessErrorStatus =
+    initialModule === "audit-log"
+      ? auditRead.accessErrorStatus ??
+        auditOverviewRead.accessErrorStatus ??
+        roleChangeRead.accessErrorStatus ??
+        notificationRead.accessErrorStatus
+      : initialModule === "admin-health"
+        ? systemHealthRead.accessErrorStatus
+        : initialModule === null || initialModule === "admin"
+          ? auditOverviewRead.accessErrorStatus ??
+            roleChangeRead.accessErrorStatus ??
+            notificationRead.accessErrorStatus ??
+            systemHealthRead.accessErrorStatus
+          : null;
   const hasSystemHealthFetchError = systemHealth === null;
   const serviceChecks = systemHealth?.services ?? {};
   const contactRecipients = getConfiguredContactRecipients(serviceChecks);
@@ -817,6 +850,7 @@ export default async function AdminPage({
         <Suspense>
           <AdminDashboardWorkspaceController
             initialModule={initialModule}
+            initialAccessErrorStatus={initialAccessErrorStatus}
             pageHeader={
               <DashboardPageHeader
                 title="Administración"

--- a/frontend/src/lib/admin-access-error.ts
+++ b/frontend/src/lib/admin-access-error.ts
@@ -1,0 +1,52 @@
+import {
+  isAdminAccessErrorStatus,
+  type AdminAccessErrorStatus,
+} from "@/lib/api-error";
+
+export type { AdminAccessErrorStatus } from "@/lib/api-error";
+
+type AdminAccessErrorListener = () => void;
+
+let browserAccessErrorStatus: AdminAccessErrorStatus | null = null;
+const browserAccessErrorListeners = new Set<AdminAccessErrorListener>();
+
+export function publishAdminAccessErrorStatus(status: number): boolean {
+  if (
+    typeof window === "undefined" ||
+    !isAdminAccessErrorStatus(status)
+  ) {
+    return false;
+  }
+
+  if (browserAccessErrorStatus === status) {
+    return true;
+  }
+
+  browserAccessErrorStatus = status;
+  browserAccessErrorListeners.forEach((listener) => listener());
+  return true;
+}
+
+export function clearAdminAccessError(): void {
+  if (typeof window === "undefined" || browserAccessErrorStatus === null) {
+    return;
+  }
+
+  browserAccessErrorStatus = null;
+  browserAccessErrorListeners.forEach((listener) => listener());
+}
+
+export function subscribeAdminAccessError(
+  listener: AdminAccessErrorListener,
+): () => void {
+  browserAccessErrorListeners.add(listener);
+  return () => browserAccessErrorListeners.delete(listener);
+}
+
+export function getAdminAccessErrorSnapshot(): AdminAccessErrorStatus | null {
+  return browserAccessErrorStatus;
+}
+
+export function getAdminAccessErrorServerSnapshot(): null {
+  return null;
+}

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -8,6 +8,60 @@ export class ApiResponseError extends Error {
   }
 }
 
+export type AdminAccessErrorStatus = 401 | 403;
+
+export type AdminAccessErrorState = {
+  status: AdminAccessErrorStatus;
+  title: string;
+  message: string;
+  supportText?: string;
+};
+
+const ADMIN_ACCESS_ERROR_STATES: Record<
+  AdminAccessErrorStatus,
+  AdminAccessErrorState
+> = {
+  401: {
+    status: 401,
+    title: "Sesión expirada",
+    message:
+      "Tu sesión de Administración expiró. Volvé a iniciar sesión para continuar.",
+  },
+  403: {
+    status: 403,
+    title: "Acceso restringido",
+    message: "No tenés permisos suficientes para acceder a este módulo.",
+    supportText: "Contactá a Administración si necesitás acceso.",
+  },
+};
+
+export function isAdminAccessErrorStatus(
+  status: number,
+): status is AdminAccessErrorStatus {
+  return status === 401 || status === 403;
+}
+
+export function getAdminAccessErrorStatus(
+  error: unknown,
+): AdminAccessErrorStatus | null {
+  return error instanceof ApiResponseError &&
+    isAdminAccessErrorStatus(error.status)
+    ? error.status
+    : null;
+}
+
+export function getAdminAccessErrorState(
+  errorOrStatus: unknown,
+): AdminAccessErrorState | null {
+  const status =
+    typeof errorOrStatus === "number" &&
+    isAdminAccessErrorStatus(errorOrStatus)
+      ? errorOrStatus
+      : getAdminAccessErrorStatus(errorOrStatus);
+
+  return status ? ADMIN_ACCESS_ERROR_STATES[status] : null;
+}
+
 export function isUnauthorizedApiError(
   error: unknown,
 ): error is ApiResponseError {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,7 +45,13 @@ import type {
   AdminFailedLoginAlertsQuery,
   AdminFailedLoginAlertsSnapshot,
 } from "@/types";
+import {
+  getAdminAccessErrorState,
+  getAdminAccessErrorStatus,
+  isAdminAccessErrorStatus,
+} from "@/lib/api-error";
 import { ApiResponseError } from "@/lib/api-error";
+import { publishAdminAccessErrorStatus } from "@/lib/admin-access-error";
 
 const LOCAL_DEVELOPMENT_API_BASE_URL = "http://localhost:3000";
 const SAME_ORIGIN_API_BASE_URL = "";
@@ -56,8 +62,6 @@ export const BACKEND_CONNECTION_ERROR_MESSAGE =
   "No se pudo conectar con el backend. Verifique sesión admin, CORS y despliegue backend/frontend.";
 export const BACKEND_OPERATION_ERROR_MESSAGE =
   "El backend no pudo completar la operación. Reintentá y, si persiste, revisá estado del sistema y logs de backend.";
-export const ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE =
-  "Sesión admin no autenticada o inválida. Iniciá sesión nuevamente.";
 export const LOGIN_RATE_LIMIT_CLIENT_ERROR_MESSAGE =
   "Acceso temporalmente restringido. Intentá nuevamente más tarde.";
 
@@ -255,6 +259,15 @@ async function apiFetch<T>(
   }
 
   if (!res.ok) {
+    if (isAdminApiPath(path) && isAdminAccessErrorStatus(res.status)) {
+      publishAdminAccessErrorStatus(res.status);
+      const accessState = getAdminAccessErrorState(res.status);
+
+      if (accessState) {
+        throw new ApiResponseError(res.status, accessState.message);
+      }
+    }
+
     const body = (await res.json().catch(() => ({}))) as {
       error?: unknown;
       message?: unknown;
@@ -296,6 +309,10 @@ async function apiFetch<T>(
   }
 
   return res.json() as Promise<T>;
+}
+
+function isAdminApiPath(path: string): boolean {
+  return path === "/api/admin" || path.startsWith("/api/admin/");
 }
 
 export async function loginClinic(
@@ -1708,6 +1725,10 @@ export async function getAdminSystemHealth(
       options,
     );
   } catch (error) {
+    if (getAdminAccessErrorStatus(error)) {
+      throw error;
+    }
+
     warnApiFallback("getAdminSystemHealth", error);
     return null;
   }
@@ -1761,12 +1782,17 @@ export async function getAdminSchemaHealth(
     throw error;
   }
 
+  if (isAdminAccessErrorStatus(res.status)) {
+    publishAdminAccessErrorStatus(res.status);
+    const accessState = getAdminAccessErrorState(res.status);
+
+    if (accessState) {
+      throw new ApiResponseError(res.status, accessState.message);
+    }
+  }
+
   const body = (await res.json().catch(() => null)) as unknown;
   const backendMessage = readBackendMessageFromBody(body);
-
-  if (res.status === 401) {
-    throw new Error(ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE);
-  }
 
   const parsedSnapshot =
     body && typeof body === "object"

--- a/test/frontend-admin-unauthorized-ui-consistency.test.ts
+++ b/test/frontend-admin-unauthorized-ui-consistency.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+  ApiResponseError,
+  getAdminAccessErrorState,
+} from "../frontend/src/lib/api-error.ts";
+
+const API_PATH = "frontend/src/lib/api.ts";
+const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const ADMIN_CONTROLLER_PATH =
+  "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
+const ADMIN_ACCESS_STATE_PATH =
+  "frontend/src/app/dashboard/admin/AdminAccessErrorState.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("admin access policy classifies only typed HTTP 401 and 403 errors", () => {
+  assert.deepEqual(
+    getAdminAccessErrorState(new ApiResponseError(401, "raw unauthorized")),
+    {
+      status: 401,
+      title: "Sesión expirada",
+      message:
+        "Tu sesión de Administración expiró. Volvé a iniciar sesión para continuar.",
+    },
+  );
+  assert.deepEqual(
+    getAdminAccessErrorState(new ApiResponseError(403, "raw forbidden")),
+    {
+      status: 403,
+      title: "Acceso restringido",
+      message: "No tenés permisos suficientes para acceder a este módulo.",
+      supportText: "Contactá a Administración si necesitás acceso.",
+    },
+  );
+  assert.equal(
+    getAdminAccessErrorState(new ApiResponseError(500, "backend unavailable")),
+    null,
+  );
+  assert.equal(getAdminAccessErrorState(new Error("HTTP 401")), null);
+  assert.equal(getAdminAccessErrorState({ status: 403 }), null);
+});
+
+test("admin 401 and 403 copy is uniform and excludes sensitive or technical detail", () => {
+  const copy = [401, 403]
+    .map((status) => {
+      const state = getAdminAccessErrorState(
+        new ApiResponseError(status, "cookie token stack Supabase JWT role_id permission_id"),
+      );
+      assert.ok(state);
+      return [state.title, state.message, state.supportText].filter(Boolean).join(" ");
+    })
+    .join(" ");
+
+  assert.doesNotMatch(
+    copy,
+    /cookie|token|stack|supabase|jwt|role_id|permission_id/i,
+  );
+  assert.doesNotMatch(copy, /HTTP\s*(401|403)|Unauthorized|Forbidden/i);
+});
+
+test("admin API normalizes 401 and 403 before reading backend error copy", () => {
+  const source = read(API_PATH);
+  const authGuardIndex = source.indexOf(
+    "isAdminApiPath(path) && isAdminAccessErrorStatus(res.status)",
+  );
+  const backendBodyIndex = source.indexOf(
+    "const body = (await res.json().catch(() => ({})))",
+  );
+
+  assert.ok(authGuardIndex >= 0);
+  assert.ok(backendBodyIndex > authGuardIndex);
+  assert.ok(source.includes("publishAdminAccessErrorStatus(res.status);"));
+  assert.ok(source.includes("throw new ApiResponseError(res.status, accessState.message);"));
+  assert.equal(
+    source.includes("ADMIN_SCHEMA_HEALTH_UNAUTHORIZED_MESSAGE"),
+    false,
+  );
+});
+
+test("admin access state replaces the workspace instead of rendering an empty state", () => {
+  const controllerSource = read(ADMIN_CONTROLLER_PATH);
+  const stateSource = read(ADMIN_ACCESS_STATE_PATH);
+  const pageSource = read(ADMIN_PAGE_PATH);
+
+  assert.ok(controllerSource.includes("useSyncExternalStore"));
+  assert.ok(controllerSource.includes("initialAccessErrorStatus"));
+  assert.ok(
+    controllerSource.includes(
+      "accessErrorStatus ? (\n          <AdminAccessErrorState status={accessErrorStatus} />\n        ) : (\n          workspaces[activeModule]\n        )",
+    ),
+  );
+  assert.ok(stateSource.includes('role="alert"'));
+  assert.ok(stateSource.includes("ROUTES.login"));
+  assert.equal(stateSource.includes("EmptyState"), false);
+  assert.equal(stateSource.includes("error.message"), false);
+  assert.ok(pageSource.includes("getAdminAccessErrorStatus(error)"));
+  assert.ok(pageSource.includes("initialAccessErrorStatus={initialAccessErrorStatus}"));
+});
+
+test("server-side 401 redirect remains in force while 403 reaches the Admin state", () => {
+  const pageSource = read(ADMIN_PAGE_PATH);
+
+  assert.ok(pageSource.includes("redirectToLoginOnUnauthorized(error);"));
+  assert.ok(pageSource.includes("accessErrorStatus: getAdminAccessErrorStatus(error)"));
+  assert.ok(pageSource.includes("loadAdminSystemHealth(requestOptions)"));
+});


### PR DESCRIPTION
## Summary
- Unify Admin 401/403 UI states with safe, consistent copy.
- Preserve SSR 401 redirect while rendering a controlled Admin access state for client-side 401 and 403 cases.
- Replace affected workspaces with the access state so auth failures do not appear as empty data.
- Normalize Admin API 401/403 handling without exposing backend messages, cookies, tokens, roles, permissions, or stack details.
- Add focused contracts and implementation documentation.

## Tests
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-unauthorized-ui-consistency.test.ts
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-unauthorized-ui-consistency.test.ts test/frontend-api-client-request.test.ts test/frontend-dashboard-admin.test.ts test/frontend-native-link-preview-contract.test.ts test/frontend-public-devtools-exposure-contract.test.ts
- pnpm test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build

## Notes
- No backend, database, migrations, auth, cookies, roles, permissions, dependencies, lockfile, CI, App Shell, .env, or secret changes.
- Non-auth errors and legitimate empty states preserve their existing behavior.