### PR TITLE
docs(admin): close enterprise density audit block

### DIFF
--- a/docs/implementation/admin-enterprise-density-closeout.md
+++ b/docs/implementation/admin-enterprise-density-closeout.md
@@ -1,0 +1,122 @@
+# Admin Enterprise Density Closeout
+
+## Base
+
+- Rama: `docs/admin-enterprise-density-closeout`.
+- Base esperada: `b6e6258 fix(admin): unify unauthorized UI states (#1053)`.
+- Scope: cierre documental del bloque Admin Enterprise Density.
+- Tipo de cambio: documentación únicamente.
+
+## Objetivo
+
+Dejar constancia del cierre del bloque de auditoría Admin Enterprise Density después de resolver los hallazgos P1 y P2 priorizados para Administración.
+
+Este documento no introduce cambios de producto, backend, base de datos, autenticación, dependencias ni CI.
+
+## PRs cerrados
+
+### PR #1050 — `fix(admin): guard audit hydration boundary`
+
+Resultado:
+
+- Se corrigió el riesgo de hydration mismatch en Admin Audit.
+- Se protegió la frontera entre server/client components.
+- Se agregó cobertura para prevenir regresión.
+- `main` quedó actualizado con el fix antes de continuar con cobertura poblada.
+
+### PR #1051 — `test(admin): add populated admin e2e coverage`
+
+Resultado:
+
+- Se agregó cobertura E2E poblada para módulos críticos de Administración:
+  - Overview.
+  - Tokens.
+  - Reports.
+  - Audit.
+  - Users/Roles.
+- Se incorporó fixture local determinística para datos Admin.
+- Se validó contenido poblado, ausencia de empty states erróneos, navegación activa, errores de navegador/hidratación y contrato no-scroll.
+- Se compactaron localmente Tokens, Reports y Users/Roles para sostener nueve filas visibles en `1366x768` y `1440x900`.
+- El alcance excluyó backend, DB, auth, dependencias, secretos y rediseños globales.
+
+### PR #1052 — `fix(admin): hide clinic passwords by default`
+
+Resultado:
+
+- Las contraseñas de alta y recuperación de Clínica quedaron ocultas por defecto.
+- Reveal/hide quedó explícito, reversible y accesible.
+- Se preservaron payloads, confirmación, `autocomplete` y workflows existentes.
+- Se agregaron contratos y E2E para bloquear regresión.
+- Se actualizaron runbooks/documentación operativa.
+
+### PR #1053 — `fix(admin): unify unauthorized UI states`
+
+Resultado:
+
+- Se unificó la UI Admin para `401/403`.
+- `401` cliente muestra estado uniforme de sesión expirada.
+- `401` SSR conserva redirect seguro existente.
+- `403` muestra estado uniforme de acceso restringido.
+- Los estados auth sustituyen el workspace y evitan empty states engañosos.
+- Se evita exponer mensajes crudos, cookies, tokens, roles/permisos internos o stack traces.
+- Errores no-auth y empty states legítimos conservan su comportamiento.
+
+## Estado final del bloque
+
+| Hallazgo | Prioridad | Estado |
+| --- | --- | --- |
+| Hydration mismatch Admin Audit | P1 | Cerrado en #1050 |
+| Falta de E2E poblado Admin crítico | P1 | Cerrado en #1051 |
+| Contraseñas de Clínica visibles por defecto | P2 | Cerrado en #1052 |
+| UI no uniforme para `401/403` en Admin | P2 | Cerrado en #1053 |
+
+## Validaciones acumuladas reportadas
+
+Durante los PRs del bloque se reportaron, entre otras, estas validaciones:
+
+- `pnpm test`.
+- `pnpm build`.
+- `pnpm security:public-surface`.
+- `pnpm --dir frontend lint`.
+- `pnpm --dir frontend typecheck`.
+- `pnpm --dir frontend build`.
+- E2E focales de Admin.
+- Contratos estáticos/documentales focales.
+- `git diff --check`.
+
+Los checks remotos de GitHub Actions quedaron verdes antes de cada merge.
+
+## Scope explícitamente no modificado
+
+Este cierre no modifica:
+
+- Producto.
+- Backend.
+- Base de datos.
+- Migraciones.
+- Auth, cookies, sesiones, roles o permisos.
+- Dependencias.
+- Lockfile.
+- CI/workflows.
+- `.env` o secretos.
+- Dependabot.
+- App Shell global.
+- Rediseños visuales.
+
+## Riesgos residuales
+
+- QA visual humana sigue siendo necesaria en desktop, laptop, tablet y móvil.
+- Cambios futuros en tipografía, layout, App Shell o densidad deben repetir los E2E no-scroll poblados.
+- Cambios futuros de auth deben preservar el contrato uniforme `401/403`.
+- Los PRs de Dependabot permanecen abiertos y deben tratarse por separado, uno por uno, con scope propio.
+
+## Recomendación operativa
+
+Antes de iniciar nuevas mejoras visuales o funcionales del dashboard, usar este bloque como nueva base estable:
+
+- `#1050` para hidratación Admin Audit.
+- `#1051` para E2E poblado y no-scroll.
+- `#1052` para seguridad visual de credenciales Clínica.
+- `#1053` para UI segura y uniforme de `401/403`.
+
+Cualquier cambio nuevo sobre Admin/Dashboard debe ejecutarse en PR chico, con rama propia, validaciones completas y sin mezclar Dependabot.


### PR DESCRIPTION
## Summary
- Document the closeout of the Admin Enterprise Density audit block.
- Record PRs #1050, #1051, #1052, and #1053 as completed.
- Summarize resolved P1/P2 findings, validations, residual risks, and future operating guidance.

## Tests
- git diff --check

## Notes
- Documentation only.
- No product, backend, database, auth, dependency, lockfile, CI, App Shell, .env, secret, or Dependabot changes.