### PR TITLE
fix(admin): add mobile no-scroll config modules

### DIFF
--- a/frontend/e2e/admin-mobile-config-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-config-modules-no-scroll.spec.ts
@@ -1,0 +1,460 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type Route,
+  type TestInfo,
+} from "@playwright/test";
+
+// PR-C — Admin mobile CONFIG modules (Precios + Mantenimiento). These rendered
+// the desktop editor card / ModuleTabs on mobile; with populated data they
+// overflowed under the bottom nav. This spec pins dedicated mobile variants
+// (`[data-admin-mobile-config-module]`) that fit 360/390/430 in light + dark
+// with zero scroll, balanced bottom gutter and no header divider.
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+const COLOR_MODES = ["light", "dark"] as const;
+
+const DESKTOP_VIEWPORT = { name: "desktop-1280x800", width: 1280, height: 800 } as const;
+
+type ColorMode = (typeof COLOR_MODES)[number];
+type Viewport = { name: string; width: number; height: number };
+
+type ConfigModule = {
+  key: "admin-pricing" | "admin-maintenance";
+  moduleId: "admin-pricing" | "admin-maintenance";
+  desktopReady: string | RegExp;
+};
+
+const CONFIG_MODULES: ConfigModule[] = [
+  { key: "admin-pricing", moduleId: "admin-pricing", desktopReady: "Lista de precios" },
+  {
+    key: "admin-maintenance",
+    moduleId: "admin-maintenance",
+    desktopReady: /Mantenimiento|Estado de esquema/i,
+  },
+];
+
+const PRICING_CATEGORIES = ["Histopatología", "Citología", "Inmunohistoquímica"].map(
+  (category, c) => ({
+    category,
+    items: Array.from({ length: 4 }, (_, i) => {
+      const id = 5000 + c * 10 + i;
+      return {
+        id,
+        studyName: `${category} — estudio ${i + 1}`,
+        priceLabel: i % 3 === 0 ? null : `$${(c + 1) * 1000 + i * 100}`,
+        displayOrder: i,
+        isActive: i % 4 !== 3,
+        updatedAt: "2026-06-18T10:00:00.000Z",
+      };
+    }),
+  }),
+);
+
+const DRY_RUN_CANDIDATES = Array.from({ length: 7 }, (_, i) => ({
+  label: `Grupo de limpieza ${i + 1}`,
+  category: `purge.category.${i + 1}`,
+  supported: i % 2 === 0,
+  count: 10 + i,
+  destructiveAction: i % 2 === 0 ? `delete_${i}` : null,
+  reason: i % 3 === 0 ? "Pendiente de soporte backend." : null,
+}));
+
+const CONFIG_SNAPSHOT_PHASE =
+  process.env.CONFIG_SNAPSHOT_PHASE === "before" ? "before" : "after";
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function fulfillJson(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockConfigApis(page: Page) {
+  await page.route("**/api/admin/pricing**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() === "GET" && url.pathname === "/api/admin/pricing") {
+      await fulfillJson(route, { success: true, categories: PRICING_CATEGORIES });
+      return;
+    }
+    if (request.method() === "PATCH" && /\/api\/admin\/pricing\/\d+$/.test(url.pathname)) {
+      const id = Number(url.pathname.split("/").pop());
+      let patch: Record<string, unknown> = {};
+      try {
+        patch = JSON.parse(request.postData() ?? "{}");
+      } catch {
+        patch = {};
+      }
+      await fulfillJson(route, {
+        success: true,
+        pricingItem: {
+          id,
+          category: "Histopatología",
+          studyName: "Estudio actualizado",
+          priceLabel: "priceLabel" in patch ? patch.priceLabel : "$1000",
+          displayOrder: "displayOrder" in patch ? patch.displayOrder : 0,
+          isActive: "isActive" in patch ? patch.isActive : true,
+          updatedAt: "2026-06-19T10:00:00.000Z",
+        },
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route("**/api/admin/system/schema-health**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, {
+      success: true,
+      status: "ok",
+      generatedAt: "2026-06-18T14:30:00.000Z",
+      checkedBy: { adminUserId: 41, username: "admin_operaciones" },
+      summary: { requiredTables: 18, requiredColumns: 96, presentColumns: 96, missingColumns: 0 },
+      missing: [],
+    });
+  });
+
+  await page.route("**/api/admin/system/maintenance/purge-dry-run**", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, {
+      success: true,
+      dryRun: true,
+      generatedAt: "2026-06-18T14:30:00.000Z",
+      checkedBy: { adminUserId: 41, username: "admin_operaciones" },
+      totals: { candidateRecords: 88, supportedCandidateRecords: 40, unsupportedGroups: 3 },
+      candidates: DRY_RUN_CANDIDATES,
+    });
+  });
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({ content: "nextjs-portal { display: none !important; }" });
+}
+
+async function applyColorMode(page: Page, mode: ColorMode) {
+  if (mode === "dark") {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("vetneb-theme-mode", "dark-gray");
+      } catch {
+        /* localStorage unavailable */
+      }
+    });
+  }
+  await page.emulateMedia({ colorScheme: mode, reducedMotion: "reduce" });
+}
+
+type NoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  module: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  forbiddenOverflow: Array<{ tag: string; className: string; overflowX: string; overflowY: string }>;
+};
+
+async function readNoScrollContract(page: Page, selector: string): Promise<NoScrollContract> {
+  return page.evaluate((moduleSelector) => {
+    const shell = document.querySelector<HTMLElement>('[data-vetneb-app-shell-surface="admin"]');
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const moduleRoot = document.querySelector<HTMLElement>(moduleSelector);
+    if (!moduleRoot) throw new Error(`Missing module root: ${moduleSelector}`);
+
+    const candidates = [
+      document.documentElement,
+      document.body,
+      ...(shell ? [shell] : []),
+      ...(main ? [main] : []),
+      moduleRoot,
+      ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")),
+    ];
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      if (
+        !["auto", "scroll"].includes(style.overflowX) &&
+        !["auto", "scroll"].includes(style.overflowY)
+      ) {
+        return [];
+      }
+      return [
+        {
+          tag: element.tagName,
+          className: element.className,
+          overflowX: style.overflowX,
+          overflowY: style.overflowY,
+        },
+      ];
+    });
+
+    const metrics = (element: HTMLElement) => ({
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    });
+
+    return {
+      html: metrics(document.documentElement),
+      body: metrics(document.body),
+      module: metrics(moduleRoot),
+      forbiddenOverflow,
+    };
+  }, selector);
+}
+
+function assertNoScrollContract(contract: NoScrollContract, label: string) {
+  for (const [surface, metrics] of Object.entries({
+    html: contract.html,
+    body: contract.body,
+    module: contract.module,
+  })) {
+    expect(metrics.scrollHeight, `${label}: ${surface} vertical clipping/overflow`).toBeLessThanOrEqual(
+      metrics.clientHeight + TOLERANCE,
+    );
+    expect(metrics.scrollWidth, `${label}: ${surface} horizontal clipping/overflow`).toBeLessThanOrEqual(
+      metrics.clientWidth + TOLERANCE,
+    );
+  }
+  expect(contract.forbiddenOverflow, `${label}: overflow auto/scroll`).toEqual([]);
+}
+
+type ContentGutters = {
+  bottomGutter: number;
+  sideGutter: number;
+  appBarToChipsGap: number;
+};
+
+async function readContentGutters(page: Page, moduleSelector: string): Promise<ContentGutters> {
+  return page.evaluate((selector) => {
+    const moduleRoot = document.querySelector<HTMLElement>(selector);
+    const panel = moduleRoot?.querySelector<HTMLElement>("[data-admin-mobile-config-panel]");
+    const chipRow = moduleRoot?.querySelector<HTMLElement>('[role="tablist"]');
+    const bottomNav = document.querySelector<HTMLElement>('[data-admin-mobile-bottom-nav="true"]');
+    const appBar = document.querySelector<HTMLElement>('[data-admin-mobile-app-bar="true"]');
+    if (!moduleRoot || !panel || !chipRow || !bottomNav || !appBar) {
+      throw new Error(`Gutter contract incomplete for ${selector}`);
+    }
+    const navTop = bottomNav.getBoundingClientRect().top;
+    let maxBottom = Number.NEGATIVE_INFINITY;
+    for (const element of Array.from(panel.querySelectorAll<HTMLElement>("*"))) {
+      const rect = element.getBoundingClientRect();
+      if (rect.width > 1 && rect.height > 1 && rect.bottom > maxBottom) maxBottom = rect.bottom;
+    }
+    const panelRect = panel.getBoundingClientRect();
+    return {
+      bottomGutter: navTop - maxBottom,
+      sideGutter: Math.min(panelRect.left, window.innerWidth - panelRect.right),
+      appBarToChipsGap: chipRow.getBoundingClientRect().top - appBar.getBoundingClientRect().bottom,
+    };
+  }, moduleSelector);
+}
+
+function assertGutterContract(gutters: ContentGutters, label: string) {
+  expect(gutters.bottomGutter, `${label}: bottom gutter not pegged (>= 10px); got ${gutters.bottomGutter}`).toBeGreaterThanOrEqual(
+    10,
+  );
+  expect(gutters.bottomGutter, `${label}: bottom gutter >= side gutter (${gutters.sideGutter})`).toBeGreaterThanOrEqual(
+    gutters.sideGutter - 2,
+  );
+  expect(
+    gutters.bottomGutter,
+    `${label}: bottom gutter balanced with side gutter ${gutters.sideGutter} (no void)`,
+  ).toBeLessThanOrEqual(gutters.sideGutter + 24);
+}
+
+async function expectInsideContentBand(page: Page, locator: Locator, viewport: Viewport, label: string) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const [appBarBox, bottomNavBox, box] = await Promise.all([
+    page.locator('[data-admin-mobile-app-bar="true"]').boundingBox(),
+    page.locator('[data-admin-mobile-bottom-nav="true"]').boundingBox(),
+    locator.boundingBox(),
+  ]);
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(appBarBox, `${label}: app bar box`).not.toBeNull();
+  expect(bottomNavBox, `${label}: bottom nav box`).not.toBeNull();
+  expect(box!.x, `${label}: left`).toBeGreaterThanOrEqual(-TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right`).toBeLessThanOrEqual(viewport.width + TOLERANCE);
+  expect(box!.y, `${label}: below app bar`).toBeGreaterThanOrEqual(appBarBox!.y + appBarBox!.height - TOLERANCE);
+  expect(box!.y + box!.height, `${label}: above bottom nav`).toBeLessThanOrEqual(bottomNavBox!.y + TOLERANCE);
+}
+
+async function captureScreen(page: Page, testInfo: TestInfo, fileName: string) {
+  const dir = resolve(
+    testInfo.config.rootDir,
+    "..",
+    "test-results",
+    "admin-mobile-config-modules-no-scroll",
+  );
+  await mkdir(dir, { recursive: true });
+  await page.screenshot({ path: resolve(dir, `${fileName}.png`), animations: "disabled", fullPage: false });
+}
+
+for (const moduleSpec of CONFIG_MODULES) {
+  for (const viewport of MOBILE_VIEWPORTS) {
+    for (const mode of COLOR_MODES) {
+      test(`Admin mobile config "${moduleSpec.key}" is no-scroll at ${viewport.name} ${mode}`, async ({
+        page,
+      }, testInfo) => {
+        test.setTimeout(60_000);
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await applyColorMode(page, mode);
+        await setPopulatedAdminSession(page);
+        await mockConfigApis(page);
+        await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+        await suppressNextDevIndicator(page);
+
+        await expect(
+          page.locator('[data-admin-mobile-app-bar="true"]'),
+          `${viewport.name} ${mode}: app bar`,
+        ).toBeVisible({ timeout: 15_000 });
+        await expect(
+          page.locator('[data-admin-mobile-bottom-nav="true"]'),
+          `${viewport.name} ${mode}: bottom nav`,
+        ).toBeVisible();
+        await expect(
+          page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+          `${viewport.name} ${mode}: desktop nav hidden`,
+        ).toBeHidden();
+
+        const shortViewport = String(viewport.width);
+        await captureScreen(page, testInfo, `${CONFIG_SNAPSHOT_PHASE}-${shortViewport}-${mode}-${moduleSpec.key}`);
+
+        const moduleSelector = `[data-admin-mobile-config-module="${moduleSpec.key}"]`;
+        const moduleRoot = page.locator(moduleSelector);
+        await expect(moduleRoot, `${viewport.name} ${mode}: config module root`).toBeVisible({
+          timeout: 15_000,
+        });
+
+        await expectInsideContentBand(page, moduleRoot, viewport, `${viewport.name} ${mode} ${moduleSpec.key} module`);
+        assertNoScrollContract(
+          await readNoScrollContract(page, moduleSelector),
+          `${viewport.name} ${mode} ${moduleSpec.key} initial`,
+        );
+
+        // No redundant workspace-header divider between the app bar and the chips.
+        await expect(
+          page.locator(`[data-dashboard-module-workspace="${moduleSpec.moduleId}"] .dashboard-workspace-header`),
+          `${viewport.name} ${mode} ${moduleSpec.key}: workspace header hidden`,
+        ).toBeHidden();
+
+        const consoleErrors: string[] = [];
+        page.on("console", (m) => {
+          if (m.type() === "error") consoleErrors.push(m.text());
+        });
+
+        const chips = moduleRoot.locator("[data-admin-mobile-config-chip]");
+        const chipCount = await chips.count();
+        expect(chipCount, `${viewport.name} ${mode} ${moduleSpec.key}: section chips`).toBeGreaterThan(1);
+
+        for (let index = 0; index < chipCount; index += 1) {
+          const chip = chips.nth(index);
+          const chipId = (await chip.getAttribute("data-admin-mobile-config-chip")) ?? String(index);
+          await expectInsideContentBand(page, chip, viewport, `${viewport.name} ${mode} ${moduleSpec.key} chip ${chipId}`);
+          await chip.click();
+
+          const panel = moduleRoot.locator("[data-admin-mobile-config-panel]");
+          await expect(panel, `${viewport.name} ${mode} ${moduleSpec.key} panel ${chipId}`).toBeVisible();
+
+          // Dry-run starts empty: populate it so the contract is checked against
+          // real content (also exercises the analyze action).
+          const analyze = panel.getByRole("button", { name: "Analizar", exact: true });
+          if (await analyze.count()) await analyze.click();
+
+          await panel
+            .locator('[data-admin-mobile-config-item="true"], [data-admin-mobile-ops-pager="true"]')
+            .first()
+            .waitFor({ state: "visible", timeout: 10_000 })
+            .catch(() => {});
+
+          await expectInsideContentBand(page, panel, viewport, `${viewport.name} ${mode} ${moduleSpec.key} panel ${chipId}`);
+          assertNoScrollContract(
+            await readNoScrollContract(page, moduleSelector),
+            `${viewport.name} ${mode} ${moduleSpec.key} section ${chipId}`,
+          );
+
+          const gutters = await readContentGutters(page, moduleSelector);
+          expect(
+            gutters.appBarToChipsGap,
+            `${viewport.name} ${mode} ${moduleSpec.key} ${chipId}: app bar -> chips gap <= 14px; got ${gutters.appBarToChipsGap}`,
+          ).toBeLessThanOrEqual(14);
+          assertGutterContract(gutters, `${viewport.name} ${mode} ${moduleSpec.key} ${chipId}`);
+
+          await captureScreen(page, testInfo, `${CONFIG_SNAPSHOT_PHASE}-${shortViewport}-${mode}-${moduleSpec.key}-${chipId}`);
+        }
+
+        await page
+          .locator('[data-admin-mobile-bottom-nav="true"]')
+          .getByRole("button", { name: "Inicio", exact: true })
+          .click();
+        await expect(
+          page.locator('[data-admin-mobile-hub-launcher="true"]'),
+          `${viewport.name} ${mode}: back to hub`,
+        ).toBeVisible({ timeout: 15_000 });
+
+        expect(consoleErrors, `${viewport.name} ${mode} ${moduleSpec.key}: console errors`).toEqual([]);
+      });
+    }
+  }
+}
+
+for (const moduleSpec of CONFIG_MODULES) {
+  test(`Admin desktop preserves ${moduleSpec.key} layout at 1280x800`, async ({ page }) => {
+    await page.setViewportSize({ width: DESKTOP_VIEWPORT.width, height: DESKTOP_VIEWPORT.height });
+    await setPopulatedAdminSession(page);
+    await mockConfigApis(page);
+    await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
+
+    await expect(
+      page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+      `${moduleSpec.key} desktop: horizontal nav visible`,
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.locator('[data-admin-mobile-bottom-nav="true"]'),
+      `${moduleSpec.key} desktop: bottom nav absent`,
+    ).toBeHidden();
+    await expect(
+      page.locator(`[data-admin-mobile-config-module="${moduleSpec.key}"]`),
+      `${moduleSpec.key} desktop: mobile config module hidden`,
+    ).toBeHidden();
+    await expect(
+      page.locator(`[data-dashboard-module-workspace="${moduleSpec.moduleId}"] .dashboard-workspace-header`),
+      `${moduleSpec.key} desktop: workspace header visible`,
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page
+        .locator(`[data-dashboard-module-workspace="${moduleSpec.moduleId}"]`)
+        .getByText(moduleSpec.desktopReady)
+        .filter({ visible: true })
+        .first(),
+      `${moduleSpec.key} desktop: populated desktop content`,
+    ).toBeVisible({ timeout: 15_000 });
+  });
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileConfigModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileConfigModule.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+export type AdminMobileConfigSection = {
+  id: string;
+  label: string;
+  content: ReactNode;
+};
+
+type AdminMobileConfigModuleProps = {
+  /** Module key exposed as `data-admin-mobile-config-module`. */
+  moduleKey: string;
+  ariaLabel: string;
+  sections: AdminMobileConfigSection[];
+};
+
+/**
+ * Mobile-only ("md:hidden") chip-segmented shell for Admin CONFIG modules
+ * (Precios / Mantenimiento). Mirrors AdminMobileStatusModule but exposes
+ * `data-admin-mobile-config-*` hooks so the no-scroll/gutter CSS + e2e stay
+ * scoped per family. Only the active section mounts (lazy fetch), the chip row
+ * is fixed and the panel fills the remaining height with zero scroll.
+ */
+export function AdminMobileConfigModule({
+  moduleKey,
+  ariaLabel,
+  sections,
+}: AdminMobileConfigModuleProps) {
+  const baseId = useId();
+  const fallbackId = sections[0]?.id ?? "";
+  const [activeId, setActiveId] = useState(fallbackId);
+
+  useEffect(() => {
+    if (!sections.some((section) => section.id === activeId)) {
+      setActiveId(fallbackId);
+    }
+  }, [sections, activeId, fallbackId]);
+
+  if (!sections.length) return null;
+
+  const active = sections.find((section) => section.id === activeId) ?? sections[0];
+
+  function handleKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
+    const backward = event.key === "ArrowLeft" || event.key === "ArrowUp";
+    if (!forward && !backward) return;
+    event.preventDefault();
+    const last = sections.length - 1;
+    const nextIndex =
+      (index + (forward ? 1 : -1) + sections.length) % sections.length;
+    const next = sections[nextIndex] ?? sections[last];
+    setActiveId(next.id);
+    window.requestAnimationFrame(() => {
+      document.getElementById(`${baseId}-chip-${next.id}`)?.focus();
+    });
+  }
+
+  return (
+    <section
+      data-admin-mobile-config-module={moduleKey}
+      aria-label={ariaLabel}
+      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/80 bg-card md:hidden"
+    >
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        className="flex shrink-0 items-center gap-1 overflow-hidden border-b border-vetneb-line/70 p-1.5"
+      >
+        {sections.map((section, index) => {
+          const isActive = section.id === active.id;
+          return (
+            <button
+              key={section.id}
+              id={`${baseId}-chip-${section.id}`}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`${baseId}-panel-${section.id}`}
+              tabIndex={isActive ? 0 : -1}
+              data-admin-mobile-config-chip={section.id}
+              data-active={isActive ? "true" : undefined}
+              onClick={() => setActiveId(section.id)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              className={cn(
+                "min-w-0 flex-1 truncate rounded-md px-2 py-1.5 text-[0.72rem] font-semibold leading-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-1",
+                isActive
+                  ? "bg-vetneb-navy text-white shadow-sm"
+                  : "bg-vetneb-surface-muted/60 text-muted-foreground hover:bg-vetneb-surface-muted",
+              )}
+            >
+              {section.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`${baseId}-panel-${active.id}`}
+        aria-label={active.label}
+        data-admin-mobile-config-panel={active.id}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden p-2"
+      >
+        {active.content}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobileMaintenanceModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileMaintenanceModule.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  getAdminMaintenancePurgeDryRun,
+  getAdminSchemaHealth,
+} from "@/lib/api";
+import { formatDateTime } from "@/lib/utils";
+import type {
+  AdminSchemaHealthSnapshot,
+  MaintenancePurgeCandidateGroup,
+  MaintenancePurgeDryRunSnapshot,
+} from "@/types";
+import { AdminMobileConfigModule } from "./AdminMobileConfigModule";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
+
+const CANDIDATE_PAGE_SIZE = 3;
+
+function useIsMobileViewport() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+  return isMobileViewport;
+}
+
+function MaintenanceMetric({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div
+      data-admin-mobile-config-item="true"
+      className="flex min-h-0 flex-col justify-center overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+    >
+      <p className="truncate text-[0.62rem] text-muted-foreground">{label}</p>
+      <p className="mt-0.5 truncate text-base font-semibold leading-tight text-vetneb-ink">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+// ── Esquema ──────────────────────────────────────────────────────────────────
+function MaintenanceSchemaSection() {
+  const isMobileViewport = useIsMobileViewport();
+  const [snapshot, setSnapshot] = useState<AdminSchemaHealthSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function loadSchema() {
+    if (!isMobileViewport) return;
+    setError(null);
+    startTransition(() => {
+      void (async () => {
+        try {
+          setSnapshot(await getAdminSchemaHealth());
+        } catch {
+          setSnapshot(null);
+          setError("No se pudo consultar el estado del esquema.");
+        } finally {
+          setHasLoadedOnce(true);
+        }
+      })();
+    });
+  }
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    loadSchema();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileViewport]);
+
+  const summary = snapshot?.summary;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        {snapshot ? (
+          <Badge variant={snapshot.status === "ok" ? "default" : "secondary"}>
+            {snapshot.status === "ok" ? "Esquema compatible" : "Faltan columnas"}
+          </Badge>
+        ) : (
+          <p className="truncate text-xs font-semibold text-vetneb-ink">
+            Estado de esquema
+          </p>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 shrink-0 px-2 text-xs"
+          onClick={loadSchema}
+          disabled={isPending || !isMobileViewport}
+          aria-busy={isPending ? true : undefined}
+        >
+          {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : null}
+          Reintentar
+        </Button>
+      </div>
+
+      {summary ? (
+        <div className="grid shrink-0 grid-cols-2 gap-1.5">
+          <MaintenanceMetric label="Tablas req." value={summary.requiredTables} />
+          <MaintenanceMetric label="Columnas req." value={summary.requiredColumns} />
+          <MaintenanceMetric label="Presentes" value={summary.presentColumns} />
+          <MaintenanceMetric label="Faltantes" value={summary.missingColumns} />
+        </div>
+      ) : null}
+
+      {snapshot ? (
+        <div
+          data-admin-mobile-config-item="true"
+          className="min-h-0 flex-1 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/92 px-2.5 py-1.5"
+        >
+          <p className="truncate text-[0.66rem] text-muted-foreground">
+            Generado: {formatDateTime(snapshot.generatedAt)}
+          </p>
+          <p className="mt-0.5 truncate text-[0.66rem] text-muted-foreground">
+            Revisado por:{" "}
+            {snapshot.checkedBy
+              ? `${snapshot.checkedBy.username} #${snapshot.checkedBy.adminUserId}`
+              : "—"}
+          </p>
+          {snapshot.status === "degraded" ? (
+            <p className="mt-1 line-clamp-2 text-[0.66rem] text-vetneb-navy">
+              {snapshot.missing.length
+                ? `${snapshot.missing.length} columna(s) crítica(s) faltante(s).`
+                : "Faltan columnas críticas sin detalle."}
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+          {error
+            ? "Esquema no disponible."
+            : !hasLoadedOnce || isPending
+              ? "Consultando estado de esquema…"
+              : "Sin datos de esquema."}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Dry-run ──────────────────────────────────────────────────────────────────
+function MaintenanceDryRunSection() {
+  const isMobileViewport = useIsMobileViewport();
+  const [snapshot, setSnapshot] = useState<MaintenancePurgeDryRunSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [isPending, startTransition] = useTransition();
+
+  function analyze() {
+    if (!isMobileViewport) return;
+    setError(null);
+    startTransition(() => {
+      void (async () => {
+        try {
+          setSnapshot(await getAdminMaintenancePurgeDryRun());
+          setOffset(0);
+        } catch (err) {
+          setError(
+            err instanceof Error ? err.message : "No se pudo analizar la limpieza.",
+          );
+        }
+      })();
+    });
+  }
+
+  const candidates: MaintenancePurgeCandidateGroup[] = useMemo(
+    () => snapshot?.candidates ?? [],
+    [snapshot],
+  );
+  const pageCandidates = useMemo(
+    () => candidates.slice(offset, offset + CANDIDATE_PAGE_SIZE),
+    [candidates, offset],
+  );
+  const page = Math.floor(offset / CANDIDATE_PAGE_SIZE) + 1;
+  const pageCount = Math.max(1, Math.ceil(candidates.length / CANDIDATE_PAGE_SIZE));
+  const hasNext = offset + CANDIDATE_PAGE_SIZE < candidates.length;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-xs font-semibold text-vetneb-ink">
+          {snapshot ? `Dry-run: ${snapshot.dryRun ? "true" : "false"}` : "Mantenimiento dry-run"}
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 shrink-0 px-2 text-xs"
+          onClick={analyze}
+          disabled={isPending || !isMobileViewport}
+          aria-busy={isPending ? true : undefined}
+        >
+          {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : null}
+          Analizar
+        </Button>
+      </div>
+
+      {snapshot ? (
+        <>
+          <div className="grid shrink-0 grid-cols-3 gap-1.5">
+            <MaintenanceMetric label="Candidatos" value={snapshot.totals.candidateRecords} />
+            <MaintenanceMetric label="Soportados" value={snapshot.totals.supportedCandidateRecords} />
+            <MaintenanceMetric label="No sop." value={snapshot.totals.unsupportedGroups} />
+          </div>
+          <div className="grid min-h-0 flex-1 grid-rows-3 gap-1.5 overflow-hidden">
+            {pageCandidates.length ? (
+              pageCandidates.map((candidate) => (
+                <div
+                  key={candidate.category}
+                  data-admin-mobile-config-item="true"
+                  className="flex min-h-0 items-center justify-between gap-2 overflow-hidden rounded-md border border-vetneb-line/70 bg-card/95 px-2.5 py-1.5"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-medium text-vetneb-ink">
+                      {candidate.label}
+                    </p>
+                    <p className="truncate font-mono text-[0.62rem] text-muted-foreground">
+                      {candidate.category}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    <Badge
+                      variant={candidate.supported ? "secondary" : "outline"}
+                      className="h-5 px-1.5 text-[10px]"
+                    >
+                      {candidate.supported ? "Soportado" : "No sop."}
+                    </Badge>
+                    <span className="text-xs font-semibold tabular-nums text-vetneb-ink">
+                      {candidate.count}
+                    </span>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="row-span-3 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+                Sin candidatos de limpieza.
+              </div>
+            )}
+          </div>
+          <AdminMobileOpsPager
+            ariaLabel="Paginación de candidatos"
+            page={candidates.length ? page : 0}
+            pageCount={pageCount}
+            rangeLabel={
+              candidates.length
+                ? `${offset + 1}–${Math.min(offset + CANDIDATE_PAGE_SIZE, candidates.length)} de ${candidates.length}`
+                : "Sin candidatos"
+            }
+            previousDisabled={offset === 0}
+            nextDisabled={!hasNext}
+            disabled={isPending}
+            onPrevious={() => setOffset(Math.max(0, offset - CANDIDATE_PAGE_SIZE))}
+            onNext={() => setOffset(offset + CANDIDATE_PAGE_SIZE)}
+          />
+        </>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+          {error
+            ? error
+            : isPending
+              ? "Analizando…"
+              : "Sin análisis ejecutado. Presioná Analizar para consultar el endpoint dry-run."}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AdminMobileMaintenanceModule() {
+  return (
+    <AdminMobileConfigModule
+      moduleKey="admin-maintenance"
+      ariaLabel="Mantenimiento del sistema"
+      sections={[
+        { id: "esquema", label: "Esquema", content: <MaintenanceSchemaSection /> },
+        { id: "dry-run", label: "Dry-run", content: <MaintenanceDryRunSection /> },
+      ]}
+    />
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminMobilePricingModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobilePricingModule.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  getAdminPricing,
+  updateAdminPricingItem,
+  type AdminPricingUpdatePayload,
+} from "@/lib/api";
+import { AdminMobileConfigModule } from "./AdminMobileConfigModule";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
+
+type FlatPricingItem = {
+  id: number;
+  category: string;
+  studyName: string;
+  priceLabel: string | null;
+  displayOrder: number;
+  isActive: boolean;
+};
+
+const CATALOG_PAGE_SIZE = 4;
+
+function normalizePriceLabel(value: string | null): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed ? trimmed : "Consultar";
+}
+
+export function AdminMobilePricingModule() {
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [items, setItems] = useState<FlatPricingItem[]>([]);
+  const [index, setIndex] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [priceDraft, setPriceDraft] = useState("");
+  const [orderDraft, setOrderDraft] = useState("");
+  const [activeDraft, setActiveDraft] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const current = items[index] ?? null;
+
+  function syncDraftFromItem(item: FlatPricingItem | null) {
+    setPriceDraft(item?.priceLabel ?? "");
+    setOrderDraft(item ? String(item.displayOrder) : "");
+    setActiveDraft(item ? item.isActive : true);
+    setSaveMessage(null);
+    setSaveError(null);
+  }
+
+  async function loadPricing() {
+    if (!isMobileViewport) return;
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const snapshot = await getAdminPricing();
+      const flat: FlatPricingItem[] = snapshot.categories.flatMap((category) =>
+        [...category.items]
+          .sort((a, b) => a.displayOrder - b.displayOrder || a.id - b.id)
+          .map((item) => ({
+            id: item.id,
+            category: category.category,
+            studyName: item.studyName,
+            priceLabel: item.priceLabel,
+            displayOrder: item.displayOrder,
+            isActive: item.isActive,
+          })),
+      );
+      setItems(flat);
+      setIndex(0);
+      syncDraftFromItem(flat[0] ?? null);
+    } catch (error) {
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : "No se pudieron cargar los precios.",
+      );
+      setItems([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileViewport) return;
+    void loadPricing();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobileViewport]);
+
+  function goToIndex(next: number) {
+    const bounded = Math.max(0, Math.min(items.length - 1, next));
+    setIndex(bounded);
+    syncDraftFromItem(items[bounded] ?? null);
+  }
+
+  function parseOrder(value: string): number | null {
+    if (!value.trim()) return null;
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+  }
+
+  async function handleSave() {
+    if (!current || isSaving) return;
+    const nextOrder = parseOrder(orderDraft);
+    if (nextOrder === null) {
+      setSaveMessage(null);
+      setSaveError("El orden debe ser un entero ≥ 0.");
+      return;
+    }
+    const payload: AdminPricingUpdatePayload = {};
+    const nextPrice = priceDraft.trim() ? priceDraft.trim() : null;
+    if (nextPrice !== (current.priceLabel?.trim() ? current.priceLabel : null)) {
+      payload.priceLabel = nextPrice;
+    }
+    if (activeDraft !== current.isActive) payload.isActive = activeDraft;
+    if (nextOrder !== current.displayOrder) payload.displayOrder = nextOrder;
+
+    if (Object.keys(payload).length === 0) {
+      setSaveError(null);
+      setSaveMessage("Sin cambios para guardar.");
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+    setSaveMessage(null);
+    try {
+      const { pricingItem } = await updateAdminPricingItem(current.id, payload);
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === pricingItem.id
+            ? {
+                ...item,
+                priceLabel: pricingItem.priceLabel,
+                displayOrder: pricingItem.displayOrder,
+                isActive: pricingItem.isActive,
+              }
+            : item,
+        ),
+      );
+      setSaveMessage("Precio actualizado.");
+    } catch (error) {
+      setSaveError(
+        error instanceof Error
+          ? error.message
+          : "No se pudo actualizar el precio.",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const catalogPage = Math.floor(index / CATALOG_PAGE_SIZE);
+  const catalogRows = useMemo(
+    () =>
+      items.slice(
+        catalogPage * CATALOG_PAGE_SIZE,
+        catalogPage * CATALOG_PAGE_SIZE + CATALOG_PAGE_SIZE,
+      ),
+    [items, catalogPage],
+  );
+  const catalogTotalPages = Math.max(
+    1,
+    Math.ceil(items.length / CATALOG_PAGE_SIZE),
+  );
+
+  const editorSection = (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <div className="flex shrink-0 items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-vetneb-ink">
+            {current ? current.studyName : isLoading ? "Cargando…" : "Sin estudios"}
+          </p>
+          {current ? (
+            <p className="truncate text-[0.66rem] text-muted-foreground">
+              {current.category}
+            </p>
+          ) : null}
+        </div>
+        {loadError ? null : (
+          <Badge
+            variant={activeDraft ? "default" : "outline"}
+            className="h-5 shrink-0 px-1.5 text-[10px]"
+          >
+            {activeDraft ? "Activo" : "Inactivo"}
+          </Badge>
+        )}
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-rows-3 gap-1.5 overflow-hidden">
+        <label className="flex min-h-0 flex-col justify-center gap-0.5 text-[0.66rem] font-medium text-muted-foreground">
+          Precio
+          <Input
+            className="h-8 text-sm"
+            value={priceDraft}
+            placeholder="Consultar"
+            disabled={!current || isSaving}
+            onChange={(event) => {
+              setPriceDraft(event.target.value);
+              setSaveMessage(null);
+              setSaveError(null);
+            }}
+          />
+        </label>
+        <label className="flex min-h-0 flex-col justify-center gap-0.5 text-[0.66rem] font-medium text-muted-foreground">
+          Orden
+          <Input
+            className="h-8 text-sm"
+            type="number"
+            min="0"
+            inputMode="numeric"
+            value={orderDraft}
+            disabled={!current || isSaving}
+            onChange={(event) => {
+              setOrderDraft(event.target.value);
+              setSaveMessage(null);
+              setSaveError(null);
+            }}
+          />
+        </label>
+        <label className="flex min-h-0 flex-col justify-center gap-0.5 text-[0.66rem] font-medium text-muted-foreground">
+          Estado
+          <select
+            className="field-select h-8 text-sm"
+            value={activeDraft ? "active" : "inactive"}
+            disabled={!current || isSaving}
+            onChange={(event) => {
+              setActiveDraft(event.target.value === "active");
+              setSaveMessage(null);
+              setSaveError(null);
+            }}
+          >
+            <option value="active">Activo</option>
+            <option value="inactive">Inactivo</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        <p
+          className={`min-w-0 truncate text-[0.66rem] ${saveError ? "text-destructive" : "text-muted-foreground"}`}
+          role={saveError ? "alert" : undefined}
+          aria-live="polite"
+        >
+          {saveError ?? saveMessage ?? `Vista pública: ${normalizePriceLabel(priceDraft)}`}
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 shrink-0 px-3 text-xs"
+          disabled={!current || isSaving}
+          aria-busy={isSaving ? true : undefined}
+          onClick={() => void handleSave()}
+        >
+          {isSaving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          ) : null}
+          Guardar
+        </Button>
+      </div>
+
+      <AdminMobileOpsPager
+        ariaLabel="Paginación de estudios"
+        page={items.length ? index + 1 : 0}
+        pageCount={items.length || 1}
+        rangeLabel={
+          current ? `${index + 1} de ${items.length}` : "Sin estudios"
+        }
+        previousDisabled={index === 0}
+        nextDisabled={index >= items.length - 1}
+        disabled={isSaving || !items.length}
+        onPrevious={() => goToIndex(index - 1)}
+        onNext={() => goToIndex(index + 1)}
+      />
+    </div>
+  );
+
+  const catalogSection = (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+      <p className="shrink-0 truncate text-xs font-semibold text-vetneb-ink">
+        {items.length ? `${items.length} estudios` : isLoading ? "Cargando…" : "Catálogo de precios"}
+      </p>
+      <div className="grid min-h-0 flex-1 grid-rows-4 gap-1.5 overflow-hidden">
+        {catalogRows.length ? (
+          catalogRows.map((item) => {
+            const itemIndex = items.indexOf(item);
+            const isCurrent = itemIndex === index;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                data-admin-mobile-config-item="true"
+                onClick={() => goToIndex(itemIndex)}
+                className={`flex min-h-0 items-center justify-between gap-2 overflow-hidden rounded-md border px-2.5 py-1.5 text-left ${isCurrent ? "border-vetneb-teal/60 bg-vetneb-surface-muted/60" : "border-vetneb-line/70 bg-card/95"}`}
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium text-vetneb-ink">
+                    {item.studyName}
+                  </p>
+                  <p className="truncate text-[0.66rem] text-muted-foreground">
+                    {item.category} · {normalizePriceLabel(item.priceLabel)}
+                  </p>
+                </div>
+                <Badge
+                  variant={item.isActive ? "default" : "outline"}
+                  className="h-5 shrink-0 px-1.5 text-[10px]"
+                >
+                  {item.isActive ? "Activo" : "Inactivo"}
+                </Badge>
+              </button>
+            );
+          })
+        ) : (
+          <div className="row-span-4 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+            {loadError ?? (isLoading ? "Cargando precios…" : "Sin precios configurados.")}
+          </div>
+        )}
+      </div>
+      <AdminMobileOpsPager
+        ariaLabel="Paginación de catálogo"
+        page={items.length ? catalogPage + 1 : 0}
+        pageCount={catalogTotalPages}
+        rangeLabel={
+          items.length
+            ? `${catalogPage * CATALOG_PAGE_SIZE + 1}–${Math.min((catalogPage + 1) * CATALOG_PAGE_SIZE, items.length)} de ${items.length}`
+            : "Sin precios"
+        }
+        previousDisabled={catalogPage === 0}
+        nextDisabled={catalogPage >= catalogTotalPages - 1}
+        disabled={!items.length}
+        onPrevious={() => goToIndex((catalogPage - 1) * CATALOG_PAGE_SIZE)}
+        onNext={() => goToIndex((catalogPage + 1) * CATALOG_PAGE_SIZE)}
+      />
+    </div>
+  );
+
+  return (
+    <AdminMobileConfigModule
+      moduleKey="admin-pricing"
+      ariaLabel="Precios"
+      sections={[
+        { id: "editar", label: "Editar", content: editorSection },
+        { id: "catalogo", label: "Catálogo", content: catalogSection },
+      ]}
+    />
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -26,6 +26,8 @@ import { AdminDashboardWorkspaceController } from "./AdminDashboardWorkspaceCont
 import type { AdminModule } from "./AdminDashboardWorkspaceController";
 import { AdminMobileCommandModule } from "./AdminMobileCommandModule";
 import { AdminMobileHealthModule } from "./AdminMobileHealthModule";
+import { AdminMobilePricingModule } from "./AdminMobilePricingModule";
+import { AdminMobileMaintenanceModule } from "./AdminMobileMaintenanceModule";
 import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { Button } from "@/components/ui/button";
@@ -841,10 +843,18 @@ export default async function AdminPage({
   );
 
   // ── Precios workspace ───────────────────────────────────────────────────────
+  // Mobile (md:hidden) compact segmented editor; desktop card stays in hidden
+  // md:flex so the per-study form never collapses under the bottom nav on mobile.
   const pricingWorkspaceSlot = (
-    <section id="admin-pricing" className="flex min-h-0 flex-1 flex-col">
-      <AdminPricingEditorCard />
-    </section>
+    <>
+      <AdminMobilePricingModule />
+      <section
+        id="admin-pricing"
+        className="hidden min-h-0 flex-1 flex-col md:flex"
+      >
+        <AdminPricingEditorCard />
+      </section>
+    </>
   );
 
   // ── Sesiones workspace ──────────────────────────────────────────────────────
@@ -904,25 +914,30 @@ export default async function AdminPage({
   // Single-viewport App Shell: schema health and the dry-run card switch via tabs
   // so each owns the viewport without the previous space-y-4 vertical stack.
   const maintenanceWorkspaceSlot = (
-    <ModuleTabs
-      ariaLabel="Mantenimiento del sistema"
-      tabs={[
-        {
-          id: "esquema",
-          label: "Esquema",
-          content: <AdminSchemaHealthStatusCard />,
-        },
-        {
-          id: "dry-run",
-          label: "Dry-run",
-          content: (
-            <section id="admin-maintenance">
-              <AdminMaintenanceDryRunCard />
-            </section>
-          ),
-        },
-      ]}
-    />
+    <>
+      <AdminMobileMaintenanceModule />
+      <div className="hidden min-h-0 flex-1 flex-col md:flex">
+        <ModuleTabs
+          ariaLabel="Mantenimiento del sistema"
+          tabs={[
+            {
+              id: "esquema",
+              label: "Esquema",
+              content: <AdminSchemaHealthStatusCard />,
+            },
+            {
+              id: "dry-run",
+              label: "Dry-run",
+              content: (
+                <section id="admin-maintenance">
+                  <AdminMaintenanceDryRunCard />
+                </section>
+              ),
+            },
+          ]}
+        />
+      </div>
+    </>
   );
 
   return (

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2888,6 +2888,29 @@
   }
 }
 /* admin-mobile-status-modules:end */
+/* admin-mobile-config-modules:start */
+/* PR-C — Precios / Mantenimiento config modules. Same no-scroll safety as the
+   status family (header-hide + viewport reclaim already applied by
+   admin-mobile-module-header-reclaim). Scoped to Admin mobile only; desktop and
+   Clínica untouched. */
+@media (max-width: 767px) {
+  [data-vetneb-app-shell-surface="admin"]
+    [data-dashboard-module-workspace]:has([data-admin-mobile-config-module])
+    [data-dashboard-module-viewport] {
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="admin"] [data-admin-mobile-config-module],
+  [data-vetneb-app-shell-surface="admin"]
+    [data-admin-mobile-config-module]
+    :is(article, nav, header) {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+    overflow-y: hidden;
+  }
+}
+/* admin-mobile-config-modules:end */
 /* admin-mobile-real-device-layer-isolation:start */
 /* PR-A — real-device GPU layer recycling guard.
    The Hub leaf surface ([data-admin-mobile-hub-launcher]) and the active module


### PR DESCRIPTION
## Summary
- Add dedicated Admin mobile no-scroll modules for dmin-pricing and dmin-maintenance
- Add AdminMobileConfigModule, AdminMobilePricingModule, and AdminMobileMaintenanceModule
- Replace mobile desktop-collapsed config layouts with compact segmented variants
- Preserve desktop via hidden md:flex desktop copies
- Add E2E coverage for 360/390/430 viewports in light and dark mode
- Preserve #1071 hub/layer behavior and #1072 status-module behavior

## Root cause
dmin-pricing and dmin-maintenance were still rendering desktop-oriented cards on mobile. With populated pricing/configuration data, the pricing form and maintenance cards could exceed the fixed Admin mobile safe band and place fields, pagers, or candidates under the bottom nav.

## Changes
- AdminMobileConfigModule.tsx: shared mobile segmented primitive for config modules
- AdminMobilePricingModule.tsx: mobile pricing editor with compact per-study editing, category/catalog view, pager, save action, and lazy fetch
- AdminMobileMaintenanceModule.tsx: mobile maintenance module with compact schema and dry-run panels
- page.tsx: renders mobile config modules plus desktop content isolated behind hidden md:flex
- globals.css: scoped Admin mobile config-module layout rules, no scroll
- dmin-mobile-config-modules-no-scroll.spec.ts: 360/390/430, light/dark, no-scroll, gutter, gap, chip/panel, screenshots, console, and desktop-preservation coverage

## Screenshots
Generated under:
rontend/test-results/admin-mobile-config-modules-no-scroll/

Includes before/after evidence for:
- dmin-pricing
- dmin-maintenance
- 360/390/430
- light/dark
- per-chip mobile panels

Screenshots are gitignored test artifacts and are not included in the commit.

## Scope
- Frontend only
- Admin mobile config modules only
- No backend / API / DB / auth
- No Clínica
- No deps / lockfiles / CI
- No scroll introduced
- No tests relaxed
- Desktop preserved

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-config-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-status-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-module-layer-isolation.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-app-shell-visibility-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface
- git diff --check