### PR TITLE
test(frontend): cover clinic informes mobile parity

### DIFF
--- a/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+const LONG_PATIENT_NAME =
+  "Paciente con nombre clínico extraordinariamente extenso para validar el detalle mobile";
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+type LayoutContract = {
+  htmlScrollWidth: number;
+  htmlClientWidth: number;
+  htmlScrollHeight: number;
+  htmlClientHeight: number;
+  bodyScrollWidth: number;
+  bodyClientWidth: number;
+  bodyScrollHeight: number;
+  bodyClientHeight: number;
+  mainScrollHeight: number;
+  mainClientHeight: number;
+  listClientHeight: number;
+  hasMain: boolean;
+  hasList: boolean;
+};
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readLayoutContract(page: Page): Promise<LayoutContract> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const list = document.querySelector<HTMLElement>(".dashboard-inline-scroll");
+
+    return {
+      htmlScrollWidth: html.scrollWidth,
+      htmlClientWidth: html.clientWidth,
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollWidth: body.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+      mainScrollHeight: main?.scrollHeight ?? 0,
+      mainClientHeight: main?.clientHeight ?? 0,
+      listClientHeight: list?.clientHeight ?? 0,
+      hasMain: main !== null,
+      hasList: list !== null,
+    };
+  });
+}
+
+function assertNoGlobalOverflow(metrics: LayoutContract, label: string) {
+  expect(metrics.hasMain, `${label}: main.dashboard-main present`).toBe(true);
+  expect(
+    metrics.htmlScrollWidth,
+    `${label}: documentElement horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.htmlClientWidth + TOLERANCE);
+  expect(
+    metrics.bodyScrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.bodyClientWidth + TOLERANCE);
+  expect(
+    metrics.htmlScrollHeight,
+    `${label}: documentElement global scroll`,
+  ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+  expect(
+    metrics.bodyScrollHeight,
+    `${label}: body global scroll`,
+  ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+  expect(metrics.mainScrollHeight, `${label}: dashboard shell scroll`).toBeLessThanOrEqual(
+    metrics.mainClientHeight + TOLERANCE,
+  );
+  expect(metrics.hasList, `${label}: inline list present`).toBe(true);
+  expect(
+    metrics.listClientHeight,
+    `${label}: inline list must keep an operable height`,
+  ).toBeGreaterThanOrEqual(44);
+}
+
+async function expectHorizontallyUnclipped(
+  locator: Locator,
+  viewportWidth: number,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
+    viewportWidth + TOLERANCE,
+  );
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`clinic Informes populated mobile parity at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setClinicSession(page);
+
+    await page.goto("/dashboard?module=informes");
+
+    const workspace = page
+      .locator('[data-dashboard-module-workspace="informes"]')
+      .first();
+    const card = workspace.locator(
+      '[aria-label="Informes recientes de la clínica"]',
+    );
+    const inlineList = card.locator(".dashboard-inline-scroll");
+    const reportRows = inlineList.locator('button[aria-pressed]');
+    const fullModuleButton = card.getByRole("button", {
+      name: "Abrir módulo completo de informes",
+      exact: true,
+    });
+
+    await expect(async () => {
+      await expect(workspace).toBeVisible();
+      await expect(card).toBeVisible();
+      await expect(reportRows).toHaveCount(3);
+
+      for (let index = 0; index < 3; index += 1) {
+        await expect(reportRows.nth(index)).toBeVisible();
+      }
+
+      await expect(fullModuleButton).toBeVisible();
+      await expect(fullModuleButton).toBeEnabled();
+    }).toPass({ timeout: 12_000 });
+
+    await expect(card.locator("table")).toHaveCount(0);
+    await expectHorizontallyUnclipped(
+      fullModuleButton,
+      viewport.width,
+      `${viewport.name}: full Informes CTA`,
+    );
+
+    for (let index = 0; index < 3; index += 1) {
+      await expectHorizontallyUnclipped(
+        reportRows.nth(index),
+        viewport.width,
+        `${viewport.name}: report row ${index + 1}`,
+      );
+    }
+
+    await expect(async () => {
+      const metrics = await readLayoutContract(page);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: initial layout`);
+    }).toPass({ timeout: 10_000 });
+
+    const secondReport = reportRows.nth(1);
+    await secondReport.click();
+
+    await expect(async () => {
+      await expect(secondReport).toHaveAttribute("aria-expanded", "true");
+
+      const inlineDetail = card.locator('[data-detail-state="selected"]');
+      await expect(inlineDetail).toHaveCount(1);
+      await expect(inlineDetail).toBeVisible();
+      await expect(inlineDetail).toContainText(LONG_PATIENT_NAME);
+
+      const metrics = await readLayoutContract(page);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: expanded inline detail`);
+    }).toPass({ timeout: 10_000 });
+  });
+}

