### PR TITLE
fix(admin): add mobile hub launcher no scroll contract

### DIFF
--- a/frontend/e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts
@@ -97,7 +97,9 @@ for (const viewport of MOBILE_VIEWPORTS) {
     );
 
     await nav.getByRole("button", { name: "Inicio", exact: true }).click();
-    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible({
+    await expect(
+      page.locator('[data-admin-mobile-hub-launcher="true"]'),
+    ).toBeVisible({
       timeout: 15_000,
     });
 

--- a/frontend/e2e/admin-mobile-hub-launcher-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-hub-launcher-no-scroll.spec.ts
@@ -1,0 +1,257 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const TOLERANCE = 1;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function expectInsideViewport(
+  locator: Locator,
+  viewportWidth: number,
+  viewportHeight: number,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.y, `${label}: top edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
+    viewportWidth + TOLERANCE,
+  );
+  expect(box!.y + box!.height, `${label}: bottom edge`).toBeLessThanOrEqual(
+    viewportHeight + TOLERANCE,
+  );
+}
+
+type NoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  shellOverflowX: string;
+  shellOverflowY: string;
+  mainOverflowX: string;
+  mainOverflowY: string;
+  forbiddenLauncherOverflow: Array<{ selector: string; overflowX: string; overflowY: string }>;
+};
+
+async function readNoScrollContract(page: Page): Promise<NoScrollContract> {
+  return page.evaluate(() => {
+    const launcher = document.querySelector<HTMLElement>(
+      '[data-admin-mobile-hub-launcher="true"]',
+    );
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+
+    if (!launcher || !shell || !main) {
+      throw new Error("Admin mobile hub launcher contract is incomplete");
+    }
+
+    const shellStyle = window.getComputedStyle(shell);
+    const mainStyle = window.getComputedStyle(main);
+
+    const forbiddenLauncherOverflow = [
+      launcher,
+      ...Array.from(launcher.querySelectorAll<HTMLElement>("*")),
+    ].flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      return ["auto", "scroll"].includes(style.overflowX) ||
+        ["auto", "scroll"].includes(style.overflowY)
+        ? [
+            {
+              selector: element.tagName + "." + element.className,
+              overflowX: style.overflowX,
+              overflowY: style.overflowY,
+            },
+          ]
+        : [];
+    });
+
+    return {
+      html: {
+        scrollHeight: document.documentElement.scrollHeight,
+        clientHeight: document.documentElement.clientHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      },
+      body: {
+        scrollHeight: document.body.scrollHeight,
+        clientHeight: document.body.clientHeight,
+        scrollWidth: document.body.scrollWidth,
+        clientWidth: document.body.clientWidth,
+      },
+      shellOverflowX: shellStyle.overflowX,
+      shellOverflowY: shellStyle.overflowY,
+      mainOverflowX: mainStyle.overflowX,
+      mainOverflowY: mainStyle.overflowY,
+      forbiddenLauncherOverflow,
+    };
+  });
+}
+
+async function expectModuleWorkspace(page: Page, moduleId: string) {
+  await expect(
+    page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+async function backToHubViaBottomNav(page: Page) {
+  await page
+    .locator('[data-admin-mobile-bottom-nav="true"]')
+    .getByRole("button", { name: "Inicio", exact: true })
+    .click();
+  await expect(
+    page.locator('[data-admin-mobile-hub-launcher="true"]'),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`Admin mobile hub is a paginated no-scroll launcher at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setPopulatedAdminSession(page);
+    await page.goto("/dashboard/admin");
+    await suppressNextDevIndicator(page);
+
+    const appBar = page.locator('[data-admin-mobile-app-bar="true"]');
+    const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+    const horizontalNav = page.locator(
+      '[data-dashboard-horizontal-nav-shell="true"]',
+    );
+    const launcher = page.locator('[data-admin-mobile-hub-launcher="true"]');
+    const pager = page.locator('[data-admin-mobile-hub-pager="true"]');
+
+    await expect(appBar).toBeVisible({ timeout: 15_000 });
+    await expect(bottomNav).toBeVisible();
+    await expect(horizontalNav).toBeHidden();
+    await expect(launcher).toBeVisible({ timeout: 15_000 });
+    await expect(pager).toBeVisible();
+
+    // No-scroll contract: html/body never exceed the viewport.
+    const contract = await readNoScrollContract(page);
+    expect(contract.html.scrollHeight).toBeLessThanOrEqual(
+      contract.html.clientHeight + TOLERANCE,
+    );
+    expect(contract.body.scrollHeight).toBeLessThanOrEqual(
+      contract.body.clientHeight + TOLERANCE,
+    );
+    expect(contract.html.scrollWidth).toBeLessThanOrEqual(
+      contract.html.clientWidth + TOLERANCE,
+    );
+    expect(contract.body.scrollWidth).toBeLessThanOrEqual(
+      contract.body.clientWidth + TOLERANCE,
+    );
+    expect(["auto", "scroll"]).not.toContain(contract.shellOverflowX);
+    expect(["auto", "scroll"]).not.toContain(contract.shellOverflowY);
+    expect(["auto", "scroll"]).not.toContain(contract.mainOverflowX);
+    expect(["auto", "scroll"]).not.toContain(contract.mainOverflowY);
+    expect(contract.forbiddenLauncherOverflow).toEqual([]);
+
+    // Pager must be fully inside the viewport.
+    await expectInsideViewport(pager, viewport.width, viewport.height, `${viewport.name}: pager`);
+
+    // Page 1 tiles must all be fully visible and inside the viewport (no clipped tiles).
+    const page1Tiles = launcher.locator('[data-admin-mobile-hub-tile]');
+    const page1Count = await page1Tiles.count();
+    expect(page1Count).toBeGreaterThan(0);
+    for (let index = 0; index < page1Count; index += 1) {
+      await expectInsideViewport(
+        page1Tiles.nth(index),
+        viewport.width,
+        viewport.height,
+        `${viewport.name}: page1 tile ${index + 1}`,
+      );
+    }
+
+    // Going to page 2 must not introduce scroll, and tiles must stay onscreen.
+    const nextButton = pager.getByRole("button", { name: "Siguiente", exact: true });
+    await nextButton.click();
+
+    const page2Tiles = launcher.locator('[data-admin-mobile-hub-tile]');
+    const page2Count = await page2Tiles.count();
+    expect(page2Count).toBeGreaterThan(0);
+    for (let index = 0; index < page2Count; index += 1) {
+      await expectInsideViewport(
+        page2Tiles.nth(index),
+        viewport.width,
+        viewport.height,
+        `${viewport.name}: page2 tile ${index + 1}`,
+      );
+    }
+
+    const contractAfterPaging = await readNoScrollContract(page);
+    expect(contractAfterPaging.html.scrollHeight).toBeLessThanOrEqual(
+      contractAfterPaging.html.clientHeight + TOLERANCE,
+    );
+    expect(contractAfterPaging.body.scrollHeight).toBeLessThanOrEqual(
+      contractAfterPaging.body.clientHeight + TOLERANCE,
+    );
+
+    // All 10 modules must be reachable across the two pages.
+    expect(page1Count + page2Count).toBe(10);
+
+    // Go back to page 1.
+    await pager.getByRole("button", { name: "Anterior", exact: true }).click();
+
+    // Navigation: a page-1 tile (Clínicas) must navigate to its module.
+    await launcher.locator('[data-admin-mobile-hub-tile="admin-clinics"]').click();
+    await expectModuleWorkspace(page, "admin-clinics");
+    await backToHubViaBottomNav(page);
+
+    // Navigation: page-2 tiles (Auditoría, Sesiones) must navigate to their modules.
+    await launcher
+      .locator('[data-admin-mobile-hub-pager="true"]')
+      .getByRole("button", { name: "Siguiente", exact: true })
+      .click();
+    await launcher.locator('[data-admin-mobile-hub-tile="audit-log"]').click();
+    await expectModuleWorkspace(page, "audit-log");
+    await backToHubViaBottomNav(page);
+
+    await launcher
+      .locator('[data-admin-mobile-hub-pager="true"]')
+      .getByRole("button", { name: "Siguiente", exact: true })
+      .click();
+    await launcher.locator('[data-admin-mobile-hub-tile="admin-sessions"]').click();
+    await expectModuleWorkspace(page, "admin-sessions");
+    await backToHubViaBottomNav(page);
+  });
+}
+
+test("Admin desktop hub keeps the previous layout and has no mobile launcher", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await setPopulatedAdminSession(page);
+  await page.goto("/dashboard/admin");
+  await suppressNextDevIndicator(page);
+
+  await expect(
+    page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeHidden();
+  await expect(
+    page.locator('[data-admin-mobile-hub-launcher="true"]'),
+  ).toBeHidden();
+  await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible();
+});

--- a/frontend/e2e/admin-mobile-module-layer-isolation.spec.ts
+++ b/frontend/e2e/admin-mobile-module-layer-isolation.spec.ts
@@ -225,15 +225,21 @@ async function openModule(
   moduleId: string,
   viewportLabel: string,
 ) {
-  const moduleCard = page.locator(
-    `[data-dashboard-module-hub="true"] [data-dashboard-module-card="${moduleId}"]`,
-  );
+  const launcher = page.locator('[data-admin-mobile-hub-launcher="true"]');
+  const moduleTile = launcher.locator(`[data-admin-mobile-hub-tile="${moduleId}"]`);
   const workspace = page.locator(
     `[data-dashboard-module-workspace="${moduleId}"]`,
   );
 
-  await expect(moduleCard).toBeVisible();
-  await moduleCard.click();
+  if ((await moduleTile.count()) === 0) {
+    await launcher
+      .locator('[data-admin-mobile-hub-pager="true"]')
+      .getByRole("button", { name: "Siguiente", exact: true })
+      .click();
+  }
+
+  await expect(moduleTile).toBeVisible();
+  await moduleTile.click();
   await expect(workspace).toBeVisible({ timeout: 15_000 });
   await expectLayerContract(
     page,
@@ -250,12 +256,12 @@ async function backToHub(page: Page, viewportLabel: string) {
     .getByRole("button", { name: "Inicio", exact: true })
     .click();
 
-  const hub = page.locator('[data-dashboard-module-hub="true"]');
+  const hub = page.locator('[data-admin-mobile-hub-launcher="true"]');
   await expect(hub).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("[data-dashboard-module-workspace]")).toHaveCount(0);
   await expectLayerContract(
     page,
-    '[data-dashboard-module-hub="true"]',
+    '[data-admin-mobile-hub-launcher="true"]',
     `${viewportLabel} hub`,
   );
 }
@@ -274,11 +280,11 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await page.goto("/dashboard/admin");
     await suppressNextDevIndicator(page);
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = page.locator('[data-admin-mobile-hub-launcher="true"]');
     await expect(hub).toBeVisible({ timeout: 15_000 });
     await expectLayerContract(
       page,
-      '[data-dashboard-module-hub="true"]',
+      '[data-admin-mobile-hub-launcher="true"]',
       `${viewport.name} initial hub`,
     );
 

--- a/frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts
+++ b/frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts
@@ -55,7 +55,7 @@ const SHELLS: ShellCase[] = [
     label: "admin dashboard shell",
     surface: "admin",
     path: "/dashboard/admin",
-    ready: '[data-dashboard-module-hub="true"]',
+    ready: '[data-dashboard-hub-root="true"]',
   },
 ];
 

--- a/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
+++ b/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
@@ -38,7 +38,7 @@ const SHELL_ROUTES: ShellRouteCase[] = [
     label: "admin hub",
     surface: "admin",
     path: "/dashboard/admin",
-    ready: '[data-dashboard-module-hub="true"]',
+    ready: '[data-dashboard-hub-root="true"]',
   },
   {
     label: "admin audit",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2646,3 +2646,172 @@
   }
 }
 /* admin-mobile-app-shell:end */
+/* admin-mobile-hub-launcher:start */
+@media (min-width: 768px) {
+  [data-admin-mobile-hub-launcher="true"] {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  [data-vetneb-app-shell-surface="admin"] .dashboard-cockpit {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-hero-slot,
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-desktop-launcher {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] [data-admin-mobile-hub-launcher="true"] {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    gap: 0.5rem;
+    overflow: hidden;
+    isolation: isolate;
+    background: hsl(var(--card));
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-launcher-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: repeat(3, minmax(0, 1fr));
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    gap: 0.5rem;
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-launcher-grid > li {
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-tile {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    min-height: 0;
+    gap: 0.3rem;
+    overflow: hidden;
+    border-radius: 0.85rem;
+    border: 1px solid hsl(var(--vetneb-line) / 0.8);
+    background: hsl(var(--card));
+    padding: 0.4rem;
+    text-align: center;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-tile-icon {
+    display: inline-flex;
+    height: 1.85rem;
+    width: 1.85rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 0.6rem;
+    color: #fff;
+    background: linear-gradient(135deg, hsl(var(--vetneb-navy)), hsl(var(--vetneb-teal) / 0.85));
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-tile-label {
+    display: -webkit-box;
+    width: 100%;
+    overflow: hidden;
+    color: hsl(var(--vetneb-ink));
+    font-size: 0.7rem;
+    font-weight: 650;
+    line-height: 1.15;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager {
+    display: flex;
+    flex: 0 0 auto;
+    min-width: 0;
+    min-height: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager-button {
+    display: inline-flex;
+    min-height: 2.1rem;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 0.3rem 0.65rem;
+    border: 1px solid hsl(var(--vetneb-line));
+    border-radius: 0.5rem;
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    font-size: 0.72rem;
+    font-weight: 650;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager-button:disabled {
+    opacity: 0.45;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager-dots {
+    display: flex;
+    flex: 0 1 auto;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager-dot {
+    display: block;
+    width: 0.4rem;
+    height: 0.4rem;
+    flex: 0 0 auto;
+    overflow: hidden;
+    border-radius: 999px;
+    background: hsl(var(--vetneb-line));
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager-dot[aria-current="page"] {
+    background: hsl(var(--vetneb-teal));
+  }
+
+  [data-vetneb-app-shell-surface="admin"] .admin-mobile-hub-pager-status {
+    flex: 0 0 auto;
+    overflow: hidden;
+    white-space: nowrap;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.64rem;
+    font-weight: 600;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    :is(
+      .admin-mobile-hub-launcher-grid,
+      .admin-mobile-hub-tile,
+      .admin-mobile-hub-pager,
+      .admin-mobile-hub-pager-dots
+    ) {
+    overflow-x: hidden;
+    overflow-y: hidden;
+  }
+}
+/* admin-mobile-hub-launcher:end */

--- a/frontend/src/components/dashboard/AdminMobileHubLauncher.tsx
+++ b/frontend/src/components/dashboard/AdminMobileHubLauncher.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import type { DashboardModuleCard } from "./DashboardModuleHub";
+import { AdminMobileLauncherTile } from "./AdminMobileLauncherTile";
+import { AdminMobileHubPager } from "./AdminMobileHubPager";
+
+const PAGE_SIZE = 6;
+
+type AdminMobileHubLauncherProps = {
+  heading: string;
+  cards: DashboardModuleCard[];
+};
+
+export function AdminMobileHubLauncher({ heading, cards }: AdminMobileHubLauncherProps) {
+  const [page, setPage] = useState(0);
+  const pageCount = Math.max(1, Math.ceil(cards.length / PAGE_SIZE));
+  const start = page * PAGE_SIZE;
+  const pageCards = cards.slice(start, start + PAGE_SIZE);
+
+  return (
+    <section
+      aria-label={heading}
+      data-admin-mobile-hub-launcher="true"
+      className="admin-mobile-hub-launcher"
+    >
+      <ul className="admin-mobile-hub-launcher-grid list-none p-0">
+        {pageCards.map((card) => (
+          <li key={card.moduleId ?? card.href ?? card.title} className="min-h-0">
+            <AdminMobileLauncherTile card={card} />
+          </li>
+        ))}
+      </ul>
+      {pageCount > 1 ? (
+        <AdminMobileHubPager page={page} pageCount={pageCount} onPageChange={setPage} />
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/AdminMobileHubPager.tsx
+++ b/frontend/src/components/dashboard/AdminMobileHubPager.tsx
@@ -1,0 +1,44 @@
+type AdminMobileHubPagerProps = {
+  page: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+};
+
+export function AdminMobileHubPager({
+  page,
+  pageCount,
+  onPageChange,
+}: AdminMobileHubPagerProps) {
+  return (
+    <div data-admin-mobile-hub-pager="true" className="admin-mobile-hub-pager">
+      <button
+        type="button"
+        className="admin-mobile-hub-pager-button"
+        disabled={page === 0}
+        onClick={() => onPageChange(page - 1)}
+      >
+        Anterior
+      </button>
+      <div className="admin-mobile-hub-pager-dots" aria-hidden="true">
+        {Array.from({ length: pageCount }, (_, index) => (
+          <span
+            key={index}
+            className="admin-mobile-hub-pager-dot"
+            aria-current={index === page ? "page" : undefined}
+          />
+        ))}
+      </div>
+      <span className="admin-mobile-hub-pager-status" aria-live="polite">
+        Página {page + 1} de {pageCount}
+      </span>
+      <button
+        type="button"
+        className="admin-mobile-hub-pager-button"
+        disabled={page === pageCount - 1}
+        onClick={() => onPageChange(page + 1)}
+      >
+        Siguiente
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/AdminMobileLauncherTile.tsx
+++ b/frontend/src/components/dashboard/AdminMobileLauncherTile.tsx
@@ -1,0 +1,47 @@
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import type { DashboardModuleCard } from "./DashboardModuleHub";
+
+type AdminMobileLauncherTileProps = {
+  card: DashboardModuleCard;
+};
+
+export function AdminMobileLauncherTile({ card }: AdminMobileLauncherTileProps) {
+  const ariaLabel = `${card.title}: ${card.description}`;
+  const sharedClassName =
+    "admin-mobile-hub-tile group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2";
+
+  const body = (
+    <>
+      <span className="admin-mobile-hub-tile-icon">
+        <card.icon className="h-4 w-4" aria-hidden="true" />
+      </span>
+      <span className="admin-mobile-hub-tile-label">{card.title}</span>
+    </>
+  );
+
+  if (card.onClick) {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        data-admin-mobile-hub-tile={card.moduleId}
+        onClick={card.onClick}
+        className={sharedClassName}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <PublicRouteControl
+      href={card.href ?? "#"}
+      variant="bare"
+      aria-label={ariaLabel}
+      data-admin-mobile-hub-tile={card.moduleId}
+      className={sharedClassName}
+    >
+      {body}
+    </PublicRouteControl>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardModuleHub.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleHub.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { ChevronRight } from "lucide-react";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { AdminMobileHubLauncher } from "./AdminMobileHubLauncher";
 import { cn } from "@/lib/utils";
 
 export type DashboardModuleCard = {
@@ -36,18 +37,30 @@ export function DashboardModuleHub({
   const showDescription = !isDenseLauncher;
 
   return (
-    <div className={cn("dashboard-cockpit min-h-0 lg:flex-1", className)}>
+    <div
+      data-dashboard-hub-root="true"
+      className={cn("dashboard-cockpit min-h-0 lg:flex-1", className)}
+    >
       {hero ? (
-        <div data-dashboard-hub-hero-slot="true" className="dashboard-cockpit-rail">
+        <div
+          data-dashboard-hub-hero-slot="true"
+          className={cn(
+            "dashboard-cockpit-rail",
+            isDenseLauncher && "admin-mobile-hub-hero-slot",
+          )}
+        >
           {hero}
         </div>
+      ) : null}
+      {isDenseLauncher ? (
+        <AdminMobileHubLauncher heading={heading} cards={cards} />
       ) : null}
       <section
         aria-label={heading}
         data-dashboard-module-hub="true"
         className={cn(
           "dashboard-cockpit-launcher",
-          isDenseLauncher && "dashboard-cockpit-launcher-dense",
+          isDenseLauncher && "dashboard-cockpit-launcher-dense admin-mobile-hub-desktop-launcher",
         )}
       >
         <div className="flex items-baseline justify-between gap-3">


### PR DESCRIPTION
﻿## Summary
- add Admin mobile Hub launcher with compact paginated app-style module tiles
- keep Hub mobile no-scroll across 360x740, 390x844 and 430x932
- make all 10 Admin modules accessible without document/internal scroll
- preserve #1066 app bar, bottom navigation and More menu behavior
- preserve desktop Hub layout and Clinic dashboard behavior
- update legacy Hub selectors to stable Admin mobile root selectors

## Validation
- TDD red first: new Hub launcher spec initially failed because [data-admin-mobile-hub-launcher="true"] did not exist
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-hub-launcher-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts e2e/admin-mobile-module-layer-isolation.spec.ts e2e/dashboard-mobile-shell-nav-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface

## Notes
- Scoped to Admin mobile Hub / launcher PR 2
- Does not redesign dense internal modules yet; those remain for PR 3/4
- Does not touch backend, auth, API, DB, dependencies, lockfiles, CI, docs, or Clinic dashboard
- One unrelated admin-clinic-edit-drawer test was flaky in the broad run and passed when retried in isolation
