### PR TITLE
test(frontend): cover clinic logistica mobile parity

### DIFF
--- a/frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+const LONG_VISIT_ADDRESS =
+  "Avenida de los Diagnósticos Veterinarios Integrales 4850, Torre Norte, Piso 12, Consultorio 1204, Ciudad Autónoma de Buenos Aires";
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+type LayoutContract = {
+  htmlScrollWidth: number;
+  htmlClientWidth: number;
+  htmlScrollHeight: number;
+  htmlClientHeight: number;
+  bodyScrollWidth: number;
+  bodyClientWidth: number;
+  bodyScrollHeight: number;
+  bodyClientHeight: number;
+  mainScrollHeight: number;
+  mainClientHeight: number;
+  listClientHeight: number;
+  hasMain: boolean;
+  hasList: boolean;
+};
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readLayoutContract(page: Page): Promise<LayoutContract> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const list = document.querySelector<HTMLElement>(".dashboard-inline-scroll");
+
+    return {
+      htmlScrollWidth: html.scrollWidth,
+      htmlClientWidth: html.clientWidth,
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollWidth: body.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+      mainScrollHeight: main?.scrollHeight ?? 0,
+      mainClientHeight: main?.clientHeight ?? 0,
+      listClientHeight: list?.clientHeight ?? 0,
+      hasMain: main !== null,
+      hasList: list !== null,
+    };
+  });
+}
+
+function assertNoGlobalOverflow(metrics: LayoutContract, label: string) {
+  expect(metrics.hasMain, `${label}: main.dashboard-main present`).toBe(true);
+  expect(
+    metrics.htmlScrollWidth,
+    `${label}: documentElement horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.htmlClientWidth + TOLERANCE);
+  expect(
+    metrics.bodyScrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.bodyClientWidth + TOLERANCE);
+  expect(
+    metrics.htmlScrollHeight,
+    `${label}: documentElement global scroll`,
+  ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+  expect(
+    metrics.bodyScrollHeight,
+    `${label}: body global scroll`,
+  ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+  expect(metrics.mainScrollHeight, `${label}: dashboard shell scroll`).toBeLessThanOrEqual(
+    metrics.mainClientHeight + TOLERANCE,
+  );
+  expect(metrics.hasList, `${label}: inline list present`).toBe(true);
+  expect(
+    metrics.listClientHeight,
+    `${label}: inline list must keep an operable height`,
+  ).toBeGreaterThanOrEqual(44);
+}
+
+async function expectHorizontallyUnclipped(
+  locator: Locator,
+  viewportWidth: number,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
+    viewportWidth + TOLERANCE,
+  );
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`clinic Logística populated mobile parity at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setClinicSession(page);
+
+    await page.goto("/dashboard?module=logistica");
+
+    const workspace = page
+      .locator('[data-dashboard-module-workspace="logistica"]')
+      .first();
+    const card = workspace.locator(
+      '[aria-label="Visitas de campo recientes de la clínica"]',
+    );
+    const inlineList = card.locator(".dashboard-inline-scroll");
+    const visitRows = inlineList.locator('button[aria-pressed]');
+    const fullModuleButton = card.getByRole("button", {
+      name: "Abrir módulo completo de logística",
+      exact: true,
+    });
+
+    await expect(async () => {
+      await expect(workspace).toBeVisible();
+      await expect(card).toBeVisible();
+      await expect(visitRows).toHaveCount(3);
+
+      for (let index = 0; index < 3; index += 1) {
+        await expect(visitRows.nth(index)).toBeVisible();
+      }
+
+      await expect(fullModuleButton).toBeVisible();
+      await expect(fullModuleButton).toBeEnabled();
+    }).toPass({ timeout: 12_000 });
+
+    await expect(card.locator("table")).toHaveCount(0);
+    await expectHorizontallyUnclipped(
+      fullModuleButton,
+      viewport.width,
+      `${viewport.name}: full Logística CTA`,
+    );
+
+    for (let index = 0; index < 3; index += 1) {
+      await expectHorizontallyUnclipped(
+        visitRows.nth(index),
+        viewport.width,
+        `${viewport.name}: visit row ${index + 1}`,
+      );
+    }
+
+    await expect(async () => {
+      const metrics = await readLayoutContract(page);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: initial layout`);
+    }).toPass({ timeout: 10_000 });
+
+    const secondVisit = visitRows.nth(1);
+    await secondVisit.click();
+
+    await expect(async () => {
+      await expect(secondVisit).toHaveAttribute("aria-expanded", "true");
+
+      const inlineDetail = card.locator('[data-detail-state="selected"]');
+      await expect(inlineDetail).toHaveCount(1);
+      await expect(inlineDetail).toBeVisible();
+      await expect(inlineDetail).toContainText(LONG_VISIT_ADDRESS);
+
+      const metrics = await readLayoutContract(page);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: expanded inline detail`);
+    }).toPass({ timeout: 10_000 });
+  });
+}

