### PR TITLE
test(admin): share final polish e2e primitives

### DIFF
--- a/frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts
@@ -5,11 +5,15 @@ import {
   test,
   type Locator,
   type Page,
-  type Route,
   type TestInfo,
 } from "@playwright/test";
 
-const TOLERANCE = 2;
+import {
+  ADMIN_MOBILE_TOLERANCE as TOLERANCE,
+  fulfillJson,
+  setPopulatedAdminSession,
+  suppressNextDevIndicator,
+} from "./helpers/admin-mobile-contracts";
 
 const MOBILE_VIEWPORTS = [
   { name: "android-small-360x740", width: 360, height: 740 },
@@ -128,24 +132,6 @@ const MODULE_SCREENS: AdminModuleScreen[] = [
   },
 ];
 
-async function setPopulatedAdminSession(page: Page) {
-  await page.context().addCookies([
-    {
-      name: "admin_session_id",
-      value: "e2e_populated_admin_session",
-      url: "http://127.0.0.1:3000",
-    },
-  ]);
-}
-
-function fulfillJson(route: Route, body: unknown) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: JSON.stringify(body),
-  });
-}
-
 async function mockMissingPopulatedApis(page: Page) {
   await page.route("**/api/admin/clinics**", async (route) => {
     const request = route.request();
@@ -184,12 +170,6 @@ async function mockMissingPopulatedApis(page: Page) {
       offset,
       currentAdminSessionId: 8200,
     });
-  });
-}
-
-async function suppressNextDevIndicator(page: Page) {
-  await page.addStyleTag({
-    content: "nextjs-portal { display: none !important; }",
   });
 }
 


### PR DESCRIPTION
## Summary
- Reuse shared Admin Mobile E2E primitives in final-polish spec
- Replace local duplicate session, JSON fulfill, dev-indicator and tolerance helpers with shared imports
- Preserve final-polish coverage, screenshots and unique assertions

## Scope
- frontend/e2e/admin-mobile-final-polish-no-scroll.spec.ts only

## Explicit non-scope
- No production code changes
- No frontend/src changes
- No backend/API/auth/DB/migration changes
- No dependency or lockfile changes
- No CI changes
- No screenshot changes
- No E2E coverage reduction
- No final-polish unique helper changes
- No test rename or skip

## Coverage preserved
- Admin mobile final polish closeout: 3 viewports
- Admin desktop final polish smoke: 1 viewport
- Total: 4 tests before = 4 tests after

## Validation
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend exec playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts
- git diff --check