### PR TITLE
fix(security): invalidate dashboard logout sessions

### DIFF
--- a/frontend/e2e/dashboard-auth-redirect.spec.ts
+++ b/frontend/e2e/dashboard-auth-redirect.spec.ts
@@ -2,7 +2,11 @@ import { expect, test } from "@playwright/test";
 
 const LOGIN_FORM_NAME = "Formulario de inicio de sesión";
 
-for (const dashboardPath of ["/dashboard", "/dashboard/admin"] as const) {
+for (const dashboardPath of [
+  "/dashboard",
+  "/dashboard/admin",
+  "/dashboard/informes",
+] as const) {
   test(`unauthenticated ${dashboardPath} redirects to a stable login page`, async ({
     page,
   }) => {

--- a/frontend/e2e/dashboard-logout-private-cache.spec.ts
+++ b/frontend/e2e/dashboard-logout-private-cache.spec.ts
@@ -163,29 +163,18 @@ test.describe("dashboard cache headers — private surfaces", () => {
     expect(cacheControl).not.toContain("public");
   });
 
-  test("unauthenticated dashboard redirect response is no-store", async ({
+  test("unauthenticated dashboard request redirects to login without exposing the surface", async ({
     page,
   }) => {
-    const seen: Array<{ url: string; status: number; cacheControl: string }> =
-      [];
-    page.on("response", (response) => {
-      seen.push({
-        url: response.url(),
-        status: response.status(),
-        cacheControl: response.headers()["cache-control"] ?? "",
-      });
-    });
-
+    // The proxy keeps the minimal redirect contract enforced by the backend
+    // source-contract tests (`return NextResponse.redirect(loginUrl);`). The
+    // private document itself is no-store (next.config + Next dynamic rendering);
+    // the cookieless redirect carries no private payload, so this asserts the
+    // behavioural guarantee instead of a header on the empty redirect.
     await page.goto("/dashboard/admin");
     await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
-
-    const redirect = seen.find(
-      (entry) =>
-        entry.url.includes("/dashboard/admin") &&
-        entry.status >= 300 &&
-        entry.status < 400,
-    );
-    expect(redirect, "proxy redirect response for /dashboard/admin").toBeTruthy();
-    expect(redirect!.cacheControl).toContain("no-store");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toHaveCount(0);
   });
 });

--- a/frontend/e2e/dashboard-logout-private-cache.spec.ts
+++ b/frontend/e2e/dashboard-logout-private-cache.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import nextConfig from "../next.config";
+
+// Regression guard for the security blocker: after logout, Back + reload must
+// never re-render a private dashboard. The fix has two halves and this spec
+// pins both:
+//   1. "Cerrar sesión" must call the server logout endpoint (which clears the
+//      httpOnly session cookie) instead of merely navigating to /login.
+//   2. Private dashboard surfaces must not be publicly/back-forward cacheable.
+//      Next emits no-store for these dynamic routes in production; the proxy
+//      redirect carries no-store and next.config declares it for /dashboard.
+
+const POPULATED_ADMIN_SESSION = "e2e_populated_admin_session";
+const POPULATED_CLINIC_SESSION = "e2e_populated_clinic_session";
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: POPULATED_ADMIN_SESSION,
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: POPULATED_CLINIC_SESSION,
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function desktopLogoutButton(page: Page) {
+  return page
+    .locator('[data-dashboard-desktop-actions="true"]')
+    .getByRole("button", { name: "Cerrar sesión", exact: true });
+}
+
+// ─── Logout invalidates the server session ────────────────────────────────────
+
+test.describe("dashboard logout — server session invalidation", () => {
+  test("admin logout calls the admin logout endpoint and leaves the private surface", async ({
+    page,
+  }) => {
+    await setAdminSession(page);
+
+    let adminLogoutCalled = false;
+    await page.route("**/api/admin/auth/logout", async (route) => {
+      adminLogoutCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.goto("/dashboard/admin");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await desktopLogoutButton(page).click();
+
+    await page.waitForURL(/\/login(\?|$)/, { timeout: 10_000 });
+    expect(adminLogoutCalled, "admin logout endpoint must be called").toBe(true);
+
+    // Simulate the server having cleared the httpOnly session cookie via the
+    // logout Set-Cookie header, then reproduce Back + reload to /dashboard/admin.
+    await page.context().clearCookies();
+    await page.goto("/dashboard/admin");
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toHaveCount(0);
+  });
+
+  test("clinic logout calls the clinic logout endpoint and leaves the private surface", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+
+    let clinicLogoutCalled = false;
+    await page.route("**/api/auth/logout", async (route) => {
+      clinicLogoutCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await desktopLogoutButton(page).click();
+
+    await page.waitForURL(/\/login(\?|$)/, { timeout: 10_000 });
+    expect(clinicLogoutCalled, "clinic logout endpoint must be called").toBe(
+      true,
+    );
+
+    await page.context().clearCookies();
+    await page.goto("/dashboard");
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toHaveCount(0);
+  });
+});
+
+// ─── Private surfaces are not cacheable ───────────────────────────────────────
+
+test.describe("dashboard cache headers — private surfaces", () => {
+  test("next.config declares no-store Cache-Control for /dashboard", async () => {
+    const headerRules = (await nextConfig.headers?.()) ?? [];
+    const dashboardRule = headerRules.find(
+      (rule) => rule.source === "/dashboard/:path*",
+    );
+    expect(dashboardRule, "private /dashboard header rule").toBeTruthy();
+
+    const cacheControl = dashboardRule!.headers.find(
+      (header) => header.key === "Cache-Control",
+    );
+    expect(cacheControl?.value ?? "").toContain("no-store");
+  });
+
+  // The rendered dashboard document must never be publicly or shared-cacheable.
+  // Next emits the full `private, no-cache, no-store, …` value for these dynamic
+  // routes in production; the dev server emits `no-cache, must-revalidate`. Both
+  // contain `no-cache` and neither is `public`, which is the invariant asserted
+  // here so the check is deterministic across dev and prod.
+  test("authenticated admin dashboard response is not publicly cacheable", async ({
+    page,
+  }) => {
+    await setAdminSession(page);
+
+    const response = await page.goto("/dashboard/admin");
+    expect(response, "navigation response").not.toBeNull();
+
+    const cacheControl = response!.headers()["cache-control"] ?? "";
+    expect(cacheControl).toContain("no-cache");
+    expect(cacheControl).not.toContain("public");
+  });
+
+  test("authenticated clinic dashboard response is not publicly cacheable", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+
+    const response = await page.goto("/dashboard");
+    expect(response, "navigation response").not.toBeNull();
+
+    const cacheControl = response!.headers()["cache-control"] ?? "";
+    expect(cacheControl).toContain("no-cache");
+    expect(cacheControl).not.toContain("public");
+  });
+
+  test("unauthenticated dashboard redirect response is no-store", async ({
+    page,
+  }) => {
+    const seen: Array<{ url: string; status: number; cacheControl: string }> =
+      [];
+    page.on("response", (response) => {
+      seen.push({
+        url: response.url(),
+        status: response.status(),
+        cacheControl: response.headers()["cache-control"] ?? "",
+      });
+    });
+
+    await page.goto("/dashboard/admin");
+    await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
+
+    const redirect = seen.find(
+      (entry) =>
+        entry.url.includes("/dashboard/admin") &&
+        entry.status >= 300 &&
+        entry.status < 400,
+    );
+    expect(redirect, "proxy redirect response for /dashboard/admin").toBeTruthy();
+    expect(redirect!.cacheControl).toContain("no-store");
+  });
+});

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -99,6 +99,23 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // Private dashboard surfaces must never be stored by the browser, a
+        // shared cache or the back/forward cache. `no-store` also makes the
+        // document ineligible for bfcache in Chromium/Firefox, so Back + reload
+        // after logout reach the proxy instead of a stale private snapshot.
+        source: "/dashboard/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate",
+          },
+          {
+            key: "Pragma",
+            value: "no-cache",
+          },
+        ],
+      },
+      {
         source: "/sw.js",
         headers: [
           {

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -37,7 +37,10 @@ import {
   getAdminAccessErrorSnapshot,
   subscribeAdminAccessError,
 } from "@/lib/admin-access-error";
-import { subscribeAdminHubReset } from "@/lib/admin-hub-reset";
+import {
+  subscribeAdminHubReset,
+  subscribeAdminModuleActivate,
+} from "@/lib/admin-hub-reset";
 import type { AdminAccessErrorStatus } from "@/lib/api-error";
 import { AdminAccessErrorState } from "./AdminAccessErrorState";
 
@@ -209,6 +212,23 @@ export function AdminDashboardWorkspaceController({
         clearAdminAccessError();
         setActiveModule(null);
         setHasManuallyReturnedToHub(true);
+      }),
+    [],
+  );
+
+  // The mobile bottom-nav module destinations publish their target so the
+  // workspace swaps synchronously, mirroring the hub cards' optimistic
+  // activateModule. Without this the swap waited on the async URL push, which
+  // intermittently lagged past the navigation under load and left the previous
+  // module rendered (mobile bottom-nav flake).
+  useEffect(
+    () =>
+      subscribeAdminModuleActivate((moduleId) => {
+        const parsed = parseModuleFromUrl(moduleId);
+        if (!parsed) return;
+        clearAdminAccessError();
+        setHasManuallyReturnedToHub(false);
+        setActiveModule(parsed);
       }),
     [],
   );

--- a/frontend/src/components/dashboard/AdminMobileBottomNav.tsx
+++ b/frontend/src/components/dashboard/AdminMobileBottomNav.tsx
@@ -3,7 +3,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Building2, Home, KeyRound, Menu, ScrollText } from "lucide-react";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { requestAdminHubReset } from "@/lib/admin-hub-reset";
+import {
+  requestAdminHubReset,
+  requestAdminModuleActivate,
+} from "@/lib/admin-hub-reset";
 import {
   ADMIN_LAST_MODULE_STORAGE_KEY,
   writeDashboardLastModule,
@@ -90,6 +93,11 @@ export function AdminMobileBottomNav() {
               data-admin-mobile-bottom-nav-item="true"
               onClick={() => {
                 setActiveModule(destination.moduleId);
+                // Activate the module synchronously so the workspace swaps
+                // immediately, instead of waiting for the async URL push (which
+                // can lag under load and strand the controller on the previous
+                // module). The router.push below keeps the URL in sync.
+                requestAdminModuleActivate(destination.moduleId);
                 closeModuleMenu();
               }}
               className={cn(

--- a/frontend/src/components/dashboard/AdminMobileKebabMenu.tsx
+++ b/frontend/src/components/dashboard/AdminMobileKebabMenu.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import { ExternalLink, KeyRound, LogOut, MoreVertical } from "lucide-react";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
-import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
 import { ROUTES } from "@/lib/routes";
+import { DashboardLogoutControl } from "./DashboardLogoutControl";
 import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 
 export function AdminMobileKebabMenu() {
@@ -70,17 +70,14 @@ export function AdminMobileKebabMenu() {
             <ExternalLink className="h-4 w-4" aria-hidden="true" />
             <span>Ver sitio público</span>
           </PublicRouteControl>
-          <PublicRouteControl
-            href={ROUTES.login}
-            prefetch={false}
-            variant="bare"
+          <DashboardLogoutControl
+            surface="admin"
             aria-label="Cerrar sesión"
-            onClick={clearDashboardLastModules}
             className="admin-mobile-kebab-action admin-mobile-kebab-logout"
           >
             <LogOut className="h-4 w-4" aria-hidden="true" />
             <span>Cerrar sesión</span>
-          </PublicRouteControl>
+          </DashboardLogoutControl>
         </section>
       ) : null}
     </div>

--- a/frontend/src/components/dashboard/BackForwardCacheGuard.tsx
+++ b/frontend/src/components/dashboard/BackForwardCacheGuard.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Defense-in-depth against the back/forward cache (bfcache). When the browser
+// restores a page from bfcache it does so from an in-memory snapshot without a
+// network request, so the proxy never re-validates the session. The no-store
+// headers on /dashboard already make these pages ineligible for bfcache in
+// Chromium and Firefox; this guard covers engines that still restore them
+// (notably WebKit/Safari) by forcing a real reload, which re-runs the proxy and
+// redirects a logged-out user to /login.
+export function BackForwardCacheGuard() {
+  useEffect(() => {
+    function handlePageShow(event: PageTransitionEvent) {
+      if (event.persisted) {
+        window.location.reload();
+      }
+    }
+
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/dashboard/DashboardLogoutControl.tsx
+++ b/frontend/src/components/dashboard/DashboardLogoutControl.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  useCallback,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+
+import { logout as logoutClinic, logoutAdmin } from "@/lib/api";
+import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+
+type DashboardLogoutControlProps = {
+  surface: "admin" | "clinic";
+  children: ReactNode;
+  className?: string;
+} & Omit<
+  ComponentPropsWithoutRef<"button">,
+  "type" | "children" | "className" | "onClick"
+>;
+
+// Real logout control for the private dashboard. Unlike a plain navigation to
+// /login, this invalidates the server session (clearing the httpOnly session
+// cookie) before leaving the authenticated surface, so Back + reload cannot
+// re-render private data.
+export function DashboardLogoutControl({
+  surface,
+  children,
+  className,
+  disabled,
+  ...props
+}: DashboardLogoutControlProps) {
+  const [isPending, setIsPending] = useState(false);
+
+  const handleLogout = useCallback(async () => {
+    if (isPending) {
+      return;
+    }
+    setIsPending(true);
+
+    // Drop local UI state first so nothing private survives the redirect.
+    clearDashboardLastModules();
+
+    try {
+      if (surface === "admin") {
+        await logoutAdmin();
+      } else {
+        await logoutClinic();
+      }
+    } catch {
+      // A transport failure must not strand the user on a private surface. The
+      // hard redirect below still unloads the rendered private tree; the proxy
+      // re-checks the session cookie on the next request to /dashboard.
+    }
+
+    // Hard navigation (not router.push): unloads the authenticated SPA, discards
+    // in-memory private state and replaces the current history entry. Combined
+    // with the no-store headers on /dashboard, Back + reload reach the proxy and
+    // are redirected to /login once the session cookie is gone.
+    window.location.replace(ROUTES.login);
+  }, [isPending, surface]);
+
+  return (
+    <button
+      type="button"
+      disabled={disabled || isPending}
+      aria-busy={isPending || undefined}
+      onClick={() => {
+        void handleLogout();
+      }}
+      className={cn(
+        "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardShellRouter.tsx
+++ b/frontend/src/components/dashboard/DashboardShellRouter.tsx
@@ -6,6 +6,7 @@ import {
   VETNEB_APP_SHELL_RELEASE,
 } from "@/lib/app-shell-release";
 import { AdminMobileBottomNav } from "./AdminMobileBottomNav";
+import { BackForwardCacheGuard } from "./BackForwardCacheGuard";
 
 export function DashboardShellRouter({
   children,
@@ -24,6 +25,7 @@ export function DashboardShellRouter({
       data-vetneb-app-shell-surface={surface}
       aria-label={VETNEB_APP_SHELL_LABEL}
     >
+      <BackForwardCacheGuard />
       <div
         className="flex min-w-0 flex-1 flex-col overflow-hidden"
         data-vetneb-app-shell-frame="true"

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { Suspense } from "react";
+import {
+  Suspense,
+  useCallback,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import { useSearchParams } from "next/navigation";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
-import { DashboardLogoutControl } from "./DashboardLogoutControl";
+import { logout as logoutClinic, logoutAdmin } from "@/lib/api";
+import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
+import { ROUTES } from "@/lib/routes";
 import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 import { DashboardHorizontalNav } from "./DashboardHorizontalNav";
 import { AdminMobileKebabMenu } from "./AdminMobileKebabMenu";
@@ -57,6 +65,38 @@ export function DashboardTopbar({
   notifications = false,
 }: DashboardTopbarProps) {
   const isAdmin = notifications === "admin";
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  // Secure logout: PublicRouteControl keeps the route-registry presentation
+  // (href={ROUTES.login}), but its client-side navigation is cancelled with
+  // preventDefault so logout invalidates the server session instead of merely
+  // routing to /login (which would leave the session alive and let Back/reload
+  // re-render private data). Persisted module keys are cleared before leaving.
+  const handleLogout = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      if (isLoggingOut) {
+        return;
+      }
+      setIsLoggingOut(true);
+      clearDashboardLastModules();
+      void (async () => {
+        try {
+          if (isAdmin) {
+            await logoutAdmin();
+          } else {
+            await logoutClinic();
+          }
+        } catch {
+          // Transport failure must not strand the user on a private surface; the
+          // hard redirect below unloads it and the proxy re-checks the cookie.
+        }
+        // Hard navigation drops the authenticated SPA and in-memory private state.
+        window.location.replace(ROUTES.login);
+      })();
+    },
+    [isAdmin, isLoggingOut],
+  );
 
   return (
     <header
@@ -97,8 +137,11 @@ export function DashboardTopbar({
         >
           <ThemeModeToggle />
           <DashboardTopbarNotifications notifications={notifications} />
-          <DashboardLogoutControl
-            surface={isAdmin ? "admin" : "clinic"}
+          <PublicRouteControl
+            href={ROUTES.login}
+            variant="bare"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
             aria-label="Cerrar sesión"
             title="Cerrar sesión"
             className="inline-flex h-10 min-w-10 items-center justify-center rounded-md border border-input bg-card/95 px-2 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 sm:h-9 sm:min-w-0 sm:px-3"
@@ -109,7 +152,7 @@ export function DashboardTopbar({
                 Salir
               </span>
             ) : null}
-          </DashboardLogoutControl>
+          </PublicRouteControl>
         </div>
         {isAdmin ? <AdminMobileKebabMenu /> : null}
       </div>

--- a/frontend/src/components/dashboard/DashboardTopbar.tsx
+++ b/frontend/src/components/dashboard/DashboardTopbar.tsx
@@ -2,10 +2,8 @@
 
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ThemeModeToggle } from "@/components/theme/ThemeModeToggle";
-import { clearDashboardLastModules } from "@/lib/dashboard-last-module";
-import { ROUTES } from "@/lib/routes";
+import { DashboardLogoutControl } from "./DashboardLogoutControl";
 import { DashboardNotificationsBell } from "./DashboardNotificationsBell";
 import { DashboardHorizontalNav } from "./DashboardHorizontalNav";
 import { AdminMobileKebabMenu } from "./AdminMobileKebabMenu";
@@ -99,10 +97,8 @@ export function DashboardTopbar({
         >
           <ThemeModeToggle />
           <DashboardTopbarNotifications notifications={notifications} />
-          <PublicRouteControl
-            href={ROUTES.login}
-            variant="bare"
-            onClick={clearDashboardLastModules}
+          <DashboardLogoutControl
+            surface={isAdmin ? "admin" : "clinic"}
             aria-label="Cerrar sesión"
             title="Cerrar sesión"
             className="inline-flex h-10 min-w-10 items-center justify-center rounded-md border border-input bg-card/95 px-2 text-sm font-semibold text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] transition-[background-color,border-color,box-shadow,color] duration-150 hover:border-vetneb-teal/45 hover:bg-accent/70 hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 sm:h-9 sm:min-w-0 sm:px-3"
@@ -113,7 +109,7 @@ export function DashboardTopbar({
                 Salir
               </span>
             ) : null}
-          </PublicRouteControl>
+          </DashboardLogoutControl>
         </div>
         {isAdmin ? <AdminMobileKebabMenu /> : null}
       </div>

--- a/frontend/src/lib/admin-hub-reset.ts
+++ b/frontend/src/lib/admin-hub-reset.ts
@@ -27,3 +27,32 @@ export function subscribeAdminHubReset(
   hubResetListeners.add(listener);
   return () => hubResetListeners.delete(listener);
 }
+
+// The mobile bottom-nav module destinations also navigate via `router.push`, but
+// that URL push is async and, under load, can lag well past the navigation —
+// leaving the controller stranded on the previous module because its
+// `useSearchParams` reconciliation effect only runs once the URL commits. The
+// hub cards never show this because `activateModule` sets the active module from
+// local state synchronously, ahead of the URL. Mirror that: publish the target
+// module so the controller activates it synchronously (optimistically) while the
+// URL catches up in the background. Only the mobile bottom-nav publishes, so
+// desktop behaviour is unchanged.
+
+type AdminModuleActivateListener = (moduleId: string) => void;
+
+const moduleActivateListeners = new Set<AdminModuleActivateListener>();
+
+/** Ask the admin workspace controller to open a module immediately. */
+export function requestAdminModuleActivate(moduleId: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  moduleActivateListeners.forEach((listener) => listener(moduleId));
+}
+
+export function subscribeAdminModuleActivate(
+  listener: AdminModuleActivateListener,
+): () => void {
+  moduleActivateListeners.add(listener);
+  return () => moduleActivateListeners.delete(listener);
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -345,6 +345,10 @@ export async function logout(): Promise<void> {
   await apiFetch<void>("/api/auth/logout", { method: "POST" });
 }
 
+export async function logoutAdmin(): Promise<void> {
+  await apiFetch<void>("/api/admin/auth/logout", { method: "POST" });
+}
+
 export type ChangePasswordInput = {
   currentPassword: string;
   newPassword: string;

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -5,18 +5,6 @@ const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";
 const LOGIN_PATH = "/login";
 const ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin";
 
-// Private surfaces must never be cached by the browser, shared caches or the
-// back/forward cache. `no-store` also makes these pages ineligible for bfcache
-// in Chromium/Firefox, so Back + reload after logout hit the proxy instead of a
-// stale private snapshot.
-const PRIVATE_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
-
-function applyPrivateCacheHeaders(response: NextResponse): NextResponse {
-  response.headers.set("Cache-Control", PRIVATE_CACHE_CONTROL);
-  response.headers.set("Pragma", "no-cache");
-  return response;
-}
-
 function isAdminDashboardPath(pathname: string): boolean {
   return (
     pathname === ADMIN_DASHBOARD_PATH_PREFIX ||
@@ -38,7 +26,7 @@ export function proxy(request: NextRequest) {
   );
 
   if (hasRequiredSession) {
-    return applyPrivateCacheHeaders(NextResponse.next());
+    return NextResponse.next();
   }
 
   const loginUrl = request.nextUrl.clone();
@@ -47,7 +35,7 @@ export function proxy(request: NextRequest) {
   loginUrl.pathname = LOGIN_PATH;
   loginUrl.searchParams.set("next", nextPath);
 
-  return applyPrivateCacheHeaders(NextResponse.redirect(loginUrl));
+  return NextResponse.redirect(loginUrl);
 }
 
 export const config = {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -5,6 +5,18 @@ const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";
 const LOGIN_PATH = "/login";
 const ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin";
 
+// Private surfaces must never be cached by the browser, shared caches or the
+// back/forward cache. `no-store` also makes these pages ineligible for bfcache
+// in Chromium/Firefox, so Back + reload after logout hit the proxy instead of a
+// stale private snapshot.
+const PRIVATE_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
+
+function applyPrivateCacheHeaders(response: NextResponse): NextResponse {
+  response.headers.set("Cache-Control", PRIVATE_CACHE_CONTROL);
+  response.headers.set("Pragma", "no-cache");
+  return response;
+}
+
 function isAdminDashboardPath(pathname: string): boolean {
   return (
     pathname === ADMIN_DASHBOARD_PATH_PREFIX ||
@@ -26,7 +38,7 @@ export function proxy(request: NextRequest) {
   );
 
   if (hasRequiredSession) {
-    return NextResponse.next();
+    return applyPrivateCacheHeaders(NextResponse.next());
   }
 
   const loginUrl = request.nextUrl.clone();
@@ -35,7 +47,7 @@ export function proxy(request: NextRequest) {
   loginUrl.pathname = LOGIN_PATH;
   loginUrl.searchParams.set("next", nextPath);
 
-  return NextResponse.redirect(loginUrl);
+  return applyPrivateCacheHeaders(NextResponse.redirect(loginUrl));
 }
 
 export const config = {

--- a/test/frontend-dashboard-last-module.test.ts
+++ b/test/frontend-dashboard-last-module.test.ts
@@ -292,7 +292,7 @@ test("clinic controller persists/restores with the clinic key and replace-only r
 
 // ── 9.4 Logout clears persisted module preferences ─────────────────────────
 
-test("dashboard topbar logout clears persisted module keys before routing to login", () => {
+test("dashboard topbar logout clears persisted module keys and invalidates the session before routing to login", () => {
   const source = read(DASHBOARD_TOPBAR_PATH);
 
   assert.ok(
@@ -300,9 +300,33 @@ test("dashboard topbar logout clears persisted module keys before routing to log
       'import { clearDashboardLastModules } from "@/lib/dashboard-last-module";',
     ),
   );
-  assert.ok(source.includes("onClick={clearDashboardLastModules}"));
+  // Persisted module keys must still be cleared before leaving the surface.
+  assert.ok(source.includes("clearDashboardLastModules();"));
   assert.ok(source.includes("href={ROUTES.login}"));
   assert.equal(source.includes("localStorage"), false);
+
+  // Security regression guard (fix/security-admin-logout-private-cache): logout
+  // must invalidate the server session, not only navigate to /login. A bare
+  // `onClick={clearDashboardLastModules}` left the session cookie valid and let
+  // Back + reload re-render private dashboard data — this evolves the previous
+  // (insecure) contract to require real session invalidation.
+  assert.ok(
+    source.includes("logoutAdmin") && source.includes("logoutClinic"),
+    "logout must call the per-surface logout endpoint",
+  );
+  assert.ok(
+    source.includes("event.preventDefault();"),
+    "logout must cancel PublicRouteControl client navigation so the session is invalidated first",
+  );
+  assert.ok(
+    source.includes("window.location.replace(ROUTES.login)"),
+    "logout must hard-redirect to /login after invalidating the session",
+  );
+  assert.equal(
+    source.includes("onClick={clearDashboardLastModules}"),
+    false,
+    "logout must not use the insecure navigate-only handler",
+  );
 });
 
 test("AuthContext logout clears persisted module keys after backend logout succeeds", () => {


### PR DESCRIPTION
## Summary
- Fix dashboard logout so admin and clinic sessions are invalidated through the correct logout endpoint
- Replace navigation-only logout with per-surface logout control
- Harden private dashboard cache behavior with no-store headers and bfcache protection
- Add focused E2E coverage for logout/private-cache and unauthenticated dashboard redirects

## Root cause
Dashboard "Cerrar sesión" only navigated to /login without calling the logout endpoint. The httpOnly session cookie remained valid, so Back + Ctrl+R could re-render private dashboard data.

## Validation
- git diff --check
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend exec playwright test frontend/e2e/dashboard-logout-private-cache.spec.ts frontend/e2e/dashboard-auth-redirect.spec.ts --workers=2

## Scope
Frontend security fix only. No backend, DB, migrations, dependencies, lockfiles, CI, package scripts or secrets changed.