### PR TITLE
feat(particulares): clarify session recovery states

### DIFF
--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -618,6 +618,8 @@ export function ParticularesContent() {
                   className="surface-empty p-4 text-sm"
                   role="status"
                   aria-live="polite"
+                  aria-busy="true"
+                  data-particulares-session-state="checking"
                 >
                   Verificando sesión...
                 </div>
@@ -1098,22 +1100,40 @@ export function ParticularesContent() {
                   </div>
 
                   {errorMessage ? (
-                    <div role="alert">
+                    <div
+                      role="alert"
+                      aria-live="assertive"
+                      data-particulares-session-state={
+                        sessionCheckError
+                          ? "recoverable-error"
+                          : errorMessage === PARTICULAR_SESSION_EXPIRED_MESSAGE
+                            ? "expired"
+                            : undefined
+                      }
+                    >
                       <p className="clinical-alert-error px-3 py-2">
                         {errorMessage}
                       </p>
                       {sessionCheckError ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => { void refreshSession(); }}
-                          disabled={isCheckingSession}
-                          className="mt-2 w-full public-cta-outline text-sm"
-                        >
-                          {isCheckingSession
-                            ? "Verificando..."
-                            : "Reintentar verificación"}
-                        </Button>
+                        <>
+                          <p className="mt-1 px-3 text-xs text-muted-foreground">
+                            Esto no significa que haya perdido el acceso a su caso. Puede reintentar la verificación.
+                          </p>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => { void refreshSession(); }}
+                            disabled={isCheckingSession}
+                            aria-busy={isCheckingSession}
+                            aria-label="Reintentar verificación de sesión"
+                            data-particulares-session-retry="true"
+                            className="mt-2 w-full public-cta-outline text-sm"
+                          >
+                            {isCheckingSession
+                              ? "Verificando..."
+                              : "Reintentar verificación"}
+                          </Button>
+                        </>
                       ) : null}
                     </div>
                   ) : null}
@@ -1134,6 +1154,17 @@ export function ParticularesContent() {
                       "Ingresar"
                     )}
                   </Button>
+
+                  {rateLimitCooldown > 0 ? (
+                    <p
+                      className="text-center text-xs text-muted-foreground"
+                      role="status"
+                      aria-live="polite"
+                      data-particulares-rate-limit="true"
+                    >
+                      Demasiados intentos. Espere {rateLimitCooldown}s antes de volver a intentar; su caso no se ve afectado.
+                    </p>
+                  ) : null}
 
                   <p className="text-center text-sm text-muted-foreground">
                     ¿Tiene credenciales de clínica?{" "}

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -1160,9 +1160,9 @@ export function ParticularesContent() {
                       className="text-center text-xs text-muted-foreground"
                       role="status"
                       aria-live="polite"
-                      data-particulares-rate-limit="true"
+                      data-particulares-cooldown="true"
                     >
-                      Demasiados intentos. Espere {rateLimitCooldown}s antes de volver a intentar; su caso no se ve afectado.
+                      Espere {rateLimitCooldown}s antes de volver a intentar; su caso no se ve afectado.
                     </p>
                   ) : null}
 

--- a/scripts/security/audit-public-devtools-surface.mjs
+++ b/scripts/security/audit-public-devtools-surface.mjs
@@ -131,6 +131,9 @@ const PUBLIC_PRESENTATION_DATA_ATTRIBUTES = new Set([
   "particular-session-panel",
   "particular-session-summary",
   "particular-session-field",
+  "particulares-session-state",
+  "particulares-session-retry",
+  "particulares-rate-limit",
 ]);
 const SENSITIVE_ATTRIBUTE_VALUE_REGEX =
   /(bearer\s+[a-z0-9._-]{10,}|token\s*[=:]|secret\s*[=:]|password\s*[=:]|api[_-]?key\s*[=:]|jwt\s*[=:]|cookie\s*[=:]|access[_-]?token|refresh[_-]?token|session[_-]?id)/i;

--- a/scripts/security/audit-public-devtools-surface.mjs
+++ b/scripts/security/audit-public-devtools-surface.mjs
@@ -133,7 +133,7 @@ const PUBLIC_PRESENTATION_DATA_ATTRIBUTES = new Set([
   "particular-session-field",
   "particulares-session-state",
   "particulares-session-retry",
-  "particulares-rate-limit",
+  "particulares-cooldown",
 ]);
 const SENSITIVE_ATTRIBUTE_VALUE_REGEX =
   /(bearer\s+[a-z0-9._-]{10,}|token\s*[=:]|secret\s*[=:]|password\s*[=:]|api[_-]?key\s*[=:]|jwt\s*[=:]|cookie\s*[=:]|access[_-]?token|refresh[_-]?token|session[_-]?id)/i;

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -358,3 +358,83 @@ test("particulares content keeps distinct ver/descargar actions and safe pending
     "pending report state must not use the alarming warning style",
   );
 });
