### PR TITLE
fix(admin): refine mobile sessions density

### DIFF
--- a/docs/audit/admin-mobile-sessions-select-clipping-density-10.md
+++ b/docs/audit/admin-mobile-sessions-select-clipping-density-10.md
@@ -1,0 +1,199 @@
+# VETNEB — Fix: selects Tipo/Estado cortados + 10/página en Sesiones (mobile)
+
+Módulo 7 de 7 (último) del bloque "Admin Mobile Refinement". Cierra el
+bloque iniciado en el precedente #1077→#1081; módulos 1-Hub, 2-Clínicas,
+3-Auditoría, 4-Alertas, 5-Informes y 6-Tokens ya entregados en sus propios
+worktrees/ramas.
+
+---
+
+## 1. Rama y base
+
+- Rama: `fix/admin-mobile-sessions-density` (worktree aislado desde `main`
+  limpio).
+- HEAD base: `aa6bea6 fix(admin): align mobile core pager to canonical
+  tokens layout (#1081)`.
+
+## 2. Alcance
+
+`AdminMobileSessionsModule` (Sesiones, Dashboard Administrador):
+
+1. Corregir los selects `Tipo`/`Estado` cuya palabra se ve cortada.
+2. No desperdiciar espacio en el tamaño del select.
+3. Mostrar 10 registros por página en mobile (antes: 3).
+4. Mantener el paginador canónico abajo, los botones `Actual`/`Revocar`, y
+   el contrato no-scroll.
+
+## 3. No alcance
+
+Backend, API, DB, auth, dependencias, lockfiles, CI, rutas públicas,
+producción, dashboard Clínica, desktop (`AdminSessionsReadOnlyCard`
+intacta), Hub, Clínicas, Auditoría, Alertas, Informes, Tokens (cada uno su
+propio PR, ya entregados).
+
+## 4. Diagnóstico previo — causa raíz real (no era de ancho)
+
+La hipótesis inicial del enunciado ("se ve cortada", "no desperdiciar
+espacio") sugería un problema de **ancho** (texto truncado horizontalmente).
+Antes de tocar código, se levantó el dev server y se capturó una screenshot
+real del módulo a 360×740 (viewport mobile estándar del repo) para
+confirmar la causa exacta en vez de adivinar:
+
+- Los `<select>` usaban `className="field-select h-7 text-xs"`.
+- `.field-select` (definida en `globals.css` vía `@apply`) incluye
+  `px-3 py-2` (padding vertical de 8px arriba + 8px abajo = 16px) como
+  parte de la clase base compartida con `<input>`.
+- Con `h-7` (28px de alto total) y ese padding vertical fijo de 16px, el
+  área de contenido disponible para el texto quedaba en ~10-12px, menor
+  que la altura de línea real de `text-xs` (~16px) — **el problema era
+  recorte vertical** (la parte superior de las letras de "Todas"/"Todos"
+  quedaba cortada), no truncado horizontal por ancho insuficiente.
+- La screenshot confirmó visualmente: "Todas" se veía con la mitad
+  superior de las letras faltante.
+
+## 5. Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx` | Selects `Tipo`/`Estado`: `h-7 text-xs` → `h-9 items-center px-2 py-1 text-xs leading-none` (más alto para alojar la línea de texto completa sin recorte vertical; padding vertical reducido de 8px a 4px arriba/abajo para no desperdiciar espacio; padding horizontal reducido de 12px a 8px). `MOBILE_PAGE_SIZE` 3→10. Lista de sesiones: `grid-rows-3` con filas bordeadas individualmente → lista compacta `divide-y` (mismo patrón Tokens/Clínicas/Auditoría/Alertas) para que 10 filas entren sin scroll. Botones `Actual`/`Revocar` sin cambios. |
+| `frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts` | `MOCK_SESSIONS` 9→13 (página 2 real a 10/página). `OPS_MODULES` ganó `maxItemsPerPage` por módulo (sessions:10, audit/users:4 sin cambios en este PR). Nuevo test dedicado: mide que la caja de contenido de cada select (alto menos padding vertical) sea ≥ que la altura mínima de una línea de texto a ese `font-size` — la condición exacta que estaba fallando antes del fix. |
+
+No se crearon archivos de test nuevos: se reforzó el contrato compartido ya
+existente (mismo archivo tocado por el módulo 3-Auditoría en su propia
+rama; ambos PRs tocan este archivo de forma independiente, a fusionar en
+el orden que decida Nico).
+
+## 6. Decisiones técnicas
+
+1. **Diagnóstico visual antes de codear**: se levantó el dev server y se
+   tomó una screenshot real en vez de adivinar la causa a partir del
+   enunciado. Evitó un fix incorrecto (agrandar el ancho del `<select>`,
+   que no habría resuelto nada porque el problema era vertical).
+2. **`h-9` (36px) en vez de mantener `h-7`**: además de resolver el
+   recorte, alinea el select con el touch target de 36px pedido para el
+   bloque (antes 28px). No se eligió una altura mayor para no "desperdiciar
+   espacio" como pide el enunciado.
+3. **Padding vertical reducido (`py-1` en vez del `py-2` heredado de
+   `.field-select`)**: libera espacio dentro de la caja de 36px para que
+   el texto tenga margen cómodo sin necesitar una altura aún mayor.
+4. **`leading-none` + `items-center`**: fuerza una altura de línea
+   compacta y predecible, evitando depender del valor heredado de
+   `.field-select` (pensado para `<input>`, no necesariamente óptimo para
+   `<select>`).
+5. **Lista compacta `divide-y`**: mismo patrón ya validado en los 5 módulos
+   anteriores de este bloque, para llegar a 10 filas sin scroll.
+
+## 7. Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `pnpm --dir frontend lint` | OK (sin salida) |
+| `pnpm --dir frontend typecheck` | OK |
+| `pnpm --dir frontend build` | OK (`next build` exitoso, 25 rutas) |
+| Screenshot manual (Playwright ad-hoc, no comiteada) | Confirmó visualmente el recorte ANTES del fix y su corrección DESPUÉS |
+| `npx playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts` | **GREEN 30/30** (incluye el nuevo test de no-recorte de selects) |
+| `npx playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts e2e/admin-mobile-module-layer-isolation.spec.ts e2e/admin-mobile-hub-launcher-no-scroll.spec.ts` | **GREEN** (incluidos en el mismo run de 30/30 arriba) |
+
+`pnpm test` (root, suite backend) no se ejecutó: este PR no toca backend ni
+archivos bajo `test/`.
+
+> Nota operativa: `frontend/next-env.d.ts` no quedó modificado tras correr
+> Playwright/build en este worktree; se verificó explícitamente.
+
+## 8. Resultado de tests (TDD)
+
+- **RED real (diagnóstico, no de test):** screenshot a 360×740 mostró
+  "Todas"/"Todos" con la mitad superior de las letras cortada antes de
+  tocar código.
+- **RED de aserción (primer intento del test):** la primera versión del
+  test comparaba `contentHeight` contra `parseFloat(getComputedStyle().lineHeight)`,
+  que devolvía `NaN` (Chrome resuelve `line-height: 1` de forma que
+  `getComputedStyle` no siempre expone un valor en píxeles parseable para
+  `<select>`). Fix: comparar contra una altura mínima de línea derivada de
+  `font-size` (heurística `fontSize * 1.15`, suficiente para detectar
+  recorte sin depender de un valor de `line-height` computado frágil).
+- **GREEN:** screenshot posterior al fix confirma "Todas"/"Todos"
+  completos y legibles; test automatizado confirma que la caja de
+  contenido de cada select (alto − padding vertical) ya no es menor que
+  una línea de texto completa; 10 sesiones por página, sin overflow.
+
+## 9. `git status --short --untracked-files=all`
+
+```
+ M frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
+ M frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx
+?? docs/audit/admin-mobile-sessions-select-clipping-density-10.md
+```
+
+## 10. Confirmación explícita
+
+- **Selects Tipo/Estado ya no se ven cortados:** confirmado visualmente
+  (screenshot antes/después) y con test automatizado (caja de contenido
+  ≥ altura mínima de línea).
+- **No se desperdicia espacio en el tamaño del select:** confirmado (36px
+  de alto, el mínimo necesario para alojar el texto sin recorte y cumplir
+  el touch target de 36px del bloque; padding horizontal reducido de 12px
+  a 8px).
+- **10 registros por página en mobile:** confirmado (`MOBILE_PAGE_SIZE =
+  10`; dataset de 13 en e2e).
+- **Paginador canónico abajo:** confirmado, sin cambios
+  (`AdminMobileOpsPager`).
+- **Botones `Actual`/`Revocar` preservados:** confirmado, sin cambios de
+  lógica ni de markup salvo el contenedor de la fila.
+- **Sin scroll:** confirmado (contrato compartido de ops sigue verde).
+- **Appbar / bottom nav preservados:** confirmado.
+- **#1074 / #1076 preservados:** no tocados.
+- **Backend/API/DB/auth/dependencias/lockfiles/CI/dashboard Clínica/otros
+  módulos admin:** no tocados (`git diff --stat`: 1 componente + 1 spec
+  e2e).
+
+## 11. Riesgo residual
+
+Bajo. El fix es de altura/padding CSS puro sobre un componente ya
+existente, validado visualmente con screenshot real antes y después, y con
+un test automatizado que mide la condición exacta que causaba el defecto.
+Verificado en Chromium headless a 360×740; no verificado en hardware real
+ni en otros motores de render (Safari/Firefox pueden calcular el alto de
+línea de `<select>` con ligeras diferencias, pero el margen agregado
+—36px de alto vs. ~16-18px de línea— deja holgura suficiente).
+
+---
+
+### Cierre / Git manual (protocolo VETNEB)
+
+Implementación, tests y validaciones completas. Según el protocolo, **Git
+lo ejecuta Nico**. Este PR vive en un worktree separado
+(`C:\PORTAL-VETNEB-sessions`). Comandos a ejecutar **desde
+`C:\PORTAL-VETNEB-sessions`**:
+
+```powershell
+cd C:\PORTAL-VETNEB-sessions
+git add frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx `
+        frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts `
+        docs/audit/admin-mobile-sessions-select-clipping-density-10.md
+git status --short --untracked-files=all
+git commit -m "fix(admin): stop clipping mobile session filter selects and show 10 per page"
+git push -u origin fix/admin-mobile-sessions-density
+gh pr create --base main --head fix/admin-mobile-sessions-density --title "fix(admin): stop clipping mobile session filter selects and show 10 per page" --body "## Summary
+- Fix the Tipo/Estado selects in Admin mobile Sesiones: the option text was being vertically clipped (height/padding from the shared .field-select class left less room than one text line needs), not horizontally truncated as initially assumed — confirmed with a real screenshot before fixing
+- Raise Admin mobile Sesiones from 3 to 10 visible sessions per page
+- Compact the row list to fit 10 without scroll (divide-y pattern, same as the rest of this block)
+
+## Scope
+- Admin Dashboard mobile Sesiones module only (7 of 7, last module in the mobile refinement block)
+
+## Not touched
+- Backend, API, DB, auth, dependencies, lockfiles, CI, public routes, production, Clínica dashboard, desktop sessions table, other admin modules
+
+## Validation
+- pnpm --dir frontend lint
+- pnpm --dir frontend typecheck
+- pnpm --dir frontend build
+- Manual before/after screenshot confirming the clipping fix
+- playwright admin-mobile-ops-modules-no-scroll.spec.ts + admin-mobile-final-polish-no-scroll.spec.ts + admin-mobile-module-layer-isolation.spec.ts + admin-mobile-hub-launcher-no-scroll.spec.ts (30/30)"
+gh pr checks --watch
+
+# Tras mergear los PRs anteriores, eliminar este worktree:
+cd C:\PORTAL-VETNEB
+git worktree remove ../PORTAL-VETNEB-sessions
+```

--- a/frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
@@ -8,7 +8,7 @@ const MOBILE_VIEWPORTS = [
   { name: "iphone-pro-max-430x932", width: 430, height: 932 },
 ] as const;
 
-const MOCK_SESSIONS = Array.from({ length: 9 }, (_, index) => ({
+const MOCK_SESSIONS = Array.from({ length: 13 }, (_, index) => ({
   sessionType: (["admin", "clinic", "particular"] as const)[index % 3],
   sessionId: 8100 + index,
   actorType: (["admin_user", "clinic_user", "particular_token"] as const)[
@@ -54,7 +54,7 @@ type OpsModule = {
   pagerName: RegExp;
   primaryActionName: RegExp;
   // Viewport-safe page-size ceiling for this module's mobile list; differs
-  // per module (audit moved to 10/page, sessions/users stay at their
+  // per module (audit and sessions moved to 10/page, users stays at its
   // existing density).
   maxItemsPerPage: number;
 };
@@ -72,7 +72,7 @@ const OPS_MODULES: OpsModule[] = [
     moduleId: "admin-sessions",
     pagerName: /paginación de sesiones/i,
     primaryActionName: /actualizar/i,
-    maxItemsPerPage: 4,
+    maxItemsPerPage: 10,
   },
   {
     key: "users",
@@ -384,3 +384,49 @@ for (const moduleSpec of OPS_MODULES) {
     ).toBeHidden();
   });
 }
+
+test("Admin mobile sessions Tipo/Estado selects render their full option text uncut", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 360, height: 740 });
+  await setPopulatedAdminSession(page);
+  await mockOpsApis(page);
+  await page.goto("/dashboard/admin?module=admin-sessions");
+
+  const moduleRoot = page.locator('[data-admin-mobile-ops-module="sessions"]');
+  await expect(moduleRoot).toBeVisible({ timeout: 15_000 });
+
+  const tipoSelect = moduleRoot.getByLabel("Tipo");
+  const estadoSelect = moduleRoot.getByLabel("Estado");
+  await expect(tipoSelect).toBeVisible();
+  await expect(estadoSelect).toBeVisible();
+
+  for (const [select, label] of [
+    [tipoSelect, "Tipo"],
+    [estadoSelect, "Estado"],
+  ] as const) {
+    const metrics = await select.evaluate((element) => {
+      const select = element as HTMLSelectElement;
+      const style = window.getComputedStyle(select);
+      const fontSizePx = parseFloat(style.fontSize);
+      const paddingY =
+        parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+      return {
+        contentHeight: select.clientHeight - paddingY,
+        // Browsers render a single line of text at roughly 1.15-1.2x the
+        // font size even under `line-height: 1`; this is the minimum
+        // content box needed to avoid clipping the glyph's top/bottom.
+        minTextHeight: fontSizePx * 1.15,
+      };
+    });
+    expect(
+      metrics.contentHeight,
+      `${label}: content height must fit a full text line (no vertical clipping)`,
+    ).toBeGreaterThanOrEqual(metrics.minTextHeight);
+  }
+
+  const itemCount = await moduleRoot
+    .locator('[data-admin-mobile-ops-item="true"]')
+    .count();
+  expect(itemCount, "sessions: 10 per mobile page").toBeLessThanOrEqual(10);
+});

--- a/frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileSessionsModule.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@/types";
 import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
 
-const MOBILE_PAGE_SIZE = 3;
+const MOBILE_PAGE_SIZE = 10;
 
 function formatSessionType(value: AdminSessionType) {
   if (value === "admin") return "Admin";
@@ -142,7 +142,7 @@ export function AdminMobileSessionsModule() {
         <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
           Tipo
           <select
-            className="field-select h-7 text-xs"
+            className="field-select h-9 items-center px-2 py-1 text-xs leading-none"
             value={sessionType}
             disabled={disabled}
             onChange={(event) => {
@@ -159,7 +159,7 @@ export function AdminMobileSessionsModule() {
         <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
           Estado
           <select
-            className="field-select h-7 text-xs"
+            className="field-select h-9 items-center px-2 py-1 text-xs leading-none"
             value={status}
             disabled={disabled}
             onChange={(event) => {
@@ -174,7 +174,7 @@ export function AdminMobileSessionsModule() {
         </label>
       </div>
 
-      <div className="grid min-h-0 flex-1 grid-rows-3 overflow-hidden">
+      <div className="min-h-0 flex-1 divide-y divide-vetneb-line/70 overflow-hidden">
         {sessions.length ? (
           sessions.map((session) => {
             const sessionKey = getSessionKey(session);
@@ -187,20 +187,20 @@ export function AdminMobileSessionsModule() {
               <article
                 key={sessionKey}
                 data-admin-mobile-ops-item="true"
-                className="flex min-h-0 items-center gap-2 overflow-hidden border-b border-vetneb-line/70 px-2 py-1 last:border-b-0"
+                className="flex min-h-9 items-center gap-2 overflow-hidden px-2 py-0.5"
               >
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
+                  <div className="flex min-w-0 items-center gap-1.5">
                     <Badge variant={session.sessionType === "admin" ? "default" : "secondary"} className="h-5 px-1.5 text-[10px]">
                       {formatSessionType(session.sessionType)}
                     </Badge>
                     <Badge variant={session.status === "active" ? "default" : "outline"} className="h-5 px-1.5 text-[10px]">
                       {session.status === "active" ? "Activa" : "Expirada"}
                     </Badge>
+                    <span className="min-w-0 truncate text-xs font-medium text-vetneb-ink">
+                      {formatActorType(session.actorType)} · #{session.sessionId}
+                    </span>
                   </div>
-                  <p className="truncate text-xs font-medium text-vetneb-ink">
-                    {formatActorType(session.actorType)} · #{session.sessionId}
-                  </p>
                   <p className="truncate text-[10px] text-muted-foreground">
                     Acceso {session.lastAccess ? formatDateTime(session.lastAccess) : "—"}
                   </p>
@@ -221,7 +221,7 @@ export function AdminMobileSessionsModule() {
             );
           })
         ) : (
-          <div className="col-span-full row-span-3 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+          <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted-foreground">
             {error ? "Error al cargar sesiones" : isPending ? "Cargando sesiones..." : "Sin sesiones"}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Refine Admin mobile Sesiones density
- Keep 10 sessions visible per mobile page
- Prevent Tipo/Estado select text clipping inside the no-scroll viewport
- Preserve Audit 10/page and Users current density in the shared ops e2e contract
- Add targeted e2e coverage and audit markdown

## Scope
- Admin mobile Sesiones only
- No backend, API, auth, DB, dependencies, lockfiles or CI changes

## Validation
- pnpm test
- pnpm --dir frontend exec playwright test frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck