### PR TITLE
docs(audit): add enterprise readiness wave 0 audits

### DIFF
--- a/docs/audit/repository-operational-ordering-audit.md
+++ b/docs/audit/repository-operational-ordering-audit.md
@@ -1,0 +1,549 @@
+# Repository Operational Ordering — Audit
+
+> Documento de auditoría **docs-only**. **No modifica** código productivo, `frontend/src`,
+> `server`, specs, helpers, fixtures, `test`, `.github/workflows`, `package.json`,
+> `frontend/package.json`, `pnpm-lock.yaml`, Playwright config, `scripts`, `drizzle`/migrations,
+> dependencias, screenshots ni archivos generados. Solo describe el **orden** actual del repositorio
+> y propone los cambios mínimos de ordenamiento (docs/move/rename/scripts) que harán las próximas
+> auditorías de Claude más rápidas, baratas, seguras y menos ambiguas. **No** es una auditoría de
+> producto, arquitectura, seguridad profunda ni tecnología.
+
+## 1. Executive Summary
+
+**Estado actual del ordenamiento.** El repositorio está **funcionalmente sano pero
+documentalmente sobrecargado**. El historial reciente muestra disciplina alta (PRs chicos de un
+solo eje, closeouts, auditorías docs-only previas), pero la **documentación creció más rápido que
+su índice**: hay **174 archivos bajo `docs/`** + **34 en `IMPLEMENTATION_NOTES/`**, repartidos en
+~12 subcarpetas con **cinco convenciones de nombre de "PR doc" coexistiendo** y **sin ningún índice,
+mapa de fuente-de-verdad ni README** en `docs/`. Claude, al iniciar cualquier tarea, no tiene un
+punto de entrada: debe redescubrir qué doc es actual, cuál es histórico y cuál fue reemplazado, lo
+que es la mayor fuga de tokens del repo.
+
+**Bloqueadores principales a la eficiencia de Claude (orden de impacto):**
+
+1. **`docs/audit/` (singular, actual) vs `docs/audits/` (plural, histórico)** — dos carpetas casi
+   homónimas, **intencionalmente separadas** (confirmado en
+   `IMPLEMENTATION_NOTES/chore-docs-organize-audit-implementation-notes.md`) pero **sin nota que lo
+   declare en el árbol**. Cualquier agente nuevo las confunde y lee la equivocada.
+2. **Sin índice ni mapa de fuente-de-verdad.** No existe `docs/README.md` ni
+   `docs/audit/README.md`. Para saber "cuál es el doc vigente de X" hay que abrir varios.
+3. **Sprawl en la raíz de `docs/`** — ~40 archivos sueltos (`pr-1`…`pr-10`, `pr0`…`pr5b`,
+   `pr-815`…`pr-826`, `fix-*`, `audit-premium-*`, `production-readiness-*`) sin agrupar.
+4. **Tres hogares de "implementation docs"** (`docs/implementation`, `docs/implementation-history`,
+   `IMPLEMENTATION_NOTES`) — **sancionado por `AGENTS.md`**, pero sin nota que explique cuándo usar
+   cada uno.
+5. **Solape de fuentes de protocolo de IA**: `AGENTS.md`, `docs/protocol/vetneb-ai-working-protocol.md`,
+   `.cursor/rules/*` (6 reglas) y las skills VETNEB describen el mismo protocolo en 4 lugares.
+
+**Lo que ya está bien ordenado (no tocar):** `server/` (backend Fastify, 101 archivos, sub-foldered
+`lib/routes/middlewares`), `scripts/` (21 archivos sub-foldered por dominio), `.github/workflows`
+(solo 2 workflows claros), `frontend/e2e/helpers` y `frontend/e2e/fixtures` (mínimos: 1 + 1), y la
+**raíz del repo** (limpia tras el doc-org previo: solo `README.md`, `SETUP.md`, `AGENTS.md` +
+configs). La auditoría **E2E CI Layering** (#1095) es ejemplar y **ya tiene su scripts-only
+ejecutado** (#1096).
+
+**Qué ordenar primero:** un **índice de docs/audit + mapa de fuente-de-verdad** (docs-only, cero
+riesgo) y una **nota disambiguadora `docs/audit` vs `docs/audits`**. Esto solo, sin mover nada,
+elimina la mayor parte de la fuga de tokens.
+
+**Qué NO tocar todavía:** ningún `frontend/src`, `server`, `test`, spec, helper, fixture, CI,
+`package.json`, lockfile, Playwright config, `drizzle`/migrations ni `scripts`. **No** mover ni
+renombrar archivos hasta que el índice exista y congele el mapa actual. **No** abrir PR-C3 (CI-only
+de capas E2E): está fuera de este eje y requiere validación previa `unión == full`.
+
+**Dictamen anticipado para §12:** el **PR-C2 scripts-only ya está hecho** (#1096 añadió
+`e2e:smoke/admin-mobile/visual-contract/public-clinic/full`). Por tanto el próximo paso de
+ordenamiento **no** es PR-C2; es **PR-O1 docs-only: índice de auditorías + mapa de fuente-de-verdad**.
+
+---
+
+## 2. Audited Base
+
+| Campo | Valor |
+| --- | --- |
+| Branch | `main` |
+| HEAD (`git log -1 --oneline`) | `8e29cc2 test(e2e): add layered e2e scripts (#1096)` |
+| HEAD esperado por la misión | `acdea9b … (#1095)` → **desfasado +2 commits** (`acdea9b` #1095 docs, luego `8e29cc2` #1096 scripts) |
+| `origin/main` / `origin/HEAD` | `8e29cc2` (idéntico al HEAD local) |
+| `git status --short --untracked-files=all` | **limpio** antes de crear este archivo |
+| Fecha | 2026-06-23 |
+| Plataforma | Windows / PowerShell / PNPM |
+| Worktree | único (`C:/PORTAL-VETNEB`); sin worktrees adicionales |
+| Branches locales | `main` + 1 rama vieja sin borrar: `test/admin-mobile-final-polish-shared-primitives` |
+| Open PRs | **19, todas Dependabot** (#1018–#1038). **Ninguna** PR funcional abierta |
+
+**Desfase de HEAD — implicación.** La misión esperaba `acdea9b` (#1095, la auditoría E2E layering
+docs-only). El repo ya avanzó a `8e29cc2` (#1096), que es exactamente el **PR-C2 scripts-only**
+descrito como "próximo paso" en esa auditoría. Esto **cambia el dictamen final**: el scripts-only de
+capas E2E ya no es pendiente.
+
+**Comandos read-only ejecutados (evidencia):**
+
+```
+git branch --show-current
+git status --short --untracked-files=all
+git log -1 --oneline
+git log --oneline --decorate -n 30
+git branch
+git worktree list
+gh pr list --state open
+git ls-files docs IMPLEMENTATION_NOTES AGENTS.md .cursor .cursorignore README.md
+git ls-files frontend/e2e test .github/workflows frontend/playwright.config.*
+git ls-files frontend/src server backend scripts supabase legacy shared drizzle  (conteos)
+git ls-files | group by top-level dir
+git show --stat 8e29cc2            # diff de #1096 (scripts-only)
+Grep "e2e" frontend/package.json   # confirmación de capas E2E
+Grep status-markers en docs/       # freshness
+```
+
+**Read budget realmente usado (dentro de presupuesto):**
+
+| Tipo | Presupuesto | Usado | Archivos |
+| --- | --- | --- | --- |
+| Docs completos | 6 | **3** | `docs/audit/e2e-ci-layering-strategy-audit.md`; `IMPLEMENTATION_NOTES/chore-docs-organize-audit-implementation-notes.md`; `AGENTS.md` |
+| Config/workflow completos | 4 | **0** | (`frontend/package.json` solo por snippet/Grep) |
+| Test/spec completos | 2 | **0** | — |
+| Producción completos | 0 | **0** | — |
+| Snippets de búsqueda | libre/targeted | ~8 | git ls-files, git show --stat, 2 Grep |
+
+**Confirmación de scope.** Solo se crea `docs/audit/repository-operational-ordering-audit.md`.
+No se modificó, movió, renombró ni borró ningún otro archivo. No se ejecutó `git add/commit/push`,
+ni `gh pr`. No se instalaron dependencias. No se tocó `frontend/next-env.d.ts` (no se levantó
+`next dev`).
+
+---
+
+## 3. Repository Structure Inventory
+
+> Nota de mapeo: la misión nombra áreas prohibidas `backend` y `supabase` que **no existen como
+> carpetas**. El backend real es `server/` (Fastify) y las migraciones viven en `drizzle/`. Se
+> auditan bajo sus nombres reales.
+
+| Área / path | Propósito inferido | Orden actual | Issue | Recomendación | Prio |
+| --- | --- | --- | --- | --- | --- |
+| `docs/audit/` (~31) | Auditorías **actuales** (kebab-case, en curso) | Medio | Sin README/índice; mezcla auditorías abiertas, closeouts y un informe backend mayúsculo (`INFORME_FINAL_BACKEND.md`, `IMPLEMENTACION_AUDITORIA.md`) que rompen el patrón | Añadir `docs/audit/README.md` índice con estado por archivo (docs-only) | **P0** |
+| `docs/audits/` (~10) | Auditorías/planes **históricos** mayúsculos (`AUDIT_*`, `DASHBOARD_*_PLAN`) | Malo (ambiguo) | Nombre casi idéntico a `docs/audit/`; intencional pero **no declarado en el árbol** | Nota disambiguadora + marcar como histórico en el mapa SoT (docs-only). **No** mover/renombrar aún | **P0** |
+| `docs/implementation/` (~30) | Notas de entrega de implementaciones (kebab-case) | Medio | Solapa conceptualmente con los otros dos hogares; sin índice | Indexar; **no** consolidar (sancionado por `AGENTS.md`) | P1 |
+| `docs/implementation-history/` (PR-3…PR-15) | Historia de implementación pública/dashboard (Spanish `IMPLEMENTACION-PR-*`) | Bien (nombre dice "history") | Convención distinta a las otras carpetas; aceptable por ser histórica | Marcar "historical, avoid reading" en mapa SoT | P2 |
+| `IMPLEMENTATION_NOTES/` (34, raíz) | Notas de entrega (mezcla `IMPLEMENTATION_*` mayúsc. movidas + kebab-case) | Medio | Tercer hogar de implementation docs; dos convenciones internas | Indexar; dejar como está (movido a propósito en doc-org PR) | P1 |
+| `frontend/e2e` (42 specs) | Suite Playwright | Bien | Nombres por familia (`admin-mobile-*`, `dashboard-*`, `public-*`) claros; ya mapeados a capas en #1095/#1096 | **No mover** hasta que capas/CI estén estables (PR-C3) | P3 |
+| `frontend/e2e/helpers` (1) | Helper compartido admin-mobile | Bien | Solo `admin-mobile-contracts.ts` (268 líneas) | No tocar | — |
+| `frontend/e2e/fixtures` (1) | Mock API server global | Bien | Solo `admin-populated-api-server.mjs` (521 líneas); infra global | No tocar (blast radius total) | — |
+| `test/` (404 archivos planos) | Suite backend/frontend/contract (node `--test`) | Aceptable-Malo | **Directorio plano de ~350 `.test.ts`**; difícil de escanear; subset `*.fastify.test.ts`, `*-invariants.test.ts`, `security-*` agrupables por nombre | **Solo diagnóstico**: posible carpeteo futuro **move-only**, pero `test` está prohibido en este eje → `requires later test-only audit` | P3 |
+| `frontend/src` (158) | App Next.js | Fuera de scope | — | No evaluar (no es eje de ordenamiento) | — |
+| `server/` (101; `lib` 41, `routes` 34, `middlewares` 7) | Backend Fastify (el "backend" de la misión) | Bien | Sub-foldered y claro | No tocar | — |
+| `drizzle/` (38) | Migraciones/schema (el "supabase/migrations" de la misión) | Bien | — | No tocar | — |
+| `legacy/` (3) | `drizzle-old/` SQL viejo + README | Aceptable | Marcado "legacy" en el path; bajo riesgo si nadie lo lee | Marcar "historical, do not read" en mapa SoT | P2 |
+| `shared/` (3) | `errors.ts`, `const.ts`, `types.ts` compartidos | Bien | — | No tocar | — |
+| `.github/workflows` (2) | `backend-ci.yml`, `frontend-ci.yml` | Bien | Claros; ya documentados en `docs/ops/CI_PR_CHECKS_RUNBOOK.md` | No tocar en este eje | — |
+| `.cursor/` (6 reglas `.mdc` + `.cursorignore`) | Reglas de IA para Cursor | Medio | Solapa con `AGENTS.md` y skills VETNEB | Apuntar a `AGENTS.md` como SoT en el mapa; no duplicar | P1 |
+| `AGENTS.md` (raíz) | **Protocolo operativo de agentes (SoT)** | Bien | Es la fuente de verdad real del protocolo; podría enlazar al índice de docs | Designar SoT del protocolo en el mapa; añadir 1 línea al índice | P0 |
+| Raíz del repo | `README.md`, `SETUP.md`, `AGENTS.md`, configs | Bien | Limpia tras `chore(docs): organize…` | No tocar | — |
+| `docs/` (raíz, ~40 sueltos) | `pr-*`, `fix-*`, `audit-premium-*`, `production-readiness-*`, `release-readiness`, `review-governance`, `smoke-*`, `legal-*`, `entrega-*` | Malo | Sprawl sin agrupar; **5 convenciones PR-doc** coexisten | Indexar y clasificar (docs-only); agrupar move-only **solo después** del índice | P1 |
+
+**Cinco convenciones de "PR doc" detectadas** (síntoma de naming inconsistente, no corregir por
+move aún): `docs/pr-1`…`pr-10` · `docs/pr0`/`pr1`/`pr3b`/`pr5b` · `docs/pr-815`…`pr-826` ·
+`docs/pr-history/PR-fix-*` · `docs/implementation-history/IMPLEMENTACION-PR-*`.
+
+---
+
+## 4. Documentation Freshness and Source-of-Truth Inventory
+
+> Conciso y agrupado. "SoT" = fuente de verdad. "Leer en futuras auditorías" = vale abrir completo.
+
+| Path / grupo | Tema | Estado | SoT | Leer en futuras auditorías | Recomendación |
+| --- | --- | --- | --- | --- | --- |
+| `AGENTS.md` | Protocolo de trabajo del agente | **current** | **sí** | sí | SoT del protocolo. Único punto canónico |
+| `docs/protocol/vetneb-ai-working-protocol.md` | Protocolo IA (prosa larga) | current/duplicado | no | solo si `AGENTS.md` ambiguo | Marcar "secundario de AGENTS.md" |
+| `.cursor/rules/*.mdc` (6) | Reglas IA por dominio (Cursor) | current | no | no (resumen de AGENTS.md) | Mantener; no es SoT |
+| `docs/audit/e2e-ci-layering-strategy-audit.md` | Estrategia capas E2E/CI | **current/closeout-parcial** | **sí** (E2E/CI) | sí | SoT de la estrategia de capas; PR-C1✔ PR-C2✔ |
+| `docs/audit/admin-mobile-e2e-helper-optimization-closeout.md` | Cierre helper E2E admin-mobile | **closeout** | sí (cerrado) | no (ya cerrado) | No reabrir |
+| `docs/audit/admin-mobile-*` (densidad, no-scroll, hub-stage, etc., ~18) | Admin Mobile densa/no-scroll | mayoría **closeout/current** | parcial | no (cerrados) | Indexar como bloque cerrado |
+| `docs/audit/dashboard-horizontal-navigation-information-architecture.md` + `docs/implementation/dashboard-horizontal-shell-navigation.md` | Rediseño dashboard a nav horizontal | **current (en curso)** | **sí** (dashboard IA) | sí | SoT del rediseño activo (plan 11 PRs, 2026-06-18) |
+| `docs/audit/2026-06-22-auditoria-algoritmica-dashboard.md` + `docs/audit/.../algorithmic audit roadmap` (#1075) | Auditoría algorítmica dashboard | **current/roadmap** | sí (roadmap) | sí | SoT del roadmap algorítmico |
+| `docs/audits/DASHBOARD_PREMIUM_VISUAL_REDESIGN_PLAN.md`, `DASHBOARD_NO_SCROLL_PREMIUM_REDESIGN_PLAN.md`, `DASHBOARD_SINGLE_VIEWPORT_APP_SHELL_PLAN.md` | Planes dashboard premium/single-viewport | **historical / likely superseded** por nav horizontal | no | **no** | Marcar "superseded by horizontal-nav" (requiere confirmación 1 línea) |
+| `docs/audits/AUDIT_*` (production readiness, role communication, white-box) | Auditorías globales históricas | **historical** | no | no salvo necesidad | Marcar histórico en mapa |
+| `docs/implementation-history/IMPLEMENTACION-PR-3…15` | Historia implementación pública/dashboard | **historical** | no | no | "avoid reading unless needed" |
+| `docs/pr-history/PR-*` (~30) | Historia de PRs antiguos | **historical** | no | no | Histórico; no leer por defecto |
+| `docs/pr-1…pr-10`, `pr0…pr5b`, `pr-815…pr-826` (raíz docs) | Notas PR antiguas dashboard/API | **historical** | no | no | Histórico; candidatos a agrupar (move-only futuro) |
+| `docs/security/*` (RBAC_MATRIX, ENDPOINT_PERMISSION_MATRIX, ENDPOINT_TEST_MATRIX, csp-*) | Matrices de seguridad | **current** | **sí** (seguridad) | sí (solo el matrix relevante) | SoT de fronteras de seguridad |
+| `docs/ops/*` (CI_PR_CHECKS_RUNBOOK, BACKUP_RESTORE_ROLLBACK, METRICS_BASELINE, production-readiness-audit) | Runbooks operativos | **current** | **sí** (release/ops) | sí | SoT de ops/release |
+| `docs/PRODUCTION_PROGRESS_INVARIANTS.md` + `test/progress-production-invariants.test.ts` | Invariantes de progreso productivo | **current** (lockeado por test) | **sí** | sí | SoT de invariantes; cambios requieren test |
+| `docs/logistics/*`, `docs/product/vetneb-platform-blueprint.md` | Blueprint/roadmap producto | current/reference | parcial | no salvo necesidad | Reference; fuera de eje ordenamiento |
+| `docs/changelog/*` (CAMBIOS, CHANGELOG, CAMBIOS_EFICIENCIA) | Changelog | current/append | no | no | Append-only; no SoT |
+| `docs/notes/*` (todo.md, NOTAS_TECNICAS, PENDIENTE_NORMALIZACION_CLINICS) | Notas sueltas/pendientes | **ambiguous** | no | no | Revisar si `PENDIENTE_*` sigue vigente (later audit) |
+
+---
+
+## 5. Closed, Open, and Ambiguous Work Blocks
+
+| Bloque | PRs/docs relacionados | Estado | Closeout | Próxima acción | Riesgo si se re-audita de cero |
+| --- | --- | --- | --- | --- | --- |
+| **Admin Mobile E2E Helper Optimization** | #1089→#1094; `admin-mobile-e2e-helper-optimization-closeout.md`, `admin-mobile-whitebox-e2e-optimization-audit.md`, `admin-mobile-final-polish-e2e-overlap-audit.md` | **CERRADO** | **sí** | Ninguna | **Alto** — re-auditar repetiría trabajo ya cerrado y consumido en tokens |
+| **E2E CI Layering Strategy** | #1095 (docs `e2e-ci-layering-strategy-audit.md`) + #1096 (scripts `e2e:*`) | **PR-C1 ✔ docs, PR-C2 ✔ scripts**; PR-C3 (CI) **pendiente, fuera de scope** | parcial (auditoría hace de plan vivo) | Validar `unión de capas == e2e:full` (test/local) → recién luego PR-C3 CI-only | **Alto** — el plan ya está escrito; rehacerlo es puro desperdicio |
+| **Admin Mobile / Enterprise Density** | #1076→#1088, #1082→#1088; `admin-mobile-density-closeout.md`, `admin-enterprise-density-completion-audit.md`, `docs/implementation/admin-*-enterprise-density.md` | **CERRADO** | **sí** | Ninguna | **Alto** — bloque maduro con closeout y tests de densidad |
+| **Admin Mobile No-scroll / Hub stage / Layer isolation** | #1067→#1074; `admin-mobile-final-polish-no-scroll-closeout.md`, `admin-mobile-hub-stale-layer-stage.md`; memoria `admin_mobile_hub_stage` | **CERRADO** | **sí** | Ninguna | **Alto** |
+| **Dashboard horizontal-nav redesign** | `docs/audit/dashboard-horizontal-navigation-information-architecture.md`, `docs/implementation/dashboard-horizontal-shell-navigation.md`; memoria `dashboard_horizontal_nav_redesign` (plan 11 PRs, 2026-06-18) | **ABIERTO / en curso** | no | Continuar plan por su propio eje (no es eje de ordenamiento) | Medio — **debe** quedar marcado como SoT activo o se re-audita |
+| **Algorithmic dashboard audit** | `2026-06-22-auditoria-algoritmica-dashboard.md`; #1075 algorithmic roadmap | **ABIERTO / roadmap** | no | Seguir roadmap; no mezclar con ordenamiento | Medio |
+| **Dashboard Premium / Single-viewport / No-scroll (legacy plans)** | `docs/audits/DASHBOARD_*_PLAN.md`; `IMPLEMENTATION_NOTES/feat-dashboard-*` | **probable SUPERSEDED** por horizontal-nav | no | Marcar "superseded" en mapa (1 línea, requiere confirmación de Nico) | Medio — leerlos como vigentes induce decisiones obsoletas |
+| **Security / sessions** | `docs/security/*` (RBAC/ENDPOINT/CSP matrices); ~40 `test/security-*`, `test/auth-*`, `test/*-session-last-access-contract` | **ESTABLE / mantenido** (no hay bloque abierto) | n/a | Solo `requires later domain-specific audit` si surge necesidad | Bajo — bien cubierto por tests/matrices |
+| **Dependabot** | 19 PRs abiertas #1018–#1038 (Radix, lucide, supabase-js, tailwind, react-hook-form, **eslint 9→10**, **@playwright/test 1.60→1.61**) | **ABIERTO / sin tocar** | no | Eje propio; **no** mezclar con ordenamiento ni con capas E2E | Bajo para ordenamiento, pero acumulación = ruido en `gh pr list` |
+| **Perspective scroll PR-24/PR-26** | memoria `pr24_perspective_audit`; `public-perspective-scroll.spec.ts` | **AUDITADO, correctivo propuesto** | no | Decisión de Nico (fuera de eje) | Bajo |
+| **Rama local huérfana** | `test/admin-mobile-final-polish-shared-primitives` | **residuo** | n/a | Nico borra local cuando quiera (no es acción de IA) | Trivial |
+
+---
+
+## 6. E2E and Testing Organization Diagnosis
+
+**Naming clarity — bien.** Los 42 specs usan prefijos de familia consistentes: `admin-mobile-*`
+(13), `dashboard-*` (incl. `-no-scroll-contract`, `-mobile-parity`), `public-*`, más smokes
+sueltos (`visual-smoke`, `theme-mode`, `login-hydration`, `contacto-hydration`). La auditoría
+#1095 ya **mapeó cada spec a una capa** y verificó que la unión == 42 specs (7+13+11+11). Esto es
+ordenamiento de testing **ya resuelto a nivel de nombres**.
+
+**Helper organization — mínima y sana.** Un solo helper (`helpers/admin-mobile-contracts.ts`).
+No hay sprawl de helpers. **No** crear estructura nueva.
+
+**Fixture organization — mínima y crítica.** Un solo fixture (`fixtures/admin-populated-api-server.mjs`),
+levantado por `webServer` en **toda** corrida. Blast radius total: **prohibido tocar** en cualquier
+PR de ordenamiento.
+
+**Specs grandes/ambiguos.** Sin specs "legacy/unclear": todos atribuibles a una familia. Los más
+pesados (`dashboard-card-navigation-shell` = 75 tests, `public-clinics-b2b-operations` = 32,
+`public-report-preview` = 31) están identificados y mapeados a capa. No requieren reordenamiento de
+archivos; su costo se gestiona vía las capas E2E ya creadas.
+
+**`test/` (raíz, ~350 planos) — única deuda de organización real de testing.** Directorio plano
+enorme. Subconjuntos claros por nombre (`*.fastify.test.ts`, `*-invariants.test.ts`, `security-*`,
+`logistics-*`, `admin-*`, `frontend-*`). Un carpeteo move-only mejoraría el escaneo, **pero `test`
+está fuera del eje permitido** y mover ~350 archivos rompería rutas leídas por contratos
+(p. ej. `package-scripts-contract.test.ts`, `production-readiness.test.ts` leen paths). → Clasificar
+como **`requires later test-only audit` (move-only, alto riesgo, baja prioridad)**.
+
+**Relación con PR-C2 scripts-only.** **Ya ejecutado** (#1096): `frontend/package.json` contiene
+`e2e:smoke`, `e2e:admin-mobile`, `e2e:visual-contract`, `e2e:public-clinic`, `e2e:full`. El único
+pendiente de ese hilo es **validar que la unión de capas reproduce `e2e:full`** y, recién entonces,
+PR-C3 CI-only. Ninguno de esos dos es eje de ordenamiento de repo.
+
+**¿Mover carpetas E2E ahora o después?** **Después, y probablemente nunca por ahora.** Mover specs
+invalidaría los scripts de capa por-ruta recién creados (#1096 selecciona por `e2e/<archivo>.spec.ts`)
+y la matriz spec→capa de #1095. **Regla: no mover specs hasta que capas + CI estén estables.**
+
+**Recomendación exacta (organización de testing):** **no** hacer nada estructural en `frontend/e2e`
+ni `test/` en este eje. Solo **documentar** en el índice: (a) que las capas E2E ya existen como
+scripts, (b) que el siguiente paso es validación `unión==full` (no PR de ordenamiento), (c) que el
+carpeteo de `test/` queda como later test-only audit.
+
+---
+
+## 7. Documentation and AI-Tooling Diagnosis
+
+**¿Demasiadas fuentes dispersas para Claude? Sí.** Al arrancar, Claude enfrenta: `AGENTS.md` +
+`docs/protocol/vetneb-ai-working-protocol.md` + `.cursor/rules/*` (6) + 6 skills VETNEB + 174 docs
+sin índice. El **contenido de protocolo** es consistente entre las cuatro fuentes (verificado: las
+skills y `AGENTS.md` repiten el mismo protocolo), así que el problema **no** es contradicción sino
+**ausencia de un punto de entrada que diga "empieza aquí y lee solo esto"**.
+
+**Solape concreto:**
+
+| Fuente | Rol real | Veredicto |
+| --- | --- | --- |
+| `AGENTS.md` | Protocolo operativo canónico (entorno, git boundaries, seguridad, entrega, calidad ISO) | **SoT — conservar como único canónico** |
+| `docs/protocol/vetneb-ai-working-protocol.md` | Misma materia en prosa larga | Secundario; enlazar desde el índice, no duplicar |
+| `.cursor/rules/*.mdc` (6) | Reglas IDE-specific (Cursor) | Derivado; útil para Cursor, no SoT |
+| Skills VETNEB (6) | Protocolo + know-how por dominio en runtime | Operacional; repiten protocolo de `AGENTS.md` |
+| `docs/audit/**` | Estado de auditorías | Necesita índice para ser navegable |
+| `IMPLEMENTATION_NOTES/**` + `docs/implementation*` | Entregas | Tres hogares sancionados; necesitan índice |
+
+**¿Hace falta un README/índice operativo pequeño? Sí — es la recomendación central.** No un doc
+nuevo grande, sino **dos artefactos docs-only chicos**:
+
+1. **`docs/audit/README.md`** — índice de auditorías: por archivo, una línea con estado
+   (`current` / `closeout` / `historical` / `superseded`) y si debe leerse completo. Evita que
+   Claude abra 31 archivos para saber cuál importa.
+2. **`docs/SOURCES_OF_TRUTH.md`** (o `docs/README.md`) — mapa por dominio: "para X, lee Y; evita Z".
+   Convierte la §8 de esta auditoría en un artefacto vivo y corto.
+
+**Cómo evitar leer docs obsoletos:** el mapa SoT marca explícitamente `historical` / `avoid reading`
+para `docs/audits/AUDIT_*`, `docs/pr-history/*`, `docs/implementation-history/*`, `docs/pr-*` raíz y
+`legacy/`. Una sola lectura del mapa (≈1 doc) reemplaza decenas de aperturas exploratorias.
+
+**Documento que debe volverse el "mapa operativo":** **`AGENTS.md` para el protocolo** +
+**`docs/SOURCES_OF_TRUTH.md` para la geografía de docs**. `AGENTS.md` gana una línea: "Índice de
+documentación: ver `docs/SOURCES_OF_TRUTH.md`".
+
+---
+
+## 8. Recommended Sources of Truth by Domain
+
+| Dominio | Fuente de verdad primaria | Secundaria | Histórico (no leer salvo necesidad) | Nota |
+| --- | --- | --- | --- | --- |
+| Protocolo de trabajo | `AGENTS.md` | `docs/protocol/vetneb-ai-working-protocol.md`, skills VETNEB | — | `.cursor/rules/*` derivado |
+| Admin Mobile | `admin-mobile-density-closeout.md` + `admin-mobile-final-polish-no-scroll-closeout.md` | helper `e2e/helpers/admin-mobile-contracts.ts`; memoria `admin_mobile_*` | resto de `admin-mobile-*` audits (cerrados) | Bloque **cerrado**; no reabrir |
+| Dashboard Admin | `docs/audit/dashboard-horizontal-navigation-information-architecture.md` | `docs/implementation/dashboard-horizontal-shell-navigation.md`; `2026-06-22-auditoria-algoritmica-dashboard.md` | `docs/audits/DASHBOARD_*_PLAN.md`, `docs/pr-2/pr-7` | Rediseño **activo** |
+| Dashboard Clínica | `docs/implementation/clinic-enterprise-density-closeout.md` | `dashboard-clinic-*-mobile-parity.spec.ts` | `docs/pr-4-dashboard-clinic-command-center.md` | Paridad mobile estable |
+| E2E / CI | `docs/audit/e2e-ci-layering-strategy-audit.md` | `frontend/package.json` (`e2e:*`), `docs/ops/CI_PR_CHECKS_RUNBOOK.md` | — | PR-C1✔C2✔; falta validación unión==full → PR-C3 |
+| Security / sessions | `docs/security/RBAC_MATRIX.md` + `ENDPOINT_PERMISSION_MATRIX.md` | `AGENTS.md` (invariantes), tests `security-*`/`auth-*` | — | Estable; cambios requieren test |
+| Public / tokens / reports | `docs/implementation/clinic-public-profile-safe-surface.md`, `docs/security/ENDPOINT_TEST_MATRIX.md` | `docs/pr-history/PR-feat-report-workflow-*`, `docs/entrega-particular-email-generated-token.md` | `docs/pr-815…826` (raíz) | Múltiples docs; consolidar referencia vía índice |
+| Production / release | `docs/ops/production-readiness-audit.md`, `docs/PRODUCTION_PROGRESS_INVARIANTS.md` | `docs/release-readiness.md`, `docs/staging-smoke-runbook.md`, `docs/ops/BACKUP_RESTORE_ROLLBACK.md` | `docs/production-readiness-snapshot-2026-05-27.md` | Invariantes lockeados por test |
+| Visual premium / no-scroll | `docs/implementation/dashboard-internal-no-scroll-contract.md` | specs `dashboard-*-no-scroll-contract`; memoria `dashboard_single_viewport_app_shell` | `docs/audits/DASHBOARD_PREMIUM_VISUAL_REDESIGN_PLAN.md` | "Visual contract" = estructural, no pixel |
+| Historical implementations | — | — | `docs/implementation-history/*`, `docs/pr-history/*`, `docs/pr-*` raíz, `legacy/` | **Avoid reading** salvo trazabilidad puntual |
+| Dependency maintenance | `gh pr list` (Dependabot #1018–#1038) | `.github/` config | — | Eje propio; no mezclar |
+
+---
+
+## 9. Required Repository-Ordering Changes
+
+> Todo lo siguiente es **repository-ordering only**. Prioridad P0 (primero) → P3 (último/diferido).
+
+### P0 — Crear índice de auditorías (`docs/audit/README.md`)
+
+- **Problema:** 31 archivos en `docs/audit/` sin índice; Claude abre varios para ubicarse.
+- **Evidencia:** `git ls-files docs/audit` (31); no existe README (Grep confirmó ausencia de índice).
+- **PR type:** docs-only.
+- **Allowed scope:** crear `docs/audit/README.md` (tabla archivo→estado→leer-sí/no).
+- **Non-scope:** no tocar los audits existentes; no mover/renombrar.
+- **Probable files:** `docs/audit/README.md`.
+- **Validación:** `git status --short`, `git diff --check`; lectura humana.
+- **Rollback:** borrar el archivo.
+- **Dependency:** ninguna (puede ir primero).
+
+### P0 — Mapa de fuente-de-verdad por dominio (`docs/SOURCES_OF_TRUTH.md`)
+
+- **Problema:** no hay mapa que diga "para X lee Y, evita Z"; §4/§8 viven solo en auditorías.
+- **Evidencia:** ausencia de `docs/README.md`/`SOURCES_OF_TRUTH.md` (Grep).
+- **PR type:** docs-only.
+- **Allowed scope:** crear `docs/SOURCES_OF_TRUTH.md` (materializar §8); 1 línea opcional en
+  `AGENTS.md` apuntando al mapa.
+- **Non-scope:** no consolidar carpetas; no mover docs.
+- **Probable files:** `docs/SOURCES_OF_TRUTH.md` (+ `AGENTS.md` 1 línea — autorización explícita de Nico por ser raíz).
+- **Validación:** `git diff --check`; lectura humana.
+- **Rollback:** borrar archivo / revertir la línea.
+- **Dependency:** idealmente tras el índice P0 anterior.
+
+### P0 — Nota disambiguadora `docs/audit` vs `docs/audits`
+
+- **Problema:** carpetas casi homónimas, separación intencional pero no declarada.
+- **Evidencia:** `chore-docs-organize-audit-implementation-notes.md` líneas 39–41 ("plural requested
+  explicitly; singular `docs/audit/` unrelated and left untouched").
+- **PR type:** docs-only (puede ir dentro del índice P0 o como sección del mapa SoT).
+- **Allowed scope:** una sección/encabezado en `docs/SOURCES_OF_TRUTH.md` y/o nota al inicio de
+  `docs/audit/README.md` y de un futuro `docs/audits/README.md`.
+- **Non-scope:** **no** fusionar ni renombrar las carpetas.
+- **Probable files:** `docs/SOURCES_OF_TRUTH.md`, `docs/audit/README.md`.
+- **Validación:** lectura humana.
+- **Rollback:** borrar la sección.
+- **Dependency:** acoplada a los dos P0 anteriores.
+
+### P1 — Clasificación de docs históricos vs actuales
+
+- **Problema:** ~70 docs históricos (pr-history, implementation-history, pr-* raíz, AUDIT_*) se leen
+  como si fueran vigentes.
+- **Evidencia:** §4 de esta auditoría; convenciones de nombre múltiples.
+- **PR type:** docs-only.
+- **Allowed scope:** ampliar `docs/SOURCES_OF_TRUTH.md` con una sección "historical / avoid reading"
+  enumerando carpetas/patrones. **Marcar por contenido, no mover.**
+- **Non-scope:** no mover/renombrar/borrar; no tocar el contenido histórico.
+- **Probable files:** `docs/SOURCES_OF_TRUTH.md`.
+- **Validación:** lectura humana.
+- **Rollback:** revertir sección.
+- **Dependency:** tras P0.
+
+### P1 — Marcar planes dashboard "superseded"
+
+- **Problema:** `DASHBOARD_PREMIUM/NO_SCROLL/SINGLE_VIEWPORT_*_PLAN.md` probablemente reemplazados por
+  el rediseño horizontal-nav.
+- **Evidencia:** memoria `dashboard_horizontal_nav_redesign`; `docs/audit/dashboard-horizontal-navigation-information-architecture.md`.
+- **PR type:** docs-only.
+- **Allowed scope:** una línea de estado en el mapa SoT ("superseded by horizontal-nav, ver …").
+  **Requiere confirmación de Nico** de que están superados.
+- **Non-scope:** no editar los planes; no moverlos.
+- **Probable files:** `docs/SOURCES_OF_TRUTH.md`.
+- **Validación:** confirmación de Nico + lectura humana.
+- **Rollback:** revertir la línea.
+- **Dependency:** P0/P1.
+
+### P1 — Índice del prompt-pack para futuras auditorías
+
+- **Problema:** cada auditoría futura re-deriva contexto (qué leer, qué no, presupuesto).
+- **Evidencia:** esta misión repite inventarios que ya existen en closeouts.
+- **PR type:** docs-only.
+- **Allowed scope:** sección en `docs/audit/README.md`: "antes de auditar, lee el mapa SoT; un
+  dominio por auditoría; un archivo de salida; no reabrir bloques cerrados (§5)".
+- **Non-scope:** no crear plantillas de código ni tooling.
+- **Probable files:** `docs/audit/README.md`.
+- **Validación:** lectura humana.
+- **Rollback:** revertir sección.
+- **Dependency:** tras índice P0.
+
+### P2 — (Diferido) Agrupar `docs/` raíz suelta — **move-only**
+
+- **Problema:** ~40 archivos sueltos en raíz de `docs/`.
+- **Evidencia:** §3.
+- **PR type:** move-only (futuro).
+- **Allowed scope:** `git mv` de `docs/pr-*`, `docs/fix-*` a subcarpetas existentes (`docs/pr-history/`
+  o nueva `docs/pr-archive/`).
+- **Non-scope:** **no** ejecutar hasta que el índice/mapa exista y se valide que ningún test lee esos
+  paths (precedente: el doc-org PR tuvo que actualizar 1 path en un test).
+- **Probable files:** docs sueltas + posible 1 path en test (requiere autorización, igual que el
+  precedente).
+- **Validación:** `pnpm test` (paths), `git diff --check`.
+- **Rollback:** revertir el move.
+- **Dependency:** **después** de P0/P1.
+
+### P3 — (Diferido) Carpeteo de `test/` — **requires later test-only audit**
+
+- **Problema:** ~350 archivos planos en `test/`.
+- **PR type:** move-only (fuera de este eje).
+- **Allowed scope / non-scope:** **no** en este eje; `test` está prohibido. Solo se registra como
+  deuda. Alto riesgo (contratos leen paths).
+- **Validación / rollback / dependency:** N/A aquí.
+
+---
+
+## 10. Recommended Ordering PR Sequence
+
+> PRs chicos, un solo eje, reversibles. Git lo ejecuta Nico.
+
+### PR-O1 — docs-only: índice de auditorías
+
+- **Objetivo:** crear `docs/audit/README.md` con estado por archivo (current/closeout/historical/superseded).
+- **Por qué mejora eficiencia:** Claude ubica el doc vigente en 1 lectura en vez de N aperturas.
+- **Allowed scope:** `docs/audit/README.md`.
+- **Non-scope:** no tocar audits; no mover/renombrar; no CI/scripts/tests.
+- **Validación:** `git status --short`, `git diff --check`, lectura humana.
+- **Rollback:** borrar archivo.
+- **Dependency:** ninguna. **Primero.**
+
+### PR-O2 — docs-only: mapa de fuente-de-verdad + disambiguación audit/audits
+
+- **Objetivo:** `docs/SOURCES_OF_TRUTH.md` (materializa §8) + nota `docs/audit` vs `docs/audits`;
+  1 línea en `AGENTS.md` apuntando al mapa (con autorización de Nico).
+- **Por qué:** un único punto que enruta cada dominio a su SoT y marca lo histórico.
+- **Allowed scope:** `docs/SOURCES_OF_TRUTH.md` (+ `AGENTS.md` 1 línea).
+- **Non-scope:** no consolidar carpetas; no mover docs.
+- **Validación:** `git diff --check`, lectura humana.
+- **Rollback:** borrar archivo / revertir línea.
+- **Dependency:** tras PR-O1.
+
+### PR-O3 — docs-only: clasificación histórica + planes superseded
+
+- **Objetivo:** sección "historical / avoid reading" y marca "superseded by horizontal-nav" en los
+  `DASHBOARD_*_PLAN`.
+- **Por qué:** evita que auditorías futuras lean docs obsoletos como vigentes.
+- **Allowed scope:** `docs/SOURCES_OF_TRUTH.md`.
+- **Non-scope:** no editar/mover/borrar el contenido histórico.
+- **Validación:** confirmación de Nico (superseded) + lectura humana.
+- **Rollback:** revertir sección.
+- **Dependency:** tras PR-O2.
+
+### PR-O4 — (NO necesario) scripts-only de capas E2E
+
+- **Estado:** **YA HECHO en #1096.** `frontend/package.json` tiene `e2e:smoke/admin-mobile/visual-contract/public-clinic/full`.
+- **Acción real pendiente (otro eje, no ordenamiento):** validar `unión de capas == e2e:full` antes
+  de cualquier PR-C3 CI-only. **No** abrir como PR de ordenamiento.
+
+### PR-O5 — docs-only: prompt-pack index para futuras auditorías
+
+- **Objetivo:** sección en `docs/audit/README.md` con reglas de §11 (un dominio/auditoría, un
+  archivo de salida, no reabrir cerrados, leer mapa SoT primero).
+- **Por qué:** reduce el costo fijo de arranque de cada auditoría.
+- **Allowed scope:** `docs/audit/README.md`.
+- **Non-scope:** sin tooling/plantillas de código.
+- **Validación:** lectura humana.
+- **Rollback:** revertir sección.
+- **Dependency:** tras PR-O1.
+
+### PR-O6 — (Diferido) move-only: agrupar `docs/` raíz suelta
+
+- **Objetivo:** `git mv` de `docs/pr-*`/`docs/fix-*` a subcarpeta de archivo.
+- **Por qué:** limpia la raíz de `docs/` que el índice ya habrá catalogado.
+- **Allowed scope:** docs sueltas (+ posible 1 path en test, con autorización, precedente doc-org).
+- **Non-scope:** no antes de PR-O1..O3; no mezclar con cambios de contenido.
+- **Validación:** `pnpm test` (paths intactos), `git diff --check`.
+- **Rollback:** revertir el move.
+- **Dependency:** **solo** tras tener índice + mapa estables.
+
+---
+
+## 11. Rules for Future Audits
+
+- Claude **no elige prioridades** sin una matriz (P0/P1/P2/P3) explícita.
+- **Un dominio por auditoría.** No mezclar dominios en un solo archivo.
+- **Un archivo de salida por auditoría**, en `docs/audit/`, con nombre kebab-case descriptivo.
+- **Docs-only antes que implementación.** Auditar, luego (en PR aparte) implementar.
+- **Scripts-only separado de CI-only.** Nunca tocar `.github/workflows` en el mismo PR que scripts.
+- **Move-only separado de cambios de contenido.** Un PR mueve **o** edita, nunca ambos.
+- **No reabrir bloques cerrados** (§5: Admin Mobile E2E Helper, Density, No-scroll) sin **nueva
+  evidencia** documentada.
+- **No mover archivos E2E** antes de que las capas (scripts) + CI estén estables.
+- **No tocar CI** antes de validar localmente `unión de capas == e2e:full`.
+- **No usar frameworks/librerías** como solución de ordenamiento (es un problema de docs, no de deps).
+- **No mezclar** cambios visuales, de seguridad, de CI y de producto en un mismo PR.
+- **No mezclar Dependabot** con trabajo funcional o de ordenamiento.
+- **No tocar `frontend/next-env.d.ts`** (se regenera con `next dev`; revertir si se ensucia).
+- **No ejecutar Git reservado a Nico** (`add`/`commit`/`push`/`merge`/`gh pr *`).
+- **No usar comandos con `exit`.**
+- **Leer primero el mapa SoT** (`docs/SOURCES_OF_TRUTH.md`) y el índice (`docs/audit/README.md`)
+  antes de abrir docs individuales.
+
+---
+
+## 12. Final Recommendation
+
+**Qué ordenar primero.** **PR-O1 docs-only: `docs/audit/README.md`** (índice de auditorías con
+estado por archivo). Es el cambio de menor riesgo y mayor retorno: convierte 31 aperturas
+exploratorias en 1 lectura. Inmediatamente después, **PR-O2** (mapa de fuente-de-verdad +
+disambiguación `docs/audit`/`docs/audits`).
+
+**¿Sigue siendo viable PR-C2 scripts-only "ahora"?** **No aplica: ya está hecho.** El HEAD actual
+(`8e29cc2`, #1096) **ya añadió** los scripts de capa E2E a `frontend/package.json`. Lo que queda de
+ese hilo es **validación** (`unión de capas == e2e:full`) y luego PR-C3 **CI-only** — y eso **no es
+un PR de ordenamiento**; pertenece al eje E2E/CI y queda fuera de scope aquí.
+
+**¿Debe ir un PR-O docs-index antes que PR-C2?** La pregunta queda superada porque PR-C2 ya se
+mergeó. La regla a futuro es: **los PR-O docs-index (PR-O1/O2) van antes que cualquier PR-C3 CI-only**,
+porque el índice/mapa reduce el costo de razonar sobre la matriz spec→capa y evita reauditar lo ya
+cerrado.
+
+**Qué NO tocar todavía.** `frontend/src`, `server`, `drizzle`/migraciones, `test`, specs, helpers,
+fixtures, `.github/workflows`, `package.json`, `frontend/package.json`, `pnpm-lock.yaml`, Playwright
+config, `scripts`, dependencias, secretos, producción, base de datos real, `frontend/next-env.d.ts`,
+y **cualquier move/rename de archivos** hasta que el índice + mapa existan y congelen el estado actual.
+
+**Próximo PR recomendado (exacto).** `PR-O1 docs-only` — crear `docs/audit/README.md` (índice de
+auditorías con estado: current / closeout / historical / superseded, y "leer completo: sí/no").
+Único archivo. Sin mover nada. Validación: `git status --short`, `git diff --check`, lectura humana.
+
+**Cómo esta auditoría reduce tokens y mejora a Claude:**
+
+- **Un mapa, no N aperturas:** futuras auditorías leen `docs/SOURCES_OF_TRUTH.md` (1 doc) en vez de
+  explorar 174.
+- **Bloques cerrados marcados (§5):** evita reauditar Admin Mobile E2E Helper / Density / No-scroll
+  (alto ahorro: son los bloques más densos del historial reciente).
+- **Histórico señalizado:** `docs/audits`, `pr-history`, `implementation-history`, `pr-*` raíz y
+  `legacy/` marcados "avoid reading" → cero lecturas exploratorias inútiles.
+- **Estado de PR-C2 aclarado:** ya hecho en #1096 → no se vuelve a planear ni implementar.
+- **Reglas de scope (§11):** Claude no inventa prioridades ni mezcla ejes; cada auditoría futura
+  arranca acotada.
+
+---
+
+## Final validation
+
+```powershell
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git diff --check
+```
+
+**Resultado esperado de esos comandos** (este PR solo agrega un archivo **untracked**):
+
+- `git status --short --untracked-files=all` → `?? docs/audit/repository-operational-ordering-audit.md`
+- `git diff --name-only` → vacío (no hay archivos tracked modificados)
+- `git diff --stat` → vacío
+- `git diff --check` → limpio (sin whitespace errors en cambios tracked)
+
+> Los comandos de validación los ejecuta Nico manualmente. Esta auditoría **no** ejecuta
+> `git add/commit/push`, `gh pr create/merge` ni ningún comando con `exit`.

--- a/docs/audit/vetneb-enterprise-engineering-readiness-audit.md
+++ b/docs/audit/vetneb-enterprise-engineering-readiness-audit.md
@@ -1,0 +1,831 @@
+# VETNEB Enterprise Engineering Readiness — Audit
+
+> **docs-only.** Este documento **no modifica** código productivo, `frontend/src`, `frontend/e2e`,
+> `server`/backend, `test`, `.github/workflows`, `package.json`, `frontend/package.json`,
+> `pnpm-lock.yaml`, Playwright config, `scripts`, `drizzle`/migraciones, deps, lockfiles, CI,
+> screenshots ni archivos generados. No mueve, no renombra y no borra archivos. Es **auditoría +
+> asesoría de ingeniería + roadmap de implementación**, no una implementación ni una lista de deseos
+> de producto/tecnología. Cada recomendación se ata a uno o más PRs chicos con rollback.
+>
+> Skills VETNEB aplicadas (declaradas): `vetneb-briefing-planificacion-diseno-desarrollo-pruebas`,
+> `vetneb-staff-senior-full-stack-engineer`, `vetneb-web-end-to-end-global`,
+> `vetneb-security-production-invariants`, `vetneb-admin-dashboard-operational-actions`,
+> `vetneb-production-web-optimization-engineer`, `vetneb-pwa-end-to-end`,
+> `vetneb-lanzamiento-mantenimiento`, `vetneb-bugs-errores-optimizacion-rutas`,
+> `vetneb-protocolos-comunicacion`. Ninguna skill se usa como autorización para ampliar el alcance;
+> prevalece el Protocolo Maestro VETNEB y el flujo Git manual de Nico.
+
+---
+
+## 1. Executive Summary
+
+**Estado actual de enterprise-readiness: VETNEB es un producto de ingeniería *sólido y bien
+gobernado*, en nivel "estable pero todavía no enterprise-grade" (≈2.7/5 promedio ponderado).** El
+núcleo —seguridad, separación de superficies, testing y disciplina de PRs chicos— está cerca de
+nivel enterprise. Lo que falta para "enterprise SaaS" no es reescribir nada: es **instrumentar y
+medir** (observabilidad, budgets de performance) y **formalizar contratos** (API/integración,
+gobernanza de datos), todo de forma aditiva sobre una base limpia.
+
+**Áreas más fuertes (no tocar la arquitectura):**
+
+- **Seguridad y aislamiento de sesiones (4/5):** CSP con nonce + endpoint de report
+  (`frontend/src/lib/security/csp-policy.ts`, `csp-nonce.ts`, `app/api/security/csp-report/route.ts`),
+  headers de respuesta endurecidos (`server/lib/api-response-security.ts`: no-store/nosniff/
+  referrer-policy/request-id), CSRF con cobertura propia, `middlewares/trusted-origin.ts`, hashing
+  `argon2`, rate-limit **por superficie** (8+ archivos `*-rate-limit.ts`), y separación estricta
+  `admin_session_id` / `app_session_id`.
+- **Separación público/clínica/admin (4/5):** middlewares dedicados (`admin-auth`, `auth`,
+  `clinic-permissions`, `particular-auth`), matrices `docs/security/RBAC_MATRIX.md` /
+  `ENDPOINT_PERMISSION_MATRIX.md`, y tests E2E (`dashboard-auth-redirect`) que fijan
+  "admin sin sesión → 404, privado sin sesión → redirect".
+- **Testing (4/5):** ~400 tests unit/integration en `test/` + 42 specs E2E ya **capeados** (#1096),
+  con contract-tests de runtime-timing, session-last-access, no-secrets, no-store, CSP, schema-health.
+- **Backend Fastify maduro (3-4/5):** separación `lib`(41)/`routes`(34)/`middlewares`(7), un
+  `db-*.ts` por dominio, `error-handler`, validación `zod`, `permissions.ts`, `audit-log.ts`.
+
+**Áreas más débiles (foco del roadmap):**
+
+- **Performance budgets (1/5):** **no hay budgets medidos ni gates**. No hay `next/dynamic`/lazy
+  para deps pesadas; no hay medición de LCP/INP/CLS ni de bundle.
+- **Integraciones/API/webhooks (1/5):** sin OpenAPI/Swagger, sin versionado (`/api/...` sin `/v1`),
+  sin webhooks ni idempotency keys.
+- **Background jobs/async (1/5):** email/PDF/report-workflow son **síncronos**; no hay cola.
+- **Observabilidad/SRE (2/5):** `server/lib/logger.ts` es un wrapper de `console.log` **no
+  estructurado**; hay health checks y request-id, pero **sin** Sentry/OTel, métricas agregadas ni
+  alerting.
+- **Gobernanza de datos/lifecycle (2/5)** y **documentación/source-of-truth (2/5)** (ver auditoría
+  previa `docs/audit/repository-operational-ordering-audit.md`).
+
+**Riesgos enterprise de mayor severidad (con evidencia):**
+
+1. **Ceguera en producción (P0-obs):** logging plano `console.*` sin estructura ni agregación → un
+   incidente real es difícil de diagnosticar; no hay error-monitoring de frontend ni backend.
+2. **Sin red de performance (P1-perf):** sin budgets ni medición, una regresión de bundle/latencia
+   pasa el gate sin ser vista.
+3. **Deps pesadas sin consumidor (P1-deps):** `@tanstack/react-query`, `@tanstack/react-table` y
+   `echarts`/`echarts-for-react` están en `dependencies` pero **no se usan en `frontend/src`** (solo
+   `gsap` aparece, en `PublicScrollReveal.tsx`) → peso de bundle/superficie de supply-chain sin
+   valor. Decidir: **cablear o quitar**.
+4. **CI engañoso (P1-ci):** el único step E2E sigue etiquetado "smoke" pero corre la regresión
+   completa; las capas `e2e:*` existen (#1096) pero CI no las usa (PR-C3 pendiente).
+
+**Mejoras de mayor valor (orden de retorno):** (a) baseline de observabilidad **sin nuevas deps**
+(logger estructurado JSON + request-id ya existente); (b) budgets de performance medibles + CI-only
+de capas E2E (PR-C3); (c) higiene de deps (cablear/retirar las 3 no usadas); (d) índice/mapa de
+fuentes de verdad (ya iniciado por la auditoría de ordenamiento).
+
+**Qué debe hacerse antes de trabajo de producto grande:** Fase 0 (índice + mapa de fuentes de
+verdad) y Fase 1 (gate de testing/CI: PR-C3 validando `unión == e2e:full`). Sin esto, cada feature
+grande paga el costo de re-descubrir contexto y arriesga pérdida de cobertura.
+
+**Qué NO debe implementarse todavía:** realtime/WebSockets, CRDTs, WebGL, micro-frontends, colas,
+PWA-offline para datos privados, y **adopción de cualquier dependencia nueva**. Ninguno tiene hoy un
+gap probado que lo justifique.
+
+**Próximo PR exacto recomendado:** **PR-O1 docs-only** — `docs/audit/README.md` (índice de
+auditorías vigentes con estado), continuación directa de la auditoría de ordenamiento. Es cero
+riesgo y desbloquea la secuencia.
+
+---
+
+## 2. Audited Base
+
+| Campo | Valor |
+| --- | --- |
+| Branch | `main` |
+| HEAD (`git log -1 --oneline`) | `8e29cc2 test(e2e): add layered e2e scripts (#1096)` |
+| `origin/main` / `origin/HEAD` | `8e29cc2` (idéntico al HEAD local) |
+| `git status --short --untracked-files=all` | `?? docs/audit/repository-operational-ordering-audit.md` (de la auditoría previa) + (este archivo nuevo, untracked) |
+| Worktree | único — `C:/PORTAL-VETNEB 8e29cc2 [main]` |
+| Branches locales | `main` + `test/admin-mobile-final-polish-shared-primitives` (residual, ya integrada) |
+| Open PRs | **19, todas Dependabot** (#1018–#1038) |
+| Fecha | 2026-06-23 |
+| Plataforma | Windows / PowerShell / PNPM 10.8.1 |
+
+**Comandos read-only ejecutados (evidencia):**
+
+```
+git branch --show-current ; git status --short --untracked-files=all ; git log -1 --oneline
+git log --oneline --decorate -n 30 ; git branch ; git worktree list ; gh pr list --state open
+git ls-files server/** ; git ls-files frontend/src/** ; git ls-files frontend/public/* ; git ls-files supabase/** (vacío)
+git ls-files frontend/*.ts frontend/next.config.* frontend/src/lib/** frontend/src/app/**
+Grep (server): seguridad (helmet/CSP/headers/rate-limit/csrf/no-store/trusted-origin) → 52/16 archivos
+Grep (server): observabilidad (logger/request-id/health/metrics/trace/otel/sentry/runtime-timing) → 132/38
+Grep (repo): integración/async (websocket/realtime/webhook/idempoten/openapi/queue/cron) → casi todo en docs
+Grep (frontend/src): estado/perf (zustand/redux/xstate/dynamic/lazy/react-window/tanstack/useQuery) → 8/4
+Grep (frontend/src): tanstack/echarts/gsap reales → 1 archivo (gsap)
+Grep (frontend/src): sentry/otel/openapi/idempoten/feature-flag/websocket/api-version → 0
+Grep (frontend/src): deuda (TODO/FIXME/as any/console.log/ts-ignore) → 14/14
+Grep (server): integración/logging externo + console.* → 54/30
+```
+
+**Archivos leídos completos (5):** `frontend/package.json`, `package.json` (raíz), `server/lib/logger.ts`,
+`docs/audit/e2e-ci-layering-strategy-audit.md` (en sesión previa), `docs/audit/repository-operational-ordering-audit.md`
+(redactado en sesión previa). **Closeouts/protocolo** (`AGENTS.md`, `docs/protocol/vetneb-ai-working-protocol.md`,
+`admin-mobile-e2e-helper-optimization-closeout.md`) leídos en sesión previa de este mismo chat.
+
+**Archivos inspeccionados por búsqueda/snippet (no leídos completos):** todo `server/**` (estructura
++ greps), `frontend/src/**` (estructura + greps), `frontend/public/*`, ambos `package.json` de
+scripts E2E.
+
+**Confirmación de scope.** Solo se crea `docs/audit/vetneb-enterprise-engineering-readiness-audit.md`.
+No se modificó, movió, renombró ni borró ningún otro archivo. No se ejecutó `git add/commit/push`,
+`gh pr create/merge`. No se instalaron dependencias. No se levantó `next dev` (no se tocó
+`frontend/next-env.d.ts`). **Esta auditoría es docs-only.**
+
+**Nota de mapeo de nombres.** La misión menciona `backend` y `supabase` como carpetas; **no
+existen** con esos nombres. El backend real es `server/` (Fastify); las migraciones viven en
+`drizzle/`; Supabase se consume vía `server/lib/supabase.ts` + `@supabase/supabase-js`. Se audita
+bajo los nombres reales.
+
+---
+
+## 3. Enterprise Scorecard
+
+> Escala: 0 ausente · 1 ad hoc/frágil · 2 parcial · 3 estable (no enterprise) · 4 fuerte/casi
+> enterprise · 5 enterprise-grade.
+
+| Dominio | Score | Evidencia (repo) | Gap | Riesgo enterprise | Impacto producto/negocio | Próximo PR | Prio |
+| --- | :--: | --- | --- | --- | --- | --- | :--: |
+| Product operational excellence | **3** | Dashboards admin/clínica con acciones reales; no-scroll contracts; closeouts density | Sin métricas de operación (tiempo de tarea, clicks) | Decisiones de UX sin datos | Eficiencia operativa diaria | PR-D1 docs (valor operativo) | P2 |
+| Premium UI/UX & design system | **3** | Radix + `class-variance-authority` + tailwind4 + `tailwind-merge`; dark/light (`theme.ts`, `theme-init.js`); no-scroll | Sin catálogo de design tokens documentado; sin auditoría visual formal | Inconsistencia visual al escalar módulos | Percepción premium | PR-D1 docs (design-system map) | P2 |
+| Frontend architecture/performance | **3** | API client centralizado (`lib/api.ts`), `routes.ts`, estado cliente mínimo, Next16/React19 | Sin `next/dynamic`/lazy; deps pesadas sin uso; sin budgets | Bundle crece sin control | Carga lenta percibida | PR-P1 docs + PR-P2 measure | P1 |
+| Backend/API reliability | **3** | Fastify sep. `lib/routes/middlewares`; `error-handler`; `zod`; `db-*.ts` por dominio | Sin contratos OpenAPI; sin idempotency; sin versionado | Integración frágil a futuro | Estabilidad de API | PR-A1 docs (API readiness) | P2 |
+| Security/session isolation | **4** | CSP nonce+report, `api-response-security.ts`, CSRF, rate-limit/superficie, argon2, sesiones separadas | Sin rotación documentada; sin auditoría de secret-scanning en CI | Brecha si se relaja una frontera | Confianza/compliance | PR-S1 docs (security audit) | P1 |
+| Public/clinic/admin separation | **4** | middlewares por rol; RBAC matrices; E2E redirect/404 | Falta verificación periódica anti-enumeración | Cross-tenant si regresiona | Aislamiento de datos | PR-S1 docs | P1 |
+| Data governance/lifecycle | **2** | `audit-log.ts`, `study-tracking`, `report-workflow`; `docs/ops/BACKUP_RESTORE_ROLLBACK.md` | Sin política de retención/exportación/borrado formal; trazabilidad de fechas no auditada | Cumplimiento y soporte | Continuidad/legal | PR-G1 docs (data governance) | P2 |
+| Testing strategy | **4** | ~400 unit/integration + 42 E2E + contract-tests | Sin gate de cobertura por capa en CI todavía | Regresión silenciosa | Confiabilidad | PR-C3 CI-only | P1 |
+| E2E layering & CI readiness | **3** | `e2e:smoke/admin-mobile/visual-contract/public-clinic/full` (#1096) | CI no usa capas; step "smoke" engañoso | Feedback lento, nombre confuso | Velocidad de entrega | PR-C3 CI-only | P1 |
+| Release engineering | **3** | `build-info` route; `smoke:staging`; `BACKUP_RESTORE_ROLLBACK`; `review-governance.md`; CI 2 workflows | Sin checklist de release versionado ni gate de artefactos | Releases riesgosos | Estabilidad de deploy | PR-R1 docs (release readiness) | P2 |
+| Observability/SRE | **2** | `logger.ts` (console), `api-request-id.ts`, `request-logger.ts`, `admin-system-health`, `runtime-timing` | Logger no estructurado; sin Sentry/OTel/métricas/alerting | Ceguera en incidentes | Soporte productivo | PR-R1 docs + PR-R2 structured logging | **P0/P1** |
+| Performance budgets | **1** | `docs/pr-history/PR-audit-performance-routes-web-vitals.md` (histórico, sin enforcement) | Sin budgets, sin LCP/INP/CLS, sin bundle gate | Degradación invisible | Velocidad percibida | PR-P1 docs (budgets) | P1 |
+| Accessibility/mobile operability | **3** | `dashboard-accessibility-keyboard.spec.ts`; aria/focus; mobile parity specs; no-scroll | Sin auditoría a11y formal (axe) ni budget de a11y | Exclusión/legal | Inclusión | PR-D1/PR-A11y docs | P2 |
+| Integrations/API/webhooks | **1** | Solo `/api/...` interno; sin OpenAPI/versionado/webhooks | Sin contrato externo ni firmas | No integrable por terceros | Comercial B2B | PR-A1 docs (API/webhook) | P2 |
+| Background jobs/async | **1** | email (`nodemailer`), report-workflow, PDF — **síncronos** | Sin cola; trabajos largos bloquean request | Timeouts/latencia | Escalabilidad | PR-A2 docs (async candidates) | P3 |
+| PWA/offline safety | **3** | `public/sw.js`, `app/manifest.ts`, `/offline`, iconos maskable, `PwaServiceWorkerRegistrar` | Política de cache no auditada contra privados recientemente | Cache de privados si regresiona | Instalabilidad | PR-PWA1 docs (cache policy audit) | P3 |
+| Dependency/supply-chain hygiene | **3** | `pnpm.overrides` (brace-expansion/esbuild/ws/js-yaml); Dependabot activo | 3 deps sin consumidor; 19 PRs en cola | Superficie/peso sin valor | Mantenibilidad | PR-DEP1 docs (dep audit) | P1 |
+| Documentation/source-of-truth | **2** | `repository-operational-ordering-audit.md`; closeouts | Sin índice/mapa todavía; 174 docs | Re-descubrimiento costoso | DX/consumo IA | PR-O1/PR-O2 docs | P0 |
+| Developer/AI workflow efficiency | **3** | Protocolo + 10 skills + closeouts + git manual disciplinado | Doc overload; contexto repetido | Consumo de tokens | Velocidad de entrega | PR-O2 docs (SoT map) | P1 |
+| Compliance/privacy readiness | **2** | Audit logs; sanitización; no-secrets tests | Sin controles de privacidad documentados (datos clínicos) | Legal/regulatorio | Confianza B2B | PR-G1 docs (requires legal) | P2 |
+
+**Lectura del scorecard.** Perfil "T invertida": cimientos transversales fuertes (seguridad 4,
+separación 4, testing 4) y **picos bajos en instrumentación** (observabilidad 2, performance 1,
+integración 1, jobs 1). Es el patrón típico de un producto bien construido que **aún no fue
+medido/operado a escala**. La ruta enterprise es instrumentar, no reconstruir.
+
+---
+
+## 4. Critical Enterprise Gaps
+
+> Solo gaps con evidencia de repo. Prioridad por la matriz de §Decision rules.
+
+### P0 — Observabilidad de producción insuficiente (logging no estructurado, sin error-monitoring)
+
+- **Dominio:** Observability/SRE.
+- **Evidencia:** `server/lib/logger.ts` = wrapper de `console.log('[INFO]', ...)` (22 líneas, no
+  JSON, sin campos de correlación); 54 llamadas `console.*` directas en `server` (30 archivos);
+  Grep `sentry|otel|opentelemetry` = **0** en `frontend/src` y `server`.
+- **Por qué importa:** sin logs estructurados ni monitoreo de errores, un incidente real es
+  diagnosticable solo por inspección manual; no hay correlación automática request→error→usuario.
+- **Riesgo si se ignora:** MTTR alto, incidentes silenciosos, imposible cumplir SLOs.
+- **Dirección de implementación (sin deps nuevas primero):** estructurar `logger.ts` a JSON
+  (timestamp, level, request-id, ruta, status) reutilizando `api-request-id.ts`; consolidar
+  `console.*` dispersos detrás del logger. Sentry/OTel = fase posterior, opcional.
+- **First safe PR:** **PR-R1 docs-only** (baseline de observabilidad) → luego **PR-R2 backend-only**
+  (logger estructurado, contrato testeable, sin deps).
+- **Validación:** test de contrato del shape del log; `pnpm test`; no exponer secretos en logs.
+- **Rollback:** revertir `logger.ts` (cambio acotado de 1 archivo + su test).
+
+### P1 — Sin budgets ni medición de performance
+
+- **Dominio:** Performance budgets.
+- **Evidencia:** Grep `next/dynamic|lazy|react-window` en `frontend/src` = 0; no hay web-vitals
+  medido en repo; `PR-audit-performance-routes-web-vitals.md` es histórico sin enforcement.
+- **Por qué importa:** una regresión de bundle o latencia pasa el gate sin verse.
+- **Riesgo si se ignora:** degradación acumulativa de LCP/INP en dashboards densos.
+- **Dirección:** definir budgets (tabla §12), medir build output (Next ya reporta tamaños), agregar
+  web-vitals client mínimo más adelante.
+- **First safe PR:** **PR-P1 docs-only** (budgets propuestos) → **PR-P2** (medición no intrusiva).
+- **Validación:** comparar tamaños de build antes/después; budgets documentados.
+- **Rollback:** docs/medición son aditivas; revertir doc/medición.
+
+### P1 — Dependencias pesadas sin consumidor
+
+- **Dominio:** Dependency/supply-chain hygiene.
+- **Evidencia:** `frontend/package.json` declara `@tanstack/react-query`, `@tanstack/react-table`,
+  `echarts`, `echarts-for-react`; Grep en `frontend/src` de su uso real = **0** (solo `gsap` aparece
+  en `PublicScrollReveal.tsx`).
+- **Por qué importa:** peso potencial de bundle y superficie de supply-chain sin valor entregado;
+  además sesga el roadmap (parecen "adoptados" cuando no lo están).
+- **Riesgo si se ignora:** Dependabot mantiene/actualiza deps sin consumidor; ruido y CVE-surface.
+- **Dirección:** decisión explícita por dep: **cablear** (si hay un plan concreto: tablas con
+  TanStack Table, gráficos con ECharts, server-state con React Query) **o retirar**. No mezclar con
+  feature work.
+- **First safe PR:** **PR-DEP1 docs-only** (auditoría de deps usadas vs no usadas + decisión) →
+  luego PR de cableado **o** de retiro, separado.
+- **Validación:** `git grep` de import por dep; build size; `pnpm test`.
+- **Rollback:** decisión documentada; cambios de deps son reversibles (pero los hace Nico, fuera de
+  esta auditoría).
+
+### P1 — CI no usa las capas E2E y el step "smoke" es engañoso
+
+- **Dominio:** E2E layering & CI readiness.
+- **Evidencia:** `frontend/package.json` tiene `e2e:smoke/admin-mobile/visual-contract/public-clinic/full`
+  (#1096); auditoría `e2e-ci-layering-strategy-audit.md` documenta que el único step E2E corre la
+  suite completa bajo etiqueta "smoke".
+- **Por qué importa:** feedback lento, nombre confuso, sin gate barato por superficie.
+- **Riesgo si se ignora:** desincentivo a correr E2E; al separar mal, **pérdida de cobertura
+  silenciosa**.
+- **Dirección:** PR-C3 CI-only **aditivo**: agregar job `e2e:smoke` rápido **manteniendo** `full`
+  como gate hasta probar `unión de capas == full`.
+- **First safe PR:** **PR-C3 CI-only** (precedido de validación local `unión == full`).
+- **Validación:** CI verde; suma de specs por capa == 42; renombrar el step.
+- **Rollback:** revertir el workflow al step único.
+
+### P2 — Gobernanza de datos / lifecycle sin formalizar
+
+- **Dominio:** Data governance.
+- **Evidencia:** existen `audit-log.ts`, `study-tracking`, `report-workflow`, `report-access-token`,
+  `BACKUP_RESTORE_ROLLBACK.md`; **no** hay política documentada de retención/exportación/borrado ni
+  auditoría de consistencia de fechas críticas (recepción/entrega).
+- **Por qué importa:** trazabilidad y cumplimiento de datos clínicos.
+- **Riesgo si se ignora:** vacíos de retención/borrado; soporte difícil.
+- **Dirección:** **PR-G1 docs-only** que mapee lifecycle real (estudio→reporte→token→entrega) y
+  marque obligaciones legales como "requires legal/domain confirmation".
+- **Validación:** revisión humana + confirmación de Nico.
+- **Rollback:** docs.
+
+### P2 — Integración/API no contractual
+
+- **Dominio:** Integrations.
+- **Evidencia:** rutas `/api/...` sin `/v1`; Grep `openapi|swagger|webhook|idempoten|apiVersion` en
+  código = 0 real.
+- **Por qué importa:** terceros (clínicas/labs externos) no pueden integrarse de forma estable.
+- **Dirección:** **PR-A1 docs-only** (readiness de API: versionado, errores estándar ya existentes,
+  paginación ya existente vía `list-pagination.ts`, idempotency para mutaciones, webhooks firmados).
+- **Validación:** revisión humana.
+- **Rollback:** docs.
+
+---
+
+## 5. Product and Operational Excellence Audit
+
+**Evidencia.** Dashboards admin y clínica son **command centers operativos reales**: módulos admin
+(`AdminMobilePricingModule`, `AdminMobileSessionsModule`, `AdminMobileUsersModule`,
+`AdminMobileAuditModule`, `AdminMobileHealthModule`, `AdminMobileMaintenanceModule`,
+`AdminMobileCommandModule`) y read-only cards (`AdminSessionsReadOnlyCard`,
+`AdminFailedLoginAlertsReadOnlyCard`, `AdminUsersRolesReadOnlyCard`). Existen contratos no-scroll
+(`usePagedRows.ts`, specs `*-no-scroll-contract`) y la skill de acciones operativas exige
+"backend real o deshabilitado con motivo". Estados loading/empty/error están testeados
+(`frontend-dashboard-empty-states.test.ts`, `*-live-read-contract`, `*-no-mock-fallback`).
+
+| Gap operativo | Evidencia | Mejora de mayor valor | Métrica de éxito |
+| --- | --- | --- | --- |
+| Sin métricas de operación (tiempo de tarea, clicks por acción) | No hay instrumentación cliente | Definir KPIs operativos por módulo admin | Reducción de clicks/tiempo por tarea crítica |
+| Visibilidad de acciones críticas dispersa | Múltiples módulos mobile/desktop | Mapa de "acciones críticas" por superficie (docs) | 100% acciones críticas con feedback real |
+| Eficiencia no-scroll lograda pero no medida | specs no-scroll | Budget de "viewport fit" por densidad 25/50/100 | 0 overflow en datos densos |
+
+**PR sequence (operacional):** PR-D1 docs (valor operativo + mapa de acciones críticas) → (luego,
+fuera de esta auditoría) PRs frontend-only por módulo, cada uno con su contract-test.
+
+---
+
+## 6. Premium UI/UX and Design-System Audit
+
+**Evidencia.** Sistema visual basado en **Radix UI** (10 primitivos) + `class-variance-authority`
+(variants) + **Tailwind 4** + `tailwind-merge` + `tailwindcss-animate`; tema claro/oscuro
+(`lib/theme.ts`, `public/theme-init.js`, `theme-mode.spec.ts`); `lucide-react` para iconografía;
+`gsap` para motion en público (`PublicScrollReveal.tsx`, `useScrollPerspective.ts`); contratos
+no-scroll y stage persistente del hub (memoria de proyecto). Componentes base testeados
+(`frontend-button-component`, `card`, `badge`, `input`).
+
+| Eje | Estado | Acción segura | Requiere auditoría visual enfocada |
+| --- | --- | --- | --- |
+| Tokens de diseño | Implícitos en tailwind/CVA | Documentar catálogo de tokens (docs) | Sí (consistencia cross-módulo) |
+| Densidad / spacing | Resuelto por bloque density (cerrado) | No reabrir | No |
+| Tablas/listas | Custom + `usePagedRows` | Evaluar TanStack Table (ya instalado) si crece complejidad | Sí (antes de cablear) |
+| Dark/light | Consistente y testeado | Mantener | No |
+| Premium polish | Alto en mobile admin | Auditoría visual formal por superficie | Sí |
+
+**Qué sube más la percepción enterprise:** consistencia de **design tokens documentados** +
+microinteracciones de feedback en acciones críticas. **Qué es seguro ya:** documentar tokens
+(docs-only). **First PRs:** PR-D1 docs (design-system map + tokens) → PRs visuales por superficie con
+`visual-contract` E2E. **Validación:** capa `e2e:visual-contract` (estructural) + QA humana.
+
+---
+
+## 7. Frontend Engineering Audit
+
+**Evidencia.** App Router Next 16 / React 19; `frontend/src`: `components`(70), `app`(67), `lib`(16),
+`hooks`(2: `useAuth`, `useScrollPerspective`), `context`(1: `AuthContext`). API client **centralizado**
+(`lib/api.ts`), rutas centralizadas (`lib/routes.ts`), auth de servidor (`lib/dashboard-server-auth.ts`),
+`proxy.ts`. Estado cliente **deliberadamente mínimo** (sin zustand/redux/xstate — Grep = 0).
+
+| Aspecto | Hallazgo | Recomendación |
+| --- | --- | --- |
+| Rendering model | App Router + server components; estado mínimo | Mantener; no introducir store global sin necesidad |
+| Organización rutas/componentes | Clara por dominio (admin/dashboard/public) | OK |
+| Complejidad de estado | Muy baja (1 context) | **No** adoptar Zustand/Redux: no hay evidencia de necesidad |
+| Client/server boundaries | Server-auth en `lib`, UI en componentes | Mantener; auditar fetchs dispersos puntualmente |
+| Code splitting / lazy | **Ausente** (`next/dynamic`=0) | Lazy-load deps pesadas (echarts/gsap) **si se cablean** |
+| Pagination/search/list | Server (`list-pagination.ts`) + `usePagedRows` | OK; virtualización solo si listas no paginadas crecen |
+| Virtualización | Ausente | **Conditional**: solo si aparece lista grande no paginable |
+| Bundle/performance | Sin budget; 3 deps sin uso | PR-DEP1 + PR-P1 |
+| Estados error/loading | Consistentes y testeados | Mantener |
+| Mantenibilidad | Alta (deuda 14 hits) | Mantener |
+
+**Regla aplicada:** no se recomienda ninguna librería de estado nueva — la evidencia muestra estado
+mínimo bien resuelto. El riesgo frontend real es **bundle/performance no medido** + **deps muertas**,
+no la arquitectura.
+
+---
+
+## 8. Backend / API / Data Audit
+
+**Evidencia.** Fastify 5 con separación limpia: `server/lib`(41), `server/routes`(34, todos
+`*.fastify.ts`), `server/middlewares`(7). Un `db-*.ts` por dominio (admin-clinics, admin-sessions,
+audit, logistics, particular, pricing, report-access, report-workflow, study-tracking, etc.).
+Validación con `zod`; `error-handler.ts` central; `permissions.ts`; `audit-log.ts`; `list-pagination.ts`;
+caches dedicadas (`public-pricing-cache`, `sensitive-response-cache`, `logistics-route-plans-cache`);
+`schema-health.ts` + `runtime-timing.ts`. DB: `postgres` + `drizzle-orm`, storage/Supabase vía
+`lib/supabase.ts`. Hashing `argon2`. Build: `esbuild` bundle → `node dist/index.js`.
+
+| Aspecto | Hallazgo | Recomendación (sin rewrite) |
+| --- | --- | --- |
+| Organización API | Rutas finas por dominio | Mantener |
+| Validación | `zod` por endpoint | Mantener; documentar contratos (PR-A1) |
+| Domain modeling | `db-*.ts` por dominio + `lib/*` de negocio | OK |
+| Study/report/token lifecycle | `study-tracking`, `report-workflow`, `report-access-token` | Mapear lifecycle (PR-G1) |
+| DB/storage health | `schema-health`, `schema:verify`, `db-pool-contract.test.ts` | Mantener; vigilar `select('*')`/paginación (audit puntual) |
+| Error handling | `error-handler.ts` + tests no-stack/no-secrets | Fuerte |
+| Background-job candidates | email/PDF/report-workflow síncronos | Documentar candidatos async (PR-A2), no implementar aún |
+| Consistencia API | snake/camel y métodos: requiere verificación puntual | "requires focused API contract audit" |
+| Latency risks | caches presentes; sin medición | Medir endpoints críticos (PR-P1) |
+| Integration readiness | sin OpenAPI/versionado/idempotency | PR-A1 docs |
+
+**Regla aplicada:** **no** se recomienda rewrite de backend. El backend es el activo más maduro; las
+acciones son contractuales/observabilidad, no estructurales.
+
+---
+
+## 9. Security and Session Isolation Audit
+
+**Evidencia (fuerte).**
+
+- **Aislamiento de sesión:** `admin_session_id` (admin) vs `app_session_id` (clínica) +
+  `particular-auth`; middlewares `admin-auth`, `auth`, `clinic-permissions`, `particular-auth`;
+  `session-last-access.ts`; tests `auth-session-boundaries`, `*-session-last-access-contract`.
+- **Superficie pública:** `scripts/security/audit-public-devtools-surface.mjs`
+  (`pnpm security:public-surface`), test `frontend-public-devtools-exposure-contract`.
+- **Headers/cache:** `server/lib/api-response-security.ts` (no-store/nosniff/referrer-policy),
+  `sensitive-response-cache.ts`, tests `backend-api-no-store-cache`, `backend-api-nosniff-responses`,
+  `api-error-no-secrets`, `api-error-no-stack-traces`.
+- **CSP:** `frontend/src/lib/security/csp-policy.ts` + `csp-nonce.ts` + `app/api/security/csp-report`
+  + `frontend-csp-*` tests (nonce, report-only, report-uri, inline-blockers, policy-builder).
+- **CSRF:** `PR-security-csrf-mutating-route-coverage.md` + `middlewares/trusted-origin.ts`.
+- **Rate-limit / anti-enumeración:** `login-rate-limit`, `contact-rate-limit`,
+  `public-professionals-rate-limit`, `public-report-access-rate-limit`,
+  `report-access-token-rate-limit`, `rate-limit-store.ts`.
+- **RBAC:** `docs/security/RBAC_MATRIX.md`, `ENDPOINT_PERMISSION_MATRIX.md`, `permissions.ts`.
+- **Supply-chain:** `pnpm.overrides` (brace-expansion, esbuild, ws, fast-uri, postcss, js-yaml);
+  Dependabot activo (19 PRs).
+
+| Invariante P0 (no debilitar) | Evidencia | Verificación |
+| --- | --- | --- |
+| Admin sin sesión → 404 | `dashboard-auth-redirect.spec.ts` | E2E smoke |
+| Clínica sin sesión → redirect login | idem + `frontend-dashboard-server-401-redirect` | E2E + unit |
+| No mezclar `admin_session_id`/`app_session_id` | middlewares + `auth-session-boundaries` | unit |
+| No exponer hashes/tokens/cookies/signed URLs | `api-error-no-secrets`, audit sanitizado | unit |
+| No cachear privados (SW/API) | PWA skill + `sensitive-response-cache` | contract |
+
+**Focused security audit PRs:** **PR-S1 docs-only** (revisión de invariantes + plan de
+secret-scanning en CI + rotación de sesión) → luego PRs security-only acotados. **Validación:**
+`pnpm security:public-surface`, suite `security-*`/`auth-*`, sin secretos en logs.
+
+**Riesgo residual:** la postura es fuerte pero **no hay secret-scanning automatizado en CI** ni
+revisión periódica anti-enumeración; documentarlo en PR-S1.
+
+---
+
+## 10. Testing, E2E, CI, and Release Engineering Audit
+
+**Evidencia.** `test/` ≈ 400 archivos (unit/integration/contract, `node --test`); `frontend/e2e` =
+42 specs Playwright capeados (#1096): `smoke`(7) + `admin-mobile`(13) + `visual-contract`(11) +
+`public-clinic`(11) = **42 = full**. Contract-tests notables: `frontend-ci-workflow`,
+`backend-ci-workflow`, `fastify-only-guardrail`, `audit-suite-completeness`,
+`api-request-id-observability-contract`, `db-pool-contract`. CI: `.github/workflows/backend-ci.yml`
+(audit/migrate/typecheck/test/build con Postgres) + `frontend-ci.yml` (lint/typecheck/build/
+security:public-surface/E2E). `build-info` route + `smoke:staging` + `BACKUP_RESTORE_ROLLBACK` +
+`review-governance.md`.
+
+| Aspecto | Estado | Recomendación |
+| --- | --- | --- |
+| Balance unit/integration/E2E | Muy bueno (400 + 42) | Mantener |
+| Capas E2E post-#1096 | Scripts listos; CI no las usa | PR-C3 CI-only aditivo |
+| ¿PR-C3 CI-only listo? | **Casi** — falta validar localmente `unión == full` | Validar conteo por capa primero |
+| Naming CI | Step "smoke" corre full → engañoso | Renombrar en PR-C3 |
+| Smoke vs full | Definido en scripts; no en CI | Separar gate barato + full |
+| Tests visuales | Estructurales (no pixel) | OK; no convertir screenshots a baseline |
+| Tests a11y | `dashboard-accessibility-keyboard` | Ampliar con axe (futuro) |
+| Tests seguridad | Amplios (`security-*`, `csp-*`, `no-secrets`) | Mantener |
+| Flake risk | `fullyParallel` + fixture mock + `next dev` | Tratar reproduciendo, no relajando |
+| Artefactos/screenshots | Evidencia, no baseline versionado | Mantener |
+| Release/rollback | Docs + build-info + staging smoke | Formalizar checklist (PR-R1) |
+
+**¿Es seguro PR-C3 CI-only ahora?** **Sí, condicionado:** primero validar localmente que la suma de
+specs por capa == `e2e:full` (42) sin huérfanos ni duplicados; luego CI-only **aditivo** (smoke
+rápido + full como gate hasta probar la unión). **Qué validar antes:** conteo por capa, que
+`dashboard-auth-redirect` (seguridad) quede siempre en gate, y que Dependabot siga validando contra
+suite estable.
+
+**PR sequence:** validación local (no-PR) → **PR-C3 CI-only** → (luego, otro bloque) PR-C4
+full→nightly si corresponde.
+
+---
+
+## 11. Observability and Production Diagnostics Audit
+
+**Evidencia.** `server/lib/logger.ts` = `console.log/warn/error` con prefijos `[INFO]/[WARN]/[ERROR]`
++ `serializeError` (no JSON, sin campos estructurados); `api-request-id.ts` (correlación request-id),
+`middlewares/request-logger.ts`, `runtime-timing.ts`, `admin-system-health.fastify.ts`,
+`admin-system-schema-health.fastify.ts`, `schema-health.ts`, `app/api/build-info/route.ts`. **Sin**
+Sentry/OTel/métricas agregadas/alerting (Grep = 0).
+
+| Capacidad | Estado | Baseline mínimo (sin deps) | Opcional futuro |
+| --- | --- | --- | --- |
+| Logs | console plano | **Estructurar a JSON** (level, ts, request-id, ruta, status) | Pino/aggregator |
+| Métricas | ausente | Contadores básicos en health | OTel metrics |
+| Tracing | ausente | request-id ya correlaciona | OTel traces |
+| Error monitoring FE | ausente | CSP-report ya captura violaciones | Sentry FE |
+| Error monitoring BE | `error-handler` + console | Logger estructurado de errores | Sentry BE |
+| Health checks | presentes | Mantener + documentar | uptime externo |
+| Job monitoring | n/a (sin jobs) | — | con cola futura |
+| Alerting | ausente | Definir umbrales en docs | PagerDuty/etc. |
+| SLO/SLA | ausente | Definir SLOs objetivo (docs) | dashboards |
+| Incident diagnostics | manual | Runbook + request-id | tracing |
+
+**Primeros pasos sin dependencias:** (1) **PR-R1 docs-only** — baseline de observabilidad + SLOs
+objetivo + runbook de diagnóstico usando request-id existente. (2) **PR-R2 backend-only** — logger
+estructurado JSON (1 archivo + test de shape), consolidando `console.*`. Sentry/OTel quedan como
+**Recommended later / Conditional**, nunca como primer paso.
+
+---
+
+## 12. Performance Budget Audit
+
+> Budgets **propuestos** (no medidos aún). "Evidencia actual" = lo que el repo permite observar hoy.
+
+| Métrica | Evidencia actual | Falta medir | Budget propuesto | Primer PR |
+| --- | --- | --- | --- | --- |
+| Admin dashboard load | sin medición | LCP/TTI admin | LCP < 2.5s (desktop), < 3.5s (mobile mid) | PR-P2 measure |
+| Clinic dashboard load | sin medición | LCP/TTI clínica | LCP < 2.5s / < 3.5s | PR-P2 |
+| Public report/token page | sin medición | LCP público | LCP < 2.0s | PR-P2 |
+| API latency (críticos: auth, list, report) | `runtime-timing.ts` existe (no agregado) | p95 por endpoint | p95 < 400ms (lecturas), < 800ms (escrituras) | PR-P3 backend metric |
+| Search response | server pagination | latencia búsqueda | p95 < 500ms | PR-P3 |
+| CI duration | sin reporte | tiempo por job | full E2E < 12min; smoke < 4min | PR-C3 |
+| E2E layer duration | capas en scripts | tiempo por capa | smoke < 4min; admin-mobile < 6min | PR-C3 |
+| Bundle / initial JS | Next reporta en build | tamaño por ruta | initial JS < 200KB gzip (público) | PR-P1/P2 |
+| LCP / INP / CLS | sin medición | web-vitals | LCP<2.5s, INP<200ms, CLS<0.1 | PR-P2 |
+| Mobile no-scroll perf | specs estructurales | jank/frame budget | 0 overflow; transición < 100ms | PR-P2 |
+
+**Acción:** **PR-P1 docs-only** fija estos budgets como objetivo; **PR-P2** mide (web-vitals client
+mínimo + lectura del build output de Next, sin deps pesadas); **PR-P3** agrega `runtime-timing`
+agregado por endpoint. Sin budget no hay gate; con budget documentado, cada PR futuro se compara.
+
+---
+
+## 13. Integration Readiness Audit
+
+**Evidencia.** API interna `/api/...` consumida por el propio frontend (no `/v1`); errores
+estandarizados (`api-error.ts`, `error-handler.ts`, request-id en respuestas); paginación
+(`list-pagination.ts`); **sin** OpenAPI/Swagger, versionado, webhooks ni idempotency (Grep = 0).
+
+| Capacidad | Estado | Recomendación | Condición para adoptar |
+| --- | --- | --- | --- |
+| API-first readiness | parcial (interna sólida) | Documentar contratos antes de exponer | Si hay consumidor externo real |
+| OpenAPI/Swagger | ausente | **Recommended later** (generar desde zod) | Cuando haya integradores |
+| API versioning | ausente | Definir estrategia `/v1` antes de exponer | Pre-exposición externa |
+| Errores estándar | presentes | Mantener; documentar | — |
+| Paginación | presente | Mantener; documentar contrato | — |
+| Idempotency keys | ausente | **Conditional** para mutaciones expuestas | Si terceros reintentan |
+| Webhooks | ausente | **Recommended later** con firma HMAC | Si clínicas/labs consumen eventos |
+| Firmas de webhook | ausente | Junto con webhooks | — |
+| Retries | n/a | Con webhooks/jobs | — |
+| SDK | ausente | Solo tras OpenAPI estable | — |
+| Integración clínica/lab externa | potencial comercial | Roadmap Fase 6 | Demanda concreta |
+
+**Roadmap de integración:** PR-A1 docs (readiness + contratos) → (Fase 6) versionado → OpenAPI desde
+zod → webhooks firmados → SDK. **No recomendado aún:** webhooks/SDK sin consumidor externo probado.
+
+---
+
+## 14. Data Governance and Compliance Readiness Audit
+
+**Evidencia.** Audit trails (`audit-log.ts`, `db-audit.ts`, `clinic-audit`, `particular-audit`,
+`admin-audit`); lifecycle de estudio/reporte (`study-tracking`, `report-workflow`,
+`report-access-token`, `token-study-tracking`); `lab-received-date-delivery-estimate.md`
+(fechas críticas); `docs/ops/BACKUP_RESTORE_ROLLBACK.md`; `docs/notes/PENDIENTE_NORMALIZACION_CLINICS.md`
+(deuda de datos pendiente).
+
+| Aspecto | Estado | Recomendación |
+| --- | --- | --- |
+| Trazabilidad estudio→reporte→entrega | parcial (tracking existe) | Mapear lifecycle completo (PR-G1) |
+| Consistencia de fechas críticas | doc de delivery estimate | Auditar consistencia (focused audit) |
+| Historial de auditoría | presente y sanitizado | Mantener |
+| Retención | **no documentada** | Definir política (PR-G1) |
+| Backups/restore | doc presente | Validar restore real (staging) |
+| Borrado/exportación | no formalizado | Definir (requires legal) |
+| Logs de acceso | audit presente | Verificar cobertura de accesos a reportes |
+| Fronteras de privacidad | sanitización + no-secrets | Documentar clasificación de datos |
+| Cumplimiento | **desconocido** | **requires legal/domain confirmation** |
+
+**Regla aplicada:** no se inventan obligaciones legales. Todo lo regulatorio se marca
+"requires legal/domain confirmation". **First PR:** PR-G1 docs-only (lifecycle + retención propuesta).
+
+---
+
+## 15. Technology Recommendation Matrix
+
+> Regla: no recomendar por "moderno". Cada decisión exige evidencia y un consumidor real.
+
+| Tecnología/Patrón | Evidencia actual en repo | Valor enterprise | Riesgo/complejidad | Recomendación | Condición para adoptar | Alternativa más simple | Primer PR seguro |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **Zustand** | 0 (estado cliente mínimo, 1 context) | Bajo | Bajo | **Not recommended now** | Estado cliente compartido complejo real | `useState`/Context actual | — |
+| **Redux Toolkit** | 0 | Bajo | Medio | **Not recommended now** | Múltiples flujos globales con time-travel | Context + React Query | — |
+| **XState** | 0 | Bajo-medio | Medio | **Not recommended now** | Máquinas de estado críticas (wizard report) | Reducer local | — |
+| **TanStack Table** | **instalado, sin uso en `src`** | Medio-alto | Bajo-medio | **Conditional** | Tablas admin con sort/filtros server complejos | `usePagedRows` actual | PR-DEP1 (decidir cablear/retirar) |
+| **react-window / virtualization** | 0 | Medio | Medio | **Recommended later / Conditional** | Lista no paginable > ~1k filas | Server pagination actual | — |
+| **Recharts / Chart.js / D3** | 0 | Medio | Medio | **Not recommended now** | — | **ECharts ya instalado** | — |
+| **ECharts** (ya en deps) | **instalado, sin uso en `src`** | Medio-alto | Medio | **Conditional** | Dashboards con gráficos reales | Tablas/métricas actuales | PR-DEP1 (cablear o retirar) |
+| **WebGL dashboards** | 0 | Bajo | Alto | **Not recommended now** | Visualización masiva (>100k puntos) | ECharts canvas | — |
+| **WebSockets / Supabase Realtime** | 0 (supabase-js sí, realtime no) | Medio | Medio-alto | **Not recommended now** | Colaboración/estado vivo con valor concreto | Polling/refetch | — |
+| **CRDTs / Yjs / Automerge** | 0 | Bajo | Muy alto | **Not recommended now** | Edición concurrente real | Bloqueo optimista | — |
+| **BullMQ / colas / async jobs** | 0 (email/PDF síncronos) | Medio-alto | Medio | **Recommended later** | Trabajos largos que bloquean request | Procesamiento síncrono actual | PR-A2 docs (candidatos) |
+| **OpenAPI / Swagger** | 0 | Alto (B2B) | Medio | **Recommended later** | Integradores externos | Contratos `zod` + docs | PR-A1 docs |
+| **Webhooks** | 0 | Medio-alto (B2B) | Medio | **Recommended later** | Consumidor externo de eventos | — | PR-A1 docs |
+| **Service Worker / IndexedDB** | **SW presente**; IndexedDB 0 | Medio | Medio | **Conditional** (SW ya OK) | Offline de datos privados con política de cache | SW público actual | PR-PWA1 docs (audit cache) |
+| **OpenTelemetry / Sentry** | 0 | Alto | Medio | **Recommended later** | Tras logger estructurado | request-id + logs JSON | PR-R2 (logger) primero |
+| **Feature flags** | 0 | Medio | Bajo-medio | **Conditional** | Rollouts graduales de features grandes | Deploy + revert | PR-R1 docs (evaluar) |
+| **Micro-frontends / Module Federation** | 0 (monorepo único) | Bajo | Muy alto | **Not recommended now** | Independencia de equipos/módulos real | App Router actual | — |
+| **CSP / security headers** | **presente y fuerte** | Alto | Bajo | **Already adopted** | — | — | mantener (PR-S1 review) |
+| **RBAC / ABAC** | **RBAC presente** (`permissions.ts` + matrices) | Alto | Medio | **Already adopted (RBAC)**; ABAC **later** | Reglas por atributo complejas | RBAC actual | PR-S1 docs |
+| **API versioning** | 0 | Medio-alto | Bajo | **Recommended later** | Pre-exposición externa | `/api` interno | PR-A1 docs |
+| **Idempotency keys** | 0 | Medio | Bajo-medio | **Conditional** | Mutaciones expuestas/reintentos | — | PR-A1 docs |
+| **Structured logging** | console plano | Alto | Bajo | **Recommended now** | — | — | **PR-R2 backend-only** |
+
+**Conclusión del matrix:** la única adopción **"now"** es **structured logging** (sin dep nueva). El
+resto es "later/conditional/not-now". Y hay **3 deps ya instaladas sin consumidor** (react-query,
+react-table, echarts) que deben resolverse (cablear o retirar) antes de hablar de "adoptar" nada.
+
+---
+
+## 16. Enterprise Implementation Roadmap
+
+> Fases ordenadas por dependencia. Cada fase = PRs chicos, un eje, con rollback. Git lo ejecuta Nico.
+
+### Phase 0 — Repository & Source-of-Truth Foundation
+- **Objetivo:** índice de auditorías, mapa de fuentes de verdad, disciplina de closeout, prompt-packs.
+- **Valor:** reduce consumo de IA y re-descubrimiento; base para todo lo demás.
+- **Prerrequisitos:** ninguno.
+- **PRs:** PR-O1 (índice), PR-O2 (mapa SoT), PR-O3 (clasificación histórica) — todos docs-only.
+- **Validación:** `git diff --check`, lectura humana.
+- **Rollback:** borrar archivos.
+- **DoD:** existe `docs/audit/README.md` + `docs/SOURCES_OF_TRUTH.md`; histórico marcado.
+
+### Phase 1 — Testing & CI Enterprise Gate
+- **Objetivo:** validar `unión de capas == e2e:full`; PR-C3 CI-only aditivo; separar smoke/full.
+- **Valor:** feedback rápido sin pérdida de cobertura.
+- **Prerrequisitos:** Phase 0 (para no reauditar) + validación local de conteo por capa.
+- **PRs:** validación local (no-PR) → PR-C3 CI-only.
+- **Validación:** suma specs por capa == 42; CI verde; seguridad siempre en gate.
+- **Rollback:** revertir workflow al step único.
+- **DoD:** smoke como gate rápido + full como red; step renombrado.
+
+### Phase 2 — Security & Session Invariants
+- **Objetivo:** confirmar invariantes, plan de secret-scanning en CI, rotación de sesión, anti-enumeración.
+- **Valor:** mantener la frontera más crítica del producto.
+- **Prerrequisitos:** Phase 0.
+- **PRs:** PR-S1 docs (audit) → PRs security-only acotados.
+- **Validación:** `security:public-surface`, suite `security-*`/`auth-*`.
+- **Rollback:** por PR (acotado).
+- **DoD:** invariantes documentados + verificados; plan de secret-scanning.
+
+### Phase 3 — Premium Dashboard Operational Value
+- **Objetivo:** pulido enterprise admin/clínica, densidad no-scroll, design-system, mobile.
+- **Valor:** percepción premium + eficiencia operativa.
+- **Prerrequisitos:** Phase 0/1 (E2E visual-contract estable).
+- **PRs:** PR-D1 docs (valor + tokens) → PRs frontend-only por superficie con `visual-contract`.
+- **Validación:** `e2e:visual-contract` + QA humana.
+- **Rollback:** por PR.
+- **DoD:** tokens documentados; acciones críticas con feedback real.
+
+### Phase 4 — Performance Budgets & Scalability
+- **Objetivo:** budgets medibles; search/pagination/list; bundle/route loading; API latency.
+- **Valor:** velocidad percibida + escalabilidad controlada.
+- **Prerrequisitos:** Phase 1 (CI estable) + PR-DEP1 (deps resueltas).
+- **PRs:** PR-P1 docs (budgets) → PR-P2 (medición) → PR-P3 (latency) → lazy-load si se cablean deps.
+- **Validación:** comparación build size + web-vitals vs budget.
+- **Rollback:** medición/lazy son aditivos.
+- **DoD:** budgets en repo + medición en CI/local.
+
+### Phase 5 — Observability & Release Engineering
+- **Objetivo:** logger estructurado, diagnósticos de producción, checklist rollback/staging/release.
+- **Valor:** soporte productivo y MTTR bajo.
+- **Prerrequisitos:** Phase 0.
+- **PRs:** PR-R1 docs (baseline + SLOs + runbook) → PR-R2 backend-only (logger JSON) → (opcional) Sentry/OTel.
+- **Validación:** test de shape de log; sin secretos; health checks.
+- **Rollback:** revertir `logger.ts`.
+- **DoD:** logs estructurados + runbook + SLOs objetivo.
+
+### Phase 6 — API / Integration Readiness
+- **Objetivo:** gobernanza de API, versionado, webhooks firmados, contratos.
+- **Valor:** habilita integración B2B.
+- **Prerrequisitos:** Phase 2/5; demanda externa real.
+- **PRs:** PR-A1 docs (readiness) → versionado → OpenAPI desde zod → webhooks.
+- **Validación:** contract-tests; compatibilidad.
+- **Rollback:** versionado aditivo.
+- **DoD:** contrato externo estable + versionado.
+
+### Phase 7 — Advanced Enterprise Capabilities
+- **Objetivo:** realtime/async/scoring/PWA-offline **solo si se justifican**.
+- **Valor:** condicional al caso de uso.
+- **Prerrequisitos:** Fases previas + evidencia de demanda.
+- **PRs:** por capacidad, cada uno con PRD corto.
+- **Validación:** por capacidad.
+- **Rollback:** por capacidad.
+- **DoD:** cada capacidad con consumidor real y guardrails (no privados en cache offline, no realtime sin valor).
+
+---
+
+## 17. Top 25 Enterprise Value Opportunities
+
+| # | Oportunidad | Dominio | Tipo de valor | Impacto esperado | Complejidad | Riesgo | Prioridad | Primer PR |
+| --: | --- | --- | --- | --- | --- | --- | :--: | --- |
+| 1 | Índice de auditorías | Docs/SoT | DX | Alto | Baja | Bajo | P0 | PR-O1 docs |
+| 2 | Mapa de fuentes de verdad | Docs/SoT | DX | Alto | Baja | Bajo | P0 | PR-O2 docs |
+| 3 | Logger estructurado JSON | Observability | reliability | Alto | Baja | Bajo | P0/P1 | PR-R2 backend |
+| 4 | PR-C3 CI-only (capas E2E) | CI | reliability/DX | Alto | Baja-media | Medio | P1 | PR-C3 CI |
+| 5 | Auditoría de deps sin uso | Deps | reliability/perf | Medio-alto | Baja | Bajo | P1 | PR-DEP1 docs |
+| 6 | Budgets de performance | Perf | performance | Alto | Baja | Bajo | P1 | PR-P1 docs |
+| 7 | Medición web-vitals mínima | Perf | performance | Alto | Media | Bajo | P1 | PR-P2 |
+| 8 | Baseline observabilidad + SLOs | Observability | reliability | Alto | Baja | Bajo | P1 | PR-R1 docs |
+| 9 | Security/session audit | Security | security | Alto | Baja | Bajo | P1 | PR-S1 docs |
+| 10 | Secret-scanning en CI (plan) | Security | security | Medio-alto | Baja | Bajo | P1 | PR-S1 docs |
+| 11 | Lazy-load deps pesadas (si se cablean) | Frontend | performance | Medio | Media | Medio | P2 | post PR-DEP1 |
+| 12 | Design tokens documentados | UI/UX | visual | Medio-alto | Baja | Bajo | P2 | PR-D1 docs |
+| 13 | Mapa de acciones críticas admin | Product ops | operational | Medio-alto | Baja | Bajo | P2 | PR-D1 docs |
+| 14 | API readiness (versionado/errores) | Integrations | commercial | Medio-alto | Media | Medio | P2 | PR-A1 docs |
+| 15 | Lifecycle de datos + retención | Governance | compliance | Medio-alto | Media | Medio | P2 | PR-G1 docs |
+| 16 | Latencia agregada por endpoint | Perf/Backend | performance | Medio | Media | Medio | P2 | PR-P3 backend |
+| 17 | Release checklist + rollback | Release | reliability | Medio | Baja | Bajo | P2 | PR-R1 docs |
+| 18 | Auditoría a11y formal (axe) | A11y | operational/legal | Medio | Media | Bajo | P2 | PR-A11y docs |
+| 19 | Auditoría política cache PWA | PWA | security | Medio | Baja | Bajo | P3 | PR-PWA1 docs |
+| 20 | Consolidar `console.*` tras logger | Observability | reliability | Medio | Media | Bajo | P2 | post PR-R2 |
+| 21 | Candidatos de jobs async (doc) | Async | scalability | Medio | Baja | Bajo | P3 | PR-A2 docs |
+| 22 | OpenAPI desde zod | Integrations | commercial | Medio | Media-alta | Medio | P3 | post PR-A1 |
+| 23 | Feature flags (evaluación) | Release | DX | Bajo-medio | Media | Medio | P3 | PR-R1 docs |
+| 24 | Webhooks firmados | Integrations | commercial | Medio | Media-alta | Medio | P3 | post PR-A1 |
+| 25 | Cierre de bloques dashboard premium/legacy | Docs/SoT | DX | Bajo-medio | Baja | Bajo | P2 | PR-O3 docs |
+
+---
+
+## 18. Recommended PR Sequence
+
+> Solo PRs chicos. Cada uno: tipo, objetivo, scope permitido, no-scope, validación, rollback, dependencia.
+
+| PR | Tipo | Objetivo | Scope permitido | No-scope | Validación | Rollback | Dependencia |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **PR-O1** | docs-only | Índice de auditorías (`docs/audit/README.md`) | crear 1 archivo | mover/editar audits | `git diff --check`, lectura | borrar archivo | ninguna |
+| **PR-O2** | docs-only | Mapa de fuentes de verdad (`docs/SOURCES_OF_TRUTH.md`) | crear 1 archivo (+1 línea AGENTS.md con OK de Nico) | consolidar carpetas | lectura humana | borrar/revertir | PR-O1 |
+| **PR-O3** | docs-only | Clasificar histórico/superseded (banners) | editar cabeceras | mover/renombrar/borrar | `git diff --check` + no-lectura por test | revertir | PR-O1/O2 |
+| **PR-DEP1** | docs-only | Auditoría deps usadas vs no usadas (react-query/table/echarts) | crear 1 doc | tocar `package.json` | `git grep` imports, build size | borrar doc | ninguna |
+| **PR-C3** | CI-only | Usar capas E2E sin pérdida de cobertura (smoke gate + full) | `.github/workflows/frontend-ci.yml` | tocar specs/scripts/Playwright config | unión == 42; CI verde; renombrar step | revertir workflow | validación local previa |
+| **PR-S1** | docs-only | Auditoría seguridad/aislamiento + plan secret-scanning | crear 1 doc | tocar auth/middlewares | revisión + `security:public-surface` | borrar doc | PR-O1 |
+| **PR-D1** | docs-only | Valor operativo dashboard + design tokens map | crear 1 doc | tocar `frontend/src` | revisión humana | borrar doc | PR-O1 |
+| **PR-P1** | docs-only | Budgets de performance propuestos | crear 1 doc | medir/instrumentar | revisión humana | borrar doc | ninguna |
+| **PR-R1** | docs-only | Baseline observabilidad/SLO + release/rollback checklist | crear 1 doc | tocar logger/CI | revisión humana | borrar doc | PR-O1 |
+| **PR-A1** | docs-only | Readiness API/webhooks/versionado/idempotency | crear 1 doc | tocar rutas | revisión humana | borrar doc | PR-O1 |
+| **PR-G1** | docs-only | Gobernanza de datos/lifecycle/retención | crear 1 doc (legal flags) | inventar obligaciones legales | revisión + confirmación Nico | borrar doc | PR-O1 |
+| **PR-R2** | backend-only | Logger estructurado JSON (post PR-R1) | `server/lib/logger.ts` + su test | tocar otras capas | test de shape, `pnpm test`, sin secretos | revertir 1 archivo | PR-R1 |
+| **PR-P2** | frontend-only | Medición web-vitals mínima (post PR-P1) | medición no intrusiva | budgets nuevos | build size + vitals vs budget | revertir medición | PR-P1 |
+
+**Orden recomendado:** PR-O1 → PR-O2 → PR-O3 → PR-DEP1 → (validación local capas) → PR-C3 → PR-S1 /
+PR-R1 / PR-P1 / PR-A1 / PR-D1 / PR-G1 (docs en paralelo) → PR-R2 / PR-P2 (implementación acotada).
+
+---
+
+## 19. Enterprise Guardrails
+
+- **No reescrituras grandes.** Backend y frontend son activos maduros; instrumentar, no reconstruir.
+- **No adoptar dependencias sin gap probado.** Y resolver primero las 3 ya instaladas sin uso.
+- **No mezclar visual + seguridad + CI en un PR.** Un eje por PR.
+- **No mezclar backend + frontend** salvo PR contract-only explícito.
+- **No tocar CI sin validar scripts localmente** (unión de capas == `e2e:full`).
+- **No mover E2E** antes de estabilizar capas + CI.
+- **No riesgo de cache público/privado:** SW no cachea `/dashboard`, `/dashboard/admin`, `/api`
+  privadas, auth, reports, downloads, signed URLs, ni respuestas con `Set-Cookie`.
+- **No debilitar fronteras de sesión** (`admin_session_id` vs `app_session_id`).
+- **No mezclar Dependabot con feature work.**
+- **No PWA/offline para datos privados** sin política de cache resuelta y auditada.
+- **No realtime** salvo valor de usuario concreto y medible.
+- **No micro-frontends** antes de independencia real de equipos/módulos.
+- **No CRDTs** sin edición concurrente real.
+- **No WebGL** sin visualización masiva.
+- **No exponer secretos/tokens/hashes/cookies/signed URLs** en UI, logs, fixtures, screenshots.
+- **Siempre definir rollback** y mantener cada PR reversible.
+- **Git lo ejecuta Nico** (no `add`/`commit`/`push`/PR/merge por la IA); **no comandos con `exit`**.
+
+---
+
+## 20. Final Recommendation
+
+1. **¿VETNEB es hoy enterprise-grade?** **No todavía**, pero está cerca en los cimientos. Nivel
+   "estable, no enterprise" (≈2.7/5). Fuerte en seguridad/separación/testing; débil en
+   observabilidad, performance budgets, integración y jobs async.
+
+2. **Camino más rápido y seguro a enterprise-grade:** instrumentar y formalizar de forma **aditiva**,
+   no reescribir. Fase 0 (SoT) → Fase 1 (CI gate) → Fase 5 (observabilidad) → Fase 4 (performance).
+
+3. **Qué hacer primero:** **Fase 0** (índice + mapa de fuentes de verdad) y validación local de las
+   capas E2E para habilitar **PR-C3**.
+
+4. **Qué NO hacer aún:** realtime, CRDTs, WebGL, micro-frontends, colas, PWA-offline de privados,
+   OpenAPI/webhooks sin consumidor, y **adoptar cualquier dependencia nueva** (resolver antes las 3
+   instaladas sin uso).
+
+5. **Próximo PR exacto:** **PR-O1 docs-only** — `docs/audit/README.md` (índice de auditorías
+   vigentes con estado por archivo). Cero riesgo; desbloquea la secuencia.
+
+6. **Qué auditoría debe seguir:** tras Fase 0, **PR-S1 docs (security/session)** y **PR-R1 docs
+   (observabilidad/release)** como auditorías de dominio único, antes de cualquier implementación.
+
+7. **Área que más sube el valor:** **observabilidad** (logger estructurado + baseline) — convierte un
+   producto "que funciona" en uno "operable y soportable".
+
+8. **Área que más reduce el riesgo:** **CI gate por capas (PR-C3)** + **seguridad (PR-S1)** —
+   protegen cobertura e invariantes críticos sin tocar arquitectura.
+
+9. **Área que más mejora la calidad premium percibida:** **design tokens documentados + pulido
+   operativo del dashboard** (PR-D1) sobre los contratos no-scroll ya logrados.
+
+10. **Área que más mejora la madurez de ingeniería:** **fuentes de verdad + budgets de performance**
+    (Fase 0 + Fase 4) — instalan medición y trazabilidad como práctica permanente.
+
+---
+
+## Appendix — Evidence Traceability Map
+
+> Mapa claim → archivo/símbolo exacto, para que auditorías futuras salten directo a la evidencia sin
+> re-escanear. Reduce consumo y evita reabrir lo ya verificado (alineado con ISO/IEC 14598:
+> evaluación trazable).
+
+| Claim de la auditoría | Evidencia exacta (archivo / símbolo) | Verificación read-only usada |
+| --- | --- | --- |
+| Backend Fastify separado por capas | `server/lib`(41), `server/routes`(34, `*.fastify.ts`), `server/middlewares`(7) | `git ls-files server/**` |
+| Un acceso a datos por dominio | `server/db-admin-clinics.ts`, `db-admin-sessions.ts`, `db-audit.ts`, `db-pricing.ts`, `db-report-workflow.ts`, `db-study-tracking.ts`, … | `git ls-files server/*` |
+| Rate-limit por superficie | `server/lib/login-rate-limit.ts`, `contact-rate-limit.ts`, `public-professionals-rate-limit.ts`, `public-report-access-rate-limit.ts`, `report-access-token-rate-limit.ts`, `rate-limit-store.ts` | `git ls-files` + Grep |
+| Headers de respuesta endurecidos | `server/lib/api-response-security.ts`, `sensitive-response-cache.ts`; tests `backend-api-no-store-cache`, `backend-api-nosniff-responses` | Grep server (52/16) |
+| CSP nonce + report | `frontend/src/lib/security/csp-policy.ts`, `csp-nonce.ts`, `frontend/src/app/api/security/csp-report/route.ts`; tests `frontend-csp-*` | `git ls-files frontend/src/lib/**` |
+| CSRF / origen confiable | `server/middlewares/trusted-origin.ts`; `docs/pr-history/PR-security-csrf-mutating-route-coverage.md` | `git ls-files` |
+| Aislamiento de sesión | `server/middlewares/{admin-auth,auth,clinic-permissions,particular-auth}.ts`; `lib/session-last-access.ts`; `app_session_id`/`admin_session_id` | Grep server |
+| RBAC | `server/lib/permissions.ts`; `docs/security/RBAC_MATRIX.md`, `ENDPOINT_PERMISSION_MATRIX.md` | `git ls-files docs/security/*` |
+| Logger NO estructurado | `server/lib/logger.ts` (`console.log('[INFO]', …)`, 22 líneas) | Read completo |
+| Request-id / health / timing | `server/lib/api-request-id.ts`, `middlewares/request-logger.ts`, `lib/runtime-timing.ts`, `routes/admin-system-health.fastify.ts`, `lib/schema-health.ts`, `frontend/src/app/api/build-info/route.ts` | Grep server (132/38) |
+| Sin Sentry/OTel/OpenAPI/webhooks/idempotency/realtime | Grep en `frontend/src` y `server` = 0 (real); menciones solo en `docs/**` | Grep dirigido |
+| Capas E2E (#1096) | `frontend/package.json` scripts `e2e:smoke/admin-mobile/visual-contract/public-clinic/full` (7+13+11+11=42) | Read `frontend/package.json` |
+| Deps instaladas sin uso | `frontend/package.json` deps `@tanstack/react-query`, `@tanstack/react-table`, `echarts`, `echarts-for-react`; Grep uso en `src` → solo `gsap` (`PublicScrollReveal.tsx`) | Read + Grep |
+| Estado cliente mínimo | `frontend/src/context/AuthContext.tsx`, `hooks/useAuth.ts`; sin zustand/redux/xstate (Grep=0) | Grep frontend/src |
+| API client centralizado | `frontend/src/lib/api.ts`, `lib/routes.ts`, `lib/api-error.ts`, `lib/dashboard-server-auth.ts` | `git ls-files frontend/src/lib/**` |
+| PWA segura | `frontend/public/sw.js`, `frontend/src/app/manifest.ts`, ruta `app/offline`, iconos maskable 192/512, `components/pwa/PwaServiceWorkerRegistrar.tsx` | `git ls-files frontend/public/*` |
+| Deuda técnica baja | TODO/FIXME/as any/console.log/ts-ignore = 14 hits / 14 archivos | Grep frontend/src |
+| Supply-chain gestionado | `package.json` → `pnpm.overrides` (brace-expansion, esbuild, ws, fast-uri, postcss, js-yaml); Dependabot #1018–#1038 | Read + `gh pr list` |
+| Backups/rollback documentados | `docs/ops/BACKUP_RESTORE_ROLLBACK.md`, `docs/ops/CI_PR_CHECKS_RUNBOOK.md`, `docs/review-governance.md` | `git ls-files docs/ops/*` |
+| Lifecycle de datos | `server/lib/study-tracking.ts`, `report-status.ts`, `report-access-token.ts`, `token-study-tracking.ts`; `docs/implementation/lab-received-date-delivery-estimate.md` | `git ls-files` |
+| Deuda de datos pendiente | `docs/notes/PENDIENTE_NORMALIZACION_CLINICS.md`, `docs/notes/todo.md` | `git ls-files docs/notes/*` |
+
+> Áreas marcadas **"requires focused audit"** (no expandidas aquí): consistencia camel/snake y
+> métodos HTTP por endpoint; uso de `select('*')`/índices en `db-*.ts`; consistencia de fechas
+> críticas estudio→entrega; cobertura a11y con axe. Cada una merece su propia auditoría de dominio
+> único con archivo de salida propio.
+
+---
+
+## Final validation
+
+```powershell
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git diff --check
+```
+
+**Resultado esperado** (esta auditoría solo agrega un archivo **untracked**):
+
+- `git status --short --untracked-files=all` → `?? docs/audit/repository-operational-ordering-audit.md`
+  y `?? docs/audit/vetneb-enterprise-engineering-readiness-audit.md`
+- `git diff --name-only` → vacío (sin archivos tracked modificados)
+- `git diff --stat` → vacío
+- `git diff --check` → limpio
+
+> Los comandos los ejecuta Nico manualmente. Esta auditoría **no** ejecuta `git add/commit/push`,
+> `gh pr create/merge` ni comandos con `exit`.

--- a/docs/audit/vetneb-extreme-multinational-enterprise-readiness-audit.md
+++ b/docs/audit/vetneb-extreme-multinational-enterprise-readiness-audit.md
@@ -1,0 +1,598 @@
+# VETNEB Extreme Multinational Enterprise Readiness — Audit
+
+> **docs-only · auditoría de segundo nivel.** Este documento audita y critica
+> `docs/audit/vetneb-enterprise-engineering-readiness-audit.md` y lo eleva a un estándar de
+> **empresa multinacional extrema**. **No** modifica código productivo, `frontend/src`, `frontend/e2e`,
+> `server`/backend, `test`, `.github/workflows`, `package.json`, `frontend/package.json`,
+> `pnpm-lock.yaml`, Playwright config, `scripts`, `drizzle`/migraciones, deps, lockfiles, CI,
+> screenshots ni generados. No mueve, renombra ni borra archivos. No re-audita el repo desde cero:
+> solo verifica afirmaciones de alto riesgo. Cada hallazgo se ata a un PR chico o a una auditoría
+> enfocada posterior.
+>
+> Skills VETNEB aplicadas (declaradas, ya cargadas en esta sesión): briefing-planificación,
+> staff-senior-full-stack, web-end-to-end-global, security-production-invariants,
+> admin-dashboard-operational-actions, production-web-optimization-engineer, pwa-end-to-end,
+> lanzamiento-mantenimiento, bugs-errores-optimización-rutas, protocolos-comunicación. Prevalece el
+> Protocolo Maestro VETNEB y el flujo Git manual de Nico.
+
+---
+
+## 1. Executive Summary
+
+**Calidad de la auditoría previa: alta, pero de alcance "enterprise SaaS", no "multinacional".** El
+`vetneb-enterprise-engineering-readiness-audit.md` es un documento sólido: evidencia trazable,
+scorecard de 20 dominios, matriz de tecnología con disciplina "not recommended now", secuencia de
+PRs con rollback y apéndice de trazabilidad. Como diagnóstico de **baseline de ingeniería SaaS** es
+correcto y accionable.
+
+**¿El 2.7/5 es exacto?** Para la rúbrica que usó (5 = "enterprise-grade"), **sí, es razonable**.
+Re-medido contra la rúbrica **multinacional** más estricta de este documento (5 = multinacional-grade,
+4 = enterprise-ready, 3 = baseline SaaS sólido), el **score corregido baja a ≈2.1/5** — no porque el
+sistema empeore, sino porque **el listón sube** y porque la auditoría previa **omitió dos dominios
+enteros**: (A) **gobernanza de ingeniería corporativa** y (J) **capa de confianza ejecutiva
+multinacional**, además de facetas multinacionales específicas (residencia de datos, i18n/l10n,
+modelo de tenant/RLS verificado, soporte/escalamiento). Por eso el 2.7 es **ligeramente optimista**
+para la pregunta multinacional.
+
+**Qué le faltó a la auditoría previa (resumen):**
+
+1. **No hay capa de gobernanza:** sin ADRs, sin RFC/change-control, sin risk register, sin
+   Production-Readiness Review (PRR), sin modelo de ownership/CODEOWNERS, sin trazabilidad de
+   decisiones. Es el vacío #1 para una multinacional.
+2. **No verificó el aislamiento multi-tenant a nivel datos.** La frontera por `clinic_id` existe y es
+   fuerte a nivel **aplicación** (middlewares + RBAC + `permissions.ts`), pero **RLS a nivel DB no
+   está verificada** (Grep confirma `clinic_id`/`clinicId` masivo, no confirma policies). Para datos
+   clínicos multi-cliente es un control crítico.
+3. **No tocó dimensiones multinacionales:** residencia de datos, i18n/l10n (producto **español
+   único**, Grep i18n=14 hits solo `Intl.`/SEO), multi-moneda (solo ARS), zonas horarias,
+   DPA/privacidad por jurisdicción.
+4. **No propuso un "evidence room" de cumplimiento** para due-diligence (DD) de ventas enterprise.
+5. **Sin capa de soporte/escalamiento/on-call** ni narrativa de confianza ejecutiva.
+6. **Recomendaciones sin criterio de aceptación medible** en varios PRs docs (p. ej. "design tokens",
+   "valor operativo") y **sin rollback-drill ni data-impact** (lo exige `docs/review-governance.md`).
+
+**Gaps de mayor riesgo (multinacional):** (P0) gobernanza ausente; (P0) aislamiento de tenant/RLS
+sin verificar; (P0) ceguera de observabilidad (logger `console.*` plano); (P0) source-of-truth/índice
+inexistente; (P1) sin budgets de performance ni gate CI por capas; (P1) Dependabot **envejeciendo**
+(19 PRs abiertas desde 2026-06-18).
+
+**Pasos de mayor valor:** instituir **gobernanza docs-only** (ADR + risk register + release/rollback
+checklist + índice/SoT), cerrar el **gate de CI** (PR-C3) con política de flakes, y **abrir el
+camino de observabilidad** (runbook + logger estructurado) — todo aditivo, sin reescrituras.
+
+**Próximo PR exacto recomendado:** **PR-O1 docs-only** — `docs/audit/README.md` (índice de
+auditorías vigentes con estado). Cero riesgo, prerequisito de toda la cadena de gobernanza.
+
+---
+
+## 2. Audited Base
+
+| Campo | Valor |
+| --- | --- |
+| Branch | `main` |
+| HEAD | `8e29cc2 test(e2e): add layered e2e scripts (#1096)` |
+| `origin/main` | `8e29cc2` (idéntico) |
+| `git status --short --untracked-files=all` | `?? docs/audit/repository-operational-ordering-audit.md`, `?? docs/audit/vetneb-enterprise-engineering-readiness-audit.md` (+ este archivo nuevo) |
+| Worktree | único — `C:/PORTAL-VETNEB 8e29cc2 [main]` |
+| Open PRs | **19, todas Dependabot** (#1018–#1038), más antiguas con timestamp 2026-06-18 |
+| Fecha | 2026-06-23 |
+| Plataforma | Windows / PowerShell / PNPM 10.8.1 |
+
+**Archivo primario auditado:** `docs/audit/vetneb-enterprise-engineering-readiness-audit.md` (leído
+completo; autoría de esta misma sesión).
+
+**Archivos de soporte leídos/consultados:** `docs/audit/repository-operational-ordering-audit.md`
+(contexto de source-of-truth; sesión previa), `docs/audit/e2e-ci-layering-strategy-audit.md`
+(contexto E2E; sesión previa), `AGENTS.md` + `docs/protocol/vetneb-ai-working-protocol.md` +
+`docs/review-governance.md` (gobernanza existente; sesión previa).
+
+**Comandos de búsqueda ejecutados (verificación de alto riesgo, no re-auditoría):**
+
+```
+git branch --show-current ; git status --short --untracked-files=all ; git log -1 --oneline
+git log --oneline --decorate -n 30 ; git branch ; git worktree list ; gh pr list --state open
+rg "2\.7|enterprise-grade|scorecard" docs/audit/vetneb-enterprise-engineering-readiness-audit.md
+Grep (server): rls|policy|tenant|clinic_id|i18n|locale|currency|timezone|region → 420/30 (dominado por clinic_id)
+Grep (frontend/src): i18n|locale|next-intl|Intl.|currency|ARS|USD|timezone → 14/9 (solo Intl./SEO; sin framework i18n)
+```
+
+**Archivos leídos completos en esta corrida:** 1 (`vetneb-enterprise-engineering-readiness-audit.md`).
+**Inspeccionados por snippet/grep:** `server/**`, `frontend/src/**` (solo conteos para verificar
+tenant/i18n). **No** se re-abrieron los archivos ya auditados en las dos corridas previas.
+
+**Confirmación de scope.** Solo se crea
+`docs/audit/vetneb-extreme-multinational-enterprise-readiness-audit.md`. No se modificó, movió,
+renombró ni borró ningún otro archivo. No se ejecutó `git add/commit/push`, `gh pr create/merge`. No
+se instalaron dependencias. No se levantó `next dev`. **Esta auditoría es docs-only.**
+
+---
+
+## 3. Audit of the Previous Enterprise Readiness Document
+
+### 3.1 Fortalezas (conservar)
+
+| Fortaleza | Evidencia en el doc previo |
+| --- | --- |
+| Evidencia trazable | Apéndice "Evidence Traceability Map" (claim → archivo/símbolo) |
+| Scorecard estructurado | 20 dominios con score/gap/riesgo/PR/prioridad |
+| Disciplina tecnológica | Matriz "Recommended now / later / conditional / not now" con condición de adopción |
+| Hallazgo de deps muertas | react-query/react-table/echarts instaladas sin consumidor |
+| PRs chicos + rollback | §18 secuencia con tipo/scope/no-scope/validación/rollback |
+| Lectura correcta del perfil | "T invertida": cimientos fuertes, instrumentación débil |
+
+### 3.2 Debilidades y vacíos (corregir en este documento)
+
+| # | Debilidad | Tipo | Corrección aquí |
+| --: | --- | --- | --- |
+| 1 | **Falta dominio de gobernanza** (ADR/RFC/risk register/PRR/ownership) | Dominio faltante | Dominio A + §9 + Fase 0 |
+| 2 | **Falta capa de confianza ejecutiva/DD** | Dominio faltante | Dominio J + §13 |
+| 3 | **No verifica aislamiento de tenant/RLS** | Claim no verificado | Dominio B/G, P0, "focused audit" |
+| 4 | **Ignora i18n/l10n, multi-moneda, residencia, zonas horarias** | Faceta multinacional faltante | Dominio B/F/H, conditional |
+| 5 | **Recos sin criterio de aceptación medible** (design tokens, valor operativo) | Reco vaga | §12 métricas + acceptance por PR |
+| 6 | **Rollback genérico ("borrar archivo"); sin rollback-drill ni data-impact** | Rollback incompleto | §10/§11 con data-impact + drill |
+| 7 | **SLOs mencionados sin números** | Reco no medible | §12 con targets numéricos |
+| 8 | **Scores calibrados a "enterprise SaaS", no multinacional** | Score optimista | §4 re-scoring rúbrica estricta |
+| 9 | **No clasifica evidencia de cumplimiento (evidence room)** | Control faltante | §9 + Fase 5 |
+| 10 | **No define modelo de soporte/escalamiento** | Control faltante | Dominio C/J + §9 |
+| 11 | **Dependabot tratado como "backlog", no como métrica de riesgo con SLA** | Métrica faltante | §12 (dependency risk age) |
+| 12 | **Privileged-action logging asumido, no verificado** | Claim a verificar | Dominio B, "focused audit" |
+
+### 3.3 Claims que requieren auditoría enfocada posterior (no afirmar como hecho)
+
+- **Tenant isolation / RLS** a nivel DB (solo verificado a nivel app).
+- **Privileged-action audit coverage** (qué acciones admin mutantes quedan en `audit-log`).
+- **Backup/restore real** (existe doc `BACKUP_RESTORE_ROLLBACK.md`; no hay evidencia de restore drill).
+- **Consistencia de fechas críticas** estudio→entrega.
+- **`select('*')`/índices** en `db-*.ts`.
+- **Cobertura a11y** con herramienta (axe).
+
+---
+
+## 4. Corrected Extreme Enterprise Scorecard
+
+> Rúbrica multinacional: **0** ausente · **1** ad hoc · **2** parcial · **3** baseline SaaS sólido ·
+> **4** enterprise-ready · **5** multinacional-grade. "Prev." mapea los dominios del scorecard previo
+> (20 dominios) a los dominios A–J de este modelo.
+
+| Dom | Dominio | Prev. (rúbrica SaaS) | Corregido (rúbrica multinacional) | Target 5/5 multinacional | Gap | Riesgo | Primer PR | Prio |
+| --- | --- | :--: | :--: | --- | --- | --- | --- | :--: |
+| **A** | Corporate engineering governance | *(ausente)* ~1 | **1** | ADRs, RFC/change-control, CODEOWNERS, PRR gate, risk register, release checklist, decision traceability | Sin proceso de decisión formal | Cambios sin aprobación/traza | PR-GOV1 docs | **P0** |
+| **B** | Security & compliance governance | 4+4 | **3** | + secret-scanning CI, privileged-action log verificado, RLS verificada, retención/export/delete, residencia, evidence room | App-layer fuerte; DB/compliance sin evidencia | Aislamiento/compliance no demostrable | PR-S1 docs | **P0** |
+| **C** | Production operations & SRE | 2 | **2** | Logs estructurados, correlación FE↔BE, métricas, alerting, SLO/SLA, runbooks, error budgets, synthetic checks, rollback drills, ownership | Logger `console.*`; sin alerting/SLO/runbook | Ceguera en incidentes; MTTR alto | PR-OBS1 docs | **P0/P1** |
+| **D** | Quality engineering maturity | 4+3 | **3** | + capas E2E en CI, flake policy, coverage invariants, contract tests, release gates, test ownership | Volumen alto; sin gate por capa ni flake policy | Regresión/flake silenciosa | PR-C3 CI | **P1** |
+| **E** | Enterprise product operability | 3+3+3 | **3** | + KPIs operativos, executive reporting, a11y certificada, premium polish verificado | Dashboards reales; sin KPIs ni a11y formal | UX no medida | PR-UX1 docs | P2 |
+| **F** | Integration & platform maturity | 1+3 | **2** | + versioning, OpenAPI, idempotency, webhooks firmados, event schema versioning, SDK, tenant boundary model | API interna sólida; sin contrato externo | No integrable por terceros | PR-API1 docs | P2 |
+| **G** | Data governance & auditability | 2+2 | **2** | + modelo canónico, lifecycle states, historia inmutable, lineage, retención, restore evidence, reconciliación | Audit/tracking existen; sin políticas | Cumplimiento/soporte | PR-DATA1 docs | P1/P2 |
+| **H** | Scalability, performance, resilience | 1+3 | **2** | + budgets enforced, latency SLOs, caching policy, async candidates, graceful degradation, failover | Caches sí; sin budgets/medición | Degradación invisible | PR-PERF1 docs | P1 |
+| **I** | Documentation & knowledge transfer | 2+3 | **2** | + índice, SoT map, ADRs, API/onboarding/runbooks, prompt packs, clasificación histórica | 174 docs sin índice/mapa | Re-descubrimiento costoso | PR-O1/O2 docs | **P0** |
+| **J** | Multinational executive trust layer | *(ausente)* ~1 | **1** | Exec reporting, evidence room, risk review, compliance/DD pack, narrativa seguridad/reliability | Sin artefactos de DD | Bloquea ventas enterprise | PR-GOV2/REL1 docs | P1 |
+
+**Score multinacional corregido = (1+3+2+3+3+2+2+2+2+1)/10 = ≈2.1/5** (rango 2.0–2.3). **Veredicto:**
+el 2.7 previo se **corrige a la baja** para la pregunta multinacional, y se agregan **2 dominios
+ausentes** (A, J). El sistema sigue siendo un baseline SaaS sólido; la brecha a multinacional es de
+**gobernanza, evidencia y operación**, no de arquitectura.
+
+---
+
+## 5. P0 Foundation Gaps
+
+> P0 = requerido antes de poder **afirmar** enterprise/multinacional. Prioridad por la fórmula
+> Extreme Enterprise Priority (riesgo seguridad/incidente/datos/operación/confianza + confianza de
+> implementación − complejidad − blast radius). Los P0 son mayormente **docs-only** (bajo blast
+> radius, alto valor de control).
+
+### P0-1 — Gobernanza de ingeniería inexistente (Dominio A/I)
+
+- **Evidencia:** existe protocolo (`AGENTS.md`, `vetneb-ai-working-protocol.md`) y `review-governance.md`,
+  pero **no** hay ADRs, RFC/change-control, CODEOWNERS, risk register, PRR ni índice/SoT.
+- **Por qué bloquea multinacional:** una multinacional exige **decisiones trazables y aprobables**;
+  sin ADR/risk register no hay narrativa de control interno para DD.
+- **Dirección mínima:** plantillas ADR + RFC + risk register + release/rollback checklist en `docs/`;
+  índice de auditorías + SoT map.
+- **First safe PR:** PR-O1 (índice) → PR-O2 (SoT) → PR-GOV1 (ADR/RFC) → PR-GOV2 (risk register) →
+  PR-REL1 (release/rollback checklist). Todos docs-only.
+- **Validación:** `git diff --check`; lectura humana; cada plantilla con ejemplo real.
+- **Rollback:** borrar archivos (docs-only). **Data impact:** ninguno.
+- **Owner/dominio:** Engineering governance (Nico).
+- **Dependencias:** ninguna.
+
+### P0-2 — Aislamiento multi-tenant a nivel datos no verificado (Dominio B/G)
+
+- **Evidencia:** frontera por `clinic_id`/`clinicId` masiva (Grep: admin-clinics 61, db-logistics 67)
+  + middlewares `clinic-permissions`/`auth` + `permissions.ts` + matrices RBAC → **app-layer fuerte**.
+  **No** se verificó RLS/policies a nivel Postgres.
+- **Por qué bloquea:** datos clínicos multi-cliente sin defensa en profundidad a nivel DB es el riesgo
+  de aislamiento más caro de un multinacional (un bug de query cruza tenants).
+- **Dirección mínima:** auditoría enfocada **docs-only** que verifique presencia/ausencia de RLS y
+  cobertura de `clinic_id` en cada acceso; **no** implementar RLS aquí.
+- **First safe PR:** PR-S1 docs (incluye sección "tenant isolation / RLS verification").
+- **Validación:** revisión + (futuro) test de aislamiento cross-tenant.
+- **Rollback:** docs. **Data impact:** ninguno (auditoría).
+- **Owner:** Security. **Dependencias:** ninguna.
+
+### P0-3 — Ceguera de observabilidad (Dominio C)
+
+- **Evidencia:** `server/lib/logger.ts` = `console.log('[INFO]', …)` no estructurado; sin
+  Sentry/OTel/alerting/SLO; request-id existe (`api-request-id.ts`) pero no se propaga a logs
+  estructurados ni a soporte.
+- **Por qué bloquea:** sin logs estructurados + runbook no hay diagnóstico de incidentes ni narrativa
+  de reliability para DD.
+- **Dirección mínima:** runbook + baseline (docs) → logger JSON reutilizando request-id (1 archivo +
+  test). Sentry/OTel = posterior.
+- **First safe PR:** PR-OBS1 docs → PR-S2 backend-only (logger estructurado).
+- **Validación:** test de shape del log; sin secretos; `pnpm test`.
+- **Rollback:** revertir `logger.ts`. **Data impact:** logs (verificar no-secretos).
+- **Owner:** SRE/backend. **Dependencias:** PR-OBS1 antes de PR-S2.
+
+### P0-4 — Source-of-truth / índice inexistente (Dominio I)
+
+- **Evidencia:** auditoría de ordenamiento ya documentó 174 docs sin índice/SoT.
+- **Por qué bloquea:** onboarding, DD y consumo de IA dependen de un punto de entrada único.
+- **First safe PR:** PR-O1 (índice) + PR-O2 (SoT map).
+- **Validación / Rollback:** lectura humana / borrar. **Data impact:** ninguno.
+- **Owner:** Docs. **Dependencias:** ninguna (es la base).
+
+### P0-5 — Gate de calidad CI sin capas + sin política de flakes (Dominio D)
+
+- **Evidencia:** capas `e2e:*` existen (#1096); CI corre el step "smoke" = full; sin flake/coverage
+  policy.
+- **Por qué bloquea:** riesgo de **pérdida silenciosa de cobertura** al cambiar CI sin política.
+- **Dirección mínima:** validar localmente `unión == 42`; luego PR-C3 CI-only aditivo; PR-QA1 docs
+  (flake/regression policy).
+- **First safe PR:** PR-QA1 docs → PR-C3 CI-only.
+- **Validación:** suma specs por capa == 42; CI verde; seguridad siempre en gate.
+- **Rollback:** revertir workflow. **Data impact:** ninguno.
+- **Owner:** QA/CI. **Dependencias:** validación local previa.
+
+---
+
+## 6. P1 High-Value Multinational Maturity Gaps
+
+### P1-1 — Risk register vivo (Dominio A/J)
+
+- **Evidencia:** ninguno. **Por qué:** DD multinacional exige registro de riesgos con dueño/mitigación.
+- **First PR:** PR-GOV2 docs. **Validación:** revisión. **Rollback:** borrar. **Owner:** Governance.
+- **Dependencias:** PR-O1.
+
+### P1-2 — Logger estructurado + correlación FE↔BE (Dominio C)
+
+- **Evidencia:** request-id backend; sin propagación FE ni surface a soporte.
+- **First PR:** PR-S2 (logger JSON) → PR-S3 (correlation IDs FE↔BE).
+- **Validación:** test de shape + e2e que verifique header de correlación. **Rollback:** revertir
+  archivos. **Data impact:** logs sin secretos. **Owner:** SRE.
+
+### P1-3 — Performance budgets medibles (Dominio H)
+
+- **Evidencia:** sin budgets/medición; sin `next/dynamic`.
+- **First PR:** PR-PERF1 docs (spec budgets) → medición posterior.
+- **Validación:** comparación build size vs budget. **Rollback:** docs/medición aditiva. **Owner:** FE/Perf.
+
+### P1-4 — Data lifecycle + retención (Dominio G)
+
+- **Evidencia:** audit/tracking existen; sin políticas de retención/export/delete; restore sin evidencia.
+- **First PR:** PR-DATA1 docs (lifecycle + retención propuesta; legal flags).
+- **Validación:** revisión + confirmación Nico. **Rollback:** docs. **Owner:** Data/Legal.
+
+### P1-5 — Dependency governance + Dependabot SLA (Dominio A/B)
+
+- **Evidencia:** `pnpm.overrides` (manual) + **19 PRs Dependabot abiertas desde 2026-06-18**.
+- **Por qué:** deps envejeciendo = superficie CVE y deriva; falta política de cadencia/agrupado.
+- **First PR:** PR-GOV3 docs (dependency governance + SLA de merge de seguridad) ; **no** mezclar con
+  feature work.
+- **Validación:** edad de PR Dependabot. **Rollback:** docs. **Owner:** Governance.
+
+### P1-6 — Release readiness + rollback drill (Dominio A/C)
+
+- **Evidencia:** `review-governance.md` exige rollback+data-impact; no hay checklist de release ni drill.
+- **First PR:** PR-REL1 docs. **Validación:** revisión. **Rollback:** docs. **Owner:** Release.
+
+### P1-7 — Capa de confianza ejecutiva / DD pack (Dominio J)
+
+- **Evidencia:** ninguna. **First PR:** PR-EXEC1 docs (narrativa + evidence room índice).
+- **Validación:** revisión. **Rollback:** docs. **Owner:** Eng leadership.
+
+---
+
+## 7. P2 / P3 Advanced Capabilities
+
+> Importantes pero dependientes de P0/P1. **No** se promueven a P0 sin evidencia que lo exija.
+
+| Item | Dominio | Prio | Condición/Dependencia | Primer PR |
+| --- | --- | :--: | --- | --- |
+| KPIs operativos + executive reporting dashboard | E/J | P2 | Tras observabilidad (C) | PR-UX1 docs |
+| Accessibility acceptance criteria (axe) | E | P2 | Tras CI gate (D) | PR-A11Y1 docs |
+| API governance / OpenAPI desde zod | F | P2 | Demanda externa real | PR-API1 docs |
+| Idempotency keys (mutaciones expuestas) | F | P2 | Pre-exposición externa | post PR-API1 |
+| Webhooks firmados (HMAC) + event schema versioning | F | P3 | Consumidor externo | post PR-API1 |
+| SDK cliente | F | P3 | OpenAPI estable | post PR-API1 |
+| Async jobs / cola (email/PDF/report-workflow) | H | P3 | Trabajos largos que bloqueen request | PR-ASYNC1 docs |
+| i18n/l10n framework | B/E | P3 | **Expansión internacional real** | PR-I18N1 docs (conditional) |
+| Multi-moneda (hoy ARS) | F/G | P3 | Venta en otra moneda | post PR-DATA1 |
+| Data residency / multi-region | B/H | P3 | Requisito legal por país | requires legal/domain confirmation |
+| Tenant model formal (más allá de `clinic_id`) | F/G | P2 | Multi-cliente a escala | post PR-S1 |
+| Synthetic monitoring / uptime externo | C | P2 | Tras SLOs | post PR-OBS1 |
+| Error budgets formales | C | P2 | Tras SLOs + métricas | post PR-OBS1 |
+
+---
+
+## 8. Not Recommended Now
+
+| Capacidad | Por qué no ahora | Condición que lo haría válido | Alternativa actual más simple |
+| --- | --- | --- | --- |
+| Micro-frontends / Module Federation | Monorepo único, sin equipos independientes | Independencia real de equipos/módulos | App Router + closeouts |
+| CRDTs / Yjs / Automerge | Sin edición concurrente | Co-edición real con conflicto | Bloqueo optimista |
+| WebGL dashboards | Sin visualización masiva | >100k puntos en una vista | ECharts (ya instalado) canvas |
+| Full offline / PWA de datos privados | Riesgo de cachear privados | Política de cache de privados resuelta y auditada | PWA pública actual (`sw.js`) |
+| Realtime en todo | Sin valor de usuario probado | Caso concreto medible (estado vivo crítico) | Refetch/polling |
+| Backend rewrite | Backend es el activo más maduro | — (nunca como "mejora") | Instrumentar + contratos |
+| Frontend rewrite | Base limpia, deuda baja (14 hits) | — | Optimización incremental |
+| Adopción amplia de dependencias | 3 deps ya instaladas sin uso | Gap probado con consumidor | Resolver react-query/table/echarts primero |
+| Rewrite grande de dashboard | Contratos no-scroll ya logrados | — | Pulido por superficie con `visual-contract` |
+
+---
+
+## 9. Multinational-Grade Controls Missing from Current Plan
+
+| Control | Evidencia actual | Evidencia faltante | Riesgo | Prio | Primer PR |
+| --- | --- | --- | --- | :--: | --- |
+| **ADRs** | ninguna | template + decisiones clave registradas | Decisiones sin traza | P0 | PR-GOV1 |
+| **RFC / change control** | protocolo de scope | proceso de propuesta/aprobación | Cambios sin gate | P0 | PR-GOV1 |
+| **Source-of-truth map** | auditoría de ordenamiento lo pide | `docs/SOURCES_OF_TRUTH.md` | Re-descubrimiento | P0 | PR-O2 |
+| **Audit index** | closeouts dispersos | `docs/audit/README.md` | Navegación lenta | P0 | PR-O1 |
+| **Risk register** | ninguna | registro vivo con dueño/mitigación | DD sin control interno | P1 | PR-GOV2 |
+| **Incident response runbook** | ninguna | runbook + severidades + roles | MTTR alto | P0/P1 | PR-OBS1 |
+| **Release readiness checklist** | `review-governance.md` parcial | checklist versionado | Releases riesgosos | P1 | PR-REL1 |
+| **Rollback checklist + drill + data impact** | rollback genérico | drill + data-impact por PR | Recuperación incierta | P1 | PR-REL1 |
+| **Security review checklist** | tests `security-*` | checklist de gate por PR | Brecha por omisión | P1 | PR-S1 |
+| **Dependency governance + Dependabot SLA** | `pnpm.overrides` manual | política/cadencia + SLA seguridad | CVE aging (19 PRs) | P1 | PR-GOV3 |
+| **SLO/SLA draft** | health checks | SLOs numéricos | Sin objetivo de fiabilidad | P1 | PR-OBS1 |
+| **Structured logs** | `logger.ts` console | JSON + niveles + campos | Sin diagnóstico | P0/P1 | PR-S2 |
+| **Correlation IDs (FE↔BE)** | request-id backend | propagación + surface soporte | Trazabilidad parcial | P1 | PR-S3 |
+| **Audit logs (privileged actions)** | `audit-log.ts` existe | verificación de cobertura de acciones admin | Acciones sin traza | P1 | PR-S1 (verify) |
+| **Backup/restore evidence** | `BACKUP_RESTORE_ROLLBACK.md` | evidencia de restore drill | Recuperación no probada | P1 | PR-DATA1 |
+| **Data retention policy** | ninguna | política + flags legales | Cumplimiento | P1 | PR-DATA1 |
+| **OpenAPI / API governance** | API interna `/api` | contrato + versionado | No integrable | P2 | PR-API1 |
+| **Webhook governance** | ninguna | firma + retry + schema versioning | Integración insegura | P3 | post PR-API1 |
+| **Performance budgets** | ninguna | budgets + medición | Degradación invisible | P1 | PR-PERF1 |
+| **Accessibility acceptance criteria** | `dashboard-accessibility-keyboard` | criterios axe formales | Exclusión/legal | P2 | PR-A11Y1 |
+| **Support escalation process** | ninguna | niveles + SLA soporte | Soporte improvisado | P2 | PR-EXEC1 |
+| **Tenant isolation / RLS evidence** | app-layer (`clinic_id`+RBAC) | RLS DB verificada | Cross-tenant | P0 | PR-S1 |
+| **Compliance evidence room / DD pack** | sanitización + no-secrets | índice de evidencia | Bloquea ventas | P1 | PR-EXEC1 |
+| **Ownership model (CODEOWNERS)** | `review-governance.md` lo menciona | CODEOWNERS real | Responsabilidad difusa | P1 | PR-GOV1 |
+
+---
+
+## 10. Extreme Enterprise Implementation Roadmap
+
+> Fases por dependencia. Cada PR es chico, un eje, reversible. Git lo ejecuta Nico.
+
+### Phase 0 — Governance Foundation
+- **Objetivo:** índice + SoT + ADR/RFC + risk register + release/rollback checklist + CODEOWNERS.
+- **Valor:** control interno y trazabilidad (base de DD).
+- **Controles entregados:** ADRs, RFC, risk register, audit index, SoT, release/rollback checklist, ownership.
+- **PRs:** PR-O1, PR-O2, PR-GOV1, PR-GOV2, PR-GOV3, PR-REL1 (todos docs-only).
+- **Validación:** `git diff --check`, lectura humana, cada plantilla con ejemplo.
+- **Rollback:** borrar archivos. **Data impact:** ninguno.
+- **DoD:** existe `docs/audit/README.md`, `docs/SOURCES_OF_TRUTH.md`, `docs/governance/{adr,rfc,risk-register,release-checklist}.md`.
+
+### Phase 1 — CI, Quality Gates & Test Governance
+- **Objetivo:** capas E2E en CI, split smoke/full, flake policy, coverage invariants, regression strategy.
+- **Valor:** feedback rápido sin pérdida de cobertura.
+- **Controles:** release gates, flake policy, coverage invariants.
+- **PRs:** PR-QA1 docs → (validación local unión==42) → PR-C3 CI-only.
+- **Validación:** suma specs por capa == 42; CI verde; seguridad siempre en gate.
+- **Rollback:** revertir workflow. **DoD:** smoke gate rápido + full red; step renombrado; flake policy publicada.
+
+### Phase 2 — Security & Auditability
+- **Objetivo:** verificar invariantes + RLS/tenant, secret-scanning plan, privileged-action coverage, headers/CSP/rate-limit review.
+- **Valor:** demostrabilidad del control más crítico (datos clínicos multi-tenant).
+- **Controles:** security review checklist, tenant isolation evidence, secret-scanning, audit coverage.
+- **PRs:** PR-S1 docs → PRs security-only acotados.
+- **Validación:** `security:public-surface`, suite `security-*`/`auth-*`, (futuro) test cross-tenant.
+- **Rollback:** por PR. **DoD:** invariantes verificados + plan de secret-scanning + RLS dictaminada.
+
+### Phase 3 — Observability & Incident Readiness
+- **Objetivo:** logs estructurados, correlación FE↔BE, health por dependencia, runbooks, alerting, proceso de incidentes.
+- **Valor:** soporte productivo y narrativa de reliability.
+- **Controles:** SLO/SLA draft, runbooks, correlation IDs, structured logs.
+- **PRs:** PR-OBS1 docs → PR-S2 (logger JSON) → PR-S3 (correlation) → (opcional) Sentry/OTel.
+- **Validación:** test de shape de log; e2e de correlación; sin secretos.
+- **Rollback:** revertir archivos acotados. **DoD:** logs JSON + runbook + SLOs numéricos.
+
+### Phase 4 — Performance Budgets & Resilience
+- **Objetivo:** budgets, latencia API, budgets FE/CI/E2E, candidatos async, degradación elegante.
+- **Valor:** predictibilidad de performance.
+- **Controles:** performance budgets, latency SLOs.
+- **PRs:** PR-PERF1 docs → medición → lazy-load (si se cablean deps) → PR-ASYNC1 docs (candidatos).
+- **Validación:** build size + vitals vs budget. **Rollback:** aditivo. **DoD:** budgets en repo + medición.
+
+### Phase 5 — Data Governance & Lifecycle
+- **Objetivo:** retención, export/delete, backup/restore evidence, lifecycle estudio/reporte, audit trail, reconciliación.
+- **Valor:** cumplimiento y auditabilidad.
+- **Controles:** retention policy, restore evidence, lineage, reconciliation.
+- **PRs:** PR-DATA1 docs (legal flags) → focused audits.
+- **Validación:** revisión + confirmación Nico + (futuro) restore drill en staging.
+- **Rollback:** docs. **DoD:** política de retención + lifecycle mapeado + evidencia de restore.
+
+### Phase 6 — Multinational Product Operability
+- **Objetivo:** command center admin/clínica, KPIs ejecutivos, no-scroll enterprise, a11y, capa premium.
+- **Valor:** confianza operativa y percepción premium.
+- **Controles:** KPIs operativos, a11y acceptance, executive reporting.
+- **PRs:** PR-UX1 docs → PR-A11Y1 docs → PRs frontend-only por superficie con `visual-contract`.
+- **Validación:** `e2e:visual-contract` + QA humana + axe. **Rollback:** por PR. **DoD:** KPIs + tokens + a11y certificada.
+
+### Phase 7 — Integration & Platform Maturity
+- **Objetivo:** OpenAPI, versioning, idempotency, webhooks firmados, SDK, contratos de sistemas externos, tenant boundary.
+- **Valor:** habilita integración B2B/multinacional.
+- **Controles:** API governance, webhook governance, idempotency.
+- **PRs:** PR-API1 docs → versioning → OpenAPI desde zod → webhooks → SDK.
+- **Validación:** contract-tests; compatibilidad. **Rollback:** versioning aditivo. **DoD:** contrato externo estable.
+
+### Phase 8 — Advanced Capabilities Only When Justified
+- **Objetivo:** realtime/colas/PWA-offline/automatización/analytics avanzados **solo con evidencia**.
+- **Valor:** condicional al caso de uso.
+- **Controles:** por capacidad, con PRD corto + guardrails.
+- **PRs:** por capacidad. **Validación/Rollback:** por capacidad. **DoD:** consumidor real + guardrails (no privados en cache, no realtime sin valor).
+
+---
+
+## 11. Recommended PR Sequence
+
+| PR | Tipo | Objetivo | Scope permitido | No-scope | Validación | Rollback | Dependencia | Control entregado |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **PR-O1** | docs-only | Índice de auditorías | `docs/audit/README.md` | mover/editar audits | `git diff --check`, lectura | borrar | — | Audit index |
+| **PR-O2** | docs-only | Mapa de fuentes de verdad | `docs/SOURCES_OF_TRUTH.md` (+1 línea AGENTS.md OK Nico) | consolidar carpetas | lectura | borrar/revertir | PR-O1 | SoT map |
+| **PR-GOV1** | docs-only | Plantillas ADR/RFC/change-control + CODEOWNERS doc | `docs/governance/*` | tocar `.github/CODEOWNERS` real sin OK | lectura | borrar | PR-O1 | ADR/RFC/ownership |
+| **PR-GOV2** | docs-only | Risk register enterprise | `docs/governance/risk-register.md` | inventar riesgos sin evidencia | lectura | borrar | PR-GOV1 | Risk register |
+| **PR-GOV3** | docs-only | Dependency governance + Dependabot SLA | `docs/governance/dependency-policy.md` | tocar deps/lockfile | revisión + edad PRs | borrar | PR-GOV1 | Dependency governance |
+| **PR-REL1** | docs-only | Release readiness + rollback + data-impact checklist | `docs/ops/release-readiness-checklist.md` | tocar CI | lectura | borrar | PR-O1 | Release/rollback control |
+| **PR-QA1** | docs-only | Política de flaky tests + regression strategy | `docs/qa/flaky-and-regression-policy.md` | tocar tests/CI | lectura | borrar | — | Flake policy |
+| **PR-C3** | CI-only | Capas E2E en CI sin pérdida de cobertura | `.github/workflows/frontend-ci.yml` | specs/scripts/Playwright config | unión==42; CI verde; renombrar step | revertir workflow | validación local + PR-QA1 | Release gate |
+| **PR-S1** | docs-only | Auditoría seguridad/aislamiento (incl. RLS/tenant + privileged audit) | `docs/security/security-session-focused-audit.md` | tocar auth/middlewares | revisión + `security:public-surface` | borrar | PR-O1 | Security review + tenant evidence |
+| **PR-OBS1** | docs-only | Baseline observabilidad + SLO numérico + incident runbook | `docs/ops/observability-baseline.md` | tocar logger/CI | revisión | borrar | PR-O1 | SLO/SLA + runbook |
+| **PR-S2** | backend-only | Logger estructurado JSON (sin deps si posible) | `server/lib/logger.ts` + su test | otras capas | test shape, `pnpm test`, no-secretos | revertir 1 archivo | PR-OBS1 | Structured logs |
+| **PR-S3** | backend/security-only | Correlation/request IDs FE↔BE (si factible) | `server/lib/api-request-id.ts` + propagación | otras capas | e2e de correlación | revertir | PR-S2 | Correlation IDs |
+| **PR-PERF1** | docs-only | Spec de performance budgets | `docs/perf/performance-budgets.md` | medir/instrumentar | revisión | borrar | — | Performance budgets |
+| **PR-DATA1** | docs-only | Auditoría lifecycle + retención (legal flags) | `docs/data/data-governance-audit.md` | inventar obligaciones legales | revisión + Nico | borrar | PR-O1 | Retention + lifecycle |
+| **PR-API1** | docs-only | Readiness API governance/OpenAPI | `docs/api/api-governance-readiness.md` | tocar rutas | revisión | borrar | PR-O1 | API governance |
+| **PR-UX1** | docs-only | Valor premium multinacional dashboard + KPIs | `docs/ux/dashboard-multinational-value.md` | tocar `frontend/src` | revisión | borrar | PR-O1 | Operational KPIs |
+| **PR-A11Y1** | docs-only | Criterios de aceptación a11y enterprise | `docs/ux/accessibility-acceptance-criteria.md` | tocar `frontend/src`/tests | revisión | borrar | PR-O1 | A11y acceptance |
+| **PR-EXEC1** | docs-only | DD pack / evidence room + narrativa ejecutiva | `docs/exec/multinational-readiness-narrative.md` | exponer secretos/evidencia real sensible | revisión + Nico | borrar | PR-GOV2 | Exec trust layer |
+
+**Orden recomendado:** PR-O1 → PR-O2 → PR-GOV1 → PR-GOV2 → PR-REL1 → PR-QA1 → (validación local) →
+PR-C3 → PR-S1 / PR-OBS1 / PR-PERF1 / PR-DATA1 / PR-API1 / PR-UX1 / PR-A11Y1 / PR-EXEC1 (docs en
+paralelo) → PR-S2 → PR-S3.
+
+---
+
+## 12. Metrics for Multinational Enterprise Readiness
+
+| Métrica | Target multinacional | Cómo medir inicialmente | Primer PR que la introduce |
+| --- | --- | --- | --- |
+| Deployment confidence | ≥95% PRs sin rollback | Conteo de rollbacks vs merges (release log) | PR-REL1 |
+| Rollback time objective (RTO lógico) | < 15 min | Documentar pasos + cronometrar drill | PR-REL1 |
+| Incident detection time (MTTD) | < 5 min | Alerting (futuro); hoy manual | PR-OBS1 |
+| Incident diagnosis time | < 30 min | Runbook + correlation IDs | PR-OBS1 / PR-S3 |
+| API p95 latency (críticos) | < 400ms lectura / < 800ms escritura | `runtime-timing` agregado | PR-PERF1 / PR-S2 |
+| Dashboard load (admin/clínica) | LCP < 2.5s desktop / < 3.5s mobile | web-vitals client | PR-PERF1 |
+| E2E smoke duration | < 4 min | medir en CI | PR-C3 |
+| Full regression duration | < 12 min | medir en CI | PR-C3 |
+| Flaky rate | < 1% por corrida | registro de reruns | PR-QA1 |
+| Dependency risk age (seguridad) | < 7 días | edad de PRs Dependabot | PR-GOV3 |
+| Unresolved Dependabot age | < 14 días promedio | hoy 19 PRs desde 2026-06-18 (~5 días) | PR-GOV3 |
+| Public surface regression count | 0 por release | `security:public-surface` | PR-S1 |
+| Audit log coverage (privileged actions) | 100% acciones admin mutantes | inventario vs `audit-log` | PR-S1 |
+| Structured log coverage | 100% rutas vía logger JSON | conteo `console.*` vs logger | PR-S2 |
+| Documented controls coverage | 100% controles §9 con doc | checklist §9 | PR-GOV2 |
+| Docs source-of-truth coverage | 100% dominios en SoT map | SoT map | PR-O2 |
+| Performance budget compliance | 100% rutas dentro de budget | medición vs budget | PR-PERF1 |
+| Accessibility acceptance pass rate | 100% criterios críticos | axe + criterios | PR-A11Y1 |
+| Support escalation readiness | proceso documentado + SLA | doc soporte | PR-EXEC1 |
+
+---
+
+## 13. Executive Multinational Readiness Narrative
+
+**Fortalezas actuales (creíbles para DD).** VETNEB tiene cimientos de ingeniería que muchas empresas
+"enterprise" no alcanzan: **separación estricta de superficies** (público/clínica/admin con
+middlewares y RBAC + matrices documentadas), **postura de seguridad fuerte** (CSP con nonce + report,
+headers endurecidos, rate-limit por superficie, CSRF, argon2, sesiones aisladas
+`admin_session_id`/`app_session_id`), **disciplina de testing** (~400 unit/integration + 42 E2E
+capeados) y **deuda técnica baja** (14 marcadores). El backend Fastify está limpio y modular; la PWA
+es segura; el control de cambios es maduro (Git manual, scope estricto, closeouts).
+
+**Brechas actuales (honestas).** La madurez **operacional y de gobernanza** es lo que falta:
+observabilidad (logs `console.*` no estructurados, sin SLO/alerting/runbook), **gobernanza formal**
+(sin ADR/RFC/risk register/PRR), **evidencia de aislamiento multi-tenant a nivel datos** (RLS sin
+verificar), **gobernanza de datos** (retención/restore sin evidencia) y **dimensiones
+multinacionales** (i18n/l10n, multi-moneda, residencia) que hoy no existen porque el producto es
+single-locale (ARS, español).
+
+**Credibilidad del roadmap.** El plan es **incremental y reversible**: gobernanza docs-only primero
+(bajo riesgo, alto valor de control), luego gate de CI, luego observabilidad y seguridad demostrable,
+después performance y datos. Ningún paso reescribe arquitectura. Esto es **más seguro que un
+"enterprise rewrite"** y produce evidencia DD en cada fase.
+
+**Posturas.** *Seguridad:* fuerte en controles, débil en **evidencia/compliance packaging** y RLS.
+*Reliability:* health checks sí, **diagnóstico/alerting no**. *Datos:* trazabilidad operativa sí,
+**políticas de ciclo de vida no**. *Soporte:* informal, **sin escalamiento documentado**.
+
+**Qué debe completarse antes de afirmar "enterprise/multinacional-grade":** Fase 0 (gobernanza +
+SoT), Fase 1 (gate CI), Fase 2 (seguridad/RLS demostrable) y Fase 3 (observabilidad + runbook). Hasta
+entonces, la afirmación correcta es **"baseline SaaS sólido con roadmap multinacional creíble"**, no
+"multinacional-grade".
+
+---
+
+## 14. Final Recommendation
+
+1. **¿VETNEB es multinacional-enterprise-grade hoy?** **No.** Es un baseline SaaS sólido con
+   cimientos fuertes y un roadmap creíble; faltan gobernanza, observabilidad operacional, evidencia de
+   aislamiento/compliance y dimensiones multinacionales.
+
+2. **Score de madurez corregido (rúbrica multinacional):** **≈2.1/5** (el 2.7 previo era correcto
+   para "enterprise SaaS" pero optimista para "multinacional"; se corrige a la baja y se agregan los
+   dominios A y J ausentes).
+
+3. **Qué hacer antes de cualquier implementación visual/producto grande:** Fase 0 (PR-O1, PR-O2,
+   PR-GOV1, PR-GOV2, PR-REL1) + Fase 1 (PR-QA1 → PR-C3). Sin índice/SoT/gobernanza y sin gate de CI,
+   todo trabajo grande arriesga cobertura y trazabilidad.
+
+4. **Camino más rápido y seguro a multinacional-grade:** gobernanza docs-only → gate CI →
+   seguridad/RLS demostrable → observabilidad → performance/datos. Aditivo, reversible, sin rewrites.
+
+5. **Próximo PR exacto:** **PR-O1 docs-only** (`docs/audit/README.md`, índice de auditorías).
+
+6. **PR que más reduce riesgo:** **PR-S1 docs** (seguridad/aislamiento incl. verificación RLS/tenant
+   + cobertura de privileged-action log) — ataca el riesgo más caro: cruce de datos multi-tenant.
+
+7. **PR que más aumenta la confianza del cliente:** **PR-EXEC1 docs** (DD pack/evidence room +
+   narrativa) apoyado en **PR-OBS1** (SLO/runbook) — convierte controles en evidencia presentable.
+
+8. **PR que más sube la calidad premium percibida:** **PR-UX1 docs** (KPIs + design tokens) sobre los
+   contratos no-scroll ya logrados, antes de PRs visuales por superficie.
+
+9. **PR que más sube la madurez de ingeniería:** **PR-GOV1/GOV2** (ADR/RFC + risk register) — instala
+   decisión trazable y gestión de riesgo como práctica permanente.
+
+10. **Qué NO hacer aún:** micro-frontends, CRDTs, WebGL, PWA-offline de privados, realtime,
+    backend/frontend rewrite, adopción amplia de deps (resolver antes las 3 instaladas sin uso), i18n/
+    multi-region/residencia salvo expansión internacional real (requires legal/domain confirmation).
+
+---
+
+## Appendix — Verification Notes (this run)
+
+| Afirmación verificada | Resultado | Comando |
+| --- | --- | --- |
+| HEAD y estado base | `8e29cc2`, worktree único, 19 PRs Dependabot | `git log/worktree/gh pr list` |
+| Score previo 2.7 presente | Confirmado (líneas 23, 742-743 del doc previo) | `rg "2\.7" …enterprise-…md` |
+| Tenant key omnipresente, RLS no confirmada | `clinic_id`/`clinicId` masivo (admin-clinics 61, db-logistics 67); policies no verificadas | Grep server |
+| i18n framework ausente | 14 hits, solo `Intl.`/SEO; sin next-intl/react-intl | Grep frontend/src |
+| Multi-moneda ausente | Solo ARS vía `Intl.NumberFormat` | Grep frontend/src |
+| Dependabot envejeciendo | 19 PRs abiertas desde 2026-06-18 | `gh pr list` |
+
+> Áreas marcadas **"requires focused audit"** (no afirmadas como hecho): RLS/tenant a nivel DB;
+> cobertura de privileged-action en `audit-log`; restore drill real; consistencia de fechas críticas;
+> `select('*')`/índices; cobertura a11y con axe.
+
+---
+
+## Final validation
+
+```powershell
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git diff --check
+```
+
+**Resultado esperado** (esta auditoría solo agrega un archivo **untracked**):
+
+- `git status --short --untracked-files=all` → los dos audits previos untracked + este nuevo
+  `?? docs/audit/vetneb-extreme-multinational-enterprise-readiness-audit.md`
+- `git diff --name-only` / `git diff --stat` → vacíos (sin tracked modificados)
+- `git diff --check` → limpio
+
+> Los comandos los ejecuta Nico manualmente. Esta auditoría **no** ejecuta `git add/commit/push`,
+> `gh pr create/merge` ni comandos con `exit`.

--- a/docs/audit/vetneb-supreme-system-level-alignment-plan.md
+++ b/docs/audit/vetneb-supreme-system-level-alignment-plan.md
@@ -1,0 +1,620 @@
+# VETNEB Supreme System-Level Alignment Plan
+
+> **docs-only · plan de alineación de sistema.** Este documento **no** implementa, **no** reescribe y
+> **no** es una lista de compras tecnológica. Sintetiza las tres auditorías existentes en una
+> **secuencia ejecutable de PRs chicos y controlados**. No modifica código productivo, `frontend/src`,
+> `frontend/e2e`, `server`/backend, `test`, `.github/workflows`, `package.json`,
+> `frontend/package.json`, `pnpm-lock.yaml`, Playwright config, `scripts`, `drizzle`/migraciones,
+> deps, lockfiles, CI, screenshots ni generados. No mueve, renombra ni borra archivos.
+>
+> **Base estratégica primaria (autoría de esta sesión):**
+> `docs/audit/repository-operational-ordering-audit.md`,
+> `docs/audit/vetneb-enterprise-engineering-readiness-audit.md`,
+> `docs/audit/vetneb-extreme-multinational-enterprise-readiness-audit.md`.
+>
+> Skills VETNEB aplicadas (10, ya cargadas en sesión, declaradas): briefing-planificación,
+> staff-senior-full-stack, web-end-to-end-global, security-production-invariants,
+> admin-dashboard-operational-actions, production-web-optimization-engineer, pwa-end-to-end,
+> lanzamiento-mantenimiento, bugs-errores-optimización-rutas, protocolos-comunicación. Prevalece el
+> Protocolo Maestro VETNEB y el flujo Git manual de Nico.
+
+---
+
+## 1. Executive Summary
+
+**Situación estratégica actual.** Las tres auditorías previas ya entregaron el diagnóstico completo:
+VETNEB es un **baseline SaaS sólido (≈2.1/5 en rúbrica multinacional)** con cimientos fuertes
+(seguridad, separación de superficies, testing/E2E) y brechas en **gobernanza, source-of-truth,
+observabilidad, verificación tenant/RLS, performance budgets, gobernanza de datos, integración,
+incident readiness y capa de confianza ejecutiva**. No falta arquitectura: falta **instrumentación,
+evidencia y gobierno**. Este plan convierte ese diagnóstico en **olas (waves) de PRs chicos con
+phase-gates**.
+
+**Por qué las auditorías previas alcanzan para empezar a ejecutar.** El diagnóstico ya está
+priorizado (P0/P1/P2/P3), con evidencia trazable y secuencia de PRs. No hace falta re-auditar: hace
+falta **cerrar las auditorías (commit) y ejecutar la cadena de gobernanza primero**. Re-auditar
+bloques cerrados sería desperdicio (regla anti-patrón §10).
+
+**Por qué alinear por dominios y no reescribir.** El sistema tiene perfil "T invertida": transversales
+fuertes, instrumentación débil. Reescribir destruiría los activos maduros (backend Fastify modular,
+suite de ~400 tests + 42 E2E, controles de seguridad) para resolver problemas que son **aditivos**
+(logs, budgets, ADRs, índices). Cada dominio sube a "supremo" sin tocar los demás, con gates entre
+medio.
+
+**Top blockers a nivel supremo:**
+
+1. **Gobernanza ausente** (sin ADR/RFC/risk register/PRR/ownership) → decisiones no trazables.
+2. **Source-of-truth inexistente** (174 docs sin índice/mapa) → re-descubrimiento costoso, ya
+   diagnosticado.
+3. **Observabilidad ciega** (`server/lib/logger.ts` = `console.*` plano; sin SLO/runbook/alerting).
+4. **Tenant/RLS sin verificar** (aislamiento por `clinic_id` a nivel app; RLS DB no confirmada).
+5. **3 auditorías base aún untracked** → riesgo de acumulación de scope sin cerrar (Wave 0).
+
+**Top aceleradores:**
+
+- La cadena de gobernanza es **docs-only** (bajo blast radius, alto valor de control).
+- Las capas E2E ya existen (#1096): PR-C3 es CI-only aditivo, no necesita tocar specs.
+- La observabilidad arranca **sin deps** (logger JSON reutilizando `api-request-id.ts`).
+- Hay un patrón de closeout maduro reutilizable como plantilla de evidencia.
+
+**Próximo PR inmediato:** **PR-O1 docs-only** — `docs/audit/README.md` (índice de auditorías
+vigentes con estado). Pero antes, **Wave 0**: commitear las 3 auditorías + este plan (Nico, manual).
+
+**Dominios que NO deben tocarse sin auditoría enfocada previa:** tenant/RLS a nivel DB,
+privileged-action audit coverage, backup/restore real, consistencia de fechas críticas, `select('*')`/
+índices, cobertura a11y con axe. Todos marcados **"Requires focused audit before implementation."**
+
+---
+
+## 2. Audited Base
+
+| Campo | Valor |
+| --- | --- |
+| Branch | `main` |
+| HEAD | `8e29cc2 test(e2e): add layered e2e scripts (#1096)` |
+| `origin/main` | `8e29cc2` (idéntico) |
+| `git status --short --untracked-files=all` | `?? repository-operational-ordering-audit.md`, `?? vetneb-enterprise-engineering-readiness-audit.md`, `?? vetneb-extreme-multinational-enterprise-readiness-audit.md` (+ este plan, untracked) — **las 3 base siguen sin commitear** |
+| Worktree | único — `C:/PORTAL-VETNEB 8e29cc2 [main]` |
+| Open PRs | **19, todas Dependabot** (#1018–#1038), envejeciendo desde 2026-06-18 |
+| Fecha | 2026-06-24 |
+| Plataforma | Windows / PowerShell / PNPM 10.8.1 |
+
+**Documentos primarios usados (en contexto de sesión, no re-leídos completos):** los tres audits
+base. **Comandos ejecutados:** `git branch/status/log/worktree`, `gh pr list --state open`,
+`git ls-files` de los tres audits (confirmado untracked). **No** se re-auditó el repo ni se re-leyó
+cada fuente — síntesis pura, según las reglas de eficiencia de la misión.
+
+**Confirmación de scope.** Solo se crea `docs/audit/vetneb-supreme-system-level-alignment-plan.md`.
+No se modificó/movió/renombró/borró ningún otro archivo. No se ejecutó `git add/commit/push`,
+`gh pr create/merge`, ni comandos con `exit`. No se instalaron dependencias. **docs-only.**
+
+---
+
+## 3. Supreme-Level Control Model
+
+> "Supremo" = cada dominio tiene dueño/SoT, cada control tiene evidencia, cada dominio de alto riesgo
+> tiene auditoría enfocada antes de implementar, y todo avanza por PRs chicos con rollback.
+
+| Control domain | Supreme standard | Current evidence | Current gap | Required control | First PR | Prio |
+| --- | --- | --- | --- | --- | --- | :--: |
+| Governance | ADR+RFC+PRR+ownership+decision traceability | `AGENTS.md`, `review-governance.md` | Sin ADR/RFC/risk register | Plantillas + registro | PR-GOV1 | **P0** |
+| Source of truth | Índice + mapa por dominio, histórico marcado | ordering audit lo pide | Sin índice/mapa | `docs/audit/README.md` + SoT map | PR-O1/O2 | **P0** |
+| ADR/RFC discipline | Decisiones registradas y aprobadas | ninguna | Inexistente | ADR/RFC templates | PR-GOV1 | **P0** |
+| Security/session isolation | Invariantes verificados + secret-scanning CI | CSP, headers, rate-limit, sesiones aisladas | Sin secret-scanning; sin verificación periódica | Security review checklist | PR-S1 | **P0** |
+| Tenant isolation/RLS | RLS DB + cobertura `clinic_id` probada | app-layer (`clinic_id`+RBAC) | RLS DB sin verificar | Focused audit + (futuro) test cross-tenant | PR-S1 | **P0** |
+| Observability | Logs JSON + correlación + métricas + alerting | `logger.ts` console, request-id, health | No estructurado, sin alerting/SLO | Baseline + runbook + logger | PR-OBS1→PR-OBS2 | **P0/P1** |
+| Incident readiness | Runbook + severidades + MTTD/MTTR | ninguna | Inexistente | Incident runbook | PR-OBS1 | P1 |
+| Release/rollback | Checklist + drill + data-impact | `review-governance.md` parcial | Sin checklist/drill | Release/rollback checklist | PR-REL1 | P1 |
+| Testing/E2E layers | Capas en CI, unión==full probada | scripts `e2e:*` (#1096) | CI no las usa | CI-only aditivo | PR-C3 | **P1** |
+| CI quality gates | Smoke gate + flake/coverage policy | 2 workflows; step "smoke"=full | Sin política de flakes/cobertura | Flake/regression policy | PR-QA1 | P1 |
+| Performance budgets | Budgets enforced + medición | ninguna; sin `next/dynamic` | Sin budgets/medición | Budget spec + medición | PR-PERF1 | P1 |
+| Data governance | Lifecycle + retención + restore evidence | audit/tracking; backup doc | Sin políticas; restore sin evidencia | Lifecycle/retención audit | PR-DATA1 | P1/P2 |
+| API/integration governance | Versioning + OpenAPI + idempotency + webhooks | API interna `/api` | Sin contrato externo | API readiness audit | PR-API1 | P2 |
+| Dependency governance | Política + SLA + risk register | `pnpm.overrides`; Dependabot | 3 deps sin uso; 19 PRs aging | Dep policy + uso audit | PR-DEP1/GOV3 | P1 |
+| Accessibility | Criterios axe aceptados | a11y keyboard E2E | Sin criterios formales | A11y acceptance criteria | PR-A11Y1 | P2 |
+| Premium UX | Tokens + KPIs + polish certificado | Radix/CVA/tailwind, no-scroll | Sin tokens doc ni KPIs | Dashboard value audit | PR-UX1 | P2 |
+| Executive trust | DD pack + evidence room + narrativa | sanitización/no-secrets | Sin artefactos DD | Exec narrative + evidence index | PR-EXEC1 | P1 |
+| Support readiness | Escalamiento + SLA soporte | ninguna | Inexistente | Support escalation doc | PR-EXEC1 | P2 |
+| AI workflow efficiency | Prompt-packs + SoT + reglas de auditoría | protocolo + skills | Doc overload | Prompt-pack index | PR-O4/O5 | P1 |
+
+---
+
+## 4. System Parity Matrix
+
+> ¿Está cada superficie al mismo nivel? Maduración 0–5 (rúbrica multinacional). El objetivo supremo es
+> **paridad en 5/5**; hoy hay **dispersión 1–4**.
+
+| Surface | Maturity 0–5 | Target | Strongest control | Weakest control | Missing evidence | Blocking gap | First PR | Dependency |
+| --- | :--: | :--: | --- | --- | --- | --- | --- | --- |
+| Public website | **3** | 5 | SEO (manifest/robots/sitemap), CSP | Performance budget | LCP/CLS medidos | Sin budgets | PR-PERF1 | — |
+| Public tokens | **3** | 5 | Rate-limit + sanitización | Lifecycle/retención | Política de expiración/retención | Data governance | PR-DATA1 | PR-S1 |
+| Public reports | **3** | 5 | Access-token + no-cache privados | Audit de acceso | Cobertura de access log | Data/observ. | PR-DATA1/OBS1 | PR-S1 |
+| Clinic dashboard | **3** | 5 | No-scroll contracts, live-read | KPIs/observabilidad | Métricas operativas | UX KPIs | PR-UX1 | PR-OBS1 |
+| Admin dashboard | **3** | 5 | Acciones reales (skill ops) | Executive KPIs | Reporting ejecutivo | UX/exec | PR-UX1 | PR-OBS1 |
+| Admin mobile | **3** | 5 | No-scroll, helper consolidado | a11y formal | axe acceptance | A11y | PR-A11Y1 | PR-C3 |
+| Session/auth layer | **4** | 5 | Aislamiento `admin/app_session_id` | Rotación/secret-scanning | Rotación documentada | Security gov | PR-S1 | — |
+| API/backend | **3** | 5 | Fastify modular, error-handler | Contratos/versioning | OpenAPI/idempotency | API gov | PR-API1 | PR-OBS2 |
+| Data/storage | **2** | 5 | Drizzle + caches | RLS/retención | RLS DB + restore evidence | Data/tenant | PR-S1/DATA1 | — |
+| E2E/CI | **3** | 5 | 42 specs capeados (#1096) | CI usa capas | unión==full en CI | Quality gate | PR-C3 | PR-QA1 |
+| Documentation/governance | **2** | 5 | Closeouts + protocolo | Índice/SoT/ADR | Índice + ADR + risk register | Governance | PR-O1/GOV1 | — |
+| Release process | **3** | 5 | build-info, staging smoke | Checklist/rollback drill | Release checklist | Release | PR-REL1 | PR-O1 |
+| Observability | **2** | 5 | request-id, health | Logs estructurados/alerting | JSON logs + SLO + runbook | Observability | PR-OBS1 | — |
+| Security controls | **3** | 5 | CSP/headers/rate-limit/CSRF | Secret-scanning + RLS | CI secret-scan + RLS | Security gov | PR-S1 | — |
+| Integration/API readiness | **1** | 5 | Errores estándar, paginación | Versioning/OpenAPI/webhooks | Contrato externo | Integration | PR-API1 | PR-API1 |
+
+**Lectura:** ninguna superficie está bajo 1 salvo integración (capacidad ausente, aceptable hoy). La
+**paridad se rompe** por la base transversal débil (governance 2, observability 2, data 2): subir esas
+tres **eleva todas las superficies simultáneamente** → confirma "alinear por dominios transversales
+antes que por superficie".
+
+---
+
+## 5. Gap Consolidation
+
+> Gaps fusionados y deduplicados de las tres auditorías. `R-OO`=ordering audit, `R-ENT`=enterprise
+> audit, `R-EXT`=extreme audit.
+
+### P0 — Foundation
+
+| Gap | Fuente | Dominio | Razón | Riesgo | First PR | Validación | Rollback | Dependencia |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Índice de auditorías | R-OO/R-EXT | SoT | 174 docs sin entrada única | Re-descubrimiento | PR-O1 | lectura + `git diff --check` | borrar | — |
+| Mapa de fuentes de verdad | R-OO | SoT | Sin "para X leé Y" | Decisiones contradictorias | PR-O2 | lectura | borrar | PR-O1 |
+| Gobernanza (ADR/RFC/ownership) | R-EXT | Governance | Decisiones no trazables | DD sin control interno | PR-GOV1 | lectura | borrar | PR-O1 |
+| Tenant/RLS sin verificar | R-EXT | Security/Data | Aislamiento DB no probado | Cross-tenant clínico | PR-S1 | revisión (+test futuro) | docs | — |
+| Observabilidad ciega | R-ENT/R-EXT | Observability | Logs `console.*` | MTTR alto | PR-OBS1→OBS2 | test shape, no-secretos | revertir 1 archivo | PR-OBS1 |
+| Cerrar 3 audits untracked | este plan | Governance | Scope sin cerrar | Pérdida/duplicación | Wave 0 (Nico) | `git status` limpio | — | — |
+
+### P1 — High-value maturity
+
+| Gap | Fuente | Dominio | Razón | Riesgo | First PR | Validación | Rollback | Dependencia |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| CI no usa capas E2E | R-ENT/R-EXT | CI | Feedback lento, nombre engañoso | Coverage loss | PR-C3 | unión==42; CI verde | revertir workflow | PR-QA1 + val. local |
+| Flake/regression policy | R-EXT | QA | Sin política | Flake silencioso | PR-QA1 | lectura | borrar | — |
+| Risk register | R-EXT | Governance | Sin registro vivo | DD débil | PR-GOV2 | lectura | borrar | PR-GOV1 |
+| Release/rollback checklist | R-ENT/R-EXT | Release | Sin drill/data-impact | Recuperación incierta | PR-REL1 | lectura | borrar | PR-O1 |
+| Performance budgets | R-ENT/R-EXT | Performance | Sin medición | Degradación invisible | PR-PERF1 | build size vs budget | docs | — |
+| Structured logger | R-ENT/R-EXT | Observability | console plano | Diagnóstico nulo | PR-OBS2(=R2/S2) | test shape | revertir | PR-OBS1 |
+| Correlation IDs FE↔BE | R-EXT | Observability | request-id sin propagación | Traza parcial | PR-S3 | e2e correlación | revertir | PR-OBS2 |
+| Dep governance + Dependabot SLA | R-EXT | Dependencies | 19 PRs aging; deps sin uso | CVE aging | PR-DEP1/GOV3 | edad PRs | docs | — |
+| Data lifecycle/retención | R-ENT/R-EXT | Data | Sin políticas | Cumplimiento | PR-DATA1 | revisión + Nico | docs | PR-O1 |
+| Exec trust / DD pack | R-EXT | Exec | Sin artefactos | Bloquea ventas | PR-EXEC1 | revisión | borrar | PR-GOV2 |
+
+### P2 — Dependent maturity
+
+| Gap | Fuente | First PR | Dependencia |
+| --- | --- | --- | --- |
+| API governance/OpenAPI | R-ENT/R-EXT | PR-API1 | demanda externa |
+| KPIs operativos + executive reporting | R-EXT | PR-UX1 | PR-OBS1 |
+| A11y acceptance (axe) | R-ENT/R-EXT | PR-A11Y1 | PR-C3 |
+| Design tokens documentados | R-ENT | PR-UX1 | PR-O1 |
+| Tenant model formal | R-EXT | post PR-S1 | PR-S1 |
+| Synthetic monitoring / error budgets | R-EXT | post PR-OBS1 | PR-OBS1 |
+
+### P3 — Advanced / later
+
+| Gap | Fuente | Condición |
+| --- | --- | --- |
+| Idempotency keys / webhooks firmados / SDK | R-ENT/R-EXT | consumidor externo real |
+| Async jobs / cola | R-ENT/R-EXT | trabajos largos que bloqueen request |
+| i18n/l10n / multi-moneda / residencia | R-EXT | expansión internacional real (requires legal) |
+
+### Not recommended now
+
+micro-frontends · CRDTs · WebGL · PWA-offline de privados · realtime en todo · backend/frontend
+rewrite · adopción amplia de deps · rewrite grande de dashboard. (Detalle y condiciones en §10.)
+
+---
+
+## 6. Supreme PR Architecture
+
+> Reglas: PRs chicos, **un dominio y una clase de riesgo por PR**, docs-only antes de implementación,
+> implementación solo con auditoría/SoT previa, CI-only ≠ scripts-only, move-only ≠ contenido,
+> security-only ≠ visual, backend-only ≠ frontend (salvo contract-only), rollback y no-scope
+> explícitos siempre.
+
+### Registro canónico de PRs (reconcilia el drift de nombres entre las 3 auditorías)
+
+| Canónico | Alias en auditorías previas | Tipo | Familia |
+| --- | --- | --- | --- |
+| PR-O1 | PR-O1 | docs-only | Ordering |
+| PR-O2 | PR-O2 | docs-only | Ordering |
+| PR-O3 | PR-O3 (clasificación histórica) | docs-only | Ordering |
+| PR-O4 | PR-O5 (prompt-pack) | docs-only | Ordering |
+| PR-O5 | (nuevo: operating map auditorías) | docs-only | Ordering |
+| PR-GOV1 | PR-GOV1 | docs-only | Governance |
+| PR-GOV2 | PR-GOV2 (risk register) | docs-only | Governance |
+| PR-GOV3 | PR-GOV3 / PR-DEP1 (dep gov) | docs-only | Governance/Dep |
+| PR-REL1 | PR-REL1 | docs-only | Release |
+| PR-QA1 | PR-QA1 | docs-only | CI/QA |
+| PR-C3 | PR-C3 | CI-only | CI |
+| PR-S1 | PR-S1 | docs-only | Security |
+| PR-OBS1 | PR-OBS1 / PR-R1 | docs-only | Observability |
+| PR-OBS2 | PR-S2 / PR-R2 (logger JSON) | backend-only | Observability |
+| PR-S3 | PR-S3 (correlation IDs) | backend/security-only | Observability/Security |
+| PR-PERF1 | PR-PERF1 / PR-P1 | docs-only | Performance |
+| PR-PERF2 | PR-P2 (medición) | frontend-only | Performance |
+| PR-DATA1 | PR-DATA1 / PR-G1 | docs-only | Data |
+| PR-API1 | PR-API1 / PR-A1 | docs-only | API |
+| PR-UX1 | PR-UX1 / PR-D1 | docs-only | UX |
+| PR-A11Y1 | PR-A11Y1 | docs-only | UX/A11y |
+| PR-EXEC1 | PR-EXEC1 / PR-EXEC | docs-only | Exec |
+| PR-DEP1 | PR-DEP1 | docs-only | Dependencies |
+
+### PR families
+
+**PR-O — Repository Ordering & Source of Truth.** *Objetivo:* punto de entrada único. *Por qué:*
+reduce consumo y re-descubrimiento. *First PR:* PR-O1. *Deps:* ninguna. *Validación:* `git diff --check`
++ lectura. *Rollback:* borrar. *DoD:* `docs/audit/README.md` + `docs/SOURCES_OF_TRUTH.md` + histórico
+clasificado + prompt-pack + operating-map. *PRs:* PR-O1 índice, PR-O2 SoT, PR-O3 clasificación
+histórica, PR-O4 prompt-pack index, PR-O5 operating map para futuras auditorías Claude.
+
+**PR-GOV — Engineering Governance.** *Objetivo:* decisiones trazables y gestión de riesgo. *First PR:*
+PR-GOV1. *Deps:* PR-O1. *Validación/Rollback:* lectura/borrar. *DoD:* ADR template, RFC/change-control
+template, risk register, ownership matrix (CODEOWNERS doc), enterprise readiness checklist.
+
+**PR-C — CI & Quality Gates.** *Objetivo:* gate barato sin pérdida de cobertura. *First PR:* PR-C3
+(precedido de validación local `unión==42` + PR-QA1). *Deps:* PR-QA1. *Validación:* unión==42, CI
+verde, seguridad siempre en gate. *Rollback:* revertir workflow. *DoD:* smoke/full split, coverage
+invariant, flake policy, regression policy.
+
+**PR-S — Security & Isolation.** *Objetivo:* invariantes demostrables. *First PR:* PR-S1. *Deps:*
+PR-O1. *Validación:* `security:public-surface`, suites `security-*`/`auth-*`. *Rollback:* por PR.
+*DoD:* auditoría session isolation, tenant/RLS verification, public surface hardening, rate-limit/CSP/
+headers review, audit-log strategy.
+
+**PR-OBS — Observability & Incident Readiness.** *Objetivo:* diagnóstico y reliability. *First PR:*
+PR-OBS1 docs. *Deps:* PR-O1. *Validación:* test de shape de log, e2e de correlación. *Rollback:*
+revertir archivos. *DoD:* structured logging audit, JSON logger (PR-OBS2), correlation/request IDs
+(PR-S3), health checks por dependencia, incident runbook, alerting/SLO baseline.
+
+**PR-REL — Release Engineering.** *Objetivo:* releases predecibles y reversibles. *First PR:* PR-REL1.
+*Deps:* PR-O1. *Validación:* lectura + drill cronometrado. *Rollback:* docs. *DoD:* release readiness
+checklist, rollback checklist (+data-impact), postdeploy smoke, staging/prod validation, release notes
+discipline.
+
+**PR-PERF — Performance & Scalability.** *Objetivo:* predictibilidad. *First PR:* PR-PERF1 docs.
+*Deps:* PR-DEP1 (deps resueltas). *Validación:* build size + vitals vs budget. *Rollback:* aditivo.
+*DoD:* budget spec, baseline measurement, CI/perf timing, budgets FE/admin/clínica/público, API
+latency budgets.
+
+**PR-DATA — Data Governance.** *Objetivo:* auditabilidad y cumplimiento. *First PR:* PR-DATA1 docs
+(legal flags). *Deps:* PR-O1. *Validación:* revisión + Nico + (futuro) restore drill. *Rollback:*
+docs. *DoD:* lifecycle states, retención/export/delete, backup/restore evidence, audit trail strategy,
+reconciliation strategy.
+
+**PR-API — Platform & Integration.** *Objetivo:* integrabilidad B2B. *First PR:* PR-API1 docs. *Deps:*
+PR-O1 + demanda real. *Validación:* contract-tests. *Rollback:* versioning aditivo. *DoD:* API
+governance audit, OpenAPI readiness, versioning, idempotency, webhooks, standard errors, pagination.
+
+**PR-UX — Supreme Product Operability & Premium UX.** *Objetivo:* confianza operativa + premium.
+*First PR:* PR-UX1 docs. *Deps:* PR-OBS1 (medir antes de pulir). *Validación:* `e2e:visual-contract`
++ QA humana + axe. *Rollback:* por PR. *DoD:* admin/clínica command-center audit, no-scroll enterprise
+UX audit, executive KPI layer, premium visual system audit, accessibility acceptance criteria.
+
+**PR-DEP — Dependency & Supply Chain.** *Objetivo:* superficie mínima y actualizada. *First PR:*
+PR-DEP1 docs. *Deps:* ninguna. *Validación:* `git grep` imports + edad PRs Dependabot. *Rollback:*
+docs. *DoD:* used vs unused audit (react-query/table/echarts), Dependabot aging policy, dependency risk
+register, update cadence.
+
+### 6.x Per-PR execution detail (scope / no-scope / validación / rollback / success metric)
+
+> Tabla operable: cada PR con todo lo que la misión exige por PR. "Éxito" = métrica observable de
+> cierre. Todos los PRs `docs-only` salvo donde se indique. Git lo ejecuta Nico.
+
+| PR | Tipo | Objetivo (1 línea) | Allowed scope | Explicit no-scope | Validación | Rollback | Success metric | Dep |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| PR-O1 | docs-only | Índice de auditorías | `docs/audit/README.md` | mover/editar audits | `git diff --check`, lectura | borrar | índice cubre 100% audits | — |
+| PR-O2 | docs-only | Mapa de fuentes de verdad | `docs/SOURCES_OF_TRUTH.md` (+1 línea AGENTS.md OK Nico) | consolidar carpetas | lectura | borrar/revertir | 100% dominios mapeados | PR-O1 |
+| PR-O3 | docs-only | Clasificar histórico/vigente | banners en docs | mover/renombrar/borrar | `git diff --check` + no-lectura por test | revertir | 0 docs vigentes sin clasificar | PR-O1 |
+| PR-O4 | docs-only | Prompt-pack index para Claude | `docs/audit/README.md` (sección) | tooling/código | lectura | revertir sección | auditorías referencian SoT | PR-O1 |
+| PR-O5 | docs-only | Operating map de futuras auditorías | `docs/audit/README.md` (sección) | scope nuevo | lectura | revertir sección | reglas de auditoría publicadas | PR-O1 |
+| PR-GOV1 | docs-only | ADR/RFC/change-control + ownership doc | `docs/governance/*` | `.github/CODEOWNERS` real sin OK | lectura | borrar | templates con ejemplo real | PR-O1 |
+| PR-GOV2 | docs-only | Risk register vivo | `docs/governance/risk-register.md` | inventar riesgos sin evidencia | lectura | borrar | 100% riesgos con dueño/mitigación | PR-GOV1 |
+| PR-GOV3 | docs-only | Dependency governance + Dependabot SLA | `docs/governance/dependency-policy.md` | tocar deps/lockfile | edad PRs | borrar | SLA seguridad <7d definido | PR-GOV1 |
+| PR-REL1 | docs-only | Release readiness + rollback + data-impact | `docs/ops/release-readiness-checklist.md` | tocar CI | lectura + drill | borrar | RTO <15min documentado | PR-O1 |
+| PR-QA1 | docs-only | Flaky + regression policy | `docs/qa/flaky-and-regression-policy.md` | tocar tests/CI | lectura | borrar | política publicada | — |
+| PR-C3 | CI-only | Capas E2E en CI sin pérdida cobertura | `.github/workflows/frontend-ci.yml` | specs/scripts/Playwright config | unión==42; CI verde | revertir workflow | smoke <4min; full red | PR-QA1 + val. local |
+| PR-S1 | docs-only | Auditoría seguridad/aislamiento (incl. RLS/tenant) | `docs/security/security-session-focused-audit.md` | tocar auth/middlewares | revisión + `security:public-surface` | borrar | RLS verificada o gap doc | PR-O1 |
+| PR-OBS1 | docs-only | Baseline observabilidad + SLO + incident runbook | `docs/ops/observability-baseline.md` | tocar logger/CI | revisión | borrar | SLOs numéricos + runbook | PR-O1 |
+| PR-OBS2 | backend-only | Logger estructurado JSON (sin deps) | `server/lib/logger.ts` + test | otras capas | test shape, `pnpm test`, no-secretos | revertir 1 archivo | 100% rutas vía logger | PR-OBS1 |
+| PR-S3 | backend/security-only | Correlation IDs FE↔BE | `server/lib/api-request-id.ts` + propagación | otras capas | e2e de correlación | revertir | correlación FE↔BE 100% | PR-OBS2 |
+| PR-PERF1 | docs-only | Spec de performance budgets | `docs/perf/performance-budgets.md` | medir/instrumentar | revisión | borrar | budgets por superficie | PR-DEP1 |
+| PR-PERF2 | frontend-only | Medición web-vitals mínima | medición no intrusiva | budgets nuevos | build size + vitals vs budget | revertir | LCP/INP/CLS medidos | PR-PERF1 |
+| PR-DATA1 | docs-only | Lifecycle + retención (legal flags) | `docs/data/data-governance-audit.md` | inventar obligaciones legales | revisión + Nico | borrar | retención definida | PR-O1 |
+| PR-API1 | docs-only | API governance/OpenAPI readiness | `docs/api/api-governance-readiness.md` | tocar rutas | revisión | borrar | path de versioning definido | PR-O1 |
+| PR-UX1 | docs-only | Valor premium dashboard + KPIs + tokens | `docs/ux/dashboard-multinational-value.md` | tocar `frontend/src` | revisión | borrar | KPIs operativos definidos | PR-OBS1 |
+| PR-A11Y1 | docs-only | Criterios de aceptación a11y (axe) | `docs/ux/accessibility-acceptance-criteria.md` | tocar `frontend/src`/tests | revisión | borrar | criterios críticos definidos | PR-C3 |
+| PR-EXEC1 | docs-only | DD pack / evidence room + narrativa | `docs/exec/multinational-readiness-narrative.md` | exponer evidencia sensible | revisión + Nico | borrar | índice de evidencia completo | PR-GOV2 |
+| PR-DEP1 | docs-only | Used vs unused deps + risk register | `docs/governance/dependency-audit.md` | tocar `package.json` | `git grep` imports | borrar | 3 deps con decisión cablear/retirar | — |
+
+### 6.y PR dependency DAG (orden de habilitación)
+
+```text
+Wave0 commit-audits
+   └─> PR-O1 ──> PR-O2 ──> PR-O3 / PR-O4 / PR-O5        (Gate 0)
+         ├─> PR-GOV1 ─> PR-GOV2 ─> PR-EXEC1
+         │      └─> PR-GOV3                              (Gate 1)
+         ├─> PR-REL1                                     (Gate 1)
+         ├─> PR-QA1 ─> PR-C3                             (Gate 2)
+         ├─> PR-S1                                       (Gate 3)
+         ├─> PR-OBS1 ─> PR-OBS2 ─> PR-S3                 (Gate 4)
+         ├─> PR-DEP1 ─> PR-PERF1 ─> PR-PERF2             (Gate 5)
+         ├─> PR-DATA1                                    (Gate 6)
+         ├─> PR-API1                                     (Gate 6)
+         └─> PR-OBS1 ─> PR-UX1 ; PR-C3 ─> PR-A11Y1       (Gate 7)
+```
+
+> Lectura del DAG: nada arranca antes de **PR-O1** (raíz). La rama de governance (PR-GOV*) y la de
+> calidad (PR-QA1→PR-C3) son independientes y pueden correr en paralelo tras Gate 0. La
+> implementación de observabilidad (PR-OBS2/PR-S3) depende de su auditoría docs (PR-OBS1). El trabajo
+> visual (PR-UX1/PR-A11Y1) es **hoja del grafo**: requiere observabilidad (medir antes de pulir) y el
+> gate de calidad (a11y tras CI estable).
+
+---
+
+## 7. Phase Gates
+
+> Ningún wave avanza si su gate no pasa. Los gates son **criterios de evidencia**, no fechas.
+
+| Gate | Nombre | Criterios de salida (todos verdaderos) | Bloquea hasta |
+| --- | --- | --- | --- |
+| **Gate 0** | Repository control | Índice existe · SoT map existe · docs current/histórico clasificados · próximas auditorías referencian docs correctos | Cualquier wave ≥1 |
+| **Gate 1** | Governance control | ADR/RFC templates · risk register · release checklist · rollback checklist | Wave ≥3 |
+| **Gate 2** | Quality control | E2E layer CI seguro (unión==full) · smoke/full split · coverage invariant documentado · flake policy | Wave ≥4 cambios de riesgo |
+| **Gate 3** | Security control | Session isolation auditada · tenant/RLS verificada o gap documentado · riesgos de superficie pública clasificados · audit-log strategy definida | Wave ≥6 datos/API |
+| **Gate 4** | Observability control | Logs estructurados existen · correlation IDs diseñados/implementados · incident runbook · health checks clasificados | Wave ≥5/8 |
+| **Gate 5** | Performance control | Budgets definidos · baseline medido · budgets admin/clínica/público/API trackeados | Wave ≥8 UX pesado |
+| **Gate 6** | Data/API control | Data lifecycle documentado · retención/export/delete evaluado · OpenAPI/API governance path · webhook/idempotency readiness | Wave ≥9 |
+| **Gate 7** | Supreme UX/Product | Admin/clínica premium command-center path definido · no-scroll preservado · a11y acceptance criteria · visual separado de security/CI | Wave 9 features visuales |
+
+---
+
+## 8. Execution Roadmap
+
+> Olas (waves) ordenadas por gate. Git lo ejecuta Nico. Cada wave = scope, no-scope, precondición,
+> criterio de éxito, rollback, artefactos.
+
+### Wave 0 — Commit & close current audits
+- **Objetivo:** llevar las 3 auditorías base (+ este plan) a `main` limpiamente; evitar acumulación
+  de scope untracked.
+- **Allowed scope:** Nico hace `git add` de los 4 `.md` de `docs/audit/` + commit + push + PR docs-only.
+- **Non-scope:** ningún cambio de código; no mezclar con otros archivos.
+- **Preconditions:** ninguna.
+- **Success:** `git status` limpio; 4 audits en `main`.
+- **Rollback:** revert del commit docs.
+- **Artifacts:** 4 documentos de auditoría versionados.
+
+### Wave 1 — Source-of-truth & audit control (Gate 0)
+- **Objetivo:** PR-O1, PR-O2, PR-O3. **Scope:** crear `docs/audit/README.md`, `docs/SOURCES_OF_TRUTH.md`,
+  banners de histórico. **Non-scope:** mover/renombrar/borrar. **Precond:** Wave 0.
+- **Success:** Gate 0 pasa. **Rollback:** borrar archivos/banners. **Artifacts:** índice + mapa.
+
+### Wave 2 — Governance & release safety (Gate 1)
+- **Objetivo:** PR-GOV1, PR-GOV2, PR-REL1. **Scope:** `docs/governance/*`, `docs/ops/release-readiness-checklist.md`.
+  **Non-scope:** tocar `.github/CODEOWNERS` real sin OK. **Precond:** Gate 0.
+- **Success:** Gate 1 pasa. **Rollback:** borrar docs. **Artifacts:** ADR/RFC/risk-register/checklist.
+
+### Wave 3 — CI quality gate (Gate 2)
+- **Objetivo:** PR-C3, PR-QA1. **Scope:** `.github/workflows/frontend-ci.yml` (CI-only) + `docs/qa/*`.
+  **Non-scope:** specs/scripts/Playwright config. **Precond:** Gate 1 + validación local `unión==42`.
+- **Success:** smoke gate + full red; Gate 2 pasa. **Rollback:** revertir workflow. **Artifacts:**
+  CI por capas + flake policy.
+
+### Wave 4 — Security & isolation (Gate 3)
+- **Objetivo:** PR-S1, y (si auditoría lo habilita) PR-S2/S3 viven en Wave 5 (observability). **Scope:**
+  `docs/security/*` (auditoría enfocada incl. RLS/tenant + privileged audit + secret-scanning plan).
+  **Non-scope:** tocar auth/middlewares en este wave. **Precond:** Gate 2.
+- **Success:** Gate 3 pasa (RLS verificada o gap documentado). **Rollback:** docs. **Artifacts:**
+  security focused audit + tenant evidence.
+
+### Wave 5 — Observability & incident readiness (Gate 4)
+- **Objetivo:** PR-OBS1 (docs), PR-OBS2 (logger JSON backend-only), PR-S3 (correlation IDs). **Scope:**
+  `docs/ops/observability-baseline.md`, `server/lib/logger.ts` + test, `api-request-id.ts` propagación.
+  **Non-scope:** otras capas; deps nuevas. **Precond:** Gate 1 (no requiere Gate 3 para docs, sí para
+  implementación si toca seguridad).
+- **Success:** Gate 4 pasa. **Rollback:** revertir archivos acotados. **Artifacts:** runbook + logs
+  JSON + SLO baseline.
+
+### Wave 6 — Performance budgets (Gate 5)
+- **Objetivo:** PR-PERF1 (docs), PR-PERF2 (medición). **Scope:** `docs/perf/*`, medición no intrusiva.
+  **Non-scope:** budgets sin medición; deps. **Precond:** Gate 2 + PR-DEP1.
+- **Success:** Gate 5 pasa. **Rollback:** aditivo. **Artifacts:** budgets + baseline.
+
+### Wave 7 — Data/API governance (Gate 6)
+- **Objetivo:** PR-DATA1, PR-API1. **Scope:** `docs/data/*`, `docs/api/*` (legal flags). **Non-scope:**
+  inventar obligaciones legales; tocar rutas. **Precond:** Gate 3 + Gate 4.
+- **Success:** Gate 6 pasa. **Rollback:** docs. **Artifacts:** lifecycle/retención + API readiness.
+
+### Wave 8 — Supreme dashboard & product operability (Gate 7)
+- **Objetivo:** PR-UX1, PR-UX2, PR-UX3 (+ PR-A11Y1). **Scope:** `docs/ux/*` primero, luego PRs
+  frontend-only por superficie con `visual-contract`. **Non-scope:** mezclar visual con security/CI.
+  **Precond:** Gates 0–5.
+- **Success:** Gate 7 pasa; tokens + KPIs + a11y. **Rollback:** por PR. **Artifacts:** dashboard value
+  + a11y criteria.
+
+### Wave 9 — Advanced capabilities only if justified
+- **Objetivo:** realtime/colas/PWA-offline/analytics/automatización **solo con evidencia + PRD corto**.
+  **Scope:** por capacidad. **Non-scope:** todo lo de §10. **Precond:** todos los gates + demanda real.
+- **Success:** por capacidad. **Rollback:** por capacidad. **Artifacts:** PRD + guardrails.
+
+---
+
+## 9. Supreme Standards by Domain
+
+| Domain | Current baseline | Supreme standard | Min PRs | Measurable acceptance | Evidence required | What not to do |
+| --- | --- | --- | --- | --- | --- | --- |
+| Governance | protocolo + closeouts | ADR/RFC/risk register/PRR/ownership | PR-GOV1/2 | 100% decisiones clave con ADR | ADR repo + risk register | No gobernanza ceremonial sin uso |
+| Security | CSP/headers/rate-limit/sesiones | + secret-scanning + RLS verificada + rotación | PR-S1(+impl) | 0 regresión superficie pública; RLS dictaminada | security audit + test cross-tenant | No relajar fronteras por conveniencia |
+| Observability | console + request-id + health | logs JSON + correlación + alerting + SLO | PR-OBS1/2, PR-S3 | 100% rutas vía logger; correlación FE↔BE | runbook + log shape test | No agregar Sentry/OTel antes de logs JSON |
+| CI/testing | 400 unit + 42 E2E | capas en CI + flake/coverage policy | PR-C3, PR-QA1 | unión==42; flaky <1% | CI verde + policy | No tocar CI sin validación local |
+| Release | build-info + staging smoke | checklist + rollback drill + data-impact | PR-REL1 | RTO <15min documentado | checklist + drill | No release sin rollback definido |
+| Performance | sin budgets | budgets enforced + medición | PR-PERF1/2 | 100% rutas en budget | budgets + vitals | No optimizar sin medir |
+| Data | audit/tracking + backup doc | lifecycle + retención + restore evidence | PR-DATA1 | retención definida; restore probado | lifecycle doc + restore drill | No inventar obligaciones legales |
+| API/integration | API interna `/api` | versioning + OpenAPI + idempotency + webhooks | PR-API1 | contrato versionado estable | OpenAPI + contract-tests | No exponer API sin versioning |
+| UX/product | Radix/no-scroll | tokens + KPIs + premium certificado | PR-UX1/2/3 | KPIs operativos medidos | tokens doc + KPIs | No rewrite de dashboard |
+| Accessibility | a11y keyboard E2E | criterios axe aceptados | PR-A11Y1 | 100% criterios críticos | axe report | No marcar a11y "ok" sin herramienta |
+| Documentation | 174 docs sin índice | índice + SoT + ADR + runbooks | PR-O1/O2 | 100% dominios en SoT | índice + mapa | No mover docs sin índice |
+| Dependencies | overrides + Dependabot | política + SLA + risk register | PR-DEP1/GOV3 | dep risk age <7d (seguridad) | dep audit + policy | No adoptar deps sin consumidor |
+| AI workflow | protocolo + skills | prompt-packs + SoT + reglas auditoría | PR-O4/O5 | auditorías referencian SoT | prompt-pack index | No dejar a Claude elegir prioridad sin matriz |
+
+---
+
+## 10. Anti-Patterns to Block
+
+| Anti-patrón | Por qué se bloquea | Alternativa controlada |
+| --- | --- | --- |
+| Rewrites grandes | Destruye activos maduros | Instrumentar/aditivo por dominio |
+| Adopción amplia de deps | 3 deps ya sin uso | Resolver react-query/table/echarts primero |
+| Dashboard rewrite antes de governance/security/observability | Inversión sin red ni evidencia | Wave 8 tras Gates 0–5 |
+| CI sin validación de scripts | Pérdida de cobertura silenciosa | Validar `unión==42` antes de PR-C3 |
+| Mover E2E antes de estabilidad de capas | Rompe scripts por-ruta (#1096) | No mover hasta capas+CI estables |
+| Visual mezclado con security | Diff irrevisable, riesgo cruzado | PRs separados (un eje) |
+| Producto mezclado con docs/SoT | Confunde control con feature | PRs separados |
+| Backend+frontend en un PR sin contrato | Blast radius | Contract-only o PRs separados |
+| Realtime en todo | Sin valor probado | Refetch/polling; Wave 9 condicional |
+| PWA-offline de datos privados | Cache de privados | PWA pública actual |
+| Micro-frontends | Sin equipos independientes | Monorepo + App Router |
+| CRDTs sin co-edición | Complejidad sin caso | Bloqueo optimista |
+| WebGL sin visualización masiva | Riesgo sin necesidad | ECharts (ya instalado) |
+| Mover docs históricos sin índice | Rompe referencias/tests por path | PR-O1/O2 primero, move-only después |
+| Re-auditar bloques cerrados | Desperdicio de tokens | Consultar closeouts/SoT |
+| Claude elige prioridad sin matriz | Decisión no trazable | Matriz P0–P3 obligatoria |
+
+---
+
+## 11. Supreme Metrics
+
+| Categoría / Métrica | Target | Evidencia actual | First PR para medir | Owner/Dominio | Frecuencia |
+| --- | --- | --- | --- | --- | --- |
+| Governance maturity | 100% controles §3 con doc | ~0 | PR-GOV2 | Governance | por release |
+| Source-of-truth coverage | 100% dominios en SoT | 0 (sin mapa) | PR-O2 | Docs | por audit |
+| Audit closure rate | 100% bloques con closeout | parcial | PR-O1 | Docs | mensual |
+| PR size/risk | <~400 LOC, 1 eje | alto (disciplina ya buena) | PR-GOV1 | Eng | por PR |
+| CI duration | full <12min | sin reporte | PR-C3 | CI | por corrida |
+| E2E smoke duration | <4min | sin medición | PR-C3 | CI | por corrida |
+| Full regression duration | <12min | sin medición | PR-C3 | CI | por corrida |
+| Flaky rate | <1% | sin registro | PR-QA1 | QA | semanal |
+| Incident detection time (MTTD) | <5min | manual | PR-OBS1 | SRE | por incidente |
+| Incident diagnosis time | <30min | manual | PR-OBS1/S3 | SRE | por incidente |
+| Rollback time objective | <15min | sin drill | PR-REL1 | Release | por release |
+| Structured log coverage | 100% rutas | 0 (console) | PR-OBS2 | SRE | por release |
+| Correlation ID coverage | 100% FE↔BE | parcial (BE) | PR-S3 | SRE | por release |
+| API latency p95 | <400ms lectura/<800ms escritura | `runtime-timing` sin agregar | PR-PERF1 | Backend | continuo |
+| Dashboard load time | LCP<2.5s/<3.5s | sin medición | PR-PERF2 | FE | por release |
+| Public report load time | LCP<2.0s | sin medición | PR-PERF2 | FE | por release |
+| Accessibility acceptance | 100% criterios críticos | a11y E2E parcial | PR-A11Y1 | UX | por release |
+| Dependency aging (seguridad) | <7d | 19 PRs desde 2026-06-18 | PR-DEP1 | Governance | semanal |
+| Security invariant coverage | 100% invariantes con test | alto | PR-S1 | Security | por release |
+| Docs freshness | 0 docs vigentes sin clasificar | 174 sin índice | PR-O1/O3 | Docs | por audit |
+
+---
+
+## 12. Supreme Readiness Narrative
+
+VETNEB está hoy en un **baseline SaaS sólido (≈2.1/5 multinacional)** con cimientos que muchas
+empresas no alcanzan: separación estricta de superficies, postura de seguridad fuerte, disciplina de
+testing y control de cambios maduro. Lo que falta es **madurez operacional y de gobierno**, no
+arquitectura.
+
+**Por qué el camino es incremental.** El sistema tiene perfil "T invertida": transversales fuertes,
+instrumentación débil. Subir los transversales (governance, observability, data) **eleva todas las
+superficies a la vez**; reescribir las destruiría. Cada wave es aditiva, reversible y con gate.
+
+**Por qué governance/source-of-truth va primero.** Sin índice, mapa de fuentes de verdad, ADRs y risk
+register, cada wave posterior paga el costo de re-descubrir contexto y carece de decisión trazable —
+exactamente lo que una due-diligence multinacional exige ver primero. Es además el wave de **menor
+riesgo** (docs-only).
+
+**Por qué observability/security/performance preceden a la expansión de producto.** Hacer trabajo
+visual pesado sin logs estructurados, sin verificación de aislamiento de tenant y sin budgets es
+construir sobre terreno no medido: un incidente sería ciego, una regresión de performance invisible y
+un cruce de datos indetectable. Los Gates 3–5 instalan la red antes de acelerar.
+
+**Cómo encaja el trabajo premium de dashboard de forma segura.** El pulido premium (Wave 8) llega
+**después** de los gates de fundación, sobre los contratos no-scroll ya logrados, con tokens y KPIs
+documentados y separando siempre lo visual de lo de seguridad/CI. Así el premium es **medible y
+reversible**, no cosmético.
+
+**Por qué esto es más fuerte que un rewrite.** Un rewrite tiraría ~400 tests, 42 E2E y un backend
+modular para resolver problemas aditivos, introduciendo riesgo masivo y meses sin evidencia. La ruta
+de waves entrega **evidencia de DD en cada paso** y mantiene producción intacta.
+
+**Cómo soporta DD multinacional y confianza enterprise.** Al cerrar los gates, VETNEB acumula un
+**evidence room** (ADRs, risk register, security audit, SLOs, runbooks, budgets, lifecycle de datos)
+que responde directamente a las preguntas de una venta enterprise: ¿cómo deciden?, ¿cómo aíslan
+datos?, ¿cómo operan incidentes?, ¿cómo recuperan?, ¿cómo miden calidad?
+
+---
+
+## 13. Final Recommendation
+
+1. **¿Próximo PR exacto?** **PR-O1 docs-only** — `docs/audit/README.md` (índice de auditorías
+   vigentes con estado).
+
+2. **¿Qué commitear/mergear antes de iniciar el plan?** **Wave 0:** las 3 auditorías base + este plan
+   (hoy untracked) → commit docs-only a `main` por Nico. Sin esto, el plan ejecuta sobre scope sin
+   cerrar.
+
+3. **¿Camino más rápido y seguro a nivel supremo?** Gates en orden: 0 (SoT) → 1 (governance) → 2 (CI)
+   → 3 (security/RLS) → 4 (observability) → 5 (performance) → 6 (data/API) → 7 (UX). Aditivo, por
+   waves, sin rewrites.
+
+4. **¿Qué se retrasa hasta pasar governance/security/observability?** Todo trabajo visual/producto
+   grande (Wave 8), API externa/webhooks (Wave 7), y capacidades avanzadas (Wave 9).
+
+5. **¿Qué familia de PR da más valor inmediato?** **PR-O** (ordering/SoT) — desbloquea todo y reduce
+   consumo de IA ya.
+
+6. **¿Qué familia reduce más riesgo?** **PR-S** (security/aislamiento, incl. verificación RLS/tenant)
+   — ataca el riesgo más caro: cruce de datos clínicos multi-tenant.
+
+7. **¿Qué familia sube más la calidad premium percibida?** **PR-UX** (tokens + KPIs + premium) —
+   pero solo en Wave 8, tras los gates de fundación.
+
+8. **¿Qué familia sube más la confianza multinacional?** **PR-GOV** + **PR-OBS** (governance +
+   observabilidad/SLO/runbook) — son la base del evidence room de DD.
+
+9. **¿Qué familia mejora más la eficiencia de Claude?** **PR-O** (índice + SoT map + prompt-packs) —
+   convierte 174 docs en un punto de entrada único.
+
+10. **¿Qué NO debe hacerse bajo ninguna circunstancia ahora?** Rewrites (backend/frontend/dashboard),
+    adopción amplia de deps, tocar CI sin validación local, mover E2E/docs sin índice, mezclar
+    visual+security en un PR, realtime/PWA-offline de privados/micro-frontends/CRDTs/WebGL, y dejar a
+    Claude elegir prioridades sin matriz.
+
+---
+
+## Appendix — Verification Notes (this run)
+
+| Afirmación | Resultado | Comando |
+| --- | --- | --- |
+| HEAD/estado base | `8e29cc2`, worktree único, 19 PRs Dependabot | `git log/worktree/gh pr list` |
+| 3 auditorías base untracked | Confirmado (`??` las tres) | `git status` + `git ls-files` |
+| E2E capeado (#1096) | Confirmado en sesión previa (7+13+11+11=42) | contexto |
+| Dependabot aging | 19 PRs desde 2026-06-18 | `gh pr list` |
+
+> Marcado **"Requires focused audit before implementation"**: tenant/RLS a nivel DB, privileged-action
+> audit coverage, backup/restore real, consistencia de fechas críticas, `select('*')`/índices,
+> cobertura a11y con axe. No se afirman como hechos; cada uno tiene su PR de auditoría enfocada.
+
+---
+
+## Final validation
+
+```powershell
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git diff --check
+```
+
+**Resultado esperado** (este plan solo agrega un archivo **untracked**):
+
+- `git status --short --untracked-files=all` → las 3 auditorías previas untracked + este nuevo
+  `?? docs/audit/vetneb-supreme-system-level-alignment-plan.md`
+- `git diff --name-only` / `git diff --stat` → vacíos (sin tracked modificados)
+- `git diff --check` → limpio
+
+> Los comandos los ejecuta Nico manualmente. Este plan **no** ejecuta `git add/commit/push`,
+> `gh pr create/merge` ni comandos con `exit`.


### PR DESCRIPTION
## Summary
- Add repository operational ordering audit
- Add enterprise engineering readiness audit
- Add extreme multinational enterprise readiness audit
- Add supreme system-level alignment plan

## Scope
- Docs-only
- No frontend/src changes
- No frontend/e2e changes
- No helpers or fixtures changes
- No backend/server changes
- No API/auth/DB/migrations changes
- No dependencies, lockfiles, CI, package scripts, or Playwright config changes

## Validation
- git diff --check
- staged diff limited to docs/audit markdown files