### PR TITLE
fix(admin): align mobile tokens pagination and modal copy

### DIFF
--- a/docs/audit/admin-mobile-tokens-copy-pagination-align.md
+++ b/docs/audit/admin-mobile-tokens-copy-pagination-align.md
@@ -1,0 +1,114 @@
+# Fix quirúrgico — Mobile Tokens: paginador centrado + copy del modal "Generar token"
+
+## Rama y base
+
+- Rama: `fix/admin-mobile-tokens-copy-pagination-align`
+- HEAD base: `b0a985d fix(admin): anchor mobile tokens pagination (#1078)`
+- Working tree base: limpio (verificado antes de crear rama)
+
+## Problema observado
+
+En el módulo mobile **Tokens** del dashboard Administrador:
+
+1. El footer del paginador mostraba un rango lateral izquierdo (`1–6`, `1–10`, etc.) que el bloque pidió eliminar, dejando `Anterior / Pág. X / Siguiente` centrados.
+2. El modal "Generar token particular":
+   - Tenía un campo **"ID informe vinculado"** (input numérico libre, opcional) que no correspondía a la búsqueda/selección de clínica.
+   - El copy `Generar token particular` desbordaba el margen lateral en mobile (título del modal y CTA final).
+   - La botonera del paso final (`Limpiar / Anterior / Generar token particular`) podía exceder el ancho útil del modal en viewports angostos (360–430px).
+
+## Scope
+
+- Único componente tocado: [`AdminParticularTokensCard.tsx`](../../frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx) (módulo Tokens del dashboard Administrador) y sus specs/guardrails asociados.
+- Cambios estrictamente de copy, estructura de paginador mobile y layout del footer del modal de creación.
+
+## No alcance (no tocado)
+
+Backend, API, DB, auth, lógica de negocio ajena, contratos de tokens fuera del modal afectado, módulo **Clínica** (`ClinicParticularTokensCard.tsx` y su suite de tests quedaron intactos), dependencias, lockfiles, CI, Hub, Auditoría, Clínicas, Sesiones, Mantenimiento, desktop (salvo el ajuste mínimo de grilla descrito abajo), otros módulos admin, rutas públicas, producción.
+
+## Archivos modificados
+
+| Archivo | Motivo |
+|---|---|
+| [`frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`](../../frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx) | Implementación: paginador centrado, copy del modal, campo "Clínica vinculada", footer sin overflow |
+| [`frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts`](../../frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts) | TDD: reforzar/agregar tests que cubren los 4 requisitos del bloque |
+| [`test/frontend-admin-particular-tokens.test.ts`](../../test/frontend-admin-particular-tokens.test.ts) | Guardrail: quitar `admin-token-report-id` de la lista de inputs sensibles (el input ya no existe) |
+| [`test/progress-production-invariants.test.ts`](../../test/progress-production-invariants.test.ts) | Guardrail: idem, quitar la misma referencia obsoleta en el set de invariantes |
+
+## Implementación aplicada
+
+### A) Paginador Tokens mobile
+- Se eliminó el `<span>{mobileRangeStart}–{mobileRangeEnd}</span>` y las variables derivadas `mobileRangeStart`/`mobileRangeEnd` (quedaron sin uso).
+- El contenedor del footer del paginador pasó de `justify-between` a `justify-center`, alojando directamente `Anterior`, `Pág. X` y `Siguiente` (se removió el `<div>` interno que ya no hace falta).
+- Se preservó `data-admin-mobile-core-pager="true"`, el anclaje inferior (`border-t`, `pt-1.5`, `shrink-0`) y no se tocó ningún `overflow`.
+- El paginador **desktop** (`rangeStart`/`rangeEnd`, sección `hidden md:flex`) no fue modificado — es un bloque separado, no comparte JSX con el mobile.
+
+### B) Modal "Generar token" — copy y campo
+- `title="Generar token particular"` → `title="Generar token"` (ModuleDialog).
+- CTA final: `"Generar token particular"` → `"Generar token"`.
+- Label `"Clínica"` (paso 1, el input que ya implementaba búsqueda/selección de clínicas registradas vía `getAdminUsersRoles` + listbox filtrable) → `"Clínica vinculada"`. Se reutilizó el mecanismo existente, sin crear un campo nuevo.
+- Se eliminó el bloque `"ID informe vinculado"` (input numérico libre `reportId`, opcional, sin uso real en el flujo de alta — el vínculo informe↔token particular se gestiona desde `AdminReportsUploadPanel.tsx`, no desde este modal). El campo `Email del particular` pasó a ocupar el ancho completo de la grilla (`md:col-span-2`) para no dejar una celda vacía en desktop.
+- `formState.reportId`, `parseOptionalReportId` y el envío de `reportId: null` en el payload **se mantienen intactos** en el código (no se tocó el contrato `AdminParticularTokenCreatePayload` de `api.ts`); solo se quitó el control visible. El campo simplemente nunca se completa desde la UI ahora.
+
+### C) Modal "Generar token" — footer/botonera
+- Contenedor del footer: se agregó `flex-wrap` (antes solo `flex ... justify-between`) como red de seguridad de layout.
+- Grupo derecho (`Anterior` + CTA): se agregó `flex-wrap` y `justify-end`.
+- Combinado con el copy corto (`Generar token` en vez de `Generar token particular`), se validó por medición real (`boundingBox()` en Playwright) que ningún botón excede el viewport en 360/390/430px, y que la altura de touch target permanece en 36px (`size="sm"` → `h-9`).
+
+## Tests agregados/reforzados (TDD)
+
+Todos en [`admin-tokens-mobile-toolbar-layout.spec.ts`](../../frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts):
+
+1. **`assertPagerHasNoRangeText`** (nuevo helper): falla si aparece cualquier texto con forma `N–M`/`N-M` dentro del paginador mobile. Aplicado a los casos de página completa (10 tokens) y dataset corto (6 tokens) — antes el test de dataset corto exigía que `"1–6"` **sí** fuera visible; ahora exige lo contrario.
+2. **`assertPagerControlsCentered`** (nuevo helper): mide `boundingBox()` de `Anterior`/`Siguiente` contra el contenedor del paginador y exige que el margen izquierdo y derecho sean iguales (tolerancia 6px) — verifica centrado real, no una clase CSS.
+3. **Nuevo test `admin tokens create dialog uses linked-clinic search and short copy`** (uno por viewport mobile):
+   - Abre el modal, confirma que `"Generar token particular"` y `"ID informe vinculado"` no existen (`toHaveCount(0)`).
+   - Completa la búsqueda de clínica (`"Clínica vinculada"`), selecciona una opción mockeada (`/api/admin/users-roles`) y confirma que el input refleja la clínica elegida.
+   - Avanza los 3 pasos (completando los campos obligatorios reales del formulario) y en el paso final mide `Limpiar`/`Anterior`/`Generar token`: ningún botón se recorta a izquierda/derecha del viewport, altura ≥36px, y no hay overflow horizontal de página.
+
+Se confirmó la fase roja: los 9 tests nuevos/reforzados fallaron contra el código pre-fix exactamente en los puntos esperados (rango visible, copy largo presente) antes de implementar.
+
+## Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend exec playwright test frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts` | ✅ 12/12 |
+| `pnpm --dir frontend exec playwright test frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts` | ✅ 13/13 |
+| `pnpm --dir frontend exec playwright test` (specs de regresión #1074/#1076: `admin-mobile-hub-stale-layer-stage`, `admin-mobile-app-shell-absolute-no-scroll`, `admin-mobile-config-modules-no-scroll`, `admin-mobile-status-modules-no-scroll`, `admin-mobile-hub-launcher-no-scroll`) | ✅ 60/60 |
+| `pnpm test` (raíz) | ✅ 2815/2815 |
+| `pnpm --dir frontend lint` | ✅ sin hallazgos |
+| `pnpm --dir frontend typecheck` | ✅ sin errores |
+| `pnpm --dir frontend build` | ✅ build de producción exitoso |
+| `pnpm build` (raíz, backend) | ✅ bundle generado |
+
+Nota operativa: cada corrida de `next dev` (Playwright) o `next build` reescribe `frontend/next-env.d.ts` (archivo autogenerado, comentario "should not be edited"). Se restauró a su estado committeado (`git checkout -- frontend/next-env.d.ts`) después de cada corrida para no ensuciar el diff final — comportamiento ya documentado como guardrail conocido del repo.
+
+## Confirmaciones explícitas
+
+- ✅ Rango izquierdo del paginador (`1–6`/`1–10`/equivalente) eliminado del footer mobile de Tokens.
+- ✅ `Anterior / Pág. X / Siguiente` quedan centrados horizontalmente (verificado por medición de bounding box, no solo por clase CSS).
+- ✅ El footer del paginador sigue anclado al borde inferior interno del módulo (test `assertPagerAnchoredToModuleBottom` sigue pasando).
+- ✅ `ID informe vinculado` → ya no existe en el modal; existe `Clínica vinculada`.
+- ✅ El campo `Clínica vinculada` busca/selecciona una clínica registrada (reutiliza el mecanismo de búsqueda ya existente — no es input libre de "informe").
+- ✅ `Generar token particular` → `Generar token` en título del modal y CTA final.
+- ✅ Botonera final del modal (`Limpiar`/`Anterior`/`Generar token`) entra dentro del ancho útil en 360/390/430px, sin desbordar el margen lateral, con touch targets ≥36px.
+- ✅ Sin scroll global ni interno introducido.
+- ✅ Sin `overflow:auto`/`overflow:scroll` agregado (verificado con `git diff | Select-String`).
+- ✅ #1074 (anti-ghosting / stale layer stage) y #1076 (tokens fluidos mobile) preservados — specs de regresión asociadas pasan 60/60.
+- ✅ No se tocó backend, API, DB, auth, Clínica (`ClinicParticularTokensCard.tsx` y su spec quedaron intactos), dependencias, lockfiles, CI, Hub, Auditoría, Clínicas, Sesiones, Mantenimiento, desktop (salvo el `md:col-span-2` cosmético del campo Email tras retirar el campo vecino), otros módulos admin.
+
+## Riesgo residual
+
+- El campo "ID informe vinculado" permitía, opcionalmente, vincular un informe ya existente al token particular en el momento de la creación. Esa capacidad de UI desaparece (el contrato de API sigue soportando `reportId: null | number`, no se tocó); el vínculo informe↔token sigue disponible por la vía ya existente y más usada: `AdminReportsUploadPanel.tsx` (selección de token particular al subir el informe). Si algún flujo operativo dependía de fijar el `reportId` *en el momento del alta* del token, ese atajo ya no está disponible desde este modal.
+- El `flex-wrap` agregado al footer del modal es una red de seguridad de layout; en los anchos probados (360/390/430px) el contenido entra en una sola línea, pero si en el futuro se alarga el texto de algún botón del footer, podría pasar a dos líneas en vez de desbordar (comportamiento intencional y validado, no un bug).
+
+## Comandos manuales para Nico (no ejecutados por Claude)
+
+```powershell
+git status --short --untracked-files=all
+git add frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx test/frontend-admin-particular-tokens.test.ts test/progress-production-invariants.test.ts docs/audit/admin-mobile-tokens-copy-pagination-align.md
+git status --short --untracked-files=all
+git commit -m "fix(admin): align mobile tokens pagination and modal copy"
+git push -u origin fix/admin-mobile-tokens-copy-pagination-align
+gh pr create --title "fix(admin): align mobile tokens pagination and modal copy" --body "..."
+gh pr checks --watch
+```

--- a/frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
+++ b/frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
@@ -109,6 +109,45 @@ async function assertPagerAnchoredToModuleBottom(
   ).toBeLessThanOrEqual(PAGER_BOTTOM_TOLERANCE);
 }
 
