### PR TITLE
docs: add governance foundation

### DIFF
--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,44 @@
+# VETNEB Governance
+
+Base documental vigente de gobernanza de ingeniería para VETNEB.
+
+## Propósito
+
+Este directorio define cómo registrar decisiones, proponer cambios, asignar ownership y revisar PRs antes de implementación.
+
+Es una base docs-only. No modifica CODEOWNERS, CI, workflows, dependencias, backend, frontend, tests, auth, DB ni migraciones.
+
+## Fuentes relacionadas
+
+| Fuente | Uso |
+| --- | --- |
+| `AGENTS.md` | Protocolo operativo principal para agentes e IA |
+| `.github/CODEOWNERS` | Ownership técnico efectivo aplicado por GitHub |
+| `docs/review-governance.md` | Reglas existentes de contenido, checks, rollback y scope |
+| `docs/SOURCES_OF_TRUTH.md` | Mapa vigente de fuentes por dominio |
+| `docs/HISTORICAL_DOCUMENTATION.md` | Clasificación de documentos históricos y superseded |
+
+## Documentos de este directorio
+
+| Documento | Propósito |
+| --- | --- |
+| `adr-template.md` | Plantilla para registrar decisiones arquitectónicas |
+| `rfc-change-control-template.md` | Plantilla para proponer cambios relevantes antes de implementarlos |
+| `ownership-model.md` | Modelo documental de ownership por dominio |
+| `pr-readiness-review-checklist.md` | Checklist de preparación antes de abrir o revisar PRs |
+
+## Regla de uso
+
+Antes de una implementación con riesgo técnico, operativo, de seguridad, datos, CI o arquitectura:
+
+1. Confirmar fuente vigente en `docs/SOURCES_OF_TRUTH.md`.
+2. Confirmar si existe documentación histórica en `docs/HISTORICAL_DOCUMENTATION.md`.
+3. Crear RFC si el cambio requiere diseño previo.
+4. Crear ADR si se toma una decisión duradera.
+5. Revisar ownership del dominio afectado.
+6. Completar checklist de PR readiness.
+7. Mantener el PR con un solo scope.
+
+## Estado
+
+Este directorio nace como PR-GOV1 docs-only. Cualquier cambio posterior debe mantener separación estricta entre documentación, código, CI, dependencias y configuración productiva.

--- a/docs/governance/adr-template.md
+++ b/docs/governance/adr-template.md
@@ -1,0 +1,78 @@
+# ADR: <short-title>
+
+## Status
+
+Proposed | Accepted | Superseded | Rejected
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+Describe the technical, product, operational, security, or architectural context that requires a decision.
+
+Include:
+
+- Current source of truth reviewed.
+- Historical documents checked, if relevant.
+- Constraints from `AGENTS.md`.
+- Scope boundaries.
+- Risk level.
+
+## Decision
+
+State the decision clearly.
+
+Use direct language:
+
+- We will...
+- We will not...
+- This decision applies to...
+- This decision does not apply to...
+
+## Alternatives considered
+
+| Alternative | Pros | Cons | Reason rejected or deferred |
+| --- | --- | --- | --- |
+| Option A |  |  |  |
+| Option B |  |  |  |
+
+## Consequences
+
+### Positive
+
+-
+
+### Negative / tradeoffs
+
+-
+
+### Operational impact
+
+-
+
+### Security / data impact
+
+-
+
+### Rollback or supersession path
+
+Describe how this decision can be reverted, replaced, or superseded.
+
+## Validation
+
+List how the decision will be validated.
+
+Examples:
+
+- Docs review.
+- Existing tests.
+- New tests in later PR.
+- CI checks.
+- Manual verification.
+- Security review.
+
+## Related PRs / documents
+
+-

