### PR TITLE
fix(admin): add persistent mobile hub stage

### DIFF
--- a/docs/audit/admin-mobile-hub-stale-layer-stage.md
+++ b/docs/audit/admin-mobile-hub-stale-layer-stage.md
@@ -1,0 +1,272 @@
+# VETNEB — Fix P1: bleed-through / capa vieja detrás del Hub (Admin mobile)
+
+Auditoría extrema + corrección quirúrgica del bug visual de **Inicio / Hub** del
+dashboard administrador en mobile, donde al volver a Inicio quedaba visible por
+detrás el módulo anterior (Clínicas / Auditoría / Login / Mantenimiento).
+
+---
+
+## 1. Resumen ejecutivo
+
+El dashboard admin ya tenía un contrato de “pintado opaco” extenso y **verde**
+(PRs #1071–#1073): topbar, bottom-nav, frame del app-shell, `main` y hub-root
+pintan fondo opaco `--card`, sin `backdrop-filter` ni `transform`. Aun así el
+usuario seguía viendo restos del módulo anterior en mobile.
+
+**Causa raíz real (por eliminación, con evidencia de código y tests):** el Hub y
+el módulo activo se montan como **dos subárboles aislados de tipo distinto que se
+reemplazan entre sí directamente bajo `<main>`**. Cada uno crea su propio
+`isolation: isolate` (stacking context). En cada navegación el contexto de
+apilamiento del punto de intercambio se **destruye y se recrea con otras
+dimensiones**. En GPUs móviles eso permite que un *tile* reciclado del módulo
+recién desmontado sobreviva **por detrás** del nuevo contexto del Hub; un ancestro
+opaco que queda **debajo** en el orden Z no puede taparlo. Por eso “hacer todo
+opaco” no bastó: faltaba una **superficie estable** en el punto de swap.
+
+**Corrección:** se introduce **una única “stage” persistente, opaca y aislada**
+(`[data-dashboard-module-stage]`) que envuelve ambas ramas. El nodo **no se
+desmonta nunca** (sólo cambian sus hijos), y en Admin mobile se promueve a **una
+sola capa de composición estable** (`transform: translateZ(0)`). Como esa capa es
+persistente, el compositor **la repinta en su sitio** en cada swap en vez de
+reciclar un tile huérfano de una capa por-módulo destruida. Resultado: Hub =
+superficie opaca, aislada y estable. Desktop y Clínica quedan intactos.
+
+TDD real: **RED** reproducible (no existía la stage) → implementación → **GREEN**
+(stage persiste con identidad de nodo a través de Hub→módulo→Inicio).
+
+---
+
+## 2. Rama usada
+
+`fix/admin-mobile-hub-stale-layer-stage` (creada desde `main` actualizado).
+
+## 3. HEAD inicial
+
+`d796ae0d2829c372a07691fae3100d3054bd18a9`
+(`d796ae0 fix(admin): add mobile no-scroll config modules (#1073)`)
+
+---
+
+## 4. Root cause exacto
+
+| Hecho verificado | Evidencia |
+|---|---|
+| El controller renderiza Hub **o** workspace de forma mutuamente excluyente (no hay DOM viejo persistente en React). | `AdminDashboardWorkspaceController.tsx`; e2e existente: `[data-dashboard-module-workspace]` count = 0 en el Hub. |
+| Todo ancestro persistente ya pinta opaco `--card`, sin blur ni transform. | `admin-mobile-real-device-layer-isolation` en `globals.css`; `admin-mobile-module-layer-isolation.spec.ts` (verde). |
+| Hay **4–5 `isolation: isolate` anidados** en la ruta del swap (app-shell, surface, `dashboard-main`, hub-root/workspace, leaf launcher/status/ops). | `globals.css` líneas ~1993, 2293, 2333, 2677, etc. |
+| El punto de swap (hijo directo de `<main>`) **no tenía** una superficie estable: se recrea un stacking context por navegación. | Render de `AdminDashboardWorkspaceController` (rama hub-root vs rama workspace). |
+
+**Conclusión:** el síntoma residual es **reciclaje de tiles del compositor móvil**
+en el punto de swap por recreación del stacking context, no una transparencia
+estática (ya descartada y testeada) ni DOM React persistente (ya descartado y
+testeado).
+
+---
+
+## 5. Archivos inspeccionados (auditoría)
+
+- `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx`
+- `frontend/src/app/dashboard/admin/page.tsx`
+- `frontend/src/lib/admin-hub-reset.ts`
+- `frontend/src/components/dashboard/DashboardShellRouter.tsx`
+- `frontend/src/components/dashboard/DashboardModuleHub.tsx`
+- `frontend/src/components/dashboard/DashboardModuleWorkspace.tsx`
+- `frontend/src/components/dashboard/DashboardPageHeader.tsx`
+- `frontend/src/components/dashboard/AdminMobileBottomNav.tsx`
+- `frontend/src/components/dashboard/AdminMobileHubLauncher.tsx`,
+  `AdminMobileHubPager.tsx`, `AdminMobileModuleMenu.tsx`
+- `frontend/src/app/dashboard/admin/AdminMobileStatusModule.tsx`
+- `frontend/src/app/globals.css` (bloques shell / app-shell / admin-mobile-*)
+- e2e: `admin-mobile-module-layer-isolation.spec.ts` y familia `admin-mobile-*`
+- Tests de contrato: `test/frontend-dashboard-admin.test.ts`,
+  `test/frontend-admin-unauthorized-ui-consistency.test.ts`
+
+---
+
+## 6. Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx` | Envuelve las 3 ramas (módulo / access-error / hub) en **una stage persistente** `div[data-dashboard-module-stage]`. Lógica de estado/efectos **sin cambios**. |
+| `frontend/src/app/globals.css` | (a) Regla de ritmo adaptativo para los hijos de la stage (espejo de `dashboard-main`, token `--dash-rhythm`). (b) Nuevo bloque `admin-mobile-stage-layer`: en Admin mobile la stage es opaca `--card`, `isolation: isolate`, `transform: translateZ(0)`. |
+| `frontend/src/app/dashboard/admin/__nuevo__` | — |
+| `frontend/e2e/admin-mobile-hub-stale-layer-stage.spec.ts` | **Nuevo** spec TDD: identidad de nodo de la stage persistente a través de Hub→módulo→Inicio, opacidad, aislamiento, promoción de capa y no-scroll, en 360/390/430 y light/dark. |
+| `test/frontend-admin-unauthorized-ui-consistency.test.ts` | Alineación in-PR de un contrato de estructura `.tsx` (indentación del bloque access-error que ahora anida un nivel más). Significado preservado. |
+
+---
+
+## 7. Qué legacy se eliminó o preservó y por qué
+
+- **Preservado** todo el contrato opaco previo (`admin-mobile-real-device-layer-isolation`,
+  `admin-mobile-module-layer-isolation`): sigue siendo correcto y necesario; la
+  stage lo **complementa**, no lo reemplaza. Eliminarlo habría reabierto el caso
+  de ancestros transparentes.
+- **No se eliminó** ninguna `isolation` anidada existente: quitarlas globalmente
+  arriesga regresiones desktop/Clínica y otros contratos. La stage añade el punto
+  estable que faltaba sin tocar los demás.
+- **No se introdujo** scroll, ni dependencias, ni rediseño. Cambio quirúrgico.
+
+---
+
+## 8. Decisiones técnicas
+
+1. **Una stage persistente** en vez de más fondos opacos: ataca la *recreación del
+   stacking context*, que es la causa real; los fondos opacos ya estaban.
+2. **`translateZ(0)` sólo en Admin mobile**: una capa de composición persistente se
+   repinta en sitio; no hay capa por-módulo que reciclar. Respeta la filosofía del
+   repo (sin promociones en desktop/Clínica). No hay descendientes `position: fixed`
+   dentro de la stage (bottom-nav, app-bar, menús y diálogos Radix se montan fuera),
+   por lo que el nuevo containing-block es inerte.
+3. **Ritmo adaptativo** replicado con `--dash-rhythm` para que el gap header↔hub no
+   se rompa en ningún viewport/zoom (mismo comportamiento que tenía `main`).
+4. **Sin tocar backend** ni `page.tsx` ni la lógica de URL/estado del controller.
+
+---
+
+## 9. Preparación para 5000 clínicas / 1000 informes por clínica
+
+El cambio es estructural del shell, no del data layer, y **no degrada** la
+escalabilidad ya presente; la consolida:
+
+- La **stage es estable** durante el swap → repaints más baratos al navegar entre
+  módulos de alta densidad (menos rasterización redundante por navegación).
+- Se conserva la paginación/lazy ya existente: `usePagedRows`/`CompactPager`,
+  paginación server-side de auditoría (`limit/offset`), montaje perezoso por
+  sección (`AdminMobileStatusModule` sólo monta la sección activa), variantes
+  mobile/desktop desacopladas (`md:hidden` / `hidden md:flex`).
+- El contrato no-scroll por viewport sigue intacto (la stage es `overflow: hidden`,
+  nunca un contenedor scrollable), lista para virtualización futura sin reescritura.
+
+No se añadió backend porque la causa raíz es de composición/UI; tocarlo habría
+sido fuera de scope.
+
+---
+
+## 10. Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend exec playwright test admin-mobile-hub-stale-layer-stage.spec.ts` | **RED** antes del fix (stage ausente) → **GREEN** 4/4 después |
+| `pnpm --dir frontend exec playwright test admin-mobile … shell contracts` | **112 passed** (sin regresión) |
+| `git diff --check` | limpio |
+| `pnpm --dir frontend typecheck` | OK |
+| `pnpm --dir frontend lint` | OK |
+| `pnpm typecheck` (root) | OK |
+| `pnpm test` (root) | **2815 pass / 0 fail** |
+| `pnpm --dir frontend build` | OK |
+| `pnpm build` (root) | OK |
+| `pnpm security:public-surface` | **PASS** (sólo markers server-only en `proxy.ts`) |
+
+> Nota operativa aplicada: tras cada corrida e2e se revierte `frontend/next-env.d.ts`
+> (el dev server lo regenera) y se limpia `frontend/.next` antes de re-correr
+> Playwright tras editar `globals.css` (cache stale de Turbopack).
+
+---
+
+## 11. Resultado de tests (TDD)
+
+- **RED** (pre-fix): los 4 casos fallan con `module stage missing while stamping`
+  → confirma que el punto de swap no tenía superficie estable.
+- **GREEN** (post-fix): 4/4 — la stage existe, es opaca (alpha 1), `isolation:
+  isolate`, promovida (`transform != none`) y **conserva identidad de nodo** a
+  través de Hub→Clínicas→Inicio, con el workspace/launcher anidados dentro y sin
+  scroll.
+
+---
+
+## 12. `git status --short --untracked-files=all`
+
+```
+ M frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+ M frontend/src/app/globals.css
+ M test/frontend-admin-unauthorized-ui-consistency.test.ts
+?? frontend/e2e/admin-mobile-hub-stale-layer-stage.spec.ts
+```
+
+## 13. `git diff --stat`
+
+```
+ .../admin/AdminDashboardWorkspaceController.tsx    | 76 ++++++++++++----------
+ frontend/src/app/globals.css                       | 37 +++++++++++
+ ...ntend-admin-unauthorized-ui-consistency.test.ts |  2 +-
+ 3 files changed, 79 insertions(+), 36 deletions(-)
+```
+
+## 14. `git diff --name-only`
+
+```
+frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+frontend/src/app/globals.css
+test/frontend-admin-unauthorized-ui-consistency.test.ts
+```
+
+## 15. `git diff --check`
+
+Sin hallazgos (salida vacía).
+
+---
+
+## 16. Capturas before/after
+
+Carpeta de salida (Playwright; se regenera por corrida):
+`frontend/test-results/admin-mobile-hub-stale-layer-stage/`
+
+- `360-light-hub-after-clinics.png`
+- `360-dark-hub-after-clinics.png`
+- `390-light-hub-after-clinics.png`
+- `430-light-hub-after-clinics.png`
+
+**After (post-fix):** Hub limpio, opaco, sin restos de Clínicas tras
+Hub→Clínicas→Inicio en 360/390/430 y light/dark.
+
+**Honestidad técnica sobre el “before” visual:** el artefacto es **reciclaje de
+tiles de GPU específico de dispositivos móviles reales**; **Chromium headless no lo
+reproduce** (ya documentado en el spec PR-A). Por eso el before/after *visual* en
+headless sería idéntico (Hub limpio) y **no** probaría el fix. La evidencia
+determinista del cambio es el **RED→GREEN estructural** (la stage pasa de ausente a
+presente y persistente con identidad de nodo). Recomendado: verificación final en
+dispositivo real (ver riesgos residuales).
+
+---
+
+## 17. Riesgos residuales
+
+1. **Verificación en hardware real pendiente:** el fix ataca el mecanismo correcto
+   (capa de composición persistente), pero como headless no reproduce el reciclaje
+   de tiles, conviene una confirmación visual en un Android/iOS real con
+   Hub→módulo→Inicio repetido en light/dark. Bajo riesgo de regresión; alta
+   probabilidad de cierre del síntoma.
+2. **`translateZ(0)` crea containing-block** para `position: fixed` descendiente.
+   Verificado que **no hay** ninguno dentro de la stage (menús/diálogos se portan a
+   `body` o viven en el bottom-nav/app-bar, fuera de la stage). Si en el futuro se
+   añade un `fixed` dentro de un módulo, recordar este contexto.
+
+---
+
+## 18. Confirmación de no-regresión
+
+- **Desktop:** la stage es un passthrough flex transparente fuera de mobile (sin
+  fondo ni `translateZ`); el ritmo header↔hub se preserva vía `--dash-rhythm`.
+  Typecheck/lint/build/tests de contrato verdes. **Sin regresión desktop.**
+- **Clínica:** el cambio está acotado a `AdminDashboardWorkspaceController` y a
+  selectores `surface="admin"`; el controller de Clínica
+  (`ClinicDashboardWorkspaceController`) **no se toca**. Suite e2e mobile
+  (incl. parity Clínica) y `pnpm test` verdes. **Sin regresión Clínica.**
+
+---
+
+### Cierre / Git manual (protocolo VETNEB)
+
+Implementación y validación completas. Según el protocolo, **Git lo ejecuta Nico**:
+
+```powershell
+git add frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx `
+        frontend/src/app/globals.css `
+        frontend/e2e/admin-mobile-hub-stale-layer-stage.spec.ts `
+        test/frontend-admin-unauthorized-ui-consistency.test.ts
+git status
+git commit -m "fix(admin): persistent isolated stage to kill mobile hub bleed-through"
+git push -u origin fix/admin-mobile-hub-stale-layer-stage
+gh pr create --fill
+gh pr checks --watch
+```

--- a/frontend/e2e/admin-mobile-hub-stale-layer-stage.spec.ts
+++ b/frontend/e2e/admin-mobile-hub-stale-layer-stage.spec.ts
@@ -1,0 +1,241 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+import type { Page, TestInfo } from "@playwright/test";
+
+// PR — single persistent, opaque, isolated "module stage" for the admin
+// Hub<->module swap. Root cause of the residual mobile bleed-through: the Hub
+// and the active module mount as two DIFFERENTLY-typed isolated subtrees that
+// REPLACE each other directly under <main>, so the stacking context at the swap
+// site is destroyed and recreated (different bounds) on every navigation. On
+// mobile GPUs that lets a recycled tile of the just-unmounted module survive
+// behind the freshly-created Hub context — opaque ancestors below it in z-order
+// cannot cover it. The fix wraps BOTH branches in ONE persistent stage node
+// ([data-dashboard-module-stage]) that never unmounts (only its children swap),
+// is opaque + isolated, and on mobile is promoted to a single stable compositor
+// layer so the GPU repaints THAT layer in place instead of recycling an orphan.
+//
+// This guards the structural invariant deterministically (element identity is
+// preserved across Hub->module->Hub; the stage is opaque, isolated and promoted
+// on mobile). Headless Chromium does not reproduce the GPU recycling itself, so
+// the screenshots are structural evidence and the persistence/paint invariants
+// are the automated guard.
+
+const STAGE_SELECTOR = '[data-dashboard-module-stage="true"]';
+
+const MATRIX = [
+  { width: 360, height: 740, mode: "light" as const },
+  { width: 360, height: 740, mode: "dark" as const },
+  { width: 390, height: 844, mode: "light" as const },
+  { width: 430, height: 932, mode: "light" as const },
+];
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+async function applyColorMode(page: Page, mode: "light" | "dark") {
+  if (mode === "dark") {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("vetneb-theme-mode", "dark-gray");
+      } catch {
+        /* localStorage unavailable: emulateMedia below still hints dark */
+      }
+    });
+  }
+  await page.emulateMedia({ colorScheme: mode, reducedMotion: "reduce" });
+}
+
+function readCssAlpha(color: string) {
+  const normalized = color.trim().toLowerCase();
+  if (!normalized || normalized === "transparent") return 0;
+  const commaAlpha = normalized.match(
+    /^rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\s*\)$/,
+  );
+  if (commaAlpha) return Number(commaAlpha[1]);
+  const slashAlpha = normalized.match(/\/\s*([\d.]+)(%)?\s*\)$/);
+  if (slashAlpha) {
+    const alpha = Number(slashAlpha[1]);
+    return slashAlpha[2] ? alpha / 100 : alpha;
+  }
+  return 1;
+}
+
+/**
+ * Stamp the live stage node so we can prove it survives the swap unchanged.
+ * Stored as a plain JS property (not a `data-*` attribute) so the stamp never
+ * touches the DOM attribute list React reconciles — an attribute written
+ * outside React's render risks a hydration-mismatch warning on the next
+ * render of this same node.
+ */
+async function stampStage(page: Page, token: string) {
+  await page.evaluate(
+    ({ selector, value }) => {
+      const stage = document.querySelector<HTMLElement>(selector);
+      if (!stage) throw new Error("module stage missing while stamping");
+      (stage as unknown as Record<string, string>).__e2eStageToken = value;
+    },
+    { selector: STAGE_SELECTOR, value: token },
+  );
+}
+
+async function readStageContract(page: Page, descendantSelector: string) {
+  return page.evaluate(
+    ({ selector, descendant }) => {
+      const stages = document.querySelectorAll<HTMLElement>(selector);
+      const stage = stages[0] ?? null;
+      if (!stage) {
+        throw new Error("module stage is not mounted");
+      }
+      const style = window.getComputedStyle(stage);
+      const descendantNode =
+        document.querySelector<HTMLElement>(descendant);
+      return {
+        stageCount: stages.length,
+        token:
+          (stage as unknown as Record<string, string>).__e2eStageToken ??
+          null,
+        backgroundColor: style.backgroundColor,
+        isolation: style.isolation,
+        transform: style.transform,
+        overflowY: style.overflowY,
+        descendantInsideStage: descendantNode
+          ? stage.contains(descendantNode)
+          : false,
+      };
+    },
+    { selector: STAGE_SELECTOR, descendant: descendantSelector },
+  );
+}
+
+async function expectStageContract(
+  page: Page,
+  descendantSelector: string,
+  expectedToken: string,
+  label: string,
+) {
+  await expect(async () => {
+    const contract = await readStageContract(page, descendantSelector);
+    expect(contract.stageCount, `${label}: exactly one stage`).toBe(1);
+    expect(contract.token, `${label}: stage node persisted (same DOM node)`).toBe(
+      expectedToken,
+    );
+    expect(
+      readCssAlpha(contract.backgroundColor),
+      `${label}: stage opaque background`,
+    ).toBe(1);
+    expect(contract.isolation, `${label}: stage isolates a stacking context`).toBe(
+      "isolate",
+    );
+    // Mobile promotes the stage to a single stable compositor layer.
+    expect(contract.transform, `${label}: stage promoted to its own layer`).not.toBe(
+      "none",
+    );
+    // The active surface (hub launcher / module workspace) lives INSIDE the
+    // persistent stage, so the swap happens within one stable layer.
+    expect(
+      contract.descendantInsideStage,
+      `${label}: active surface nested in the stage`,
+    ).toBe(true);
+    // The stage never becomes an operational scroll container.
+    expect(
+      ["auto", "scroll"],
+      `${label}: stage must not scroll`,
+    ).not.toContain(contract.overflowY);
+  }).toPass({ timeout: 10_000 });
+}
+
+async function openClinicsFromHub(page: Page) {
+  const launcher = page.locator('[data-admin-mobile-hub-launcher="true"]');
+  const tile = launcher.locator('[data-admin-mobile-hub-tile="admin-clinics"]');
+  const workspace = page.locator(
+    '[data-dashboard-module-workspace="admin-clinics"]',
+  );
+  await expect(async () => {
+    await tile.click();
+    await expect(workspace).toBeVisible({ timeout: 5_000 });
+  }).toPass({ timeout: 20_000 });
+}
+
+async function backToHub(page: Page) {
+  await page
+    .locator('[data-admin-mobile-bottom-nav="true"]')
+    .getByRole("button", { name: "Inicio", exact: true })
+    .click();
+  const hub = page.locator('[data-admin-mobile-hub-launcher="true"]');
+  await expect(hub).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("[data-dashboard-module-workspace]")).toHaveCount(0);
+}
+
+for (const cell of MATRIX) {
+  test(`admin mobile hub keeps one persistent isolated stage across the swap — ${cell.width}x${cell.height} ${cell.mode}`, async ({
+    page,
+  }, testInfo: TestInfo) => {
+    await page.setViewportSize({ width: cell.width, height: cell.height });
+    await applyColorMode(page, cell.mode);
+    await setPopulatedAdminSession(page);
+
+    await page.goto("/dashboard/admin");
+    await suppressNextDevIndicator(page);
+
+    const hub = page.locator('[data-admin-mobile-hub-launcher="true"]');
+    await expect(hub).toBeVisible({ timeout: 15_000 });
+
+    const token = `stage-${cell.width}-${cell.mode}`;
+    await stampStage(page, token);
+    await expectStageContract(
+      page,
+      '[data-admin-mobile-hub-launcher="true"]',
+      token,
+      `${token} initial hub`,
+    );
+
+    // Hub -> module: the stage node must persist (same stamped DOM node) and now
+    // wrap the module workspace.
+    await openClinicsFromHub(page);
+    await expectStageContract(
+      page,
+      '[data-dashboard-module-workspace="admin-clinics"]',
+      token,
+      `${token} module`,
+    );
+
+    // module -> Hub: still the same persistent stage, no stale workspace left.
+    await backToHub(page);
+    await expectStageContract(
+      page,
+      '[data-admin-mobile-hub-launcher="true"]',
+      token,
+      `${token} hub after module`,
+    );
+
+    const screenshotDirectory = resolve(
+      testInfo.config.rootDir,
+      "..",
+      "test-results",
+      "admin-mobile-hub-stale-layer-stage",
+    );
+    await mkdir(screenshotDirectory, { recursive: true });
+    await page.screenshot({
+      path: resolve(
+        screenshotDirectory,
+        `${cell.width}-${cell.mode}-hub-after-clinics.png`,
+      ),
+      animations: "disabled",
+      fullPage: false,
+    });
+  });
+}

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -358,42 +358,48 @@ export function AdminDashboardWorkspaceController({
     },
   ];
 
-  if (activeModule) {
-    const meta = ADMIN_MODULE_META[activeModule];
-    return (
-      <DashboardModuleWorkspace
-        title={meta.title}
-        description={meta.description}
-        moduleId={activeModule}
-        onBack={backToHub}
-      >
-        {accessErrorStatus ? (
-          <AdminAccessErrorState status={accessErrorStatus} />
-        ) : (
-          workspaces[activeModule]
-        )}
-      </DashboardModuleWorkspace>
-    );
-  }
+  const activeMeta = activeModule ? ADMIN_MODULE_META[activeModule] : null;
 
-  if (accessErrorStatus) {
-    return (
-      <>
-        {pageHeader}
-        <AdminAccessErrorState status={accessErrorStatus} />
-      </>
-    );
-  }
-
+  // Single persistent, opaque, isolated stage for the Hub<->module swap. The
+  // stage node never unmounts (only its children swap), so the swap happens
+  // inside one stable stacking/paint surface instead of recreating a new
+  // stacking context per navigation — which let mobile GPUs keep a recycled
+  // tile of the previous module behind the freshly-mounted hub (the reported
+  // ghosting / bleed-through). See admin-mobile-stage-layer in globals.css.
   return (
-    <>
-      {pageHeader}
-      <DashboardModuleHub
-        heading="Módulos de administración"
-        description="Acceso a clínicas, precios, sesiones, auditoría y estado del sistema."
-        cards={adminCards}
-        hero={adminHero}
-      />
-    </>
+    <div
+      data-dashboard-module-stage="true"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden dashboard-module-stage"
+    >
+      {activeModule && activeMeta ? (
+        <DashboardModuleWorkspace
+          title={activeMeta.title}
+          description={activeMeta.description}
+          moduleId={activeModule}
+          onBack={backToHub}
+        >
+          {accessErrorStatus ? (
+            <AdminAccessErrorState status={accessErrorStatus} />
+          ) : (
+            workspaces[activeModule]
+          )}
+        </DashboardModuleWorkspace>
+      ) : accessErrorStatus ? (
+        <>
+          {pageHeader}
+          <AdminAccessErrorState status={accessErrorStatus} />
+        </>
+      ) : (
+        <>
+          {pageHeader}
+          <DashboardModuleHub
+            heading="Módulos de administración"
+            description="Acceso a clínicas, precios, sesiones, auditoría y estado del sistema."
+            cards={adminCards}
+            hero={adminHero}
+          />
+        </>
+      )}
+    </div>
   );
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2159,6 +2159,15 @@
     margin-block-start: var(--dash-rhythm);
   }
 
+  /* The persistent module stage is now main's single flex child and owns the
+     hub page-header <-> content rhythm, so mirror the adaptive gap token here. */
+  .dashboard-app-shell
+    [data-dashboard-module-stage="true"]
+    > :not([hidden])
+    ~ :not([hidden]) {
+    margin-block-start: var(--dash-rhythm);
+  }
+
   .dashboard-app-shell .dashboard-cockpit {
     gap: var(--dash-cockpit-gap);
   }
@@ -2934,3 +2943,31 @@
   }
 }
 /* admin-mobile-real-device-layer-isolation:end */
+/* admin-mobile-stage-layer:start */
+/* Root-cause fix for the residual Hub<->module bleed-through. The opaque-ancestor
+   guard (above) painted every PERSISTENT ancestor, but the swap site itself had
+   no stable surface: the Hub root and the module workspace are differently-typed
+   isolated subtrees that REPLACE each other directly under <main>, so the
+   stacking context at the swap point is destroyed and recreated (different
+   bounds) on every navigation. On mobile GPUs that lets a recycled tile of the
+   just-unmounted module survive behind the freshly-created Hub context — an
+   opaque ancestor below it in z-order cannot cover it.
+
+   The controller now wraps BOTH branches in one persistent stage
+   ([data-dashboard-module-stage]) that never unmounts; only its children swap.
+   On Admin mobile the stage becomes a single opaque, isolated, GPU-promoted
+   layer (translateZ(0)). Because that layer is persistent, the compositor
+   repaints IT in place on every swap instead of recycling an orphan tile from a
+   destroyed per-module layer. No fixed-position descendant lives inside the
+   stage (the bottom nav, app bar, menus and Radix dialogs render outside it), so
+   the new containing block is inert. Scoped to Admin mobile (<=767px); desktop
+   and Clinic keep the stage as a transparent flex passthrough. */
+@media (max-width: 767px) {
+  [data-vetneb-app-shell-surface="admin"] [data-dashboard-module-stage="true"] {
+    isolation: isolate;
+    background: hsl(var(--card));
+    transform: translateZ(0);
+    overscroll-behavior: none;
+  }
+}
+/* admin-mobile-stage-layer:end */

--- a/test/frontend-admin-unauthorized-ui-consistency.test.ts
+++ b/test/frontend-admin-unauthorized-ui-consistency.test.ts
@@ -95,7 +95,7 @@ test("admin access state replaces the workspace instead of rendering an empty st
   assert.ok(controllerSource.includes("initialAccessErrorStatus"));
   assert.ok(
     controllerSource.includes(
-      "accessErrorStatus ? (\n          <AdminAccessErrorState status={accessErrorStatus} />\n        ) : (\n          workspaces[activeModule]\n        )",
+      "accessErrorStatus ? (\n            <AdminAccessErrorState status={accessErrorStatus} />\n          ) : (\n            workspaces[activeModule]\n          )",
     ),
   );
   assert.ok(stateSource.includes('role="alert"'));


### PR DESCRIPTION
## Summary
- Add a persistent Admin mobile module stage for Hub/module swaps
- Prevent previous module bleed-through behind Inicio / Hub on real mobile devices
- Keep Hub, workspace, and access-error branches inside one stable paint/compositor surface
- Add E2E coverage for persistent stage identity, opacity, isolation, compositor promotion, and no-scroll
- Preserve #1071 hub reset/layer isolation, #1072 status modules, and #1073 config modules
- Add audit handoff under docs/audit

## Root cause
The Admin mobile Hub and active modules were mounted as different isolated subtrees that replaced each other directly under main. Even with opaque ancestors, the swap point itself did not have a persistent paint surface. On real mobile GPUs this can leave a recycled tile from the previous module visible behind the newly mounted Hub.

## Changes
- AdminDashboardWorkspaceController.tsx: wraps Hub, module workspace, and access-error branches in a persistent data-dashboard-module-stage
- globals.css: adds Admin-mobile scoped stage isolation, opaque background, compositor promotion, and rhythm preservation
- dmin-mobile-hub-stale-layer-stage.spec.ts: verifies one persistent stage survives Hub → module → Hub, remains opaque/isolated/promoted, contains the active surface, and does not scroll
- rontend-admin-unauthorized-ui-consistency.test.ts: aligns contract fixture with the new workspace branch indentation
- docs/audit/admin-mobile-hub-stale-layer-stage.md: implementation/audit handoff

## Scope
- Frontend only
- Admin mobile Hub/stage only
- No backend / API / DB / auth
- No Clínica
- No deps / lockfiles / CI
- No scroll introduced
- No tests relaxed
- Desktop preserved

## Validation
- pnpm --dir frontend exec playwright test e2e/admin-mobile-hub-stale-layer-stage.spec.ts --workers=1 --retries=0 --reporter=line
- pnpm --dir frontend exec playwright test e2e/admin-mobile-module-layer-isolation.spec.ts e2e/admin-mobile-hub-launcher-no-scroll.spec.ts e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-final-polish-no-scroll.spec.ts e2e/admin-mobile-core-modules-no-scroll.spec.ts e2e/admin-mobile-ops-modules-no-scroll.spec.ts e2e/admin-mobile-status-modules-no-scroll.spec.ts e2e/admin-mobile-config-modules-no-scroll.spec.ts --workers=1 --retries=0 --reporter=line
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm typecheck
- pnpm --dir frontend build
- pnpm build
- pnpm test
- pnpm security:public-surface
- git diff --check

## Notes
The underlying artifact is specific to real-device mobile GPU compositing. Chromium headless does not reproduce the visual tile recycling deterministically, so the automated guard verifies the structural invariant: the swap happens inside one persistent opaque isolated stage.