### PR TITLE
docs(clinic): close enterprise density block post admin mobile fix

### DIFF
--- a/docs/implementation/clinic-enterprise-density-closeout.md
+++ b/docs/implementation/clinic-enterprise-density-closeout.md
@@ -1,0 +1,122 @@
+# Clínica Enterprise Density Closeout
+
+## Estado / Base
+
+- Rama: `docs/clinic-enterprise-density-closeout-post-admin-mobile-fix`.
+- Base actual: `ae1a039 fix(frontend): isolate admin mobile module layers (#1064)`.
+- Tipo de PR: documentación únicamente.
+- Archivo único: `docs/implementation/clinic-enterprise-density-closeout.md`.
+- Estado: closeout documental reanudado después del desbloqueo de Admin mobile en `#1064`.
+
+La auditoría previa confirmó paridad entre la rama, el HEAD esperado y los archivos técnicos referenciados. Este PR no modifica producto ni incorpora validaciones funcionales nuevas.
+
+## Objetivo del bloque
+
+Dejar trazabilidad del cierre del bloque Clínica Enterprise Density después de completar la operabilidad y cobertura mobile priorizadas para las superficies críticas del dashboard clínico.
+
+Este closeout no representa una feature nueva, un rediseño ni un cambio de comportamiento del producto. Registra el alcance ya mergeado y el desbloqueo transversal que permitió retomar su cierre documental.
+
+## Alcance cerrado
+
+### #1060 — Perfil público mobile operable
+
+- El editor de perfil público de Clínica quedó operable en mobile.
+- Se preservaron la alcanzabilidad de campos, el contrato de densidad y el comportamiento no-scroll aplicable.
+
+### #1061 — Tokens Clínica operable en 360px
+
+- Tokens particulares de Clínica quedó operable en `360px`.
+- Se protegieron la lista, el paginador, la selección y el detalle frente al recorte o la interceptación de interacciones.
+
+### #1062 — Informes Clínica mobile parity poblado
+
+- Informes recientes de Clínica obtuvo cobertura E2E poblada en viewports emulados de `360px`, `390px` y `430px`.
+- La cobertura verifica el estado con datos y evita tomar un frame de error como evidencia de paridad.
+
+### #1063 — Logística Clínica mobile parity poblado
+
+- Logística reciente de Clínica obtuvo cobertura E2E poblada en viewports emulados de `360px`, `390px` y `430px`.
+- La cobertura verifica lista, acceso al detalle y contratos mobile aplicables con datos poblados.
+
+## Interrupción y reanudación — P1 Admin mobile
+
+Después de `#1063` se detectó un P1 visual real en Dashboard Administrador mobile Android/iOS. El closeout se pausó para no documentar el cierre mientras permanecía abierto un defecto de prioridad alta en la misma capa mobile del producto.
+
+`#1064` resolvió ese bloqueo mediante:
+
+- CSS mobile scoped a Admin en `frontend/src/app/globals.css`.
+- El nuevo E2E `frontend/e2e/admin-mobile-module-layer-isolation.spec.ts` para cubrir el aislamiento visual de capas.
+- Un cambio aditivo y admin-scoped dentro de `globals.css`, que es un archivo compartido.
+
+`#1064` funciona como desbloqueo transversal de este closeout. No forma parte del alcance técnico de Clínica y no modificó Clínica, backend, auth, dependencias ni CI.
+
+## Contratos protegidos
+
+- Paridad mobile de las superficies Clínica incluidas en `#1060` a `#1063`.
+- Viewports Playwright emulados de `360px`, `390px` y `430px` donde aplica.
+- Contratos de no-scroll y densidad enterprise donde aplica.
+- Estados poblados para Informes y Logística, evitando cobertura limitada a estados vacíos o de error.
+- Aislamiento del layering visual de Admin mobile cubierto en `#1064` como bloqueo transversal del cierre.
+
+## Validaciones acumuladas del bloque
+
+- Los PRs `#1060`, `#1061`, `#1062`, `#1063` y `#1064` fueron mergeados con checks y CI verdes.
+- La cobertura mobile citada en este documento corresponde a E2E Playwright con viewports emulados.
+- Los E2E poblados de Clínica cubren `360px`, `390px` y `430px` en las superficies donde aplica.
+- `#1064` incorporó cobertura E2E del aislamiento visual de capas Admin mobile.
+
+Estas validaciones pertenecen a los PRs ya mergeados. Este PR docs-only no reejecuta tests, builds, lint, Playwright ni `security:public-surface`, y no aporta evidencia de smoke en dispositivos físicos Android/iOS.
+
+## Cambios de este PR
+
+- Actualización del presente closeout con la base posterior a `#1064`.
+- Registro de la interrupción por el P1 Admin mobile y de su resolución.
+- Delimitación explícita entre el alcance Clínica y el desbloqueo transversal de Admin.
+- Aclaración del tipo de cobertura mobile y de sus límites.
+
+## Archivo modificado
+
+- `docs/implementation/clinic-enterprise-density-closeout.md`.
+
+## Validación local de este PR docs-only
+
+La validación local se limita a inspección Git documental:
+
+- `git status --short --untracked-files=all`.
+- `git diff --stat`.
+- `git diff -- docs/implementation/clinic-enterprise-density-closeout.md`.
+- `git diff --check`.
+
+Resultado local:
+
+- `git status --short --untracked-files=all` muestra únicamente este documento como no trackeado.
+- `git diff --stat` y `git diff -- docs/implementation/clinic-enterprise-density-closeout.md` no producen salida porque Git no incluye archivos no trackeados en el diff sin stage.
+- `git diff --check` finaliza con código `0` y sin salida, con la misma limitación respecto del archivo no trackeado.
+
+No se ejecutan suites de producto porque este PR modifica únicamente documentación.
+
+## Fuera de alcance
+
+- Rediseño visual amplio.
+- Frontend o cambios de producto.
+- Backend.
+- Auth.
+- Base de datos o migraciones.
+- Pricing.
+- Nuevas features.
+- Dependencias o lockfiles.
+- CI o workflows.
+- Smoke device-real en Android/iOS físicos.
+
+## Riesgos residuales
+
+- El smoke visual real en Android/iOS físicos sigue recomendado y no fue realizado ni acreditado por este closeout.
+- Cambios futuros en `globals.css`, App Shell, blur, transparencias, `transform` o tipografía deben reejecutar los E2E mobile poblados relevantes.
+- El body scroll compartido de `ModuleDialog` entre Admin y Clínica queda como track separado si corresponde priorizarlo.
+- La evidencia acumulada no implica cobertura visual total fuera de los E2E y PRs mergeados mencionados.
+
+## Resultado / Estado final
+
+El bloque Clínica Enterprise Density queda documentalmente cerrado para Perfil público, Tokens particulares, Informes recientes y Logística reciente.
+
+El closeout documental puede mergearse sobre la base `ae1a039`. El smoke visual real en dispositivos físicos Android/iOS sigue recomendado, pero no es bloqueante salvo decisión explícita de producto o QA.


