### PR TITLE
docs(audit): add current audit index

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -1,0 +1,32 @@
+# VETNEB Audit Index
+
+Índice vigente de auditorías documentales activas del proyecto VETNEB.
+
+## Criterio de vigencia
+
+Este índice considera como vigentes únicamente las auditorías generadas en Wave 0, incorporadas a `main` mediante el PR #1097.
+
+Los documentos históricos previos dentro de `docs/audit/` se conservan como antecedentes, pero no forman parte del índice operativo vigente para la próxima implementación enterprise.
+
+## Auditorías vigentes
+
+| Orden | Documento | Propósito operativo | Estado |
+| --- | --- | --- | --- |
+| 1 | [repository-operational-ordering-audit.md](./repository-operational-ordering-audit.md) | Ordenamiento operacional del repositorio, flujo de trabajo, PRs, ramas, validación y disciplina de ejecución. | Vigente |
+| 2 | [vetneb-enterprise-engineering-readiness-audit.md](./vetneb-enterprise-engineering-readiness-audit.md) | Auditoría de preparación enterprise de ingeniería, calidad, testing, mantenibilidad y trazabilidad. | Vigente |
+| 3 | [vetneb-extreme-multinational-enterprise-readiness-audit.md](./vetneb-extreme-multinational-enterprise-readiness-audit.md) | Evaluación extrema de preparación multinacional, resiliencia, seguridad, operación y escalabilidad. | Vigente |
+| 4 | [vetneb-supreme-system-level-alignment-plan.md](./vetneb-supreme-system-level-alignment-plan.md) | Plan de alineación sistémica superior para convertir las auditorías en ejecución ordenada por prioridad. | Vigente |
+
+## Regla de mantenimiento
+
+Toda nueva auditoría que pretenda incorporarse al índice vigente debe cumplir estas condiciones:
+
+- Ser aprobada mediante PR docs-only independiente.
+- Tener alcance único, verificable y trazable.
+- No mezclar documentación con cambios en frontend, backend, API, auth, DB, migraciones, dependencias, lockfiles, CI, scripts de package ni configuración Playwright.
+- Definir claramente si reemplaza, complementa o deja obsoleta una auditoría previa.
+- Mantener este README como punto de entrada documental actual.
+
+## Próximo paso recomendado
+
+Crear un backlog maestro de implementación derivado exclusivamente de estas 4 auditorías vigentes, priorizado por riesgo, impacto operativo y dependencia técnica.


### PR DESCRIPTION
## Summary
- Add docs/audit/README.md as the current audit index
- Mark only the four Wave 0 audit documents as active
- Keep older docs/audit files as historical background outside the active implementation index

## Scope
- Docs-only
- No frontend/src changes
- No frontend/e2e changes
- No helpers or fixtures changes
- No backend/server changes
- No API/auth/DB/migrations changes
- No dependencies, lockfiles, CI, package scripts, or Playwright config changes

## Validation
- git diff --cached --check
- staged diff limited to docs/audit/README.md