### PR TITLE
feat(particulares): clarify report state actions

### DIFF
--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import {
   CalendarDays,
   Clipboard,
+  Clock,
   Download,
   Eye,
   FileText,
@@ -891,6 +892,7 @@ export function ParticularesContent() {
                       {/* Mobile flat report — sin VisualIcon ni clinical-muted-band */}
                       <div
                         data-particular-mobile-flat-card="report"
+                        data-particulares-report-state="available"
                         className="rounded-lg border border-vetneb-line bg-card p-4 sm:hidden"
                       >
                         <div className="flex items-start gap-3">
@@ -900,9 +902,14 @@ export function ParticularesContent() {
                             strokeWidth={1.8}
                           />
                           <div>
-                            <h3 className="font-semibold text-vetneb-navy">
-                              Informe vinculado
-                            </h3>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="font-semibold text-vetneb-navy">
+                                Informe vinculado
+                              </h3>
+                              <span className="inline-flex items-center rounded-full border border-vetneb-teal/40 bg-vetneb-teal/10 px-2 py-0.5 text-xs font-semibold text-vetneb-teal">
+                                Disponible
+                              </span>
+                            </div>
                             <p className="mt-1 text-sm text-muted-foreground">
                               {session.report.studyType ?? "Estudio"} ·{" "}
                               {session.report.fileName ?? "Archivo disponible"}
@@ -912,6 +919,7 @@ export function ParticularesContent() {
 
                         <div
                           data-particular-mobile-flat-actions="true"
+                          data-particulares-report-actions="true"
                           className="mt-4 flex flex-col gap-3"
                         >
                           <Button
@@ -939,6 +947,7 @@ export function ParticularesContent() {
                       {/* Desktop report — oculto en mobile, visible desde sm */}
                       <div
                         id="particular-report"
+                        data-particulares-report-state="available"
                         className="hidden rounded-lg p-4 shadow-sm clinical-muted-band sm:block"
                       >
                         <div className="flex items-start gap-3">
@@ -948,9 +957,14 @@ export function ParticularesContent() {
                             className="h-10 w-10 shrink-0 rounded-xl"
                           />
                           <div>
-                            <h3 className="font-semibold text-vetneb-navy">
-                              Informe vinculado
-                            </h3>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="font-semibold text-vetneb-navy">
+                                Informe vinculado
+                              </h3>
+                              <span className="inline-flex items-center rounded-full border border-vetneb-teal/40 bg-vetneb-teal/10 px-2 py-0.5 text-xs font-semibold text-vetneb-teal">
+                                Disponible
+                              </span>
+                            </div>
                             <p className="mt-1 text-sm text-muted-foreground">
                               {session.report.studyType ?? "Estudio"} ·{" "}
                               {session.report.fileName ?? "Archivo disponible"}
@@ -958,7 +972,10 @@ export function ParticularesContent() {
                           </div>
                         </div>
 
-                        <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                        <div
+                          data-particulares-report-actions="true"
+                          className="mt-4 flex flex-col gap-3 sm:flex-row"
+                        >
                           <Button
                             type="button"
                             onClick={() => openReport("preview")}
@@ -982,10 +999,25 @@ export function ParticularesContent() {
                       </div>
                     </>
                   ) : (
-                    <div className="clinical-alert-warning p-4">
-                      {trackingCase
-                        ? `El caso todavía no tiene un informe vinculado. Estado del estudio: ${getTrackingStageLabel(trackingCase.currentStage)}.`
-                        : "El caso todavía no tiene un informe vinculado. El estudio continúa en evaluación profesional y se habilitará cuando finalice la validación diagnóstica."}
+                    <div
+                      data-particulares-report-state="pending"
+                      className="clinical-alert-info flex items-start gap-3 p-4"
+                    >
+                      <Clock
+                        className="mt-0.5 h-5 w-5 shrink-0"
+                        aria-hidden="true"
+                        strokeWidth={1.8}
+                      />
+                      <div>
+                        <h3 className="font-semibold text-vetneb-navy">
+                          Sin informe vinculado todavía
+                        </h3>
+                        <p className="mt-1 text-sm">
+                          {trackingCase
+                            ? `El caso continúa en evaluación profesional. Estado del estudio: ${getTrackingStageLabel(trackingCase.currentStage)}. El informe se habilitará automáticamente al finalizar.`
+                            : "El caso continúa en evaluación profesional. El informe se habilitará automáticamente cuando finalice la validación diagnóstica."}
+                        </p>
+                      </div>
                     </div>
                   )}
 

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -317,3 +317,44 @@ test("particulares content omite datos ausentes y sensibles en mensaje de tincio
     );
   }
 });
+
+// ─── PR-PUX2: claridad de estados y acciones de informe ─────────────────────
+
+test("particulares content fija contrato de estados de informe disponible/pendiente", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  const availableCount = (
+    source.match(/data-particulares-report-state="available"/g) ?? []
+  ).length;
+  const actionsCount = (
+    source.match(/data-particulares-report-actions="true"/g) ?? []
+  ).length;
+
+  assert.equal(
+    availableCount,
+    2,
+    "must mark both mobile and desktop report blocks as available",
+  );
+  assert.ok(source.includes('data-particulares-report-state="pending"'));
+  assert.equal(
+    actionsCount,
+    2,
+    "must mark both mobile and desktop report action groups",
+  );
+});
+
+test("particulares content keeps distinct ver/descargar actions and safe pending copy", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes('onClick={() => openReport("preview")}'));
+  assert.ok(source.includes('onClick={() => openReport("download")}'));
+  assert.ok(source.includes("Ver informe"));
+  assert.ok(source.includes("Descargar"));
+  assert.ok(source.includes("Sin informe vinculado todavía"));
+  assert.ok(source.includes("clinical-alert-info"));
+  assert.equal(
+    source.includes('className="clinical-alert-warning p-4"'),
+    false,
+    "pending report state must not use the alarming warning style",
+  );
+});


### PR DESCRIPTION
## Summary
- Clarifies particulares report state when a linked report is available.
- Adds explicit available/pending report state selectors.
- Differentiates Ver informe and Descargar actions without changing report APIs.
- Reframes the no-linked-report state as neutral/informational instead of warning/error.

## Scope
- Frontend/test only.
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
- No endpoint, cookie, session, token, or signed URL behavior changes.
- No dashboard shell or private navigation changes.

## Contract fixed
- `data-particulares-report-state="available"`
- `data-particulares-report-state="pending"`
- `data-particulares-report-actions="true"`
- Keeps `openReport("preview")`
- Keeps `openReport("download")`
- Keeps safe report-state copy for available and pending states.
- Pending report state must remain neutral/informational, not warning/error.

## Validation
- git diff --check
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
- node --test test/frontend-particulares-content.test.ts test/frontend-particulares-mobile-session-card-render.test.ts test/frontend-particulares-access-contract.test.ts
- node scripts/security/audit-public-devtools-surface.mjs
