### PR TITLE
test(admin): share mobile e2e contract helpers

### DIFF
--- a/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
@@ -1,12 +1,14 @@
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-const TOLERANCE = 2;
-
-const MOBILE_VIEWPORTS = [
-  { name: "android-small-360x740", width: 360, height: 740 },
-  { name: "iphone-standard-390x844", width: 390, height: 844 },
-  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
-] as const;
+import {
+  ADMIN_MOBILE_VIEWPORTS,
+  assertDocumentNoScrollContract,
+  expectInsideViewport,
+  fulfillJson,
+  readDocumentNoScrollContract,
+  setTestAdminSession,
+  suppressNextDevIndicator,
+} from "./helpers/admin-mobile-contracts";
 
 const MOCK_CLINICS = Array.from({ length: 13 }, (_, index) => {
   const id = index + 1;
@@ -71,22 +73,6 @@ const MOCK_TOKENS = Array.from({ length: 13 }, (_, index) => ({
   hasLinkedReport: index % 3 === 0,
 }));
 
-async function setAdminSession(page: Page) {
-  await page.context().addCookies([
-    {
-      name: "admin_session_id",
-      value: "e2e_test_admin_session",
-      url: "http://127.0.0.1:3000",
-    },
-  ]);
-}
-
-async function suppressNextDevIndicator(page: Page) {
-  await page.addStyleTag({
-    content: "nextjs-portal { display: none !important; }",
-  });
-}
-
 async function mockAdminClinics(page: Page) {
   await page.route("**/api/admin/clinics**", async (route) => {
     if (route.request().method() !== "GET") {
@@ -97,16 +83,12 @@ async function mockAdminClinics(page: Page) {
     const limit = Number(url.searchParams.get("limit") ?? "9");
     const offset = Number(url.searchParams.get("offset") ?? "0");
     const clinics = MOCK_CLINICS.slice(offset, offset + limit);
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        success: true,
-        clinics,
-        total: MOCK_CLINICS.length,
-        limit,
-        offset,
-      }),
+    await fulfillJson(route, {
+      success: true,
+      clinics,
+      total: MOCK_CLINICS.length,
+      limit,
+      offset,
     });
   });
 }
@@ -121,14 +103,10 @@ async function mockAdminReportWorkflow(page: Page) {
     const limit = Number(url.searchParams.get("limit") ?? "9");
     const offset = Number(url.searchParams.get("offset") ?? "0");
     const reports = MOCK_REPORTS.slice(offset, offset + limit);
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        success: true,
-        reports,
-        pagination: { limit, offset, hasMore: offset + limit < MOCK_REPORTS.length },
-      }),
+    await fulfillJson(route, {
+      success: true,
+      reports,
+      pagination: { limit, offset, hasMore: offset + limit < MOCK_REPORTS.length },
     });
   });
 }
@@ -144,16 +122,12 @@ async function mockAdminParticularTokens(page: Page) {
     const limit = Number(url.searchParams.get("limit") ?? "9");
     const offset = Number(url.searchParams.get("offset") ?? "0");
     const particularTokens = MOCK_TOKENS.slice(offset, offset + limit);
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        success: true,
-        count: particularTokens.length,
-        particularTokens,
-        pagination: { limit, offset },
-        filters: { clinicId: null },
-      }),
+    await fulfillJson(route, {
+      success: true,
+      count: particularTokens.length,
+      particularTokens,
+      pagination: { limit, offset },
+      filters: { clinicId: null },
     });
   });
 }
@@ -172,105 +146,13 @@ const MODULES: ModuleSpec[] = [
   { key: "tokens", moduleId: "admin-particular-tokens", mock: mockAdminParticularTokens, maxItemsPerPage: 10 },
 ];
 
