### PR TITLE
fix(dashboard): make mobile shell nav touch safe

### DIFF
--- a/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
+++ b/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
@@ -1,0 +1,265 @@
+import { expect, test } from "@playwright/test";
+
+type Page = import("@playwright/test").Page;
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-mini-375x812", width: 375, height: 812 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "android-large-412x915", width: 412, height: 915 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+type Surface = "clinic" | "admin";
+
+type ShellRouteCase = {
+  label: string;
+  surface: Surface;
+  path: string;
+  ready: string;
+};
+
+const SHELL_ROUTES: ShellRouteCase[] = [
+  {
+    label: "clinic hub",
+    surface: "clinic",
+    path: "/dashboard",
+    ready: '[data-dashboard-module-hub="true"]',
+  },
+  {
+    label: "clinic tokens",
+    surface: "clinic",
+    path: "/dashboard?module=tokens",
+    ready: '[data-dashboard-module-workspace="tokens"]',
+  },
+  {
+    label: "admin hub",
+    surface: "admin",
+    path: "/dashboard/admin",
+    ready: '[data-dashboard-module-hub="true"]',
+  },
+  {
+    label: "admin audit",
+    surface: "admin",
+    path: "/dashboard/admin?module=audit-log",
+    ready: '[data-dashboard-module-workspace="audit-log"]',
+  },
+  {
+    label: "admin users",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin-users-roles",
+    ready: '[data-dashboard-module-workspace="admin-users-roles"]',
+  },
+];
+
+async function applySession(page: Page, surface: Surface) {
+  await page.context().addCookies([
+    {
+      name: surface === "clinic" ? "app_session_id" : "admin_session_id",
+      value:
+        surface === "clinic"
+          ? "e2e_test_clinic_session"
+          : "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function gotoShellRoute(page: Page, route: ShellRouteCase) {
+  await applySession(page, route.surface);
+  await page.goto(route.path);
+  await expect(page.locator(route.ready).first()).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+type ShellNavMetric = {
+  label: string;
+  text: string;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+type ShellNavContract = {
+  htmlScrollWidth: number;
+  htmlClientWidth: number;
+  bodyScrollWidth: number;
+  bodyClientWidth: number;
+  topbarVisible: boolean;
+  navVisible: boolean;
+  clippedTopbarControls: ShellNavMetric[];
+  undersizedShellControls: ShellNavMetric[];
+  activeNavItemVisible: boolean;
+};
+
+async function readShellNavContract(page: Page): Promise<ShellNavContract> {
+  return page.evaluate((tolerance) => {
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const html = document.documentElement;
+    const body = document.body;
+
+    const isVisible = (element: Element) => {
+      const el = element as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      const style = window.getComputedStyle(el);
+
+      return (
+        rect.width > 1 &&
+        rect.height > 1 &&
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        style.opacity !== "0"
+      );
+    };
+
+    const textFor = (element: Element) =>
+      ((element as HTMLElement).innerText || element.textContent || "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 80);
+
+    const labelFor = (element: Element) =>
+      (element as HTMLElement).getAttribute("aria-label") ||
+      (element as HTMLElement).getAttribute("title") ||
+      textFor(element) ||
+      element.tagName.toLowerCase();
+
+    const metricFor = (element: Element): ShellNavMetric => {
+      const rect = (element as HTMLElement).getBoundingClientRect();
+
+      return {
+        label: labelFor(element),
+        text: textFor(element),
+        left: Math.round(rect.left),
+        right: Math.round(rect.right),
+        top: Math.round(rect.top),
+        bottom: Math.round(rect.bottom),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      };
+    };
+
+    const topbar = document.querySelector(
+      "header[aria-label='Barra superior del dashboard']",
+    );
+    const nav = document.querySelector(
+      "[data-dashboard-horizontal-nav-shell='true']",
+    );
+
+    const topbarControls = Array.from(
+      document.querySelectorAll(
+        "header[aria-label='Barra superior del dashboard'] > div:first-child a, header[aria-label='Barra superior del dashboard'] > div:first-child button",
+      ),
+    ).filter(isVisible);
+
+    const shellControls = Array.from(
+      document.querySelectorAll(
+        "header[aria-label='Barra superior del dashboard'] a, header[aria-label='Barra superior del dashboard'] button",
+      ),
+    ).filter(isVisible);
+
+    const clippedTopbarControls = topbarControls
+      .filter((element) => {
+        const rect = (element as HTMLElement).getBoundingClientRect();
+
+        return (
+          rect.left < -tolerance ||
+          rect.right > viewportWidth + tolerance ||
+          rect.top < -tolerance ||
+          rect.bottom > viewportHeight + tolerance
+        );
+      })
+      .map(metricFor);
+
+    const undersizedShellControls = shellControls
+      .filter((element) => {
+        const rect = (element as HTMLElement).getBoundingClientRect();
+        return rect.width < 36 || rect.height < 36;
+      })
+      .map(metricFor);
+
+    const activeNavItem = document.querySelector(
+      "[data-dashboard-horizontal-nav-shell='true'] [aria-current='page']",
+    );
+
+    let activeNavItemVisible = false;
+    if (activeNavItem) {
+      const rect = (activeNavItem as HTMLElement).getBoundingClientRect();
+      activeNavItemVisible =
+        isVisible(activeNavItem) &&
+        rect.left >= -tolerance &&
+        rect.right <= viewportWidth + tolerance &&
+        rect.top >= -tolerance &&
+        rect.bottom <= viewportHeight + tolerance;
+    }
+
+    return {
+      htmlScrollWidth: html.scrollWidth,
+      htmlClientWidth: html.clientWidth,
+      bodyScrollWidth: body.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      topbarVisible: topbar ? isVisible(topbar) : false,
+      navVisible: nav ? isVisible(nav) : false,
+      clippedTopbarControls,
+      undersizedShellControls,
+      activeNavItemVisible,
+    };
+  }, TOLERANCE);
+}
+
+function assertShellNavContract(contract: ShellNavContract, label: string) {
+  expect(contract.topbarVisible, `${label}: topbar visible`).toBe(true);
+  expect(contract.navVisible, `${label}: horizontal nav visible`).toBe(true);
+
+  expect(
+    contract.htmlScrollWidth,
+    `${label}: documentElement horizontal overflow`,
+  ).toBeLessThanOrEqual(contract.htmlClientWidth + TOLERANCE);
+
+  expect(
+    contract.bodyScrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(contract.bodyClientWidth + TOLERANCE);
+
+  expect(
+    contract.clippedTopbarControls,
+    `${label}: topbar controls must not be clipped`,
+  ).toEqual([]);
+
+  expect(
+    contract.undersizedShellControls,
+    `${label}: topbar/nav controls must keep mobile touch target >=36px`,
+  ).toEqual([]);
+
+  expect(
+    contract.activeNavItemVisible,
+    `${label}: active nav item must remain visible in mobile viewport`,
+  ).toBe(true);
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test.describe(`dashboard mobile shell/nav contract — ${viewport.name}`, () => {
+    for (const route of SHELL_ROUTES) {
+      test(`${route.label} keeps shell/nav usable`, async ({ page }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+
+        await gotoShellRoute(page, route);
+
+        await expect(async () => {
+          const contract = await readShellNavContract(page);
+          assertShellNavContract(contract, `${viewport.name} ${route.label}`);
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+  });
+}

--- a/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
+++ b/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
@@ -78,10 +78,22 @@ function DashboardHorizontalNavInner() {
   const surface = resolveSurface(pathname);
   const items = surface === "admin" ? ADMIN_NAV_ITEMS : CLINIC_NAV_ITEMS;
   const surfaceLabel = surface === "admin" ? "Administración" : "Clínica";
+  const navScrollerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const activeElement = navScrollerRef.current?.querySelector<HTMLElement>(
+      "[aria-current='page']",
+    );
+
+    activeElement?.scrollIntoView({
+      block: "nearest",
+      inline: "center",
+    });
+  }, [activeModule, pathname, surface]);
 
   return (
     <div
-      className="flex min-h-[2.25rem] items-center gap-2 px-3 sm:px-6"
+      className="flex min-h-[2.75rem] min-w-0 items-center gap-2 px-2 sm:min-h-[2.25rem] sm:px-6"
       data-dashboard-horizontal-nav={surface}
     >
       <span className="hidden shrink-0 items-center gap-1.5 md:flex">
@@ -93,7 +105,7 @@ function DashboardHorizontalNavInner() {
         </span>
       </span>
 
-      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto overscroll-x-contain">
+      <div ref={navScrollerRef} className="flex min-w-0 flex-1 scroll-px-2 items-center gap-1 overflow-x-auto overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {items.map((item) => {
           const active = isItemActive(item, pathname, activeModule);
 
@@ -106,7 +118,7 @@ function DashboardHorizontalNavInner() {
               aria-label={item.label}
               aria-current={active ? "page" : undefined}
               className={cn(
-                "inline-flex min-h-[1.85rem] shrink-0 items-center whitespace-nowrap rounded-md border-b-2 border-transparent px-2.5 py-1 text-[0.8125rem] font-semibold dashboard-nav-interactive focus-visible:ring-offset-2",
+                "inline-flex min-h-10 shrink-0 items-center whitespace-nowrap rounded-md border-b-2 border-transparent px-2.5 py-1.5 text-[0.8125rem] font-semibold dashboard-nav-interactive focus-visible:ring-offset-2 sm:min-h-[1.85rem] sm:py-1",
                 active
                   ? "border-vetneb-teal bg-vetneb-navy/8 text-vetneb-navy"
                   : "text-foreground/70 hover:bg-accent/60 hover:text-foreground",
@@ -124,7 +136,7 @@ function DashboardHorizontalNavInner() {
         variant="bare"
         aria-label="Volver al sitio público"
         title="Volver al sitio público"
-        className="shrink-0 whitespace-nowrap rounded-md px-2.5 py-1 text-[0.75rem] font-semibold text-muted-foreground dashboard-nav-interactive hover:bg-accent/60 hover:text-foreground focus-visible:ring-offset-2"
+        className="inline-flex min-h-10 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 py-1.5 text-[0.75rem] font-semibold text-muted-foreground dashboard-nav-interactive hover:bg-accent/60 hover:text-foreground focus-visible:ring-offset-2 sm:min-h-0 sm:py-1"
       >
         <span className="hidden sm:inline">Volver al sitio público</span>
         <span className="sm:hidden" aria-hidden="true">
@@ -143,7 +155,7 @@ export function DashboardHorizontalNav() {
       data-dashboard-horizontal-nav-shell="true"
       className="shrink-0 border-t border-vetneb-line/70 bg-card/85"
     >
-      <Suspense fallback={<div className="min-h-[2.25rem]" aria-hidden="true" />}>
+      <Suspense fallback={<div className="min-h-[2.75rem] sm:min-h-[2.25rem]" aria-hidden="true" />}>
         <DashboardHorizontalNavInner />
       </Suspense>
     </nav>

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -25,7 +25,7 @@ export function DashboardTopbar({
       aria-label="Barra superior del dashboard"
       aria-labelledby="dashboard-topbar-title"
     >
-      <div className="flex min-h-[2.5rem] items-center justify-between gap-3 px-4 py-1.5 sm:px-6">
+      <div className="flex min-h-[2.75rem] min-w-0 items-center justify-between gap-2 px-3 py-1.5 sm:min-h-[2.5rem] sm:gap-3 sm:px-6">
         <div className="min-w-0">
           <h1
             id="dashboard-topbar-title"
@@ -40,16 +40,19 @@ export function DashboardTopbar({
           )}
         </div>
 
-        <div className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3">
+        <div className="ml-2 flex shrink-0 items-center gap-1.5 sm:ml-3 sm:gap-3">
           <ThemeModeToggle />
           {notifications ? <DashboardNotificationsBell surface={notifications} /> : null}
           <PublicRouteControl
             href={ROUTES.login}
             variant="bare"
             onClick={clearDashboardLastModules}
-            className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+            aria-label="Cerrar sesión"
+            title="Cerrar sesión"
+            className="inline-flex h-10 min-w-10 items-center justify-center rounded-md border border-input bg-card/95 px-2 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 sm:h-9 sm:min-w-0 sm:px-3"
           >
-            Cerrar sesión
+            <span className="hidden sm:inline">Cerrar sesión</span>
+            <span className="sm:hidden" aria-hidden="true">Salir</span>
           </PublicRouteControl>
         </div>
       </div>

--- a/test/frontend-visual-consistency.test.ts
+++ b/test/frontend-visual-consistency.test.ts
@@ -388,7 +388,7 @@ test("dashboard topbar keeps sticky hierarchy and compact responsive shell", () 
       /className="sticky top-0 z-40 flex shrink-0 flex-col border-b border-vetneb-line\/80 bg-card\/90 shadow-sm backdrop-blur supports-\[backdrop-filter\]:bg-card\/78"/,
       /className="truncate text-lg font-semibold leading-tight text-vetneb-ink sm:text-xl"/,
       /className="truncate text-xs text-muted-foreground sm:text-\[0\.8125rem\]"/,
-      /className="ml-3 flex shrink-0 items-center gap-2 sm:gap-3"/,
+      /className="ml-2 flex shrink-0 items-center gap-1.5 sm:ml-3 sm:gap-3"/,
     ],
     "dashboard topbar class contracts",
   );


### PR DESCRIPTION
## Summary
- Make dashboard horizontal nav touch-safe on mobile
- Compact logout controls in the dashboard topbar on small screens
- Auto-scroll the active nav item into view for mobile Android/iOS widths
- Add focused Playwright coverage for mobile shell/nav usability

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts --project=chromium
- pnpm --dir frontend lint
- pnpm --dir frontend build