### PR TITLE
fix(admin): add mobile no-scroll status modules

### DIFF
--- a/frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts
@@ -292,6 +292,85 @@ async function captureScreen(
   });
 }
 
+type ContentGutters = {
+  bottomGutter: number;
+  sideGutter: number;
+  appBarToChipsGap: number;
+  headerVisible: boolean;
+};
+
+// Measures, for the active panel of a status module: the gutter below the last
+// visible content element (down to the bottom nav), the side gutter of the
+// panel, the app-bar -> chips gap, and whether the redundant workspace header is
+// still painted. Used to enforce the balanced-gutter + no-divider contract.
+async function readContentGutters(
+  page: Page,
+  moduleSelector: string,
+): Promise<ContentGutters> {
+  return page.evaluate((selector) => {
+    const moduleRoot = document.querySelector<HTMLElement>(selector);
+    const panel = moduleRoot?.querySelector<HTMLElement>(
+      "[data-admin-mobile-status-panel]",
+    );
+    const chipRow = moduleRoot?.querySelector<HTMLElement>('[role="tablist"]');
+    const bottomNav = document.querySelector<HTMLElement>(
+      '[data-admin-mobile-bottom-nav="true"]',
+    );
+    const appBar = document.querySelector<HTMLElement>(
+      '[data-admin-mobile-app-bar="true"]',
+    );
+    const workspace = moduleRoot?.closest<HTMLElement>(
+      "[data-dashboard-module-workspace]",
+    );
+    const header = workspace?.querySelector<HTMLElement>(
+      ".dashboard-workspace-header",
+    );
+
+    if (!moduleRoot || !panel || !chipRow || !bottomNav || !appBar) {
+      throw new Error(`Gutter contract incomplete for ${selector}`);
+    }
+
+    const navTop = bottomNav.getBoundingClientRect().top;
+    // Lowest visible content pixel inside the active panel (the real content,
+    // not an empty wrapper): take the max bottom across visible descendants.
+    let maxBottom = Number.NEGATIVE_INFINITY;
+    for (const element of Array.from(panel.querySelectorAll<HTMLElement>("*"))) {
+      const rect = element.getBoundingClientRect();
+      if (rect.width > 1 && rect.height > 1 && rect.bottom > maxBottom) {
+        maxBottom = rect.bottom;
+      }
+    }
+    const panelRect = panel.getBoundingClientRect();
+    const headerStyle = header ? window.getComputedStyle(header) : null;
+
+    return {
+      bottomGutter: navTop - maxBottom,
+      sideGutter: Math.min(panelRect.left, window.innerWidth - panelRect.right),
+      appBarToChipsGap:
+        chipRow.getBoundingClientRect().top -
+        appBar.getBoundingClientRect().bottom,
+      headerVisible: headerStyle ? headerStyle.display !== "none" : false,
+    };
+  }, moduleSelector);
+}
+
+function assertGutterContract(gutters: ContentGutters, label: string) {
+  // Bottom margin of the visible content must mirror the side gutter: never
+  // pegged to the bottom nav, never a void above it.
+  expect(
+    gutters.bottomGutter,
+    `${label}: bottom gutter not pegged (>= 10px); got ${gutters.bottomGutter}`,
+  ).toBeGreaterThanOrEqual(10);
+  expect(
+    gutters.bottomGutter,
+    `${label}: bottom gutter >= side gutter (${gutters.sideGutter})`,
+  ).toBeGreaterThanOrEqual(gutters.sideGutter - 2);
+  expect(
+    gutters.bottomGutter,
+    `${label}: bottom gutter balanced with side gutter ${gutters.sideGutter} (no void)`,
+  ).toBeLessThanOrEqual(gutters.sideGutter + 24);
+}
+
 for (const moduleSpec of STATUS_MODULES) {
   for (const viewport of MOBILE_VIEWPORTS) {
     for (const mode of COLOR_MODES) {
@@ -349,8 +428,24 @@ for (const moduleSpec of STATUS_MODULES) {
           `${viewport.name} ${mode} ${moduleSpec.key} initial`,
         );
 
-        // Every section chip must be reachable, fit the content band and keep
-        // the no-scroll contract — no section may fall under the bottom nav.
+        // No redundant workspace-header divider/band between the app bar and the
+        // chips on Admin mobile (the app-bar -> chips gap is asserted per chip).
+        await expect(
+          page.locator(
+            `[data-dashboard-module-workspace="${moduleSpec.moduleId}"] .dashboard-workspace-header`,
+          ),
+          `${viewport.name} ${mode} ${moduleSpec.key}: workspace header hidden`,
+        ).toBeHidden();
+
+        // No console errors during the whole interaction.
+        const consoleErrors: string[] = [];
+        page.on("console", (message) => {
+          if (message.type() === "error") consoleErrors.push(message.text());
+        });
+
+        // Every section chip must be reachable, fit the content band, keep the
+        // no-scroll contract and land its last visible element ~one gutter above
+        // the bottom nav (balanced bottom margin, no void, not pegged).
         const chips = moduleRoot.locator("[data-admin-mobile-status-chip]");
         const chipCount = await chips.count();
         expect(
@@ -360,11 +455,14 @@ for (const moduleSpec of STATUS_MODULES) {
 
         for (let index = 0; index < chipCount; index += 1) {
           const chip = chips.nth(index);
+          const chipId =
+            (await chip.getAttribute("data-admin-mobile-status-chip")) ??
+            String(index);
           await expectInsideContentBand(
             page,
             chip,
             viewport,
-            `${viewport.name} ${mode} ${moduleSpec.key} chip ${index + 1}`,
+            `${viewport.name} ${mode} ${moduleSpec.key} chip ${chipId}`,
           );
           await chip.click();
 
@@ -373,25 +471,45 @@ for (const moduleSpec of STATUS_MODULES) {
           );
           await expect(
             panel,
-            `${viewport.name} ${mode} ${moduleSpec.key} panel ${index + 1}`,
+            `${viewport.name} ${mode} ${moduleSpec.key} panel ${chipId}`,
           ).toBeVisible();
+          // Wait for the (possibly lazy-fetched) content to render so the
+          // gutter is measured against real content, not a transient state.
+          await panel
+            .locator(
+              '[data-admin-mobile-status-item="true"], [data-admin-mobile-ops-pager="true"]',
+            )
+            .first()
+            .waitFor({ state: "visible", timeout: 10_000 })
+            .catch(() => {});
+
           await expectInsideContentBand(
             page,
             panel,
             viewport,
-            `${viewport.name} ${mode} ${moduleSpec.key} panel ${index + 1}`,
+            `${viewport.name} ${mode} ${moduleSpec.key} panel ${chipId}`,
           );
           assertNoScrollContract(
             await readNoScrollContract(page, moduleSelector),
-            `${viewport.name} ${mode} ${moduleSpec.key} section ${index + 1}`,
+            `${viewport.name} ${mode} ${moduleSpec.key} section ${chipId}`,
+          );
+
+          const gutters = await readContentGutters(page, moduleSelector);
+          expect(
+            gutters.appBarToChipsGap,
+            `${viewport.name} ${mode} ${moduleSpec.key} ${chipId}: app bar -> chips gap <= 14px; got ${gutters.appBarToChipsGap}`,
+          ).toBeLessThanOrEqual(14);
+          assertGutterContract(
+            gutters,
+            `${viewport.name} ${mode} ${moduleSpec.key} ${chipId}`,
+          );
+
+          await captureScreen(
+            page,
+            testInfo,
+            `${STATUS_SNAPSHOT_PHASE}-${shortViewport}-${mode}-${moduleSpec.screenshotKey}-${chipId}`,
           );
         }
-
-        // No console errors during the whole interaction.
-        const consoleErrors: string[] = [];
-        page.on("console", (message) => {
-          if (message.type() === "error") consoleErrors.push(message.text());
-        });
 
         await page
           .locator('[data-admin-mobile-bottom-nav="true"]')
@@ -435,6 +553,14 @@ for (const moduleSpec of STATUS_MODULES) {
       page.locator(`[data-admin-mobile-status-module="${moduleSpec.key}"]`),
       `${moduleSpec.key} desktop: mobile status module hidden`,
     ).toBeHidden();
+    // Desktop keeps the workspace header (back button + structural divider) —
+    // the mobile reclaim must not bleed into desktop.
+    await expect(
+      page.locator(
+        `[data-dashboard-module-workspace="${moduleSpec.moduleId}"] .dashboard-workspace-header`,
+      ),
+      `${moduleSpec.key} desktop: workspace header visible`,
+    ).toBeVisible({ timeout: 15_000 });
     await expect(
       page
         .locator(`[data-dashboard-module-workspace="${moduleSpec.moduleId}"]`)

--- a/frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts
@@ -1,0 +1,447 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type Route,
+  type TestInfo,
+} from "@playwright/test";
+
+// PR-B — Admin mobile STATUS modules (Administración/Resumen + Estado del
+// sistema). These two modules still rendered the desktop ModuleTabs/grids on
+// mobile, collapsing to a single column whose last cards fell under the bottom
+// nav (P1 no-scroll defect). This spec pins a dedicated mobile variant
+// (`[data-admin-mobile-status-module]`) that fits 360/390/430 in light + dark
+// with zero scroll, zero overflow auto/scroll, and nothing under the bottom nav.
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const COLOR_MODES = ["light", "dark"] as const;
+
+const DESKTOP_VIEWPORT = {
+  name: "desktop-1280x800",
+  width: 1280,
+  height: 800,
+} as const;
+
+type ColorMode = (typeof COLOR_MODES)[number];
+type Viewport = { name: string; width: number; height: number };
+
+type StatusModule = {
+  key: "admin" | "admin-health";
+  moduleId: "admin" | "admin-health";
+  screenshotKey: "admin" | "admin-health";
+  desktopReady: string | RegExp;
+};
+
+const STATUS_MODULES: StatusModule[] = [
+  {
+    key: "admin",
+    moduleId: "admin",
+    screenshotKey: "admin",
+    desktopReady: "Resumen operativo",
+  },
+  {
+    key: "admin-health",
+    moduleId: "admin-health",
+    screenshotKey: "admin-health",
+    desktopReady: /Base de datos|Estado y mantenimiento/i,
+  },
+];
+
+const MOCK_FAILED_LOGIN_ALERTS = Array.from({ length: 8 }, (_, index) => ({
+  id: 6100 + index,
+  surface: (["admin", "clinic", "particular"] as const)[index % 3],
+  username: index % 4 === 0 ? null : `intento_${index}`,
+  reason: (
+    ["invalid_credentials", "missing_credentials", "rate_limited"] as const
+  )[index % 3],
+  ipAddress: `203.0.113.${10 + index}`,
+  userAgent: "Mozilla/5.0 (e2e-status-module)",
+  createdAt: `2026-06-${String(10 + index).padStart(2, "0")}T09:30:00.000Z`,
+}));
+
+const STATUS_SNAPSHOT_PHASE =
+  process.env.STATUS_SNAPSHOT_PHASE === "before" ? "before" : "after";
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function fulfillJson(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+// The status modules fetch two client-side surfaces on demand (failed-login
+// alerts and schema health). The populated fixture server does not serve them,
+// so mock them here to keep the Alertas/Esquema chips populated.
+async function mockStatusApis(page: Page) {
+  await page.route("**/api/admin/failed-login-alerts**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (
+      request.method() !== "GET" ||
+      url.pathname !== "/api/admin/failed-login-alerts"
+    ) {
+      await route.fallback();
+      return;
+    }
+    const limit = Number(url.searchParams.get("limit") ?? "3");
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    await fulfillJson(route, {
+      success: true,
+      failedLoginAlerts: MOCK_FAILED_LOGIN_ALERTS.slice(offset, offset + limit),
+      total: MOCK_FAILED_LOGIN_ALERTS.length,
+      limit,
+      offset,
+    });
+  });
+
+  await page.route("**/api/admin/system/schema-health**", async (route) => {
+    const request = route.request();
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, {
+      success: true,
+      status: "ok",
+      generatedAt: "2026-06-18T14:30:00.000Z",
+      checkedBy: { adminUserId: 41, username: "admin_operaciones" },
+      summary: {
+        requiredTables: 18,
+        requiredColumns: 96,
+        presentColumns: 96,
+        missingColumns: 0,
+      },
+      missing: [],
+    });
+  });
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function applyColorMode(page: Page, mode: ColorMode) {
+  if (mode === "dark") {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("vetneb-theme-mode", "dark-gray");
+      } catch {
+        /* localStorage unavailable: emulateMedia still hints dark */
+      }
+    });
+  }
+  await page.emulateMedia({ colorScheme: mode, reducedMotion: "reduce" });
+}
+
+type NoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  module: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  forbiddenOverflow: Array<{
+    tag: string;
+    className: string;
+    overflowX: string;
+    overflowY: string;
+  }>;
+};
+
+async function readNoScrollContract(
+  page: Page,
+  selector: string,
+): Promise<NoScrollContract> {
+  return page.evaluate((moduleSelector) => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const moduleRoot = document.querySelector<HTMLElement>(moduleSelector);
+
+    if (!moduleRoot) throw new Error(`Missing module root: ${moduleSelector}`);
+
+    const candidates = [
+      document.documentElement,
+      document.body,
+      ...(shell ? [shell] : []),
+      ...(main ? [main] : []),
+      moduleRoot,
+      ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")),
+    ];
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      if (
+        !["auto", "scroll"].includes(style.overflowX) &&
+        !["auto", "scroll"].includes(style.overflowY)
+      ) {
+        return [];
+      }
+      return [
+        {
+          tag: element.tagName,
+          className: element.className,
+          overflowX: style.overflowX,
+          overflowY: style.overflowY,
+        },
+      ];
+    });
+
+    const metrics = (element: HTMLElement) => ({
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    });
+
+    return {
+      html: metrics(document.documentElement),
+      body: metrics(document.body),
+      module: metrics(moduleRoot),
+      forbiddenOverflow,
+    };
+  }, selector);
+}
+
+function assertNoScrollContract(contract: NoScrollContract, label: string) {
+  for (const [surface, metrics] of Object.entries({
+    html: contract.html,
+    body: contract.body,
+    module: contract.module,
+  })) {
+    expect(
+      metrics.scrollHeight,
+      `${label}: ${surface} vertical clipping/overflow`,
+    ).toBeLessThanOrEqual(metrics.clientHeight + TOLERANCE);
+    expect(
+      metrics.scrollWidth,
+      `${label}: ${surface} horizontal clipping/overflow`,
+    ).toBeLessThanOrEqual(metrics.clientWidth + TOLERANCE);
+  }
+
+  expect(contract.forbiddenOverflow, `${label}: overflow auto/scroll`).toEqual([]);
+}
+
+async function expectInsideContentBand(
+  page: Page,
+  locator: Locator,
+  viewport: Viewport,
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const [appBarBox, bottomNavBox, box] = await Promise.all([
+    page.locator('[data-admin-mobile-app-bar="true"]').boundingBox(),
+    page.locator('[data-admin-mobile-bottom-nav="true"]').boundingBox(),
+    locator.boundingBox(),
+  ]);
+
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(appBarBox, `${label}: app bar bounding box`).not.toBeNull();
+  expect(bottomNavBox, `${label}: bottom nav bounding box`).not.toBeNull();
+
+  expect(box!.x, `${label}: left`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right`).toBeLessThanOrEqual(
+    viewport.width + TOLERANCE,
+  );
+  expect(box!.y, `${label}: below app bar`).toBeGreaterThanOrEqual(
+    appBarBox!.y + appBarBox!.height - TOLERANCE,
+  );
+  expect(
+    box!.y + box!.height,
+    `${label}: above bottom nav`,
+  ).toBeLessThanOrEqual(bottomNavBox!.y + TOLERANCE);
+}
+
+async function captureScreen(
+  page: Page,
+  testInfo: TestInfo,
+  fileName: string,
+) {
+  const screenshotDirectory = resolve(
+    testInfo.config.rootDir,
+    "..",
+    "test-results",
+    "admin-mobile-status-modules-no-scroll",
+  );
+  await mkdir(screenshotDirectory, { recursive: true });
+  await page.screenshot({
+    path: resolve(screenshotDirectory, `${fileName}.png`),
+    animations: "disabled",
+    fullPage: false,
+  });
+}
+
+for (const moduleSpec of STATUS_MODULES) {
+  for (const viewport of MOBILE_VIEWPORTS) {
+    for (const mode of COLOR_MODES) {
+      test(`Admin mobile status "${moduleSpec.key}" is no-scroll at ${viewport.name} ${mode}`, async ({
+        page,
+      }, testInfo) => {
+        test.setTimeout(60_000);
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await applyColorMode(page, mode);
+        await setPopulatedAdminSession(page);
+        await mockStatusApis(page);
+        await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+        await suppressNextDevIndicator(page);
+
+        // Mobile chrome present, desktop nav gone.
+        await expect(
+          page.locator('[data-admin-mobile-app-bar="true"]'),
+          `${viewport.name} ${mode}: app bar`,
+        ).toBeVisible({ timeout: 15_000 });
+        await expect(
+          page.locator('[data-admin-mobile-bottom-nav="true"]'),
+          `${viewport.name} ${mode}: bottom nav`,
+        ).toBeVisible();
+        await expect(
+          page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+          `${viewport.name} ${mode}: desktop nav hidden`,
+        ).toBeHidden();
+
+        // Screenshot first so a RED (pre-fix) run still emits before-* evidence.
+        const shortViewport = String(viewport.width);
+        await captureScreen(
+          page,
+          testInfo,
+          `${STATUS_SNAPSHOT_PHASE}-${shortViewport}-${mode}-${moduleSpec.screenshotKey}`,
+        );
+
+        const moduleSelector = `[data-admin-mobile-status-module="${moduleSpec.key}"]`;
+        const moduleRoot = page.locator(moduleSelector);
+        await expect(
+          moduleRoot,
+          `${viewport.name} ${mode}: status module root`,
+        ).toBeVisible({ timeout: 15_000 });
+
+        await expectInsideContentBand(
+          page,
+          moduleRoot,
+          viewport,
+          `${viewport.name} ${mode} ${moduleSpec.key} module`,
+        );
+        assertNoScrollContract(
+          await readNoScrollContract(page, moduleSelector),
+          `${viewport.name} ${mode} ${moduleSpec.key} initial`,
+        );
+
+        // Every section chip must be reachable, fit the content band and keep
+        // the no-scroll contract — no section may fall under the bottom nav.
+        const chips = moduleRoot.locator("[data-admin-mobile-status-chip]");
+        const chipCount = await chips.count();
+        expect(
+          chipCount,
+          `${viewport.name} ${mode} ${moduleSpec.key}: section chips`,
+        ).toBeGreaterThan(1);
+
+        for (let index = 0; index < chipCount; index += 1) {
+          const chip = chips.nth(index);
+          await expectInsideContentBand(
+            page,
+            chip,
+            viewport,
+            `${viewport.name} ${mode} ${moduleSpec.key} chip ${index + 1}`,
+          );
+          await chip.click();
+
+          const panel = moduleRoot.locator(
+            "[data-admin-mobile-status-panel]",
+          );
+          await expect(
+            panel,
+            `${viewport.name} ${mode} ${moduleSpec.key} panel ${index + 1}`,
+          ).toBeVisible();
+          await expectInsideContentBand(
+            page,
+            panel,
+            viewport,
+            `${viewport.name} ${mode} ${moduleSpec.key} panel ${index + 1}`,
+          );
+          assertNoScrollContract(
+            await readNoScrollContract(page, moduleSelector),
+            `${viewport.name} ${mode} ${moduleSpec.key} section ${index + 1}`,
+          );
+        }
+
+        // No console errors during the whole interaction.
+        const consoleErrors: string[] = [];
+        page.on("console", (message) => {
+          if (message.type() === "error") consoleErrors.push(message.text());
+        });
+
+        await page
+          .locator('[data-admin-mobile-bottom-nav="true"]')
+          .getByRole("button", { name: "Inicio", exact: true })
+          .click();
+        await expect(
+          page.locator('[data-admin-mobile-hub-launcher="true"]'),
+          `${viewport.name} ${mode}: back to hub`,
+        ).toBeVisible({ timeout: 15_000 });
+
+        expect(
+          consoleErrors,
+          `${viewport.name} ${mode} ${moduleSpec.key}: console errors`,
+        ).toEqual([]);
+      });
+    }
+  }
+}
+
+for (const moduleSpec of STATUS_MODULES) {
+  test(`Admin desktop preserves ${moduleSpec.key} layout at 1280x800`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({
+      width: DESKTOP_VIEWPORT.width,
+      height: DESKTOP_VIEWPORT.height,
+    });
+    await setPopulatedAdminSession(page);
+    await mockStatusApis(page);
+    await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+
+    await expect(
+      page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+      `${moduleSpec.key} desktop: horizontal nav visible`,
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.locator('[data-admin-mobile-bottom-nav="true"]'),
+      `${moduleSpec.key} desktop: bottom nav absent`,
+    ).toBeHidden();
+    await expect(
+      page.locator(`[data-admin-mobile-status-module="${moduleSpec.key}"]`),
+      `${moduleSpec.key} desktop: mobile status module hidden`,
+    ).toBeHidden();
+    await expect(
+      page
+        .locator(`[data-dashboard-module-workspace="${moduleSpec.moduleId}"]`)
+        .getByText(moduleSpec.desktopReady)
+        .filter({ visible: true })
+        .first(),
+      `${moduleSpec.key} desktop: populated desktop content`,
+    ).toBeVisible({ timeout: 15_000 });
+  });
+}

--- a/frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
+++ b/frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
@@ -252,10 +252,21 @@ async function expectPopulatedAdminModule(
     await expect(
       workspace.getByRole("heading", { name: "Resumen operativo", exact: true }),
     ).toBeVisible();
-    await expect(workspace.getByText("47", { exact: true })).toBeVisible();
-    await expect(workspace.getByText("9", { exact: true })).toBeVisible();
-    await expect(workspace.getByText("Operativo", { exact: true })).toBeVisible();
-    await expect(workspace.getByText("Login admin", { exact: true })).toBeVisible();
+    // The Admin overview now ships a mobile-only (md:hidden) variant alongside
+    // the desktop command center, so these metric labels exist twice in the DOM.
+    // Scope to the visible (desktop) copy at these desktop viewports.
+    await expect(
+      workspace.getByText("47", { exact: true }).filter({ visible: true }),
+    ).toBeVisible();
+    await expect(
+      workspace.getByText("9", { exact: true }).filter({ visible: true }),
+    ).toBeVisible();
+    await expect(
+      workspace.getByText("Operativo", { exact: true }).filter({ visible: true }),
+    ).toBeVisible();
+    await expect(
+      workspace.getByText("Login admin", { exact: true }).filter({ visible: true }),
+    ).toBeVisible();
     await expect(
       workspace.getByText("Sin actividad de auditoría disponible."),
     ).toHaveCount(0);

--- a/frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx
@@ -244,8 +244,11 @@ export function AdminMobileCommandModule({
   recentActivity,
 }: AdminMobileCommandModuleProps) {
   const resumenSection = (
-    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
-      <div className="grid shrink-0 grid-cols-2 gap-1.5">
+    // Fill the band: KPIs stay compact on top, the two info cards grow to share
+    // the remaining height so the last card lands ~one gutter above the bottom
+    // nav (balanced bottom gutter, no empty box).
+    <div className="grid min-h-0 flex-1 grid-rows-[auto_1fr_1fr] gap-2 overflow-hidden">
+      <div className="grid grid-cols-2 gap-1.5">
         <MetricTile
           label="Auditoría"
           value={auditEntriesCount}
@@ -259,7 +262,7 @@ export function AdminMobileCommandModule({
       </div>
       <div
         data-admin-mobile-status-item="true"
-        className="shrink-0 rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+        className="flex min-h-0 flex-col justify-center overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-2"
       >
         <p className="text-[0.62rem] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
           Estado del sistema
@@ -271,7 +274,7 @@ export function AdminMobileCommandModule({
           />
           <Badge variant={systemStatusVariant}>{systemStatusLabel}</Badge>
         </div>
-        <p className="mt-1 line-clamp-2 text-[0.68rem] text-muted-foreground">
+        <p className="mt-1 line-clamp-3 text-[0.68rem] text-muted-foreground">
           {hasSystemHealthFetchError
             ? "No se pudo consultar el estado del sistema."
             : systemStatusDetail}
@@ -279,12 +282,12 @@ export function AdminMobileCommandModule({
       </div>
       <div
         data-admin-mobile-status-item="true"
-        className="surface-soft min-h-0 shrink-0"
+        className="surface-soft flex min-h-0 flex-col justify-center overflow-hidden"
       >
         <p className="text-[0.78rem] font-semibold text-vetneb-ink">
           Alertas y estados
         </p>
-        <p className="mt-1 line-clamp-2 text-[0.7rem] text-muted-foreground">
+        <p className="mt-1 line-clamp-3 text-[0.7rem] text-muted-foreground">
           {hasSystemHealthFetchError
             ? "Estado no disponible; revisar conectividad del servicio."
             : `${systemStatusLabel}: ${systemStatusDetail}`}
@@ -294,22 +297,30 @@ export function AdminMobileCommandModule({
   );
 
   const actividadSection = (
-    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
-      <div data-admin-mobile-status-item="true" className="surface-soft shrink-0">
+    // Three blocks share the height evenly so the last (accesos) lands ~one
+    // gutter above the bottom nav.
+    <div className="grid min-h-0 flex-1 grid-rows-3 gap-2 overflow-hidden">
+      <div
+        data-admin-mobile-status-item="true"
+        className="surface-soft flex min-h-0 flex-col justify-center overflow-hidden"
+      >
         <p className="text-[0.78rem] font-semibold text-vetneb-ink">
           Atención requerida
         </p>
-        <p className="mt-1 text-[0.7rem] text-muted-foreground">
+        <p className="mt-1 line-clamp-3 text-[0.7rem] text-muted-foreground">
           Revisar intentos fallidos de login y salud del sistema antes de
           cambios administrativos.
         </p>
       </div>
-      <div data-admin-mobile-status-item="true" className="surface-soft shrink-0">
+      <div
+        data-admin-mobile-status-item="true"
+        className="surface-soft flex min-h-0 flex-col justify-center overflow-hidden"
+      >
         <p className="text-[0.78rem] font-semibold text-vetneb-ink">
           Actividad reciente
         </p>
         {recentActivity ? (
-          <p className="mt-1 line-clamp-2 text-[0.7rem] text-muted-foreground">
+          <p className="mt-1 line-clamp-3 text-[0.7rem] text-muted-foreground">
             <span className="font-semibold text-foreground/85">
               {recentActivity.event}
             </span>{" "}
@@ -321,7 +332,10 @@ export function AdminMobileCommandModule({
           </p>
         )}
       </div>
-      <div className="min-h-0 shrink-0">
+      <div
+        data-admin-mobile-status-item="true"
+        className="flex min-h-0 flex-col justify-center overflow-hidden"
+      >
         <AdminOverviewQuickLinks />
       </div>
     </div>

--- a/frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getAdminFailedLoginAlerts } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import type {
+  AdminFailedLoginAlertReason,
+  AdminFailedLoginAlertSurface,
+  AdminFailedLoginAlertsSnapshot,
+} from "@/types";
+import { AdminMobileStatusModule } from "./AdminMobileStatusModule";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
+import { AdminOverviewQuickLinks } from "./AdminOverviewQuickLinks";
+
+type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
+
+type RecentAdminActivity = {
+  event: string;
+  actor: string;
+  date: string;
+};
+
+type AdminMobileCommandModuleProps = {
+  auditEntriesCount: number;
+  eventTypesCount: number;
+  systemStatusLabel: string;
+  systemStatusVariant: BadgeVariant;
+  systemStatusIndicatorClass: string;
+  systemStatusDetail: string;
+  hasSystemHealthFetchError: boolean;
+  recentActivity: RecentAdminActivity | null;
+};
+
+const FAILED_LOGIN_PAGE_SIZE = 3;
+
+function formatSurface(value: AdminFailedLoginAlertSurface) {
+  if (value === "admin") return "Admin";
+  if (value === "clinic") return "Clínica";
+  return "Particular";
+}
+
+function formatReason(value: AdminFailedLoginAlertReason) {
+  if (value === "missing_credentials") return "Credenciales faltantes";
+  if (value === "invalid_credentials") return "Credenciales inválidas";
+  return "Bloqueo temporal";
+}
+
+function getSurfaceVariant(value: AdminFailedLoginAlertSurface): BadgeVariant {
+  if (value === "admin") return "default";
+  if (value === "clinic") return "secondary";
+  return "outline";
+}
+
+function getReasonVariant(value: AdminFailedLoginAlertReason): BadgeVariant {
+  if (value === "rate_limited" || value === "invalid_credentials") {
+    return "secondary";
+  }
+  return "outline";
+}
+
+// Compact, paginated mobile view of the failed-login alerts (the desktop
+// "Alertas" tab table). Fetches lazily — only mounted when the chip is active —
+// and only on mobile so the hidden desktop copy never triggers a network call.
+function AdminMobileFailedLoginSection() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [snapshot, setSnapshot] = useState<AdminFailedLoginAlertsSnapshot | null>(
+    null,
+  );
+  const [offset, setOffset] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const query = useMemo(
+    () => ({ limit: FAILED_LOGIN_PAGE_SIZE, offset }),
+    [offset],
+  );
+
+  function loadAlerts() {
+    if (!isMobileViewport) return;
+    setError(null);
+    startTransition(() => {
+      void (async () => {
+        try {
+          setSnapshot(await getAdminFailedLoginAlerts(query));
+        } catch (err) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "No se pudieron cargar los intentos fallidos.",
+          );
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    loadAlerts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileViewport, query]);
+
+  const alerts = snapshot?.failedLoginAlerts ?? [];
+  const total = snapshot?.total ?? 0;
+  const page = Math.floor(offset / FAILED_LOGIN_PAGE_SIZE) + 1;
+  const pageCount = snapshot
+    ? Math.max(1, Math.ceil(total / FAILED_LOGIN_PAGE_SIZE))
+    : 1;
+  const rangeStart = alerts.length ? offset + 1 : 0;
+  const rangeEnd = offset + alerts.length;
+  const hasNextPage = snapshot ? rangeEnd < total : false;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-xs font-semibold text-vetneb-ink">
+          {snapshot ? `${total} intentos fallidos` : "Intentos fallidos"}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 shrink-0 px-2 text-xs"
+          onClick={loadAlerts}
+          disabled={isPending || !isMobileViewport}
+          aria-busy={isPending ? true : undefined}
+        >
+          {isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          ) : null}
+          Actualizar
+        </Button>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-rows-3 gap-1.5 overflow-hidden">
+        {alerts.length ? (
+          alerts.map((alert) => (
+            <article
+              key={alert.id}
+              data-admin-mobile-status-item="true"
+              className="flex min-h-0 flex-col justify-center gap-1 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/92 px-2.5 py-1.5"
+            >
+              <div className="flex min-w-0 items-center gap-1.5">
+                <Badge
+                  variant={getSurfaceVariant(alert.surface)}
+                  className="h-5 px-1.5 text-[10px]"
+                >
+                  {formatSurface(alert.surface)}
+                </Badge>
+                <Badge
+                  variant={getReasonVariant(alert.reason)}
+                  className="h-5 px-1.5 text-[10px]"
+                >
+                  {formatReason(alert.reason)}
+                </Badge>
+                <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+                  #{alert.id}
+                </span>
+              </div>
+              <p className="truncate text-xs font-medium text-vetneb-ink">
+                {alert.username && alert.username.trim()
+                  ? alert.username
+                  : "Sin usuario"}
+              </p>
+              <p className="truncate text-[10px] text-muted-foreground">
+                {alert.ipAddress ?? "IP —"} · {formatDateTime(alert.createdAt)}
+              </p>
+            </article>
+          ))
+        ) : (
+          <div className="row-span-3 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+            {error
+              ? "No se pudieron cargar los intentos fallidos."
+              : isPending
+                ? "Cargando intentos fallidos..."
+                : "Sin intentos fallidos registrados."}
+          </div>
+        )}
+      </div>
+
+      <AdminMobileOpsPager
+        ariaLabel="Paginación de intentos fallidos"
+        page={page}
+        pageCount={pageCount}
+        rangeLabel={
+          alerts.length ? `${rangeStart}–${rangeEnd} de ${total}` : "Sin intentos"
+        }
+        previousDisabled={offset === 0}
+        nextDisabled={!hasNextPage}
+        disabled={isPending}
+        onPrevious={() =>
+          setOffset(Math.max(0, offset - FAILED_LOGIN_PAGE_SIZE))
+        }
+        onNext={() => setOffset(offset + FAILED_LOGIN_PAGE_SIZE)}
+      />
+    </div>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: number | string;
+  hint: string;
+}) {
+  return (
+    <div
+      data-admin-mobile-status-item="true"
+      className="rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+    >
+      <p className="text-[0.62rem] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-0.5 text-lg font-semibold leading-tight tracking-tight text-vetneb-ink">
+        {value}
+      </p>
+      <p className="truncate text-[0.62rem] text-muted-foreground">{hint}</p>
+    </div>
+  );
+}
+
+export function AdminMobileCommandModule({
+  auditEntriesCount,
+  eventTypesCount,
+  systemStatusLabel,
+  systemStatusVariant,
+  systemStatusIndicatorClass,
+  systemStatusDetail,
+  hasSystemHealthFetchError,
+  recentActivity,
+}: AdminMobileCommandModuleProps) {
+  const resumenSection = (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div className="grid shrink-0 grid-cols-2 gap-1.5">
+        <MetricTile
+          label="Auditoría"
+          value={auditEntriesCount}
+          hint="Registros totales"
+        />
+        <MetricTile
+          label="Tipos de evento"
+          value={eventTypesCount}
+          hint="Categorías"
+        />
+      </div>
+      <div
+        data-admin-mobile-status-item="true"
+        className="shrink-0 rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+      >
+        <p className="text-[0.62rem] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+          Estado del sistema
+        </p>
+        <div className="mt-1 flex items-center gap-2">
+          <span
+            className={cn("h-2 w-2 rounded-full", systemStatusIndicatorClass)}
+            aria-hidden="true"
+          />
+          <Badge variant={systemStatusVariant}>{systemStatusLabel}</Badge>
+        </div>
+        <p className="mt-1 line-clamp-2 text-[0.68rem] text-muted-foreground">
+          {hasSystemHealthFetchError
+            ? "No se pudo consultar el estado del sistema."
+            : systemStatusDetail}
+        </p>
+      </div>
+      <div
+        data-admin-mobile-status-item="true"
+        className="surface-soft min-h-0 shrink-0"
+      >
+        <p className="text-[0.78rem] font-semibold text-vetneb-ink">
+          Alertas y estados
+        </p>
+        <p className="mt-1 line-clamp-2 text-[0.7rem] text-muted-foreground">
+          {hasSystemHealthFetchError
+            ? "Estado no disponible; revisar conectividad del servicio."
+            : `${systemStatusLabel}: ${systemStatusDetail}`}
+        </p>
+      </div>
+    </div>
+  );
+
+  const actividadSection = (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div data-admin-mobile-status-item="true" className="surface-soft shrink-0">
+        <p className="text-[0.78rem] font-semibold text-vetneb-ink">
+          Atención requerida
+        </p>
+        <p className="mt-1 text-[0.7rem] text-muted-foreground">
+          Revisar intentos fallidos de login y salud del sistema antes de
+          cambios administrativos.
+        </p>
+      </div>
+      <div data-admin-mobile-status-item="true" className="surface-soft shrink-0">
+        <p className="text-[0.78rem] font-semibold text-vetneb-ink">
+          Actividad reciente
+        </p>
+        {recentActivity ? (
+          <p className="mt-1 line-clamp-2 text-[0.7rem] text-muted-foreground">
+            <span className="font-semibold text-foreground/85">
+              {recentActivity.event}
+            </span>{" "}
+            · {recentActivity.actor} · {recentActivity.date}
+          </p>
+        ) : (
+          <p className="mt-1 text-[0.7rem] text-muted-foreground">
+            Sin actividad de auditoría disponible.
+          </p>
+        )}
+      </div>
+      <div className="min-h-0 shrink-0">
+        <AdminOverviewQuickLinks />
+      </div>
+    </div>
+  );
+
+  return (
+    <AdminMobileStatusModule
+      moduleKey="admin"
+      ariaLabel="Resumen de administración"
+      sections={[
+        { id: "resumen", label: "Resumen", content: resumenSection },
+        { id: "actividad", label: "Actividad", content: actividadSection },
+        {
+          id: "alertas",
+          label: "Alertas",
+          content: <AdminMobileFailedLoginSection />,
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getAdminSchemaHealth } from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type { AdminSchemaHealthSnapshot } from "@/types";
+import { AdminMobileStatusModule } from "./AdminMobileStatusModule";
+
+type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
+
+export type AdminMobileHealthService = {
+  label: string;
+  statusLabel: string;
+  variant: BadgeVariant;
+  detail: string | null;
+};
+
+export type AdminMobileHealthRuntimeTile = {
+  label: string;
+  value: string;
+  hint: string | null;
+};
+
+type AdminMobileHealthModuleProps = {
+  hasError: boolean;
+  services: AdminMobileHealthService[];
+  runtime: AdminMobileHealthRuntimeTile[];
+};
+
+function getSchemaStatusVariant(
+  status: AdminSchemaHealthSnapshot["status"],
+): BadgeVariant {
+  return status === "ok" ? "default" : "secondary";
+}
+
+function formatSchemaStatusLabel(status: AdminSchemaHealthSnapshot["status"]) {
+  return status === "ok" ? "Esquema compatible" : "Faltan columnas críticas";
+}
+
+// Compact, lazy mobile view of the schema-health card (desktop "Esquema" tab).
+// Only mounted while the chip is active and only fetches on mobile.
+function AdminMobileSchemaSection() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [snapshot, setSnapshot] = useState<AdminSchemaHealthSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function loadSchemaHealth() {
+    if (!isMobileViewport) return;
+    setError(null);
+    startTransition(() => {
+      void (async () => {
+        try {
+          setSnapshot(await getAdminSchemaHealth());
+        } catch {
+          setSnapshot(null);
+          setError("No se pudo consultar el estado del esquema.");
+        } finally {
+          setHasLoadedOnce(true);
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    loadSchemaHealth();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileViewport]);
+
+  const summary = snapshot?.summary;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          {snapshot ? (
+            <Badge variant={getSchemaStatusVariant(snapshot.status)}>
+              {formatSchemaStatusLabel(snapshot.status)}
+            </Badge>
+          ) : (
+            <p className="truncate text-xs font-semibold text-vetneb-ink">
+              Estado de esquema
+            </p>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 shrink-0 px-2 text-xs"
+          onClick={loadSchemaHealth}
+          disabled={isPending || !isMobileViewport}
+          aria-busy={isPending ? true : undefined}
+        >
+          {isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          ) : null}
+          Reintentar
+        </Button>
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          data-admin-mobile-status-item="true"
+          className="shrink-0 rounded-md border border-vetneb-line/70 bg-card/92 px-2.5 py-2 text-[0.7rem] text-destructive"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {summary ? (
+        <div className="grid shrink-0 grid-cols-2 gap-1.5">
+          <SchemaMetric label="Tablas req." value={summary.requiredTables} />
+          <SchemaMetric label="Columnas req." value={summary.requiredColumns} />
+          <SchemaMetric label="Presentes" value={summary.presentColumns} />
+          <SchemaMetric label="Faltantes" value={summary.missingColumns} />
+        </div>
+      ) : null}
+
+      {snapshot ? (
+        <div
+          data-admin-mobile-status-item="true"
+          className="min-h-0 flex-1 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/92 px-2.5 py-1.5"
+        >
+          <p className="truncate text-[0.66rem] text-muted-foreground">
+            Generado: {formatDateTime(snapshot.generatedAt)}
+          </p>
+          <p className="mt-0.5 truncate text-[0.66rem] text-muted-foreground">
+            Revisado por:{" "}
+            {snapshot.checkedBy
+              ? `${snapshot.checkedBy.username} #${snapshot.checkedBy.adminUserId}`
+              : "—"}
+          </p>
+          {snapshot.status === "degraded" ? (
+            <p className="mt-1 line-clamp-2 text-[0.66rem] text-vetneb-navy">
+              {snapshot.missing.length
+                ? `${snapshot.missing.length} columna(s) crítica(s) faltante(s).`
+                : "Faltan columnas críticas sin detalle."}
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+          {error
+            ? "Esquema no disponible."
+            : !hasLoadedOnce || isPending
+              ? "Consultando estado de esquema..."
+              : "Sin datos de esquema."}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SchemaMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      data-admin-mobile-status-item="true"
+      className="rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+    >
+      <p className="text-[0.62rem] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 text-base font-semibold leading-tight text-vetneb-ink">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function AdminMobileHealthModule({
+  hasError,
+  services,
+  runtime,
+}: AdminMobileHealthModuleProps) {
+  const serviciosSection = (
+    <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden">
+      {hasError ? (
+        <div
+          role="alert"
+          data-admin-mobile-status-item="true"
+          className="shrink-0 rounded-md border border-vetneb-line/70 bg-card/92 px-2.5 py-2 text-[0.7rem] text-vetneb-navy"
+        >
+          No se pudo consultar el estado del sistema; valores como desconocidos.
+        </div>
+      ) : null}
+      {services.map((service) => (
+        <div
+          key={service.label}
+          data-admin-mobile-status-item="true"
+          className="flex min-h-0 items-center justify-between gap-2 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+        >
+          <div className="min-w-0">
+            <p className="truncate text-xs font-semibold text-vetneb-ink">
+              {service.label}
+            </p>
+            {service.detail ? (
+              <p className="truncate text-[0.66rem] text-muted-foreground">
+                {service.detail}
+              </p>
+            ) : null}
+          </div>
+          <Badge
+            variant={service.variant}
+            className="h-5 shrink-0 px-1.5 text-[10px]"
+          >
+            {service.statusLabel}
+          </Badge>
+        </div>
+      ))}
+    </div>
+  );
+
+  const runtimeSection = (
+    <div className="grid min-h-0 flex-1 grid-cols-2 content-start gap-1.5 overflow-hidden">
+      {runtime.map((tile) => (
+        <div
+          key={tile.label}
+          data-admin-mobile-status-item="true"
+          className="rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+        >
+          <p className="truncate text-[0.62rem] text-muted-foreground">
+            {tile.label}
+          </p>
+          <p className="mt-0.5 truncate text-base font-semibold leading-tight text-vetneb-ink">
+            {tile.value}
+          </p>
+          {tile.hint ? (
+            <p className="truncate text-[0.62rem] text-muted-foreground">
+              {tile.hint}
+            </p>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <AdminMobileStatusModule
+      moduleKey="admin-health"
+      ariaLabel="Estado del sistema"
+      sections={[
+        { id: "servicios", label: "Servicios", content: serviciosSection },
+        { id: "runtime", label: "Runtime", content: runtimeSection },
+        {
+          id: "esquema",
+          label: "Esquema",
+          content: <AdminMobileSchemaSection />,
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx
@@ -196,40 +196,49 @@ export function AdminMobileHealthModule({
           No se pudo consultar el estado del sistema; valores como desconocidos.
         </div>
       ) : null}
-      {services.map((service) => (
-        <div
-          key={service.label}
-          data-admin-mobile-status-item="true"
-          className="flex min-h-0 items-center justify-between gap-2 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
-        >
-          <div className="min-w-0">
-            <p className="truncate text-xs font-semibold text-vetneb-ink">
-              {service.label}
-            </p>
-            {service.detail ? (
-              <p className="truncate text-[0.66rem] text-muted-foreground">
-                {service.detail}
-              </p>
-            ) : null}
-          </div>
-          <Badge
-            variant={service.variant}
-            className="h-5 shrink-0 px-1.5 text-[10px]"
+      {/* Service rows fill the band as equal rows so the last (CORS público)
+          lands ~one gutter above the bottom nav instead of leaving a void. */}
+      <div
+        className="grid min-h-0 flex-1 gap-1.5 overflow-hidden"
+        style={{ gridTemplateRows: `repeat(${services.length}, minmax(0, 1fr))` }}
+      >
+        {services.map((service) => (
+          <div
+            key={service.label}
+            data-admin-mobile-status-item="true"
+            className="flex min-h-0 items-center justify-between gap-2 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
           >
-            {service.statusLabel}
-          </Badge>
-        </div>
-      ))}
+            <div className="min-w-0">
+              <p className="truncate text-xs font-semibold text-vetneb-ink">
+                {service.label}
+              </p>
+              {service.detail ? (
+                <p className="truncate text-[0.66rem] text-muted-foreground">
+                  {service.detail}
+                </p>
+              ) : null}
+            </div>
+            <Badge
+              variant={service.variant}
+              className="h-5 shrink-0 px-1.5 text-[10px]"
+            >
+              {service.statusLabel}
+            </Badge>
+          </div>
+        ))}
+      </div>
     </div>
   );
 
   const runtimeSection = (
-    <div className="grid min-h-0 flex-1 grid-cols-2 content-start gap-1.5 overflow-hidden">
+    // 2×2 tiles fill the band; content vertically centered so the stretched
+    // tiles read as intentional cards, last row ~one gutter above the nav.
+    <div className="grid min-h-0 flex-1 grid-cols-2 grid-rows-2 gap-1.5 overflow-hidden">
       {runtime.map((tile) => (
         <div
           key={tile.label}
           data-admin-mobile-status-item="true"
-          className="rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+          className="flex min-h-0 flex-col justify-center overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
         >
           <p className="truncate text-[0.62rem] text-muted-foreground">
             {tile.label}

--- a/frontend/src/app/dashboard/admin/AdminMobileStatusModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileStatusModule.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+export type AdminMobileStatusSection = {
+  id: string;
+  label: string;
+  content: ReactNode;
+};
+
+type AdminMobileStatusModuleProps = {
+  /** Module key exposed as `data-admin-mobile-status-module`. */
+  moduleKey: string;
+  ariaLabel: string;
+  sections: AdminMobileStatusSection[];
+};
+
+/**
+ * Mobile-only ("md:hidden") shell for Admin status modules (Administración /
+ * Estado del sistema). The desktop ModuleTabs/grids collapse to one column on
+ * mobile and overflow under the bottom nav; this primitive splits the same
+ * content into compact chip sections so each fits the no-scroll content band.
+ *
+ * Only the active section is mounted, so fetch-backed sections (failed-login,
+ * schema) load lazily when the chip is selected. The chip row is fixed and the
+ * panel fills the remaining height (`flex-1 min-h-0`) with zero scroll.
+ */
+export function AdminMobileStatusModule({
+  moduleKey,
+  ariaLabel,
+  sections,
+}: AdminMobileStatusModuleProps) {
+  const baseId = useId();
+  const fallbackId = sections[0]?.id ?? "";
+  const [activeId, setActiveId] = useState(fallbackId);
+
+  useEffect(() => {
+    if (!sections.some((section) => section.id === activeId)) {
+      setActiveId(fallbackId);
+    }
+  }, [sections, activeId, fallbackId]);
+
+  if (!sections.length) return null;
+
+  const active = sections.find((section) => section.id === activeId) ?? sections[0];
+
+  function handleKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
+    const backward = event.key === "ArrowLeft" || event.key === "ArrowUp";
+    if (!forward && !backward) return;
+    event.preventDefault();
+    const last = sections.length - 1;
+    const nextIndex = (index + (forward ? 1 : -1) + sections.length) % sections.length;
+    const next = sections[nextIndex] ?? sections[last];
+    setActiveId(next.id);
+    window.requestAnimationFrame(() => {
+      document.getElementById(`${baseId}-chip-${next.id}`)?.focus();
+    });
+  }
+
+  return (
+    <section
+      data-admin-mobile-status-module={moduleKey}
+      aria-label={ariaLabel}
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card md:hidden"
+    >
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        className="flex shrink-0 items-center gap-1 overflow-hidden border-b border-vetneb-line/70 p-1.5"
+      >
+        {sections.map((section, index) => {
+          const isActive = section.id === active.id;
+          return (
+            <button
+              key={section.id}
+              id={`${baseId}-chip-${section.id}`}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`${baseId}-panel-${section.id}`}
+              tabIndex={isActive ? 0 : -1}
+              data-admin-mobile-status-chip={section.id}
+              data-active={isActive ? "true" : undefined}
+              onClick={() => setActiveId(section.id)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              className={cn(
+                "min-w-0 flex-1 truncate rounded-md px-2 py-1.5 text-[0.72rem] font-semibold leading-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-1",
+                isActive
+                  ? "bg-vetneb-navy text-white shadow-sm"
+                  : "bg-vetneb-surface-muted/60 text-muted-foreground hover:bg-vetneb-surface-muted",
+              )}
+            >
+              {section.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`${baseId}-panel-${active.id}`}
+        aria-label={active.label}
+        data-admin-mobile-status-panel={active.id}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden p-2"
+      >
+        {active.content}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -24,6 +24,8 @@ import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
 import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";
 import { AdminDashboardWorkspaceController } from "./AdminDashboardWorkspaceController";
 import type { AdminModule } from "./AdminDashboardWorkspaceController";
+import { AdminMobileCommandModule } from "./AdminMobileCommandModule";
+import { AdminMobileHealthModule } from "./AdminMobileHealthModule";
 import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { Button } from "@/components/ui/button";
@@ -548,9 +550,21 @@ export default async function AdminPage({
   // alerts table into tabs so each fits one desktop viewport without scroll
   // (previously stacked via space-y-6, growing past the viewport).
   const adminWorkspaceSlot = (
-    <ModuleTabs
-      ariaLabel="Resumen y alertas"
-      tabs={[
+    <>
+      <AdminMobileCommandModule
+        auditEntriesCount={auditOverviewSnapshot.pagination.total}
+        eventTypesCount={eventTypesCount}
+        systemStatusLabel={formatSystemStatus(systemStatus)}
+        systemStatusVariant={getSystemStatusVariant(systemStatus)}
+        systemStatusIndicatorClass={getSystemStatusIndicatorClass(systemStatus)}
+        systemStatusDetail={formatSystemStatusDetail(serviceChecks)}
+        hasSystemHealthFetchError={hasSystemHealthFetchError}
+        recentActivity={recentAdminActivity}
+      />
+      <div className="hidden min-h-0 flex-1 flex-col md:flex">
+        <ModuleTabs
+          ariaLabel="Resumen y alertas"
+          tabs={[
         {
           id: "resumen",
           label: "Resumen",
@@ -592,8 +606,10 @@ export default async function AdminPage({
             </section>
           ),
         },
-      ]}
-    />
+        ]}
+        />
+      </div>
+    </>
   );
 
   // ── Informes workspace ──────────────────────────────────────────────────────
@@ -721,27 +737,97 @@ export default async function AdminPage({
     </div>
   );
 
+  // Mobile (md:hidden) compact, no-scroll variant of the health module. Desktop
+  // grids collapse to one column and the last service card falls under the
+  // bottom nav; these compact display rows fit the mobile content band.
+  const healthMobileServices = [
+    {
+      label: "Base de datos",
+      statusLabel: formatServiceStatus(serviceChecks.database),
+      variant: getServiceVariant(serviceChecks.database),
+      detail: null,
+    },
+    {
+      label: "Almacenamiento",
+      statusLabel: formatServiceStatus(serviceChecks.storage),
+      variant: getServiceVariant(serviceChecks.storage),
+      detail: null,
+    },
+    {
+      label: "Transporte de correo",
+      statusLabel: formatEmailTransport(serviceChecks.email_transport),
+      variant: getEmailTransportBadgeVariant(serviceChecks.email_transport),
+      detail: `Gmail API: ${formatServiceStatus(serviceChecks.gmail_api)} · SMTP: ${formatServiceStatus(serviceChecks.smtp)}`,
+    },
+    {
+      label: "Contacto email",
+      statusLabel: formatServiceStatus(serviceChecks.contact_email),
+      variant: getServiceVariant(serviceChecks.contact_email),
+      detail:
+        contactRecipients.length > 0
+          ? `Destino: ${contactRecipients.join(", ")}`
+          : "Sin destinatarios configurados",
+    },
+    {
+      label: "CORS público",
+      statusLabel: formatServiceStatus(serviceChecks.cors),
+      variant: getServiceVariant(serviceChecks.cors),
+      detail:
+        corsOrigins.length > 0
+          ? `${corsOrigins.length} origen(es) activo(s)`
+          : "Sin orígenes configurados",
+    },
+  ];
+  const healthMobileRuntime = [
+    { label: "Entorno", value: nodeEnv, hint: "nodeEnv activo" },
+    {
+      label: "Backend",
+      value: systemHealth?.version ?? "—",
+      hint: "Versión activa",
+    },
+    {
+      label: "Tiempo activo",
+      value: formatUptime(systemHealth?.runtime.uptimeSeconds),
+      hint: `Control: ${formatHealthTimestamp(systemHealth?.health?.timestamp)}`,
+    },
+    {
+      label: "Memoria runtime",
+      value: `${systemHealth?.runtime.memory.rssMb ?? "—"} MB`,
+      hint: `Heap ${systemHealth?.runtime.memory.heapUsedMb ?? "—"}/${systemHealth?.runtime.memory.heapTotalMb ?? "—"} MB`,
+    },
+  ];
+
   const healthWorkspaceSlot = (
-    <section id="admin-health" className="flex min-h-0 flex-1 flex-col gap-3">
-      {hasSystemHealthFetchError ? (
-        <div role="alert" className="clinical-alert-warning shrink-0">
-          No se pudo consultar el estado del sistema. Los valores de salud
-          operacional se muestran como desconocidos hasta recuperar la lectura.
-        </div>
-      ) : null}
-      <ModuleTabs
-        ariaLabel="Estado y mantenimiento"
-        tabs={[
-          { id: "servicios", label: "Servicios", content: healthServicesGrid },
-          { id: "runtime", label: "Runtime", content: healthRuntimeGrid },
-          {
-            id: "esquema",
-            label: "Esquema",
-            content: <AdminSchemaHealthStatusCard />,
-          },
-        ]}
+    <>
+      <AdminMobileHealthModule
+        hasError={hasSystemHealthFetchError}
+        services={healthMobileServices}
+        runtime={healthMobileRuntime}
       />
-    </section>
+      <section
+        id="admin-health"
+        className="hidden min-h-0 flex-1 flex-col gap-3 md:flex"
+      >
+        {hasSystemHealthFetchError ? (
+          <div role="alert" className="clinical-alert-warning shrink-0">
+            No se pudo consultar el estado del sistema. Los valores de salud
+            operacional se muestran como desconocidos hasta recuperar la lectura.
+          </div>
+        ) : null}
+        <ModuleTabs
+          ariaLabel="Estado y mantenimiento"
+          tabs={[
+            { id: "servicios", label: "Servicios", content: healthServicesGrid },
+            { id: "runtime", label: "Runtime", content: healthRuntimeGrid },
+            {
+              id: "esquema",
+              label: "Esquema",
+              content: <AdminSchemaHealthStatusCard />,
+            },
+          ]}
+        />
+      </section>
+    </>
   );
 
   // ── Clínicas workspace ──────────────────────────────────────────────────────

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2842,6 +2842,40 @@
   }
 }
 /* admin-mobile-ops-modules:end */
+/* admin-mobile-status-modules:start */
+/* PR-B — Administración/Resumen + Estado del sistema previously rendered the
+   desktop ModuleTabs/grids on mobile; collapsed to one column they overflowed
+   under the bottom nav. The dedicated mobile variant carries
+   [data-admin-mobile-status-module]; here we hide the workspace header and
+   reclaim the viewport so the chip-segmented surface owns the full content band
+   with zero scroll. Scoped to Admin mobile only (<=767px + surface="admin"):
+   desktop, Clinic and the module data stay untouched. */
+@media (max-width: 767px) {
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-workspace]:has([data-admin-mobile-status-module])
+    .dashboard-workspace-header {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-workspace]:has([data-admin-mobile-status-module])
+    [data-dashboard-module-viewport] {
+    min-height: 0;
+    overflow: hidden;
+    padding-top: 0 !important;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] [data-admin-mobile-status-module],
+  [data-vetneb-app-shell-surface="admin"]
+    [data-admin-mobile-status-module]
+    :is(article, nav, header) {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+    overflow-y: hidden;
+  }
+}
+/* admin-mobile-status-modules:end */
 /* admin-mobile-real-device-layer-isolation:start */
 /* PR-A — real-device GPU layer recycling guard.
    The Hub leaf surface ([data-admin-mobile-hub-launcher]) and the active module

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2842,27 +2842,39 @@
   }
 }
 /* admin-mobile-ops-modules:end */
-/* admin-mobile-status-modules:start */
-/* PR-B — Administración/Resumen + Estado del sistema previously rendered the
-   desktop ModuleTabs/grids on mobile; collapsed to one column they overflowed
-   under the bottom nav. The dedicated mobile variant carries
-   [data-admin-mobile-status-module]; here we hide the workspace header and
-   reclaim the viewport so the chip-segmented surface owns the full content band
-   with zero scroll. Scoped to Admin mobile only (<=767px + surface="admin"):
-   desktop, Clinic and the module data stay untouched. */
+/* admin-mobile-module-header-reclaim:start */
+/* PR-B addendum — on Admin mobile the in-workspace module header (title +
+   description + a `border-bottom` divider + 1rem padding + 1rem margin, defined
+   on `.dashboard-workspace-header`) is redundant: the app bar already shows the
+   module context, the back button is hidden on mobile and the bottom nav drives
+   navigation. It only burned ~64px of critical height and left a divider/empty
+   band above the module controls/chips. Hide it on EVERY admin module and zero
+   the viewport top padding so content sits ~one gutter (≈8px) below the app bar.
+   Desktop (>=768px) keeps the header — there the back button + divider are the
+   real module chrome. Scoped to surface="admin"; Clínica uses another shell
+   surface and is untouched. */
 @media (max-width: 767px) {
   [data-vetneb-app-shell-surface="admin"]
-    [data-dashboard-module-workspace]:has([data-admin-mobile-status-module])
+    [data-dashboard-module-workspace]
     .dashboard-workspace-header {
     display: none !important;
   }
 
   [data-vetneb-app-shell-surface="admin"]
-    [data-dashboard-module-workspace]:has([data-admin-mobile-status-module])
+    [data-dashboard-module-workspace]
     [data-dashboard-module-viewport] {
     min-height: 0;
-    overflow: hidden;
     padding-top: 0 !important;
+  }
+}
+/* admin-mobile-module-header-reclaim:end */
+/* admin-mobile-status-modules:start */
+/* Status modules (admin / admin-health) overflow safety + viewport clipping. */
+@media (max-width: 767px) {
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-workspace]:has([data-admin-mobile-status-module])
+    [data-dashboard-module-viewport] {
+    overflow: hidden;
   }
 
   [data-vetneb-app-shell-surface="admin"] [data-admin-mobile-status-module],


### PR DESCRIPTION
## Summary
- Add dedicated Admin mobile no-scroll modules for `admin` and `admin-health`
- Replace mobile desktop-collapsed status layouts with compact segmented mobile variants
- Add `AdminMobileStatusModule`, `AdminMobileCommandModule`, and `AdminMobileHealthModule`
- Add mobile status-module E2E coverage for 360/390/430 viewports in light and dark mode
- Remove redundant Admin mobile workspace header divider and reclaim vertical space
- Balance bottom gutter against side gutter across status module chips/panels
- Preserve desktop via `hidden md:flex` desktop copies and mobile-only status modules
- Keep #1071 hub reset / layer isolation behavior intact

## Root cause
`admin` and `admin-health` were still rendering desktop-oriented `ModuleTabs` / grid layouts on mobile. At mobile widths those grids collapsed into vertical stacks inside the fixed Admin shell, causing lower cards such as “Alertas y estados” and “CORS público” to be clipped under the bottom nav.

After the first PR-B pass, the modules no longer clipped, but the content did not use the safe band efficiently and the shared `.dashboard-workspace-header` introduced a redundant divider plus a large empty band between the module header and the mobile chips. The addendum removes that mobile-only dead space and enforces balanced bottom/side gutters.

## Changes
- `AdminMobileStatusModule.tsx`: shared mobile primitive with segmented chips/tablist and status-module data attributes
- `AdminMobileCommandModule.tsx`: mobile `admin` module with compact Resumen, Actividad, and Alertas sections
- `AdminMobileHealthModule.tsx`: mobile `admin-health` module with Servicios, Runtime, and Esquema sections
- `page.tsx`: renders mobile modules plus desktop content isolated behind `hidden md:flex`
- `globals.css`:
  - scoped Admin mobile status-module layout rules
  - hides redundant `.dashboard-workspace-header` only in Admin mobile
  - reclaims header/divider dead space
  - no `overflow:auto` / no scroll
- `admin-mobile-status-modules-no-scroll.spec.ts`:
  - 360/390/430, light/dark coverage
  - no-scroll and no-clipping coverage
  - per-chip gutter validation
  - header-to-chip gap validation
  - desktop preservation assertions
- `dashboard-real-app-shell-no-scroll-contract.spec.ts`:
  - visible-copy locator alignment after adding mobile duplicate content
  - expected values unchanged

## Screenshots
Generated under:
`frontend/test-results/admin-mobile-status-modules-no-scroll/`

Before/after coverage:
- `admin` at 360/390/430 in light/dark
- `admin-health` at 360/390/430 in light/dark
- per-chip after screenshots for Resumen, Actividad, Alertas, Servicios, Runtime, and Esquema

Note: screenshots are gitignored test artifacts and are not included in this commit. Attach manually to the PR if inline evidence is required.

## Deferred scope
`admin-pricing` and `admin-maintenance` remain P2 candidates for a follow-up PR because their overflow depends on populated configuration data and requires dedicated config-oriented mobile modules.

## Scope
- Frontend only
- Admin mobile only
- No backend / API / DB / auth
- No Clínica
- No deps / lockfiles / CI
- No desktop behavior change
- No scroll introduced
- No tests relaxed

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-status-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-module-layer-isolation.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface
- git diff --check