### PR TITLE
docs: add QA regression policy

### DIFF
--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -1,0 +1,41 @@
+# VETNEB QA
+
+Base documental vigente para estrategia de calidad, flaky tests y regresiones.
+
+## Propósito
+
+Este directorio define cómo clasificar fallos, decidir qué suite ejecutar y evitar que un test inestable o una regresión visual/operativa se gestione de forma improvisada.
+
+Es una base docs-only. No modifica tests, fixtures, helpers, package scripts, Playwright config, CI, frontend, backend, API, auth, DB, migraciones, dependencias ni lockfiles.
+
+## Fuentes relacionadas
+
+| Fuente | Uso |
+| --- | --- |
+| `docs/SOURCES_OF_TRUTH.md` | Mapa vigente de fuentes por dominio |
+| `docs/governance/pr-readiness-review-checklist.md` | Checklist de PR readiness y validación |
+| `docs/audit/e2e-ci-layering-strategy-audit.md` | Estrategia vigente de layering E2E |
+| `docs/ops/CI_PR_CHECKS_RUNBOOK.md` | Runbook de checks de PR |
+| `package.json` | Scripts backend/root vigentes |
+| `frontend/package.json` | Scripts frontend/E2E vigentes |
+
+## Documentos de este directorio
+
+| Documento | Propósito |
+| --- | --- |
+| `flaky-test-policy.md` | Política para detectar, clasificar y resolver flaky tests |
+| `regression-strategy.md` | Estrategia de regresión por tipo de cambio y dominio afectado |
+
+## Principios
+
+1. Un fallo rojo no se ignora.
+2. Un flaky test no se desactiva sin evidencia, owner y plan.
+3. Un test inestable se trata como deuda de calidad, no como ruido.
+4. Una regresión visual/mobile debe reproducirse con evidencia concreta.
+5. No mezclar fixes de tests con cambios funcionales salvo autorización explícita.
+6. No modificar CI, package scripts ni Playwright config dentro de PR-QA1.
+7. Todo cambio futuro de suites debe tener PR propio y validación local previa.
+
+## Estado
+
+Este directorio nace como PR-QA1 docs-only.

--- a/docs/qa/flaky-test-policy.md
+++ b/docs/qa/flaky-test-policy.md
@@ -1,0 +1,93 @@
+# Flaky Test Policy
+
+Política vigente para gestionar flaky tests en VETNEB.
+
+## Definición
+
+Un test se considera flaky cuando puede pasar o fallar sin cambios de código relacionados, datos relacionados o configuración relacionada.
+
+Ejemplos:
+
+- Falla por timing.
+- Falla por dependencia de orden de ejecución.
+- Falla por estado compartido.
+- Falla por red, puerto, sesión, storage o fixture no aislado.
+- Falla solo en CI pero no local, o solo local pero no CI.
+- Falla intermitente en mobile, viewport, Playwright o hidratación.
+
+## Clasificación
+
+| Tipo | Severidad | Regla |
+| --- | --- | --- |
+| Flaky confirmado en main | P1 | No avanzar con PRs dependientes sin aislar causa |
+| Flaky en PR actual | P1 | Resolver en el mismo PR si pertenece al scope |
+| Flaky fuera de scope | P2 | Documentar evidencia y abrir PR dedicado |
+| Falla determinística | No flaky | Tratar como regresión o bug real |
+| Falla por ambiente local | P2/P3 | Documentar ambiente, comando y diferencia con CI |
+| Falla por dato/fixture | P1/P2 | Aislar fixture antes de ampliar cobertura |
+
+## Evidencia mínima
+
+Antes de declarar un test como flaky, registrar:
+
+- Comando exacto ejecutado.
+- Rama y commit.
+- Sistema operativo o ambiente.
+- Resultado esperado.
+- Resultado observado.
+- Frecuencia aproximada.
+- Si falla en CI, local o ambos.
+- Logs relevantes.
+- Relación con cambios del PR.
+
+## Reglas de acción
+
+### Permitido
+
+- Reproducir el fallo con el comando más pequeño posible.
+- Aislar fixture, helper o estado compartido en un PR test-only.
+- Separar PR funcional de PR de estabilización.
+- Documentar un follow-up si el flaky no pertenece al scope actual.
+- Usar evidencia de CI y local para clasificar severidad.
+
+### Prohibido sin autorización explícita
+
+- Eliminar tests para pasar CI.
+- Saltar tests con `.skip` sin issue/PR de seguimiento.
+- Reducir cobertura sin explicación.
+- Cambiar timeouts globales sin auditoría.
+- Cambiar Playwright config dentro de PR funcional.
+- Mezclar dependency updates con estabilización de tests.
+- Llamar flaky a una regresión determinística.
+
+## Flujo obligatorio
+
+1. Confirmar `main` limpio y actualizado.
+2. Ejecutar el comando mínimo que reproduce el fallo.
+3. Repetir si la falla parece intermitente.
+4. Clasificar como flaky, regresión, ambiente o fixture.
+5. Definir owner del dominio.
+6. Si es del scope actual, corregir antes de merge.
+7. Si está fuera de scope, documentar evidencia y abrir PR dedicado.
+8. No ocultar el fallo en el PR body.
+
+## Salida esperada en PR body
+
+Cuando haya flaky test o sospecha de flaky test, incluir:
+
+- Test afectado.
+- Comando usado.
+- Cantidad de ejecuciones.
+- Resultado.
+- Clasificación.
+- Decisión tomada.
+- Follow-up si aplica.
+
+## Criterio de cierre
+
+Un flaky se considera cerrado cuando:
+
+- Existe causa identificada o mitigación clara.
+- La suite afectada pasa con el comando definido.
+- No se redujo cobertura sin justificación.
+- El PR queda limitado al scope declarado.

--- a/docs/qa/regression-strategy.md
+++ b/docs/qa/regression-strategy.md
@@ -1,0 +1,132 @@
+# Regression Strategy
+
+Estrategia documental vigente para seleccionar validaciones de regresión en VETNEB.
+
+## Propósito
+
+Definir qué validar según el tipo de cambio, evitando tanto validación insuficiente como ejecución indiscriminada sin criterio.
+
+## Regla principal
+
+La validación debe seguir el riesgo real del PR.
+
+Un PR debe declarar:
+
+- Tipo de PR.
+- Dominio afectado.
+- Scope incluido.
+- Scope excluido.
+- Suites ejecutadas.
+- Suites no ejecutadas y motivo.
+- Riesgo residual.
+
+## Matriz por tipo de PR
+
+| Tipo de PR | Validación mínima | Validación adicional si aplica |
+| --- | --- | --- |
+| docs-only | `git diff --check` | Review de links, source of truth y contradicciones |
+| backend-only | `pnpm test`, `pnpm build` | `pnpm typecheck`, `pnpm typecheck:test`, seguridad específica |
+| frontend-only | `pnpm --dir frontend lint`, `pnpm --dir frontend typecheck`, `pnpm --dir frontend build` | E2E focalizado por dominio |
+| test-only | Suite afectada | Suite madre si cambia helper compartido |
+| CI-only | Validación local de scripts y `gh pr checks --watch` | Dry-run o PR canary si aplica |
+| dependency-only | Audit, build, tests afectados | E2E focalizado si toca frontend/runtime |
+| migration-only | Tests de migración, compatibilidad y rollback | Backup/restore si aplica |
+| security-only | Suite security específica | Public surface, auth/session, RBAC, no leakage |
+| dashboard/mobile | Tests unitarios afectados | E2E visual/mobile/no-scroll correspondiente |
+
+## Scripts vigentes observados
+
+### Root
+
+- `pnpm test`
+- `pnpm build`
+- `pnpm typecheck`
+- `pnpm typecheck:test`
+- `pnpm security:public-surface`
+
+### Frontend
+
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend typecheck`
+- `pnpm --dir frontend build`
+- `pnpm --dir frontend e2e`
+- `pnpm --dir frontend e2e:smoke`
+- `pnpm --dir frontend e2e:admin-mobile`
+- `pnpm --dir frontend e2e:visual-contract`
+- `pnpm --dir frontend e2e:public-clinic`
+
+## Estrategia E2E
+
+| Dominio | Suite sugerida |
+| --- | --- |
+| Smoke general | `pnpm --dir frontend e2e:smoke` |
+| Admin mobile/no-scroll | `pnpm --dir frontend e2e:admin-mobile` |
+| Dashboard visual/no-scroll/contracts | `pnpm --dir frontend e2e:visual-contract` |
+| Public/clinic journey | `pnpm --dir frontend e2e:public-clinic` |
+| Cambio E2E amplio | `pnpm --dir frontend e2e` |
+
+## Política de regresión
+
+### P0
+
+Ejecutar validación amplia si el PR toca:
+
+- Auth/session.
+- Tenant isolation.
+- DB/migrations.
+- Storage/report access.
+- Public sensitive surface.
+- CI workflows.
+- Shared test helpers.
+- Dashboard shell global.
+- Package scripts.
+
+### P1
+
+Ejecutar validación focalizada si el PR toca:
+
+- Un módulo dashboard.
+- Una ruta API concreta.
+- Un componente frontend con contrato existente.
+- Una suite de tests específica.
+- Documentación source-of-truth que afecta futuros PRs.
+
+### P2
+
+Validación documental o focalizada si el PR:
+
+- Solo clasifica documentación.
+- Añade plantillas.
+- Añade runbooks.
+- No toca runtime ni configuración.
+
+## Reglas anti-regresión
+
+1. No usar tests verdes como excusa para ignorar evidencia visual/manual.
+2. No usar evidencia manual como reemplazo permanente de una suite necesaria.
+3. No ampliar CI sin medir costo y cobertura.
+4. No reducir cobertura sin ADR/RFC si el cambio es duradero.
+5. No mezclar cambios de test helper con cambios funcionales grandes.
+6. No tocar Playwright config en PR funcional.
+7. No mezclar Dependabot con QA/regression fixes.
+
+## PR body esperado
+
+Todo PR con riesgo de regresión debe incluir:
+
+- Comandos ejecutados.
+- Resultado.
+- Suite omitida y motivo, si aplica.
+- Evidencia visual, si aplica.
+- Riesgo residual.
+- Follow-up si queda una brecha.
+
+## Criterio de aceptación
+
+Un PR está listo para merge cuando:
+
+- El scope está cerrado.
+- La validación ejecutada coincide con el riesgo.
+- No hay flaky test sin clasificar.
+- No hay regresión conocida sin follow-up.
+- Checks de PR están verdes o el fallo está diagnosticado antes de continuar.


### PR DESCRIPTION
## Summary
- Add docs/qa as the QA documentation foundation
- Add flaky test policy for classification, evidence, ownership, and closure
- Add regression strategy for selecting validations by PR risk and affected domain
- Document current root and frontend validation scripts without changing them

## Scope
- Docs-only
- New files limited to docs/qa/*
- No changes to tests
- No changes to frontend/e2e
- No changes to helpers or fixtures
- No changes to package scripts
- No changes to Playwright config
- No changes to CI/workflows
- No frontend/src changes
- No backend/server changes
- No API/auth/DB/migrations changes
- No dependencies or lockfiles

## Validation
- git diff --check
- git diff --cached --check
- staged diff limited to docs/qa/*