### PR TITLE
test(clinic): add controller workspace parity contract

### DIFF
--- a/docs/audit/clinic-dashboard-admin-structure-parity-audit.md
+++ b/docs/audit/clinic-dashboard-admin-structure-parity-audit.md
@@ -169,3 +169,25 @@ Este documento (PR-CL0) se considera completo si:
 - Revisión de specs e2e listados (estructura de `dashboard-clinic-*-mobile-parity.spec.ts` y `dashboard-mobile-shell-nav-contract.spec.ts` confirmando que ya cubren ambas superficies clinic/admin con rutas y selectores distintos).
 - Confirmado que `/clinicas` pública no aparece en ningún archivo tocado ni referenciado como dependencia de este bloque.
 - `git diff --check` — pendiente de ejecutar post-commit; este documento es texto plano sin código, no se esperan conflictos de whitespace.
+
+### PR-CL1 evidence (test-only, sin frontend productivo)
+
+Rama: `test/clinic-controller-workspace-parity-contract`. Base: `main` @ `5caccae` (docs(clinic): audit admin structure parity #1135).
+
+Entregado: `frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts` (nuevo). Declara el contrato controller/workspace mínimo que Clínica ya cumple respecto a Admin, sin tocar ningún componente de render:
+
+- `/dashboard` y `/dashboard?module={operaciones,informes,logistica,perfil,tokens}` resuelven hub/workspace vía los mismos selectores `data-dashboard-module-hub`/`data-dashboard-module-workspace` que usa Admin.
+- Baseline Admin no se rompe: `/dashboard/admin` (hub) y `/dashboard/admin?module=admin-clinics` (workspace) siguen resolviendo.
+- "Vista general" (mismo `DashboardModuleWorkspace` compartido con Admin) vuelve al hub en un solo click, sin URL con `module=` residual.
+- `aria-current="page"` se mantiene verificable en el nav horizontal de Clínica para `operaciones`, `tokens`, `perfil` (cuyo href de nav resuelve a `?module=` exacto). Para `informes`/`logistica` no es verificable porque el nav apunta a las rutas full `/dashboard/informes` y `/dashboard/logistica` (dualidad ya documentada como **CL-GAP-7**) en vez de a `?module=`; se documenta como hallazgo, no se fuerza un assert que no aplica a la implementación actual.
+- 390x844: sin overflow horizontal en `documentElement`/`body` y `main.dashboard-main` no se convierte en scroll container, en los 5 módulos de Clínica + hub.
+
+No se confirma ni se descarta en este PR ningún otro gap (CL-GAP-1 a CL-GAP-6); este contrato es deliberadamente el subconjunto mínimo pedido, no una auditoría ampliada.
+
+Validaciones ejecutadas:
+
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-controller-workspace-parity.spec.ts` — 18 passed.
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm typecheck:test` — sin errores.
+- `git diff --check` — sin conflictos de whitespace.
+- `next-env.d.ts` revertido a su estado de `main` tras la corrida e2e (regenerado por el dev server de Playwright; no es parte del diff de este PR).

--- a/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/test";
+
+type Page = import("@playwright/test").Page;
+
+const TOLERANCE = 2;
+const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
+
+type ClinicModule =
+  | "operaciones"
+  | "informes"
+  | "logistica"
+  | "perfil"
+  | "tokens";
+
+const CLINIC_MODULES: ClinicModule[] = [
+  "operaciones",
+  "informes",
+  "logistica",
+  "perfil",
+  "tokens",
+];
+
+/**
+ * Nav items whose href resolves to `/dashboard?module=<id>` exactly, so
+ * aria-current is verifiable there. "informes"/"logistica" nav items point to
+ * standalone routes (/dashboard/informes, /dashboard/logistica) instead of the
+ * `?module=` workspace, so aria-current is not applicable on those module URLs.
+ */
+const CLINIC_MODULES_WITH_VERIFIABLE_NAV: Record<ClinicModule, string | null> = {
+  operaciones: "Resumen",
+  informes: null,
+  logistica: null,
+  perfil: "Perfil",
+  tokens: "Tokens",
+};
+
+async function setClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_test_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function expectMainNotScrollContainer(page: Page) {
+  const metric = await page.evaluate(() => {
+    const main = document.querySelector("main.dashboard-main") as HTMLElement | null;
+    if (!main) return null;
+    return {
+      scrollHeight: main.scrollHeight,
+      clientHeight: main.clientHeight,
+      scrollWidth: main.scrollWidth,
+      clientWidth: main.clientWidth,
+    };
+  });
+
+  expect(metric, "main.dashboard-main present").not.toBeNull();
+  expect(metric!.scrollHeight).toBeLessThanOrEqual(metric!.clientHeight + TOLERANCE);
+  expect(metric!.scrollWidth).toBeLessThanOrEqual(metric!.clientWidth + TOLERANCE);
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const metric = await page.evaluate(() => ({
+    htmlScrollWidth: document.documentElement.scrollWidth,
+    htmlClientWidth: document.documentElement.clientWidth,
+    bodyScrollWidth: document.body.scrollWidth,
+    bodyClientWidth: document.body.clientWidth,
+  }));
+
+  expect(metric.htmlScrollWidth).toBeLessThanOrEqual(metric.htmlClientWidth + TOLERANCE);
+  expect(metric.bodyScrollWidth).toBeLessThanOrEqual(metric.bodyClientWidth + TOLERANCE);
+}
+
+test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
+  test("clinic /dashboard loads the module hub", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  for (const moduleId of CLINIC_MODULES) {
+    test(`clinic /dashboard?module=${moduleId} loads workspace ${moduleId}`, async ({
+      page,
+    }) => {
+      await setClinicSession(page);
+      await page.goto(`/dashboard?module=${moduleId}`);
+      await expect(
+        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+      ).toBeVisible({ timeout: 8_000 });
+    });
+  }
+
+  test("admin /dashboard/admin baseline still loads hub", async ({ page }) => {
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("admin baseline module still loads workspace", async ({ page }) => {
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin?module=admin-clinics");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="admin-clinics"]'),
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("clinic Vista general returns to hub in a single click (no double-hop)", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    const workspace = page.locator('[data-dashboard-module-workspace="operaciones"]');
+    await expect(workspace).toBeVisible({ timeout: 8_000 });
+
+    await workspace.locator('button[aria-label="Vista general"]').click();
+
+    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible({
+      timeout: 4_000,
+    });
+    await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/);
+    await expect(page).not.toHaveURL(/module=/);
+  });
+
+  for (const moduleId of CLINIC_MODULES) {
+    const navLabel = CLINIC_MODULES_WITH_VERIFIABLE_NAV[moduleId];
+    if (!navLabel) continue;
+
+    test(`clinic ${moduleId} keeps active nav item aria-current visible`, async ({
+      page,
+    }) => {
+      await setClinicSession(page);
+      await page.goto(`/dashboard?module=${moduleId}`);
+      await expect(
+        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+      ).toBeVisible({ timeout: 8_000 });
+
+      const navigation = page.getByRole("navigation", {
+        name: "Navegación principal",
+      });
+      await expect(
+        navigation.getByRole("button", { name: navLabel, exact: true }),
+      ).toHaveAttribute("aria-current", "page");
+    });
+  }
+
+  for (const moduleId of CLINIC_MODULES) {
+    test(`clinic ${moduleId} fits 390x844 without horizontal overflow or main scroll`, async ({
+      page,
+    }) => {
+      await setClinicSession(page);
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.goto(`/dashboard?module=${moduleId}`);
+      await expect(
+        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+      ).toBeVisible({ timeout: 8_000 });
+
+      await expectNoHorizontalOverflow(page);
+      await expectMainNotScrollContainer(page);
+    });
+  }
+
+  test("clinic hub fits 390x844 without horizontal overflow or main scroll", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-module-hub="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    await expectNoHorizontalOverflow(page);
+    await expectMainNotScrollContainer(page);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Clinic controller/workspace parity E2E contract.
- Verifies the private Clinic dashboard hub and canonical clinic `?module=` workspaces.
- Preserves Admin baseline coverage for hub and `admin-clinics` workspace.
- Documents PR-CL1 evidence in the Clinic admin-structure parity audit.

## Scope
- Test/docs only.
- Added `frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts`.
- Updated `docs/audit/clinic-dashboard-admin-structure-parity-audit.md`.
- No frontend production changes.
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
- No session, cookie, token, role, permission, or endpoint behavior changes.
- No public `/clinicas` changes.
- No Admin dashboard production changes.

## Contract covered
- `/dashboard` loads Clinic hub.
- `/dashboard?module=operaciones` loads workspace `operaciones`.
- `/dashboard?module=informes` loads workspace `informes`.
- `/dashboard?module=logistica` loads workspace `logistica`.
- `/dashboard?module=perfil` loads workspace `perfil`.
- `/dashboard?module=tokens` loads workspace `tokens`.
- `/dashboard/admin` and `/dashboard/admin?module=admin-clinics` baseline still load.
- `Vista general` returns Clinic module workspace to hub in a single click.
- Active nav `aria-current="page"` remains visible where canonical `?module=` hrefs apply.
- Clinic hub and all five module workspaces fit 390x844 without horizontal overflow or main scroll.

## Validation
- git diff --check
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-controller-workspace-parity.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
