### PR TITLE
fix(admin): align mobile ops pager to canonical tokens layout

### DIFF
--- a/docs/audit/admin-mobile-canonical-tokens-layout-audit.md
+++ b/docs/audit/admin-mobile-canonical-tokens-layout-audit.md
@@ -1,0 +1,189 @@
+# Auditoría — Layout canónico mobile del Dashboard Administrador basado en Tokens
+
+> Contrato visual y plan de PRs chicos para replicar el patrón mobile de **Tokens
+> particulares** en el resto de los módulos del Dashboard Administrador.
+
+- **HEAD base:** `af1639e fix(admin): align mobile tokens pagination and modal copy (#1079)`
+- **Rama de auditoría:** `audit/admin-mobile-canonical-tokens-layout`
+- **Alcance:** únicamente Dashboard Administrador mobile (`md:hidden`). No se toca
+  backend, API, DB, auth, dependencias, lockfiles, CI, rutas públicas ni Clínica.
+- **Referencia canónica funcional:** módulo **Tokens** mobile
+  (`frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`, rama
+  `md:hidden`, líneas ~1221–1306) — corresponde a la captura aportada por Nico.
+
+---
+
+## 1. Patrón canónico Tokens (definición funcional)
+
+Estructura mobile observada en Tokens (referencia a replicar):
+
+1. **Appbar fija** superior (`[data-admin-mobile-app-bar="true"]`).
+2. **Título del módulo** (provisto por `DashboardModuleWorkspace`).
+3. **Card/stage** ocupando el alto disponible:
+   `Card` → `flex min-h-0 flex-1 flex-col overflow-hidden`.
+4. **Toolbar superior** dentro del card: acción primaria fuerte
+   (`Tokens administrados`) + acción secundaria (`Generar token`), más
+   filtros/acciones (`ID clínica`, `Filtrar`, `Actualizar`).
+5. **Lista operativa** en zona central flexible:
+   `data-admin-mobile-core-module="tokens"` → contenedor
+   `flex h-full min-h-0 flex-1 flex-col`; lista
+   `data-admin-particulars-mobile-list` = `min-h-0 flex-1 overflow-hidden`.
+6. **Ítems** `data-admin-mobile-core-item` con `min-h-9` (≥36px).
+7. **Espacio sobrante** absorbido por la lista (`flex-1`), no por el footer.
+8. **Footer/paginador** anclado abajo: `data-admin-mobile-core-pager`,
+   `shrink-0`, **`justify-center`**, texto **`Anterior` / `Pág. X` /
+   `Siguiente`**, botones **`h-9` (36px)**.
+9. **Bottom nav fija** (`[data-admin-mobile-bottom-nav="true"]`).
+10. **Sin scroll global, sin scroll interno, sin `overflow:auto|scroll`**
+    (solo `overflow-hidden`). Touch targets ≥36px.
+
+### Invariantes de contrato ya bloqueadas por tests
+
+- `frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts` valida
+  `clinics`, `reports`, `tokens` (no-scroll, ítems dentro del viewport, pager
+  dentro del viewport, paginación funcional, appbar/bottom-nav).
+- `frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts` valida
+  `audit`, `sessions`, `users`.
+- `frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts` /
+  `admin-mobile-config-modules-no-scroll.spec.ts` validan las familias
+  status/config (chips+panel).
+- `test/admin-tokens-enterprise-density.test.ts` bloquea strings/clases de
+  Tokens como regresión (referencia canónica).
+
+---
+
+## 2. Inventario de módulos y familias de layout mobile
+
+El Dashboard Administrador mobile usa **tres familias** de layout, no una sola:
+
+| Familia | Componente base | Hooks de datos | Forma |
+|---|---|---|---|
+| **Core (lista + pager)** | inline en cada Card | `data-admin-mobile-core-module/-item/-pager` | Lista operativa + paginador. **Patrón Tokens.** |
+| **Ops (lista + pager)** | `AdminMobileOpsPager` | `data-admin-mobile-ops-module/-item` + `data-admin-mobile-ops-pager` | Lista `grid-rows-3` + paginador compartido. |
+| **Status/Config (chips + panel)** | `AdminMobileStatusModule` / `AdminMobileConfigModule` | `data-admin-mobile-status/config-*` | Tabs por chips, panel `flex-1`. No es una lista. |
+
+Mapa módulo → implementación mobile:
+
+| Módulo | Ruta `module=` | Componente mobile | Familia |
+|---|---|---|---|
+| Inicio / Hub | (sin módulo) | `DashboardModuleHub` + launcher | Hub |
+| Administración | `admin` | `AdminMobileCommandModule` → `AdminMobileStatusModule` | Status |
+| Informes | `admin-report-upload` | `AdminReportsCard` (`reports`) | **Core** |
+| Estado del sistema | `admin-health` | `AdminMobileHealthModule` → `AdminMobileStatusModule` | Status |
+| Clínicas | `admin-clinics` | `AdminClinicsManagementCard` (`clinics`) | **Core** |
+| **Tokens** | `admin-particular-tokens` | `AdminParticularTokensCard` (`tokens`) | **Core (canónico)** |
+| Precios | `admin-pricing` | `AdminMobilePricingModule` → `AdminMobileConfigModule` | Config |
+| Sesiones | `admin-sessions` | `AdminMobileSessionsModule` → `AdminMobileOpsPager` | **Ops** |
+| Usuarios y roles | `admin-users-roles` | `AdminMobileUsersModule` → `AdminMobileOpsPager` | **Ops** |
+| Auditoría | `audit-log` | `AdminMobileAuditModule` → `AdminMobileOpsPager` | **Ops** |
+| Mantenimiento | `admin-maintenance` | `AdminMobileMaintenanceModule` → `AdminMobileConfigModule` | Config |
+
+---
+
+## 3. Tabla de cumplimiento por módulo vs. patrón Tokens
+
+Leyenda: ✅ cumple · 🟡 casi cumple · ❌ no cumple · — no aplica.
+
+| Módulo | Stage full-height | Toolbar/filtros arriba | Zona central flexible | Footer/pager abajo | Pager centrado `Anterior/Pág./Siguiente` | Touch ≥36px (pager) | Sin overflow auto/scroll | Veredicto |
+|---|---|---|---|---|---|---|---|---|
+| **Tokens** (ref) | ✅ | ✅ | ✅ | ✅ | ✅ texto | ✅ `h-9` | ✅ | **Canónico** |
+| Clínicas | ✅ | ✅ | ✅ | ✅ | 🟡 chevron-icon + rango, `justify-between` | ✅ `h-9 w-9` | ✅ | 🟡 casi |
+| Informes | ✅ | ✅ | ✅ | ✅ | 🟡 chevron-icon + rango, `justify-between` | ✅ `h-9 w-9` | ✅ | 🟡 casi |
+| **Sesiones** | ✅ | ✅ | ✅ (`grid-rows-3`) | ✅ | ❌ chevron-icon + rango, `justify-between` | ❌ **`h-7 w-7` = 28px** | ✅ | ❌ no cumple (pager) |
+| **Usuarios y roles** | ✅ | ✅ | ✅ (`grid-rows-3`) | ✅ | ❌ chevron-icon + rango, `justify-between` | ❌ **`h-7 w-7` = 28px** | ✅ | ❌ no cumple (pager) |
+| **Auditoría** | ✅ | ✅ (filtros + contadores) | ✅ (`grid-rows-3`) | ✅ | ❌ chevron-icon + rango, `justify-between` | ❌ **`h-7 w-7` = 28px** | ✅ | ❌ no cumple (pager) |
+| Administración | ✅ | — chips | ✅ panel `flex-1` | — | — (sin lista) | — | ✅ | ✅ (familia status) |
+| Estado del sistema | ✅ | — chips | ✅ panel `flex-1` | — | — (sin lista) | — | ✅ | ✅ (familia status) |
+| Precios | ✅ | — chips | ✅ panel `flex-1` | — | — (sin lista) | — | ✅ | ✅ (familia config) |
+| Mantenimiento | ✅ | — chips | ✅ panel `flex-1` | — | — (sin lista) | — | ✅ | ✅ (familia config) |
+
+### Lectura de la tabla
+
+- **No hay módulos con scroll global, scroll interno ni `overflow:auto|scroll`.**
+  Todas las familias usan `overflow-hidden` + `min-h-0 flex-1`. La arquitectura
+  no-scroll del HUB ya está consolidada (#1074/#1076).
+- Las familias **status/config** no son listas; replicar el pager de Tokens en
+  ellas **no aplica** y sería un rediseño fuera de alcance.
+- Las familias **core (Clínicas/Informes)** ya cumplen touch target (`h-9`) pero
+  divergen visualmente del canónico Tokens (chevron-icon + rango +
+  `justify-between` en vez de texto centrado `Anterior/Pág./Siguiente`).
+- La familia **ops (Sesiones/Usuarios/Auditoría)** es la **única que viola el
+  touch target ≥36px** (`h-7 w-7` = 28px) **y** además diverge en layout. Es la
+  más alejada del canónico y la de mayor prioridad.
+
+---
+
+## 4. Riesgos por módulo
+
+| Módulo | Riesgo principal | Severidad |
+|---|---|---|
+| Sesiones / Usuarios / Auditoría | Pager `AdminMobileOpsPager` con botones de 28px (< 36px) — touch target insuficiente; layout no centrado. | Media (accesibilidad/consistencia) |
+| Clínicas / Informes | Pager con chevron-icon + rango en vez de texto centrado canónico. Touch target OK. | Baja (cosmético) |
+| Status/Config | Ninguno respecto del patrón Tokens (no son listas). Riesgo solo si se intentara forzar el pager. | — |
+| Todos | Cambiar altura del pager podría alterar el presupuesto no-scroll si no se mantiene `min-h-10`. | Controlable |
+
+Sin riesgo de ghosting/layering adicional: el stage persistente
+(`dashboard-module-stage`, #1074) ya está resuelto y no se toca.
+
+---
+
+## 5. Propuesta de PRs chicos (orden recomendado)
+
+> Cada PR toca **una sola familia/archivo**, es reversible y no mezcla módulos.
+
+1. **PR-A (este lote) — Pager ops canónico.**
+   Alinear `AdminMobileOpsPager.tsx` al pager canónico Tokens: **centrado**,
+   texto **`Anterior` / `Pág. X / Y` / `Siguiente`**, botones **`h-9` (36px)**,
+   manteniendo `min-h-10` (altura neta sin cambios → no-scroll intacto) y el
+   `<nav aria-label>` + `data-admin-mobile-ops-pager`. Beneficia a Sesiones,
+   Usuarios y Auditoría con un único archivo. Corrige la **única violación real
+   de touch target**. _Es el primer PR de implementación._
+
+2. **PR-B — Pager core a texto canónico.**
+   Unificar los pagers inline de `AdminClinicsManagementCard` y
+   `AdminReportsCard` al texto centrado `Anterior/Pág./Siguiente` (hoy
+   chevron-icon). Cambio cosmético, touch target ya cumple. Opcional.
+
+3. **PR-C — (opcional) extraer pager core compartido.**
+   Evaluar un componente único de pager mobile reutilizable por core+ops para
+   eliminar la duplicación. Solo si PR-A/PR-B confirman el contrato.
+
+No se proponen cambios en status/config: ya cumplen y no son listas.
+
+---
+
+## 6. Criterios de aceptación
+
+### Visuales
+- Pager de la familia ops **centrado**, con texto `Anterior`, `Pág. X / Y`,
+  `Siguiente`.
+- Botones del pager con altura `h-9` (≥36px).
+- Appbar y bottom nav preservadas y visibles.
+- Sin bloques introductorios redundantes.
+
+### No-scroll (bloqueantes)
+- `html`/`body`/módulo: `scrollHeight ≤ clientHeight + 2px` (sin overflow
+  vertical ni horizontal) en 360×740, 390×844, 430×932.
+- Cero elementos con `overflow:auto|scroll` dentro del módulo.
+- La zona central (`grid-rows-3` / lista) absorbe el espacio sobrante; el pager
+  queda anclado abajo.
+- Tokens (`clinics`/`reports`/`tokens`) sigue pasando como regresión.
+
+### No tocar
+Backend, API, DB, auth, dependencias, lockfiles, CI, rutas públicas,
+producción ni Clínica. Sin migrations. Sin secretos.
+
+---
+
+## 7. Primer PR de implementación
+
+**PR-A — Pager ops canónico (`AdminMobileOpsPager.tsx`).**
+
+- Único archivo de producto modificado + un test de contrato nuevo.
+- TDD: `test/admin-mobile-ops-pager-canonical-layout.test.ts` (falla con el
+  estado actual `h-7 w-7`/chevron/`justify-between`; pasa tras alinear a
+  `h-9`/texto/`justify-center`).
+- Riesgo no-scroll neutralizado: `min-h-10` + `py-0.5` + `h-9` = 40px (sin
+  delta de altura respecto del actual).
+- Beneficia a Sesiones, Usuarios y Auditoría sin mezclar módulos (un componente
+  compartido de la familia ops).

--- a/frontend/src/app/dashboard/admin/AdminMobileOpsPager.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileOpsPager.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 type AdminMobileOpsPagerProps = {
@@ -30,38 +29,36 @@ export function AdminMobileOpsPager({
     <nav
       aria-label={ariaLabel}
       data-admin-mobile-ops-pager="true"
-      className="flex min-h-10 shrink-0 items-center justify-between gap-2 overflow-hidden border-t border-vetneb-line/70 px-2 py-1 text-[11px] text-muted-foreground"
+      className="flex min-h-10 shrink-0 items-center justify-center gap-1.5 overflow-hidden border-t border-vetneb-line/70 px-2 py-0.5 text-xs text-muted-foreground"
     >
-      <span className="min-w-0 truncate" aria-live="polite">
+      <span className="sr-only" aria-live="polite">
         {rangeLabel}
       </span>
-      <div className="flex shrink-0 items-center gap-1.5">
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className="h-7 w-7"
-          aria-label="Anterior"
-          disabled={disabled || previousDisabled}
-          onClick={onPrevious}
-        >
-          <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
-        </Button>
-        <span className="min-w-14 text-center tabular-nums">
-          {page} / {pageCount}
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className="h-7 w-7"
-          aria-label="Siguiente"
-          disabled={disabled || nextDisabled}
-          onClick={onNext}
-        >
-          <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-9 px-2.5 text-xs"
+        aria-label="Anterior"
+        disabled={disabled || previousDisabled}
+        onClick={onPrevious}
+      >
+        Anterior
+      </Button>
+      <span className="min-w-16 text-center tabular-nums">
+        Pág. {page} / {pageCount}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-9 px-2.5 text-xs"
+        aria-label="Siguiente"
+        disabled={disabled || nextDisabled}
+        onClick={onNext}
+      >
+        Siguiente
+      </Button>
     </nav>
   );
 }

--- a/test/admin-mobile-ops-pager-canonical-layout.test.ts
+++ b/test/admin-mobile-ops-pager-canonical-layout.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const OPS_PAGER_PATH =
+  "frontend/src/app/dashboard/admin/AdminMobileOpsPager.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("admin mobile ops pager matches the canonical Tokens pager layout", () => {
+  const source = read(OPS_PAGER_PATH);
+
+  // Canonical Tokens mobile pager is centered, not split (justify-between).
+  assert.ok(source.includes("justify-center"), "pager must be centered");
+  assert.equal(
+    source.includes("justify-between"),
+    false,
+    "pager must not use justify-between",
+  );
+
+  // Text controls "Anterior" / "Pág. X" / "Siguiente" instead of icon chevrons.
+  assert.ok(source.includes("Pág."), "pager must render the Pág. label");
+  assert.equal(
+    source.includes("ChevronLeft"),
+    false,
+    "pager must not import/use chevron icons",
+  );
+  assert.equal(
+    source.includes("ChevronRight"),
+    false,
+    "pager must not import/use chevron icons",
+  );
+});
+
+test("admin mobile ops pager uses >=36px touch targets", () => {
+  const source = read(OPS_PAGER_PATH);
+
+  assert.ok(source.includes("h-9"), "pager buttons must be h-9 (36px)");
+  assert.equal(
+    source.includes("h-7 w-7"),
+    false,
+    "pager buttons must not be 28px icon buttons",
+  );
+});
+
+test("admin mobile ops pager preserves the no-scroll nav contract", () => {
+  const source = read(OPS_PAGER_PATH);
+
+  assert.ok(source.includes('data-admin-mobile-ops-pager="true"'));
+  assert.ok(source.includes("aria-label={ariaLabel}"));
+  assert.ok(source.includes("min-h-10"));
+  assert.equal(source.includes("overflow-auto"), false);
+  assert.equal(source.includes("overflow-scroll"), false);
+});


### PR DESCRIPTION
## Summary
- Align AdminMobileOpsPager for Sesiones / Usuarios / Auditoría with the canonical Tokens mobile pager
- Replace 28px icon-only pager controls with centered Anterior / Pág. X / Y / Siguiente controls
- Preserve rangeLabel as sr-only for accessibility/live-region behavior
- Keep no-scroll budget intact with no height delta
- Document the canonical Tokens layout audit and future PR plan

## Validation
- New ops pager canonical contract: 3/3
- Tokens regression admin-tokens-enterprise-density: 6/6
- pnpm --dir frontend typecheck: OK
- pnpm --dir frontend lint: OK
- pnpm --dir frontend build: OK
- pnpm typecheck: OK
- pnpm build: OK
- git diff --check: OK
- overflow auto/scroll diff control: empty

## Documentation
- docs/audit/admin-mobile-canonical-tokens-layout-audit.md