### PR TITLE
docs(dashboard): define sidebar navigation contract

### DIFF
--- a/docs/audit/product-ux-dashboard-audit.md
+++ b/docs/audit/product-ux-dashboard-audit.md
@@ -1098,3 +1098,23 @@ veto de deps/CI sin autorización.
 - ✅ Cobertura global: 6 superficies (admin/clínica/particulares × desktop/mobile), con
   particulares explícitamente marcado como **EXISTENTE fuera del OS** y su aplicación como
   **frontend-only / sin backend**.
+
+## PR-GD4 — Sidebar / orphan navigation contract
+
+Decision:
+- DashboardSidebarFrame, ClinicDashboardSidebar and AdminDashboardSidebar remain legacy/shared navigation components covered by tests, but they must not be reintroduced as the primary dashboard shell navigation.
+- Desktop dashboard navigation must remain the canonical horizontal navigation contract.
+- Admin mobile navigation must remain the dedicated bottom navigation contract.
+- Clinic dashboard navigation must remain inside the current in-shell module navigation contract.
+- Future sidebar work must prove that it does not create parallel navigation, duplicate hierarchy, or a double-hop path.
+
+Scope:
+- Documentation-only contract.
+- No production code changes.
+- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
+- No dashboard visual redesign.
+
+Acceptance:
+- The current dashboard shell remains no-sidebar as primary navigation.
+- Existing sidebar components stay governed by tests but are not promoted back into the primary shell.
+- Any future change must preserve no-scroll SLA and role-specific navigation separation.


### PR DESCRIPTION
## Summary
- Document the dashboard sidebar/orphan navigation contract
- Keep DashboardSidebarFrame, ClinicDashboardSidebar, and AdminDashboardSidebar as tested legacy/shared components
- Explicitly prevent sidebars from being reintroduced as the primary dashboard shell navigation
- Preserve the current canonical navigation split: desktop horizontal nav, admin mobile bottom nav, clinic in-shell module navigation

## Scope
- Documentation-only
- No production code changes
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes
- No dashboard visual redesign
- No reports master-detail changes
- No particulares changes

## Global Dashboard OS alignment
- Adds a lightweight navigation contract to the existing Product/UX dashboard audit
- Prevents future orphan/parallel navigation regressions
- Preserves no-scroll SLA and role-specific navigation separation

## Validation
- git diff --check
- Scope verified: docs/audit/product-ux-dashboard-audit.md only
