### PR TITLE
fix(dashboard): clarify clinic summary module actions

### DIFF
--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -35,7 +35,7 @@ export function ClinicInformesWorkspaceSummary({
       aria-label="Abrir módulo completo de informes"
     >
       <ExternalLink className="h-4 w-4" aria-hidden="true" />
-      Ver módulo de informes completo
+      Abrir módulo completo
     </PublicRouteControl>
   );
 

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -35,7 +35,7 @@ export function ClinicLogisticaWorkspaceSummary({
       aria-label="Abrir módulo completo de logística"
     >
       <ExternalLink className="h-4 w-4" aria-hidden="true" />
-      Ver módulo de logística completo
+      Abrir módulo completo
     </PublicRouteControl>
   );
 


### PR DESCRIPTION
## Summary
- Clarify clinic summary toolbar CTAs with a unified "Abrir módulo completo" label
- Preserve detail-level deep links because they are functional contextual exits
- Keep clinic summary wrappers, tabs, standalone routes, sidebar, and navigation behavior unchanged

## Scope
- Frontend-only
- Clinic dashboard summary wrappers only
- Copy-only change
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes
- No reports master-detail changes
- No particulares changes
- No navigation rewrite
- No visual redesign

## Global Dashboard OS alignment
- Implements PR-GD3 as a low-risk consolidation pass
- Reframes clinic wrappers as operational summaries instead of redundant redirects
- Keeps module-level and detail-level actions distinct
- Avoids removing functional deep links such as reportId and visits

## Validation
- git diff --check
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- node --test test/frontend-dashboard-home.test.ts
