### PR TITLE
fix(admin): close mobile no scroll polish

### DIFF
--- a/docs/audit/admin-mobile-final-polish-no-scroll-closeout.md
+++ b/docs/audit/admin-mobile-final-polish-no-scroll-closeout.md
@@ -1,0 +1,151 @@
+# Admin Mobile Final Polish / No-Scroll Closeout
+
+## Estado base
+
+- Fecha: 2026-06-20.
+- Rama: `polish/admin-mobile-final-no-scroll`.
+- HEAD inicial: `6a951f6 fix(admin): add mobile ops modules no scroll contract (#1069)`.
+- Working tree inicial: limpio.
+- Entorno: Windows, PowerShell y PNPM.
+
+## Scope incluido
+
+- Auditoría visual y geométrica final de Admin mobile.
+- Viewports mobile: 360×740, 390×844 y 430×932.
+- Smoke desktop: 1280×800.
+- Superficies auditadas:
+  - launcher, páginas 1 y 2;
+  - Clínicas;
+  - Informes;
+  - Tokens;
+  - Auditoría;
+  - Sesiones;
+  - Usuarios;
+  - menú Más;
+  - menú de administración;
+  - notificaciones;
+  - app bar, bottom nav y navegación horizontal desktop.
+- Nuevo spec final con datos poblados, screenshots y contrato no-scroll.
+- Dos correcciones visuales mínimas demostradas en 360×740.
+
+No existe una pantalla de perfil Admin dedicada en el shell actual. Las acciones personales aplicables se auditaron en el menú de administración: apariencia, notificaciones, cambio de contraseña, sitio público y cierre de sesión.
+
+## Scope excluido
+
+- Backend, DB, Drizzle, schema y migraciones.
+- Auth, cookies, roles, permisos, CSRF, CORS, CSP y rate limits.
+- Endpoints y contratos de datos.
+- Dependencias, `package.json`, `pnpm-lock.yaml`, CI, workflows y Dependabot.
+- Cambios en Clínica.
+- Cambios de page size.
+- Refactors, rediseño del shell o reapertura de módulos cerrados.
+- Commit, push y PR.
+
+## Auditoría previa
+
+- Rama, HEAD y working tree coincidieron con la base esperada.
+- Se identificaron los diez specs contractuales solicitados.
+- Se confirmaron los scripts nativos de typecheck, lint, build, test y seguridad.
+- No se encontraron referencias relacionadas en `legacy/`.
+- Se identificaron los componentes Admin mobile y el CSS scoped existentes.
+- Se confirmó el patrón documental mediante `docs/audit/admin-mobile-density-closeout.md`.
+
+## Spec y screenshots
+
+Se creó:
+
+- `frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts`.
+
+El spec valida:
+
+- `html`, `body`, app shell, `main` y superficie activa sin overflow geométrico;
+- ausencia de `overflow:auto` y `overflow:scroll` en Admin mobile;
+- ausencia de overflow horizontal;
+- app bar y bottom nav dentro del viewport;
+- superficie, ítems y pagers entre app bar y bottom nav;
+- ítems no recortados por ancestros con overflow de clipping;
+- launcher, menú Más, menú de administración y notificaciones;
+- contenido poblado en los seis módulos operativos auditados;
+- navegación horizontal desktop visible;
+- bottom nav y raíces mobile ausentes en desktop;
+- contenido desktop poblado antes de capturar.
+
+Las capturas se generan en la carpeta estable e ignorada por Git:
+
+- `frontend/test-results/admin-mobile-final-polish-no-scroll/`.
+
+Resultado final: 40 capturas, una por viewport y pantalla auditada.
+
+## Hallazgos visuales reales
+
+### 1. Clínicas 360×740
+
+El wrapper del buscador mobile tenía `flex-1`. Consumía una franja vertical vacía y empujaba la tercera card aproximadamente 42 px debajo del inicio de la bottom nav.
+
+Corrección:
+
+- se eliminó `flex-1` únicamente del wrapper del buscador mobile;
+- se conservaron tres cards por página;
+- no se eliminó información;
+- no se introdujo scroll.
+
+### 2. Tokens 360×740
+
+Los tabs `Tokens administrados` y `Generar token` usaban tamaño mobile mayor que desktop. En 360 px, el segundo tab saltaba a una fila adicional y la tercera fila de tokens quedaba recortada por el contenedor no-scroll.
+
+Corrección:
+
+- ambos tabs usan `h-8 px-2 text-xs`, el mismo tamaño compacto ya aplicado en desktop;
+- los tabs quedan en una sola fila;
+- las tres filas y el pager quedan completos;
+- no se cambió el page size ni el contrato de datos.
+
+No se detectaron otros defectos visuales o geométricos que justificaran cambios de producto.
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts` | Spec final, datos poblados deterministas, screenshots, no-scroll, geometría, clipping y desktop smoke. |
+| `frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx` | Elimina crecimiento vertical incorrecto del buscador mobile. |
+| `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx` | Compacta los dos tabs de Tokens para evitar wrap y clipping a 360 px. |
+| `docs/audit/admin-mobile-final-polish-no-scroll-closeout.md` | Evidencia de auditoría, cambios y validaciones. |
+
+## Validaciones
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend typecheck` | PASS |
+| `pnpm --dir frontend lint` | PASS |
+| `pnpm typecheck` | PASS |
+| `pnpm --dir frontend exec playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts` | PASS, 4/4 |
+| Matriz Admin mobile/no-scroll principal solicitada | PASS, 68/68 |
+| App shell real + visibilidad solicitados | PASS, 41/41 |
+| Paridad Clínica solicitada | PASS, 12/12 |
+| `pnpm --dir frontend build` | PASS |
+| `pnpm build` | PASS |
+| `pnpm test` | PASS, 2815/2815 |
+| `pnpm security:public-surface` | PASS |
+
+Los E2E emitieron mensajes esperados de fixtures para endpoints no disponibles en escenarios no poblados. La matriz de app shell también mostró warnings Radix preexistentes de título/descripción en dialogs de Clínica. No hubo fallos asociados y no se modificó Clínica.
+
+## Resultado
+
+- Launcher, módulos core, módulos ops, menús y notificaciones cubiertos.
+- Sin scroll global, interno ni horizontal en Admin mobile.
+- Sin cards, filas, acciones o pagers recortados.
+- App bar y bottom nav visibles y sin solapamientos.
+- Desktop preserva navegación y layouts propios.
+- Clínica preservada y su matriz solicitada permanece verde.
+- Scope mínimo, sin arquitectura nueva y sin commit.
+
+## Riesgo residual
+
+- Bajo.
+- Las correcciones son clases scoped en dos componentes Admin existentes.
+- Las capturas no se versionan; se regeneran al ejecutar el spec final.
+- Los warnings Radix observados pertenecen a Clínica y quedan fuera de este PR.
+
+## Estado final
+
+Closeout Admin mobile completo y validado. Pendiente únicamente la revisión manual de diff, stage, commit, push, PR y checks por Nico.