+const CENTER_TOLERANCE = 6;
+const RANGE_TEXT_PATTERN = /^\d+[–-]\d+$/;
+
+async function assertPagerHasNoRangeText(page: Page, label: string) {
+  const pager = page.locator(
+    '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-pager="true"]',
+  );
+  await expect(
+    pager.getByText(RANGE_TEXT_PATTERN),
+    `${label}: pager range text removed`,
+  ).toHaveCount(0);
+}
+
+async function assertPagerControlsCentered(page: Page, label: string) {
+  const pager = page.locator(
+    '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-pager="true"]',
+  );
+  const pagerBox = await pager.boundingBox();
+  const anteriorBox = await pager
+    .getByRole("button", { name: "Anterior" })
+    .boundingBox();
+  const siguienteBox = await pager
+    .getByRole("button", { name: "Siguiente" })
+    .boundingBox();
+
+  expect(pagerBox, `${label}: pager bounding box`).not.toBeNull();
+  expect(anteriorBox, `${label}: Anterior bounding box`).not.toBeNull();
+  expect(siguienteBox, `${label}: Siguiente bounding box`).not.toBeNull();
+
+  const leftGap = anteriorBox!.x - pagerBox!.x;
+  const rightGap =
+    pagerBox!.x + pagerBox!.width - (siguienteBox!.x + siguienteBox!.width);
+
+  expect(
+    Math.abs(leftGap - rightGap),
+    `${label}: pager controls not centered (left=${leftGap}, right=${rightGap})`,
+  ).toBeLessThanOrEqual(CENTER_TOLERANCE);
+}
+
 for (const viewport of MOBILE_VIEWPORTS) {
   test(`admin tokens toolbar stays operable — ${viewport.name}`, async ({
     page,
@@ -265,6 +304,8 @@ for (const viewport of MOBILE_VIEWPORTS) {
       page,
       `${viewport.name}: full page (10 tokens)`,
     );
+    await assertPagerHasNoRangeText(page, `${viewport.name}: full page (10 tokens)`);
+    await assertPagerControlsCentered(page, `${viewport.name}: full page (10 tokens)`);
   });
 
   test(`admin tokens mobile pager stays bottom-anchored with a short dataset — ${viewport.name}`, async ({
@@ -285,10 +326,8 @@ for (const viewport of MOBILE_VIEWPORTS) {
     );
     await expect(items).toHaveCount(6);
 
-    const pager = page.locator(
-      '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-pager="true"]',
-    );
-    await expect(pager.getByText("1–6", { exact: true })).toBeVisible();
+    await assertPagerHasNoRangeText(page, `${viewport.name}: short dataset (6 tokens)`);
+    await assertPagerControlsCentered(page, `${viewport.name}: short dataset (6 tokens)`);
 
     await assertPagerAnchoredToModuleBottom(
       page,
@@ -311,5 +350,132 @@ for (const viewport of MOBILE_VIEWPORTS) {
       forbiddenOverflow,
       `${viewport.name}: forbidden overflow auto/scroll (short dataset)`,
     ).toEqual([]);
+  });
+}
+
+async function mockAdminUsersRolesClinics(page: Page) {
+  await page.route("**/api/admin/users-roles**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        users: [
+          {
+            userType: "clinic",
+            userId: 501,
+            username: "clinica.norte",
+            role: "clinic_owner",
+            clinicId: 77,
+            clinicName: "Clínica Norte",
+            clinicLocality: "Rosario",
+            createdAt: "2026-05-01T10:00:00.000Z",
+            updatedAt: "2026-05-01T10:00:00.000Z",
+          },
+        ],
+        total: 1,
+        limit: 100,
+        offset: 0,
+        totals: { adminUsers: 0, clinicUsers: 1 },
+      }),
+    });
+  });
+}
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  test(`admin tokens create dialog uses linked-clinic search and short copy — ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setAdminSession(page);
+    await mockAdminParticularTokens(page, MOCK_TOKENS_SHORT);
+    await mockAdminUsersRolesClinics(page);
+    await page.goto("/dashboard/admin?module=admin-particular-tokens");
+
+    const workspace = page.locator(
+      '[data-dashboard-module-workspace="admin-particular-tokens"]',
+    );
+    await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+    const toolbar = workspace.locator('[data-admin-particulars-toolbar="true"]');
+    await toolbar.getByRole("tab", { name: "Generar token" }).click();
+
+    const dialog = page.locator('[data-module-dialog="true"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    await expect(
+      dialog.getByText("Generar token particular"),
+      `${viewport.name}: legacy long copy removed`,
+    ).toHaveCount(0);
+    await expect(
+      dialog.getByText("ID informe vinculado"),
+      `${viewport.name}: report-id label removed`,
+    ).toHaveCount(0);
+
+    const clinicSearchInput = dialog.getByLabel("Clínica vinculada");
+    await expect(clinicSearchInput).toBeVisible();
+
+    await clinicSearchInput.fill("Norte");
+    const clinicOption = dialog.getByRole("option", { name: /Clínica Norte/ });
+    await expect(clinicOption).toBeVisible();
+    await clinicOption.click();
+    await expect(clinicSearchInput).toHaveValue("Clínica Norte");
+
+    await page.locator("#admin-token-particular-email").fill("particular@example.com");
+    await dialog.getByRole("button", { name: "Siguiente" }).click();
+    await expect(dialog.getByText("Paso 2 de 3: Paciente")).toBeVisible();
+
+    await page.locator("#admin-token-tutor-last-name").fill("Tutor Demo");
+    await page.locator("#admin-token-pet-name").fill("Paciente Demo");
+    await page.locator("#admin-token-pet-age").fill("4 años");
+    await page.locator("#admin-token-pet-breed").fill("Mestizo");
+    await dialog.getByRole("button", { name: "Siguiente" }).click();
+    await expect(dialog.getByText("Paso 3 de 3: Muestra")).toBeVisible();
+
+    const limpiarButton = dialog.getByRole("button", { name: "Limpiar" });
+    const anteriorButton = dialog.getByRole("button", { name: "Anterior" });
+    const submitButton = dialog.getByRole("button", {
+      name: "Generar token",
+      exact: true,
+    });
+
+    await expect(limpiarButton).toBeVisible();
+    await expect(anteriorButton).toBeVisible();
+    await expect(submitButton).toBeVisible();
+
+    for (const [label, button] of [
+      ["Limpiar", limpiarButton],
+      ["Anterior", anteriorButton],
+      ["Generar token", submitButton],
+    ] as const) {
+      const box = await button.boundingBox();
+      expect(box, `${viewport.name}: ${label} bounding box`).not.toBeNull();
+      expect(
+        box!.x,
+        `${viewport.name}: ${label} clipped on the left`,
+      ).toBeGreaterThanOrEqual(-TOLERANCE);
+      expect(
+        box!.x + box!.width,
+        `${viewport.name}: ${label} clipped on the right`,
+      ).toBeLessThanOrEqual(viewport.width + TOLERANCE);
+      expect(
+        box!.height,
+        `${viewport.name}: ${label} touch target height`,
+      ).toBeGreaterThanOrEqual(36);
+    }
+
+    const overflow = await page.evaluate(() => ({
+      htmlScrollWidth: document.documentElement.scrollWidth,
+      htmlClientWidth: document.documentElement.clientWidth,
+    }));
+    expect(
+      overflow.htmlScrollWidth,
+      `${viewport.name}: dialog causes horizontal page overflow`,
+    ).toBeLessThanOrEqual(overflow.htmlClientWidth + TOLERANCE);
   });
 }

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -469,10 +469,6 @@ export function AdminParticularTokensCard() {
   const rangeStart = tokens.length ? page * PAGE_SIZE + 1 : 0;
   const rangeEnd = page * PAGE_SIZE + tokens.length;
   const canGoNext = tokens.length === PAGE_SIZE;
-  const mobileRangeStart = mobileTokens.length
-    ? mobilePage * MOBILE_PAGE_SIZE + 1
-    : 0;
-  const mobileRangeEnd = mobilePage * MOBILE_PAGE_SIZE + mobileTokens.length;
   const canGoNextMobile = mobileTokens.length === MOBILE_PAGE_SIZE;
   const createStepIndex = getCreateStepIndex(createStep);
   const isLastCreateStep = createStep === "sample";
@@ -1275,41 +1271,36 @@ export function AdminParticularTokensCard() {
 
             {mobileTokens.length ? (
               <div
-                className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 pt-1.5 text-xs text-muted-foreground"
+                className="flex shrink-0 items-center justify-center gap-1.5 border-t border-vetneb-line/65 pt-1.5 text-xs text-muted-foreground"
                 data-admin-mobile-core-pager="true"
               >
-                <span>
-                  {mobileRangeStart}–{mobileRangeEnd}
-                </span>
-                <div className="flex items-center gap-1.5">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-9 px-2.5 text-xs"
-                    disabled={mobilePage === 0 || isLoadingMobileTokens}
-                    onClick={() => {
-                      setIsDetailDialogOpen(false);
-                      setMobilePage((current) => Math.max(0, current - 1));
-                    }}
-                  >
-                    Anterior
-                  </Button>
-                  <span className="min-w-12 text-center">Pág. {mobilePage + 1}</span>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-9 px-2.5 text-xs"
-                    disabled={!canGoNextMobile || isLoadingMobileTokens}
-                    onClick={() => {
-                      setIsDetailDialogOpen(false);
-                      setMobilePage((current) => current + 1);
-                    }}
-                  >
-                    Siguiente
-                  </Button>
-                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9 px-2.5 text-xs"
+                  disabled={mobilePage === 0 || isLoadingMobileTokens}
+                  onClick={() => {
+                    setIsDetailDialogOpen(false);
+                    setMobilePage((current) => Math.max(0, current - 1));
+                  }}
+                >
+                  Anterior
+                </Button>
+                <span className="min-w-12 text-center">Pág. {mobilePage + 1}</span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9 px-2.5 text-xs"
+                  disabled={!canGoNextMobile || isLoadingMobileTokens}
+                  onClick={() => {
+                    setIsDetailDialogOpen(false);
+                    setMobilePage((current) => current + 1);
+                  }}
+                >
+                  Siguiente
+                </Button>
               </div>
             ) : null}
           </div>
@@ -1365,7 +1356,7 @@ export function AdminParticularTokensCard() {
         open={isCreateDialogOpen}
         onOpenChange={handleCreateDialogOpenChange}
         busy={isSubmitting}
-        title="Generar token particular"
+        title="Generar token"
         description={`Paso ${createStepIndex + 1} de ${CREATE_STEP_ORDER.length}: ${CREATE_STEP_LABELS[createStep]}`}
       >
         <form className="space-y-4" onSubmit={handleSubmit} autoComplete="off">
@@ -1390,7 +1381,7 @@ export function AdminParticularTokensCard() {
             <div className="grid grid-cols-1 gap-2.5 md:grid-cols-2">
               <div className="md:col-span-2">
                 <label htmlFor="admin-token-clinic-search" className="field-label">
-                  Clínica
+                  Clínica vinculada
                 </label>
                 <Input
                   id="admin-token-clinic-search"
@@ -1445,22 +1436,7 @@ export function AdminParticularTokensCard() {
                 </div>
               </div>
 
-              <label className="block">
-                <span className="field-label">ID informe vinculado</span>
-                <Input
-                  id="admin-token-report-id"
-                  name="reportId"
-                  type="number"
-                  min="1"
-                  inputMode="numeric"
-                  placeholder="Opcional"
-                  autoComplete="off"
-                  value={formState.reportId}
-                  onChange={(event) => updateField("reportId", event.target.value)}
-                  disabled={isSubmitting}
-                />
-              </label>
-              <label className="block">
+              <label className="block md:col-span-2">
                 <span className="field-label">Email del particular</span>
                 <Input
                   id="admin-token-particular-email"
@@ -1542,12 +1518,12 @@ export function AdminParticularTokensCard() {
             <p className="clinical-alert-error px-2.5 py-1.5 text-xs" role="alert">{errorMessage}</p>
           ) : null}
 
-          <div className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 pt-3">
+          <div className="flex flex-wrap shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 pt-3">
             <Button type="button" variant="ghost" size="sm" onClick={resetForm} disabled={isSubmitting}>Limpiar</Button>
-            <div className="flex gap-1.5">
+            <div className="flex flex-wrap items-center justify-end gap-1.5">
               {createStepIndex > 0 ? <Button type="button" variant="outline" size="sm" onClick={goToPreviousCreateStep} disabled={isSubmitting}>Anterior</Button> : null}
               {isLastCreateStep ? (
-                <Button type="submit" size="sm" disabled={isSubmitting || generatedToken !== null}>{isSubmitting ? "Generando…" : "Generar token particular"}</Button>
+                <Button type="submit" size="sm" disabled={isSubmitting || generatedToken !== null}>{isSubmitting ? "Generando…" : "Generar token"}</Button>
               ) : (
                 <Button type="submit" size="sm" disabled={isSubmitting}>Siguiente</Button>
               )}

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -376,7 +376,6 @@ test("admin particular token form has autoComplete off on form element and all s
     "admin-token-sample-evolution",
     "admin-token-extraction-date",
     "admin-token-shipping-date",
-    "admin-token-report-id",
   ];
 
   for (const id of sensitiveInputIds) {

--- a/test/progress-production-invariants.test.ts
+++ b/test/progress-production-invariants.test.ts
@@ -332,11 +332,6 @@ test("particular token invariants: hard delete, legacy revoke hard-delete, casca
     adminCardFile,
     "admin-token-pet-name",
   );
-  assertInputAutocompleteOff(
-    adminCardSource,
-    adminCardFile,
-    "admin-token-report-id",
-  );
 
   const clinicCardFile = "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
   const clinicCardSource = read(clinicCardFile);


### PR DESCRIPTION
## Summary
- Remove the mobile Tokens pagination left range and center Anterior / Pág. X / Siguiente
- Keep the pagination footer anchored to the internal bottom edge
- Rename ID informe vinculado to Clínica vinculada and reuse existing registered clinic search/selection
- Shorten Generar token particular to Generar token so the modal CTA stays inside mobile margins
- Keep the final modal button row within 360/390/430px mobile bounds

## Validation
- Playwright targeted: 12/12
- Admin mobile no-scroll core modules: 13/13
- #1074/#1076 regression: 60/60
- pnpm test: 2815/2815
- pnpm --dir frontend lint: OK
- pnpm --dir frontend typecheck: OK
- pnpm --dir frontend build: OK
- pnpm build: OK

## Documentation
- docs/audit/admin-mobile-tokens-copy-pagination-align.md