### PR TITLE
fix(admin): anchor mobile tokens pagination

### DIFF
--- a/docs/audit/admin-mobile-tokens-pagination-bottom.md
+++ b/docs/audit/admin-mobile-tokens-pagination-bottom.md
@@ -1,0 +1,148 @@
+# Fix: paginador Tokens mobile anclado al margen inferior interno del módulo
+
+- Rama: `fix/admin-mobile-tokens-pagination-bottom`
+- HEAD base: `5b82400 fix(admin): compact mobile tokens dashboard (#1077)`
+
+## Problema real observado
+
+Posterior a #1077, en Dashboard Administrador mobile, módulo **Tokens**, el
+paginador (`1–6` / `1–10` · Anterior · Pág. N · Siguiente) quedaba ubicado
+justo debajo de la lista de tokens, sin anclarse al borde inferior interno del
+módulo. Cuando la lista no llenaba el alto disponible (dataset corto, p. ej.
+6 tokens), el espacio vacío quedaba **debajo del paginador** en lugar de ser
+absorbido por la zona de lista, dejando el paginador "flotando" arriba de un
+bloque inferior vacío.
+
+Causa raíz: el contenedor mobile (`data-admin-mobile-core-module="tokens"`)
+era un `flex flex-col` con `gap-1.5`, pero ni la lista
+(`data-admin-particulars-mobile-list="true"`) ni el paginador
+(`data-admin-mobile-core-pager="true"`) tenían `flex-1`/`mt-auto`. Sin un
+elemento que absorbiera el espacio restante, el paginador quedaba inmediatamente
+después de la lista (su altura natural), y el sobrante de altura del flex
+padre quedaba como hueco debajo de todo, después del paginador.
+
+## Scope
+
+- Layout del módulo Tokens mobile en
+  [AdminParticularTokensCard.tsx](../../frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx).
+- Tests e2e existentes del módulo Tokens mobile.
+
+## No alcance
+
+- Backend / API / DB / auth.
+- Clínicas, Sesiones, Intentos fallidos, Auditoría, System health, Mantenimiento, desktop.
+- Lógica de paginación (page size, offsets, fetch).
+- Dependencias / lockfiles / CI.
+- #1074 (anti-ghosting) y #1076 (tokens fluidos): preservados sin tocar sus clases.
+
+## Archivos modificados
+
+- [frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx](../../frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx)
+- [frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts](../../frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts)
+
+## Implementación aplicada
+
+En el contenedor mobile del módulo Tokens:
+
+```diff
+- <div className="flex min-h-0 flex-1 flex-col gap-1.5 md:hidden" data-admin-mobile-core-module="tokens">
++ <div className="flex h-full min-h-0 flex-1 flex-col gap-1.5 md:hidden" data-admin-mobile-core-module="tokens">
+    <div
+      data-admin-particulars-mobile-list="true"
+-     className="divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
++     className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
+    >
+```
+
+- `h-full` en el stage del módulo asegura que el contenedor ocupe todo el alto
+  disponible cedido por el `CardContent`/`section` padres (ya `flex-1 min-h-0`).
+- `flex-1 min-h-0` en la caja de la lista hace que esa caja (con
+  `overflow-hidden`, sin scroll) absorba todo el espacio vertical sobrante
+  cuando el dataset es corto. El hueco vacío queda *dentro* del borde de la
+  lista, no debajo del paginador.
+- El paginador (`shrink-0`, sin cambios) queda empujado naturalmente al final
+  de la columna flex, pegado al borde inferior interno del módulo.
+- No se tocó el `mt-auto`/posición del paginador; el fix resuelve el problema
+  haciendo que el espacio sobrante se reparta en la lista, no después del pager.
+- Cuando no hay tokens (dataset vacío + mobile viewport) el estado vacío
+  (`surface-empty`) sigue siendo `flex-1`; en ese caso no hay paginador
+  renderizado (no aplica el contrato de anclaje).
+
+## Tests agregados/reforzados
+
+En `frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts`:
+
+- `mockAdminParticularTokens` ahora acepta un dataset de origen configurable.
+- Nuevo helper `assertPagerAnchoredToModuleBottom`: compara el borde inferior
+  del módulo (`data-admin-mobile-core-module="tokens"`) contra el borde
+  inferior del paginador (`data-admin-mobile-core-pager="true"`), con
+  tolerancia de 28px (padding/border del `CardContent`).
+- `admin tokens mobile pager stays bottom-anchored with a full page` (10
+  tokens, 3 viewports): paginador anclado abajo con dataset completo.
+- `admin tokens mobile pager stays bottom-anchored with a short dataset` (6
+  tokens, 3 viewports): paginador anclado abajo con dataset corto (`1–6`),
+  además de verificar ausencia de `overflow: auto|scroll`.
+
+Estos tests fallaban contra el estado previo (gaps medidos de 150–316px) y
+pasan tras el fix (TDD confirmado).
+
+## Validaciones ejecutadas
+
+Todas en PowerShell, desde `C:\PORTAL-VETNEB`:
+
+```powershell
+pnpm --dir frontend exec playwright test frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
+# 9 passed
+
+pnpm --dir frontend exec playwright test frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+# 13 passed
+
+pnpm test
+# 2815 passed (nota: `next dev` reescribe frontend/next-env.d.ts como efecto
+# colateral de levantar el server de Playwright; se revirtió con
+# `git checkout -- frontend/next-env.d.ts` antes de correr pnpm test, según
+# el guardrail PR-N conocido del repo)
+
+pnpm --dir frontend lint
+pnpm --dir frontend typecheck
+pnpm --dir frontend build
+# Compiled successfully, 0 errores
+
+pnpm build
+# esbuild backend bundle, Done
+```
+
+## Evidencia de paginador anclado abajo
+
+Test `assertPagerAnchoredToModuleBottom` mide en runtime:
+`moduleBottom - pagerBottom <= 28px` en los 3 viewports mobile
+(360x740, 390x844, 430x932), tanto con 10 tokens (`1–10`) como con 6 tokens
+(`1–6`). Antes del fix, el mismo assert fallaba con gaps de 150px a 316px.
+
+## Evidencia de no-scroll
+
+- `admin-tokens-mobile-toolbar-layout.spec.ts`: assert de
+  `overflowX`/`overflowY` distinto de `auto`/`scroll` en todo el subárbol del
+  módulo, para el dataset corto (6 tokens) y ya existente para el dataset
+  estándar.
+- `admin-mobile-core-modules-no-scroll.spec.ts`: contrato completo de
+  `html`/`body` sin overflow vertical/horizontal, módulo Tokens incluido,
+  sigue pasando en página 1 y página 2.
+
+## Confirmación de no tocar backend/API/DB/auth/Clínica/dependencias/lockfiles/CI/otros módulos
+
+- `git diff --stat` solo afecta `AdminParticularTokensCard.tsx` (2 líneas de
+  clases) y el spec de tests del propio módulo Tokens.
+- No se modificó ningún archivo de backend, rutas API, esquema DB, middleware
+  de auth, `package.json`, lockfiles, ni workflows de CI.
+- Módulos Clínicas, Sesiones, Intentos fallidos, Auditoría, System health,
+  Mantenimiento y desktop no fueron tocados; sus tests (`admin-mobile-core-modules-no-scroll.spec.ts`
+  para clinics/reports) siguen en verde sin cambios.
+
+## Riesgo residual
+
+- La tolerancia de 28px asumida para el gap inferior del paginador depende
+  del padding actual de `CardContent` (`px-4 py-2`); si un PR futuro cambia
+  ese padding de forma significativa, el test de anclaje debería revisarse.
+- El estado vacío (sin tokens) no tiene paginador y no quedó cubierto por el
+  contrato de anclaje porque no aplica (sin dataset no hay `1–N` que anclar).

