### PR TITLE
fix(clinic): canonicalize module navigation

### DIFF
--- a/docs/audit/clinic-dashboard-admin-structure-parity-audit.md
+++ b/docs/audit/clinic-dashboard-admin-structure-parity-audit.md
@@ -82,9 +82,9 @@ Características estructurales clave del benchmark Admin:
 - **CL-GAP-2** — El hub de Clínica (`ClinicDashboardWorkspaceController` en modo hub) es funcionalmente un launcher de cards + hero, mientras que el módulo `operaciones` (`ClinicCommandCenter`) ya es un cockpit razonable pero más liviano que `AdminCommandCenter` (sin bloques de "atención requerida", "actividad reciente" ni "alertas y estados" equivalentes).
 - **CL-GAP-3** — No existe taxonomía de módulos mobile dedicados para Clínica (cero archivos `Clinic*Mobile*.tsx`), mientras Admin tiene 10 módulos con wrapper mobile propio. La densidad mobile de Clínica depende enteramente de componentes genéricos compartidos.
 - **CL-GAP-4** — La evidencia poblada de Clínica (specs `dashboard-clinic-*-mobile-parity.spec.ts`) no tiene un cuerpo de auditoría documental equivalente al de `docs/audit/admin-mobile-*.md` (10+ documentos de densidad, paginación, overlap). No hay comparación formal admin↔clínica de evidencia.
-- **CL-GAP-5** — La navegación activa de Clínica no tiene señalización sync equivalente a `admin-hub-reset`/`admin-module-activate` para el bottom-nav mobile; depende solo de `router.push`/`searchParams`. Riesgo de flake de bottom-nav bajo carga, análogo al que Admin ya resolvió y documentó (memoria `project_admin_mobile_bottomnav_removechild_flake`), no verificado todavía para Clínica.
+- **CL-GAP-5** — *(mitigado en PR-CL4, ver evidencia abajo)* La navegación activa de Clínica no tiene señalización sync equivalente a `admin-hub-reset`/`admin-module-activate` para el bottom-nav mobile; depende solo de `router.push`/`searchParams`. Riesgo de flake de bottom-nav bajo carga, análogo al que Admin ya resolvió y documentó (memoria `project_admin_mobile_bottomnav_removechild_flake`). PR-CL4 hace que `aria-current="page"` sea uniformemente verificable en los 5 módulos (antes solo 3 de 5), reduciendo la superficie de inconsistencia; la señalización sync en sí (análoga a `admin-hub-reset`) sigue sin implementarse y queda diferida — no hay segunda implementación de nav mobile-only en Clínica que compita con la de desktop, así que el patrón de flake que resolvió Admin no tiene la misma superficie aquí.
 - **CL-GAP-6** — Estados loading/empty/error/retry son inconsistentes entre módulos de Clínica: `operaciones`/`informes`/`logistica` propagan `*LoadError` explícito con `EmptyState` + alerta; `perfil` y `tokens` no tienen un contrato de loading/error de módulo visible en `page.tsx`. Admin centraliza esto vía `AdminAccessErrorState` para todos los módulos.
-- **CL-GAP-7** *(adicional, no solicitado explícitamente pero detectado)* — Dualidad de navegación: `informes` y `logistica` tienen tanto un resumen dentro de `?module=` como rutas full independientes (`/dashboard/informes`, `/dashboard/logistica/*`) fuera del sistema de módulos. Admin no tiene este patrón dual. Se documenta como gap estructural a resolver o a justificar explícitamente en el roadmap.
+- **CL-GAP-7** — *(cerrado en PR-CL4, ver evidencia abajo)* Dualidad de navegación: `informes` y `logistica` tenían tanto un resumen dentro de `?module=` como rutas full independientes (`/dashboard/informes`, `/dashboard/logistica/*`) fuera del sistema de módulos, y el nav horizontal apuntaba a las rutas full en vez del workspace canónico. PR-CL4 hizo que el nav resuelva los 5 módulos vía `?module=`; las rutas full se conservan como superficie extendida, accesible desde los CTAs "Abrir módulo completo" ya existentes dentro de cada `*WorkspaceSummary`.
 
 ## Target architecture
 