--- a/frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts
@@ -1,0 +1,634 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type Route,
+  type TestInfo,
+} from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const DESKTOP_VIEWPORT = {
+  name: "desktop-1280x800",
+  width: 1280,
+  height: 800,
+} as const;
+
+const MOCK_CLINICS = Array.from({ length: 9 }, (_, index) => {
+  const id = index + 1;
+  return {
+    clinicId: id,
+    clinicName: `Clínica Final ${id}`,
+    contactEmail: `clinica.final.${id}@example.test`,
+    contactPhone: `+54 11 5555-${String(id).padStart(4, "0")}`,
+    createdAt: "2026-06-01T10:00:00.000Z",
+    updatedAt: `2026-06-${String(id).padStart(2, "0")}T12:00:00.000Z`,
+    users: [
+      {
+        userId: 100 + id,
+        username: `final-owner-${id}`,
+        createdAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      },
+    ],
+  };
+});
+
+const MOCK_SESSIONS = Array.from({ length: 9 }, (_, index) => ({
+  sessionType: (["admin", "clinic", "particular"] as const)[index % 3],
+  sessionId: 8200 + index,
+  actorType: (["admin_user", "clinic_user", "particular_token"] as const)[
+    index % 3
+  ],
+  actorId: 410 + index,
+  createdAt: "2026-06-15T09:00:00.000Z",
+  lastAccess: "2026-06-19T18:45:00.000Z",
+  expiresAt: "2026-06-30T09:00:00.000Z",
+  status: index % 4 === 0 ? ("expired" as const) : ("active" as const),
+}));
+
+type Viewport = {
+  name: string;
+  width: number;
+  height: number;
+};
+
+type AdminModuleScreen = {
+  key: "clinics" | "reports" | "tokens" | "audit" | "sessions" | "users";
+  moduleId:
+    | "admin-clinics"
+    | "admin-report-upload"
+    | "admin-particular-tokens"
+    | "audit-log"
+    | "admin-sessions"
+    | "admin-users-roles";
+  mobileRoot: string;
+  itemSelector: string;
+  pagerSelector: string;
+  desktopReady: string | RegExp;
+};
+
+const MODULE_SCREENS: AdminModuleScreen[] = [
+  {
+    key: "clinics",
+    moduleId: "admin-clinics",
+    mobileRoot: '[data-admin-mobile-core-module="clinics"]',
+    itemSelector: '[data-admin-mobile-core-item="true"]',
+    pagerSelector: '[data-admin-mobile-core-pager="true"]',
+    desktopReady: "Clínica Final 1",
+  },
+  {
+    key: "reports",
+    moduleId: "admin-report-upload",
+    mobileRoot: '[data-admin-mobile-core-module="reports"]',
+    itemSelector: '[data-admin-mobile-core-item="true"]',
+    pagerSelector: '[data-admin-mobile-core-pager="true"]',
+    desktopReady: "#7301",
+  },
+  {
+    key: "tokens",
+    moduleId: "admin-particular-tokens",
+    mobileRoot: '[data-admin-mobile-core-module="tokens"]',
+    itemSelector: '[data-admin-mobile-core-item="true"]',
+    pagerSelector: '[data-admin-mobile-core-pager="true"]',
+    desktopReady: "****4201",
+  },
+  {
+    key: "audit",
+    moduleId: "audit-log",
+    mobileRoot: '[data-admin-mobile-ops-module="audit"]',
+    itemSelector: '[data-admin-mobile-ops-item="true"]',
+    pagerSelector: 'nav[aria-label="Paginación de auditoría"]',
+    desktopReady: "Login admin",
+  },
+  {
+    key: "sessions",
+    moduleId: "admin-sessions",
+    mobileRoot: '[data-admin-mobile-ops-module="sessions"]',
+    itemSelector: '[data-admin-mobile-ops-item="true"]',
+    pagerSelector: 'nav[aria-label="Paginación de sesiones"]',
+    desktopReady: "#8200",
+  },
+  {
+    key: "users",
+    moduleId: "admin-users-roles",
+    mobileRoot: '[data-admin-mobile-ops-module="users"]',
+    itemSelector: '[data-admin-mobile-ops-item="true"]',
+    pagerSelector: 'nav[aria-label="Paginación de usuarios"]',
+    desktopReady: "admin_operaciones",
+  },
+];
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function fulfillJson(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockMissingPopulatedApis(page: Page) {
+  await page.route("**/api/admin/clinics**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== "GET" || url.pathname !== "/api/admin/clinics") {
+      await route.fallback();
+      return;
+    }
+
+    const limit = Number(url.searchParams.get("limit") ?? "9");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    await fulfillJson(route, {
+      success: true,
+      clinics: MOCK_CLINICS.slice(offset, offset + limit),
+      total: MOCK_CLINICS.length,
+      limit,
+      offset,
+    });
+  });
+
+  await page.route("**/api/admin/sessions**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() !== "GET" || url.pathname !== "/api/admin/sessions") {
+      await route.fallback();
+      return;
+    }
+
+    const limit = Number(url.searchParams.get("limit") ?? "8");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    await fulfillJson(route, {
+      success: true,
+      sessions: MOCK_SESSIONS.slice(offset, offset + limit),
+      total: MOCK_SESSIONS.length,
+      limit,
+      offset,
+      currentAdminSessionId: 8200,
+    });
+  });
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function preparePage(page: Page, viewport: Viewport, path: string) {
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.emulateMedia({ colorScheme: "light", reducedMotion: "reduce" });
+  await page.goto(path);
+  await suppressNextDevIndicator(page);
+}
+
+async function captureScreen(
+  page: Page,
+  testInfo: TestInfo,
+  viewportName: string,
+  screenName: string,
+) {
+  const screenshotDirectory = resolve(
+    testInfo.config.rootDir,
+    "..",
+    "test-results",
+    "admin-mobile-final-polish-no-scroll",
+  );
+  await mkdir(screenshotDirectory, { recursive: true });
+  await page.screenshot({
+    path: resolve(screenshotDirectory, `${viewportName}--${screenName}.png`),
+    animations: "disabled",
+    fullPage: false,
+  });
+}
+
+type SurfaceContract = {
+  metrics: Array<{
+    label: string;
+    scrollHeight: number;
+    clientHeight: number;
+    scrollWidth: number;
+    clientWidth: number;
+  }>;
+  forbiddenOverflow: Array<{
+    tag: string;
+    className: string;
+    overflowX: string;
+    overflowY: string;
+  }>;
+};
+
+async function readSurfaceContract(
+  page: Page,
+  activeSelector: string,
+  includeDescendants = true,
+): Promise<SurfaceContract> {
+  return page.evaluate(({ selector, includeActiveDescendants }) => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const activeRoot = document.querySelector<HTMLElement>(selector);
+
+    if (!shell || !main || !activeRoot) {
+      throw new Error(`Admin final polish contract is incomplete for ${selector}`);
+    }
+
+    const roots: Array<{ label: string; element: HTMLElement }> = [
+      { label: "html", element: document.documentElement },
+      { label: "body", element: document.body },
+      { label: "shell", element: shell },
+      { label: "main", element: main },
+      { label: "active", element: activeRoot },
+    ];
+    const overflowCandidates = [
+      shell,
+      main,
+      activeRoot,
+      ...(includeActiveDescendants
+        ? Array.from(activeRoot.querySelectorAll<HTMLElement>("*"))
+        : []),
+    ];
+
+    return {
+      metrics: roots.map(({ label, element }) => ({
+        label,
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+        scrollWidth: element.scrollWidth,
+        clientWidth: element.clientWidth,
+      })),
+      forbiddenOverflow: overflowCandidates.flatMap((element) => {
+        const style = window.getComputedStyle(element);
+        if (
+          !["auto", "scroll"].includes(style.overflowX) &&
+          !["auto", "scroll"].includes(style.overflowY)
+        ) {
+          return [];
+        }
+
+        return [
+          {
+            tag: element.tagName,
+            className: element.className,
+            overflowX: style.overflowX,
+            overflowY: style.overflowY,
+          },
+        ];
+      }),
+    };
+  }, { selector: activeSelector, includeActiveDescendants: includeDescendants });
+}
+
+function assertSurfaceContract(contract: SurfaceContract, label: string) {
+  for (const metrics of contract.metrics) {
+    expect(
+      metrics.scrollHeight,
+      `${label}: ${metrics.label} vertical overflow or clipping`,
+    ).toBeLessThanOrEqual(metrics.clientHeight + TOLERANCE);
+    expect(
+      metrics.scrollWidth,
+      `${label}: ${metrics.label} horizontal overflow or clipping`,
+    ).toBeLessThanOrEqual(metrics.clientWidth + TOLERANCE);
+  }
+
+  expect(contract.forbiddenOverflow, `${label}: overflow auto/scroll`).toEqual([]);
+}
+
+async function expectInsideViewport(
+  locator: Locator,
+  viewport: Viewport,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.y, `${label}: top edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
+    viewport.width + TOLERANCE,
+  );
+  expect(box!.y + box!.height, `${label}: bottom edge`).toBeLessThanOrEqual(
+    viewport.height + TOLERANCE,
+  );
+}
+
+async function expectInsideMobileContentBand(
+  page: Page,
+  locator: Locator,
+  viewport: Viewport,
+  label: string,
+) {
+  await expectInsideViewport(locator, viewport, label);
+
+  const [appBarBox, bottomNavBox, elementBox] = await Promise.all([
+    page.locator('[data-admin-mobile-app-bar="true"]').boundingBox(),
+    page.locator('[data-admin-mobile-bottom-nav="true"]').boundingBox(),
+    locator.boundingBox(),
+  ]);
+
+  expect(appBarBox, `${label}: app bar bounding box`).not.toBeNull();
+  expect(bottomNavBox, `${label}: bottom nav bounding box`).not.toBeNull();
+  expect(elementBox, `${label}: element bounding box`).not.toBeNull();
+  expect(elementBox!.y, `${label}: below app bar`).toBeGreaterThanOrEqual(
+    appBarBox!.y + appBarBox!.height - TOLERANCE,
+  );
+  expect(elementBox!.y + elementBox!.height, `${label}: above bottom nav`).toBeLessThanOrEqual(
+    bottomNavBox!.y + TOLERANCE,
+  );
+}
+
+async function expectNotClippedByAncestors(locator: Locator, label: string) {
+  const violations = await locator.evaluate((element, tolerance) => {
+    const elementRect = element.getBoundingClientRect();
+    const clippedBy: Array<{
+      tag: string;
+      className: string;
+      overflowX: string;
+      overflowY: string;
+    }> = [];
+    let ancestor = element.parentElement;
+
+    while (ancestor && ancestor !== document.body) {
+      const style = window.getComputedStyle(ancestor);
+      const clipsX = ["auto", "clip", "hidden", "scroll"].includes(style.overflowX);
+      const clipsY = ["auto", "clip", "hidden", "scroll"].includes(style.overflowY);
+
+      if (clipsX || clipsY) {
+        const ancestorRect = ancestor.getBoundingClientRect();
+        const clippedHorizontally =
+          clipsX &&
+          (elementRect.left < ancestorRect.left - tolerance ||
+            elementRect.right > ancestorRect.right + tolerance);
+        const clippedVertically =
+          clipsY &&
+          (elementRect.top < ancestorRect.top - tolerance ||
+            elementRect.bottom > ancestorRect.bottom + tolerance);
+
+        if (clippedHorizontally || clippedVertically) {
+          clippedBy.push({
+            tag: ancestor.tagName,
+            className: ancestor.className,
+            overflowX: style.overflowX,
+            overflowY: style.overflowY,
+          });
+        }
+      }
+
+      ancestor = ancestor.parentElement;
+    }
+
+    return clippedBy;
+  }, TOLERANCE);
+
+  expect(violations, `${label}: clipped by ancestor`).toEqual([]);
+}
+
+async function expectMobileChrome(page: Page, viewport: Viewport, label: string) {
+  const appBar = page.locator('[data-admin-mobile-app-bar="true"]');
+  const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+  const horizontalNav = page.locator('[data-dashboard-horizontal-nav-shell="true"]');
+
+  await expectInsideViewport(appBar, viewport, `${label}: app bar`);
+  await expectInsideViewport(bottomNav, viewport, `${label}: bottom nav`);
+  await expect(horizontalNav, `${label}: desktop nav absent`).toBeHidden();
+
+  const navItems = bottomNav.locator('[data-admin-mobile-bottom-nav-item="true"]');
+  await expect(navItems).toHaveCount(5);
+  for (let index = 0; index < 5; index += 1) {
+    await expectInsideViewport(
+      navItems.nth(index),
+      viewport,
+      `${label}: bottom nav item ${index + 1}`,
+    );
+  }
+}
+
+async function auditMobileSurface(
+  page: Page,
+  viewport: Viewport,
+  activeSelector: string,
+  label: string,
+) {
+  await expectMobileChrome(page, viewport, label);
+  const activeRoot = page.locator(activeSelector);
+  await expectInsideMobileContentBand(page, activeRoot, viewport, `${label}: active surface`);
+  assertSurfaceContract(await readSurfaceContract(page, activeSelector), label);
+}
+
+async function auditModuleItems(
+  page: Page,
+  viewport: Viewport,
+  moduleScreen: AdminModuleScreen,
+) {
+  const moduleRoot = page.locator(moduleScreen.mobileRoot);
+  const items = moduleRoot.locator(moduleScreen.itemSelector);
+  await expect(items.first(), `${viewport.name} ${moduleScreen.key}: populated items`).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const itemCount = await items.count();
+  expect(itemCount, `${viewport.name} ${moduleScreen.key}: populated item count`).toBeGreaterThan(0);
+  for (let index = 0; index < itemCount; index += 1) {
+    await expectInsideMobileContentBand(
+      page,
+      items.nth(index),
+      viewport,
+      `${viewport.name} ${moduleScreen.key}: item ${index + 1}`,
+    );
+    await expectNotClippedByAncestors(
+      items.nth(index),
+      `${viewport.name} ${moduleScreen.key}: item ${index + 1}`,
+    );
+  }
+
+  const pager = moduleRoot.locator(moduleScreen.pagerSelector);
+  await expectInsideMobileContentBand(
+    page,
+    pager,
+    viewport,
+    `${viewport.name} ${moduleScreen.key}: pager`,
+  );
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`Admin mobile final polish closeout at ${viewport.name}`, async ({ page }, testInfo) => {
+    test.setTimeout(120_000);
+    await setPopulatedAdminSession(page);
+    await mockMissingPopulatedApis(page);
+    await preparePage(page, viewport, "/dashboard/admin");
+
+    const launcher = page.locator('[data-admin-mobile-hub-launcher="true"]');
+    await expect(launcher).toBeVisible({ timeout: 15_000 });
+    await auditMobileSurface(
+      page,
+      viewport,
+      '[data-admin-mobile-hub-launcher="true"]',
+      `${viewport.name} launcher page 1`,
+    );
+
+    const launcherItems = launcher.locator('[data-admin-mobile-hub-tile]');
+    const launcherItemCount = await launcherItems.count();
+    expect(launcherItemCount).toBeGreaterThan(0);
+    for (let index = 0; index < launcherItemCount; index += 1) {
+      await expectInsideMobileContentBand(
+        page,
+        launcherItems.nth(index),
+        viewport,
+        `${viewport.name} launcher page 1 tile ${index + 1}`,
+      );
+    }
+
+    const hubPager = launcher.locator('[data-admin-mobile-hub-pager="true"]');
+    await expectInsideMobileContentBand(
+      page,
+      hubPager,
+      viewport,
+      `${viewport.name} launcher pager`,
+    );
+    await captureScreen(page, testInfo, viewport.name, "launcher-page-1");
+
+    await hubPager.getByRole("button", { name: "Siguiente", exact: true }).click();
+    await auditMobileSurface(
+      page,
+      viewport,
+      '[data-admin-mobile-hub-launcher="true"]',
+      `${viewport.name} launcher page 2`,
+    );
+    await captureScreen(page, testInfo, viewport.name, "launcher-page-2");
+
+    const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
+    await bottomNav.getByRole("button", { name: "Más", exact: true }).click();
+    const moduleMenu = page.locator('[data-admin-mobile-module-menu="true"]');
+    await expectInsideViewport(moduleMenu, viewport, `${viewport.name} Más menu`);
+    assertSurfaceContract(
+      await readSurfaceContract(page, '[data-admin-mobile-module-menu="true"]'),
+      `${viewport.name} Más menu`,
+    );
+    const moduleLinks = moduleMenu.locator('[data-admin-mobile-module-link="true"]');
+    const moduleLinkCount = await moduleLinks.count();
+    expect(moduleLinkCount).toBeGreaterThan(0);
+    for (let index = 0; index < moduleLinkCount; index += 1) {
+      await expectInsideViewport(
+        moduleLinks.nth(index),
+        viewport,
+        `${viewport.name} Más menu item ${index + 1}`,
+      );
+    }
+    await captureScreen(page, testInfo, viewport.name, "more-menu");
+    await moduleMenu.getByRole("button", { name: "Cerrar menú de módulos", exact: true }).click();
+
+    await page.getByRole("button", { name: "Menú de administración", exact: true }).click();
+    const kebabMenu = page.locator('[data-admin-mobile-kebab-menu="true"]');
+    await expectInsideViewport(kebabMenu, viewport, `${viewport.name} administration menu`);
+    assertSurfaceContract(
+      await readSurfaceContract(page, '[data-admin-mobile-kebab-menu="true"]'),
+      `${viewport.name} administration menu`,
+    );
+    await captureScreen(page, testInfo, viewport.name, "administration-menu");
+
+    await kebabMenu.getByRole("button", { name: "Notificaciones", exact: true }).click();
+    const notificationsPanel = page.locator('[data-admin-mobile-notifications-panel="true"]');
+    await expectInsideViewport(notificationsPanel, viewport, `${viewport.name} notifications`);
+    await expect(
+      notificationsPanel.getByRole("button", { name: "Actualizar", exact: true }),
+    ).toBeEnabled({ timeout: 15_000 });
+    assertSurfaceContract(
+      await readSurfaceContract(page, '[data-admin-mobile-notifications-panel="true"]'),
+      `${viewport.name} notifications`,
+    );
+    await captureScreen(page, testInfo, viewport.name, "notifications");
+    await notificationsPanel
+      .getByRole("button", { name: "Cerrar panel de notificaciones", exact: true })
+      .click();
+    await page.keyboard.press("Escape");
+
+    for (const moduleScreen of MODULE_SCREENS) {
+      await preparePage(
+        page,
+        viewport,
+        `/dashboard/admin?module=${moduleScreen.moduleId}`,
+      );
+      const workspace = page.locator(
+        `[data-dashboard-module-workspace="${moduleScreen.moduleId}"]`,
+      );
+      await expect(workspace, `${viewport.name} ${moduleScreen.key}: workspace`).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(page.locator(moduleScreen.mobileRoot)).toBeVisible({ timeout: 15_000 });
+      await auditMobileSurface(
+        page,
+        viewport,
+        moduleScreen.mobileRoot,
+        `${viewport.name} ${moduleScreen.key}`,
+      );
+      await captureScreen(page, testInfo, viewport.name, moduleScreen.key);
+      await auditModuleItems(page, viewport, moduleScreen);
+    }
+  });
+}
+
+test("Admin desktop final polish smoke at 1280x800", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await setPopulatedAdminSession(page);
+  await mockMissingPopulatedApis(page);
+  await preparePage(page, DESKTOP_VIEWPORT, "/dashboard/admin");
+
+  const horizontalNav = page.locator('[data-dashboard-horizontal-nav-shell="true"]');
+  await expect(horizontalNav).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeHidden();
+  await expect(page.locator('[data-admin-mobile-hub-launcher="true"]')).toBeHidden();
+  const desktopHub = page.locator('[data-dashboard-module-hub="true"]');
+  await expect(desktopHub).toBeVisible();
+  await expectInsideViewport(desktopHub, DESKTOP_VIEWPORT, "desktop launcher");
+  assertSurfaceContract(
+    await readSurfaceContract(page, '[data-dashboard-module-hub="true"]'),
+    "desktop launcher",
+  );
+  await captureScreen(page, testInfo, DESKTOP_VIEWPORT.name, "launcher");
+
+  for (const moduleScreen of MODULE_SCREENS) {
+    await preparePage(
+      page,
+      DESKTOP_VIEWPORT,
+      `/dashboard/admin?module=${moduleScreen.moduleId}`,
+    );
+    await expect(horizontalNav).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeHidden();
+    await expect(page.locator(moduleScreen.mobileRoot)).toBeHidden();
+
+    const workspaceSelector = `[data-dashboard-module-workspace="${moduleScreen.moduleId}"]`;
+    const workspace = page.locator(workspaceSelector);
+    await expect(workspace, `desktop ${moduleScreen.key}: workspace`).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      workspace.getByText(moduleScreen.desktopReady).filter({ visible: true }).first(),
+      `desktop ${moduleScreen.key}: populated content`,
+    ).toBeVisible({ timeout: 15_000 });
+    await expectInsideViewport(workspace, DESKTOP_VIEWPORT, `desktop ${moduleScreen.key}`);
+    assertSurfaceContract(
+      await readSurfaceContract(page, workspaceSelector, false),
+      `desktop ${moduleScreen.key}`,
+    );
+    await captureScreen(page, testInfo, DESKTOP_VIEWPORT.name, moduleScreen.key);
+  }
+});

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -597,7 +597,7 @@ export function AdminClinicsManagementCard() {
           className="flex min-h-0 flex-1 flex-col gap-2 md:hidden"
           data-admin-mobile-core-module="clinics"
         >
-          <div className="relative max-w-xs flex-1 shrink-0">
+          <div className="relative max-w-xs shrink-0">
             <Search
               className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
               aria-hidden="true"

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -1086,7 +1086,7 @@ export function AdminParticularTokensCard() {
               size="sm"
               role="tab"
               aria-selected={!isCreateDialogOpen}
-              className="md:h-8 md:px-2 md:text-xs"
+              className="h-8 px-2 text-xs"
             >
               Tokens administrados
             </Button>
@@ -1096,7 +1096,7 @@ export function AdminParticularTokensCard() {
               size="sm"
               role="tab"
               aria-selected={isCreateDialogOpen}
-              className="md:h-8 md:px-2 md:text-xs"
+              className="h-8 px-2 text-xs"
               onClick={() => handleCreateDialogOpenChange(true)}
               disabled={generatedToken !== null}
             >


### PR DESCRIPTION
## Summary
- add final Admin mobile no-scroll visual audit spec with screenshots coverage
- fix final 360x740 polish issues in Clinics and Tokens
- document final Admin mobile no-scroll closeout
- preserve desktop layout, Clinic dashboard, backend, API, auth, DB, dependencies, lockfiles and CI

## Findings fixed
- Clinics 360x740: mobile search wrapper consumed excess vertical space and pushed the third card under the bottom nav
- Tokens 360x740: mobile tab buttons wrapped and clipped the third row inside the module

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts e2e/admin-mobile-hub-launcher-no-scroll.spec.ts e2e/admin-mobile-core-modules-no-scroll.spec.ts e2e/admin-mobile-ops-modules-no-scroll.spec.ts e2e/admin-mobile-module-layer-isolation.spec.ts e2e/dashboard-mobile-shell-nav-contract.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface

## Notes
- 40 screenshots generated during local audit under frontend/test-results/admin-mobile-final-polish-no-scroll
- Final E2E requested set passed 125/125
- Root tests passed 2815/2815
- Clinic mobile parity remained green 12/12