--- a/frontend/e2e/fixtures/admin-populated-api-server.mjs
+++ b/frontend/e2e/fixtures/admin-populated-api-server.mjs
@@ -46,6 +46,48 @@ const CLINIC_REPORTS = [
   },
 ];
 
+const CLINIC_FIELD_VISITS = [
+  {
+    id: 8501,
+    clinicId: 77,
+    clinicName: "Clínica Veterinaria Palermo Norte",
+    status: "scheduled",
+    scheduledAt: "2026-06-20T13:30:00.000Z",
+    completedAt: null,
+    address: "Avenida Santa Fe 3250, Palermo, Ciudad Autónoma de Buenos Aires",
+    notes: "Retiro programado de muestras para anatomía patológica.",
+    createdAt: "2026-06-18T10:00:00.000Z",
+    updatedAt: "2026-06-19T09:15:00.000Z",
+  },
+  {
+    id: 8502,
+    clinicId: 78,
+    clinicName:
+      "Centro Veterinario Integral de Diagnóstico y Seguimiento Los Arrayanes",
+    status: "in_progress",
+    scheduledAt: "2026-06-19T15:45:00.000Z",
+    completedAt: null,
+    address:
+      "Avenida de los Diagnósticos Veterinarios Integrales 4850, Torre Norte, Piso 12, Consultorio 1204, Ciudad Autónoma de Buenos Aires",
+    notes:
+      "Entrega de resultados y retiro de material refrigerado con trazabilidad prioritaria.",
+    createdAt: "2026-06-17T11:20:00.000Z",
+    updatedAt: "2026-06-19T15:50:00.000Z",
+  },
+  {
+    id: 8503,
+    clinicId: 79,
+    clinicName: "Hospital Veterinario del Parque",
+    status: "done",
+    scheduledAt: "2026-06-18T12:00:00.000Z",
+    completedAt: "2026-06-18T13:10:00.000Z",
+    address: "Calle 14 865, La Plata, Provincia de Buenos Aires",
+    notes: "Visita completada con recepción conforme.",
+    createdAt: "2026-06-16T08:30:00.000Z",
+    updatedAt: "2026-06-18T13:10:00.000Z",
+  },
+];
+
 const AUDIT_EVENTS = [
   {
     event: "auth.admin.login.succeeded",
@@ -408,6 +450,14 @@ const server = createServer((request, response) => {
 
   if (hasPopulatedClinicSession(request) && url.pathname === "/api/reports") {
     sendJson(response, 200, { reports: CLINIC_REPORTS });
+    return;
+  }
+
+  if (
+    hasPopulatedClinicSession(request) &&
+    url.pathname === "/api/logistics/field-visits"
+  ) {
+    sendJson(response, 200, { visits: CLINIC_FIELD_VISITS });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add populated mobile E2E coverage for Clinic Logistica summary at 360/390/430px
- Extend the populated E2E fixture additively for clinic /api/logistics/field-visits
- Validate the Logistica summary with real SSR data instead of the fallback/error frame
- Assert populated rows, CTA visibility, inline detail, no table, no horizontal overflow and no shell/global scroll
- Keep product code unchanged

## Validation
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-logistica-mobile-parity.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts --project=chromium
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm test
- pnpm typecheck:test
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend build