### PR TITLE
docs(security): close pr-s5 runtime evidence block

### DIFF
--- a/docs/release/security-runtime-pr-s5-closeout.md
+++ b/docs/release/security-runtime-pr-s5-closeout.md
@@ -1,0 +1,101 @@
+# PR-S5 - Security runtime/staging evidence closeout
+
+Date: 2026-06-24
+Base closeout commit: `2de19c1 docs(security): record health and private route evidence (#1117)`
+Scope: documentation-only closeout for PR-S5 runtime/security evidence.
+
+## Decision
+
+PR-S5 is closed as a partial runtime-evidence block.
+
+This is **not** a full security release GO.
+
+| Area | Decision |
+|---|---|
+| Evidence already collected | GO to keep as release evidence |
+| Full production/security release | NO-GO until remaining runtime tenant/session/deployment evidence is completed |
+| Further product/UX work | GO only if it does not claim unresolved PR-S5 evidence as Passed |
+
+## Merged evidence chain
+
+| PR | Purpose | Result |
+|---|---|---|
+| #1112 | Fixed dashboard logout session invalidation | Security fix merged |
+| #1113 | Recorded logout runtime evidence | Passed evidence recorded |
+| #1114 | Recorded HTTP cache and PWA cache evidence | Passed evidence recorded |
+| #1115 | Recorded unauthorized API access and secret sanitization evidence | Passed evidence recorded |
+| #1116 | Recorded cross-tenant smoke and audit logging evidence gap | Pending evidence preserved honestly |
+| #1117 | Recorded backend health/readiness and private route no-session evidence | Passed evidence recorded |
+
+## Passed rows
+
+- Backend health.
+- Backend readiness.
+- Admin private route without cookie.
+- Clinic private route without cookie.
+- Secret sanitization.
+- PWA cache.
+- HTTP cache headers.
+- Logout behavior.
+- Unauthorized API access.
+
+## Pending rows
+
+- Admin session cookie.
+- Clinic session cookie.
+- Session separation.
+- RLS tenant isolation.
+- Cross-tenant smoke.
+- Audit logging for cross-tenant/resource denials.
+- Deployment commit mapping.
+- PR-S1 continuity.
+- PR-S2 continuity.
+- PR-S3 continuity.
+- PR-S4 continuity.
+
+## Why this is not full GO
+
+Full release approval still requires:
+
+1. Cookie-name-only runtime review for admin and clinic sessions without copying cookie values.
+2. Runtime session-separation verification across admin and clinic surfaces.
+3. Two-tenant Clinic A/B cross-tenant smoke using the approved runbook.
+4. Audit or observability verification for denied cross-tenant resource attempts, or a documented product gap.
+5. Deployment dashboard or approved release record mapping runtime evidence to the intended deployment commit.
+6. Coordinated updates to the RLS and endpoint matrices once tenant smoke evidence is collected.
+
+## No-scope confirmation
+
+This closeout does not change:
+
+- Backend/server code.
+- Frontend runtime code.
+- API/auth behavior.
+- Database, migrations or RLS policy.
+- Dependencies or lockfiles.
+- CI workflows or package scripts.
+
+## Secret handling
+
+The PR-S5 evidence chain intentionally avoids recording:
+
+- Cookie values.
+- Bearer tokens.
+- Passwords.
+- Hashes.
+- Signed URLs.
+- Secret environment values.
+- Full private response bodies.
+- Patient, tutor, clinic or tenant-sensitive private payloads.
+
+## Next required block
+
+The next security block should be a controlled runtime-evidence block for:
+
+1. Admin/clinic cookie-name-only verification.
+2. Session separation runtime verification.
+3. Clinic A/B cross-tenant smoke.
+4. Cross-tenant denial audit logging or documented product gap.
+5. Deployment commit mapping.
+
+Until that block is completed, PR-S5 remains a partial closeout with full security release NO-GO.

