### PR TITLE
feat(clinic): improve command center parity

### DIFF
--- a/docs/audit/clinic-dashboard-admin-structure-parity-audit.md
+++ b/docs/audit/clinic-dashboard-admin-structure-parity-audit.md
@@ -191,3 +191,38 @@ Validaciones ejecutadas:
 - `pnpm typecheck:test` — sin errores.
 - `git diff --check` — sin conflictos de whitespace.
 - `next-env.d.ts` revertido a su estado de `main` tras la corrida e2e (regenerado por el dev server de Playwright; no es parte del diff de este PR).
+
+### PR-CL2 evidence (clinic hub command center parity)
+
+Rama: `feat/clinic-command-center-parity`. Base: `main` @ `3d25d28` (test(clinic): add controller workspace parity contract #1136).
+
+Archivos tocados:
+
+- `frontend/src/app/dashboard/ClinicCommandCenter.tsx`
+- `frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts`
+- `docs/audit/clinic-dashboard-admin-structure-parity-audit.md` (este archivo)
+
+Mejora agregada (cierra parcialmente **CL-GAP-2**): se agregó una tercera pestaña "Estado" dentro del `ModuleTabs` ya existente en `ClinicCommandCenter` (junto a "Métricas" y "Recientes"), con tres bloques estructurales análogos a los de `AdminCommandCenter` — pero derivados exclusivamente de los props ya disponibles (`stats`, `recentReports`, `recentVisits`, `*LoadError`), sin nuevos fetches ni endpoints:
+
+- **Atención requerida** (`data-clinic-command-attention="true"`): lista informes pendientes y visitas activas con conteo > 0, o el mensaje de error de métricas si `statsLoadError`. Estado vacío seguro ("Sin pendientes operativos detectados.") cuando no hay nada que atender.
+- **Actividad reciente** (`data-clinic-command-activity="true"`): selecciona el ítem más reciente entre el primer informe y la primera visita ya cargados (comparando fecha), sin inventar datos. Estado vacío seguro si ambas listas están vacías.
+- **Continuidad operativa** (`data-clinic-command-continuity="true"`): mensaje binario operativo/degradado derivado de `statsLoadError || reportsLoadError || visitsLoadError`, sin exponer detalles sensibles.
+
+El componente raíz quedó envuelto en `<section data-clinic-command-center="true">` para dar un selector estable de evidencia equivalente al patrón Admin.
+
+Límites preservados:
+
+- No se tocó `fetch`/API ni `frontend/src/app/dashboard/page.tsx` (los props que ya se pasaban a `ClinicCommandCenter` fueron suficientes).
+- No se copiaron controles admin-only (precios, sesiones, usuarios/roles, auditoría, mantenimiento).
+- No se tocó `/clinicas` pública ni `frontend/src/app/dashboard/admin/**`.
+- Se mantuvo `ModuleSurface` + `ModuleTabs` y el contrato no-scroll (cada tab renderiza solo su panel activo, igual que "Métricas"/"Recientes").
+- No se agregaron dependencias nuevas.
+
+Validaciones ejecutadas:
+
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-controller-workspace-parity.spec.ts` — 21 passed (18 del contrato PR-CL1 + 3 nuevos del cockpit PR-CL2, incluyendo verificación 390x844 sin overflow horizontal ni scroll en `main.dashboard-main` con la pestaña "Estado" activa).
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm typecheck:test` — sin errores.
+- `pnpm test` — 2839 passed, 0 failed (suite completa, incluye contratos de estructura existentes sobre `ClinicCommandCenter.tsx`).
+- `git diff --check` — sin conflictos de whitespace.
+- `next-env.d.ts` revertido a su estado de `main` tras la corrida e2e.

--- a/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
@@ -189,3 +189,60 @@ test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
     await expectMainNotScrollContainer(page);
   });
 });
+
+test.describe("clinic command center operational cockpit (PR-CL2)", () => {
+  test("operaciones module renders the command center root", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    await expect(
+      page.locator('[data-clinic-command-center="true"]'),
+    ).toBeVisible();
+  });
+
+  test("Estado tab exposes attention, activity and continuity blocks", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    const commandCenter = page.locator('[data-clinic-command-center="true"]');
+    await commandCenter.getByRole("tab", { name: "Estado" }).click();
+
+    await expect(
+      commandCenter.locator('[data-clinic-command-attention="true"]'),
+    ).toBeVisible();
+    await expect(
+      commandCenter.locator('[data-clinic-command-activity="true"]'),
+    ).toBeVisible();
+    await expect(
+      commandCenter.locator('[data-clinic-command-continuity="true"]'),
+    ).toBeVisible();
+  });
+
+  test("Estado tab fits 390x844 without horizontal overflow or main scroll", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 8_000 });
+
+    const commandCenter = page.locator('[data-clinic-command-center="true"]');
+    await commandCenter.getByRole("tab", { name: "Estado" }).click();
+    await expect(
+      commandCenter.locator('[data-clinic-command-continuity="true"]'),
+    ).toBeVisible();
+
+    await expectNoHorizontalOverflow(page);
+    await expectMainNotScrollContainer(page);
+  });
+});

--- a/frontend/src/app/dashboard/ClinicCommandCenter.tsx
+++ b/frontend/src/app/dashboard/ClinicCommandCenter.tsx
@@ -17,6 +17,45 @@ export type ClinicCommandCenterProps = {
   visitsLoadError: boolean;
 };
 