--- a/frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
+++ b/frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
@@ -46,7 +46,7 @@ async function setAdminSession(page: Page) {
   ]);
 }
 
-async function mockAdminParticularTokens(page: Page) {
+async function mockAdminParticularTokens(page: Page, sourceTokens = MOCK_TOKENS) {
   await page.route("**/api/admin/particular-tokens**", async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -64,8 +64,8 @@ async function mockAdminParticularTokens(page: Page) {
     const clinicIdParam = url.searchParams.get("clinicId");
     const clinicId = clinicIdParam ? Number(clinicIdParam) : null;
     const filteredTokens = clinicId
-      ? MOCK_TOKENS.filter((token) => token.clinicId === clinicId)
-      : MOCK_TOKENS;
+      ? sourceTokens.filter((token) => token.clinicId === clinicId)
+      : sourceTokens;
     const particularTokens = filteredTokens.slice(offset, offset + limit);
 
     await route.fulfill({
@@ -80,6 +80,33 @@ async function mockAdminParticularTokens(page: Page) {
       }),
     });
   });
+}
+
+const MOCK_TOKENS_SHORT = MOCK_TOKENS.slice(0, 6);
+
+const PAGER_BOTTOM_TOLERANCE = 28;
+
+async function assertPagerAnchoredToModuleBottom(
+  page: Page,
+  label: string,
+) {
+  const moduleRoot = page.locator('[data-admin-mobile-core-module="tokens"]');
+  const pager = moduleRoot.locator('[data-admin-mobile-core-pager="true"]');
+
+  await expect(pager, `${label}: pager visible`).toBeVisible();
+
+  const moduleBox = await moduleRoot.boundingBox();
+  const pagerBox = await pager.boundingBox();
+  expect(moduleBox, `${label}: module bounding box`).not.toBeNull();
+  expect(pagerBox, `${label}: pager bounding box`).not.toBeNull();
+
+  const moduleBottom = moduleBox!.y + moduleBox!.height;
+  const pagerBottom = pagerBox!.y + pagerBox!.height;
+
+  expect(
+    moduleBottom - pagerBottom,
+    `${label}: gap below pager inside module`,
+  ).toBeLessThanOrEqual(PAGER_BOTTOM_TOLERANCE);
 }
 
 for (const viewport of MOBILE_VIEWPORTS) {
@@ -212,5 +239,77 @@ for (const viewport of MOBILE_VIEWPORTS) {
       updateMetrics.height,
       `${viewport.name}: Actualizar touch target height`,
     ).toBeGreaterThanOrEqual(34);
+  });
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`admin tokens mobile pager stays bottom-anchored with a full page — ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setAdminSession(page);
+    await mockAdminParticularTokens(page, MOCK_TOKENS);
+    await page.goto("/dashboard/admin?module=admin-particular-tokens");
+
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="admin-particular-tokens"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+    const items = page.locator(
+      '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-item="true"]',
+    );
+    await expect(items).toHaveCount(10);
+
+    await assertPagerAnchoredToModuleBottom(
+      page,
+      `${viewport.name}: full page (10 tokens)`,
+    );
+  });
+
+  test(`admin tokens mobile pager stays bottom-anchored with a short dataset — ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setAdminSession(page);
+    await mockAdminParticularTokens(page, MOCK_TOKENS_SHORT);
+    await page.goto("/dashboard/admin?module=admin-particular-tokens");
+
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="admin-particular-tokens"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+    const items = page.locator(
+      '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-item="true"]',
+    );
+    await expect(items).toHaveCount(6);
+
+    const pager = page.locator(
+      '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-pager="true"]',
+    );
+    await expect(pager.getByText("1–6", { exact: true })).toBeVisible();
+
+    await assertPagerAnchoredToModuleBottom(
+      page,
+      `${viewport.name}: short dataset (6 tokens)`,
+    );
+
+    const forbiddenOverflow = await page.evaluate((selector) => {
+      const root = document.querySelector(selector);
+      if (!root) return [];
+      const elements = [root, ...Array.from(root.querySelectorAll("*"))];
+      return elements.flatMap((element) => {
+        const style = window.getComputedStyle(element);
+        return ["auto", "scroll"].includes(style.overflowX) ||
+          ["auto", "scroll"].includes(style.overflowY)
+          ? [`${element.tagName}.${(element as HTMLElement).className}`]
+          : [];
+      });
+    }, '[data-admin-mobile-core-module="tokens"]');
+    expect(
+      forbiddenOverflow,
+      `${viewport.name}: forbidden overflow auto/scroll (short dataset)`,
+    ).toEqual([]);
   });
 }

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -1223,12 +1223,12 @@ export function AdminParticularTokensCard() {
           </div>
 
           <div
-            className="flex min-h-0 flex-1 flex-col gap-1.5 md:hidden"
+            className="flex h-full min-h-0 flex-1 flex-col gap-1.5 md:hidden"
             data-admin-mobile-core-module="tokens"
           >
             <div
               data-admin-particulars-mobile-list="true"
-              className="divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
+              className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
             >
               {mobileTokens.map((token) => (
                 <div


### PR DESCRIPTION
## Summary
- Anchor the Admin mobile Tokens pagination footer to the internal bottom edge of the module
- Let the token list absorb spare vertical space when datasets are short, including the real 1–6 case
- Preserve 10 visible tokens when datasets have enough rows
- Keep no global/internal scroll and avoid overflow:auto/scroll

## Validation
- pnpm --dir frontend exec playwright test frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts: 9 passed
- pnpm --dir frontend exec playwright test frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts: 13 passed
- pnpm test: 2815 passed
- pnpm --dir frontend lint: OK
- pnpm --dir frontend typecheck: OK
- pnpm --dir frontend build: OK
- pnpm build: OK

## Documentation
- docs/audit/admin-mobile-tokens-pagination-bottom.md