--- a/docs/governance/ownership-model.md
+++ b/docs/governance/ownership-model.md
@@ -1,0 +1,58 @@
+# VETNEB Ownership Model
+
+Modelo documental de ownership por dominio.
+
+## Propósito
+
+Este documento define ownership operativo y de revisión sin modificar `.github/CODEOWNERS`.
+
+`.github/CODEOWNERS` sigue siendo la fuente efectiva de GitHub para reviewers automáticos. Este archivo complementa esa configuración con una lectura humana por dominio.
+
+## Reglas
+
+- Cada PR debe declarar el dominio afectado.
+- Cada PR debe declarar scope incluido y excluido.
+- Si un PR toca más de un dominio de riesgo, debe dividirse salvo autorización explícita.
+- Si un cambio afecta seguridad, auth, DB, migraciones, CI, dependencias o configuración productiva, requiere revisión reforzada.
+- La documentación no autoriza cambios fuera de scope.
+
+## Dominios
+
+| Dominio | Ownership documental | Fuente vigente | Revisión requerida |
+| --- | --- | --- | --- |
+| Protocolo operativo / agentes | Proyecto | `AGENTS.md` | Scope, seguridad, comandos permitidos |
+| Auditorías vigentes | Proyecto | `docs/audit/README.md` | Vigencia, prioridad, no mezclar históricos |
+| Source of truth documental | Proyecto | `docs/SOURCES_OF_TRUTH.md` | Dominio correcto y documento vigente |
+| Documentación histórica | Proyecto | `docs/HISTORICAL_DOCUMENTATION.md` | No usar históricos como fuente primaria |
+| Gobernanza | Proyecto | `docs/governance/*` | ADR/RFC/checklist antes de cambios grandes |
+| Review governance | Proyecto | `docs/review-governance.md` | PR content, checks, rollback, branch protection |
+| CI / E2E | Ingeniería | `docs/audit/e2e-ci-layering-strategy-audit.md` | No mezclar scripts-only con CI-only |
+| Operaciones / rollback | Ingeniería | `docs/ops/*` | Rollback, data impact, runbooks |
+| Seguridad / sesiones | Seguridad / backend | `docs/security/*` | Auth, session, CSP, RBAC, no sensitive leakage |
+| Backend / API | Backend | Server routes, tests, API docs vigentes | Contratos, errores, seguridad, rollback |
+| DB / migraciones / datos | Backend / data | DB docs y auditorías vigentes | Migración, compatibilidad, backup/restore |
+| Frontend / dashboard | Frontend / UX | Dashboard SoT vigente | Responsive, mobile, no-scroll, UX operativa |
+| Dependencias | Ingeniería | Dependabot + futura policy | No tocar junto a cambios funcionales |
+
+## Ownership por tipo de PR
+
+| Tipo de PR | Revisión mínima |
+| --- | --- |
+| docs-only | Vigencia documental, scope, no contradicción con SoT |
+| frontend-only | UX/responsive, build, lint, typecheck, no scope backend |
+| backend-only | Tests backend, seguridad, contratos, rollback |
+| test-only | Cobertura, estabilidad, no cambio runtime |
+| CI-only | Workflow, checks, duración, rollback |
+| dependency-only | Lockfile, audit, compatibilidad, rollback |
+| migration-only | Backward compatibility, backup, rollback, data impact |
+
+## Escalamiento
+
+Elevar revisión si aparece cualquiera de estos casos:
+
+- Auth, sesiones, permisos, RBAC o tokens.
+- Datos clínicos, tenant isolation, RLS o migraciones.
+- CI, workflows, Dependabot, lockfiles o dependencias.
+- Cambios visuales con impacto mobile/responsive.
+- Cambios que mezclan dominios.
+- Cambios basados en documentación histórica o superseded.