--- a/docs/release/security-runtime-staging-evidence-checklist.md
+++ b/docs/release/security-runtime-staging-evidence-checklist.md
@@ -55,9 +55,9 @@ This PR does not change:
 | Backend readiness | Runtime readiness is stable before release | Runtime /health and API root request without cookies or secrets | Readiness endpoints respond successfully for the observed runtime | Passed | Production /health returned HTTP 200 with database/storage readiness; API root returned HTTP 200 with service identity and production environment. Deployment commit mapping remains tracked separately in the Deployment commit row. |
 | Admin private route without cookie | Admin private surface rejects unauthenticated access | Terminal HEAD request without cookies | Request is rejected or redirected without exposing private data | Passed | No-session request to /dashboard/admin returned HTTP 307 to /login?next=%2Fdashboard%2Fadmin with Cache-Control: no-store, no-cache, must-revalidate; no private response body was printed. |
 | Clinic private route without cookie | Clinic private surface rejects unauthenticated access | Terminal HEAD request without cookies | Request is rejected or redirected without exposing private data | Passed | No-session requests to /dashboard and /dashboard/informes returned HTTP 307 to login with Cache-Control: no-store, no-cache, must-revalidate; no private response bodies were printed. |
-| Admin session cookie | Admin session uses dmin_session_id only | Browser DevTools Application/Cookies with values redacted | Admin flow does not require or create pp_session_id as admin session authority | Pending | Source review confirms admin session authority is represented as dmin_session_id in rontend/src/proxy.ts and server env defaults, but browser/runtime cookie review was not performed in this PR. Do not mark Passed until cookie-name-only runtime evidence is collected without copying values. |
-| Clinic session cookie | Clinic session uses pp_session_id only | Browser DevTools Application/Cookies with values redacted | Clinic flow does not require or create dmin_session_id as clinic session authority | Pending | Source review confirms clinic session authority is represented as pp_session_id in rontend/src/proxy.ts and server env defaults, but browser/runtime cookie review was not performed in this PR. Do not mark Passed until cookie-name-only runtime evidence is collected without copying values. |
-| Session separation | Admin and clinic session authorities remain separated | Manual two-browser or two-profile verification with cookie names only | No session authority mixing between admin and clinic surfaces | Pending | Source review confirms /dashboard/admin requires dmin_session_id while non-admin dashboard routes require pp_session_id; runtime two-surface cookie review was not performed in this PR, so this row remains Pending. |
+| Admin session cookie | Admin session uses `admin_session_id` only | Browser DevTools Application/Cookies with values redacted | Admin flow does not require or create `app_session_id` as admin session authority | Pending | Source review confirms admin session authority is represented as `admin_session_id` in `frontend/src/proxy.ts` and server env defaults, but browser/runtime cookie review was not performed. Do not mark Passed until cookie-name-only runtime evidence is collected without copying values. |
+| Clinic session cookie | Clinic session uses `app_session_id` only | Browser DevTools Application/Cookies with values redacted | Clinic flow does not require or create `admin_session_id` as clinic session authority | Pending | Source review confirms clinic session authority is represented as `app_session_id` in `frontend/src/proxy.ts` and server env defaults, but browser/runtime cookie review was not performed. Do not mark Passed until cookie-name-only runtime evidence is collected without copying values. |
+| Session separation | Admin and clinic session authorities remain separated | Manual two-browser or two-profile verification with cookie names only | No session authority mixing between admin and clinic surfaces | Pending | Source review confirms `/dashboard/admin` requires `admin_session_id` while non-admin dashboard routes require `app_session_id`; runtime two-surface cookie review was not performed, so this row remains Pending. |
 | RLS tenant isolation | Tenant-scoped data remains isolated | Existing RLS matrix evidence and staging verification with sanitized identifiers | Tenant A cannot access Tenant B data | Pending | RLS/enforcement matrices remain represented, but runtime two-tenant cross-tenant smoke remains pending per PR #1116. This row must not be marked Passed until sanitized Clinic A/B evidence is executed and recorded. |
 | Cross-tenant smoke | Cross-tenant smoke runbook evidence is collected | Existing cross-tenant smoke runbook, sanitized output only | Smoke attempt is blocked and produces no sensitive leakage | Pending | See "Runtime evidence gap - cross-tenant smoke and audit logging" below: the runbook itself records NO-GO and no live two-tenant smoke has been executed. |
 | Audit logging | Security-relevant denied access is auditable | Staging logs, observability dashboard or approved audit source | Denied access is observable without logging secrets | Pending | See "Runtime evidence gap - cross-tenant smoke and audit logging" below: denied-login auditing has code/test evidence, cross-tenant resource denial has no audit event and no staging log review was performed. |
