### PR TITLE
fix(frontend): make clinic profile editor mobile operable

### DIFF
--- a/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
+++ b/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "@playwright/test";
+
+type Page = import("@playwright/test").Page;
+
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "360x740", width: 360, height: 740 },
+  { name: "390x844", width: 390, height: 844 },
+  { name: "430x932", width: 430, height: 932 },
+] as const;
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function mockClinicProfile(page: Page) {
+  await page.route("**/api/clinic/profile**", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        profile: {
+          clinicId: 1,
+          displayName: "Clinica Perfil Mobile Operable",
+          specialtyText: "Anatomia patologica veterinaria especializada",
+          servicesText:
+            "Citologia, histopatologia, inmunohistoquimica y diagnostico integral veterinario.",
+          aboutText:
+            "Perfil institucional denso para verificar la operabilidad completa del editor en mobile.",
+          email: "perfil-mobile@example.test",
+          phone: "+54 11 5555-1234",
+          publicAddress: "Avenida Veterinaria 1234, Ciudad Autonoma de Buenos Aires",
+          mapLink: "https://maps.google.com/maps?q=vetneb",
+          locality: "Buenos Aires",
+          country: "Argentina",
+          avatarUrl: null,
+          isPublic: true,
+          publication: {
+            isSearchEligible: true,
+            qualityScore: 95,
+            minimumQualityScore: 75,
+            hasRequiredPublicFields: true,
+            missingRequiredFields: [],
+            missingRecommendedFields: [],
+            publicationErrors: [],
+          },
+        },
+      }),
+    });
+  });
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`clinic perfil public editor is operable at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({
+      width: viewport.width,
+      height: viewport.height,
+    });
+    await setClinicSession(page);
+    await mockClinicProfile(page);
+
+    await page.goto("/dashboard?module=perfil");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="perfil"]'),
+    ).toBeVisible({ timeout: 12_000 });
+
+    await expect(async () => {
+      const publicProfileTab = page
+        .getByRole("tab", { name: "Perfil público", exact: true })
+        .first();
+      await expect(publicProfileTab).toBeVisible();
+      await publicProfileTab.click();
+      await expect(page.locator("#clinic-public-profile")).toBeVisible();
+    }).toPass({ timeout: 12_000 });
+
+    const editor = page.locator('[data-clinic-profile-editor="true"]');
+    await expect(editor).toBeVisible();
+
+    await expect(async () => {
+      await editor.getByRole("tab", { name: "Datos", exact: true }).click();
+      await expect(
+        editor.locator('[data-clinic-profile-fields="true"]'),
+      ).toBeVisible();
+    }).toPass({ timeout: 12_000 });
+
+    const fields = editor.locator('[data-clinic-profile-fields="true"]');
+    await expect(fields).toBeVisible();
+
+    const shellMetrics = await page.evaluate(() => {
+      const main = document.querySelector<HTMLElement>("main.dashboard-main");
+      return {
+        html: {
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+          scrollHeight: document.documentElement.scrollHeight,
+          clientHeight: document.documentElement.clientHeight,
+        },
+        body: {
+          scrollWidth: document.body.scrollWidth,
+          clientWidth: document.body.clientWidth,
+          scrollHeight: document.body.scrollHeight,
+          clientHeight: document.body.clientHeight,
+        },
+        main: main
+          ? {
+              scrollHeight: main.scrollHeight,
+              clientHeight: main.clientHeight,
+            }
+          : null,
+      };
+    });
+
+    expect(shellMetrics.html.scrollWidth).toBeLessThanOrEqual(
+      shellMetrics.html.clientWidth + TOLERANCE,
+    );
+    expect(shellMetrics.body.scrollWidth).toBeLessThanOrEqual(
+      shellMetrics.body.clientWidth + TOLERANCE,
+    );
+    expect(shellMetrics.html.scrollHeight).toBeLessThanOrEqual(
+      shellMetrics.html.clientHeight + TOLERANCE,
+    );
+    expect(shellMetrics.body.scrollHeight).toBeLessThanOrEqual(
+      shellMetrics.body.clientHeight + TOLERANCE,
+    );
+    expect(shellMetrics.main).not.toBeNull();
+    expect(shellMetrics.main!.scrollHeight).toBeLessThanOrEqual(
+      shellMetrics.main!.clientHeight + TOLERANCE,
+    );
+
+    const mapLink = page.locator("#clinic-profile-map-link");
+    await mapLink.scrollIntoViewIfNeeded();
+    await expect(mapLink).toBeVisible();
+    const mapLinkBox = await mapLink.boundingBox();
+    expect(mapLinkBox).not.toBeNull();
+    expect(mapLinkBox!.y).toBeGreaterThanOrEqual(-TOLERANCE);
+    expect(mapLinkBox!.y + mapLinkBox!.height).toBeLessThanOrEqual(
+      viewport.height + TOLERANCE,
+    );
+
+    const saveButton = page.getByRole("button", {
+      name: "Guardar perfil público",
+      exact: true,
+    });
+    await expect(saveButton).toBeVisible();
+    const saveButtonBox = await saveButton.boundingBox();
+    expect(saveButtonBox).not.toBeNull();
+    expect(saveButtonBox!.x).toBeGreaterThanOrEqual(-TOLERANCE);
+    expect(saveButtonBox!.x + saveButtonBox!.width).toBeLessThanOrEqual(
+      viewport.width + TOLERANCE,
+    );
+    expect(saveButtonBox!.y + saveButtonBox!.height).toBeLessThanOrEqual(
+      viewport.height + TOLERANCE,
+    );
+  });
+}

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -479,7 +479,10 @@ export function ClinicPublicProfileCard() {
   );
 
   const statusTab = (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <div
+      data-clinic-profile-fields="true"
+      className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
+    >
       <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
         <div className="surface-soft">
           <p className="text-xs text-muted-foreground">Estado</p>
@@ -489,7 +492,7 @@ export function ClinicPublicProfileCard() {
         </div>
         <div className="surface-soft">
           <p className="text-xs text-muted-foreground">Calidad</p>
-          <p className="mt-1 text-2xl font-bold text-vetneb-ink">
+          <p className="mt-1 text-xl sm:text-2xl font-bold text-vetneb-ink">
             {publication ? publication.qualityScore : "—"}
             <span className="text-sm font-medium text-muted-foreground">
               /{publication?.minimumQualityScore ?? 75}
@@ -515,7 +518,7 @@ export function ClinicPublicProfileCard() {
           Avatar o logo
         </label>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-vetneb-line/70 bg-white">
+          <div className="flex h-12 w-12 sm:h-16 sm:w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-vetneb-line/70 bg-white">
             {profileAvatarSrc ? (
               <NextImage
                 src={profileAvatarSrc}
@@ -569,131 +572,139 @@ export function ClinicPublicProfileCard() {
   );
 
   const detailsTab = (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <div>
-        <label htmlFor="clinic-profile-display-name" className="field-label">
-          Nombre visible
-        </label>
-        <Input
-          id="clinic-profile-display-name"
-          name="displayName"
-          type="text"
-          required
-          value={formState.displayName}
-          onChange={(event) => updateField("displayName", event.target.value)}
-          disabled={isWorking}
-        />
-      </div>
+    <div
+      data-clinic-profile-fields="true"
+      className="min-h-0 flex-1 overflow-y-auto lg:overflow-y-visible"
+    >
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <label htmlFor="clinic-profile-display-name" className="field-label">
+            Nombre visible
+          </label>
+          <Input
+            id="clinic-profile-display-name"
+            name="displayName"
+            type="text"
+            required
+            value={formState.displayName}
+            onChange={(event) => updateField("displayName", event.target.value)}
+            disabled={isWorking}
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-specialty" className="field-label">
-          Especialidad
-        </label>
-        <Input
-          id="clinic-profile-specialty"
-          name="specialtyText"
-          type="text"
-          required
-          value={formState.specialtyText}
-          onChange={(event) => updateField("specialtyText", event.target.value)}
-          disabled={isWorking}
-          placeholder="Ej: Anatomía patológica veterinaria"
-        />
-      </div>
+        <div>
+          <label htmlFor="clinic-profile-specialty" className="field-label">
+            Especialidad
+          </label>
+          <Input
+            id="clinic-profile-specialty"
+            name="specialtyText"
+            type="text"
+            required
+            value={formState.specialtyText}
+            onChange={(event) => updateField("specialtyText", event.target.value)}
+            disabled={isWorking}
+            placeholder="Ej: Anatomía patológica veterinaria"
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-locality" className="field-label">
-          Localidad
-        </label>
-        <Input
-          id="clinic-profile-locality"
-          name="locality"
-          type="text"
-          required
-          value={formState.locality}
-          onChange={(event) => updateField("locality", event.target.value)}
-          disabled={isWorking}
-        />
-      </div>
+        <div>
+          <label htmlFor="clinic-profile-locality" className="field-label">
+            Localidad
+          </label>
+          <Input
+            id="clinic-profile-locality"
+            name="locality"
+            type="text"
+            required
+            value={formState.locality}
+            onChange={(event) => updateField("locality", event.target.value)}
+            disabled={isWorking}
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-country" className="field-label">
-          País
-        </label>
-        <Input
-          id="clinic-profile-country"
-          name="country"
-          type="text"
-          required
-          value={formState.country}
-          onChange={(event) => updateField("country", event.target.value)}
-          disabled={isWorking}
-        />
-      </div>
+        <div>
+          <label htmlFor="clinic-profile-country" className="field-label">
+            País
+          </label>
+          <Input
+            id="clinic-profile-country"
+            name="country"
+            type="text"
+            required
+            value={formState.country}
+            onChange={(event) => updateField("country", event.target.value)}
+            disabled={isWorking}
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-email" className="field-label">
-          Email público
-        </label>
-        <Input
-          id="clinic-profile-email"
-          name="email"
-          type="email"
-          value={formState.email}
-          onChange={(event) => updateField("email", event.target.value)}
-          disabled={isWorking}
-        />
-      </div>
+        <div>
+          <label htmlFor="clinic-profile-email" className="field-label">
+            Email público
+          </label>
+          <Input
+            id="clinic-profile-email"
+            name="email"
+            type="email"
+            value={formState.email}
+            onChange={(event) => updateField("email", event.target.value)}
+            disabled={isWorking}
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-phone" className="field-label">
-          Teléfono público
-        </label>
-        <Input
-          id="clinic-profile-phone"
-          name="phone"
-          type="text"
-          value={formState.phone}
-          onChange={(event) => updateField("phone", event.target.value)}
-          disabled={isWorking}
-        />
-      </div>
+        <div>
+          <label htmlFor="clinic-profile-phone" className="field-label">
+            Teléfono público
+          </label>
+          <Input
+            id="clinic-profile-phone"
+            name="phone"
+            type="text"
+            value={formState.phone}
+            onChange={(event) => updateField("phone", event.target.value)}
+            disabled={isWorking}
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-public-address" className="field-label">
-          Dirección pública
-        </label>
-        <Input
-          id="clinic-profile-public-address"
-          name="publicAddress"
-          type="text"
-          maxLength={160}
-          value={formState.publicAddress}
-          onChange={(event) => updateField("publicAddress", event.target.value)}
-          disabled={isWorking}
-          placeholder="Calle, número, ciudad"
-        />
-      </div>
+        <div>
+          <label htmlFor="clinic-profile-public-address" className="field-label">
+            Dirección pública
+          </label>
+          <Input
+            id="clinic-profile-public-address"
+            name="publicAddress"
+            type="text"
+            maxLength={160}
+            value={formState.publicAddress}
+            onChange={(event) => updateField("publicAddress", event.target.value)}
+            disabled={isWorking}
+            placeholder="Calle, número, ciudad"
+          />
+        </div>
 
-      <div>
-        <label htmlFor="clinic-profile-map-link" className="field-label">
-          Enlace a mapa
-        </label>
-        <Input
-          id="clinic-profile-map-link"
-          name="mapLink"
-          type="url"
-          value={formState.mapLink}
-          onChange={(event) => updateField("mapLink", event.target.value)}
-          disabled={isWorking}
-          placeholder="https://maps.google.com/..."
-        />
+        <div>
+          <label htmlFor="clinic-profile-map-link" className="field-label">
+            Enlace a mapa
+          </label>
+          <Input
+            id="clinic-profile-map-link"
+            name="mapLink"
+            type="url"
+            value={formState.mapLink}
+            onChange={(event) => updateField("mapLink", event.target.value)}
+            disabled={isWorking}
+            placeholder="https://maps.google.com/..."
+          />
+        </div>
       </div>
     </div>
   );
 
   const contentTab = (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <div
+      data-clinic-profile-fields="true"
+      className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
+    >
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         <div>
           <label htmlFor="clinic-profile-services" className="field-label">
@@ -747,6 +758,7 @@ export function ClinicPublicProfileCard() {
   return (
     <Card
       id="clinic-public-profile"
+      data-clinic-profile-editor="true"
       className="dashboard-surface flex min-h-0 flex-1 flex-col"
     >
       <CardHeader className="shrink-0 border-b border-vetneb-line/70 px-5 py-3">

--- a/test/frontend-clinic-public-profile.test.ts
+++ b/test/frontend-clinic-public-profile.test.ts
@@ -68,6 +68,16 @@ test("clinic public profile card exposes required publication fields", () => {
   assert.ok(source.includes("isSearchEligible"));
 });
 
+test("clinic public profile editor keeps mobile fields operable", () => {
+  const source = read(PROFILE_CARD_PATH);
+
+  assert.ok(source.includes('data-clinic-profile-editor="true"'));
+  assert.ok(source.includes('data-clinic-profile-fields="true"'));
+  assert.ok(source.includes("h-12 w-12 sm:h-16 sm:w-16"));
+  assert.ok(source.includes("text-xl sm:text-2xl"));
+  assert.ok(source.includes("min-h-0 flex-1 overflow-y-auto"));
+});
+
 test("frontend api exposes clinic public profile helpers", () => {
   const source = read(API_PATH);
 


### PR DESCRIPTION
## Summary
- Make the clinic public profile editor operable on 360/390/430px mobile widths
- Add internal scroll only to the profile editor field region
- Keep dashboard shell/global page no-scroll behavior intact
- Reduce profile score/avatar density responsively
- Add focused Playwright coverage for mobile profile operability
- Add static profile contract coverage

## Validation
- pnpm exec node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-clinic-public-profile.test.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-perfil-mobile-operability.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "perfil"
- pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts --project=chromium
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm test
- pnpm security:public-surface
- pnpm build
- pnpm --dir frontend build