--- a/docs/governance/pr-readiness-review-checklist.md
+++ b/docs/governance/pr-readiness-review-checklist.md
@@ -1,0 +1,100 @@
+# PR Readiness Review Checklist
+
+Checklist documental para preparar y revisar PRs en VETNEB.
+
+## Antes de crear rama
+
+- [ ] `main` está limpio.
+- [ ] `main` está actualizado con `origin/main`.
+- [ ] Se leyó `docs/SOURCES_OF_TRUTH.md`.
+- [ ] Se leyó `docs/audit/README.md`.
+- [ ] Se verificó `docs/HISTORICAL_DOCUMENTATION.md` si hay documentos antiguos o ambiguos.
+- [ ] El scope del PR está definido.
+- [ ] El no-scope del PR está definido.
+- [ ] No hay Dependabot mezclado con trabajo funcional/documental.
+
+## Clasificación del PR
+
+Marcar uno:
+
+- [ ] docs-only
+- [ ] frontend-only
+- [ ] backend-only
+- [ ] test-only
+- [ ] CI-only
+- [ ] dependency-only
+- [ ] migration-only
+- [ ] mixed scope autorizado explícitamente
+
+## Scope incluido
+
+-
+
+## Scope excluido
+
+-
+
+## Riesgos
+
+| Riesgo | Aplica | Nota |
+| --- | --- | --- |
+| Frontend/runtime | yes/no |  |
+| Backend/API | yes/no |  |
+| Auth/session/security | yes/no |  |
+| DB/migrations/data | yes/no |  |
+| CI/workflows | yes/no |  |
+| Dependencies/lockfiles | yes/no |  |
+| Mobile/responsive | yes/no |  |
+| Production/ops | yes/no |  |
+
+## Validaciones requeridas
+
+Completar solo lo que aplique.
+
+| Scope | Validación |
+| --- | --- |
+| docs-only | `git diff --check` |
+| backend | `pnpm test`, `pnpm build` |
+| frontend | `pnpm --dir frontend lint`, `pnpm --dir frontend typecheck`, `pnpm --dir frontend build` |
+| e2e | scripts `pnpm --dir frontend e2e:*` correspondientes |
+| security | `pnpm security:public-surface` o suite específica vigente |
+| CI | `gh pr checks --watch` |
+| dependencies | `pnpm audit`, lockfile review |
+| migration | tests de compatibilidad, rollback y data impact |
+
+## Rollback
+
+- [ ] Rollback trigger definido.
+- [ ] Rollback steps definidos.
+- [ ] Data impact definido.
+- [ ] Si hay migración, compatibilidad backward definida.
+- [ ] Si hay CI/workflow, revert directo del workflow definido.
+- [ ] Si hay dependency update, versión anterior identificada.
+
+## PR body mínimo
+
+- [ ] Summary.
+- [ ] Scope.
+- [ ] No-scope.
+- [ ] Validation.
+- [ ] Rollback.
+- [ ] Data impact, si aplica.
+- [ ] Screenshots/evidence, si aplica.
+- [ ] Links a ADR/RFC, si aplica.
+
+## Revisión final antes de push
+
+- [ ] `git status --short --untracked-files=all` revisado.
+- [ ] `git diff --name-only` revisado.
+- [ ] `git diff --stat` revisado.
+- [ ] `git diff --check` limpio.
+- [ ] No hay archivos fuera del scope.
+- [ ] No hay secretos.
+- [ ] No hay cambios generados accidentalmente.
+
+## Checks posteriores
+
+- [ ] PR creado.
+- [ ] `gh pr checks --watch` ejecutado.
+- [ ] Checks verdes o fallo diagnosticado.
+- [ ] Merge solo con estado limpio y scope confirmado.

--- a/docs/governance/rfc-change-control-template.md
+++ b/docs/governance/rfc-change-control-template.md
@@ -1,0 +1,70 @@
+# RFC / Change Control: <short-title>
+
+## Status
+
+Draft | Ready for review | Approved | Rejected | Superseded
+
+## Owner
+
+Primary owner:
+
+Reviewers:
+
+Affected domains:
+
+## Problem
+
+Describe the problem, gap, risk, or opportunity.
+
+## Source of truth reviewed
+
+| Source | Reviewed | Notes |
+| --- | --- | --- |
+| `docs/SOURCES_OF_TRUTH.md` | yes/no |  |
+| `docs/audit/README.md` | yes/no |  |
+| `docs/HISTORICAL_DOCUMENTATION.md` | yes/no |  |
+| Domain-specific document | yes/no |  |
+
+## Proposed change
+
+Describe the proposed change.
+
+## Scope included
+
+-
+
+## Scope excluded
+
+-
+
+## Risk classification
+
+| Risk area | Level | Notes |
+| --- | --- | --- |
+| Frontend | none/low/medium/high |  |
+| Backend/API | none/low/medium/high |  |
+| Auth/session/security | none/low/medium/high |  |
+| DB/migrations/data | none/low/medium/high |  |
+| CI/dependencies/config | none/low/medium/high |  |
+| UX/mobile/responsive | none/low/medium/high |  |
+| Operations/rollback | none/low/medium/high |  |
+
+## Implementation plan
+
+Break the work into small PRs.
+
+| PR | Type | Scope | Validation | Rollback |
+| --- | --- | --- | --- | --- |
+| PR-1 | docs-only/backend-only/frontend-only/test-only/CI-only |  |  |  |
+
+## Validation plan
+
+List exact commands or review actions expected.
+
+## Rollback plan
+
+Describe rollback trigger, rollback steps, and data impact.
+
+## Decision required
+
+State what must be approved before implementation starts.


### PR DESCRIPTION
## Summary
- Add docs/governance as the governance foundation for engineering decisions
- Add ADR and RFC/change-control templates
- Add a documentary ownership model without modifying CODEOWNERS
- Add PR readiness checklist for scope, validation, rollback, and review discipline

## Scope
- Docs-only
- New files limited to docs/governance/*
- No changes to .github/CODEOWNERS
- No changes to docs/review-governance.md
- No frontend/src changes
- No frontend/e2e changes
- No helpers or fixtures changes
- No backend/server changes
- No API/auth/DB/migrations changes
- No dependencies, lockfiles, CI, package scripts, or Playwright config changes

## Validation
- git diff --check
- git diff --cached --check
- staged diff limited to docs/governance/*