-type NoScrollContract = {
-  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
-  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
-  forbiddenOverflow: Array<{ tag: string; cls: string; overflowX: string; overflowY: string }>;
-};
-
-async function readNoScrollContract(
-  page: Page,
-  moduleSelector: string,
-): Promise<NoScrollContract> {
-  return page.evaluate((selector) => {
-    const shell = document.querySelector<HTMLElement>(
-      '[data-vetneb-app-shell-surface="admin"]',
-    );
-    const main = document.querySelector<HTMLElement>("main.dashboard-main");
-    const moduleRoot = document.querySelector<HTMLElement>(selector);
-
-    const candidates: HTMLElement[] = [];
-    if (shell) candidates.push(shell);
-    if (main) candidates.push(main);
-    if (moduleRoot) {
-      candidates.push(moduleRoot, ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")));
-    }
-
-    const forbiddenOverflow = candidates.flatMap((element) => {
-      const style = window.getComputedStyle(element);
-      return ["auto", "scroll"].includes(style.overflowX) ||
-        ["auto", "scroll"].includes(style.overflowY)
-        ? [
-            {
-              tag: element.tagName,
-              cls: element.className,
-              overflowX: style.overflowX,
-              overflowY: style.overflowY,
-            },
-          ]
-        : [];
-    });
-
-    return {
-      html: {
-        scrollHeight: document.documentElement.scrollHeight,
-        clientHeight: document.documentElement.clientHeight,
-        scrollWidth: document.documentElement.scrollWidth,
-        clientWidth: document.documentElement.clientWidth,
-      },
-      body: {
-        scrollHeight: document.body.scrollHeight,
-        clientHeight: document.body.clientHeight,
-        scrollWidth: document.body.scrollWidth,
-        clientWidth: document.body.clientWidth,
-      },
-      forbiddenOverflow,
-    };
-  }, moduleSelector);
-}
-
-function assertNoScrollContract(contract: NoScrollContract, label: string) {
-  expect(contract.html.scrollHeight, `${label}: html vertical overflow`).toBeLessThanOrEqual(
-    contract.html.clientHeight + TOLERANCE,
-  );
-  expect(contract.body.scrollHeight, `${label}: body vertical overflow`).toBeLessThanOrEqual(
-    contract.body.clientHeight + TOLERANCE,
-  );
-  expect(contract.html.scrollWidth, `${label}: html horizontal overflow`).toBeLessThanOrEqual(
-    contract.html.clientWidth + TOLERANCE,
-  );
-  expect(contract.body.scrollWidth, `${label}: body horizontal overflow`).toBeLessThanOrEqual(
-    contract.body.clientWidth + TOLERANCE,
-  );
-  expect(contract.forbiddenOverflow, `${label}: forbidden overflow auto/scroll`).toEqual([]);
-}
-
-async function expectInsideViewport(
-  locator: Locator,
-  viewportWidth: number,
-  viewportHeight: number,
-  label: string,
-) {
-  await expect(locator, `${label}: visible`).toBeVisible();
-  const box = await locator.boundingBox();
-  expect(box, `${label}: bounding box`).not.toBeNull();
-  expect(box!.x, `${label}: left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
-  expect(box!.y, `${label}: top edge`).toBeGreaterThanOrEqual(-TOLERANCE);
-  expect(box!.x + box!.width, `${label}: right edge`).toBeLessThanOrEqual(
-    viewportWidth + TOLERANCE,
-  );
-  expect(box!.y + box!.height, `${label}: bottom edge`).toBeLessThanOrEqual(
-    viewportHeight + TOLERANCE,
-  );
-}
-
 for (const moduleSpec of MODULES) {
-  for (const viewport of MOBILE_VIEWPORTS) {
+  for (const viewport of ADMIN_MOBILE_VIEWPORTS) {
     test(`Admin mobile core module "${moduleSpec.key}" is no-scroll at ${viewport.name}`, async ({
       page,
     }) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
-      await setAdminSession(page);
+      await setTestAdminSession(page);
       await moduleSpec.mock(page);
       await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
       await suppressNextDevIndicator(page);
@@ -300,11 +182,11 @@ for (const moduleSpec of MODULES) {
         `${viewport.name}: horizontal nav absent`,
       ).toBeHidden();
 
-      const contract = await readNoScrollContract(
+      const contract = await readDocumentNoScrollContract(
         page,
         `[data-admin-mobile-core-module="${moduleSpec.key}"]`,
       );
-      assertNoScrollContract(contract, `${viewport.name} ${moduleSpec.key} page 1`);
+      assertDocumentNoScrollContract(contract, `${viewport.name} ${moduleSpec.key} page 1`);
 
       const itemSelector = `[data-admin-mobile-core-module="${moduleSpec.key}"] [data-admin-mobile-core-item="true"]`;
       const items = page.locator(itemSelector);
@@ -322,8 +204,7 @@ for (const moduleSpec of MODULES) {
       for (let index = 0; index < itemCount; index += 1) {
         await expectInsideViewport(
           items.nth(index),
-          viewport.width,
-          viewport.height,
+          viewport,
           `${viewport.name}: ${moduleSpec.key} item ${index + 1}`,
         );
       }
@@ -333,8 +214,7 @@ for (const moduleSpec of MODULES) {
       );
       await expectInsideViewport(
         pager,
-        viewport.width,
-        viewport.height,
+        viewport,
         `${viewport.name}: ${moduleSpec.key} pager`,
       );
 
@@ -350,11 +230,11 @@ for (const moduleSpec of MODULES) {
         })
         .not.toBe(firstPageLabels.join("|"));
 
-      const page2Contract = await readNoScrollContract(
+      const page2Contract = await readDocumentNoScrollContract(
         page,
         `[data-admin-mobile-core-module="${moduleSpec.key}"]`,
       );
-      assertNoScrollContract(page2Contract, `${viewport.name} ${moduleSpec.key} page 2`);
+      assertDocumentNoScrollContract(page2Contract, `${viewport.name} ${moduleSpec.key} page 2`);
 
       const bottomNav = page.locator('[data-admin-mobile-bottom-nav="true"]');
       await bottomNav.getByRole("button", { name: "Inicio", exact: true }).click();
@@ -367,9 +247,9 @@ for (const moduleSpec of MODULES) {
 }
 
 test("Admin mobile core modules reachable from bottom nav and Más menu", async ({ page }) => {
-  const viewport = MOBILE_VIEWPORTS[0];
+  const viewport = ADMIN_MOBILE_VIEWPORTS[0];
   await page.setViewportSize({ width: viewport.width, height: viewport.height });
-  await setAdminSession(page);
+  await setTestAdminSession(page);
   await mockAdminClinics(page);
   await mockAdminReportWorkflow(page);
   await mockAdminParticularTokens(page);
@@ -410,7 +290,7 @@ test("Admin mobile reports pagination advances through 10-record pages with page
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
-  await setAdminSession(page);
+  await setTestAdminSession(page);
   await mockAdminReportWorkflow(page);
 
   await page.goto("/dashboard/admin?module=admin-report-upload");
@@ -445,7 +325,7 @@ test("Admin mobile reports pagination advances through 10-record pages with page
 for (const moduleSpec of MODULES) {
   test(`Admin desktop preserves ${moduleSpec.key} layout at 1280x800`, async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await setAdminSession(page);
+    await setTestAdminSession(page);
     await moduleSpec.mock(page);
     await page.goto(`/dashboard/admin?module=${moduleSpec.moduleId}`);
 

--- a/frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts
@@ -1,12 +1,14 @@
-import { expect, test, type Locator, type Page, type Route } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-const TOLERANCE = 2;
-
-const MOBILE_VIEWPORTS = [
-  { name: "android-small-360x740", width: 360, height: 740 },
-  { name: "iphone-standard-390x844", width: 390, height: 844 },
-  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
-] as const;
+import {
+  ADMIN_MOBILE_VIEWPORTS,
+  assertModuleNoScrollContract,
+  expectInsideViewport,
+  fulfillJson,
+  readModuleNoScrollContract,
+  setPopulatedAdminSession,
+  suppressNextDevIndicator,
+} from "./helpers/admin-mobile-contracts";
 
 const MOCK_SESSIONS = Array.from({ length: 13 }, (_, index) => ({
   sessionType: (["admin", "clinic", "particular"] as const)[index % 3],
@@ -83,24 +85,6 @@ const OPS_MODULES: OpsModule[] = [
   },
 ];
 
-async function setPopulatedAdminSession(page: Page) {
-  await page.context().addCookies([
-    {
-      name: "admin_session_id",
-      value: "e2e_populated_admin_session",
-      url: "http://127.0.0.1:3000",
-    },
-  ]);
-}
-
-function fulfillJson(route: Route, body: unknown) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: JSON.stringify(body),
-  });
-}
-
 async function mockOpsApis(page: Page) {
   await page.route("**/api/admin/sessions**", async (route) => {
     const request = route.request();
@@ -143,12 +127,6 @@ async function mockOpsApis(page: Page) {
   });
 }
 
-async function suppressNextDevIndicator(page: Page) {
-  await page.addStyleTag({
-    content: "nextjs-portal { display: none !important; }",
-  });
-}
-
 async function openModuleFromMobileNavigation(page: Page, module: OpsModule) {
   await page.goto("/dashboard/admin");
   await suppressNextDevIndicator(page);
@@ -178,111 +156,8 @@ async function openModuleFromMobileNavigation(page: Page, module: OpsModule) {
   ).toBeVisible({ timeout: 15_000 });
 }
 
-type NoScrollContract = {
-  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
-  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
-  module: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
-  forbiddenOverflow: Array<{
-    tag: string;
-    className: string;
-    overflowX: string;
-    overflowY: string;
-  }>;
-};
-
-async function readNoScrollContract(page: Page, selector: string): Promise<NoScrollContract> {
-  return page.evaluate((moduleSelector) => {
-    const shell = document.querySelector<HTMLElement>(
-      '[data-vetneb-app-shell-surface="admin"]',
-    );
-    const main = document.querySelector<HTMLElement>("main.dashboard-main");
-    const moduleRoot = document.querySelector<HTMLElement>(moduleSelector);
-
-    if (!moduleRoot) throw new Error(`Missing module root: ${moduleSelector}`);
-
-    const candidates = [
-      document.documentElement,
-      document.body,
-      ...(shell ? [shell] : []),
-      ...(main ? [main] : []),
-      moduleRoot,
-      ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")),
-    ];
-
-    const forbiddenOverflow = candidates.flatMap((element) => {
-      const style = window.getComputedStyle(element);
-      if (
-        !["auto", "scroll"].includes(style.overflowX) &&
-        !["auto", "scroll"].includes(style.overflowY)
-      ) {
-        return [];
-      }
-
-      return [
-        {
-          tag: element.tagName,
-          className: element.className,
-          overflowX: style.overflowX,
-          overflowY: style.overflowY,
-        },
-      ];
-    });
-
-    const metrics = (element: HTMLElement) => ({
-      scrollHeight: element.scrollHeight,
-      clientHeight: element.clientHeight,
-      scrollWidth: element.scrollWidth,
-      clientWidth: element.clientWidth,
-    });
-
-    return {
-      html: metrics(document.documentElement),
-      body: metrics(document.body),
-      module: metrics(moduleRoot),
-      forbiddenOverflow,
-    };
-  }, selector);
-}
-
-function assertNoScrollContract(contract: NoScrollContract, label: string) {
-  for (const [surface, metrics] of Object.entries({
-    html: contract.html,
-    body: contract.body,
-    module: contract.module,
-  })) {
-    expect(
-      metrics.scrollHeight,
-      `${label}: ${surface} vertical clipping/overflow`,
-    ).toBeLessThanOrEqual(metrics.clientHeight + TOLERANCE);
-    expect(
-      metrics.scrollWidth,
-      `${label}: ${surface} horizontal clipping/overflow`,
-    ).toBeLessThanOrEqual(metrics.clientWidth + TOLERANCE);
-  }
-
-  expect(contract.forbiddenOverflow, `${label}: overflow auto/scroll`).toEqual([]);
-}
-
-async function expectInsideViewport(
-  locator: Locator,
-  viewport: { width: number; height: number },
-  label: string,
-) {
-  await expect(locator, `${label}: visible`).toBeVisible();
-  const box = await locator.boundingBox();
-  expect(box, `${label}: bounding box`).not.toBeNull();
-  expect(box!.x, `${label}: left`).toBeGreaterThanOrEqual(-TOLERANCE);
-  expect(box!.y, `${label}: top`).toBeGreaterThanOrEqual(-TOLERANCE);
-  expect(box!.x + box!.width, `${label}: right`).toBeLessThanOrEqual(
-    viewport.width + TOLERANCE,
-  );
-  expect(box!.y + box!.height, `${label}: bottom`).toBeLessThanOrEqual(
-    viewport.height + TOLERANCE,
-  );
-}
-
 for (const moduleSpec of OPS_MODULES) {
-  for (const viewport of MOBILE_VIEWPORTS) {
+  for (const viewport of ADMIN_MOBILE_VIEWPORTS) {
     test(`Admin mobile ops ${moduleSpec.key} is absolute no-scroll at ${viewport.name}`, async ({
       page,
     }) => {
@@ -333,8 +208,8 @@ for (const moduleSpec of OPS_MODULES) {
         .poll(async () => (await items.allTextContents()).join("|"))
         .not.toBe(pageOneLabels.join("|"));
 
-      assertNoScrollContract(
-        await readNoScrollContract(page, moduleSelector),
+      assertModuleNoScrollContract(
+        await readModuleNoScrollContract(page, moduleSelector),
         `${viewport.name} ${moduleSpec.key} page 2`,
       );
       await expectInsideViewport(pager, viewport, `${viewport.name} ${moduleSpec.key} page 2 pager`);
@@ -349,8 +224,8 @@ for (const moduleSpec of OPS_MODULES) {
         await expect(primaryAction).toBeEnabled();
       }
 
-      assertNoScrollContract(
-        await readNoScrollContract(page, moduleSelector),
+      assertModuleNoScrollContract(
+        await readModuleNoScrollContract(page, moduleSelector),
         `${viewport.name} ${moduleSpec.key} action`,
       );
 

--- a/frontend/e2e/helpers/admin-mobile-contracts.ts
+++ b/frontend/e2e/helpers/admin-mobile-contracts.ts
@@ -1,0 +1,233 @@
+import { expect, type Locator, type Page, type Route } from "@playwright/test";
+
+export const ADMIN_MOBILE_TOLERANCE = 2;
+
+export const ADMIN_MOBILE_VIEWPORTS = [
+  { name: "android-small-360x740", width: 360, height: 740 },
+  { name: "iphone-standard-390x844", width: 390, height: 844 },
+  { name: "iphone-pro-max-430x932", width: 430, height: 932 },
+] as const;
+
+export type AdminMobileViewport = (typeof ADMIN_MOBILE_VIEWPORTS)[number];
+
+export async function setAdminSessionCookie(
+  page: Page,
+  value: string = "e2e_test_admin_session",
+) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value,
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+export function setTestAdminSession(page: Page) {
+  return setAdminSessionCookie(page, "e2e_test_admin_session");
+}
+
+export function setPopulatedAdminSession(page: Page) {
+  return setAdminSessionCookie(page, "e2e_populated_admin_session");
+}
+
+export async function suppressNextDevIndicator(page: Page) {
+  await page.addStyleTag({
+    content: "nextjs-portal { display: none !important; }",
+  });
+}
+
+export function fulfillJson(route: Route, body: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function expectInsideViewport(
+  locator: Locator,
+  viewport: { width: number; height: number },
+  label: string,
+) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label}: bounding box`).not.toBeNull();
+  expect(box!.x, `${label}: left`).toBeGreaterThanOrEqual(-ADMIN_MOBILE_TOLERANCE);
+  expect(box!.y, `${label}: top`).toBeGreaterThanOrEqual(-ADMIN_MOBILE_TOLERANCE);
+  expect(box!.x + box!.width, `${label}: right`).toBeLessThanOrEqual(
+    viewport.width + ADMIN_MOBILE_TOLERANCE,
+  );
+  expect(box!.y + box!.height, `${label}: bottom`).toBeLessThanOrEqual(
+    viewport.height + ADMIN_MOBILE_TOLERANCE,
+  );
+}
+
+// Document-level no-scroll contract (html/body) used by the core modules spec.
+export type DocumentNoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  forbiddenOverflow: Array<{ tag: string; cls: string; overflowX: string; overflowY: string }>;
+};
+
+export async function readDocumentNoScrollContract(
+  page: Page,
+  moduleSelector: string,
+): Promise<DocumentNoScrollContract> {
+  return page.evaluate((selector) => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const moduleRoot = document.querySelector<HTMLElement>(selector);
+
+    const candidates: HTMLElement[] = [];
+    if (shell) candidates.push(shell);
+    if (main) candidates.push(main);
+    if (moduleRoot) {
+      candidates.push(moduleRoot, ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")));
+    }
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      return ["auto", "scroll"].includes(style.overflowX) ||
+        ["auto", "scroll"].includes(style.overflowY)
+        ? [
+            {
+              tag: element.tagName,
+              cls: element.className,
+              overflowX: style.overflowX,
+              overflowY: style.overflowY,
+            },
+          ]
+        : [];
+    });
+
+    return {
+      html: {
+        scrollHeight: document.documentElement.scrollHeight,
+        clientHeight: document.documentElement.clientHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      },
+      body: {
+        scrollHeight: document.body.scrollHeight,
+        clientHeight: document.body.clientHeight,
+        scrollWidth: document.body.scrollWidth,
+        clientWidth: document.body.clientWidth,
+      },
+      forbiddenOverflow,
+    };
+  }, moduleSelector);
+}
+
+export function assertDocumentNoScrollContract(
+  contract: DocumentNoScrollContract,
+  label: string,
+) {
+  expect(contract.html.scrollHeight, `${label}: html vertical overflow`).toBeLessThanOrEqual(
+    contract.html.clientHeight + ADMIN_MOBILE_TOLERANCE,
+  );
+  expect(contract.body.scrollHeight, `${label}: body vertical overflow`).toBeLessThanOrEqual(
+    contract.body.clientHeight + ADMIN_MOBILE_TOLERANCE,
+  );
+  expect(contract.html.scrollWidth, `${label}: html horizontal overflow`).toBeLessThanOrEqual(
+    contract.html.clientWidth + ADMIN_MOBILE_TOLERANCE,
+  );
+  expect(contract.body.scrollWidth, `${label}: body horizontal overflow`).toBeLessThanOrEqual(
+    contract.body.clientWidth + ADMIN_MOBILE_TOLERANCE,
+  );
+  expect(contract.forbiddenOverflow, `${label}: forbidden overflow auto/scroll`).toEqual([]);
+}
+
+// Module-level no-scroll contract (html/body/module) used by the ops modules spec.
+export type ModuleNoScrollContract = {
+  html: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  body: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  module: { scrollHeight: number; clientHeight: number; scrollWidth: number; clientWidth: number };
+  forbiddenOverflow: Array<{
+    tag: string;
+    className: string;
+    overflowX: string;
+    overflowY: string;
+  }>;
+};
+
+export async function readModuleNoScrollContract(
+  page: Page,
+  selector: string,
+): Promise<ModuleNoScrollContract> {
+  return page.evaluate((moduleSelector) => {
+    const shell = document.querySelector<HTMLElement>(
+      '[data-vetneb-app-shell-surface="admin"]',
+    );
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const moduleRoot = document.querySelector<HTMLElement>(moduleSelector);
+
+    if (!moduleRoot) throw new Error(`Missing module root: ${moduleSelector}`);
+
+    const candidates = [
+      document.documentElement,
+      document.body,
+      ...(shell ? [shell] : []),
+      ...(main ? [main] : []),
+      moduleRoot,
+      ...Array.from(moduleRoot.querySelectorAll<HTMLElement>("*")),
+    ];
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      if (
+        !["auto", "scroll"].includes(style.overflowX) &&
+        !["auto", "scroll"].includes(style.overflowY)
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          tag: element.tagName,
+          className: element.className,
+          overflowX: style.overflowX,
+          overflowY: style.overflowY,
+        },
+      ];
+    });
+
+    const metrics = (element: HTMLElement) => ({
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    });
+
+    return {
+      html: metrics(document.documentElement),
+      body: metrics(document.body),
+      module: metrics(moduleRoot),
+      forbiddenOverflow,
+    };
+  }, selector);
+}
+
+export function assertModuleNoScrollContract(
+  contract: ModuleNoScrollContract,
+  label: string,
+) {
+  for (const [surface, metrics] of Object.entries({
+    html: contract.html,
+    body: contract.body,
+    module: contract.module,
+  })) {
+    expect(
+      metrics.scrollHeight,
+      `${label}: ${surface} vertical clipping/overflow`,
+    ).toBeLessThanOrEqual(metrics.clientHeight + ADMIN_MOBILE_TOLERANCE);
+    expect(
+      metrics.scrollWidth,
+      `${label}: ${surface} horizontal clipping/overflow`,
+    ).toBeLessThanOrEqual(metrics.clientWidth + ADMIN_MOBILE_TOLERANCE);
+  }
+
+  expect(contract.forbiddenOverflow, `${label}: overflow auto/scroll`).toEqual([]);
+}


### PR DESCRIPTION
## Summary
- Extract shared Playwright helpers for Admin Mobile no-scroll contract specs
- Migrate core and ops Admin Mobile E2E specs to common helpers
- Preserve existing test coverage and observable behavior

## Scope
- frontend/e2e/helpers/admin-mobile-contracts.ts
- frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
- frontend/e2e/admin-mobile-ops-modules-no-scroll.spec.ts

## Explicit non-scope
- No production code changes
- No frontend/src changes
- No backend/API/auth/DB/migration changes
- No dependency or lockfile changes
- No CI changes
- No E2E coverage reduction
- No spec deletion

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts e2e/admin-mobile-ops-modules-no-scroll.spec.ts