### PR TITLE
test(e2e): add layered e2e scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,12 @@
     "typecheck": "tsc --noEmit",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:report": "playwright show-report"
+    "e2e:report": "playwright show-report",
+    "e2e:full": "playwright test",
+    "e2e:smoke": "playwright test e2e/dashboard-auth-redirect.spec.ts e2e/visual-smoke.spec.ts e2e/public-routes.spec.ts e2e/login-hydration.spec.ts e2e/contacto-hydration.spec.ts e2e/theme-mode.spec.ts e2e/dashboard-interaction-foundation.spec.ts",
+    "e2e:admin-mobile": "playwright test e2e/admin-mobile-app-shell-absolute-no-scroll.spec.ts e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts e2e/admin-mobile-core-modules-no-scroll.spec.ts e2e/admin-mobile-ops-modules-no-scroll.spec.ts e2e/admin-mobile-status-modules-no-scroll.spec.ts e2e/admin-mobile-config-modules-no-scroll.spec.ts e2e/admin-mobile-final-polish-no-scroll.spec.ts e2e/admin-mobile-hub-launcher-no-scroll.spec.ts e2e/admin-mobile-hub-stale-layer-stage.spec.ts e2e/admin-mobile-module-layer-isolation.spec.ts e2e/admin-clinics-mobile-card-layout.spec.ts e2e/admin-tokens-mobile-toolbar-layout.spec.ts e2e/admin-clinic-edit-drawer.spec.ts",
+    "e2e:visual-contract": "playwright test e2e/dashboard-card-navigation-shell.spec.ts e2e/dashboard-accessibility-keyboard.spec.ts e2e/dashboard-app-shell-visibility-contract.spec.ts e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-single-viewport-app-shell.spec.ts e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-master-detail-state-polish.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts e2e/dashboard-viewport-zoom-adaptability.spec.ts e2e/dashboard-mobile-shell-nav-contract.spec.ts",
+    "e2e:public-clinic": "playwright test e2e/public-clinics-b2b-operations.spec.ts e2e/public-report-preview.spec.ts e2e/public-service-bento-specimen-journey.spec.ts e2e/public-pricing-actionable.spec.ts e2e/public-perspective-scroll.spec.ts e2e/public-navigation-footer.spec.ts e2e/home-hero-evidence-first.spec.ts e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-clinic-logistica-mobile-parity.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-perfil-mobile-operability.spec.ts"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.1",


### PR DESCRIPTION
## Summary
- Add layered E2E scripts in frontend/package.json
- Preserve e2e as the existing full E2E entrypoint
- Add e2e:full as an exact alias of the current full Playwright suite
- Add local E2E layers for smoke, admin mobile, visual contracts, and public/clinic surfaces
- Keep CI, Playwright config, specs, helpers, fixtures, lockfiles, frontend src, and backend untouched

## Scope
- frontend/package.json only

## Scripts
- e2e:full
- e2e:smoke
- e2e:admin-mobile
- e2e:visual-contract
- e2e:public-clinic

## Validation
- pnpm --dir frontend exec playwright --version
- pnpm --dir frontend run
- pnpm --dir frontend run e2e:full -- --list
- pnpm --dir frontend run e2e:smoke -- --list
- pnpm --dir frontend run e2e:admin-mobile -- --list
- pnpm --dir frontend run e2e:visual-contract -- --list
- pnpm --dir frontend run e2e:public-clinic -- --list
- pnpm --dir frontend run lint
- pnpm --dir frontend run typecheck

## Results
- e2e:full: 537 tests / 42 files
- e2e:smoke: 34 tests / 7 files
- e2e:admin-mobile: 132 tests / 13 files
- e2e:visual-contract: 255 tests / 11 files
- e2e:public-clinic: 116 tests / 11 files
- Layer invariant: 7 + 13 + 11 + 11 = 42 files
- Test invariant: 34 + 132 + 255 + 116 = 537 tests

## Not changed
- .github/workflows/*
- frontend/playwright.config.*
- package.json
- pnpm-lock.yaml
- specs
- helpers
- fixtures
- frontend/src
- backend