### PR TITLE
fix(admin): add mobile app shell no scroll contract

### DIFF
--- a/frontend/e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 1;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function readCssAlpha(color: string) {
+  const normalized = color.trim().toLowerCase();
+  if (!normalized || normalized === "transparent") return 0;
+
+  const commaAlpha = normalized.match(
+    /^rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\s*\)$/,
+  );
+  if (commaAlpha) return Number(commaAlpha[1]);
+
+  const slashAlpha = normalized.match(/\/\s*([\d.]+)(%)?\s*\)$/);
+  if (slashAlpha) {
+    const alpha = Number(slashAlpha[1]);
+    return slashAlpha[2] ? alpha / 100 : alpha;
+  }
+
+  return 1;
+}
+
+type ShellContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  shellOverflowX: string;
+  shellOverflowY: string;
+  mainOverflowX: string;
+  mainOverflowY: string;
+  appBarHeight: number;
+  appBarBackdropFilter: string;
+  appBarBackgroundColor: string;
+  shellIsolation: string;
+  mainIsolation: string;
+  forbiddenChromeOverflow: Array<{ selector: string; overflowX: string; overflowY: string }>;
+};
+
+async function readShellContract(page: Page): Promise<ShellContract> {
+  return page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const appBar = document.querySelector<HTMLElement>(
+      '[data-admin-mobile-app-bar="true"]',
+    );
+
+    if (!shell || !main || !appBar) {
+      throw new Error("Admin mobile app shell contract is incomplete");
+    }
+
+    const shellStyle = window.getComputedStyle(shell);
+    const mainStyle = window.getComputedStyle(main);
+    const appBarStyle = window.getComputedStyle(appBar);
+    const selectors = [
+      '[data-admin-mobile-app-bar="true"]',
+      '[data-admin-mobile-kebab-menu="true"]',
+      '[data-admin-mobile-bottom-nav="true"]',
+      '[data-admin-mobile-module-menu="true"]',
+    ];
+    const forbiddenChromeOverflow = selectors.flatMap((selector) =>
+      Array.from(document.querySelectorAll<HTMLElement>(selector)).flatMap((element) => {
+        const style = window.getComputedStyle(element);
+        return ["auto", "scroll"].includes(style.overflowX) ||
+          ["auto", "scroll"].includes(style.overflowY)
+          ? [{ selector, overflowX: style.overflowX, overflowY: style.overflowY }]
+          : [];
+      }),
+    );
+
+    return {
+      html: {
+        scrollHeight: document.documentElement.scrollHeight,
+        clientHeight: document.documentElement.clientHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      },
+      body: {
+        scrollHeight: document.body.scrollHeight,
+        clientHeight: document.body.clientHeight,
+        scrollWidth: document.body.scrollWidth,
+        clientWidth: document.body.clientWidth,
+      },
+      shellOverflowX: shellStyle.overflowX,
+      shellOverflowY: shellStyle.overflowY,
+      mainOverflowX: mainStyle.overflowX,
+      mainOverflowY: mainStyle.overflowY,
+      appBarHeight: appBar.getBoundingClientRect().height,
+      appBarBackdropFilter:
+        appBarStyle.getPropertyValue("backdrop-filter") || "none",
+      appBarBackgroundColor: appBarStyle.backgroundColor,
+      shellIsolation: shellStyle.isolation,
+      mainIsolation: mainStyle.isolation,
+      forbiddenChromeOverflow,
+    };
+  });
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`Admin mobile app shell is absolute no-scroll at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setPopulatedAdminSession(page);
+    await page.goto("/dashboard/admin");
+
+    const surface = page.locator('[data-vetneb-app-shell-surface="admin"]');
+    const appBar = page.locator('[data-admin-mobile-app-bar="true"]');
+    const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+    const horizontalNav = page.locator(
+      '[data-dashboard-horizontal-nav-shell="true"]',
+    );
+
+    await expect(surface).toBeVisible({ timeout: 15_000 });
+    await expect(appBar).toBeVisible();
+    await expect(bottomNav).toBeVisible();
+    await expect(horizontalNav).toBeHidden();
+    await expect(
+      appBar.locator('[data-dashboard-topbar-subtitle="true"]'),
+    ).toHaveCount(0);
+
+    const contract = await readShellContract(page);
+
+    expect(contract.html.scrollHeight).toBeLessThanOrEqual(
+      contract.html.clientHeight + TOLERANCE,
+    );
+    expect(contract.body.scrollHeight).toBeLessThanOrEqual(
+      contract.body.clientHeight + TOLERANCE,
+    );
+    expect(contract.html.scrollWidth).toBeLessThanOrEqual(
+      contract.html.clientWidth + TOLERANCE,
+    );
+    expect(contract.body.scrollWidth).toBeLessThanOrEqual(
+      contract.body.clientWidth + TOLERANCE,
+    );
+    expect(["auto", "scroll"]).not.toContain(contract.shellOverflowX);
+    expect(["auto", "scroll"]).not.toContain(contract.shellOverflowY);
+    expect(["auto", "scroll"]).not.toContain(contract.mainOverflowX);
+    expect(["auto", "scroll"]).not.toContain(contract.mainOverflowY);
+    expect(contract.appBarHeight).toBeLessThanOrEqual(49);
+    expect(contract.appBarBackdropFilter).toBe("none");
+    expect(readCssAlpha(contract.appBarBackgroundColor)).toBe(1);
+    expect(contract.shellIsolation).toBe("isolate");
+    expect(contract.mainIsolation).toBe("isolate");
+    expect(contract.forbiddenChromeOverflow).toEqual([]);
+  });
+}

--- a/frontend/e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const TOLERANCE = 1;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const EXPECTED_MODULES = [
+  "Administración",
+  "Informes",
+  "Estado",
+  "Clínicas",
+  "Tokens",
+  "Precios",
+  "Sesiones",
+  "Usuarios",
+  "Auditoría",
+  "Mantenimiento",
+] as const;
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function expectInsideViewport(
+  locator: Locator,
+  viewportWidth: number,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
+    viewportWidth + TOLERANCE,
+  );
+}
+
+async function expectModule(page: Page, moduleId: string) {
+  await expect(
+    page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`Admin bottom navigation is complete and no-scroll at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setPopulatedAdminSession(page);
+    await page.goto("/dashboard/admin?module=admin-clinics");
+    await suppressNextDevIndicator(page);
+    await expectModule(page, "admin-clinics");
+
+    const nav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+    const destinations = nav.locator('[data-admin-mobile-bottom-nav-item="true"]');
+
+    await expect(nav).toBeVisible();
+    await expect(destinations).toHaveCount(5);
+
+    for (let index = 0; index < 5; index += 1) {
+      await expectInsideViewport(
+        destinations.nth(index),
+        viewport.width,
+        `${viewport.name}: bottom destination ${index + 1}`,
+      );
+    }
+
+    const navOverflow = await nav.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return {
+        overflowX: style.overflowX,
+        overflowY: style.overflowY,
+        scrollWidth: element.scrollWidth,
+        clientWidth: element.clientWidth,
+      };
+    });
+    expect(["auto", "scroll"]).not.toContain(navOverflow.overflowX);
+    expect(["auto", "scroll"]).not.toContain(navOverflow.overflowY);
+    expect(navOverflow.scrollWidth).toBeLessThanOrEqual(
+      navOverflow.clientWidth + TOLERANCE,
+    );
+
+    await nav.getByRole("button", { name: "Inicio", exact: true }).click();
+    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await nav.getByRole("button", { name: "Clínicas", exact: true }).click();
+    await expectModule(page, "admin-clinics");
+
+    await nav.getByRole("button", { name: "Auditoría", exact: true }).click();
+    await expectModule(page, "audit-log");
+
+    await nav.getByRole("button", { name: "Sesiones", exact: true }).click();
+    await expectModule(page, "admin-sessions");
+
+    await nav.getByRole("button", { name: "Más", exact: true }).click();
+    const moduleMenu = page.locator('[data-admin-mobile-module-menu="true"]');
+    await expect(moduleMenu).toBeVisible();
+
+    const firstPageLabels = await moduleMenu
+      .locator('[data-admin-mobile-module-link="true"]')
+      .allTextContents();
+    await moduleMenu
+      .getByRole("button", { name: "Página siguiente de módulos", exact: true })
+      .click();
+    const secondPageLabels = await moduleMenu
+      .locator('[data-admin-mobile-module-link="true"]')
+      .allTextContents();
+    const moduleLabels = [...firstPageLabels, ...secondPageLabels].map((label) =>
+      label.trim(),
+    );
+    expect(new Set(moduleLabels)).toEqual(new Set(EXPECTED_MODULES));
+
+    const menuOverflow = await moduleMenu.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return { overflowX: style.overflowX, overflowY: style.overflowY };
+    });
+    expect(["auto", "scroll"]).not.toContain(menuOverflow.overflowX);
+    expect(["auto", "scroll"]).not.toContain(menuOverflow.overflowY);
+    await moduleMenu
+      .getByRole("button", { name: "Cerrar menú de módulos", exact: true })
+      .click();
+
+    await page.getByRole("button", { name: "Menú de administración" }).click();
+    const kebabMenu = page.locator('[data-admin-mobile-kebab-menu="true"]');
+    await expect(kebabMenu).toBeVisible();
+    await expect(
+      kebabMenu.getByRole("button", { name: "Cerrar sesión", exact: true }),
+    ).toHaveCount(1);
+    await expect(page.getByText("Salir", { exact: true })).toHaveCount(0);
+
+    await kebabMenu
+      .getByRole("button", { name: "Notificaciones", exact: true })
+      .click();
+    const notificationsPanel = page.locator(
+      '[data-admin-mobile-notifications-panel="true"]',
+    );
+    await expect(notificationsPanel).toBeVisible();
+    const notificationScrollContainers = await notificationsPanel.evaluate(
+      (panel) =>
+        [panel, ...Array.from(panel.querySelectorAll<HTMLElement>("*"))].flatMap(
+          (element) => {
+            const style = window.getComputedStyle(element);
+            return ["auto", "scroll"].includes(style.overflowX) ||
+              ["auto", "scroll"].includes(style.overflowY)
+              ? [
+                  {
+                    tag: element.tagName,
+                    overflowX: style.overflowX,
+                    overflowY: style.overflowY,
+                  },
+                ]
+              : [];
+          },
+        ),
+    );
+    expect(notificationScrollContainers).toEqual([]);
+    await expect(
+      page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    ).toBeHidden();
+  });
+}
+
+test("Admin desktop preserves horizontal navigation and desktop actions", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await setPopulatedAdminSession(page);
+  await page.goto("/dashboard/admin");
+
+  await expect(
+    page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeHidden();
+  await expect(page.locator('[data-theme-toggle="true"]')).toBeVisible();
+  await expect(page.getByRole("button", { name: "Notificaciones" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Cerrar sesión", exact: true }),
+  ).toBeVisible();
+});

--- a/frontend/e2e/admin-mobile-module-layer-isolation.spec.ts
+++ b/frontend/e2e/admin-mobile-module-layer-isolation.spec.ts
@@ -33,6 +33,12 @@ async function setPopulatedAdminSession(page: Page) {
   ]);
 }
 
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
 async function mockAdminSessions(page: Page) {
   await page.route("**/api/admin/sessions**", async (route) => {
     const request = route.request();
@@ -88,8 +94,9 @@ function readCssAlpha(color: string) {
 type LayerContract = {
   topbarBackdropFilter: string;
   topbarBackgroundColor: string;
-  navBackdropFilter: string;
-  navBackgroundColor: string;
+  bottomNavBackdropFilter: string;
+  bottomNavBackgroundColor: string;
+  horizontalNavVisible: boolean;
   activeIsolation: string;
   activeBackgroundColor: string;
   htmlOverflowX: number;
@@ -109,7 +116,10 @@ async function readLayerContract(
     const topbar = document.querySelector<HTMLElement>(
       '[data-dashboard-topbar-polish="true"]',
     );
-    const nav = document.querySelector<HTMLElement>(
+    const bottomNav = document.querySelector<HTMLElement>(
+      '[data-admin-mobile-bottom-nav="true"]',
+    );
+    const horizontalNav = document.querySelector<HTMLElement>(
       '[data-dashboard-horizontal-nav-shell="true"]',
     );
     const activeRegion = document.querySelector<HTMLElement>(selector);
@@ -118,12 +128,12 @@ async function readLayerContract(
     );
     const main = document.querySelector<HTMLElement>("main.dashboard-main");
 
-    if (!topbar || !nav || !activeRegion || !shell || !main) {
+    if (!topbar || !bottomNav || !activeRegion || !shell || !main) {
       throw new Error(`Admin layer contract is incomplete for ${selector}`);
     }
 
     const topbarStyle = window.getComputedStyle(topbar);
-    const navStyle = window.getComputedStyle(nav);
+    const bottomNavStyle = window.getComputedStyle(bottomNav);
     const activeStyle = window.getComputedStyle(activeRegion);
     const shellStyle = window.getComputedStyle(shell);
     const mainStyle = window.getComputedStyle(main);
@@ -132,9 +142,13 @@ async function readLayerContract(
       topbarBackdropFilter:
         topbarStyle.getPropertyValue("backdrop-filter") || "none",
       topbarBackgroundColor: topbarStyle.backgroundColor,
-      navBackdropFilter:
-        navStyle.getPropertyValue("backdrop-filter") || "none",
-      navBackgroundColor: navStyle.backgroundColor,
+      bottomNavBackdropFilter:
+        bottomNavStyle.getPropertyValue("backdrop-filter") || "none",
+      bottomNavBackgroundColor: bottomNavStyle.backgroundColor,
+      horizontalNavVisible: horizontalNav
+        ? window.getComputedStyle(horizontalNav).display !== "none" &&
+          horizontalNav.getBoundingClientRect().height > 1
+        : false,
       activeIsolation: activeStyle.isolation,
       activeBackgroundColor: activeStyle.backgroundColor,
       htmlOverflowX:
@@ -164,8 +178,16 @@ async function expectLayerContract(
     expect(readCssAlpha(contract.topbarBackgroundColor), `${label}: topbar alpha`).toBe(
       1,
     );
-    expect(contract.navBackdropFilter, `${label}: nav blur`).toBe("none");
-    expect(readCssAlpha(contract.navBackgroundColor), `${label}: nav alpha`).toBe(1);
+    expect(contract.bottomNavBackdropFilter, `${label}: bottom nav blur`).toBe(
+      "none",
+    );
+    expect(
+      readCssAlpha(contract.bottomNavBackgroundColor),
+      `${label}: bottom nav alpha`,
+    ).toBe(1);
+    expect(contract.horizontalNavVisible, `${label}: legacy nav hidden`).toBe(
+      false,
+    );
     expect(contract.activeIsolation, `${label}: active region isolation`).toBe(
       "isolate",
     );
@@ -223,7 +245,10 @@ async function openModule(
 }
 
 async function backToHub(page: Page, viewportLabel: string) {
-  await page.getByRole("button", { name: "Volver a módulos" }).click();
+  await page
+    .locator('[data-admin-mobile-bottom-nav="true"]')
+    .getByRole("button", { name: "Inicio", exact: true })
+    .click();
 
   const hub = page.locator('[data-dashboard-module-hub="true"]');
   await expect(hub).toBeVisible({ timeout: 15_000 });
@@ -247,6 +272,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await mockAdminSessions(page);
 
     await page.goto("/dashboard/admin");
+    await suppressNextDevIndicator(page);
 
     const hub = page.locator('[data-dashboard-module-hub="true"]');
     await expect(hub).toBeVisible({ timeout: 15_000 });

--- a/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
+++ b/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
@@ -92,10 +92,12 @@ type ShellNavContract = {
   bodyScrollWidth: number;
   bodyClientWidth: number;
   topbarVisible: boolean;
-  navVisible: boolean;
+  horizontalNavVisible: boolean;
+  bottomNavVisible: boolean;
   clippedTopbarControls: ShellNavMetric[];
   undersizedShellControls: ShellNavMetric[];
-  activeNavItemVisible: boolean;
+  activeHorizontalNavItemVisible: boolean;
+  activeBottomNavItemVisible: boolean;
 };
 
 async function readShellNavContract(page: Page): Promise<ShellNavContract> {
@@ -152,6 +154,9 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
     const nav = document.querySelector(
       "[data-dashboard-horizontal-nav-shell='true']",
     );
+    const bottomNav = document.querySelector(
+      "[data-admin-mobile-bottom-nav='true']",
+    );
 
     const topbarControls = Array.from(
       document.querySelectorAll(
@@ -161,7 +166,7 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
 
     const shellControls = Array.from(
       document.querySelectorAll(
-        "header[aria-label='Barra superior del dashboard'] a, header[aria-label='Barra superior del dashboard'] button",
+        "header[aria-label='Barra superior del dashboard'] a, header[aria-label='Barra superior del dashboard'] button, [data-admin-mobile-bottom-nav='true'] button",
       ),
     ).filter(isVisible);
 
@@ -185,15 +190,29 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
       })
       .map(metricFor);
 
-    const activeNavItem = document.querySelector(
+    const activeHorizontalNavItem = document.querySelector(
       "[data-dashboard-horizontal-nav-shell='true'] [aria-current='page']",
     );
+    const activeBottomNavItem = document.querySelector(
+      "[data-admin-mobile-bottom-nav='true'] [aria-current='page']",
+    );
 
-    let activeNavItemVisible = false;
-    if (activeNavItem) {
-      const rect = (activeNavItem as HTMLElement).getBoundingClientRect();
-      activeNavItemVisible =
-        isVisible(activeNavItem) &&
+    let activeHorizontalNavItemVisible = false;
+    if (activeHorizontalNavItem) {
+      const rect = (activeHorizontalNavItem as HTMLElement).getBoundingClientRect();
+      activeHorizontalNavItemVisible =
+        isVisible(activeHorizontalNavItem) &&
+        rect.left >= -tolerance &&
+        rect.right <= viewportWidth + tolerance &&
+        rect.top >= -tolerance &&
+        rect.bottom <= viewportHeight + tolerance;
+    }
+
+    let activeBottomNavItemVisible = false;
+    if (activeBottomNavItem) {
+      const rect = (activeBottomNavItem as HTMLElement).getBoundingClientRect();
+      activeBottomNavItemVisible =
+        isVisible(activeBottomNavItem) &&
         rect.left >= -tolerance &&
         rect.right <= viewportWidth + tolerance &&
         rect.top >= -tolerance &&
@@ -206,17 +225,44 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
       bodyScrollWidth: body.scrollWidth,
       bodyClientWidth: body.clientWidth,
       topbarVisible: topbar ? isVisible(topbar) : false,
-      navVisible: nav ? isVisible(nav) : false,
+      horizontalNavVisible: nav ? isVisible(nav) : false,
+      bottomNavVisible: bottomNav ? isVisible(bottomNav) : false,
       clippedTopbarControls,
       undersizedShellControls,
-      activeNavItemVisible,
+      activeHorizontalNavItemVisible,
+      activeBottomNavItemVisible,
     };
   }, TOLERANCE);
 }
 
-function assertShellNavContract(contract: ShellNavContract, label: string) {
+function assertShellNavContract(
+  contract: ShellNavContract,
+  surface: Surface,
+  label: string,
+) {
   expect(contract.topbarVisible, `${label}: topbar visible`).toBe(true);
-  expect(contract.navVisible, `${label}: horizontal nav visible`).toBe(true);
+
+  if (surface === "admin") {
+    expect(
+      contract.horizontalNavVisible,
+      `${label}: legacy horizontal nav hidden`,
+    ).toBe(false);
+    expect(contract.bottomNavVisible, `${label}: bottom nav visible`).toBe(true);
+    expect(
+      contract.activeBottomNavItemVisible,
+      `${label}: active bottom nav item visible`,
+    ).toBe(true);
+  } else {
+    expect(
+      contract.horizontalNavVisible,
+      `${label}: clinic horizontal nav visible`,
+    ).toBe(true);
+    expect(contract.bottomNavVisible, `${label}: no Admin bottom nav`).toBe(false);
+    expect(
+      contract.activeHorizontalNavItemVisible,
+      `${label}: active clinic nav item visible`,
+    ).toBe(true);
+  }
 
   expect(
     contract.htmlScrollWidth,
@@ -238,10 +284,6 @@ function assertShellNavContract(contract: ShellNavContract, label: string) {
     `${label}: topbar/nav controls must keep mobile touch target >=36px`,
   ).toEqual([]);
 
-  expect(
-    contract.activeNavItemVisible,
-    `${label}: active nav item must remain visible in mobile viewport`,
-  ).toBe(true);
 }
 
 for (const viewport of MOBILE_VIEWPORTS) {
@@ -257,7 +299,11 @@ for (const viewport of MOBILE_VIEWPORTS) {
 
         await expect(async () => {
           const contract = await readShellNavContract(page);
-          assertShellNavContract(contract, `${viewport.name} ${route.label}`);
+          assertShellNavContract(
+            contract,
+            route.surface,
+            `${viewport.name} ${route.label}`,
+          );
         }).toPass({ timeout: 10_000 });
       });
     }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2312,3 +2312,337 @@
   }
 }
 /* admin-mobile-module-layer-isolation:end */
+/* admin-mobile-app-shell:start */
+@media (max-width: 767px) {
+  html:has([data-vetneb-app-shell-surface="admin"]),
+  body:has([data-vetneb-app-shell-surface="admin"]) {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] {
+    width: 100%;
+    height: 100vh;
+    height: 100svh;
+    min-height: 0;
+    max-height: 100svh;
+    overflow: hidden;
+    overscroll-behavior: none;
+    isolation: isolate;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    > [data-vetneb-app-shell-frame="true"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    [data-admin-mobile-app-bar="true"] {
+    position: relative;
+    top: auto;
+    z-index: 60;
+    flex: 0 0 auto;
+    min-height: 0 !important;
+    overflow: visible;
+    padding: 0 !important;
+    isolation: isolate;
+    background: hsl(var(--card)) !important;
+    background-image: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    transform: none !important;
+  }
+
+  .dashboard-app-shell[data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-topbar-polish="true"][data-admin-mobile-app-bar="true"] {
+    box-sizing: border-box;
+    height: calc(3rem + env(safe-area-inset-top)) !important;
+    min-height: calc(3rem + env(safe-area-inset-top)) !important;
+    max-height: calc(3rem + env(safe-area-inset-top)) !important;
+    padding: 0 !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    [data-admin-mobile-app-bar="true"]
+    > div:first-child {
+    box-sizing: border-box;
+    height: calc(3rem + env(safe-area-inset-top));
+    min-height: calc(3rem + env(safe-area-inset-top));
+    padding: env(safe-area-inset-top) 0.75rem 0;
+    gap: 0.5rem;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] #dashboard-topbar-title,
+  [data-vetneb-app-shell-surface="admin"]
+    [data-admin-mobile-topbar-subtitle="true"],
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-desktop-actions="true"],
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-horizontal-nav-shell="true"] {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-context-title {
+    display: block !important;
+    overflow: hidden;
+    color: hsl(var(--vetneb-ink));
+    font-size: 1rem;
+    font-weight: 650;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-root {
+    position: relative;
+    display: block !important;
+    flex: 0 0 auto;
+    isolation: isolate;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-trigger,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-icon-button {
+    display: inline-flex;
+    width: 2.25rem;
+    height: 2.25rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border: 1px solid hsl(var(--vetneb-line));
+    border-radius: 0.5rem;
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-trigger:focus-visible,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-icon-button:focus-visible,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-page-button:focus-visible,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-module-link:focus-visible,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-bottom-nav-item:focus-visible,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-action:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-menu {
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    right: 0;
+    z-index: 75;
+    display: flex;
+    width: min(20rem, calc(100vw - 1.5rem));
+    max-height: calc(100svh - 4rem - env(safe-area-inset-bottom));
+    flex-direction: column;
+    gap: 0.35rem;
+    overflow: hidden;
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--vetneb-line));
+    border-radius: 0.75rem;
+    background: hsl(var(--card));
+    box-shadow: 0 12px 30px rgba(15, 45, 62, 0.18);
+    isolation: isolate;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    transform: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-row,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-action {
+    display: flex;
+    min-width: 0;
+    min-height: 2.5rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    overflow: hidden;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.45rem;
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-align: left;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-action {
+    justify-content: flex-start;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-kebab-logout {
+    color: hsl(var(--destructive));
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .dashboard-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+    padding: 0.5rem;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-back-button="true"] {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-bottom-nav {
+    position: relative;
+    z-index: 65;
+    display: flex !important;
+    width: 100%;
+    height: calc(3.5rem + env(safe-area-inset-bottom));
+    min-height: 0;
+    flex: 0 0 auto;
+    align-items: stretch;
+    overflow: hidden;
+    padding-bottom: env(safe-area-inset-bottom);
+    border-top: 1px solid hsl(var(--vetneb-line));
+    background: hsl(var(--card));
+    isolation: isolate;
+    overscroll-behavior: none;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    transform: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-bottom-nav-item {
+    display: inline-flex;
+    min-width: 0;
+    min-height: 0;
+    flex: 1 1 20%;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.15rem;
+    overflow: hidden;
+    padding: 0.25rem 0.1rem;
+    border-radius: 0;
+    background: hsl(var(--card));
+    color: hsl(var(--muted-foreground));
+    font-size: 0.64rem;
+    font-weight: 650;
+    line-height: 1;
+    white-space: nowrap;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    .admin-mobile-bottom-nav-item-active {
+    color: hsl(var(--vetneb-navy));
+    background: hsl(var(--vetneb-surface-muted));
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-module-menu {
+    position: fixed;
+    right: 0.5rem;
+    bottom: calc(4rem + env(safe-area-inset-bottom));
+    left: 0.5rem;
+    z-index: 70;
+    display: flex !important;
+    max-height: calc(
+      100svh - 7.75rem - env(safe-area-inset-top) -
+        env(safe-area-inset-bottom)
+    );
+    flex-direction: column;
+    gap: 0.5rem;
+    overflow: hidden;
+    padding: 0.65rem;
+    border: 1px solid hsl(var(--vetneb-line));
+    border-radius: 0.85rem;
+    background: hsl(var(--card));
+    box-shadow: 0 12px 30px rgba(15, 45, 62, 0.2);
+    isolation: isolate;
+    overscroll-behavior: none;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    transform: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-module-grid {
+    display: grid;
+    min-width: 0;
+    min-height: 0;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.35rem;
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-module-link {
+    display: inline-flex;
+    min-width: 0;
+    min-height: 2.6rem;
+    align-items: center;
+    gap: 0.45rem;
+    overflow: hidden;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid hsl(var(--vetneb-line));
+    border-radius: 0.55rem;
+    background: hsl(var(--vetneb-surface-raised));
+    color: hsl(var(--foreground));
+    font-size: 0.72rem;
+    font-weight: 650;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-page-button {
+    display: inline-flex;
+    min-width: 4.5rem;
+    min-height: 2.25rem;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 0.35rem 0.55rem;
+    border: 1px solid hsl(var(--vetneb-line));
+    border-radius: 0.5rem;
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    font-size: 0.7rem;
+    font-weight: 650;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    .admin-mobile-page-button:disabled {
+    opacity: 0.45;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-page-dot {
+    display: block;
+    width: 0.4rem;
+    height: 0.4rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: hsl(var(--vetneb-line));
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    .admin-mobile-page-dot[aria-current="page"] {
+    background: hsl(var(--vetneb-teal));
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    :is(
+      .admin-mobile-kebab-trigger,
+      .admin-mobile-kebab-menu,
+      .admin-mobile-bottom-nav,
+      .admin-mobile-bottom-nav-item,
+      .admin-mobile-module-menu,
+      .admin-mobile-module-grid,
+      .admin-mobile-module-link,
+      .admin-mobile-page-button
+    ) {
+    overflow-x: hidden;
+    overflow-y: hidden;
+  }
+}
+/* admin-mobile-app-shell:end */

--- a/frontend/src/components/dashboard/AdminMobileBottomNav.tsx
+++ b/frontend/src/components/dashboard/AdminMobileBottomNav.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Building2, Home, KeyRound, Menu, ScrollText } from "lucide-react";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import {
+  ADMIN_LAST_MODULE_STORAGE_KEY,
+  writeDashboardLastModule,
+} from "@/lib/dashboard-last-module";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+import { AdminMobileModuleMenu } from "./AdminMobileModuleMenu";
+
+const FIXED_DESTINATIONS = [
+  { label: "Clínicas", moduleId: "admin-clinics", icon: Building2 },
+  { label: "Auditoría", moduleId: "audit-log", icon: ScrollText },
+  { label: "Sesiones", moduleId: "admin-sessions", icon: KeyRound },
+] as const;
+
+export function AdminMobileBottomNav() {
+  const [activeModule, setActiveModule] = useState<string | null>(null);
+  const [isModuleMenuOpen, setIsModuleMenuOpen] = useState(false);
+  const closeModuleMenu = useCallback(() => setIsModuleMenuOpen(false), []);
+  const isSecondaryModuleActive =
+    activeModule !== null &&
+    !FIXED_DESTINATIONS.some(
+      (destination) => destination.moduleId === activeModule,
+    );
+
+  useEffect(() => {
+    function syncModuleFromLocation() {
+      setActiveModule(new URLSearchParams(window.location.search).get("module"));
+    }
+
+    syncModuleFromLocation();
+    window.addEventListener("popstate", syncModuleFromLocation);
+    return () => window.removeEventListener("popstate", syncModuleFromLocation);
+  }, []);
+
+  function clearPersistedAdminModule() {
+    writeDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY, "");
+    setActiveModule(null);
+    closeModuleMenu();
+  }
+
+  return (
+    <>
+      <AdminMobileModuleMenu
+        isOpen={isModuleMenuOpen}
+        onClose={closeModuleMenu}
+        onNavigate={setActiveModule}
+      />
+      <nav
+        aria-label="Navegación móvil de administración"
+        data-admin-mobile-bottom-nav="true"
+        className="admin-mobile-bottom-nav md:hidden"
+      >
+        <PublicRouteControl
+          href={ROUTES.dashboardAdmin}
+          prefetch={false}
+          variant="bare"
+          aria-label="Inicio"
+          aria-current={!activeModule ? "page" : undefined}
+          data-admin-mobile-bottom-nav-item="true"
+          onClick={clearPersistedAdminModule}
+          className={cn(
+            "admin-mobile-bottom-nav-item",
+            !activeModule && "admin-mobile-bottom-nav-item-active",
+          )}
+        >
+          <Home className="h-4 w-4" aria-hidden="true" />
+          <span>Inicio</span>
+        </PublicRouteControl>
+
+        {FIXED_DESTINATIONS.map((destination) => {
+          const Icon = destination.icon;
+          const isActive = activeModule === destination.moduleId;
+          return (
+            <PublicRouteControl
+              key={destination.moduleId}
+              href={`${ROUTES.dashboardAdmin}?module=${destination.moduleId}`}
+              prefetch={false}
+              variant="bare"
+              aria-label={destination.label}
+              aria-current={isActive ? "page" : undefined}
+              data-admin-mobile-bottom-nav-item="true"
+              onClick={() => {
+                setActiveModule(destination.moduleId);
+                closeModuleMenu();
+              }}
+              className={cn(
+                "admin-mobile-bottom-nav-item",
+                isActive && "admin-mobile-bottom-nav-item-active",
+              )}
+            >
+              <Icon className="h-4 w-4" aria-hidden="true" />
+              <span>{destination.label}</span>
+            </PublicRouteControl>
+          );
+        })}
+
+        <button
+          type="button"
+          aria-label="Más"
+          aria-expanded={isModuleMenuOpen}
+          aria-current={isSecondaryModuleActive ? "page" : undefined}
+          aria-controls={isModuleMenuOpen ? "admin-mobile-module-menu" : undefined}
+          data-admin-mobile-bottom-nav-item="true"
+          onClick={() => setIsModuleMenuOpen((current) => !current)}
+          className={cn(
+            "admin-mobile-bottom-nav-item",
+            (isModuleMenuOpen || isSecondaryModuleActive) &&
+              "admin-mobile-bottom-nav-item-active",
+          )}
+        >
+          <Menu className="h-4 w-4" aria-hidden="true" />
+          <span>Más</span>
+        </button>
+      </nav>
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/AdminMobileKebabMenu.tsx
+++ b/frontend/src/components/dashboard/AdminMobileKebabMenu.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLink, KeyRound, LogOut, MoreVertical } from "lucide-react";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
+import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
+import { ROUTES } from "@/lib/routes";
+import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
+
+export function AdminMobileKebabMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setIsOpen(false);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  return (
+    <div className="admin-mobile-kebab-root md:hidden">
+      <button
+        type="button"
+        aria-label="Menú de administración"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? "admin-mobile-kebab-menu" : undefined}
+        onClick={() => setIsOpen((current) => !current)}
+        className="admin-mobile-kebab-trigger"
+      >
+        <MoreVertical className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {isOpen ? (
+        <section
+          id="admin-mobile-kebab-menu"
+          aria-label="Acciones de administración"
+          data-admin-mobile-kebab-menu="true"
+          className="admin-mobile-kebab-menu"
+        >
+          <div className="admin-mobile-kebab-row">
+            <span>Apariencia</span>
+            <ThemeModeToggle className="h-9 w-9 bg-card" />
+          </div>
+          <div className="admin-mobile-kebab-row">
+            <span>Notificaciones</span>
+            <DashboardNotificationsBell surface="admin" mobileNoScroll />
+          </div>
+          <PublicRouteControl
+            href={`${ROUTES.dashboardAdmin}?module=admin-sessions`}
+            prefetch={false}
+            variant="bare"
+            onClick={() => setIsOpen(false)}
+            className="admin-mobile-kebab-action"
+          >
+            <KeyRound className="h-4 w-4" aria-hidden="true" />
+            <span>Cambiar contraseña</span>
+          </PublicRouteControl>
+          <PublicRouteControl
+            href={ROUTES.home}
+            prefetch={false}
+            variant="bare"
+            onClick={() => setIsOpen(false)}
+            className="admin-mobile-kebab-action"
+          >
+            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            <span>Ver sitio público</span>
+          </PublicRouteControl>
+          <PublicRouteControl
+            href={ROUTES.login}
+            prefetch={false}
+            variant="bare"
+            aria-label="Cerrar sesión"
+            onClick={clearDashboardLastModules}
+            className="admin-mobile-kebab-action admin-mobile-kebab-logout"
+          >
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            <span>Cerrar sesión</span>
+          </PublicRouteControl>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/AdminMobileModuleMenu.tsx
+++ b/frontend/src/components/dashboard/AdminMobileModuleMenu.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Activity,
+  Building2,
+  ClipboardPlus,
+  KeyRound,
+  ReceiptText,
+  ScrollText,
+  Settings2,
+  ShieldCheck,
+  TicketCheck,
+  UsersRound,
+  X,
+} from "lucide-react";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { ROUTES } from "@/lib/routes";
+
+const MODULES = [
+  { label: "Administración", moduleId: "admin", icon: Settings2 },
+  { label: "Informes", moduleId: "admin-report-upload", icon: ClipboardPlus },
+  { label: "Estado", moduleId: "admin-health", icon: Activity },
+  { label: "Clínicas", moduleId: "admin-clinics", icon: Building2 },
+  { label: "Tokens", moduleId: "admin-particular-tokens", icon: TicketCheck },
+  { label: "Precios", moduleId: "admin-pricing", icon: ReceiptText },
+  { label: "Sesiones", moduleId: "admin-sessions", icon: KeyRound },
+  { label: "Usuarios", moduleId: "admin-users-roles", icon: UsersRound },
+  { label: "Auditoría", moduleId: "audit-log", icon: ScrollText },
+  { label: "Mantenimiento", moduleId: "admin-maintenance", icon: ShieldCheck },
+] as const;
+
+const PAGE_SIZE = 5;
+
+type AdminMobileModuleMenuProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onNavigate: (moduleId: string) => void;
+};
+
+export function AdminMobileModuleMenu({
+  isOpen,
+  onClose,
+  onNavigate,
+}: AdminMobileModuleMenuProps) {
+  const [page, setPage] = useState(0);
+  const pageCount = Math.ceil(MODULES.length / PAGE_SIZE);
+  const visibleModules = MODULES.slice(
+    page * PAGE_SIZE,
+    page * PAGE_SIZE + PAGE_SIZE,
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setPage(0);
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <section
+      id="admin-mobile-module-menu"
+      aria-label="Todos los módulos de administración"
+      data-admin-mobile-module-menu="true"
+      className="admin-mobile-module-menu md:hidden"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold text-vetneb-ink">
+            Módulos
+          </h2>
+          <p className="text-[0.68rem] text-muted-foreground">
+            Página {page + 1} de {pageCount}
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="Cerrar menú de módulos"
+          onClick={onClose}
+          className="admin-mobile-icon-button"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="admin-mobile-module-grid">
+        {visibleModules.map((module) => {
+          const Icon = module.icon;
+          return (
+            <PublicRouteControl
+              key={module.moduleId}
+              href={`${ROUTES.dashboardAdmin}?module=${module.moduleId}`}
+              prefetch={false}
+              variant="bare"
+              data-admin-mobile-module-link="true"
+              onClick={() => {
+                onNavigate(module.moduleId);
+                onClose();
+              }}
+              className="admin-mobile-module-link"
+            >
+              <Icon className="h-4 w-4" aria-hidden="true" />
+              <span className="truncate">{module.label}</span>
+            </PublicRouteControl>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          aria-label="Página anterior de módulos"
+          disabled={page === 0}
+          onClick={() => setPage((current) => Math.max(0, current - 1))}
+          className="admin-mobile-page-button"
+        >
+          Anterior
+        </button>
+        <div className="flex items-center gap-1" aria-label="Páginas de módulos">
+          {Array.from({ length: pageCount }, (_, index) => (
+            <span
+              key={index}
+              aria-current={index === page ? "page" : undefined}
+              className="admin-mobile-page-dot"
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          aria-label="Página siguiente de módulos"
+          disabled={page === pageCount - 1}
+          onClick={() =>
+            setPage((current) => Math.min(pageCount - 1, current + 1))
+          }
+          className="admin-mobile-page-button"
+        >
+          Siguiente
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
+++ b/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
@@ -140,7 +140,7 @@ function DashboardHorizontalNavInner() {
       >
         <span className="hidden sm:inline">Volver al sitio público</span>
         <span className="sm:hidden" aria-hidden="true">
-          Salir
+          {surface === "admin" ? "Ver sitio público" : "Salir"}
         </span>
       </PublicRouteControl>
     </div>

--- a/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
@@ -30,6 +30,7 @@ export function DashboardModuleWorkspace({
             type="button"
             onClick={onBack}
             aria-label="Volver a módulos"
+            data-dashboard-module-back-button="true"
             className="inline-flex min-h-[2.75rem] items-center gap-2 rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm dashboard-btn-interactive hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 shrink-0"
           >
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
+++ b/frontend/src/components/dashboard/DashboardNotificationsBell.tsx
@@ -17,13 +17,18 @@ import { formatDateTime } from "@/lib/utils";
 
 const NOTIFICATIONS_LIMIT = 20;
 const POLLING_INTERVAL_MS = 30_000;
+const ADMIN_MOBILE_PAGE_SIZE = 2;
 
 type DashboardNotificationsBellProps = {
   surface: DashboardNotificationSurface;
+  mobileNoScroll?: boolean;
+  suppressMobileAutoShow?: boolean;
 };
 
 export function DashboardNotificationsBell({
   surface,
+  mobileNoScroll = false,
+  suppressMobileAutoShow = false,
 }: DashboardNotificationsBellProps) {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
@@ -38,6 +43,7 @@ export function DashboardNotificationsBell({
     number | null
   >(null);
   const [mobileBannerVisible, setMobileBannerVisible] = useState(false);
+  const [mobilePage, setMobilePage] = useState(0);
   const [portalContainer, setPortalContainer] = useState<Element | null>(null);
 
   const isFetchingRef = useRef(false);
@@ -52,6 +58,14 @@ export function DashboardNotificationsBell({
     (notification) => !notification.isRead,
   ).length;
   const unreadNotifications = notifications.filter((n) => !n.isRead);
+  const mobilePageCount = Math.max(
+    1,
+    Math.ceil(notifications.length / ADMIN_MOBILE_PAGE_SIZE),
+  );
+  const mobilePageNotifications = notifications.slice(
+    mobilePage * ADMIN_MOBILE_PAGE_SIZE,
+    mobilePage * ADMIN_MOBILE_PAGE_SIZE + ADMIN_MOBILE_PAGE_SIZE,
+  );
   const desktopPanelId = `dashboard-notifications-${surface}-panel`;
   const mobilePanelId = `dashboard-notifications-${surface}-mobile-panel`;
   const desktopPanelTitleId = `dashboard-notifications-${surface}-title`;
@@ -61,7 +75,9 @@ export function DashboardNotificationsBell({
   useEffect(() => {
     setPortalContainer(document.body);
 
-    const mq = window.matchMedia("(max-width: 639px)");
+    const mq = window.matchMedia(
+      mobileNoScroll ? "(max-width: 767px)" : "(max-width: 639px)",
+    );
     isMobileRef.current = mq.matches;
 
     const handler = (e: MediaQueryListEvent) => {
@@ -69,7 +85,7 @@ export function DashboardNotificationsBell({
     };
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
-  }, []);
+  }, [mobileNoScroll]);
 
   const loadNotifications = useCallback(async () => {
     if (isFetchingRef.current) {
@@ -98,7 +114,11 @@ export function DashboardNotificationsBell({
         autoShownUnreadCountRef.current = 0;
       } else if (newUnreadCount > autoShownUnreadCountRef.current) {
         autoShownUnreadCountRef.current = newUnreadCount;
-        if (isMobileRef.current) {
+        if (isMobileRef.current && suppressMobileAutoShow) {
+          setMobileBannerVisible(false);
+        } else if (isMobileRef.current && mobileNoScroll) {
+          setIsOpen(true);
+        } else if (isMobileRef.current) {
           setMobileBannerVisible(true);
         } else {
           setIsOpen(true);
@@ -110,7 +130,11 @@ export function DashboardNotificationsBell({
       isFetchingRef.current = false;
       setIsLoading(false);
     }
-  }, [surface]);
+  }, [mobileNoScroll, suppressMobileAutoShow, surface]);
+
+  useEffect(() => {
+    setMobilePage((current) => Math.min(current, mobilePageCount - 1));
+  }, [mobilePageCount]);
 
   // Initial silent load on mount to detect unread notifications and
   // auto-show the appropriate surface without any manual interaction.
@@ -140,6 +164,7 @@ export function DashboardNotificationsBell({
 
       if (next) {
         setMobileBannerVisible(false);
+        setMobilePage(0);
         void loadNotifications();
       }
 
@@ -281,10 +306,16 @@ export function DashboardNotificationsBell({
     titleId,
     listClassName,
     showCloseButton = false,
+    visibleNotifications = notifications,
+    showPagination = false,
+    compact = false,
   }: {
     titleId: string;
     listClassName: string;
     showCloseButton?: boolean;
+    visibleNotifications?: AdminStudyTrackingNotificationSummary[];
+    showPagination?: boolean;
+    compact?: boolean;
   }) {
     return (
       <>
@@ -356,7 +387,7 @@ export function DashboardNotificationsBell({
         ) : null}
 
         <ul className={listClassName}>
-          {notifications.map((notification) => (
+          {visibleNotifications.map((notification) => (
             <li key={notification.id}>
               <button
                 type="button"
@@ -366,14 +397,18 @@ export function DashboardNotificationsBell({
                 disabled={updatingNotificationId === notification.id}
               >
                 <div className="flex items-start justify-between gap-2">
-                  <p className="text-xs font-semibold text-vetneb-ink">
+                  <p
+                    className={`text-xs font-semibold text-vetneb-ink ${compact ? "line-clamp-1" : ""}`}
+                  >
                     {notification.title}
                   </p>
                   <span className="text-[0.66rem] text-muted-foreground">
                     {notification.isRead ? "Leída" : "No leída"}
                   </span>
                 </div>
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p
+                  className={`mt-1 text-xs text-muted-foreground ${compact ? "line-clamp-2" : ""}`}
+                >
                   {notification.message}
                 </p>
                 <p className="mt-1 text-[0.66rem] text-muted-foreground">
@@ -383,6 +418,40 @@ export function DashboardNotificationsBell({
             </li>
           ))}
         </ul>
+        {showPagination && notifications.length > ADMIN_MOBILE_PAGE_SIZE ? (
+          <div
+            className="mt-2 flex shrink-0 items-center justify-between gap-3"
+            aria-label="Paginación de notificaciones"
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={mobilePage === 0}
+              onClick={() =>
+                setMobilePage((current) => Math.max(0, current - 1))
+              }
+            >
+              Anterior
+            </Button>
+            <span className="text-[0.68rem] font-semibold text-muted-foreground">
+              {mobilePage + 1}/{mobilePageCount}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={mobilePage === mobilePageCount - 1}
+              onClick={() =>
+                setMobilePage((current) =>
+                  Math.min(mobilePageCount - 1, current + 1),
+                )
+              }
+            >
+              Siguiente
+            </Button>
+          </div>
+        ) : null}
       </>
     );
   }
@@ -406,7 +475,7 @@ export function DashboardNotificationsBell({
         ) : null}
       </button>
 
-      {isOpen ? (
+      {isOpen && !mobileNoScroll ? (
         <div
           id={desktopPanelId}
           role="region"
@@ -422,17 +491,36 @@ export function DashboardNotificationsBell({
         </div>
       ) : null}
 
+      {isOpen && mobileNoScroll ? (
+        <div
+          id={desktopPanelId}
+          role="region"
+          aria-label="Panel de notificaciones"
+          aria-labelledby={desktopPanelTitleId}
+          className="absolute right-0 z-50 mt-2 hidden w-[min(28rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-vetneb-line/80 bg-card p-3 shadow-xl md:block"
+          data-dashboard-notifications-desktop-panel="true"
+        >
+          {renderPanelContent({
+            titleId: desktopPanelTitleId,
+            listClassName: "max-h-72 space-y-2 overflow-y-auto pr-1",
+          })}
+        </div>
+      ) : null}
+
       {portalContainer && isOpen
         ? createPortal(
             <div
-              className="fixed inset-0 z-[90] bg-vetneb-navy/30 sm:hidden"
+              className={`fixed inset-0 z-[90] ${mobileNoScroll ? "bg-vetneb-surface md:hidden" : "bg-vetneb-navy/30 sm:hidden"}`}
               data-dashboard-notifications-mobile-overlay="true"
               onClick={handleClosePanel}
             >
               <div
                 id={mobilePanelId}
-                className="fixed inset-x-3 top-3 flex max-h-[calc(100vh-1.5rem)] flex-col overflow-hidden rounded-lg border border-vetneb-line/85 bg-card p-3 shadow-2xl"
+                className="fixed inset-x-3 top-3 flex max-h-[calc(100svh-1.5rem)] flex-col overflow-hidden rounded-lg border border-vetneb-line/85 bg-card p-3 shadow-2xl"
                 data-dashboard-notifications-mobile-panel="true"
+                data-admin-mobile-notifications-panel={
+                  mobileNoScroll ? "true" : undefined
+                }
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby={mobilePanelTitleId}
@@ -440,8 +528,15 @@ export function DashboardNotificationsBell({
               >
                 {renderPanelContent({
                   titleId: mobilePanelTitleId,
-                  listClassName: "min-h-0 flex-1 space-y-2 overflow-y-auto pr-1",
+                  listClassName: mobileNoScroll
+                    ? "min-h-0 flex-1 space-y-2 overflow-hidden"
+                    : "min-h-0 flex-1 space-y-2 overflow-y-auto pr-1",
                   showCloseButton: true,
+                  visibleNotifications: mobileNoScroll
+                    ? mobilePageNotifications
+                    : notifications,
+                  showPagination: mobileNoScroll,
+                  compact: mobileNoScroll,
                 })}
               </div>
             </div>,
@@ -452,7 +547,7 @@ export function DashboardNotificationsBell({
       {/* Mobile auto-show banner: visible only on narrow viewports (< 640 px).
           Portaled to document.body to avoid stacking-context clipping from the
           sticky topbar. Notifications are NOT marked as read by appearing here. */}
-      {portalContainer && mobileBannerVisible && unreadCount > 0
+      {portalContainer && mobileBannerVisible && unreadCount > 0 && !mobileNoScroll
         ? createPortal(
             <div
               className="fixed inset-x-0 top-0 z-[80] border-b border-vetneb-teal/30 bg-card shadow-xl sm:hidden"

--- a/frontend/src/components/dashboard/DashboardShellRouter.tsx
+++ b/frontend/src/components/dashboard/DashboardShellRouter.tsx
@@ -5,6 +5,7 @@ import {
   VETNEB_APP_SHELL_LABEL,
   VETNEB_APP_SHELL_RELEASE,
 } from "@/lib/app-shell-release";
+import { AdminMobileBottomNav } from "./AdminMobileBottomNav";
 
 export function DashboardShellRouter({
   children,
@@ -23,9 +24,15 @@ export function DashboardShellRouter({
       data-vetneb-app-shell-surface={surface}
       aria-label={VETNEB_APP_SHELL_LABEL}
     >
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <div
+        className="flex min-w-0 flex-1 flex-col overflow-hidden"
+        data-vetneb-app-shell-frame="true"
+      >
         {children}
       </div>
+      {isAdminDashboard ? (
+        <AdminMobileBottomNav />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
 import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
 import { ROUTES } from "@/lib/routes";
 import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 import { DashboardHorizontalNav } from "./DashboardHorizontalNav";
+import { AdminMobileKebabMenu } from "./AdminMobileKebabMenu";
 
 interface DashboardTopbarProps {
   title: string;
@@ -13,36 +16,89 @@ interface DashboardTopbarProps {
   notifications?: "admin" | "clinic" | "particular" | false;
 }
 
+const ADMIN_MOBILE_TITLES: Record<string, string> = {
+  admin: "Administración",
+  "admin-report-upload": "Informes",
+  "admin-health": "Estado",
+  "admin-clinics": "Clínicas",
+  "admin-particular-tokens": "Tokens",
+  "admin-pricing": "Precios",
+  "admin-sessions": "Sesiones",
+  "admin-users-roles": "Usuarios",
+  "audit-log": "Auditoría",
+  "admin-maintenance": "Mantenimiento",
+};
+
+function AdminMobileContextTitle() {
+  const searchParams = useSearchParams();
+  const moduleId = searchParams.get("module");
+  return <>{(moduleId && ADMIN_MOBILE_TITLES[moduleId]) || "Inicio"}</>;
+}
+
+function DashboardTopbarNotifications({
+  notifications,
+}: {
+  notifications: DashboardTopbarProps["notifications"];
+}) {
+  if (notifications === "admin") {
+    return (
+      <DashboardNotificationsBell
+        surface="admin"
+        mobileNoScroll
+        suppressMobileAutoShow
+      />
+    );
+  }
+
+  return <>{notifications ? <DashboardNotificationsBell surface={notifications} /> : null}</>;
+}
+
 export function DashboardTopbar({
   title,
   subtitle,
   notifications = false,
 }: DashboardTopbarProps) {
+  const isAdmin = notifications === "admin";
+
   return (
     <header
       className="sticky top-0 z-40 flex shrink-0 flex-col border-b border-vetneb-line/80 bg-card/90 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/78"
       data-dashboard-topbar-polish="true"
+      data-admin-mobile-app-bar={isAdmin ? "true" : undefined}
       aria-label="Barra superior del dashboard"
       aria-labelledby="dashboard-topbar-title"
     >
       <div className="flex min-h-[2.75rem] min-w-0 items-center justify-between gap-2 px-3 py-1.5 sm:min-h-[2.5rem] sm:gap-3 sm:px-6">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h1
             id="dashboard-topbar-title"
             className="truncate text-lg font-semibold leading-tight text-vetneb-ink sm:text-xl"
           >
             {title}
           </h1>
+          {isAdmin ? (
+            <h1 className="admin-mobile-context-title md:hidden">
+              <Suspense fallback="Inicio">
+                <AdminMobileContextTitle />
+              </Suspense>
+            </h1>
+          ) : null}
           {subtitle && (
-            <p className="truncate text-xs text-muted-foreground sm:text-[0.8125rem]">
+            <p
+              className="truncate text-xs text-muted-foreground sm:text-[0.8125rem]"
+              data-admin-mobile-topbar-subtitle={isAdmin ? "true" : undefined}
+            >
               {subtitle}
             </p>
           )}
         </div>
 
-        <div className="ml-2 flex shrink-0 items-center gap-1.5 sm:ml-3 sm:gap-3">
+        <div
+          className="ml-2 flex shrink-0 items-center gap-1.5 sm:ml-3 sm:gap-3"
+          data-dashboard-desktop-actions="true"
+        >
           <ThemeModeToggle />
-          {notifications ? <DashboardNotificationsBell surface={notifications} /> : null}
+          <DashboardTopbarNotifications notifications={notifications} />
           <PublicRouteControl
             href={ROUTES.login}
             variant="bare"
@@ -52,9 +108,14 @@ export function DashboardTopbar({
             className="inline-flex h-10 min-w-10 items-center justify-center rounded-md border border-input bg-card/95 px-2 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 sm:h-9 sm:min-w-0 sm:px-3"
           >
             <span className="hidden sm:inline">Cerrar sesión</span>
-            <span className="sm:hidden" aria-hidden="true">Salir</span>
+            {!isAdmin ? (
+              <span className="sm:hidden" aria-hidden="true">
+                Salir
+              </span>
+            ) : null}
           </PublicRouteControl>
         </div>
+        {isAdmin ? <AdminMobileKebabMenu /> : null}
       </div>
 
       <DashboardHorizontalNav />


### PR DESCRIPTION
## Summary
- add Admin mobile app shell with compact app bar, bottom navigation and paginated More menu
- replace Admin mobile horizontal tabs with fixed app-style navigation
- preserve desktop horizontal navigation and Clinic behavior
- add no-scroll Admin mobile E2E contracts for 360/390/430
- update legacy Admin mobile shell/layering specs to the new navigation contract
- keep anti-ghosting invariants from #1064

## Validation
- TDD red first: new specs initially failed due to missing app bar / bottom nav
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-module-layer-isolation.spec.ts e2e/dashboard-mobile-shell-nav-contract.spec.ts e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface

## Notes
- Scoped to Admin mobile app shell PR 1
- Does not redesign dense module internals yet; those remain for PR 2/3/4
- Does not touch backend, auth, API, DB, dependencies, lockfiles, CI, or Clinic dashboard