### PR DESCRIPTION
## Qué

Closeout documental del bloque Clínica Enterprise Density para el dashboard clínico.

## Trazabilidad

- Clínica mobile parity cerrada por #1060, #1061, #1062 y #1063:
  - Perfil público mobile operable.
  - Tokens Clínica operable en 360px.
  - Informes Clínica mobile parity poblado en 360/390/430.
  - Logística Clínica mobile parity poblado en 360/390/430.
- Closeout pausado al detectarse un P1 visual real en Dashboard Admin mobile Android/iOS.
- P1 Admin corregido en #1064 con CSS admin-scoped en `frontend/src/app/globals.css` y E2E de aislamiento visual.
- #1064 fue desbloqueo transversal del closeout; no forma parte del alcance técnico Clínica.

## Scope

- Documentación únicamente.
- Un solo archivo: `docs/implementation/clinic-enterprise-density-closeout.md`.
- No modifica producto, backend, DB, auth, dependencias, lockfile ni CI.

## Honestidad de validación

- Cobertura Clínica = E2E Playwright con viewports emulados 360/390/430.
- NO se ejecutó smoke visual real en dispositivos Android/iOS físicos.
- Smoke device-real queda recomendado pero NO bloqueante, salvo decisión explícita.

## Validaciones docs-only

- `git diff --cached --name-only`: único archivo de closeout.
- `git diff --cached --check`: OK.
- Revisión manual del contenido markdown.