### PR TITLE
fix(admin): add mobile ops modules no scroll contract

### DIFF
--- a/frontend/e2e/admin-mobile-module-layer-isolation.spec.ts
+++ b/frontend/e2e/admin-mobile-module-layer-isolation.spec.ts
@@ -299,7 +299,9 @@ for (const viewport of MOBILE_VIEWPORTS) {
       }),
     ).toBeVisible({ timeout: 15_000 });
     await expect(
-      sessionsWorkspace.locator('[aria-label="Paginación de sesiones"]'),
+      sessionsWorkspace.locator(
+        '[data-admin-mobile-ops-module="sessions"] [aria-label="Paginación de sesiones"]',
+      ),
     ).toBeVisible();
 
     await backToHub(page, viewport.name);
@@ -314,14 +316,14 @@ for (const viewport of MOBILE_VIEWPORTS) {
 
     const auditWorkspace = await openModule(page, "audit-log", viewport.name);
     await expect(
-      auditWorkspace.getByRole("heading", { name: "Registro operativo" }),
+      auditWorkspace.locator('[data-admin-mobile-ops-module="audit"]'),
     ).toBeVisible();
     await expect(auditWorkspace.locator("#audit-log")).toBeVisible();
 
     await backToHub(page, viewport.name);
     await expect(page.locator("#audit-log")).toHaveCount(0);
     await expect(
-      page.getByRole("heading", { name: "Registro operativo" }),
+      page.locator('[data-admin-mobile-ops-module="audit"]'),
     ).toHaveCount(0);
 
     const tokensWorkspace = await openModule(

--- a/frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
@@ -1,0 +1,379 @@
+import { expect, test, type Locator, type Page, type Route } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const MOCK_SESSIONS = Array.from({ length: 9 }, (_, index) => ({
+  sessionType: (["admin", "clinic", "particular"] as const)[index % 3],
+  sessionId: 8100 + index,
+  actorType: (["admin_user", "clinic_user", "particular_token"] as const)[
+    index % 3
+  ],
+  actorId: 310 + index,
+  createdAt: "2026-06-15T09:00:00.000Z",
+  lastAccess: "2026-06-19T18:45:00.000Z",
+  expiresAt: "2026-06-30T09:00:00.000Z",
+  status: index % 4 === 0 ? ("expired" as const) : ("active" as const),
+}));
+
+const MOCK_USERS = Array.from({ length: 9 }, (_, index) => {
+  if (index === 0) {
+    return {
+      userType: "admin" as const,
+      userId: 41,
+      username: "admin_operaciones",
+      role: "admin" as const,
+      clinicId: null,
+      clinicName: null,
+      createdAt: "2026-01-10T10:00:00.000Z",
+      updatedAt: "2026-06-18T12:00:00.000Z",
+    };
+  }
+
+  return {
+    userType: "clinic" as const,
+    userId: 9100 + index,
+    username: `usuario_clinica_${index}`,
+    role: index % 2 === 0 ? ("clinic_owner" as const) : ("clinic_staff" as const),
+    clinicId: 120 + index,
+    clinicName: `Clínica Operativa ${index}`,
+    clinicLocality: "Buenos Aires",
+    createdAt: "2026-02-10T10:00:00.000Z",
+    updatedAt: "2026-06-18T12:00:00.000Z",
+  };
+});
+
+type OpsModule = {
+  key: "audit" | "sessions" | "users";
+  moduleId: "audit-log" | "admin-sessions" | "admin-users-roles";
+  pagerName: RegExp;
+  primaryActionName: RegExp;
+};
+
+const OPS_MODULES: OpsModule[] = [
+  {
+    key: "audit",
+    moduleId: "audit-log",
+    pagerName: /paginación de auditoría/i,
+    primaryActionName: /filtros/i,
+  },
+  {
+    key: "sessions",
+    moduleId: "admin-sessions",
+    pagerName: /paginación de sesiones/i,
+    primaryActionName: /actualizar/i,
+  },
+  {
+    key: "users",
+    moduleId: "admin-users-roles",
+    pagerName: /paginación de usuarios/i,
+    primaryActionName: /actualizar/i,
+  },
+];
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function fulfillJson(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockOpsApis(page: Page) {
+  await page.route("**/api/admin/sessions**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== "GET" || url.pathname !== "/api/admin/sessions") {
+      await route.fallback();
+      return;
+    }
+
+    const limit = Number(url.searchParams.get("limit") ?? "8");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    await fulfillJson(route, {
+      success: true,
+      sessions: MOCK_SESSIONS.slice(offset, offset + limit),
+      total: MOCK_SESSIONS.length,
+      limit,
+      offset,
+      currentAdminSessionId: 8100,
+    });
+  });
+
+  await page.route("**/api/admin/users-roles**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== "GET" || url.pathname !== "/api/admin/users-roles") {
+      await route.fallback();
+      return;
+    }
+
+    const limit = Number(url.searchParams.get("limit") ?? "9");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    await fulfillJson(route, {
+      success: true,
+      users: MOCK_USERS.slice(offset, offset + limit),
+      total: MOCK_USERS.length,
+      limit,
+      offset,
+      totals: { adminUsers: 1, clinicUsers: 8 },
+    });
+  });
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function openModuleFromMobileNavigation(page: Page, module: OpsModule) {
+  await page.goto("/dashboard/admin");
+  await suppressNextDevIndicator(page);
+
+  const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+  await expect(bottomNav).toBeVisible({ timeout: 15_000 });
+
+  if (module.key === "audit") {
+    await bottomNav.getByRole("button", { name: "Auditoría", exact: true }).click();
+  } else if (module.key === "sessions") {
+    await bottomNav.getByRole("button", { name: "Sesiones", exact: true }).click();
+  } else {
+    await bottomNav.getByRole("button", { name: "Más", exact: true }).click();
+    const menu = page.locator('[data-admin-mobile-module-menu="true"]');
+    await expect(menu).toBeVisible();
+    await menu
+      .getByRole("button", { name: "Página siguiente de módulos", exact: true })
+      .click();
+    await menu
+      .locator('[data-admin-mobile-module-link="true"]')
+      .filter({ hasText: "Usuarios" })
+      .click();
+  }
+
+  await expect(
+    page.locator(`[data-dashboard-module-workspace="${module.moduleId}"]`),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+type NoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  module: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  forbiddenOverflow: Array<{
+    tag: string;
+    className: string;
+    overflowX: string;
+    overflowY: string;
+  }>;
+};
+
+async function readNoScrollContract(page: Page, selector: string): Promise<NoScrollContract> {
+  return page.evaluate((moduleSelector) => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const moduleRoot = document.querySelector<HTMLElement>(moduleSelector);
+
+    if (!moduleRoot) throw new Error(`Missing module root: ${moduleSelector}`);
+
+    const candidates = [
+      document.documentElement,
+      document.body,
+      ...(shell ? [shell] : []),
+      ...(main ? [main] : []),
+      moduleRoot,
+      ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")),
+    ];
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      if (
+        !["auto", "scroll"].includes(style.overflowX) &&
+        !["auto", "scroll"].includes(style.overflowY)
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          tag: element.tagName,
+          className: element.className,
+          overflowX: style.overflowX,
+          overflowY: style.overflowY,
+        },
+      ];
+    });
+
+    const metrics = (element: HTMLElement) => ({
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    });
+
+    return {
+      html: metrics(document.documentElement),
+      body: metrics(document.body),
+      module: metrics(moduleRoot),
+      forbiddenOverflow,
+    };
+  }, selector);
+}
+
+function assertNoScrollContract(contract: NoScrollContract, label: string) {
+  for (const [surface, metrics] of Object.entries({
+    html: contract.html,
+    body: contract.body,
+    module: contract.module,
+  })) {
+    expect(
+      metrics.scrollHeight,
+      `${label}: ${surface} vertical clipping/overflow`,
+    ).toBeLessThanOrEqual(metrics.clientHeight + TOLERANCE);
+    expect(
+      metrics.scrollWidth,
+      `${label}: ${surface} horizontal clipping/overflow`,
+    ).toBeLessThanOrEqual(metrics.clientWidth + TOLERANCE);
+  }
+
+  expect(contract.forbiddenOverflow, `${label}: overflow auto/scroll`).toEqual([]);
+}
+
+async function expectInsideViewport(
+  locator: Locator,
+  viewport: { width: number; height: number },
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.y, `${label}: top`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right`).toBeLessThanOrEqual(
+    viewport.width + TOLERANCE,
+  );
+  expect(box!.y + box!.height, `${label}: bottom`).toBeLessThanOrEqual(
+    viewport.height + TOLERANCE,
+  );
+}
+
+for (const moduleSpec of OPS_MODULES) {
+  for (const viewport of MOBILE_VIEWPORTS) {
+    test(`Admin mobile ops ${moduleSpec.key} is absolute no-scroll at ${viewport.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setPopulatedAdminSession(page);
+      await mockOpsApis(page);
+      await openModuleFromMobileNavigation(page, moduleSpec);
+
+      await expect(page.locator('[data-admin-mobile-app-bar="true"]')).toBeVisible();
+      await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeVisible();
+      await expect(page.locator('[data-dashboard-horizontal-nav-shell="true"]')).toBeHidden();
+
+      const moduleSelector = `[data-admin-mobile-ops-module="${moduleSpec.key}"]`;
+      const moduleRoot = page.locator(moduleSelector);
+      await expect(moduleRoot).toBeVisible({ timeout: 15_000 });
+
+      const items = moduleRoot.locator('[data-admin-mobile-ops-item="true"]');
+      await expect(items.first()).toBeVisible({ timeout: 15_000 });
+      const itemCount = await items.count();
+      expect(itemCount).toBeGreaterThan(0);
+      expect(itemCount).toBeLessThanOrEqual(4);
+
+      for (let index = 0; index < itemCount; index += 1) {
+        await expectInsideViewport(
+          items.nth(index),
+          viewport,
+          `${viewport.name} ${moduleSpec.key} item ${index + 1}`,
+        );
+      }
+
+      const pager = moduleRoot.getByRole("navigation", { name: moduleSpec.pagerName });
+      await expectInsideViewport(pager, viewport, `${viewport.name} ${moduleSpec.key} pager`);
+
+      const primaryAction = moduleRoot.getByRole("button", {
+        name: moduleSpec.primaryActionName,
+      }).first();
+      await expectInsideViewport(
+        primaryAction,
+        viewport,
+        `${viewport.name} ${moduleSpec.key} primary action`,
+      );
+
+      const pageOneLabels = await items.allTextContents();
+      const nextButton = pager.getByRole("button", { name: /siguiente/i });
+      await expect(nextButton).toBeEnabled();
+      await nextButton.click();
+      await expect
+        .poll(async () => (await items.allTextContents()).join("|"))
+        .not.toBe(pageOneLabels.join("|"));
+
+      assertNoScrollContract(
+        await readNoScrollContract(page, moduleSelector),
+        `${viewport.name} ${moduleSpec.key} page 2`,
+      );
+      await expectInsideViewport(pager, viewport, `${viewport.name} ${moduleSpec.key} page 2 pager`);
+
+      await primaryAction.click();
+      if (moduleSpec.key === "audit") {
+        const dialog = page.getByRole("dialog", { name: "Filtrar auditoría" });
+        await expect(dialog).toBeVisible();
+        await page.keyboard.press("Escape");
+        await expect(dialog).toBeHidden();
+      } else {
+        await expect(primaryAction).toBeEnabled();
+      }
+
+      assertNoScrollContract(
+        await readNoScrollContract(page, moduleSelector),
+        `${viewport.name} ${moduleSpec.key} action`,
+      );
+
+      await page
+        .locator('[data-admin-mobile-bottom-nav="true"]')
+        .getByRole("button", { name: "Inicio", exact: true })
+        .click();
+      await expect(page.locator('[data-admin-mobile-hub-launcher="true"]')).toBeVisible({
+        timeout: 15_000,
+      });
+    });
+  }
+}
+
+for (const moduleSpec of OPS_MODULES) {
+  test(`Admin desktop preserves ${moduleSpec.key} layout at 1280x800`, async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setPopulatedAdminSession(page);
+    await mockOpsApis(page);
+    await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+
+    await expect(page.locator('[data-dashboard-horizontal-nav-shell="true"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeHidden();
+    await expect(
+      page.locator(`[data-dashboard-module-workspace="${moduleSpec.moduleId}"]`),
+    ).toBeVisible();
+    await expect(
+      page.locator(`[data-admin-mobile-ops-module="${moduleSpec.key}"]`),
+    ).toBeHidden();
+  });
+}

--- a/frontend/src/app/dashboard/admin/AdminAuditCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminAuditCard.tsx
@@ -5,6 +5,7 @@ import {
   AdminAuditFilterBar,
   type AdminAuditFilterValues,
 } from "./AdminAuditFilterBar";
+import { AdminMobileAuditModule } from "./AdminMobileAuditModule";
 
 export const ADMIN_AUDIT_PAGE_SIZE = 9;
 
@@ -60,11 +61,25 @@ export function AdminAuditCard({
   const rangeEnd = Math.min(page * ADMIN_AUDIT_PAGE_SIZE, totalCount);
 
   return (
-    <section
-      id="audit-log"
-      aria-labelledby="admin-audit-register-title"
-      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card"
-    >
+    <div id="audit-log" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <AdminMobileAuditModule
+        rows={rows}
+        totalCount={totalCount}
+        serverPage={page}
+        serverPageSize={ADMIN_AUDIT_PAGE_SIZE}
+        loadError={loadError}
+        filters={filters}
+        eventOptions={eventOptions}
+        actorTypeOptions={actorTypeOptions}
+        globalTotal={globalTotal}
+        roleChangesTotal={roleChanges.total}
+        notificationsTotal={notifications.total}
+      />
+
+      <section
+        aria-labelledby="admin-audit-register-title"
+        className="dashboard-surface hidden min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card md:flex"
+      >
       <header className="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2 sm:px-4">
         <div className="min-w-0">
           <h2 id="admin-audit-register-title" className="text-base font-semibold text-vetneb-ink">
@@ -143,6 +158,7 @@ export function AdminAuditCard({
           </PublicRouteControl>
         </div>
       </footer>
-    </section>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/app/dashboard/admin/AdminMobileAuditModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileAuditModule.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { AdminAuditDetailDialog } from "./AdminAuditDetailDialog";
+import {
+  AdminAuditFilterBar,
+  type AdminAuditFilterValues,
+} from "./AdminAuditFilterBar";
+import type { AdminAuditRow } from "./AdminAuditDenseTable";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
+
+const MOBILE_PAGE_SIZE = 3;
+
+type FilterOption = {
+  value: string;
+  label: string;
+};
+
+type AdminMobileAuditModuleProps = {
+  rows: AdminAuditRow[];
+  totalCount: number;
+  serverPage: number;
+  serverPageSize: number;
+  loadError: boolean;
+  filters: AdminAuditFilterValues;
+  eventOptions: FilterOption[];
+  actorTypeOptions: FilterOption[];
+  globalTotal: number;
+  roleChangesTotal: number;
+  notificationsTotal: number;
+};
+
+function buildServerPageHref(filters: AdminAuditFilterValues, page: number) {
+  const query = new URLSearchParams({ module: "audit-log" });
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) query.set(key, value);
+  }
+  if (page > 1) query.set("auditPage", String(page));
+  return `/dashboard/admin?${query.toString()}`;
+}
+
+export function AdminMobileAuditModule({
+  rows,
+  totalCount,
+  serverPage,
+  serverPageSize,
+  loadError,
+  filters,
+  eventOptions,
+  actorTypeOptions,
+  globalTotal,
+  roleChangesTotal,
+  notificationsTotal,
+}: AdminMobileAuditModuleProps) {
+  const router = useRouter();
+  const [localPage, setLocalPage] = useState(0);
+  const hasActiveFilters = Object.values(filters).some(Boolean);
+  const localPageCount = Math.max(1, Math.ceil(rows.length / MOBILE_PAGE_SIZE));
+  const globalPageCount = Math.max(1, Math.ceil(totalCount / MOBILE_PAGE_SIZE));
+  const globalPage = Math.min(
+    globalPageCount,
+    (serverPage - 1) * Math.ceil(serverPageSize / MOBILE_PAGE_SIZE) + localPage + 1,
+  );
+  const visibleRows = rows.slice(
+    localPage * MOBILE_PAGE_SIZE,
+    localPage * MOBILE_PAGE_SIZE + MOBILE_PAGE_SIZE,
+  );
+  const rangeStart = visibleRows.length
+    ? (serverPage - 1) * serverPageSize + localPage * MOBILE_PAGE_SIZE + 1
+    : 0;
+  const rangeEnd = Math.min(rangeStart + visibleRows.length - 1, totalCount);
+  const hasPrevious = localPage > 0 || serverPage > 1;
+  const hasNext = localPage + 1 < localPageCount || rangeEnd < totalCount;
+
+  useEffect(() => {
+    setLocalPage(0);
+  }, [rows, serverPage]);
+
+  function goPrevious() {
+    if (localPage > 0) {
+      setLocalPage((current) => current - 1);
+      return;
+    }
+    if (serverPage > 1) {
+      router.push(buildServerPageHref(filters, serverPage - 1), { scroll: false });
+    }
+  }
+
+  function goNext() {
+    if (localPage + 1 < localPageCount) {
+      setLocalPage((current) => current + 1);
+      return;
+    }
+    if (rangeEnd < totalCount) {
+      router.push(buildServerPageHref(filters, serverPage + 1), { scroll: false });
+    }
+  }
+
+  return (
+    <section
+      data-admin-mobile-ops-module="audit"
+      aria-label="Registro operativo de auditoría"
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card md:hidden"
+    >
+      <div className="grid min-h-9 shrink-0 grid-cols-3 border-b border-vetneb-line/70 text-[11px]">
+        <div className="flex items-center justify-between gap-1 px-2">
+          <span className="truncate text-muted-foreground">Eventos</span>
+          <strong className="tabular-nums text-vetneb-ink">{globalTotal}</strong>
+        </div>
+        <div className="flex items-center justify-between gap-1 border-x border-vetneb-line/70 px-2">
+          <span className="truncate text-muted-foreground">Roles</span>
+          <strong className="tabular-nums text-vetneb-ink">{roleChangesTotal}</strong>
+        </div>
+        <div className="flex items-center justify-between gap-1 px-2">
+          <span className="truncate text-muted-foreground">Avisos</span>
+          <strong className="tabular-nums text-vetneb-ink">{notificationsTotal}</strong>
+        </div>
+      </div>
+
+      <AdminAuditFilterBar
+        values={filters}
+        eventOptions={eventOptions}
+        actorTypeOptions={actorTypeOptions}
+        hasActiveFilters={hasActiveFilters}
+      />
+
+      <div className="grid min-h-0 flex-1 grid-rows-3 overflow-hidden">
+        {loadError ? (
+          <div className="col-span-full row-span-3 flex items-center justify-center px-4 text-center text-xs text-destructive" role="alert">
+            No se pudieron cargar los eventos.
+          </div>
+        ) : visibleRows.length ? (
+          visibleRows.map((row) => (
+            <article
+              key={row.id}
+              data-admin-mobile-ops-item="true"
+              className="flex min-h-0 items-center gap-2 overflow-hidden border-b border-vetneb-line/70 px-2 py-1 last:border-b-0"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <Badge
+                    variant={row.eventVariant}
+                    className="h-5 max-w-[72%] truncate px-1.5 text-[11px] font-medium"
+                  >
+                    {row.eventLabel}
+                  </Badge>
+                  <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+                    #{row.id}
+                  </span>
+                </div>
+                <p className="truncate text-xs font-medium text-vetneb-ink">{row.actor}</p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  {row.entity} · {row.date}
+                </p>
+              </div>
+              <AdminAuditDetailDialog row={row} />
+            </article>
+          ))
+        ) : (
+          <div className="col-span-full row-span-3 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+            {hasActiveFilters
+              ? "No hay eventos para los filtros seleccionados."
+              : "No hay eventos de auditoría disponibles."}
+          </div>
+        )}
+      </div>
+
+      <AdminMobileOpsPager
+        ariaLabel="Paginación de auditoría"
+        page={globalPage}
+        pageCount={globalPageCount}
+        rangeLabel={visibleRows.length ? `${rangeStart}–${rangeEnd} de ${totalCount}` : "Sin eventos"}
+        previousDisabled={!hasPrevious}
+        nextDisabled={!hasNext}
+        disabled={loadError}
+        onPrevious={goPrevious}
+        onNext={goNext}
+      />
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileOpsPager.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileOpsPager.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type AdminMobileOpsPagerProps = {
+  ariaLabel: string;
+  page: number;
+  pageCount: number;
+  rangeLabel: string;
+  previousDisabled: boolean;
+  nextDisabled: boolean;
+  disabled?: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+};
+
+export function AdminMobileOpsPager({
+  ariaLabel,
+  page,
+  pageCount,
+  rangeLabel,
+  previousDisabled,
+  nextDisabled,
+  disabled = false,
+  onPrevious,
+  onNext,
+}: AdminMobileOpsPagerProps) {
+  return (
+    <nav
+      aria-label={ariaLabel}
+      data-admin-mobile-ops-pager="true"
+      className="flex min-h-10 shrink-0 items-center justify-between gap-2 overflow-hidden border-t border-vetneb-line/70 px-2 py-1 text-[11px] text-muted-foreground"
+    >
+      <span className="min-w-0 truncate" aria-live="polite">
+        {rangeLabel}
+      </span>
+      <div className="flex shrink-0 items-center gap-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Anterior"
+          disabled={disabled || previousDisabled}
+          onClick={onPrevious}
+        >
+          <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+        </Button>
+        <span className="min-w-14 text-center tabular-nums">
+          {page} / {pageCount}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Siguiente"
+          disabled={disabled || nextDisabled}
+          onClick={onNext}
+        >
+          <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </Button>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getAdminSessions, revokeAdminSession } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type {
+  AdminSessionStatus,
+  AdminSessionSummary,
+  AdminSessionType,
+  AdminSessionsSnapshot,
+} from "@/types";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
+
+const MOBILE_PAGE_SIZE = 3;
+
+function formatSessionType(value: AdminSessionType) {
+  if (value === "admin") return "Admin";
+  if (value === "clinic") return "Clínica";
+  return "Particular";
+}
+
+function formatActorType(value: AdminSessionSummary["actorType"]) {
+  if (value === "admin_user") return "Admin";
+  if (value === "clinic_user") return "Clínica";
+  return "Token particular";
+}
+
+function getSessionKey(session: AdminSessionSummary) {
+  return `${session.sessionType}-${session.sessionId}`;
+}
+
+export function AdminMobileSessionsModule() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [snapshot, setSnapshot] = useState<AdminSessionsSnapshot | null>(null);
+  const [sessionType, setSessionType] = useState<AdminSessionType | "all">("all");
+  const [status, setStatus] = useState<AdminSessionStatus | "all">("all");
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingSessionKey, setRevokingSessionKey] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const query = useMemo(
+    () => ({
+      ...(sessionType !== "all" ? { sessionType } : {}),
+      ...(status !== "all" ? { status } : {}),
+      limit: MOBILE_PAGE_SIZE,
+      offset,
+    }),
+    [offset, sessionType, status],
+  );
+
+  function loadSessions() {
+    if (!isMobileViewport) return;
+    setError(null);
+    startTransition(() => {
+      void (async () => {
+        try {
+          setSnapshot(await getAdminSessions(query));
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "No se pudieron cargar las sesiones.");
+        }
+      })();
+    });
+  }
+
+  async function handleRevokeSession(session: AdminSessionSummary) {
+    const sessionKey = getSessionKey(session);
+    const confirmed = window.confirm(
+      `¿Revocar la sesión ${formatSessionType(session.sessionType)} #${session.sessionId}? Esta acción cerrará esa sesión y quedará auditada.`,
+    );
+    if (!confirmed) return;
+
+    setError(null);
+    setRevokingSessionKey(sessionKey);
+    try {
+      await revokeAdminSession(session.sessionType, session.sessionId);
+      setSnapshot(await getAdminSessions(query));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo revocar la sesión seleccionada.");
+    } finally {
+      setRevokingSessionKey(null);
+    }
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    loadSessions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileViewport, query]);
+
+  const sessions = snapshot?.sessions ?? [];
+  const page = Math.floor(offset / MOBILE_PAGE_SIZE) + 1;
+  const pageCount = snapshot
+    ? Math.max(1, Math.ceil(snapshot.total / MOBILE_PAGE_SIZE))
+    : 1;
+  const rangeStart = sessions.length ? offset + 1 : 0;
+  const rangeEnd = offset + sessions.length;
+  const hasNextPage = snapshot ? rangeEnd < snapshot.total : false;
+  const disabled = isPending || revokingSessionKey !== null;
+
+  return (
+    <section
+      data-admin-mobile-ops-module="sessions"
+      aria-label="Sesiones administrativas"
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card md:hidden"
+    >
+      <header className="flex min-h-10 shrink-0 items-center justify-between gap-2 overflow-hidden border-b border-vetneb-line/70 px-2 py-1">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-vetneb-ink">
+            {snapshot ? `${snapshot.total} sesiones` : "Sesiones"}
+          </p>
+          <p className={`truncate text-[11px] ${error ? "text-destructive" : "text-muted-foreground"}`} role={error ? "alert" : undefined}>
+            {error ?? "Activas y expiradas"}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 shrink-0 px-2 text-xs"
+          onClick={loadSessions}
+          disabled={disabled || !isMobileViewport}
+          aria-busy={isPending ? true : undefined}
+        >
+          {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : null}
+          Actualizar
+        </Button>
+      </header>
+
+      <div className="grid min-h-12 shrink-0 grid-cols-2 gap-2 overflow-hidden border-b border-vetneb-line/70 bg-muted/15 px-2 py-1">
+        <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
+          Tipo
+          <select
+            className="field-select h-7 text-xs"
+            value={sessionType}
+            disabled={disabled}
+            onChange={(event) => {
+              setOffset(0);
+              setSessionType(event.target.value as AdminSessionType | "all");
+            }}
+          >
+            <option value="all">Todas</option>
+            <option value="admin">Admin</option>
+            <option value="clinic">Clínica</option>
+            <option value="particular">Particular</option>
+          </select>
+        </label>
+        <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
+          Estado
+          <select
+            className="field-select h-7 text-xs"
+            value={status}
+            disabled={disabled}
+            onChange={(event) => {
+              setOffset(0);
+              setStatus(event.target.value as AdminSessionStatus | "all");
+            }}
+          >
+            <option value="all">Todos</option>
+            <option value="active">Activas</option>
+            <option value="expired">Expiradas</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-rows-3 overflow-hidden">
+        {sessions.length ? (
+          sessions.map((session) => {
+            const sessionKey = getSessionKey(session);
+            const isRevoking = revokingSessionKey === sessionKey;
+            const isCurrentAdminSession =
+              session.sessionType === "admin" &&
+              session.sessionId === snapshot?.currentAdminSessionId;
+
+            return (
+              <article
+                key={sessionKey}
+                data-admin-mobile-ops-item="true"
+                className="flex min-h-0 items-center gap-2 overflow-hidden border-b border-vetneb-line/70 px-2 py-1 last:border-b-0"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <Badge variant={session.sessionType === "admin" ? "default" : "secondary"} className="h-5 px-1.5 text-[10px]">
+                      {formatSessionType(session.sessionType)}
+                    </Badge>
+                    <Badge variant={session.status === "active" ? "default" : "outline"} className="h-5 px-1.5 text-[10px]">
+                      {session.status === "active" ? "Activa" : "Expirada"}
+                    </Badge>
+                  </div>
+                  <p className="truncate text-xs font-medium text-vetneb-ink">
+                    {formatActorType(session.actorType)} · #{session.sessionId}
+                  </p>
+                  <p className="truncate text-[10px] text-muted-foreground">
+                    Acceso {session.lastAccess ? formatDateTime(session.lastAccess) : "—"}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 shrink-0 px-2 text-xs"
+                  disabled={disabled || isCurrentAdminSession}
+                  aria-busy={isRevoking ? true : undefined}
+                  aria-label={isCurrentAdminSession ? `Sesión ${formatSessionType(session.sessionType)} #${session.sessionId} actual, no se puede revocar` : `Revocar sesión ${formatSessionType(session.sessionType)} #${session.sessionId}`}
+                  onClick={() => void handleRevokeSession(session)}
+                >
+                  {isCurrentAdminSession ? "Actual" : isRevoking ? "Revocando..." : "Revocar"}
+                </Button>
+              </article>
+            );
+          })
+        ) : (
+          <div className="col-span-full row-span-3 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+            {error ? "Error al cargar sesiones" : isPending ? "Cargando sesiones..." : "Sin sesiones"}
+          </div>
+        )}
+      </div>
+
+      <AdminMobileOpsPager
+        ariaLabel="Paginación de sesiones"
+        page={page}
+        pageCount={pageCount}
+        rangeLabel={sessions.length ? `${rangeStart}–${rangeEnd} de ${snapshot?.total ?? 0}` : "Sin sesiones"}
+        previousDisabled={offset === 0}
+        nextDisabled={!hasNextPage}
+        disabled={disabled}
+        onPrevious={() => setOffset(Math.max(0, offset - MOBILE_PAGE_SIZE))}
+        onNext={() => setOffset(offset + MOBILE_PAGE_SIZE)}
+      />
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileUsersModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileUsersModule.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { changeAdminClinicUserRole, getAdminUsersRoles } from "@/lib/api";
+import type {
+  AdminRoleUserRole,
+  AdminRoleUserSummary,
+  AdminRoleUserType,
+  AdminUsersRolesSnapshot,
+  ClinicUserRole,
+} from "@/types";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
+
+const MOBILE_PAGE_SIZE = 3;
+
+function formatRole(value: AdminRoleUserRole) {
+  if (value === "admin") return "Admin";
+  if (value === "clinic_owner") return "Owner";
+  return "Staff";
+}
+
+function nextRole(value: ClinicUserRole): ClinicUserRole {
+  return value === "clinic_owner" ? "clinic_staff" : "clinic_owner";
+}
+
+function userKey(user: AdminRoleUserSummary) {
+  return `${user.userType}-${user.userId}`;
+}
+
+export function AdminMobileUsersModule() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [snapshot, setSnapshot] = useState<AdminUsersRolesSnapshot | null>(null);
+  const [userType, setUserType] = useState<AdminRoleUserType | "all">("all");
+  const [role, setRole] = useState<AdminRoleUserRole | "all">("all");
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [changingUserKey, setChangingUserKey] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const query = useMemo(
+    () => ({
+      ...(userType !== "all" ? { userType } : {}),
+      ...(role !== "all" ? { role } : {}),
+      limit: MOBILE_PAGE_SIZE,
+      offset,
+    }),
+    [offset, role, userType],
+  );
+
+  function loadUsers() {
+    if (!isMobileViewport) return;
+    setError(null);
+    startTransition(() => {
+      void (async () => {
+        try {
+          setSnapshot(await getAdminUsersRoles(query));
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "No se pudieron cargar usuarios y roles.");
+        }
+      })();
+    });
+  }
+
+  async function handleRoleChange(
+    user: Extract<AdminRoleUserSummary, { userType: "clinic" }>,
+  ) {
+    const targetRole = nextRole(user.role);
+    if (!window.confirm(`¿Cambiar el rol de ${user.username} a ${formatRole(targetRole)}? El cambio quedará registrado en auditoría.`)) return;
+
+    const key = userKey(user);
+    setError(null);
+    setChangingUserKey(key);
+    try {
+      const result = await changeAdminClinicUserRole(user.userId, targetRole);
+      setSnapshot((current) => current ? {
+        ...current,
+        users: current.users.map((entry) => entry.userType === "clinic" && entry.userId === result.user.userId ? result.user : entry),
+      } : current);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo cambiar el rol del usuario.");
+    } finally {
+      setChangingUserKey(null);
+    }
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    loadUsers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileViewport, query]);
+
+  const users = snapshot?.users ?? [];
+  const page = Math.floor(offset / MOBILE_PAGE_SIZE) + 1;
+  const pageCount = snapshot
+    ? Math.max(1, Math.ceil(snapshot.total / MOBILE_PAGE_SIZE))
+    : 1;
+  const rangeStart = users.length ? offset + 1 : 0;
+  const rangeEnd = offset + users.length;
+  const hasNextPage = snapshot ? rangeEnd < snapshot.total : false;
+  const disabled = isPending || changingUserKey !== null;
+
+  return (
+    <section
+      data-admin-mobile-ops-module="users"
+      aria-label="Usuarios y roles administrativos"
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card md:hidden"
+    >
+      <header className="flex min-h-10 shrink-0 items-center justify-between gap-2 overflow-hidden border-b border-vetneb-line/70 px-2 py-1">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-vetneb-ink">
+            {snapshot ? `${snapshot.total} usuarios` : "Usuarios"}
+          </p>
+          <p className={`truncate text-[11px] ${error ? "text-destructive" : "text-muted-foreground"}`} role={error ? "alert" : undefined}>
+            {error ?? "Roles y permisos"}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 shrink-0 px-2 text-xs"
+          onClick={loadUsers}
+          disabled={disabled || !isMobileViewport}
+          aria-busy={isPending ? true : undefined}
+        >
+          {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : null}
+          Actualizar
+        </Button>
+      </header>
+
+      <div className="grid min-h-12 shrink-0 grid-cols-2 gap-2 overflow-hidden border-b border-vetneb-line/70 bg-muted/15 px-2 py-1">
+        <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
+          Tipo
+          <select
+            className="field-select h-7 text-xs"
+            value={userType}
+            disabled={disabled}
+            onChange={(event) => {
+              setOffset(0);
+              setUserType(event.target.value as AdminRoleUserType | "all");
+            }}
+          >
+            <option value="all">Todos</option>
+            <option value="admin">Admin</option>
+            <option value="clinic">Clínica</option>
+          </select>
+        </label>
+        <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
+          Rol
+          <select
+            className="field-select h-7 text-xs"
+            value={role}
+            disabled={disabled}
+            onChange={(event) => {
+              setOffset(0);
+              setRole(event.target.value as AdminRoleUserRole | "all");
+            }}
+          >
+            <option value="all">Todos</option>
+            <option value="admin">Admin</option>
+            <option value="clinic_owner">Owner</option>
+            <option value="clinic_staff">Staff</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-rows-3 overflow-hidden">
+        {users.length ? (
+          users.map((user) => {
+            const key = userKey(user);
+            const isChanging = changingUserKey === key;
+            return (
+              <article
+                key={key}
+                data-admin-mobile-ops-item="true"
+                className="flex min-h-0 items-center gap-2 overflow-hidden border-b border-vetneb-line/70 px-2 py-1 last:border-b-0"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <p className="truncate text-xs font-semibold text-vetneb-ink">{user.username}</p>
+                    <Badge variant={user.role === "admin" ? "default" : user.role === "clinic_owner" ? "secondary" : "outline"} className="h-5 shrink-0 px-1.5 text-[10px]">
+                      {formatRole(user.role)}
+                    </Badge>
+                  </div>
+                  <p className="truncate text-[11px] text-muted-foreground">
+                    ID {user.userId} · {user.userType === "admin" ? "Administración" : user.clinicName ?? `Clínica #${user.clinicId}`}
+                  </p>
+                </div>
+                {user.userType === "clinic" ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 shrink-0 px-2 text-xs"
+                    disabled={disabled}
+                    aria-busy={isChanging ? true : undefined}
+                    onClick={() => void handleRoleChange(user)}
+                  >
+                    {isChanging ? "Cambiando..." : "Cambiar"}
+                  </Button>
+                ) : (
+                  <Badge variant="default" className="h-5 shrink-0 px-1.5 text-[10px]">Admin</Badge>
+                )}
+              </article>
+            );
+          })
+        ) : (
+          <div className="col-span-full row-span-3 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+            {error ? "Error al cargar usuarios" : isPending ? "Cargando usuarios..." : "Sin usuarios"}
+          </div>
+        )}
+      </div>
+
+      <AdminMobileOpsPager
+        ariaLabel="Paginación de usuarios"
+        page={page}
+        pageCount={pageCount}
+        rangeLabel={users.length ? `${rangeStart}–${rangeEnd} de ${snapshot?.total ?? 0}` : "Sin usuarios"}
+        previousDisabled={offset === 0}
+        nextDisabled={!hasNextPage}
+        disabled={disabled}
+        onPrevious={() => setOffset(Math.max(0, offset - MOBILE_PAGE_SIZE))}
+        onNext={() => setOffset(offset + MOBILE_PAGE_SIZE)}
+      />
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx
@@ -21,6 +21,7 @@ import type {
   AdminSessionType,
   AdminSessionsSnapshot,
 } from "@/types";
+import { AdminMobileSessionsModule } from "./AdminMobileSessionsModule";
 
 // Eight rows preserve the 1366×768 no-scroll contract because the workspace also
 // renders the credential-change control above this card.
@@ -95,6 +96,7 @@ function SessionStatusBadge({ status }: SessionStatusBadgeProps) {
 }
 
 export function AdminSessionsReadOnlyCard() {
+  const [isDesktopViewport, setIsDesktopViewport] = useState(false);
   const [snapshot, setSnapshot] = useState<AdminSessionsSnapshot | null>(null);
   const [sessionType, setSessionType] = useState<AdminSessionType | "all">(
     "all",
@@ -167,9 +169,18 @@ export function AdminSessionsReadOnlyCard() {
   }
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const syncViewport = () => setIsDesktopViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopViewport) return;
     loadSessions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [isDesktopViewport, query]);
 
   const sessions = snapshot?.sessions ?? [];
   const hasPreviousPage = offset > 0;
@@ -190,7 +201,9 @@ export function AdminSessionsReadOnlyCard() {
   const disableActions = isPending || revokingSessionKey !== null;
 
   return (
-    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none">
+    <>
+      <AdminMobileSessionsModule />
+      <Card className="dashboard-surface hidden min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none md:flex">
       <CardHeader className="flex min-h-11 shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-3 py-1 sm:px-4">
         <div className="min-w-0">
           <CardTitle className="text-base">Sesiones activas y expiradas</CardTitle>
@@ -521,6 +534,7 @@ export function AdminSessionsReadOnlyCard() {
           </div>
         </footer>
       </CardContent>
-    </Card>
+      </Card>
+    </>
   );
 }

--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -22,6 +22,7 @@ import type {
   AdminUsersRolesSnapshot,
   ClinicUserRole,
 } from "@/types";
+import { AdminMobileUsersModule } from "./AdminMobileUsersModule";
 
 // Nine compact rows are the viewport-safe contract established for the admin
 // modules while dashboard-main intentionally remains non-scrollable.
@@ -132,6 +133,7 @@ function AdminUserTypeBadge({ userType }: UserTypeBadgeProps) {
 }
 
 export function AdminUsersRolesReadOnlyCard() {
+  const [isDesktopViewport, setIsDesktopViewport] = useState(false);
   const [snapshot, setSnapshot] = useState<AdminUsersRolesSnapshot | null>(null);
   const [userType, setUserType] = useState<AdminRoleUserType | "all">("all");
   const [role, setRole] = useState<AdminRoleUserRole | "all">("all");
@@ -233,9 +235,18 @@ export function AdminUsersRolesReadOnlyCard() {
   }
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const syncViewport = () => setIsDesktopViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopViewport) return;
     loadUsersRoles();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [isDesktopViewport, query]);
 
   const users = snapshot?.users ?? [];
   const hasPreviousPage = offset > 0;
@@ -248,7 +259,9 @@ export function AdminUsersRolesReadOnlyCard() {
   const rangeEnd = offset + users.length;
 
   return (
-    <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none">
+    <>
+      <AdminMobileUsersModule />
+      <Card className="dashboard-surface hidden min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none md:flex">
       <CardHeader className="flex min-h-12 shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-vetneb-line/70 px-3 py-2 sm:px-4 md:min-h-10 md:py-1.5">
         <div className="min-w-0">
           <CardTitle className="text-base">Usuarios y roles</CardTitle>
@@ -535,6 +548,7 @@ export function AdminUsersRolesReadOnlyCard() {
           </div>
         </footer>
       </CardContent>
-    </Card>
+      </Card>
+    </>
   );
 }

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -767,7 +767,7 @@ export default async function AdminPage({
   // tab/card — keeping the card the primary, no-scroll surface.
   const sessionsWorkspaceSlot = (
     <section id="admin-sessions" className="flex min-h-0 flex-1 flex-col gap-2">
-      <div className="flex shrink-0 items-center justify-end">
+      <div className="hidden shrink-0 items-center justify-end md:flex">
         <ModuleDialog
           title="Cambiar contraseña"
           description="Actualizá tu contraseña de acceso sin cerrar la sesión actual."

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2815,3 +2815,30 @@
   }
 }
 /* admin-mobile-hub-launcher:end */
+/* admin-mobile-ops-modules:start */
+@media (max-width: 767px) {
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-workspace]:has([data-admin-mobile-ops-module])
+    .dashboard-workspace-header {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-workspace]:has([data-admin-mobile-ops-module])
+    [data-dashboard-module-viewport] {
+    min-height: 0;
+    overflow: hidden;
+    padding-top: 0 !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] [data-admin-mobile-ops-module],
+  [data-vetneb-app-shell-surface="admin"]
+    [data-admin-mobile-ops-module]
+    :is(article, nav, header) {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+    overflow-y: hidden;
+  }
+}
+/* admin-mobile-ops-modules:end */


### PR DESCRIPTION
## Summary
- add Admin mobile no-scroll layouts for ops modules: Audit, Sessions and Users
- introduce compact mobile paginated cards/lists with 3 items per page
- preserve desktop layouts and 1280x800 behavior
- preserve Clinic dashboard and previously closed Admin modules
- add E2E coverage for ops modules across 360x740, 390x844 and 430x932
- update the mobile layer isolation selector for the new ops mobile layouts

## Validation
- TDD red first: new ops modules spec initially failed in mobile viewports because mobile roots did not exist
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts e2e/admin-mobile-hub-launcher-no-scroll.spec.ts e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts e2e/admin-mobile-module-layer-isolation.spec.ts e2e/dashboard-mobile-shell-nav-contract.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface

## Notes
- Scoped to Admin mobile ops modules PR 4
- Does not touch Clinic dashboard, core modules already closed in #1068, backend, auth, API, DB, dependencies, lockfiles, CI or docs
- Keeps the absolute no-scroll contract for Admin mobile modules