--- a/frontend/e2e/fixtures/admin-populated-api-server.mjs
+++ b/frontend/e2e/fixtures/admin-populated-api-server.mjs
@@ -3,6 +3,48 @@ import { createServer } from "node:http";
 const HOST = "127.0.0.1";
 const PORT = 3107;
 const POPULATED_ADMIN_SESSION = "e2e_populated_admin_session";
+const POPULATED_CLINIC_SESSION = "e2e_populated_clinic_session";
+
+const CLINIC_REPORTS = [
+  {
+    id: 8401,
+    clinicId: 77,
+    clinicName: "Clínica E2E Informes Mobile",
+    patientName: "Mora",
+    studyType:
+      "Histopatología dermatológica con evaluación de márgenes quirúrgicos ampliados",
+    status: "uploaded",
+    uploadDate: "2026-06-18T12:00:00.000Z",
+    hasFile: true,
+    createdAt: "2026-06-18T12:00:00.000Z",
+    updatedAt: "2026-06-18T14:30:00.000Z",
+  },
+  {
+    id: 8402,
+    clinicId: 77,
+    clinicName: "Clínica E2E Informes Mobile",
+    patientName:
+      "Paciente con nombre clínico extraordinariamente extenso para validar el detalle mobile",
+    studyType: "Citología",
+    status: "processing",
+    uploadDate: "2026-06-17T11:30:00.000Z",
+    hasFile: false,
+    createdAt: "2026-06-17T11:30:00.000Z",
+    updatedAt: "2026-06-18T13:15:00.000Z",
+  },
+  {
+    id: 8403,
+    clinicId: 77,
+    clinicName: "Clínica E2E Informes Mobile",
+    patientName: "Simón",
+    studyType: "Inmunohistoquímica",
+    status: "delivered",
+    uploadDate: "2026-06-16T09:45:00.000Z",
+    hasFile: true,
+    createdAt: "2026-06-16T09:45:00.000Z",
+    updatedAt: "2026-06-18T10:00:00.000Z",
+  },
+];
 
 const AUDIT_EVENTS = [
   {
@@ -213,6 +255,13 @@ function hasPopulatedAdminSession(request) {
     .includes(`admin_session_id=${POPULATED_ADMIN_SESSION}`);
 }
 
+function hasPopulatedClinicSession(request) {
+  return (request.headers.cookie ?? "")
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .includes(`app_session_id=${POPULATED_CLINIC_SESSION}`);
+}
+
 function auditSnapshot(url) {
   const event = url.searchParams.get("event");
   const limit = Number(url.searchParams.get("limit") ?? 9);
@@ -354,6 +403,11 @@ const server = createServer((request, response) => {
 
   if (url.pathname === "/__e2e/health") {
     sendJson(response, 200, { ok: true });
+    return;
+  }
+
+  if (hasPopulatedClinicSession(request) && url.pathname === "/api/reports") {
+    sendJson(response, 200, { reports: CLINIC_REPORTS });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add populated mobile E2E coverage for Clinic Informes summary at 360/390/430px
- Extend the populated E2E fixture additively for clinic /api/reports
- Validate the Informes summary with real SSR data instead of the fallback/error frame
- Assert populated rows, CTA visibility, inline detail, no table, no horizontal overflow and no shell/global scroll
- Keep product code unchanged

## Validation
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts --project=chromium
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm test
- pnpm typecheck:test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend build