### PR TITLE
ci: run frontend e2e layers

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -67,8 +67,25 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --dir frontend exec playwright install --with-deps chromium
 
-      - name: Run frontend E2E smoke tests
-        run: pnpm --dir frontend e2e
+      - name: Run frontend E2E layered tests
+        run: |
+          set +e
+
+          pnpm --dir frontend e2e:smoke
+          smoke_status=$?
+
+          pnpm --dir frontend e2e:admin-mobile
+          admin_mobile_status=$?
+
+          pnpm --dir frontend e2e:visual-contract
+          visual_contract_status=$?
+
+          pnpm --dir frontend e2e:public-clinic
+          public_clinic_status=$?
+
+          if [ "$smoke_status" -ne 0 ] || [ "$admin_mobile_status" -ne 0 ] || [ "$visual_contract_status" -ne 0 ] || [ "$public_clinic_status" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Upload Playwright report
         if: failure()

--- a/test/frontend-ci-workflow.test.ts
+++ b/test/frontend-ci-workflow.test.ts
@@ -118,7 +118,7 @@ test("Frontend CI ejecuta gates obligatorios en orden", () => {
     "      - name: Build frontend\n        run: pnpm --dir frontend build",
     "      - name: Audit built public surface\n        run: pnpm security:public-surface",
     "      - name: Install Playwright browsers\n        run: pnpm --dir frontend exec playwright install --with-deps chromium",
-    "      - name: Run frontend E2E smoke tests\n        run: pnpm --dir frontend e2e",
+    "      - name: Run frontend E2E layered tests\n        run: |\n          set +e\n\n          pnpm --dir frontend e2e:smoke\n          smoke_status=$?\n\n          pnpm --dir frontend e2e:admin-mobile\n          admin_mobile_status=$?\n\n          pnpm --dir frontend e2e:visual-contract\n          visual_contract_status=$?\n\n          pnpm --dir frontend e2e:public-clinic\n          public_clinic_status=$?\n\n          if [ \"$smoke_status\" -ne 0 ] || [ \"$admin_mobile_status\" -ne 0 ] || [ \"$visual_contract_status\" -ne 0 ] || [ \"$public_clinic_status\" -ne 0 ]; then\n            exit 1\n          fi",
   ]);
 });
 

--- a/test/production-readiness.test.ts
+++ b/test/production-readiness.test.ts
@@ -287,7 +287,7 @@ test("frontend CI audits the built public surface before E2E", () => {
     "      - name: Audit built public surface\n        run: pnpm security:public-surface",
   );
   const e2eIndex = workflow.indexOf(
-    "      - name: Run frontend E2E smoke tests\n        run: pnpm --dir frontend e2e",
+    "      - name: Run frontend E2E layered tests\n        run: |\n          set +e\n\n          pnpm --dir frontend e2e:smoke",
   );
 
   assert.ok(buildIndex >= 0);


### PR DESCRIPTION
## Summary
- Replace the frontend CI full E2E command with explicit E2E layer execution
- Run smoke, admin mobile, visual contract, and public clinic E2E layers in CI
- Preserve Playwright report upload on failure
- Update workflow contract tests to match the layered E2E CI gate

## Scope
- CI/workflow contract update
- Workflow change limited to .github/workflows/frontend-ci.yml
- Test contract changes limited to test/frontend-ci-workflow.test.ts and test/production-readiness.test.ts
- No changes to frontend/package.json scripts
- No changes to frontend/e2e specs
- No changes to frontend/src
- No changes to backend/server
- No changes to API/auth/DB/migrations
- No changes to helpers, fixtures, dependencies, lockfiles, or Playwright config

## Validation
- PR-C3 A/B read-only audit
- Confirmed layered union covers 42/42 frontend E2E specs
- Confirmed 0 specs missing from layers
- Confirmed 0 stale specs referenced by layers
- pnpm exec node --test test/frontend-ci-workflow.test.ts test/production-readiness.test.ts
- git diff --check
- git diff --cached --check