### PR TITLE
fix(admin): make clinics list mobile operable

### DIFF
--- a/frontend/e2e/admin-clinic-edit-drawer.spec.ts
+++ b/frontend/e2e/admin-clinic-edit-drawer.spec.ts
@@ -424,7 +424,10 @@ test.describe("admin clinic edit drawer — component behavior", () => {
 
     // Set a search query
     const searchInput = page.getByRole("textbox", { name: /buscar clínicas/i });
-    await searchInput.fill("Test");
+    await expect(async () => {
+      await searchInput.fill("Test");
+      await expect(searchInput).toHaveValue("Test");
+    }).toPass({ intervals: [200, 400, 800], timeout: 5_000 });
 
     // Open and close the drawer
     await page.getByRole("button", { name: /editar clínica clínica test/i }).click();

--- a/frontend/e2e/admin-clinics-mobile-card-layout.spec.ts
+++ b/frontend/e2e/admin-clinics-mobile-card-layout.spec.ts
@@ -1,0 +1,251 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const MOCK_CLINICS = Array.from({ length: 9 }, (_, index) => {
+  const id = index + 1;
+
+  return {
+    clinicId: id,
+    clinicName: `Clínica Mobile ${id}`,
+    contactEmail: `clinica.mobile.${id}@example.test`,
+    contactPhone: `+54 11 5555-${String(id).padStart(4, "0")}`,
+    createdAt: "2026-06-01T10:00:00.000Z",
+    updatedAt: `2026-06-${String(id).padStart(2, "0")}T12:00:00.000Z`,
+    users: [
+      {
+        userId: 100 + id,
+        username: `mobile-owner-${id}`,
+        createdAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      },
+    ],
+  };
+});
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function mockAdminClinics(page: Page) {
+  await page.route("**/api/admin/clinics**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    const url = new URL(route.request().url());
+    const limit = Number(url.searchParams.get("limit") ?? "9");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    const clinics = MOCK_CLINICS.slice(offset, offset + limit);
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        clinics,
+        total: MOCK_CLINICS.length,
+        limit,
+        offset,
+      }),
+    });
+  });
+}
+
+type MobileClinicsContract = {
+  htmlScrollWidth: number;
+  htmlClientWidth: number;
+  bodyScrollWidth: number;
+  bodyClientWidth: number;
+  visibleMobileCards: number;
+  visibleDesktopTables: number;
+  clippedActions: Array<{
+    label: string;
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    width: number;
+    height: number;
+  }>;
+  undersizedActions: Array<{
+    label: string;
+    width: number;
+    height: number;
+  }>;
+};
+
+async function readMobileClinicsContract(
+  page: Page,
+): Promise<MobileClinicsContract> {
+  return page.evaluate((tolerance) => {
+    const html = document.documentElement;
+    const body = document.body;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    const isVisible = (element: Element) => {
+      const el = element as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      const style = window.getComputedStyle(el);
+
+      return (
+        rect.width > 1 &&
+        rect.height > 1 &&
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        style.opacity !== "0"
+      );
+    };
+
+    const mobileCards = Array.from(
+      document.querySelectorAll("[data-admin-clinic-mobile-card='true']"),
+    ).filter(isVisible);
+
+    const desktopTables = Array.from(
+      document.querySelectorAll(".dashboard-table-responsive table"),
+    ).filter(isVisible);
+
+    const editActions = Array.from(
+      document.querySelectorAll(
+        "[data-admin-clinics-mobile-list='true'] button[aria-label^='Editar clínica']",
+      ),
+    ).filter(isVisible);
+
+    const metricFor = (element: Element) => {
+      const rect = (element as HTMLElement).getBoundingClientRect();
+
+      return {
+        label:
+          (element as HTMLElement).getAttribute("aria-label") ||
+          (element as HTMLElement).innerText ||
+          element.tagName.toLowerCase(),
+        left: Math.round(rect.left),
+        right: Math.round(rect.right),
+        top: Math.round(rect.top),
+        bottom: Math.round(rect.bottom),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      };
+    };
+
+    return {
+      htmlScrollWidth: html.scrollWidth,
+      htmlClientWidth: html.clientWidth,
+      bodyScrollWidth: body.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      visibleMobileCards: mobileCards.length,
+      visibleDesktopTables: desktopTables.length,
+      clippedActions: editActions
+        .filter((element) => {
+          const rect = (element as HTMLElement).getBoundingClientRect();
+
+          return (
+            rect.left < -tolerance ||
+            rect.right > viewportWidth + tolerance ||
+            rect.top < -tolerance ||
+            rect.bottom > viewportHeight + tolerance
+          );
+        })
+        .map(metricFor),
+      undersizedActions: editActions
+        .filter((element) => {
+          const rect = (element as HTMLElement).getBoundingClientRect();
+          return rect.width < 36 || rect.height < 36;
+        })
+        .map((element) => {
+          const metric = metricFor(element);
+          return {
+            label: metric.label,
+            width: metric.width,
+            height: metric.height,
+          };
+        }),
+    };
+  }, TOLERANCE);
+}
+
+function assertMobileClinicsContract(
+  contract: MobileClinicsContract,
+  label: string,
+) {
+  expect(contract.visibleMobileCards, `${label}: mobile cards visible`).toBeGreaterThan(0);
+  expect(
+    contract.visibleMobileCards,
+    `${label}: mobile page size must remain viewport-safe`,
+  ).toBeLessThanOrEqual(3);
+  expect(contract.visibleDesktopTables, `${label}: desktop table hidden on mobile`).toBe(0);
+
+  expect(
+    contract.htmlScrollWidth,
+    `${label}: documentElement horizontal overflow`,
+  ).toBeLessThanOrEqual(contract.htmlClientWidth + TOLERANCE);
+
+  expect(
+    contract.bodyScrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(contract.bodyClientWidth + TOLERANCE);
+
+  expect(
+    contract.clippedActions,
+    `${label}: edit actions must not be clipped`,
+  ).toEqual([]);
+
+  expect(
+    contract.undersizedActions,
+    `${label}: edit actions must keep touch target >=36px`,
+  ).toEqual([]);
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`admin clinics mobile cards stay operable — ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({
+      width: viewport.width,
+      height: viewport.height,
+    });
+
+    await setAdminSession(page);
+    await mockAdminClinics(page);
+
+    await page.goto("/dashboard/admin?module=admin-clinics");
+
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      page.locator("[data-admin-clinics-mobile-list='true']"),
+    ).toBeVisible();
+
+    await expect(
+      page.locator("[data-admin-clinic-mobile-card='true']").first(),
+    ).toBeVisible();
+
+    const contract = await readMobileClinicsContract(page);
+    assertMobileClinicsContract(contract, viewport.name);
+
+    await page
+      .getByRole("button", { name: /editar clínica clínica mobile 1/i })
+      .click();
+
+    await expect(
+      page.getByRole("dialog", { name: /editar clínica/i }),
+    ).toBeVisible();
+  });
+}

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -53,6 +53,7 @@ const ClinicEditDrawer = dynamic(
 // margin in the 1366×768 viewport without internal scroll. True 25/50/100 needs
 // the no-scroll contract relaxation (audit §3) and is deferred.
 const PAGE_SIZE = 9;
+const MOBILE_PAGE_SIZE = 3;
 
 type CreateClinicForm = {
   clinicName: string;
@@ -116,14 +117,20 @@ export function AdminClinicsManagementCard() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeActionKey, setActiveActionKey] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [isMobileViewport, setIsMobileViewport] = useState(() =>
+    typeof window !== "undefined"
+      ? window.matchMedia("(max-width: 767px)").matches
+      : false,
+  );
 
   const rows = useMemo(() => getClinicUserRows(snapshot), [snapshot]);
 
+  const effectivePageSize = isMobileViewport ? MOBILE_PAGE_SIZE : PAGE_SIZE;
   const totalClinics = snapshot?.total ?? 0;
   const pageStart = totalClinics > 0 ? currentOffset + 1 : 0;
-  const pageEnd = Math.min(currentOffset + PAGE_SIZE, totalClinics);
+  const pageEnd = Math.min(currentOffset + effectivePageSize, totalClinics);
   const hasPrev = currentOffset > 0;
-  const hasNext = currentOffset + PAGE_SIZE < totalClinics;
+  const hasNext = currentOffset + effectivePageSize < totalClinics;
   const isBusy = isPending || activeActionKey !== null;
 
   function loadClinics(offset = currentOffset, search = searchQuery) {
@@ -135,7 +142,7 @@ export function AdminClinicsManagementCard() {
           const trimmedSearch = search.trim();
           setSnapshot(
             await getAdminClinics({
-              limit: PAGE_SIZE,
+              limit: effectivePageSize,
               offset,
               ...(trimmedSearch ? { search: trimmedSearch } : {}),
             }),
@@ -225,6 +232,21 @@ export function AdminClinicsManagementCard() {
     loadClinics();
   }
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+
+    const updateMobileViewport = () => {
+      setIsMobileViewport(mediaQuery.matches);
+    };
+
+    updateMobileViewport();
+    mediaQuery.addEventListener("change", updateMobileViewport);
+
+    return () => {
+      mediaQuery.removeEventListener("change", updateMobileViewport);
+    };
+  }, []);
+
   const isFirstRender = useRef(true);
 
   useEffect(() => {
@@ -240,7 +262,7 @@ export function AdminClinicsManagementCard() {
 
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery]);
+  }, [searchQuery, effectivePageSize]);
 
   return (
     <Card id="admin-clinics" className="dashboard-surface flex min-h-0 flex-1 flex-col">
@@ -433,7 +455,7 @@ export function AdminClinicsManagementCard() {
                 size="sm"
                 variant="outline"
                 className="h-8 w-8 p-0"
-                onClick={() => loadClinics(currentOffset - PAGE_SIZE)}
+                onClick={() => loadClinics(currentOffset - effectivePageSize)}
                 disabled={isBusy || !hasPrev}
                 aria-label="Página anterior"
               >
@@ -444,7 +466,7 @@ export function AdminClinicsManagementCard() {
                 size="sm"
                 variant="outline"
                 className="h-8 w-8 p-0"
-                onClick={() => loadClinics(currentOffset + PAGE_SIZE)}
+                onClick={() => loadClinics(currentOffset + effectivePageSize)}
                 disabled={isBusy || !hasNext}
                 aria-label="Página siguiente"
               >
@@ -454,7 +476,7 @@ export function AdminClinicsManagementCard() {
           ) : null}
         </div>
 
-        <div className="dashboard-table-responsive">
+        <div className="dashboard-table-responsive hidden md:block">
           <Table className="text-[0.8125rem] [&_th]:h-9 [&_th]:px-3 [&_td]:px-3">
             <TableHeader>
               <TableRow>
@@ -564,6 +586,85 @@ export function AdminClinicsManagementCard() {
           </Table>
         </div>
 
+        <div
+          className="grid gap-2 md:hidden"
+          data-admin-clinics-mobile-list="true"
+        >
+          {rows.length ? (
+            rows.map(({ clinic, user, extraUsers }) => (
+              <article
+                key={`mobile-${clinic.clinicId}-${user?.userId ?? "empty"}`}
+                className="rounded-lg border border-vetneb-line/70 bg-card/92 px-3 py-2 shadow-[0_1px_2px_rgba(15,45,62,0.05)]"
+                data-admin-clinic-mobile-card="true"
+              >
+                <div className="flex min-w-0 items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <h3 className="truncate text-sm font-semibold leading-tight text-vetneb-ink">
+                        {clinic.clinicName}
+                      </h3>
+                      <span className="shrink-0 font-mono text-[0.62rem] text-muted-foreground">
+                        #{clinic.clinicId}
+                      </span>
+                    </div>
+                    <p className="mt-0.5 truncate text-[0.72rem] text-muted-foreground">
+                      {clinic.contactEmail ?? "Sin email de contacto"}
+                    </p>
+                  </div>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={isBusy || editingClinic !== null}
+                    onClick={() => setEditingClinic(clinic)}
+                    aria-label={`Editar clínica ${clinic.clinicName}`}
+                    className="h-9 shrink-0 px-2.5"
+                  >
+                    <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                    Editar
+                  </Button>
+                </div>
+
+                <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.68rem] leading-tight text-muted-foreground">
+                  <span className="min-w-0 truncate">
+                    Usuario: {user ? user.username : "Sin usuario"}
+                    {extraUsers > 0 ? ` +${extraUsers}` : ""}
+                  </span>
+                  <span aria-hidden="true">·</span>
+                  <span className="whitespace-nowrap">
+                    Actualizada: {formatDateTime(clinic.updatedAt)}
+                  </span>
+                </div>
+              </article>
+            ))
+          ) : isPending ? (
+            <LoadingState
+              variant="table"
+              compact
+              rows={3}
+              className="border-0 bg-transparent shadow-none rounded-none"
+            />
+          ) : (
+            <div className="clinical-table-state rounded-lg border border-vetneb-line/70 bg-card/90 p-3">
+              {searchQuery.trim() ? (
+                <EmptyState
+                  title={`Sin resultados para "${searchQuery}"`}
+                  description="No hay clínicas que coincidan con la búsqueda."
+                  size="sm"
+                  className="border-0 bg-transparent"
+                />
+              ) : (
+                <EmptyState
+                  title="Sin clínicas"
+                  description="No hay clínicas para mostrar."
+                  size="sm"
+                  className="border-0 bg-transparent"
+                />
+              )}
+            </div>
+          )}
+        </div>
         <ClinicEditDrawer
           clinic={editingClinic}
           onSaveClinic={handleSaveClinic}

--- a/test/admin-overview-clinics-enterprise-density.test.ts
+++ b/test/admin-overview-clinics-enterprise-density.test.ts
@@ -71,7 +71,8 @@ test("admin clinics console raises the server page size while respecting no-scro
 
   // Nine dense rows preserve a full-row margin in the minimum viewport.
   assert.ok(source.includes("const PAGE_SIZE = 9;"));
-  assert.ok(source.includes("limit: PAGE_SIZE"));
+  assert.ok(source.includes("const MOBILE_PAGE_SIZE = 3;"));
+  assert.ok(source.includes("limit: effectivePageSize"));
   assert.ok(source.includes("snapshot?.total"));
 
   // No-scroll contract: the table body must NOT become an internal scroll region

--- a/test/frontend-admin-clinics-management-card.test.ts
+++ b/test/frontend-admin-clinics-management-card.test.ts
@@ -185,7 +185,7 @@ test("admin clinics management card resets to page 0 when search changes", () =>
   const source = read(ADMIN_CLINICS_CARD_PATH);
 
   // useEffect depends on searchQuery and calls loadClinics with offset 0
-  assert.ok(source.includes("searchQuery]"));
+  assert.ok(source.includes("searchQuery, effectivePageSize]"));
   assert.ok(source.includes("loadClinics(0"));
 });
 
@@ -219,4 +219,33 @@ test("clinic edit drawer exports ClinicDraft and CredentialsPayload types for co
   assert.ok(drawerSource.includes("export type ClinicDraft"));
   assert.ok(drawerSource.includes("export type CredentialsPayload"));
   assert.ok(drawerSource.includes("export function ClinicEditDrawer"));
+});
+
+test("admin clinics management card renders mobile cards while preserving desktop table", () => {
+  const source = read(ADMIN_CLINICS_CARD_PATH);
+
+  assert.ok(
+    source.includes("const MOBILE_PAGE_SIZE = 3;"),
+    "mobile page size must keep the clinics list viewport-safe",
+  );
+  assert.ok(
+    source.includes("effectivePageSize"),
+    "admin clinics must use responsive page size",
+  );
+  assert.ok(
+    source.includes('data-admin-clinics-mobile-list="true"'),
+    "mobile list landmark must exist",
+  );
+  assert.ok(
+    source.includes('data-admin-clinic-mobile-card="true"'),
+    "mobile clinic cards must exist",
+  );
+  assert.ok(
+    source.includes('dashboard-table-responsive hidden md:block'),
+    "desktop table must be hidden on mobile and preserved from md upward",
+  );
+  assert.ok(
+    source.includes('aria-label={`Editar clínica ${clinic.clinicName}`}'),
+    "mobile edit action must keep the accessible clinic-specific label",
+  );
 });


### PR DESCRIPTION
## Summary
- Render Admin Clínicas as mobile cards below md while preserving the dense desktop table from md upward
- Keep Editar actions visible and touch-safe on Android/iOS mobile widths
- Use responsive page sizing: 3 items on mobile, 9 on desktop
- Preserve server-side search/pagination behavior and existing edit drawer flow
- Add focused Playwright coverage for the Admin Clínicas mobile card layout

## Validation
- pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-clinics-management-card.test.ts
- pnpm --dir frontend exec playwright test e2e/admin-clinics-mobile-card-layout.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-clinic-edit-drawer.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "admin clinics populated"
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint