### PR TITLE
fix(admin): add mobile core modules no scroll contract

### DIFF
--- a/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
@@ -1,0 +1,427 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const MOCK_CLINICS = Array.from({ length: 9 }, (_, index) => {
+  const id = index + 1;
+  return {
+    clinicId: id,
+    clinicName: `Clínica Core ${id}`,
+    contactEmail: `clinica.core.${id}@example.test`,
+    contactPhone: `+54 11 5555-${String(id).padStart(4, "0")}`,
+    createdAt: "2026-06-01T10:00:00.000Z",
+    updatedAt: `2026-06-${String(id).padStart(2, "0")}T12:00:00.000Z`,
+    users: [
+      {
+        userId: 100 + id,
+        username: `core-owner-${id}`,
+        createdAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      },
+    ],
+  };
+});
+
+const REPORT_STAGES = ["sample_received", "processing", "delivered"] as const;
+const MOCK_REPORTS = Array.from({ length: 9 }, (_, index) => {
+  const id = 7400 + index;
+  return {
+    id,
+    clinicId: 20 + index,
+    clinicName: `Clínica Informe ${index + 1}`,
+    patientName: `Paciente ${index + 1}`,
+    studyType: "histopatologia",
+    workflowStage: REPORT_STAGES[index % REPORT_STAGES.length],
+    specialStainRequested: index % 4 === 0,
+    fileName: index % 2 === 0 ? `informe-${id}.pdf` : null,
+    uploadDate: "2026-06-10T10:00:00.000Z",
+    createdAt: "2026-06-09T10:00:00.000Z",
+    workflowUpdatedAt: "2026-06-11T10:00:00.000Z",
+  };
+});
+
+const MOCK_TOKENS = Array.from({ length: 9 }, (_, index) => ({
+  id: 9300 + index,
+  clinicId: 30 + index,
+  reportId: index % 3 === 0 ? 7400 + index : null,
+  tokenLast4: String(5100 + index),
+  tutorLastName: ["Gómez", "Pérez", "Luna"][index % 3],
+  petName: ["Mora", "Simón", "Lola", "Bruno", "Kira", "Toby", "Nina", "Rocco", "Uma"][index],
+  petAge: `${2 + index} años`,
+  petBreed: index % 2 === 0 ? "Mestizo" : "Labrador",
+  petSex: index % 2 === 0 ? "Hembra" : "Macho",
+  petSpecies: index % 2 === 0 ? "Caninos" : "Felinos",
+  sampleLocation: "Piel",
+  sampleEvolution: `${3 + index} semanas`,
+  detailsLesion: "Lesión nodular para evaluación anatomopatológica.",
+  extractionDate: "2026-06-10T10:00:00.000Z",
+  shippingDate: "2026-06-11T10:00:00.000Z",
+  isActive: index !== 7,
+  lastLoginAt: index % 2 === 0 ? "2026-06-17T16:20:00.000Z" : null,
+  createdAt: "2026-06-12T09:15:00.000Z",
+  updatedAt: "2026-06-17T16:20:00.000Z",
+  createdByAdminId: 41,
+  createdByClinicUserId: null,
+  hasLinkedReport: index % 3 === 0,
+}));
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function mockAdminClinics(page: Page) {
+  await page.route("**/api/admin/clinics**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const url = new URL(route.request().url());
+    const limit = Number(url.searchParams.get("limit") ?? "9");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    const clinics = MOCK_CLINICS.slice(offset, offset + limit);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        clinics,
+        total: MOCK_CLINICS.length,
+        limit,
+        offset,
+      }),
+    });
+  });
+}
+
+async function mockAdminReportWorkflow(page: Page) {
+  await page.route("**/api/admin/report-workflow**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const url = new URL(route.request().url());
+    const limit = Number(url.searchParams.get("limit") ?? "9");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    const reports = MOCK_REPORTS.slice(offset, offset + limit);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        reports,
+        pagination: { limit, offset, hasMore: offset + limit < MOCK_REPORTS.length },
+      }),
+    });
+  });
+}
+
+async function mockAdminParticularTokens(page: Page) {
+  await page.route("**/api/admin/particular-tokens**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== "GET" || url.pathname !== "/api/admin/particular-tokens") {
+      await route.fallback();
+      return;
+    }
+    const limit = Number(url.searchParams.get("limit") ?? "9");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    const particularTokens = MOCK_TOKENS.slice(offset, offset + limit);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        count: particularTokens.length,
+        particularTokens,
+        pagination: { limit, offset },
+        filters: { clinicId: null },
+      }),
+    });
+  });
+}
+
+type ModuleSpec = {
+  key: "clinics" | "reports" | "tokens";
+  moduleId: string;
+  mock: (page: Page) => Promise<void>;
+};
+
+const MODULES: ModuleSpec[] = [
+  { key: "clinics", moduleId: "admin-clinics", mock: mockAdminClinics },
+  { key: "reports", moduleId: "admin-report-upload", mock: mockAdminReportWorkflow },
+  { key: "tokens", moduleId: "admin-particular-tokens", mock: mockAdminParticularTokens },
+];
+
+type NoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  forbiddenOverflow: Array<{ tag: string; cls: string; overflowX: string; overflowY: string }>;
+};
+
+async function readNoScrollContract(
+  page: Page,
+  moduleSelector: string,
+): Promise<NoScrollContract> {
+  return page.evaluate((selector) => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const moduleRoot = document.querySelector<HTMLElement>(selector);
+
+    const candidates: HTMLElement[] = [];
+    if (shell) candidates.push(shell);
+    if (main) candidates.push(main);
+    if (moduleRoot) {
+      candidates.push(moduleRoot, ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")));
+    }
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      return ["auto", "scroll"].includes(style.overflowX) ||
+        ["auto", "scroll"].includes(style.overflowY)
+        ? [
+            {
+              tag: element.tagName,
+              cls: element.className,
+              overflowX: style.overflowX,
+              overflowY: style.overflowY,
+            },
+          ]
+        : [];
+    });
+
+    return {
+      html: {
+        scrollHeight: document.documentElement.scrollHeight,
+        clientHeight: document.documentElement.clientHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      },
+      body: {
+        scrollHeight: document.body.scrollHeight,
+        clientHeight: document.body.clientHeight,
+        scrollWidth: document.body.scrollWidth,
+        clientWidth: document.body.clientWidth,
+      },
+      forbiddenOverflow,
+    };
+  }, moduleSelector);
+}
+
+function assertNoScrollContract(contract: NoScrollContract, label: string) {
+  expect(contract.html.scrollHeight, `${label}: html vertical overflow`).toBeLessThanOrEqual(
+    contract.html.clientHeight + TOLERANCE,
+  );
+  expect(contract.body.scrollHeight, `${label}: body vertical overflow`).toBeLessThanOrEqual(
+    contract.body.clientHeight + TOLERANCE,
+  );
+  expect(contract.html.scrollWidth, `${label}: html horizontal overflow`).toBeLessThanOrEqual(
+    contract.html.clientWidth + TOLERANCE,
+  );
+  expect(contract.body.scrollWidth, `${label}: body horizontal overflow`).toBeLessThanOrEqual(
+    contract.body.clientWidth + TOLERANCE,
+  );
+  expect(contract.forbiddenOverflow, `${label}: forbidden overflow auto/scroll`).toEqual([]);
+}
+
+async function expectInsideViewport(
+  locator: Locator,
+  viewportWidth: number,
+  viewportHeight: number,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.y, `${label}: top edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
+    viewportWidth + TOLERANCE,
+  );
+  expect(box!.y + box!.height, `${label}: bottom edge`).toBeLessThanOrEqual(
+    viewportHeight + TOLERANCE,
+  );
+}
+
+for (const moduleSpec of MODULES) {
+  for (const viewport of MOBILE_VIEWPORTS) {
+    test(`Admin mobile core module "${moduleSpec.key}" is no-scroll at ${viewport.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setAdminSession(page);
+      await moduleSpec.mock(page);
+      await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+      await suppressNextDevIndicator(page);
+
+      const workspace = page.locator(
+        `[data-dashboard-module-workspace="${moduleSpec.moduleId}"]`,
+      );
+      await expect(workspace, `${viewport.name}: module workspace visible`).toBeVisible({
+        timeout: 15_000,
+      });
+
+      const moduleRoot = page.locator(
+        `[data-admin-mobile-core-module="${moduleSpec.key}"]`,
+      );
+      await expect(moduleRoot, `${viewport.name}: module root visible`).toBeVisible();
+
+      await expect(
+        page.locator('[data-admin-mobile-app-bar="true"]'),
+        `${viewport.name}: app bar visible`,
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-admin-mobile-bottom-nav="true"]'),
+        `${viewport.name}: bottom nav visible`,
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+        `${viewport.name}: horizontal nav absent`,
+      ).toBeHidden();
+
+      const contract = await readNoScrollContract(
+        page,
+        `[data-admin-mobile-core-module="${moduleSpec.key}"]`,
+      );
+      assertNoScrollContract(contract, `${viewport.name} ${moduleSpec.key} page 1`);
+
+      const itemSelector = `[data-admin-mobile-core-module="${moduleSpec.key}"] [data-admin-mobile-core-item="true"]`;
+      const items = page.locator(itemSelector);
+      await expect(
+        items.first(),
+        `${viewport.name}: ${moduleSpec.key} first item visible`,
+      ).toBeVisible({ timeout: 15_000 });
+      const itemCount = await items.count();
+      expect(itemCount, `${viewport.name}: ${moduleSpec.key} has visible items`).toBeGreaterThan(0);
+      expect(
+        itemCount,
+        `${viewport.name}: ${moduleSpec.key} page size must remain viewport-safe`,
+      ).toBeLessThanOrEqual(5);
+
+      for (let index = 0; index < itemCount; index += 1) {
+        await expectInsideViewport(
+          items.nth(index),
+          viewport.width,
+          viewport.height,
+          `${viewport.name}: ${moduleSpec.key} item ${index + 1}`,
+        );
+      }
+
+      const pager = page.locator(
+        `[data-admin-mobile-core-module="${moduleSpec.key}"] [data-admin-mobile-core-pager="true"]`,
+      );
+      await expectInsideViewport(
+        pager,
+        viewport.width,
+        viewport.height,
+        `${viewport.name}: ${moduleSpec.key} pager`,
+      );
+
+      const nextButton = pager.getByRole("button", { name: /siguiente|próxim/i });
+      await expect(nextButton, `${viewport.name}: ${moduleSpec.key} next page button`).toBeVisible();
+      await expect(nextButton, `${viewport.name}: ${moduleSpec.key} next page button enabled`).toBeEnabled();
+
+      const firstPageLabels = await items.allTextContents();
+      await nextButton.click();
+      await expect
+        .poll(async () => (await items.allTextContents()).join("|"), {
+          message: `${viewport.name}: ${moduleSpec.key} page changes after pagination`,
+        })
+        .not.toBe(firstPageLabels.join("|"));
+
+      const page2Contract = await readNoScrollContract(
+        page,
+        `[data-admin-mobile-core-module="${moduleSpec.key}"]`,
+      );
+      assertNoScrollContract(page2Contract, `${viewport.name} ${moduleSpec.key} page 2`);
+
+      const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+      await bottomNav.getByRole("button", { name: "Inicio", exact: true }).click();
+      await expect(
+        page.locator('[data-admin-mobile-hub-launcher="true"]'),
+        `${viewport.name}: returning Inicio shows hub launcher`,
+      ).toBeVisible({ timeout: 15_000 });
+    });
+  }
+}
+
+test("Admin mobile core modules reachable from bottom nav and Más menu", async ({ page }) => {
+  const viewport = MOBILE_VIEWPORTS[0];
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await setAdminSession(page);
+  await mockAdminClinics(page);
+  await mockAdminReportWorkflow(page);
+  await mockAdminParticularTokens(page);
+  await page.goto("/dashboard/admin");
+  await suppressNextDevIndicator(page);
+
+  const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+  await expect(bottomNav).toBeVisible();
+
+  await bottomNav.getByRole("button", { name: "Clínicas", exact: true }).click();
+  await expect(
+    page.locator('[data-admin-mobile-core-module="clinics"]'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await bottomNav.getByRole("button", { name: "Más", exact: true }).click();
+  const moduleMenu = page.locator('[data-admin-mobile-module-menu="true"]');
+  await expect(moduleMenu).toBeVisible();
+  await moduleMenu
+    .locator('[data-admin-mobile-module-link="true"]')
+    .filter({ hasText: "Informes" })
+    .click();
+  await expect(
+    page.locator('[data-admin-mobile-core-module="reports"]'),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await bottomNav.getByRole("button", { name: "Más", exact: true }).click();
+  await expect(moduleMenu).toBeVisible();
+  await moduleMenu
+    .locator('[data-admin-mobile-module-link="true"]')
+    .filter({ hasText: "Tokens" })
+    .click();
+  await expect(
+    page.locator('[data-admin-mobile-core-module="tokens"]'),
+  ).toBeVisible({ timeout: 15_000 });
+});
+
+for (const moduleSpec of MODULES) {
+  test(`Admin desktop preserves ${moduleSpec.key} layout at 1280x800`, async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setAdminSession(page);
+    await moduleSpec.mock(page);
+    await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+
+    await expect(
+      page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+      `${moduleSpec.key} desktop: horizontal nav visible`,
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.locator('[data-admin-mobile-bottom-nav="true"]'),
+      `${moduleSpec.key} desktop: bottom nav absent`,
+    ).toBeHidden();
+    await expect(
+      page.locator(`[data-admin-mobile-core-module="${moduleSpec.key}"]`),
+      `${moduleSpec.key} desktop: mobile core module root absent`,
+    ).toBeHidden();
+  });
+}

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -430,7 +430,7 @@ export function AdminClinicsManagementCard() {
           <div className="clinical-alert-success">{successMessage}</div>
         ) : null}
 
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="hidden items-center justify-between gap-2 md:flex">
           <div className="relative max-w-xs flex-1">
             <Search
               className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
@@ -587,15 +587,35 @@ export function AdminClinicsManagementCard() {
         </div>
 
         <div
-          className="grid gap-2 md:hidden"
-          data-admin-clinics-mobile-list="true"
+          className="flex min-h-0 flex-1 flex-col gap-2 md:hidden"
+          data-admin-mobile-core-module="clinics"
         >
+          <div className="relative max-w-xs flex-1 shrink-0">
+            <Search
+              className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              className="h-8 pl-8 text-sm"
+              placeholder="Buscar clínica..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              disabled={isBusy}
+              aria-label="Buscar clínicas"
+            />
+          </div>
+
+          <div
+            className="grid min-h-0 flex-1 gap-2 overflow-hidden"
+            data-admin-clinics-mobile-list="true"
+          >
           {rows.length ? (
             rows.map(({ clinic, user, extraUsers }) => (
               <article
                 key={`mobile-${clinic.clinicId}-${user?.userId ?? "empty"}`}
                 className="rounded-lg border border-vetneb-line/70 bg-card/92 px-3 py-2 shadow-[0_1px_2px_rgba(15,45,62,0.05)]"
                 data-admin-clinic-mobile-card="true"
+                data-admin-mobile-core-item="true"
               >
                 <div className="flex min-w-0 items-start justify-between gap-2">
                   <div className="min-w-0">
@@ -664,6 +684,42 @@ export function AdminClinicsManagementCard() {
               )}
             </div>
           )}
+          </div>
+
+          {totalClinics > 0 ? (
+            <div
+              className="flex shrink-0 items-center justify-between gap-2 text-xs text-muted-foreground"
+              data-admin-mobile-core-pager="true"
+            >
+              <span className="tabular-nums">
+                {pageStart}–{pageEnd} de {totalClinics}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-9 w-9 p-0"
+                  onClick={() => loadClinics(currentOffset - effectivePageSize)}
+                  disabled={isBusy || !hasPrev}
+                  aria-label="Página anterior"
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-9 w-9 p-0"
+                  onClick={() => loadClinics(currentOffset + effectivePageSize)}
+                  disabled={isBusy || !hasNext}
+                  aria-label="Página siguiente"
+                >
+                  <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+              </div>
+            </div>
+          ) : null}
         </div>
         <ClinicEditDrawer
           clinic={editingClinic}

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -117,11 +117,13 @@ export function AdminClinicsManagementCard() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeActionKey, setActiveActionKey] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const [isMobileViewport, setIsMobileViewport] = useState(() =>
-    typeof window !== "undefined"
-      ? window.matchMedia("(max-width: 767px)").matches
-      : false,
-  );
+  // Start false so SSR and the client's first render agree. The media-query
+  // effect below promotes this to the real viewport value right after mount,
+  // which avoids a hydration mismatch on the mobile-only branches.
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  // Gates the initial fetch below until the viewport is known, so the first
+  // load uses the resolved effectivePageSize instead of the SSR-safe default.
+  const [isViewportResolved, setIsViewportResolved] = useState(false);
 
   const rows = useMemo(() => getClinicUserRows(snapshot), [snapshot]);
 
@@ -237,6 +239,7 @@ export function AdminClinicsManagementCard() {
 
     const updateMobileViewport = () => {
       setIsMobileViewport(mediaQuery.matches);
+      setIsViewportResolved(true);
     };
 
     updateMobileViewport();
@@ -250,6 +253,10 @@ export function AdminClinicsManagementCard() {
   const isFirstRender = useRef(true);
 
   useEffect(() => {
+    // Wait for the viewport to resolve so the first fetch below uses the
+    // settled effectivePageSize, not the SSR-safe desktop default.
+    if (!isViewportResolved) return;
+
     if (isFirstRender.current) {
       isFirstRender.current = false;
       loadClinics(0, searchQuery);
@@ -262,7 +269,7 @@ export function AdminClinicsManagementCard() {
 
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, effectivePageSize]);
+  }, [isViewportResolved, searchQuery, effectivePageSize]);
 
   return (
     <Card id="admin-clinics" className="dashboard-surface flex min-h-0 flex-1 flex-col">

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -411,11 +411,13 @@ export function AdminParticularTokensCard() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isMobileViewport, setIsMobileViewport] = useState(() =>
-    typeof window !== "undefined"
-      ? window.matchMedia("(max-width: 767px)").matches
-      : false,
-  );
+  // Start false so SSR and the client's first render agree. The media-query
+  // effect below promotes this to the real viewport value right after mount,
+  // which avoids a hydration mismatch on the mobile-only branches (the empty
+  // state and mobile list/pager). A mismatch would make React discard the
+  // server tree and regenerate it, leaving the toolbar's filter handlers
+  // briefly unbound and racing the no-scroll mobile contract.
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
 
   // Mobile renders a smaller, independently paginated slice of the same
   // server-side token list. Desktop keeps its own PAGE_SIZE=9 fetch untouched

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -74,6 +74,7 @@ const CREATE_STEP_LABELS: Record<CreateStep, string> = {
 // The API supports limit/offset but does not expose a total, so pagination uses
 // the returned page length to enable the next-page control.
 const PAGE_SIZE = 9;
+const MOBILE_PAGE_SIZE = 3;
 
 const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
   clinicId: "",
@@ -410,6 +411,18 @@ export function AdminParticularTokensCard() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isMobileViewport, setIsMobileViewport] = useState(() =>
+    typeof window !== "undefined"
+      ? window.matchMedia("(max-width: 767px)").matches
+      : false,
+  );
+
+  // Mobile renders a smaller, independently paginated slice of the same
+  // server-side token list. Desktop keeps its own PAGE_SIZE=9 fetch untouched
+  // so the dense viewport-safe contract stays pinned.
+  const [mobileTokens, setMobileTokens] = useState<AdminParticularTokenSummary[]>([]);
+  const [mobilePage, setMobilePage] = useState(0);
+  const [isLoadingMobileTokens, setIsLoadingMobileTokens] = useState(false);
 
   const selectedClinic = clinicOptions.find(
     (option) => String(option.id) === formState.clinicId,
@@ -425,7 +438,9 @@ export function AdminParticularTokensCard() {
   const selectedToken =
     selectedTokenId === null
       ? null
-      : (tokens.find((token) => token.id === selectedTokenId) ?? null);
+      : (tokens.find((token) => token.id === selectedTokenId) ??
+        mobileTokens.find((token) => token.id === selectedTokenId) ??
+        null);
   const selectedTrackingCase = selectedToken
     ? trackingCasesByTokenId[selectedToken.id]
     : null;
@@ -452,6 +467,11 @@ export function AdminParticularTokensCard() {
   const rangeStart = tokens.length ? page * PAGE_SIZE + 1 : 0;
   const rangeEnd = page * PAGE_SIZE + tokens.length;
   const canGoNext = tokens.length === PAGE_SIZE;
+  const mobileRangeStart = mobileTokens.length
+    ? mobilePage * MOBILE_PAGE_SIZE + 1
+    : 0;
+  const mobileRangeEnd = mobilePage * MOBILE_PAGE_SIZE + mobileTokens.length;
+  const canGoNextMobile = mobileTokens.length === MOBILE_PAGE_SIZE;
   const createStepIndex = getCreateStepIndex(createStep);
   const isLastCreateStep = createStep === "sample";
 
@@ -487,9 +507,49 @@ export function AdminParticularTokensCard() {
     [appliedClinicId, page],
   );
 
+  const loadMobileTokens = useCallback(
+    async (nextPage = mobilePage, nextClinicId = appliedClinicId) => {
+      setIsLoadingMobileTokens(true);
+
+      try {
+        const snapshot = await getAdminParticularTokens({
+          ...(nextClinicId ? { clinicId: nextClinicId } : {}),
+          limit: MOBILE_PAGE_SIZE,
+          offset: nextPage * MOBILE_PAGE_SIZE,
+        });
+        setMobileTokens(snapshot.particularTokens);
+      } catch {
+        setMobileTokens([]);
+      } finally {
+        setIsLoadingMobileTokens(false);
+      }
+    },
+    [appliedClinicId, mobilePage],
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+
+    const updateMobileViewport = () => {
+      setIsMobileViewport(mediaQuery.matches);
+    };
+
+    updateMobileViewport();
+    mediaQuery.addEventListener("change", updateMobileViewport);
+
+    return () => {
+      mediaQuery.removeEventListener("change", updateMobileViewport);
+    };
+  }, []);
+
   useEffect(() => {
     void loadTokens();
   }, [loadTokens]);
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    void loadMobileTokens();
+  }, [isMobileViewport, loadMobileTokens]);
 
   // The clinic catalogue is only needed by the creation flow. Deferring this
   // legacy paged load avoids doing it on every visit to the operational list.
@@ -713,12 +773,14 @@ export function AdminParticularTokensCard() {
     if (!normalized) {
       setAppliedClinicId(null);
       setPage(0);
+      setMobilePage(0);
       return;
     }
 
     try {
       setAppliedClinicId(parsePositiveInteger(normalized, "El ID de clínica"));
       setPage(0);
+      setMobilePage(0);
       setErrorMessage(null);
     } catch (error) {
       setErrorMessage(
@@ -731,6 +793,7 @@ export function AdminParticularTokensCard() {
     setClinicFilterDraft("");
     setAppliedClinicId(null);
     setPage(0);
+    setMobilePage(0);
     setErrorMessage(null);
   }
 
@@ -790,7 +853,9 @@ export function AdminParticularTokensCard() {
       setStatusMessage(response.message);
       resetForm();
       setPage(0);
+      setMobilePage(0);
       await loadTokens(0, appliedClinicId);
+      if (isMobileViewport) await loadMobileTokens(0, appliedClinicId);
       setIsCreateDialogOpen(false);
     } catch (error) {
       setErrorMessage(
@@ -830,6 +895,7 @@ export function AdminParticularTokensCard() {
         return next;
       });
       await loadTokens(page, appliedClinicId);
+      if (isMobileViewport) await loadMobileTokens(mobilePage, appliedClinicId);
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -1064,7 +1130,10 @@ export function AdminParticularTokensCard() {
               variant="outline"
               size="sm"
               className="md:h-8 md:px-2 md:text-xs"
-              onClick={() => void loadTokens()}
+              onClick={() => {
+                void loadTokens();
+                if (isMobileViewport) void loadMobileTokens();
+              }}
               disabled={isLoadingTokens}
             >
               {isLoadingTokens ? "Actualizando…" : "Actualizar"}
@@ -1152,40 +1221,99 @@ export function AdminParticularTokensCard() {
           </div>
 
           <div
-            data-admin-particulars-mobile-list="true"
-            className="divide-y divide-vetneb-line/60 rounded-lg border border-vetneb-line/75 md:hidden"
+            className="flex min-h-0 flex-1 flex-col gap-2 md:hidden"
+            data-admin-mobile-core-module="tokens"
           >
-            {tokens.map((token) => (
-              <div key={token.id} className="flex min-h-10 items-center gap-2 px-2.5 py-1.5">
-                <div className="min-w-0 flex-1">
-                  <p className="truncate font-mono text-xs font-semibold">
-                    ****{token.tokenLast4} · {token.petName}
-                  </p>
-                  <p className="truncate text-[0.6875rem] text-muted-foreground">
-                    Clínica #{token.clinicId} · {token.reportId ? `Informe #${token.reportId}` : "Sin informe"}
-                  </p>
+            <div
+              data-admin-particulars-mobile-list="true"
+              className="divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
+            >
+              {mobileTokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="flex min-h-10 items-center gap-2 px-2.5 py-1.5"
+                  data-admin-mobile-core-item="true"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-mono text-xs font-semibold">
+                      ****{token.tokenLast4} · {token.petName}
+                    </p>
+                    <p className="truncate text-[0.6875rem] text-muted-foreground">
+                      Clínica #{token.clinicId} · {token.reportId ? `Informe #${token.reportId}` : "Sin informe"}
+                    </p>
+                  </div>
+                  <Badge
+                    variant={token.isActive ? "default" : "outline"}
+                    className="h-5 px-1.5 text-[0.6875rem]"
+                  >
+                    {token.isActive ? "Activo" : "Inactivo"}
+                  </Badge>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    onClick={() => openTokenDetail(token)}
+                  >
+                    Ver
+                  </Button>
                 </div>
-                <Badge
-                  variant={token.isActive ? "default" : "outline"}
-                  className="h-5 px-1.5 text-[0.6875rem]"
-                >
-                  {token.isActive ? "Activo" : "Inactivo"}
-                </Badge>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 px-2 text-xs"
-                  onClick={() => openTokenDetail(token)}
-                >
-                  Ver
-                </Button>
+              ))}
+            </div>
+
+            {!mobileTokens.length && isMobileViewport ? (
+              <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
+                {isLoadingMobileTokens
+                  ? "Cargando tokens particulares…"
+                  : appliedClinicId
+                    ? `No hay tokens para la clínica #${appliedClinicId}.`
+                    : "No hay tokens particulares administrados."}
+              </p>
+            ) : null}
+
+            {mobileTokens.length ? (
+              <div
+                className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 pt-2 text-xs text-muted-foreground"
+                data-admin-mobile-core-pager="true"
+              >
+                <span>
+                  {mobileRangeStart}–{mobileRangeEnd}
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 text-xs"
+                    disabled={mobilePage === 0 || isLoadingMobileTokens}
+                    onClick={() => {
+                      setIsDetailDialogOpen(false);
+                      setMobilePage((current) => Math.max(0, current - 1));
+                    }}
+                  >
+                    Anterior
+                  </Button>
+                  <span className="min-w-12 text-center">Pág. {mobilePage + 1}</span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 text-xs"
+                    disabled={!canGoNextMobile || isLoadingMobileTokens}
+                    onClick={() => {
+                      setIsDetailDialogOpen(false);
+                      setMobilePage((current) => current + 1);
+                    }}
+                  >
+                    Siguiente
+                  </Button>
+                </div>
               </div>
-            ))}
+            ) : null}
           </div>
 
           {!tokens.length ? (
-            <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
+            <p className="surface-empty hidden min-h-20 flex-1 items-center justify-center text-xs md:flex">
               {isLoadingTokens
                 ? "Cargando tokens particulares…"
                 : appliedClinicId
@@ -1194,7 +1322,7 @@ export function AdminParticularTokensCard() {
             </p>
           ) : null}
 
-          <div className="mt-2 flex min-h-10 shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 px-1 pt-2 text-xs text-muted-foreground md:mt-1 md:min-h-8 md:pt-1">
+          <div className="mt-2 hidden min-h-10 shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 px-1 pt-2 text-xs text-muted-foreground md:mt-1 md:flex md:min-h-8 md:pt-1">
             <span>
               {tokens.length ? `${rangeStart}–${rangeEnd}` : "0 resultados"} · 9 por página
             </span>

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -79,11 +79,10 @@ export function AdminReportsCard() {
   const [mobilePage, setMobilePage] = useState(0);
   const [mobileHasMore, setMobileHasMore] = useState(false);
   const [isMobileLoading, setIsMobileLoading] = useState(true);
-  const [isMobileViewport, setIsMobileViewport] = useState(() =>
-    typeof window !== "undefined"
-      ? window.matchMedia("(max-width: 767px)").matches
-      : false,
-  );
+  // Start false so SSR and the client's first render agree. The media-query
+  // effect below promotes this to the real viewport value right after mount,
+  // which avoids a hydration mismatch on the mobile-only branches.
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
 
   const selectedReport = useMemo(
     () =>

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -37,6 +37,7 @@ import { AdminReportsUploadPanel } from "./AdminReportsUploadPanel";
 // PR-3 established nine dense rows as the safe 1366x768 limit while the App
 // Shell intentionally has no vertical scroll region.
 const PAGE_SIZE = 9;
+const MOBILE_PAGE_SIZE = 3;
 
 const STUDY_LABELS: Record<string, string> = {
   histopatologia: "Histopatología",
@@ -71,9 +72,25 @@ export function AdminReportsCard() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
+  // Mobile renders a smaller, independently paginated slice of the same
+  // server-side workflow queue. Desktop keeps its own PAGE_SIZE=9 fetch
+  // untouched so the dense viewport-safe contract stays pinned.
+  const [mobileReports, setMobileReports] = useState<AdminReportWorkflowItem[]>([]);
+  const [mobilePage, setMobilePage] = useState(0);
+  const [mobileHasMore, setMobileHasMore] = useState(false);
+  const [isMobileLoading, setIsMobileLoading] = useState(true);
+  const [isMobileViewport, setIsMobileViewport] = useState(() =>
+    typeof window !== "undefined"
+      ? window.matchMedia("(max-width: 767px)").matches
+      : false,
+  );
+
   const selectedReport = useMemo(
-    () => reports.find((report) => report.id === selectedReportId) ?? null,
-    [reports, selectedReportId],
+    () =>
+      reports.find((report) => report.id === selectedReportId) ??
+      mobileReports.find((report) => report.id === selectedReportId) ??
+      null,
+    [mobileReports, reports, selectedReportId],
   );
 
   const deliveredCount = reports.filter(
@@ -84,6 +101,10 @@ export function AdminReportsCard() {
   ).length;
   const rangeStart = reports.length ? page * PAGE_SIZE + 1 : 0;
   const rangeEnd = page * PAGE_SIZE + reports.length;
+  const mobileRangeStart = mobileReports.length
+    ? mobilePage * MOBILE_PAGE_SIZE + 1
+    : 0;
+  const mobileRangeEnd = mobilePage * MOBILE_PAGE_SIZE + mobileReports.length;
 
   const loadReports = useCallback(async (nextPage: number) => {
     setIsLoading(true);
@@ -113,12 +134,53 @@ export function AdminReportsCard() {
     }
   }, []);
 
+  const loadMobileReports = useCallback(async (nextPage: number) => {
+    setIsMobileLoading(true);
+
+    try {
+      const snapshot = await getAdminReportWorkflow({
+        limit: MOBILE_PAGE_SIZE,
+        offset: nextPage * MOBILE_PAGE_SIZE,
+      });
+      setMobileReports(snapshot.reports);
+      setMobileHasMore(snapshot.pagination.hasMore);
+    } catch {
+      setMobileReports([]);
+      setMobileHasMore(false);
+    } finally {
+      setIsMobileLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+
+    const updateMobileViewport = () => {
+      setIsMobileViewport(mediaQuery.matches);
+    };
+
+    updateMobileViewport();
+    mediaQuery.addEventListener("change", updateMobileViewport);
+
+    return () => {
+      mediaQuery.removeEventListener("change", updateMobileViewport);
+    };
+  }, []);
+
   useEffect(() => {
     void loadReports(page);
   }, [loadReports, page]);
 
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    void loadMobileReports(mobilePage);
+  }, [isMobileViewport, loadMobileReports, mobilePage]);
+
   function replaceReport(updated: AdminReportWorkflowItem) {
     setReports((current) =>
+      current.map((report) => (report.id === updated.id ? updated : report)),
+    );
+    setMobileReports((current) =>
       current.map((report) => (report.id === updated.id ? updated : report)),
     );
   }
@@ -182,6 +244,13 @@ export function AdminReportsCard() {
       await loadReports(0);
     } else {
       setPage(0);
+    }
+    if (isMobileViewport) {
+      if (mobilePage === 0) {
+        await loadMobileReports(0);
+      } else {
+        setMobilePage(0);
+      }
     }
   }
 
@@ -253,109 +322,157 @@ export function AdminReportsCard() {
           aria-label="Cola administrativa de informes"
           className="flex min-h-0 flex-1 flex-col"
         >
-          {reports.length ? (
-            <>
-              <div className="dashboard-table-responsive hidden min-h-0 flex-1 md:block">
-                <Table className="table-fixed text-[0.8125rem] [&_th]:h-8 [&_th]:px-2.5 [&_td]:px-2.5">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[20%]">Caso / paciente</TableHead>
-                      <TableHead className="w-[18%]">Clínica</TableHead>
-                      <TableHead className="w-[14%]">Estudio</TableHead>
-                      <TableHead className="w-[15%]">Estado</TableHead>
-                      <TableHead className="hidden w-[12%] lg:table-cell">Fecha</TableHead>
-                      <TableHead className="hidden w-[13%] xl:table-cell">Archivo</TableHead>
-                      <TableHead className="w-[8%] text-right">Acción</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {reports.map((report) => (
-                      <TableRow key={report.id}>
-                        <TableCell className="py-0.5">
-                          <p className="truncate font-medium text-vetneb-ink">
-                            {report.patientName || "Paciente sin registrar"}
-                          </p>
-                          <p className="font-mono text-[0.6875rem] text-muted-foreground">
-                            Informe #{report.id}
-                          </p>
-                        </TableCell>
-                        <TableCell className="py-0.5">
-                          <p className="truncate">
-                            {report.clinicName || `Clínica #${report.clinicId}`}
-                          </p>
-                        </TableCell>
-                        <TableCell className="py-0.5">
-                          <span className="block truncate">{studyLabel(report.studyType)}</span>
-                        </TableCell>
-                        <TableCell className="py-0.5">
-                          <AdminReportStatusBadge stage={report.workflowStage} />
-                          {report.specialStainRequested ? (
-                            <span className="ml-1 text-[0.6875rem] font-semibold text-amber-700">
-                              Tinción
-                            </span>
-                          ) : null}
-                        </TableCell>
-                        <TableCell className="hidden py-0.5 text-xs lg:table-cell">
-                          {formatDate(report.uploadDate ?? report.createdAt)}
-                        </TableCell>
-                        <TableCell className="hidden py-0.5 xl:table-cell">
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {report.fileName || "Sin archivo"}
+          <div className="dashboard-table-responsive hidden min-h-0 flex-1 md:block">
+            {reports.length ? (
+              <Table className="table-fixed text-[0.8125rem] [&_th]:h-8 [&_th]:px-2.5 [&_td]:px-2.5">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[20%]">Caso / paciente</TableHead>
+                    <TableHead className="w-[18%]">Clínica</TableHead>
+                    <TableHead className="w-[14%]">Estudio</TableHead>
+                    <TableHead className="w-[15%]">Estado</TableHead>
+                    <TableHead className="hidden w-[12%] lg:table-cell">Fecha</TableHead>
+                    <TableHead className="hidden w-[13%] xl:table-cell">Archivo</TableHead>
+                    <TableHead className="w-[8%] text-right">Acción</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {reports.map((report) => (
+                    <TableRow key={report.id}>
+                      <TableCell className="py-0.5">
+                        <p className="truncate font-medium text-vetneb-ink">
+                          {report.patientName || "Paciente sin registrar"}
+                        </p>
+                        <p className="font-mono text-[0.6875rem] text-muted-foreground">
+                          Informe #{report.id}
+                        </p>
+                      </TableCell>
+                      <TableCell className="py-0.5">
+                        <p className="truncate">
+                          {report.clinicName || `Clínica #${report.clinicId}`}
+                        </p>
+                      </TableCell>
+                      <TableCell className="py-0.5">
+                        <span className="block truncate">{studyLabel(report.studyType)}</span>
+                      </TableCell>
+                      <TableCell className="py-0.5">
+                        <AdminReportStatusBadge stage={report.workflowStage} />
+                        {report.specialStainRequested ? (
+                          <span className="ml-1 text-[0.6875rem] font-semibold text-amber-700">
+                            Tinción
                           </span>
-                        </TableCell>
-                        <TableCell className="py-0.5 text-right">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="h-7 px-2 text-xs"
-                            onClick={() => setSelectedReportId(report.id)}
-                          >
-                            Ver
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+                        ) : null}
+                      </TableCell>
+                      <TableCell className="hidden py-0.5 text-xs lg:table-cell">
+                        {formatDate(report.uploadDate ?? report.createdAt)}
+                      </TableCell>
+                      <TableCell className="hidden py-0.5 xl:table-cell">
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {report.fileName || "Sin archivo"}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-0.5 text-right">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-7 px-2 text-xs"
+                          onClick={() => setSelectedReportId(report.id)}
+                        >
+                          Ver
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
+                {isLoading ? "Cargando informes…" : "No hay informes en esta página."}
+              </p>
+            )}
+          </div>
 
-              <div className="divide-y divide-vetneb-line/60 rounded-md border border-vetneb-line/75 md:hidden">
-                {reports.map((report) => (
-                  <div
-                    key={report.id}
-                    className="flex min-h-10 items-center gap-2 px-2.5 py-1.5"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-semibold">
-                        #{report.id} · {report.patientName || "Sin paciente"}
-                      </p>
-                      <p className="truncate text-[0.6875rem] text-muted-foreground">
-                        {report.clinicName || `Clínica #${report.clinicId}`} · {studyLabel(report.studyType)}
-                      </p>
+          <div
+            className="flex min-h-0 flex-1 flex-col gap-2 md:hidden"
+            data-admin-mobile-core-module="reports"
+          >
+            {mobileReports.length ? (
+              <>
+                <div
+                  className="divide-y divide-vetneb-line/60 overflow-hidden rounded-md border border-vetneb-line/75"
+                  data-admin-reports-mobile-list="true"
+                >
+                  {mobileReports.map((report) => (
+                    <div
+                      key={report.id}
+                      className="flex min-h-10 items-center gap-2 px-2.5 py-1.5"
+                      data-admin-mobile-core-item="true"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-xs font-semibold">
+                          #{report.id} · {report.patientName || "Sin paciente"}
+                        </p>
+                        <p className="truncate text-[0.6875rem] text-muted-foreground">
+                          {report.clinicName || `Clínica #${report.clinicId}`} · {studyLabel(report.studyType)}
+                        </p>
+                      </div>
+                      <AdminReportStatusBadge stage={report.workflowStage} />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => setSelectedReportId(report.id)}
+                      >
+                        Ver
+                      </Button>
                     </div>
-                    <AdminReportStatusBadge stage={report.workflowStage} />
+                  ))}
+                </div>
+
+                <div
+                  className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 pt-2 text-xs text-muted-foreground"
+                  data-admin-mobile-core-pager="true"
+                >
+                  <span>
+                    {mobileRangeStart}–{mobileRangeEnd}
+                  </span>
+                  <div className="flex items-center gap-1.5">
                     <Button
                       type="button"
                       variant="outline"
                       size="sm"
-                      className="h-7 px-2 text-xs"
-                      onClick={() => setSelectedReportId(report.id)}
+                      className="h-9 w-9 p-0"
+                      disabled={mobilePage === 0 || isMobileLoading}
+                      onClick={() => setMobilePage((current) => Math.max(0, current - 1))}
+                      aria-label="Página anterior"
                     >
-                      Ver
+                      <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-9 w-9 p-0"
+                      disabled={!mobileHasMore || isMobileLoading}
+                      onClick={() => setMobilePage((current) => current + 1)}
+                      aria-label="Página siguiente"
+                    >
+                      <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
                     </Button>
                   </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
-              {isLoading ? "Cargando informes…" : "No hay informes en esta página."}
-            </p>
-          )}
+                </div>
+              </>
+            ) : isMobileViewport ? (
+              <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
+                {isMobileLoading ? "Cargando informes…" : "No hay informes en esta página."}
+              </p>
+            ) : null}
+          </div>
 
           <nav
-            className="mt-2 flex min-h-10 shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 px-1 pt-2 text-xs text-muted-foreground md:mt-1 md:min-h-8 md:pt-1"
+            className="mt-2 hidden min-h-10 shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 px-1 pt-2 text-xs text-muted-foreground md:mt-1 md:flex md:min-h-8 md:pt-1"
             aria-label="Paginación de informes admin"
           >
             <span>


### PR DESCRIPTION
﻿## Summary
- add Admin mobile no-scroll layouts for core modules: Clinics, Reports and Tokens
- introduce mobile-specific paginated cards/lists for dense module data
- preserve desktop PAGE_SIZE contracts and existing desktop layouts
- keep Clinic dashboard, Audit, Sessions and Users untouched
- add E2E coverage for mobile core modules across 360x740, 390x844 and 430x932

## Validation
- TDD red first: new core modules spec initially failed in mobile viewports before implementation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-hub-launcher-no-scroll.spec.ts e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts e2e/admin-mobile-module-layer-isolation.spec.ts e2e/dashboard-mobile-shell-nav-contract.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface

## Notes
- Scoped to Admin mobile core modules PR 3
- Does not touch Audit, Sessions, Users, Clinic dashboard, backend, auth, API, DB, dependencies, lockfiles, CI or docs
- Desktop PAGE_SIZE guard contracts remain intact
