### PR TITLE
feat(dashboard): promote admin system modules into canonical nav

### DIFF
--- a/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
+++ b/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
@@ -25,6 +25,12 @@ const ADMIN_NAV_ITEMS: DashboardHorizontalNavItem[] = [
   { label: "Auditoría", href: `${ROUTES.dashboardAdmin}?module=audit-log` },
   { label: "Usuarios", href: `${ROUTES.dashboardAdmin}?module=admin-users-roles` },
   { label: "Sesiones", href: `${ROUTES.dashboardAdmin}?module=admin-sessions` },
+  // PR-GD1: system/configuration modules promoted into the canonical nav so they
+  // are reachable in one step instead of only through the hub (closes the hidden
+  // module gap for Estado / Precios / Mantenimiento). Same `?module=` contract.
+  { label: "Estado", href: `${ROUTES.dashboardAdmin}?module=admin-health` },
+  { label: "Precios", href: `${ROUTES.dashboardAdmin}?module=admin-pricing` },
+  { label: "Mantenimiento", href: `${ROUTES.dashboardAdmin}?module=admin-maintenance` },
 ];
 
 const CLINIC_NAV_ITEMS: DashboardHorizontalNavItem[] = [

--- a/test/frontend-dashboard-horizontal-nav.test.ts
+++ b/test/frontend-dashboard-horizontal-nav.test.ts
@@ -49,6 +49,11 @@ test("admin horizontal nav exposes the expected modules and preserves ?module=",
     { label: "Auditoría", moduleId: "audit-log" },
     { label: "Usuarios", moduleId: "admin-users-roles" },
     { label: "Sesiones", moduleId: "admin-sessions" },
+    // PR-GD1: critical system/configuration modules must be reachable from the
+    // canonical horizontal nav (no longer hidden behind the hub).
+    { label: "Estado", moduleId: "admin-health" },
+    { label: "Precios", moduleId: "admin-pricing" },
+    { label: "Mantenimiento", moduleId: "admin-maintenance" },
   ];
 
   for (const { label, moduleId } of adminModules) {


### PR DESCRIPTION
## Summary
- Add Estado, Precios and Mantenimiento to the canonical admin horizontal navigation
- Promote hidden admin system/configuration modules from hub-only access to one-step navigation
- Extend the horizontal nav contract test to include the 10 critical admin modules

## Scope
- Frontend-only
- Navigation data + focused test only
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes
- No dashboard redesign
- No clinic wrapper, reports master-detail, hero or sidebar cleanup changes

## Global Dashboard OS alignment
- Implements PR-GD1 from the approved Global Dashboard Operating System baseline
- Closes P1: critical admin modules hidden outside canonical navigation
- Preserves no-scroll SLA by using the existing horizontal overflow behavior

## Validation
- node --test test/frontend-dashboard-horizontal-nav.test.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build