@@ -264,3 +264,41 @@ Validaciones ejecutadas:
 - `next-env.d.ts` revertido a su estado de `main` tras las corridas e2e.
 
 No producción, backend, API, auth, DB, deps, lockfiles, CI ni `/clinicas` tocados. `frontend/src/app/dashboard/admin/**` no modificado (solo leído como referencia/cita).
+
+### PR-CL4 evidence (clinic canonical module nav parity — CL-GAP-7, CL-GAP-5)
+
+Rama: `fix/clinic-canonical-module-nav-parity`. Base: `main` @ `4b70d74` (test(clinic): add mobile nav stage parity evidence #1138). Nota: este PR resuelve CL-GAP-7/CL-GAP-5 directamente en vez de seguir el orden original del roadmap (que asignaba el wrapper mobile de `operaciones` a "PR-CL4"); ese ítem de roadmap queda pendiente para un PR futuro sin numeración reasignada todavía.
+
+Archivos tocados:
+
+- `frontend/src/components/dashboard/DashboardHorizontalNav.tsx`
+- `frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts`
+- `test/frontend-dashboard-horizontal-nav.test.ts` (scope test legacy que pinneaba el source de `DashboardHorizontalNav.tsx`; alineado al nuevo contrato, mismo patrón que precedente #958 documentado en memoria)
+- `docs/audit/clinic-dashboard-admin-structure-parity-audit.md` (este archivo)
+
+Cambio productivo (el único de este PR): en `CLINIC_NAV_ITEMS` de `DashboardHorizontalNav.tsx`, los ítems "Informes" y "Logística" pasan de apuntar a las rutas full (`ROUTES.dashboardInformes`/`ROUTES.dashboardLogistica` con `routePrefix: true`) a apuntar a `${ROUTES.dashboard}?module=informes` / `?module=logistica`, igual que los otros 3 módulos. Como ningún ítem usaba ya `routePrefix`, se eliminó ese campo del tipo y su rama en `isItemActive` (código muerto, no había otro consumidor — confirmado por grep).
+
+Las rutas full (`/dashboard/informes`, `/dashboard/logistica`, `/dashboard/logistica/{metricas,rutas,visitas}`) **no se tocaron ni se eliminaron**: siguen montadas en `frontend/src/app/dashboard/{informes,logistica}/`, y siguen siendo alcanzables desde los CTAs "Abrir módulo completo" ya existentes dentro de `ClinicInformesWorkspaceSummary`/`ClinicLogisticaWorkspaceSummary` (sin cambios en esos componentes).
+
+**CL-GAP-7 — cerrado.** Los 5 módulos de Clínica (`operaciones`, `informes`, `logistica`, `perfil`, `tokens`) ahora resuelven de forma canónica vía nav horizontal a `?module=`, sin dualidad. `aria-current="page"` es uniformemente verificable en los 5 (antes solo en 3: `operaciones`/`perfil`/`tokens`).
+
+**CL-GAP-5 — mitigado, no cerrado.** La señalización sync mobile-nav (análoga a `admin-hub-reset`) sigue sin implementarse — `activateModule` del controller sigue siendo `setActiveModule` optimista + `router.push`, y el nav horizontal sigue navegando solo por `router.push(href)` vía `PublicRouteControl`, derivando `activeModule` de `searchParams`. Lo que cambia es que ahora los 5 módulos comparten exactamente el mismo patrón de navegación (antes 2 de 5 navegaban por ruta full), reduciendo la superficie de inconsistencia que motivaba el gap. Cerrar CL-GAP-5 por completo seguiría requiriendo la instrumentación de clicks repetidos bajo carga descrita en la evidencia de PR-CL3.
+
+Tests actualizados:
+
+- `dashboard-clinic-controller-workspace-parity.spec.ts`: `CLINIC_MODULES_WITH_VERIFIABLE_NAV` ahora incluye `informes: "Informes"` y `logistica: "Logística"` (antes `null`), extendiendo el assert de `aria-current="page"` a los 5 módulos. Se agregaron 2 tests nuevos (`clinic /dashboard/informes full route still loads`, `clinic /dashboard/logistica full route still loads`) que confirman que las rutas full siguen cargando tras el cambio de nav.
+- `dashboard-clinic-mobile-nav-stage-parity.spec.ts`: el test de "active horizontal nav item stays visible through the round trip" ahora recorre los 5 módulos (se agregaron "Informes"/"Logística" al loop, antes solo Resumen/Tokens/Perfil). Los tests de "no stale previous module mounted" para `informes`/`logistica` pasaron de `page.goto` directo a click real sobre el nav horizontal (`navItem(page, label).click()`), con assert adicional de `aria-current="page"`, ya que ahora son alcanzables por nav igual que el resto. Comentarios que documentaban CL-GAP-7 como abierto se actualizaron para reflejar el cierre.
+
+Validaciones ejecutadas:
+
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-controller-workspace-parity.spec.ts` — ver resultado en el resumen de entrega.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts` — ver resultado en el resumen de entrega.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts` — ver resultado en el resumen de entrega.
+- `pnpm --dir frontend lint` — ver resultado en el resumen de entrega.
+- `pnpm typecheck:test` — ver resultado en el resumen de entrega.
+- `pnpm --dir frontend build` — ver resultado en el resumen de entrega (cambia frontend productivo).
+- `git diff --check` — ver resultado en el resumen de entrega.
+- `next-env.d.ts` revertido a su estado de `main` tras las corridas e2e.
+
+No producción ajena al nav horizontal de Clínica, backend, API, auth, DB, deps, lockfiles, CI ni `/clinicas` tocados. `frontend/src/app/dashboard/admin/**` no modificado. No se implementó stage persistente (CL-GAP-1) en este PR.

--- a/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
@@ -22,14 +22,14 @@ const CLINIC_MODULES: ClinicModule[] = [
 
 /**
  * Nav items whose href resolves to `/dashboard?module=<id>` exactly, so
- * aria-current is verifiable there. "informes"/"logistica" nav items point to
- * standalone routes (/dashboard/informes, /dashboard/logistica) instead of the
- * `?module=` workspace, so aria-current is not applicable on those module URLs.
+ * aria-current is verifiable there. PR-CL4 resolved the Informes/Logística
+ * nav dualism (CL-GAP-7): all 5 clinic modules now navigate through the
+ * canonical `?module=` workspace, so aria-current is uniformly verifiable.
  */
 const CLINIC_MODULES_WITH_VERIFIABLE_NAV: Record<ClinicModule, string | null> = {
   operaciones: "Resumen",
-  informes: null,
-  logistica: null,
+  informes: "Informes",
+  logistica: "Logística",
   perfil: "Perfil",
   tokens: "Tokens",
 };
@@ -103,6 +103,23 @@ test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
       ).toBeVisible({ timeout: 8_000 });
     });
   }
