### PR TITLE
test(particulares): add mobile no regression evidence

### DIFF
--- a/frontend/e2e/public-routes.spec.ts
+++ b/frontend/e2e/public-routes.spec.ts
@@ -6,6 +6,15 @@ import { expect, test, type Page } from "@playwright/test";
 // no-op and the URL stays put. Retry the click until the navigation actually
 // happens, mirroring the hydration-probe pattern used elsewhere in the suite
 // (see contacto-hydration.spec.ts).
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+}
+
 async function clickAndExpectNavigation(
   page: Page,
   name: string,
@@ -69,12 +78,52 @@ test.describe("particulares hero action hierarchy (PR-PUX1)", () => {
     await expect(primaryAction).toBeVisible();
     await expect(primaryAction).toBeInViewport();
 
-    const overflow = await page.evaluate(
-      () =>
-        document.documentElement.scrollWidth -
-        document.documentElement.clientWidth,
+    await expectNoHorizontalOverflow(page);
+  });
+});
+
+test.describe("particulares mobile no-regression evidence (PR-PUX4)", () => {
+  const mobileViewports = [
+    { width: 390, height: 844 },
+    { width: 360, height: 740 },
+  ];
+
+  for (const viewport of mobileViewports) {
+    test(`keeps hero, primary action and next-step zone visible without horizontal overflow at ${viewport.width}x${viewport.height}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.goto("/particulares");
+
+      await expect(page.locator('[data-particulares-hero="true"]')).toBeVisible();
+
+      const primaryAction = page.locator(
+        '[data-particulares-primary-action="true"]',
+      );
+      await expect(primaryAction).toBeVisible();
+      await expect(primaryAction).toBeInViewport();
+
+      await expect(
+        page.locator('[data-particulares-next-step-zone="true"]'),
+      ).toBeVisible();
+
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+
+  test("keeps public navigation to /login reachable from /particulares on mobile", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/particulares");
+
+    await expectNoHorizontalOverflow(page);
+
+    await clickAndExpectNavigation(
+      page,
+      "Inicie sesión en el portal",
+      "/login",
     );
-    expect(overflow).toBeLessThanOrEqual(0);
   });
 });
 
@@ -131,12 +180,7 @@ test("unknown route renders the branded not-found page without mobile overflow",
     await expect(page.locator("body")).not.toContainText(prohibited);
   }
 
-  const overflow = await page.evaluate(
-    () =>
-      document.documentElement.scrollWidth -
-      document.documentElement.clientWidth,
-  );
-  expect(overflow).toBeLessThanOrEqual(0);
+  await expectNoHorizontalOverflow(page);
 
   await clickAndExpectNavigation(page, "Ver servicios", "/servicios");
 


### PR DESCRIPTION
## Summary
- Adds final mobile no-regression evidence for the public `/particulares` surface.
- Reuses the existing public route E2E spec and no-overflow helper.
- Verifies hero, primary action, and next-step zone remain visible on mobile.
- Covers 390x844 and 360x740 mobile viewports.
- Confirms public navigation from `/particulares` to `/login` remains reachable.

## Scope
- Test-only.
- Modified only `frontend/e2e/public-routes.spec.ts`.
- No production component changes.
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
- No endpoint, cookie, session, token, or signed URL behavior changes.

## Evidence fixed
- `/particulares` primary action visible in first mobile viewport.
- `/particulares` hero and next-step zone visible on mobile.
- No horizontal overflow at 390x844.
- No horizontal overflow at 360x740.
- Public `/login` navigation remains reachable from `/particulares`.
- Existing public routes and metadata evidence preserved.

## Validation
- git diff --check
- pnpm --dir frontend exec playwright test e2e/public-routes.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build

## Note
- Playwright reported existing browser console `removeChild` messages from the web server, but all public route tests passed. This PR does not change that behavior.