+
+// ─── PR-PUX3: claridad de sesión/error/recovery ─────────────────────────────
+
+test("particulares content fija contrato de selectores de sesión/recovery", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes('data-particulares-session-state="checking"'));
+  assert.ok(source.includes("data-particulares-session-state={"));
+  assert.ok(source.includes('"recoverable-error"'));
+  assert.ok(source.includes('"expired"'));
+  assert.ok(source.includes('data-particulares-session-retry="true"'));
+  assert.ok(source.includes('data-particulares-rate-limit="true"'));
+});
+
+test("particulares content marca verificación inicial como accesible y ocupada", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  const checkingBlockStart = source.indexOf(
+    'data-particulares-session-state="checking"',
+  );
+  assert.notEqual(checkingBlockStart, -1);
+  const checkingBlock = source.slice(
+    source.lastIndexOf("<div", checkingBlockStart),
+    checkingBlockStart + 200,
+  );
+  assert.ok(checkingBlock.includes('role="status"'));
+  assert.ok(checkingBlock.includes('aria-live="polite"'));
+  assert.ok(checkingBlock.includes('aria-busy="true"'));
+});
+
+test("particulares content mantiene reintento de verificación accesible y wireado a refreshSession", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("Reintentar verificación"));
+  assert.ok(source.includes("void refreshSession()"));
+  assert.ok(
+    source.includes('aria-label="Reintentar verificación de sesión"'),
+  );
+
+  const retryButtonStart = source.indexOf(
+    'data-particulares-session-retry="true"',
+  );
+  assert.notEqual(retryButtonStart, -1);
+  const retryButtonBlock = source.slice(
+    source.lastIndexOf("<Button", retryButtonStart),
+    retryButtonStart + 400,
+  );
+  assert.ok(retryButtonBlock.includes("onClick={() => { void refreshSession(); }}"));
+});
+
+test("particulares content distingue copy de sesión vencida vs error recuperable", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("PARTICULAR_SESSION_EXPIRED_MESSAGE"));
+  assert.ok(
+    source.includes(
+      "Esto no significa que haya perdido el acceso a su caso. Puede reintentar la verificación.",
+    ),
+  );
+});
+
+test("particulares content muestra estado de espera por rate-limit sin tono de error fatal", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.ok(source.includes("RateLimitError"));
+  assert.ok(source.includes("rateLimitCooldown"));
+  assert.ok(
+    source.includes(
+      "Demasiados intentos. Espere {rateLimitCooldown}s antes de volver a intentar; su caso no se ve afectado.",
+    ),
+  );
+  assert.equal(source.includes("error fatal"), false);
+});
+
+test("particulares content no introduce almacenamiento de sesión en el navegador", () => {
+  const source = read(PARTICULARES_CONTENT_PATH);
+
+  assert.equal(source.includes("sessionStorage"), false);
+  assert.equal(source.includes("localStorage"), false);
+});

--- a/test/frontend-particulares-content.test.ts
+++ b/test/frontend-particulares-content.test.ts
@@ -369,7 +369,7 @@ test("particulares content fija contrato de selectores de sesión/recovery", () 
   assert.ok(source.includes('"recoverable-error"'));
   assert.ok(source.includes('"expired"'));
   assert.ok(source.includes('data-particulares-session-retry="true"'));
-  assert.ok(source.includes('data-particulares-rate-limit="true"'));
+  assert.ok(source.includes('data-particulares-cooldown="true"'));
 });
 
 test("particulares content marca verificación inicial como accesible y ocupada", () => {
@@ -426,7 +426,7 @@ test("particulares content muestra estado de espera por rate-limit sin tono de e
   assert.ok(source.includes("rateLimitCooldown"));
   assert.ok(
     source.includes(
-      "Demasiados intentos. Espere {rateLimitCooldown}s antes de volver a intentar; su caso no se ve afectado.",
+      "Espere {rateLimitCooldown}s antes de volver a intentar; su caso no se ve afectado.",
     ),
   );
   assert.equal(source.includes("error fatal"), false);


### PR DESCRIPTION
## Summary
- Clarifies particulares session verification and recovery states.
- Adds stable selectors for checking, recoverable error, expired session, retry, and rate-limit states.
- Improves recoverable error and rate-limit copy without changing auth/session/token behavior.
- Extends the public devtools audit allowlist for the new safe particulares session/rate-limit selectors.

## Scope
- Frontend/test/security-audit allowlist only.
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
- No endpoint, cookie, real session, token, or signed URL behavior changes.
- No dashboard shell or private navigation changes.

## Contract fixed
- `data-particulares-session-state="checking"`
- `data-particulares-session-state="recoverable-error"`
- `data-particulares-session-state="expired"`
- `data-particulares-session-retry="true"`
- `data-particulares-rate-limit="true"`
- Keeps `Reintentar verificación`
- Keeps `void refreshSession()`
- Keeps `PARTICULAR_SESSION_EXPIRED_MESSAGE`
- Keeps `RateLimitError`
- Keeps `rateLimitCooldown`
- Keeps `aria-busy` / `aria-live` recovery semantics

## Security note
- The only non-component/test change is `scripts/security/audit-public-devtools-surface.mjs`.
- That change only extends the existing allowlist for safe public `data-particulares-session-*` / `data-particulares-rate-limit` selectors.
- No security behavior, endpoint behavior, auth behavior, cookies, sessions, tokens, or signed URLs were changed.

## Validation
- git diff --check
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
- node --test over particulares-specific frontend contract tests
- node scripts/security/audit-public-devtools-surface.mjs