+
+  // PR-CL4: Informes/Logística nav items now resolve to `?module=`, but the
+  // standalone full routes must keep working as extended surfaces (linked
+  // from the "Abrir módulo completo" CTAs inside each workspace summary).
+  test("clinic /dashboard/informes full route still loads", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard/informes");
+    await expect(page.locator("main")).toBeVisible({ timeout: 8_000 });
+    await expect(page).toHaveURL(/\/dashboard\/informes/);
+  });
+
+  test("clinic /dashboard/logistica full route still loads", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard/logistica");
+    await expect(page.locator("main")).toBeVisible({ timeout: 8_000 });
+    await expect(page).toHaveURL(/\/dashboard\/logistica/);
+  });
 
   test("admin /dashboard/admin baseline still loads hub", async ({ page }) => {
     await setAdminSession(page);

--- a/frontend/e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts
@@ -199,7 +199,7 @@ test.describe("clinic mobile nav/stage parity evidence (PR-CL3)", () => {
     await expectNoScrollContract(page, "perfil");
 
     // perfil -> hub via the workspace "Vista general" back control (Clinic's
-    // nav has no item that targets the bare hub; see CL-GAP-7).
+    // nav has no item that targets the bare hub).
     await page
       .locator('[data-dashboard-module-workspace="perfil"]')
       .locator('button[aria-label="Vista general"]')
@@ -249,6 +249,8 @@ test.describe("clinic mobile nav/stage parity evidence (PR-CL3)", () => {
 
     for (const [label, moduleId] of [
       ["Resumen", "operaciones"],
+      ["Informes", "informes"],
+      ["Logística", "logistica"],
       ["Tokens", "tokens"],
       ["Perfil", "perfil"],
     ] as const) {
@@ -271,15 +273,14 @@ test.describe("clinic mobile nav/stage parity evidence (PR-CL3)", () => {
     }
   });
 
-  // CL-GAP-7 (documented in docs/audit/clinic-dashboard-admin-structure-parity-
-  // audit.md): the horizontal nav items for Informes/Logística point at full
-  // standalone routes, not at `?module=`, so they cannot be reached or
-  // verified via nav click the way Resumen/Tokens/Perfil are above. This
-  // exercises their `?module=` workspace directly (same access path the
-  // controller itself supports) to confirm the swap-hygiene contract still
-  // holds for them, without asserting an aria-current that the current
-  // navigation structure does not produce.
-  for (const moduleId of ["informes", "logistica"] as const) {
+  // PR-CL4 resolved CL-GAP-7: the horizontal nav items for Informes/Logística
+  // now resolve to their canonical `?module=` workspace, so they are
+  // reachable and verifiable via the same real nav click used for
+  // Resumen/Tokens/Perfil above.
+  for (const [label, moduleId] of [
+    ["Informes", "informes"],
+    ["Logística", "logistica"],
+  ] as const) {
     test(`${moduleId} module leaves no stale previous module mounted — 390x844`, async ({
       page,
     }) => {
@@ -291,7 +292,7 @@ test.describe("clinic mobile nav/stage parity evidence (PR-CL3)", () => {
         page.locator('[data-dashboard-module-workspace="operaciones"]'),
       ).toBeVisible({ timeout: 8_000 });
 
-      await page.goto(`/dashboard?module=${moduleId}`);
+      await navItem(page, label).click();
       await expect(
         page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
       ).toBeVisible({ timeout: 8_000 });
@@ -299,6 +300,7 @@ test.describe("clinic mobile nav/stage parity evidence (PR-CL3)", () => {
         page.locator('[data-dashboard-module-workspace="operaciones"]'),
       ).toHaveCount(0);
       await expect(page.locator('[data-dashboard-module-hub="true"]')).toHaveCount(0);
+      await expect(navItem(page, label)).toHaveAttribute("aria-current", "page");
 
       const contract = await expectNoScrollContract(page, moduleId);
       expect(contract.workspaceCount, `${moduleId}: exactly one workspace mounted`).toBe(1);

--- a/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
+++ b/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
@@ -13,8 +13,6 @@ type DashboardHorizontalNavItem = {
   href: string;
   /** Resumen item: also active on the base path when no module is selected. */
   baseFallback?: boolean;
-  /** Route item: active on its path and nested subroutes. */
-  routePrefix?: boolean;
 };
 
 const ADMIN_NAV_ITEMS: DashboardHorizontalNavItem[] = [
@@ -35,9 +33,14 @@ const ADMIN_NAV_ITEMS: DashboardHorizontalNavItem[] = [
 
 const CLINIC_NAV_ITEMS: DashboardHorizontalNavItem[] = [
   { label: "Resumen", href: `${ROUTES.dashboard}?module=operaciones`, baseFallback: true },
-  { label: "Informes", href: ROUTES.dashboardInformes, routePrefix: true },
+  // PR-CL4: Informes/Logística resolve to their canonical `?module=` workspace
+  // (closes CL-GAP-7's nav dualism). The standalone full routes
+  // (/dashboard/informes, /dashboard/logistica/*) stay live as extended
+  // surfaces, reachable from the "Abrir módulo completo" CTAs inside each
+  // workspace summary.
+  { label: "Informes", href: `${ROUTES.dashboard}?module=informes` },
   { label: "Tokens", href: `${ROUTES.dashboard}?module=tokens` },
-  { label: "Logística", href: ROUTES.dashboardLogistica, routePrefix: true },
+  { label: "Logística", href: `${ROUTES.dashboard}?module=logistica` },
   { label: "Perfil", href: `${ROUTES.dashboard}?module=perfil` },
 ];
 
@@ -68,10 +71,6 @@ function isItemActive(
     if (pathname !== itemPath) return false;
     if (activeModule === itemModule) return true;
     return Boolean(item.baseFallback) && !activeModule;
-  }
-
-  if (item.routePrefix) {
-    return pathname === itemPath || pathname.startsWith(`${itemPath}/`);
   }
 
   return pathname === itemPath;

--- a/test/frontend-dashboard-horizontal-nav.test.ts
+++ b/test/frontend-dashboard-horizontal-nav.test.ts
@@ -68,7 +68,7 @@ test("admin horizontal nav exposes the expected modules and preserves ?module=",
   }
 });
 
-test("clinic horizontal nav keeps existing routes and module params", () => {
+test("clinic horizontal nav resolves all 5 modules via ?module= (PR-CL4)", () => {
   const source = read(HORIZONTAL_NAV_PATH);
 
   assert.ok(source.includes('label: "Resumen"'));
@@ -77,9 +77,9 @@ test("clinic horizontal nav keeps existing routes and module params", () => {
   assert.ok(source.includes('label: "Logística"'));
   assert.ok(source.includes('label: "Perfil"'));
 
-  assert.ok(source.includes("href: ROUTES.dashboardInformes"));
-  assert.ok(source.includes("href: ROUTES.dashboardLogistica"));
   assert.ok(source.includes('`${ROUTES.dashboard}?module=operaciones`'));
+  assert.ok(source.includes('`${ROUTES.dashboard}?module=informes`'));
+  assert.ok(source.includes('`${ROUTES.dashboard}?module=logistica`'));
   assert.ok(source.includes('`${ROUTES.dashboard}?module=tokens`'));
   assert.ok(source.includes('`${ROUTES.dashboard}?module=perfil`'));
 });


### PR DESCRIPTION
## Summary
- Canonicalizes Clinic horizontal navigation for all five private dashboard modules.
- Moves Informes and Logística primary nav targets to `?module=informes` and `?module=logistica`.
- Preserves full routes as extended module surfaces reachable from existing CTAs.
- Updates E2E and unit evidence for uniform active nav `aria-current` across Clinic modules.

## Scope
- Frontend dashboard nav only.
- Updated `frontend/src/components/dashboard/DashboardHorizontalNav.tsx`.
- Updated Clinic E2E specs.
- Updated dashboard horizontal nav unit test.
- Updated `docs/audit/clinic-dashboard-admin-structure-parity-audit.md`.
- No backend/API/auth/DB/migrations/deps/lockfiles/CI/config changes.
- No session, cookie, token, role, permission, or endpoint behavior changes.
- No public `/clinicas` changes.
- No Admin dashboard production changes.
- No removal of `/dashboard/informes`, `/dashboard/logistica`, or logistics subroutes.

## Gaps
- CL-GAP-7 closed: all five Clinic modules now use canonical `?module=` navigation.
- CL-GAP-5 mitigated: `aria-current="page"` is uniformly verifiable across the five Clinic nav items.
- Full routes remain available as extended surfaces through “Abrir módulo completo” CTAs.

## Validation
- git diff --check
- pnpm test -- test/frontend-dashboard-horizontal-nav.test.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-controller-workspace-parity.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts e2e/dashboard-master-detail-state-polish.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