+type RecentActivityEntry = {
+  label: string;
+  detail: string;
+  date: string | null;
+};
+
+function pickMostRecentActivity(
+  recentReports: Report[],
+  recentVisits: FieldVisit[],
+): RecentActivityEntry | null {
+  const candidates: RecentActivityEntry[] = [];
+
+  const latestReport = recentReports[0];
+  if (latestReport) {
+    candidates.push({
+      label: latestReport.patientName ?? "Informe sin nombre",
+      detail: `${latestReport.studyType ?? "Estudio"} · ${formatDate(latestReport.uploadDate)}`,
+      date: latestReport.updatedAt ?? latestReport.uploadDate,
+    });
+  }
+
+  const latestVisit = recentVisits[0];
+  if (latestVisit) {
+    candidates.push({
+      label: latestVisit.clinicName ?? `Clínica #${latestVisit.clinicId}`,
+      detail: `Visita de campo · ${formatDate(latestVisit.scheduledAt)}`,
+      date: latestVisit.scheduledAt,
+    });
+  }
+
+  if (!candidates.length) return null;
+
+  return candidates.reduce((latest, current) => {
+    const latestTime = latest.date ? new Date(latest.date).getTime() : 0;
+    const currentTime = current.date ? new Date(current.date).getTime() : 0;
+    return currentTime > latestTime ? current : latest;
+  });
+}
+
 export function ClinicCommandCenter({
   stats,
   statsLoadError,
@@ -25,9 +64,32 @@ export function ClinicCommandCenter({
   reportsLoadError,
   visitsLoadError,
 }: ClinicCommandCenterProps) {
+  const attentionItems: string[] = [];
+  if (statsLoadError) {
+    attentionItems.push("No se pudieron cargar las métricas operativas.");
+  } else {
+    if ((stats?.pendingReports ?? 0) > 0) {
+      attentionItems.push(
+        `${stats!.pendingReports} informe(s) pendiente(s) de entrega.`,
+      );
+    }
+    if ((stats?.activeVisits ?? 0) > 0) {
+      attentionItems.push(
+        `${stats!.activeVisits} visita(s) de campo activa(s) en curso.`,
+      );
+    }
+  }
+
+  const recentActivity = pickMostRecentActivity(recentReports, recentVisits);
+  const hasAnyError = statsLoadError || reportsLoadError || visitsLoadError;
+
   return (
-    <ModuleSurface
-      ariaLabel="Centro de operaciones clínica"
+    <section
+      className="flex min-h-0 flex-1 flex-col"
+      data-clinic-command-center="true"
+    >
+      <ModuleSurface
+        ariaLabel="Centro de operaciones clínica"
       toolbar={
         <section className="surface-note-info w-full" aria-labelledby="dashboard-operational-priority">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -196,8 +258,71 @@ export function ClinicCommandCenter({
               </div>
             ),
           },
+          {
+            id: "estado",
+            label: "Estado",
+            content: (
+              <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 sm:grid-cols-3">
+                <div
+                  className="surface-soft min-h-0"
+                  data-clinic-command-attention="true"
+                >
+                  <p className="text-[0.8rem] font-semibold text-vetneb-ink">
+                    Atención requerida
+                  </p>
+                  {attentionItems.length ? (
+                    <ul className="mt-1 space-y-1 text-[0.72rem] text-muted-foreground">
+                      {attentionItems.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-1 text-[0.72rem] text-muted-foreground">
+                      Sin pendientes operativos detectados.
+                    </p>
+                  )}
+                </div>
+
+                <div
+                  className="surface-soft min-h-0"
+                  data-clinic-command-activity="true"
+                >
+                  <p className="text-[0.8rem] font-semibold text-vetneb-ink">
+                    Actividad reciente
+                  </p>
+                  {recentActivity ? (
+                    <p className="mt-1 line-clamp-2 text-[0.72rem] text-muted-foreground">
+                      <span className="font-semibold text-foreground/85">
+                        {recentActivity.label}
+                      </span>{" "}
+                      · {recentActivity.detail}
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-[0.72rem] text-muted-foreground">
+                      Sin actividad reciente disponible.
+                    </p>
+                  )}
+                </div>
+
+                <div
+                  className="surface-soft min-h-0"
+                  data-clinic-command-continuity="true"
+                >
+                  <p className="text-[0.8rem] font-semibold text-vetneb-ink">
+                    Continuidad operativa
+                  </p>
+                  <p className="mt-1 text-[0.72rem] text-muted-foreground">
+                    {hasAnyError
+                      ? "Estado degradado: revisar conectividad de informes, visitas o métricas."
+                      : "Operativo: informes y logística sincronizados sin incidentes detectados."}
+                  </p>
+                </div>
+              </div>
+            ),
+          },
         ]}
       />
     </ModuleSurface>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Improves `ClinicCommandCenter` from a lightweight operations surface into a more explicit operational cockpit.
- Adds stable Clinic command center selectors for parity evidence.
- Extends the Clinic controller/workspace parity E2E spec with PR-CL2 cockpit assertions.
- Documents PR-CL2 evidence in the Clinic admin-structure parity audit.

## Scope
- Frontend Clinic dashboard only.
- Updated `frontend/src/app/dashboard/ClinicCommandCenter.tsx`.
- Updated `frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts`.
- Updated `docs/audit/clinic-dashboard-admin-structure-parity-audit.md`.
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
- No session, cookie, token, role, permission, or endpoint behavior changes.
- No public `/clinicas` changes.
- No Admin dashboard production changes.

## Contract covered
- `ClinicCommandCenter` root has stable cockpit selector.
- Adds operational blocks for:
  - Atención requerida
  - Actividad reciente
  - Continuidad operativa
- Preserves `ModuleSurface` / `ModuleTabs` structure.
- Keeps Clinic operations usable at 390x844 without horizontal overflow or `main.dashboard-main` scroll.
- Keeps existing PR-CL1 controller/workspace parity contract passing.

## Validation
- git diff --check
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-controller-workspace-parity.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
