### PR TITLE
docs: update sources of truth foundation

### DIFF
--- a/docs/SOURCES_OF_TRUTH.md
+++ b/docs/SOURCES_OF_TRUTH.md
@@ -9,7 +9,7 @@ Este documento define qué archivo debe leerse primero para cada dominio del pro
 Regla principal:
 
 - Leer primero este archivo.
-- Luego leer `docs/audit/README.md`.
+- Luego leer `docs/audit/README.md` si el trabajo se relaciona con auditorías activas.
 - Luego leer únicamente la fuente vigente del dominio afectado.
 - No usar documentos históricos como base de implementación salvo trazabilidad puntual.
 
@@ -23,11 +23,19 @@ Regla principal:
 | Readiness multinacional extrema | `docs/audit/vetneb-extreme-multinational-enterprise-readiness-audit.md` | `docs/audit/vetneb-supreme-system-level-alignment-plan.md` | Vigente | Usar para P0/P1 de gobernanza, seguridad, SRE, datos y confianza ejecutiva |
 | Alineación sistémica superior | `docs/audit/vetneb-supreme-system-level-alignment-plan.md` | Las otras 3 auditorías Wave 0 | Vigente | Usar para reconciliar prioridades, dependencias, waves y PR families |
 | Protocolo operativo de agentes | `AGENTS.md` | `docs/protocol/vetneb-ai-working-protocol.md`, `.cursor/rules/*` | Vigente | `AGENTS.md` manda; reglas derivadas no deben contradecirlo |
-| CI / E2E layering | `docs/audit/e2e-ci-layering-strategy-audit.md` | `frontend/package.json`, `docs/ops/CI_PR_CHECKS_RUNBOOK.md` | Vigente parcial | PR-C1 y PR-C2 cerrados; antes de PR-C3 validar unión de capas == full |
+| Gobernanza / ADR / RFC / ownership | `docs/governance/README.md` | `docs/governance/adr-template.md`, `docs/governance/rfc-change-control-template.md`, `docs/governance/ownership-model.md`, `docs/governance/pr-readiness-review-checklist.md` | Vigente | Usar antes de cambios estructurales, mixed-scope, ownership ambiguo o decisiones duraderas |
+| PR readiness / scope discipline | `docs/governance/pr-readiness-review-checklist.md` | `docs/governance/ownership-model.md`, `docs/qa/regression-strategy.md` | Vigente | Usar antes de crear PR, antes de push y antes de merge |
+| QA / flaky tests / regression strategy | `docs/qa/README.md` | `docs/qa/flaky-test-policy.md`, `docs/qa/regression-strategy.md` | Vigente | Usar para clasificar fallos, elegir validaciones y evitar fixes improvisados |
+| Flaky tests | `docs/qa/flaky-test-policy.md` | `docs/qa/regression-strategy.md` | Vigente | No llamar flaky a una regresión determinística; exigir evidencia, owner y plan |
+| Regression strategy | `docs/qa/regression-strategy.md` | `frontend/package.json`, `package.json`, `docs/ops/CI_PR_CHECKS_RUNBOOK.md` | Vigente | Elegir validaciones por riesgo real del PR, no por costumbre |
+| Release / go-no-go / deployment readiness | `docs/release/README.md` | `docs/release/release-go-no-go-policy.md`, `docs/release-readiness.md`, `docs/ops/BACKUP_RESTORE_ROLLBACK.md` | Vigente | Usar antes de releases, cambios productivos o decisiones go/no-go |
+| Rollback / backup / restore operativo | `docs/ops/BACKUP_RESTORE_ROLLBACK.md` | `docs/release/release-go-no-go-policy.md`, `docs/production-readiness-evidence.md` | Vigente | Usar para rollback triggers, restore drills, evidencia sanitizada y operaciones productivas |
+| CI / PR checks runbook | `docs/ops/CI_PR_CHECKS_RUNBOOK.md` | `docs/qa/regression-strategy.md`, `docs/governance/pr-readiness-review-checklist.md` | Vigente | Usar para checks de PR, merge y limpieza local |
+| CI / E2E layering | `docs/audit/e2e-ci-layering-strategy-audit.md` | `frontend/package.json`, `docs/ops/CI_PR_CHECKS_RUNBOOK.md`, `docs/qa/regression-strategy.md` | Vigente parcial | PR-C1 y PR-C2 cerrados; antes de PR-C3 validar unión de capas == full |
 | Dashboard Admin horizontal-nav | `docs/audit/dashboard-horizontal-navigation-information-architecture.md` | `docs/implementation/dashboard-horizontal-shell-navigation.md` | Vigente en curso | No mezclar con ordenamiento documental ni con PRs enterprise foundation |
 | Dashboard mobile/admin density | `docs/audit/admin-mobile-density-closeout.md` | Closeouts y auditorías admin-mobile relacionadas | Cerrado | No re-auditar de cero salvo regresión visual nueva |
 | Seguridad / sesiones / superficie pública | `docs/security/*` | Tests `security-*`, `auth-*`, matrices RBAC/endpoints/CSP | Vigente estable | Usar para invariantes; PR-S1 debe ser auditoría enfocada antes de tocar auth/API |
-| Operación / rollback / CI runbooks | `docs/ops/*` | `review-governance.md`, build-info y smoke staging existentes | Vigente parcial | Completar con PR-REL1, no mezclar con CI-only |
+| Operación / production readiness | `docs/ops/*` | `docs/release/README.md`, `docs/release-readiness.md`, `docs/production-readiness-evidence.md` | Vigente | Usar para runbooks operativos; no mezclar con CI-only ni deploy changes |
 | Implementaciones recientes | `docs/implementation/*` | `IMPLEMENTATION_NOTES/*` | Referencia secundaria | Leer solo si el dominio lo exige; no usar como fuente primaria si hay closeout/auditoría vigente |
 
 ## Disambiguación `docs/audit` vs `docs/audits`
@@ -47,7 +55,7 @@ Antes de auditar o implementar:
 
 1. Confirmar `main` limpio.
 2. Leer este mapa.
-3. Leer `docs/audit/README.md`.
+3. Leer `docs/audit/README.md` si el trabajo toca auditorías activas o planes enterprise.
 4. Identificar el dominio afectado.
 5. Leer solo la fuente vigente de ese dominio.
 6. Clasificar cualquier documento histórico como contexto, no como instrucción vigente.
@@ -55,18 +63,31 @@ Antes de auditar o implementar:
 8. No permitir que Claude, Codex u otra IA elija prioridades sin matriz P0/P1/P2/P3 explícita.
 9. Separar docs-only, scripts-only, CI-only, test-only, backend-only y frontend-only en PRs distintos.
 10. No tocar Dependabot dentro de PRs funcionales, documentales o de ordenamiento.
+11. Usar `docs/governance/pr-readiness-review-checklist.md` antes de crear PR, antes de push y antes de merge.
+12. Usar `docs/qa/regression-strategy.md` para elegir validaciones por riesgo.
+13. Usar `docs/release/release-go-no-go-policy.md` antes de cualquier release, deploy o cambio con impacto productivo.
+
+## Foundation docs cerrados
+
+| PR | Tipo | Resultado |
+| --- | --- | --- |
+| PR-O1 | docs-only | Índice de auditorías activas en `docs/audit/README.md` |
+| PR-O2 | docs-only | Mapa inicial de sources of truth |
+| PR-O3 | docs-only | Clasificación de documentación histórica |
+| PR-GOV1 | docs-only | Base de gobernanza en `docs/governance/*` |
+| PR-QA1 | docs-only | Política QA/flaky/regression en `docs/qa/*` |
+| PR-REL1 | docs-only | Política release/go-no-go en `docs/release/*` |
 
 ## Próximo orden recomendado
 
 | Orden | PR | Tipo | Objetivo |
 | --- | --- | --- | --- |
-| 1 | PR-O3 | docs-only | Clasificar documentación histórica vs vigente y marcar planes superseded |
-| 2 | PR-GOV1 | docs-only | Crear base de gobernanza: ADR/RFC/change-control/ownership |
-| 3 | PR-QA1 | docs-only | Definir política de flaky tests y regression strategy |
-| 4 | PR-C3 | CI-only | Usar capas E2E en CI sin pérdida de cobertura, después de validación local |
-| 5 | PR-S1 | docs-only | Auditoría enfocada de seguridad, sesiones, tenant isolation y RLS |
-| 6 | PR-OBS1 | docs-only | Baseline de observabilidad, SLOs y runbook de incidentes |
+| 1 | PR-C3 | CI-only | Usar capas E2E en CI sin pérdida de cobertura, después de validación local |
+| 2 | PR-S1 | docs-only | Auditoría enfocada de seguridad, sesiones, tenant isolation y RLS |
+| 3 | PR-OBS1 | docs-only | Baseline de observabilidad, SLOs y runbook de incidentes |
+| 4 | PR-DATA1 | docs-only | Auditoría enfocada de datos, backup/restore drills, retention y evidencia sanitizada |
+| 5 | PR-DEPS1 | docs-only | Estrategia para Dependabot sin mezclar updates con cambios funcionales |
 
 ## Estado
 
-Este mapa es vigente desde PR-O2 y complementa `docs/audit/README.md`.
+Este mapa queda actualizado por PR-SOT1 después de PR-GOV1, PR-QA1 y PR-REL1.


### PR DESCRIPTION
## Summary
- Update docs/SOURCES_OF_TRUTH.md after governance, QA, and release foundation docs
- Add docs/governance, docs/qa, and docs/release as current sources of truth
- Mark completed foundation docs and move the recommended order forward to PR-C3, PR-S1, PR-OBS1, PR-DATA1, and PR-DEPS1

## Scope
- Docs-only
- Single-file change limited to docs/SOURCES_OF_TRUTH.md
- No changes to docs/governance/*
- No changes to docs/qa/*
- No changes to docs/release/*
- No changes to docs/ops/*
- No frontend/src changes
- No frontend/e2e changes
- No backend/server changes
- No API/auth/DB/migrations changes
- No tests, helpers, fixtures, scripts, CI, dependencies, lockfiles, or Playwright config changes

## Validation
- git diff --check
- git diff --cached --check
- staged diff limited to docs/SOURCES_OF_TRUTH.md