### PR TITLE
fix(dashboard): reframe module overview action

### DIFF
--- a/frontend/e2e/dashboard-accessibility-keyboard.spec.ts
+++ b/frontend/e2e/dashboard-accessibility-keyboard.spec.ts
@@ -313,10 +313,10 @@ test.describe("Admin module hub — keyboard & a11y (PR-8)", () => {
     await expect(
       page.locator('[data-dashboard-module-workspace="admin"]'),
     ).toBeVisible({ timeout: 8_000 });
-    const backBtn = page.getByRole("button", { name: /volver a módulos/i });
+    const backBtn = page.getByRole("button", { name: /vista general/i });
     await expect(backBtn).toBeVisible();
     const ariaLabel = await backBtn.getAttribute("aria-label");
-    expect(ariaLabel).toMatch(/volver a módulos/i);
+    expect(ariaLabel).toMatch(/vista general/i);
   });
 
   test("admin workspace section has accessible label", async ({ page }) => {

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -219,18 +219,18 @@ test.describe("clinic dashboard — workspace activation", () => {
     await expect(hub).not.toBeVisible();
   });
 
-  test("workspace shows Volver a módulos button", async ({ page }) => {
+  test("workspace shows Vista general button", async ({ page }) => {
     await page.goto("/dashboard");
 
     const hub = page.locator('[data-dashboard-module-hub="true"]');
     await expect(hub).toBeVisible({ timeout: 8_000 });
     await hubCard(hub, "Centro de operaciones").click();
 
-    const backBtn = page.getByRole("button", { name: "Volver a módulos" });
+    const backBtn = page.getByRole("button", { name: "Vista general" });
     await expect(backBtn).toBeVisible({ timeout: 5_000 });
   });
 
-  test("Volver a módulos returns to hub", async ({ page }) => {
+  test("Vista general returns to hub", async ({ page }) => {
     await page.goto("/dashboard");
 
     const hub = page.locator('[data-dashboard-module-hub="true"]');
@@ -241,7 +241,7 @@ test.describe("clinic dashboard — workspace activation", () => {
       page.locator('[data-dashboard-module-workspace="operaciones"]'),
     ).toBeVisible({ timeout: 5_000 });
 
-    await page.getByRole("button", { name: "Volver a módulos" }).click();
+    await page.getByRole("button", { name: "Vista general" }).click();
 
     await expect(hub).toBeVisible({ timeout: 5_000 });
     await expect(
@@ -377,18 +377,18 @@ test.describe("admin dashboard — workspace activation", () => {
     await expect(hub).not.toBeVisible();
   });
 
-  test("admin workspace shows Volver a módulos button", async ({ page }) => {
+  test("admin workspace shows Vista general button", async ({ page }) => {
     await page.goto("/dashboard/admin");
 
     const hub = page.locator('[data-dashboard-module-hub="true"]');
     await expect(hub).toBeVisible({ timeout: 8_000 });
     await hubCard(hub, "Administración").click();
 
-    const backBtn = page.getByRole("button", { name: "Volver a módulos" });
+    const backBtn = page.getByRole("button", { name: "Vista general" });
     await expect(backBtn).toBeVisible({ timeout: 5_000 });
   });
 
-  test("Volver a módulos returns to admin hub", async ({ page }) => {
+  test("Vista general returns to admin hub", async ({ page }) => {
     await page.goto("/dashboard/admin");
 
     const hub = page.locator('[data-dashboard-module-hub="true"]');
@@ -399,7 +399,7 @@ test.describe("admin dashboard — workspace activation", () => {
       page.locator('[data-dashboard-module-workspace="admin"]'),
     ).toBeVisible({ timeout: 5_000 });
 
-    await page.getByRole("button", { name: "Volver a módulos" }).click();
+    await page.getByRole("button", { name: "Vista general" }).click();
 
     await expect(hub).toBeVisible({ timeout: 5_000 });
     await expect(
@@ -518,14 +518,14 @@ test.describe("clinic dashboard — deep link direct navigation", () => {
     ).not.toBeVisible();
   });
 
-  test("Volver a módulos from clinic deep link clears query and returns to hub", async ({ page }) => {
+  test("Vista general from clinic deep link clears query and returns to hub", async ({ page }) => {
     await page.goto("/dashboard?module=operaciones");
 
     await expect(
       page.locator('[data-dashboard-module-workspace="operaciones"]'),
     ).toBeVisible({ timeout: 8_000 });
 
-    await page.getByRole("button", { name: "Volver a módulos" }).click();
+    await page.getByRole("button", { name: "Vista general" }).click();
 
     await expect(
       page.locator('[data-dashboard-module-hub="true"]'),
@@ -574,14 +574,14 @@ test.describe("admin dashboard — deep link direct navigation", () => {
     ).not.toBeVisible();
   });
 
-  test("Volver a módulos from admin deep link clears query and returns to admin hub", async ({ page }) => {
+  test("Vista general from admin deep link clears query and returns to admin hub", async ({ page }) => {
     await page.goto("/dashboard/admin?module=admin-clinics");
 
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
     ).toBeVisible({ timeout: 8_000 });
 
-    await page.getByRole("button", { name: "Volver a módulos" }).click();
+    await page.getByRole("button", { name: "Vista general" }).click();
 
     await expect(
       page.locator('[data-dashboard-module-hub="true"]'),
@@ -766,7 +766,7 @@ test.describe("admin dashboard — per-module workspace activation", () => {
     });
   }
 
-  test("each admin workspace shows Volver a módulos — Clínicas", async ({ page }) => {
+  test("each admin workspace shows Vista general — Clínicas", async ({ page }) => {
     await page.goto("/dashboard/admin");
     const hub = page.locator('[data-dashboard-module-hub="true"]');
     await expect(hub).toBeVisible({ timeout: 8_000 });
@@ -774,10 +774,10 @@ test.describe("admin dashboard — per-module workspace activation", () => {
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByRole("button", { name: "Volver a módulos" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Vista general" })).toBeVisible();
   });
 
-  test("each admin workspace shows Volver a módulos — Auditoría", async ({ page }) => {
+  test("each admin workspace shows Vista general — Auditoría", async ({ page }) => {
     await page.goto("/dashboard/admin");
     const hub = page.locator('[data-dashboard-module-hub="true"]');
     await expect(hub).toBeVisible({ timeout: 8_000 });
@@ -785,10 +785,10 @@ test.describe("admin dashboard — per-module workspace activation", () => {
     await expect(
       page.locator('[data-dashboard-module-workspace="audit-log"]'),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByRole("button", { name: "Volver a módulos" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Vista general" })).toBeVisible();
   });
 
-  test("Volver a módulos from Clínicas workspace returns to admin hub", async ({ page }) => {
+  test("Vista general from Clínicas workspace returns to admin hub", async ({ page }) => {
     await page.goto("/dashboard/admin");
     const hub = page.locator('[data-dashboard-module-hub="true"]');
     await expect(hub).toBeVisible({ timeout: 8_000 });
@@ -796,7 +796,7 @@ test.describe("admin dashboard — per-module workspace activation", () => {
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
     ).toBeVisible({ timeout: 5_000 });
-    await page.getByRole("button", { name: "Volver a módulos" }).click();
+    await page.getByRole("button", { name: "Vista general" }).click();
     await expect(hub).toBeVisible({ timeout: 5_000 });
     await expect(
       page.locator('[data-dashboard-module-workspace="admin-clinics"]'),

--- a/frontend/e2e/dashboard-interaction-foundation.spec.ts
+++ b/frontend/e2e/dashboard-interaction-foundation.spec.ts
@@ -82,7 +82,7 @@ test.describe("dashboard interaction foundation — smoke (PR-1)", () => {
     await expect(workspace).toBeVisible({ timeout: 8_000 });
 
     const volverBtn = workspace.locator(
-      'button[aria-label="Volver a módulos"]',
+      'button[aria-label="Vista general"]',
     );
     await expect(volverBtn).toBeVisible();
     await expect(volverBtn).toHaveClass(/dashboard-btn-interactive/);

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -86,7 +86,7 @@ test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
       '[data-dashboard-module-workspace="operaciones"]',
     );
     await expect(workspace).toBeVisible({ timeout: 8_000 });
-    const volverBtn = workspace.locator('button[aria-label="Volver a módulos"]');
+    const volverBtn = workspace.locator('button[aria-label="Vista general"]');
     await expect(volverBtn).toBeVisible();
     await expect(volverBtn).toHaveClass(/dashboard-btn-interactive/);
   });

--- a/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleWorkspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { ArrowLeft } from "lucide-react";
+import { LayoutDashboard } from "lucide-react";
 
 type DashboardModuleWorkspaceProps = {
   title: string;
@@ -29,12 +29,12 @@ export function DashboardModuleWorkspace({
           <button
             type="button"
             onClick={onBack}
-            aria-label="Volver a módulos"
+            aria-label="Vista general"
             data-dashboard-module-back-button="true"
-            className="inline-flex min-h-[2.75rem] items-center gap-2 rounded-md border border-input bg-card/95 px-3 text-sm font-semibold text-foreground shadow-sm dashboard-btn-interactive hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 shrink-0"
+            className="inline-flex min-h-[2.75rem] items-center gap-1.5 rounded-md px-2 text-[0.8125rem] font-medium text-muted-foreground dashboard-btn-interactive hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 shrink-0"
           >
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            <span>Volver a módulos</span>
+            <LayoutDashboard className="h-4 w-4" aria-hidden="true" />
+            <span>Vista general</span>
           </button>
           <div className="min-w-0">
             <h2 className="dashboard-section-heading truncate">{title}</h2>


### PR DESCRIPTION
﻿## Summary
- Reframe the module back action from "Volver a módulos" to "Vista general"
- Preserve the existing backToHub behavior while making the action secondary/ghost
- Replace the back-arrow semantic with an overview-oriented dashboard icon
- Update e2e accessible-name expectations to match the new contract

## Scope
- Frontend-only
- Shared dashboard workspace component + focused e2e string updates
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes
- No navigation rewrite
- No hero redesign
- No clinic wrapper cleanup
- No reports master-detail changes
- No particulares changes

## Global Dashboard OS alignment
- Implements PR-GD2 from the approved Global Dashboard Operating System baseline
- Keeps horizontal navigation as the primary canonical path between modules
- Keeps the hub available as an overview, not a competing primary navigation step
- Preserves no-scroll SLA and existing backToHub behavior

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- node --test test/frontend-dashboard-card-navigation-shell.test.ts test/frontend-dashboard-interaction-foundation.test.ts test/frontend-dashboard-workspace-layout-polish.test.ts test/frontend-dashboard-accessibility-keyboard.test.ts
- Verified no remaining "Volver a módulos" string in frontend/src or frontend/e2e
- Playwright full suite not run locally because it requires a running server; updated e2e selectors by accessible name