@@ -259,29 +259,6 @@ Scope: documentation-only review of existing runbooks, security matrices and aut
 - Cross-tenant smoke requires a live two-tenant runtime smoke that has not been executed. The runbook itself still declares NO-GO, and the only related automated test is a static contract that self-declares `pending_runtime_staging_evidence` for all 15 scenarios.
 - Audit logging has real, tested evidence for denied **login** attempts only. It has no audit trail for cross-tenant resource denial, and no staging or observability log review was available in this session. Marking it Passed would overstate current evidence and contradict the still-open status in `rls-enforcement-matrix.md` and `ENDPOINT_TEST_MATRIX.md`.
 
-## Runtime evidence — sessions, cookie separation and health readiness
-
-Date: 2026-06-24
-Evidence base commit: `94d798f docs(security): record cross-tenant and audit evidence (#1116)`
-Scope: PR-S5 runtime evidence for admin session, clinic session, cookie separation, private session boundaries and health/readiness.
-
-Evidence recorded:
-
-- Admin session: browser cookie review confirmed `admin_session_id` as the admin session cookie without copying cookie values.
-- Clinic session: browser cookie review confirmed `app_session_id` as the clinic session cookie without copying cookie values.
-- Cookie separation: source verification in `frontend/src/proxy.ts` confirms admin dashboard access requires `admin_session_id` and non-admin dashboard access requires `app_session_id`.
-- Logout continuity: prior post-merge evidence remains valid for admin and clinic logout followed by browser Back and `Ctrl+R`; private dashboard data was not displayed.
-- Private route boundary: no-session requests to `/dashboard`, `/dashboard/admin` and `/dashboard/informes` redirect to login without exposing private data.
-- Health/readiness: production `/health` was reachable and returned success/status OK with database/storage readiness fields.
-- RLS/tenant enforcement continuity: RLS and tenant-enforcement matrices remain represented, but runtime cross-tenant smoke remains Pending per PR #1116 and is not overstated as Passed.
-
-Result:
-
-- Admin session: Passed.
-- Clinic session: Passed.
-- Cookie separation: Passed.
-- Health / readiness: Passed.
-- RLS / tenant enforcement continuity: Pending until cross-tenant smoke is executed and recorded.
 
 ## Runtime evidence - backend health, readiness and no-session private routes
 


### PR DESCRIPTION
## Summary
- Add PR-S5 runtime/staging evidence closeout
- Preserve full security release NO-GO until pending tenant/session/deployment evidence is completed
- Repair checklist rows for admin/clinic session cookie and session separation so they remain Pending
- Remove contradictory stale session/cookie evidence section

## Decision
PR-S5 is closed as a partial runtime-evidence block.

This is not a full security release GO.

## Passed evidence retained
- Backend health/readiness
- Admin/clinic private routes without cookie
- Logout behavior
- HTTP cache headers
- PWA cache
- Unauthorized API access
- Secret sanitization

## Pending evidence retained
- Admin session cookie runtime review
- Clinic session cookie runtime review
- Session separation runtime review
- RLS tenant isolation
- Cross-tenant smoke
- Cross-tenant/resource denial audit logging
- Deployment commit mapping
- PR-S1/PR-S2/PR-S3/PR-S4 continuity

## Validation
- git diff --check
- pnpm test
- secret-pattern scan against docs diff and closeout file

## Scope
Docs-only. No backend, frontend runtime, API/auth, DB, migrations, RLS, dependencies, lockfiles, package scripts or CI changes.