### PR TITLE
feat(clinic): align dashboard structure with admin benchmark

### DIFF
--- a/docs/implementation/clinic-admin-structure-parity.md
+++ b/docs/implementation/clinic-admin-structure-parity.md
@@ -1,0 +1,115 @@
+# Clinic Admin Structure Parity
+
+## Estado base
+
+- Rama: `feat/clinic-admin-structure-parity`.
+- HEAD inicial auditado: `e700feb fix(clinic): clear token retry errors (#1141)`.
+- Estado inicial: `git status --short --untracked-files=all` limpio.
+- Entorno usado: Windows, PowerShell, PNPM.
+
+## Scope incluido
+
+- Paridad estructural del dashboard Clinica frente al benchmark Admin.
+- Cockpit operativo en el hub de `/dashboard`.
+- Stage unico y persistente para hub/modulos Clinica.
+- Bottom navigation mobile propia de Clinica.
+- Sincronizacion entre bottom nav, nav horizontal desktop y controller.
+- Estados de carga, error, vacio y retry en modulos Clinica dentro del dashboard.
+- Cobertura E2E y tests nativos afectados por el cambio.
+
+## Scope excluido
+
+- Backend, API, DB, Drizzle, migraciones y schema.
+- Auth, cookies, CORS, CSP, rate limits y seguridad de sesiones.
+- Dependencias, `package.json`, lockfiles, CI y workflows.
+- Publico `/clinicas`.
+- Cambios funcionales en Admin productivo fuera de mantener contratos compartidos del shell.
+- Rutas completas Clinica fuera de confirmar que siguen vivas.
+
+## Auditoria previa
+
+- Se confirmo base limpia y rama esperada.
+- Se revisaron auditorias y orden operativo existentes en `docs/audit`.
+- Se reviso el benchmark Admin: controller, hub, stage, mobile bottom nav y shell.
+- Se revisaron superficies Clinica reales: `/dashboard`, command center, resumenes de Informes/Logistica, Perfil publico y Tokens.
+- Se buscaron referencias legacy relacionadas con hub, nav, mobile shell, last module y rutas completas.
+- Riesgo principal identificado: tocar el shell compartido podia impactar Admin; los cambios quedaron limitados a mantener la misma intencion mobile existente y agregar la nav Clinica.
+
+## Cambios
+
+- `ClinicDashboardWorkspaceController` ahora renderiza un cockpit operativo Clinica con secciones de estado, atencion, continuidad, actividad, modulos y acciones primarias.
+- El controller mantiene un stage persistente con `data-dashboard-module-stage` y `data-clinic-dashboard-stage`.
+- Se agrego `ClinicMobileBottomNav` con Inicio, Operaciones, Informes, Logistica, Perfil y Tokens.
+- Se agrego `clinic-hub-reset` para senales client-side clinic-scoped de reset de hub y activacion de modulo.
+- Se agrego `ClinicMobileModuleFrame` para aislar modulos en mobile.
+- Se agrego `DashboardRefreshButton` para retry SSR mediante `router.refresh()`.
+- Command center, resumenes de Informes/Logistica, Perfil publico y Tokens exponen estados de retry/loading/empty mas claros.
+- `DashboardShellRouter` monta bottom nav Admin solo en Admin y bottom nav Clinica en superficies Clinica.
+- `DashboardHorizontalNav` sincroniza activacion con el controller Clinica y queda oculto en mobile mediante contrato de componente.
+- CSS mobile Clinica agrega no-scroll shell, stage opaco/aislado y bottom nav propia.
+- Specs Playwright y tests nativos se actualizaron para cubrir cockpit, stage persistente, bottom nav Clinica, estados y contratos mobile.
+
+## Archivos modificados
+
+- `frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx`
+- `frontend/src/components/dashboard/ClinicMobileBottomNav.tsx`
+- `frontend/src/components/dashboard/ClinicMobileModuleFrame.tsx`
+- `frontend/src/components/dashboard/DashboardRefreshButton.tsx`
+- `frontend/src/components/dashboard/DashboardHorizontalNav.tsx`
+- `frontend/src/components/dashboard/DashboardShellRouter.tsx`
+- `frontend/src/lib/clinic-hub-reset.ts`
+- `frontend/src/app/dashboard/page.tsx`
+- `frontend/src/app/dashboard/ClinicCommandCenter.tsx`
+- `frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx`
+- `frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ClinicPublicProfileCard.tsx`
+- `frontend/src/app/globals.css`
+- `frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-module-state-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts`
+- `test/frontend-dashboard-horizontal-nav.test.ts`
+- `test/frontend-dashboard-hub-hero.test.ts`
+- `docs/implementation/clinic-admin-structure-parity.md`
+
+## Validaciones
+
+- `pnpm typecheck:test`: ejecutado, paso.
+- `pnpm --dir frontend typecheck`: ejecutado, paso.
+- `pnpm --dir frontend lint`: ejecutado, paso.
+- `pnpm test`: ejecutado, paso con 2840 tests.
+- `pnpm security:public-surface`: ejecutado, paso; reporto solo hallazgos server-only existentes en `frontend/src/proxy.ts`.
+- `pnpm build`: ejecutado, paso.
+- `pnpm --dir frontend build`: ejecutado, paso.
+- Playwright Clinica + shell mobile:
+  - `dashboard-clinic-controller-workspace-parity.spec.ts`
+  - `dashboard-clinic-mobile-nav-stage-parity.spec.ts`
+  - `dashboard-clinic-module-state-parity.spec.ts`
+  - `dashboard-clinic-informes-mobile-parity.spec.ts`
+  - `dashboard-clinic-logistica-mobile-parity.spec.ts`
+  - `dashboard-clinic-perfil-mobile-operability.spec.ts`
+  - `dashboard-clinic-tokens-mobile-parity.spec.ts`
+  - `dashboard-mobile-shell-nav-contract.spec.ts`
+  - Resultado: 83 passed.
+
+## Resultado
+
+La Clinica queda con estructura de dashboard alineada al benchmark Admin: hub operativo, stage persistente, navegacion mobile propia, sincronizacion con desktop y estados de recuperacion en los modulos incluidos.
+
+Las rutas completas `/dashboard/informes`, `/dashboard/logistica`, `/dashboard/logistica/metricas`, `/dashboard/logistica/rutas` y `/dashboard/logistica/visitas` se preservan.
+
+## Riesgo residual
+
+- La evidencia mobile corresponde a Playwright en Chromium con viewports emulados; no reemplaza smoke fisico Android/iOS.
+- El shell es compartido; cambios futuros en `DashboardTopbar`, `DashboardHorizontalNav`, `DashboardShellRouter` o `globals.css` deben reejecutar los specs mobile Clinica y Admin relacionados.
+
+## Estado final
+
+- Implementacion completada dentro del scope PR-CL7.
+- Sin cambios en backend, API, DB, migraciones, dependencias, lockfiles, auth, CI ni workflows.
+- Stage, navegacion y estados Clinica quedan cubiertos por tests nativos y Playwright.

--- a/docs/implementation/clinic-cockpit-e2e-ci-fix.md
+++ b/docs/implementation/clinic-cockpit-e2e-ci-fix.md
@@ -1,0 +1,92 @@
+# Clinic Cockpit E2E CI Fix
+
+## Estado base
+
+- Rama auditada: `feat/clinic-admin-structure-parity`.
+- HEAD inicial auditado: `dea3911 feat(clinic): align dashboard structure with admin benchmark`.
+- `main` local ya estaba actualizado con `origin/main` en `e700feb fix(clinic): clear token retry errors (#1141)`.
+- `git merge --no-edit origin/main`: ya informado como `Already up to date`.
+- Estado inicial informado y revalidado: working tree limpio antes del cambio.
+- Entorno usado: Windows, PowerShell, PNPM.
+
+## Scope incluido
+
+- Fix estricto del Frontend CI fallido en `frontend/e2e/dashboard-card-navigation-shell.spec.ts`.
+- Actualizacion del contrato E2E de Clinica desde hub/cards legacy hacia cockpit operativo PR-CL7.
+- Cobertura de acciones/modulos Clinica, estructura cockpit, activacion de workspaces, retorno a `Vista general`, no-scroll global y aislamiento entre workspaces.
+- Documentacion de entrega requerida por el protocolo del repositorio.
+
+## Scope excluido
+
+- No se revirtio PR-CL7.
+- No se reintrodujo el hub viejo, hero ni launcher de cards de Clinica.
+- No se modifico implementacion productiva de Clinica.
+- No se modifico Admin productivo ni su contrato de cards.
+- No se tocaron backend, API, auth, DB, migraciones, dependencias, lockfiles, CI, workflows ni scripts de package.
+- No se toco la pagina publica `/clinicas`.
+- No se cambiaron rutas full existentes.
+
+## Auditoria previa
+
+- Se confirmo rama `feat/clinic-admin-structure-parity`, HEAD `dea3911` y ausencia de diff inicial.
+- Se confirmo que existen los scripts reales pedidos: `pnpm test`, `pnpm typecheck:test` y `pnpm --dir frontend lint`.
+- Se leyo el spec fallido `dashboard-card-navigation-shell.spec.ts`.
+- Se leyeron los componentes reales de cockpit, mobile nav, horizontal nav y shell router de Clinica.
+- Se leyeron los specs PR-CL7 relacionados para mantener paridad de contrato.
+- Se busco legado de cards y selectores `.rounded-lg.bg-gradient-to-br` dentro del scope.
+- Riesgo identificado: el spec combina Clinica y Admin; el cambio debia limitarse a Clinica sin debilitar el contrato Admin.
+
+## Cambios
+
+- Se agregaron helpers E2E de cockpit Clinica:
+  - `clinicCockpit`
+  - `clinicCockpitModule`
+  - `clinicCockpitAction`
+- Los tests iniciales de Clinica dejaron de validar cards legacy y ahora validan:
+  - `[data-clinic-cockpit="true"]`
+  - `[data-clinic-cockpit-status="true"]`
+  - `[data-clinic-cockpit-attention="true"]`
+  - `[data-clinic-cockpit-continuity="true"]`
+  - `[data-clinic-cockpit-activity="true"]`
+  - `[data-clinic-cockpit-modules="true"]`
+  - `[data-clinic-cockpit-primary-actions="true"]`
+- Los accesos de Clinica ahora usan acciones reales:
+  - `Abrir operaciones`
+  - `Abrir informes`
+  - `Abrir logistica`
+  - `Abrir perfil`
+  - `Generar o abrir tokens`
+- La activacion de workspaces Clinica ahora valida URL `?module=` y workspace visible por `data-dashboard-module-workspace`.
+- Los tests de no-scroll y aislamiento Clinica abren modulos desde el cockpit, no desde cards legacy.
+- Admin conserva el helper de cards porque su contrato productivo sigue basado en hub/cards.
+
+## Archivos modificados
+
+- `frontend/e2e/dashboard-card-navigation-shell.spec.ts`
+- `docs/implementation/clinic-cockpit-e2e-ci-fix.md`
+
+## Validaciones
+
+- `git diff --check`: ejecutado, paso.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-card-navigation-shell.spec.ts`: ejecutado, paso con `67 passed`.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-card-navigation-shell.spec.ts e2e/dashboard-clinic-controller-workspace-parity.spec.ts e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts e2e/dashboard-clinic-module-state-parity.spec.ts`: ejecutado, paso con `113 tests`.
+- `pnpm --dir frontend lint`: ejecutado, paso.
+- `pnpm typecheck:test`: ejecutado, paso.
+- `pnpm test`: primera ejecucion fallo porque Next/Playwright habia mutado `frontend/next-env.d.ts` a `./.next/dev/types/routes.d.ts`; se retiro esa mutacion generada y se reejecuto.
+- `pnpm test`: segunda ejecucion paso con `2840 passed`.
+
+## Resultado
+
+El spec de Frontend CI queda alineado al cockpit operativo real de Clinica. La cobertura ya no espera el launcher viejo de cards y valida acciones, estructura y navegacion del cockpit PR-CL7.
+
+## Riesgo residual
+
+- Playwright levanta Next dev y puede volver a mutar `frontend/next-env.d.ts` hacia `.next/dev/types/routes.d.ts`; se verifico y retiro esa mutacion generada antes de cerrar.
+- No se tocaron componentes productivos porque el DOM real ya exponia nombres accesibles suficientes por texto visible.
+
+## Estado final
+
+- Implementacion completada dentro del scope del fix CI frontend.
+- Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI ni workflows.
+- Cockpit Clinica preservado.
+- Admin preservado.

--- a/frontend/e2e/dashboard-card-navigation-shell.spec.ts
+++ b/frontend/e2e/dashboard-card-navigation-shell.spec.ts
@@ -3,6 +3,52 @@ import { expect, test } from "@playwright/test";
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 type Page = import("@playwright/test").Page;
+type Locator = import("@playwright/test").Locator;
+
+type ClinicModule =
+  | "operaciones"
+  | "informes"
+  | "logistica"
+  | "perfil"
+  | "tokens";
+
+const CLINIC_COCKPIT_MODULES: Array<{
+  moduleId: ClinicModule;
+  moduleLabel: string | RegExp;
+  actionName: string;
+  workspaceId: ClinicModule;
+}> = [
+  {
+    moduleId: "operaciones",
+    moduleLabel: /Centro de operaciones|Operaciones/i,
+    actionName: "Abrir operaciones",
+    workspaceId: "operaciones",
+  },
+  {
+    moduleId: "informes",
+    moduleLabel: "Informes",
+    actionName: "Abrir informes",
+    workspaceId: "informes",
+  },
+  {
+    moduleId: "logistica",
+    moduleLabel: "Logística",
+    actionName: "Abrir logística",
+    workspaceId: "logistica",
+  },
+  {
+    moduleId: "perfil",
+    moduleLabel: /Perfil público|Perfil/i,
+    actionName: "Abrir perfil",
+    workspaceId: "perfil",
+  },
+  {
+    moduleId: "tokens",
+    moduleLabel: /Tokens particulares|Tokens/i,
+    actionName: "Generar o abrir tokens",
+    workspaceId: "tokens",
+  },
+];
 
 async function setClinicSession(page: Page) {
   await page.context().addCookies([
@@ -24,12 +70,32 @@ async function setAdminSession(page: Page) {
   ]);
 }
 
-// ─── Card locator helper: matches only the card whose TITLE is `title` ─────────
+// ─── Admin card locator helper: matches only the card whose TITLE is `title` ──
 // Uses CSS attribute selector ^= (starts-with) so "Auditoría:" matches only
 // the Auditoría card, not cards whose description contains the word.
 
 function hubCard(hub: ReturnType<Page["locator"]>, title: string) {
   return hub.locator(`button[aria-label^="${title}:"]`);
+}
+
+function clinicCockpit(page: Page) {
+  return page.locator(
+    '[data-dashboard-module-hub="true"][data-clinic-cockpit="true"]',
+  );
+}
+
+function clinicCockpitModule(hub: Locator, moduleId: ClinicModule) {
+  return hub
+    .locator('[data-clinic-cockpit-modules="true"]')
+    .locator(`[data-clinic-cockpit-module-card="${moduleId}"]`);
+}
+
+function clinicCockpitAction(hub: Locator, name: string | RegExp) {
+  return hub
+    .locator(
+      '[data-clinic-cockpit-primary-actions="true"], [data-clinic-cockpit-modules="true"]',
+    )
+    .getByRole("button", { name, exact: typeof name === "string" });
 }
 
 // ─── Scope guard ──────────────────────────────────────────────────────────────
@@ -54,86 +120,72 @@ test.describe("clinic dashboard — module hub initial state", () => {
   test("renders the module hub section on clinic dashboard", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
   });
 
   test("initial state does not render old dashboard workspace content", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
 
     const workspace = page.locator('[data-dashboard-module-workspace]');
     await expect(workspace).not.toBeVisible();
   });
 
-  test("clinic hub renders Centro de operaciones card", async ({ page }) => {
+  for (const {
+    moduleId,
+    moduleLabel,
+    actionName,
+  } of CLINIC_COCKPIT_MODULES) {
+    test(`clinic cockpit renders ${String(moduleLabel)} action/module`, async ({
+      page,
+    }) => {
+      await page.goto("/dashboard");
+
+      const hub = clinicCockpit(page);
+      await expect(hub).toBeVisible({ timeout: 8_000 });
+      await expect(clinicCockpitModule(hub, moduleId)).toBeVisible();
+      await expect(clinicCockpitModule(hub, moduleId)).toContainText(moduleLabel);
+      await expect(clinicCockpitAction(hub, actionName)).toBeVisible();
+    });
+  }
+
+  test("clinic cockpit actions have accessible names", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    await expect(hubCard(hub, "Centro de operaciones")).toBeVisible();
-  });
-
-  test("clinic hub renders Informes card", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    await expect(hubCard(hub, "Informes")).toBeVisible();
-  });
-
-  test("clinic hub renders Logística card", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    await expect(hubCard(hub, "Logística")).toBeVisible();
-  });
-
-  test("clinic hub renders Perfil público card", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    await expect(hubCard(hub, "Perfil público")).toBeVisible();
-  });
-
-  test("clinic hub renders Tokens particulares card", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    await expect(hubCard(hub, "Tokens particulares")).toBeVisible();
-  });
-
-  test("clinic hub cards have accessible names with descriptions", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
 
-    const cards = hub.locator("button");
-    const count = await cards.count();
-    expect(count).toBeGreaterThanOrEqual(5);
+    const actions = hub.locator('[data-clinic-cockpit-primary-actions="true"]');
+    await expect(actions.getByRole("button")).toHaveCount(
+      CLINIC_COCKPIT_MODULES.length,
+    );
 
-    for (let i = 0; i < count; i++) {
-      const label = await cards.nth(i).getAttribute("aria-label");
-      expect(label, `card ${i} should have aria-label`).toBeTruthy();
-      expect(label!.length, `card ${i} aria-label should be descriptive`).toBeGreaterThan(5);
+    for (const { actionName } of CLINIC_COCKPIT_MODULES) {
+      await expect(
+        actions.getByRole("button", { name: actionName, exact: true }),
+      ).toBeVisible();
     }
   });
 
-  test("clinic hub cards render an icon container", async ({ page }) => {
+  test("clinic cockpit renders operational structure", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
 
-    const iconContainers = hub.locator(".rounded-lg.bg-gradient-to-br");
-    const count = await iconContainers.count();
-    expect(count).toBeGreaterThanOrEqual(5);
+    for (const selector of [
+      '[data-clinic-cockpit-status="true"]',
+      '[data-clinic-cockpit-attention="true"]',
+      '[data-clinic-cockpit-continuity="true"]',
+      '[data-clinic-cockpit-activity="true"]',
+      '[data-clinic-cockpit-modules="true"]',
+      '[data-clinic-cockpit-primary-actions="true"]',
+    ]) {
+      await expect(hub.locator(selector)).toBeVisible();
+    }
   });
 });
 
@@ -144,87 +196,35 @@ test.describe("clinic dashboard — workspace activation", () => {
     await setClinicSession(page);
   });
 
-  test("clicking Centro de operaciones card opens operaciones workspace", async ({ page }) => {
-    await page.goto("/dashboard");
+  for (const { actionName, workspaceId } of CLINIC_COCKPIT_MODULES) {
+    test(`clicking ${actionName} opens ${workspaceId} workspace`, async ({
+      page,
+    }) => {
+      await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    const card = hubCard(hub, "Centro de operaciones");
-    await expect(card).toBeVisible();
-    await card.click();
+      const hub = clinicCockpit(page);
+      await expect(hub).toBeVisible({ timeout: 8_000 });
+      const action = clinicCockpitAction(hub, actionName);
+      await expect(action).toBeVisible();
+      await action.click();
 
-    await expect(
-      page.locator('[data-dashboard-module-workspace="operaciones"]'),
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(hub).not.toBeVisible();
-  });
-
-  test("clicking Informes card opens informes workspace", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    const card = hubCard(hub, "Informes");
-    await expect(card).toBeVisible();
-    await card.click();
-
-    await expect(
-      page.locator('[data-dashboard-module-workspace="informes"]'),
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(hub).not.toBeVisible();
-  });
-
-  test("clicking Logística card opens logistica workspace", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    const card = hubCard(hub, "Logística");
-    await expect(card).toBeVisible();
-    await card.click();
-
-    await expect(
-      page.locator('[data-dashboard-module-workspace="logistica"]'),
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(hub).not.toBeVisible();
-  });
-
-  test("clicking Perfil público card opens perfil workspace", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    const card = hubCard(hub, "Perfil público");
-    await expect(card).toBeVisible();
-    await card.click();
-
-    await expect(
-      page.locator('[data-dashboard-module-workspace="perfil"]'),
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(hub).not.toBeVisible();
-  });
-
-  test("clicking Tokens particulares card opens tokens workspace", async ({ page }) => {
-    await page.goto("/dashboard");
-
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
-    await expect(hub).toBeVisible({ timeout: 8_000 });
-    const card = hubCard(hub, "Tokens particulares");
-    await expect(card).toBeVisible();
-    await card.click();
-
-    await expect(
-      page.locator('[data-dashboard-module-workspace="tokens"]'),
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(hub).not.toBeVisible();
-  });
+      await expect(page).toHaveURL(
+        new RegExp(`/dashboard\\?module=${workspaceId}$`),
+        { timeout: 5_000 },
+      );
+      await expect(
+        page.locator(`[data-dashboard-module-workspace="${workspaceId}"]`),
+      ).toBeVisible({ timeout: 5_000 });
+      await expect(hub).not.toBeVisible();
+    });
+  }
 
   test("workspace shows Vista general button", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
-    await hubCard(hub, "Centro de operaciones").click();
+    await clinicCockpitAction(hub, "Abrir operaciones").click();
 
     const backBtn = page.getByRole("button", { name: "Vista general" });
     await expect(backBtn).toBeVisible({ timeout: 5_000 });
@@ -233,9 +233,9 @@ test.describe("clinic dashboard — workspace activation", () => {
   test("Vista general returns to hub", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
-    await hubCard(hub, "Centro de operaciones").click();
+    await clinicCockpitAction(hub, "Abrir operaciones").click();
 
     await expect(
       page.locator('[data-dashboard-module-workspace="operaciones"]'),
@@ -418,7 +418,7 @@ test.describe("dashboard shell — no global scroll", () => {
   test("clinic dashboard shell uses h-dvh overflow-hidden container", async ({ page }) => {
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
 
     const shellClass = await page.evaluate(() => {
@@ -454,7 +454,7 @@ test.describe("dashboard shell — no global scroll", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
 
     const bodyScrollHeight = await page.evaluate(() => document.body.scrollHeight);
@@ -467,9 +467,9 @@ test.describe("dashboard shell — no global scroll", () => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/dashboard");
 
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
-    await hubCard(hub, "Centro de operaciones").click();
+    await clinicCockpitAction(hub, "Abrir operaciones").click();
     await expect(
       page.locator('[data-dashboard-module-workspace="operaciones"]'),
     ).toBeVisible({ timeout: 5_000 });
@@ -855,9 +855,9 @@ test.describe("clinic dashboard — workspace isolation", () => {
 
   test("Informes workspace does not render Logística content", async ({ page }) => {
     await page.goto("/dashboard");
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
-    await hubCard(hub, "Informes").click();
+    await clinicCockpitAction(hub, "Abrir informes").click();
     await expect(
       page.locator('[data-dashboard-module-workspace="informes"]'),
     ).toBeVisible({ timeout: 5_000 });
@@ -868,9 +868,9 @@ test.describe("clinic dashboard — workspace isolation", () => {
 
   test("Tokens workspace does not render Logística content", async ({ page }) => {
     await page.goto("/dashboard");
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
-    await hubCard(hub, "Tokens particulares").click();
+    await clinicCockpitAction(hub, "Generar o abrir tokens").click();
     await expect(
       page.locator('[data-dashboard-module-workspace="tokens"]'),
     ).toBeVisible({ timeout: 5_000 });
@@ -881,9 +881,9 @@ test.describe("clinic dashboard — workspace isolation", () => {
 
   test("Perfil público workspace does not render Informes workspace", async ({ page }) => {
     await page.goto("/dashboard");
-    const hub = page.locator('[data-dashboard-module-hub="true"]');
+    const hub = clinicCockpit(page);
     await expect(hub).toBeVisible({ timeout: 8_000 });
-    await hubCard(hub, "Perfil público").click();
+    await clinicCockpitAction(hub, "Abrir perfil").click();
     await expect(
       page.locator('[data-dashboard-module-workspace="perfil"]'),
     ).toBeVisible({ timeout: 5_000 });

--- a/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-controller-workspace-parity.spec.ts
@@ -83,13 +83,39 @@ async function expectNoHorizontalOverflow(page: Page) {
   expect(metric.bodyScrollWidth).toBeLessThanOrEqual(metric.bodyClientWidth + TOLERANCE);
 }
 
+async function expectClinicStage(page: Page) {
+  const stage = page.locator(
+    '[data-dashboard-module-stage="true"][data-clinic-dashboard-stage="true"]',
+  );
+  await expect(stage).toBeVisible({ timeout: 8_000 });
+  await expect(stage).toHaveCount(1);
+  return stage;
+}
+
+async function expectSingleClinicLayer(
+  page: Page,
+  expected: "hub" | ClinicModule,
+) {
+  await expectClinicStage(page);
+
+  if (expected === "hub") {
+    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible();
+    await expect(page.locator("[data-dashboard-module-workspace]")).toHaveCount(0);
+    return;
+  }
+
+  await expect(
+    page.locator(`[data-dashboard-module-workspace="${expected}"]`),
+  ).toBeVisible();
+  await expect(page.locator('[data-dashboard-module-hub="true"]')).toHaveCount(0);
+}
+
 test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
   test("clinic /dashboard loads the module hub", async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard");
-    await expect(
-      page.locator('[data-dashboard-module-hub="true"]'),
-    ).toBeVisible({ timeout: 8_000 });
+    await expectSingleClinicLayer(page, "hub");
+    await expect(page.locator('[data-clinic-cockpit="true"]')).toBeVisible();
   });
 
   for (const moduleId of CLINIC_MODULES) {
@@ -98,9 +124,7 @@ test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
     }) => {
       await setClinicSession(page);
       await page.goto(`/dashboard?module=${moduleId}`);
-      await expect(
-        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
-      ).toBeVisible({ timeout: 8_000 });
+      await expectSingleClinicLayer(page, moduleId);
     });
   }
 
@@ -147,11 +171,32 @@ test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
 
     await workspace.locator('button[aria-label="Vista general"]').click();
 
-    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible({
-      timeout: 4_000,
-    });
+    await expectSingleClinicLayer(page, "hub");
     await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/);
     await expect(page).not.toHaveURL(/module=/);
+  });
+
+  test("clinic stage persists when returning to hub", async ({ page }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expectSingleClinicLayer(page, "operaciones");
+
+    const stage = await expectClinicStage(page);
+    await stage.evaluate((element) => {
+      (element as HTMLElement).dataset.e2eStageToken = "clinic-stage";
+    });
+
+    await page
+      .locator('[data-dashboard-module-workspace="operaciones"]')
+      .locator('button[aria-label="Vista general"]')
+      .click();
+
+    await expectSingleClinicLayer(page, "hub");
+    await expect(
+      page.locator(
+        '[data-dashboard-module-stage="true"][data-clinic-dashboard-stage="true"][data-e2e-stage-token="clinic-stage"]',
+      ),
+    ).toBeVisible();
   });
 
   for (const moduleId of CLINIC_MODULES) {
@@ -163,9 +208,7 @@ test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
     }) => {
       await setClinicSession(page);
       await page.goto(`/dashboard?module=${moduleId}`);
-      await expect(
-        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
-      ).toBeVisible({ timeout: 8_000 });
+      await expectSingleClinicLayer(page, moduleId);
 
       const navigation = page.getByRole("navigation", {
         name: "Navegación principal",
@@ -198,12 +241,45 @@ test.describe("clinic controller/workspace parity contract (PR-CL1)", () => {
     await setClinicSession(page);
     await page.setViewportSize(MOBILE_VIEWPORT);
     await page.goto("/dashboard");
-    await expect(
-      page.locator('[data-dashboard-module-hub="true"]'),
-    ).toBeVisible({ timeout: 8_000 });
+    await expectSingleClinicLayer(page, "hub");
 
     await expectNoHorizontalOverflow(page);
     await expectMainNotScrollContainer(page);
+  });
+});
+
+test.describe("clinic cockpit hub parity (PR-CL7)", () => {
+  test("hub exposes operational cockpit sections and primary actions", async ({
+    page,
+  }) => {
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+
+    const cockpit = page.locator('[data-clinic-cockpit="true"]');
+    await expect(cockpit).toBeVisible({ timeout: 8_000 });
+
+    for (const selector of [
+      '[data-clinic-cockpit-status="true"]',
+      '[data-clinic-cockpit-attention="true"]',
+      '[data-clinic-cockpit-continuity="true"]',
+      '[data-clinic-cockpit-activity="true"]',
+      '[data-clinic-cockpit-modules="true"]',
+      '[data-clinic-cockpit-primary-actions="true"]',
+    ]) {
+      await expect(cockpit.locator(selector)).toBeVisible();
+    }
+
+    for (const label of [
+      "Abrir operaciones",
+      "Abrir informes",
+      "Abrir logística",
+      "Abrir perfil",
+      "Generar o abrir tokens",
+    ]) {
+      await expect(
+        cockpit.getByRole("button", { name: label, exact: true }),
+      ).toBeVisible();
+    }
   });
 });
 

--- a/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
@@ -36,6 +36,23 @@ async function setClinicSession(page: Page) {
   ]);
 }
 
+async function expectClinicMobileBottomNav(page: Page, label: string) {
+  const clinicNav = page.locator('[data-clinic-mobile-bottom-nav="true"]');
+  await expect(clinicNav, `${label}: clinic bottom nav visible`).toBeVisible();
+  await expect(
+    clinicNav.locator('[data-clinic-mobile-bottom-nav-item="true"]'),
+    `${label}: clinic bottom nav item count`,
+  ).toHaveCount(6);
+  await expect(
+    page.locator('[data-admin-mobile-bottom-nav="true"]'),
+    `${label}: admin bottom nav absent`,
+  ).toHaveCount(0);
+  await expect(
+    page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    `${label}: horizontal nav hidden on clinic mobile`,
+  ).toBeHidden();
+}
+
 async function readLayoutContract(page: Page): Promise<LayoutContract> {
   return page.evaluate(() => {
     const html = document.documentElement;
@@ -129,6 +146,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await expect(async () => {
       await expect(workspace).toBeVisible();
       await expect(card).toBeVisible();
+      await expectClinicMobileBottomNav(page, viewport.name);
       await expect(reportRows).toHaveCount(3);
 
       for (let index = 0; index < 3; index += 1) {

--- a/frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts
@@ -36,6 +36,23 @@ async function setClinicSession(page: Page) {
   ]);
 }
 
+async function expectClinicMobileBottomNav(page: Page, label: string) {
+  const clinicNav = page.locator('[data-clinic-mobile-bottom-nav="true"]');
+  await expect(clinicNav, `${label}: clinic bottom nav visible`).toBeVisible();
+  await expect(
+    clinicNav.locator('[data-clinic-mobile-bottom-nav-item="true"]'),
+    `${label}: clinic bottom nav item count`,
+  ).toHaveCount(6);
+  await expect(
+    page.locator('[data-admin-mobile-bottom-nav="true"]'),
+    `${label}: admin bottom nav absent`,
+  ).toHaveCount(0);
+  await expect(
+    page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    `${label}: horizontal nav hidden on clinic mobile`,
+  ).toBeHidden();
+}
+
 async function readLayoutContract(page: Page): Promise<LayoutContract> {
   return page.evaluate(() => {
     const html = document.documentElement;
@@ -129,6 +146,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await expect(async () => {
       await expect(workspace).toBeVisible();
       await expect(card).toBeVisible();
+      await expectClinicMobileBottomNav(page, viewport.name);
       await expect(visitRows).toHaveCount(3);
 
       for (let index = 0; index < 3; index += 1) {

--- a/frontend/e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-mobile-nav-stage-parity.spec.ts
@@ -1,40 +1,23 @@
-import { mkdir } from "node:fs/promises";
-import { resolve } from "node:path";
 import { expect, test } from "@playwright/test";
-import type { Page, TestInfo } from "@playwright/test";
-
-// PR-CL3 — Clinic mobile nav/stage parity evidence (test-only, no production
-// change). Decides whether Clinic needs an Admin-style persistent module
-// stage ([data-dashboard-module-stage], CL-GAP-1) and/or sync mobile-nav
-// signaling (CL-GAP-5) before either is built.
-//
-// Confirmed by reading frontend/src/app/globals.css (admin-mobile-real-device
-// -layer-isolation / admin-mobile-stage-layer blocks): the opaque-ancestor
-// forcing and the GPU-promoted persistent stage that Admin uses to prevent
-// mobile bleed-through/ghosting are BOTH explicitly scoped to
-// `[data-vetneb-app-shell-surface="admin"]`. The blocks say so directly:
-// "Scoped to Admin mobile only... desktop, Clinic and the data/layout of
-// every module stay untouched" / "desktop and Clinic keep the stage as a
-// transparent flex passthrough". Clinic's controller
-// (ClinicDashboardWorkspaceController) swaps Hub<->module the same way Admin
-// did BEFORE that fix: two differently-typed branches returned directly,
-// no persistent stage wrapper.
-//
-// Headless Chromium cannot reproduce the real-device GPU tile recycling
-// itself (documented limitation in admin-mobile-hub-stale-layer-stage.spec.ts
-// and admin-mobile-module-layer-isolation.spec.ts too), so this spec does not
-// assert opacity/isolation contracts that would fail today and that nothing
-// in this PR fixes. It instead pins what IS verifiable headlessly: real
-// nav-driven swaps leave no stale/duplicate DOM mount, frame/main keep their
-// own node identity across the swap (no remount), and the mobile no-scroll
-// contract holds through a realistic multi-step round trip (not just single
-// fresh `goto`s, which is what PR-CL1 already covered).
+import type { Page } from "@playwright/test";
 
 const VIEWPORT = { width: 390, height: 844 } as const;
 const TOLERANCE = 2;
 
-const FRAME_SELECTOR = '[data-vetneb-app-shell-frame="true"]';
-const MAIN_SELECTOR = "main.dashboard-main";
+type ClinicModule =
+  | "operaciones"
+  | "informes"
+  | "logistica"
+  | "perfil"
+  | "tokens";
+
+const MODULES: Array<{ label: string; moduleId: ClinicModule }> = [
+  { label: "Operaciones", moduleId: "operaciones" },
+  { label: "Informes", moduleId: "informes" },
+  { label: "Logística", moduleId: "logistica" },
+  { label: "Perfil", moduleId: "perfil" },
+  { label: "Tokens", moduleId: "tokens" },
+];
 
 async function setClinicSession(page: Page) {
   await page.context().addCookies([
@@ -46,54 +29,58 @@ async function setClinicSession(page: Page) {
   ]);
 }
 
+async function setAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_test_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
 async function suppressNextDevIndicator(page: Page) {
   await page.addStyleTag({
     content: "nextjs-portal { display: none !important; }",
   });
 }
 
-async function stampNode(page: Page, selector: string, token: string) {
-  await page.evaluate(
-    ({ selector, token }) => {
-      const node = document.querySelector<HTMLElement>(selector);
-      if (!node) throw new Error(`node missing while stamping: ${selector}`);
-      (node as unknown as Record<string, string>).__e2eIdentityToken = token;
-    },
-    { selector, token },
-  );
+function bottomNav(page: Page) {
+  return page.locator('[data-clinic-mobile-bottom-nav="true"]');
 }
 
-async function readStampedToken(page: Page, selector: string) {
-  return page.evaluate((selector) => {
-    const node = document.querySelector<HTMLElement>(selector);
-    return node
-      ? ((node as unknown as Record<string, string>).__e2eIdentityToken ?? null)
-      : null;
-  }, selector);
+function bottomNavItem(page: Page, label: string) {
+  return bottomNav(page).getByRole("button", { name: label, exact: true });
 }
 
-type NoScrollContract = {
-  htmlOverflowX: number;
-  bodyOverflowX: number;
-  mainOverflowY: number;
-  workspaceCount: number;
-  hubCount: number;
-};
+function horizontalNavItem(page: Page, label: string) {
+  return page
+    .getByRole("navigation", { name: "Navegación principal" })
+    .getByRole("button", { name: label, exact: true });
+}
 
-async function readNoScrollContract(page: Page): Promise<NoScrollContract> {
+async function readNoScrollContract(page: Page) {
   return page.evaluate(() => {
     const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const nav = document.querySelector<HTMLElement>(
+      '[data-clinic-mobile-bottom-nav="true"]',
+    );
+
     return {
       htmlOverflowX:
         document.documentElement.scrollWidth -
         document.documentElement.clientWidth,
       bodyOverflowX: document.body.scrollWidth - document.body.clientWidth,
       mainOverflowY: main ? main.scrollHeight - main.clientHeight : 0,
+      navOverflowX: nav ? nav.scrollWidth - nav.clientWidth : 0,
       workspaceCount: document.querySelectorAll(
         "[data-dashboard-module-workspace]",
       ).length,
       hubCount: document.querySelectorAll('[data-dashboard-module-hub="true"]')
         .length,
+      stageCount: document.querySelectorAll(
+        '[data-dashboard-module-stage="true"][data-clinic-dashboard-stage="true"]',
+      ).length,
     };
   });
 }
@@ -110,200 +97,124 @@ async function expectNoScrollContract(page: Page, label: string) {
     expect(contract.mainOverflowY, `${label}: main vertical overflow`).toBeLessThanOrEqual(
       TOLERANCE,
     );
-  }).toPass({ timeout: 10_000 });
-
-  return readNoScrollContract(page);
-}
-
-function navItem(page: Page, label: string) {
-  return page
-    .getByRole("navigation", { name: "Navegación principal" })
-    .getByRole("button", { name: label, exact: true });
-}
-
-test.describe("clinic mobile nav/stage parity evidence (PR-CL3)", () => {
-  test("frame and main keep node identity across a real hub->module->hub round trip — 390x844", async ({
-    page,
-  }, testInfo: TestInfo) => {
-    await page.setViewportSize(VIEWPORT);
-    await setClinicSession(page);
-    await page.goto("/dashboard");
-    await suppressNextDevIndicator(page);
-    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible({
-      timeout: 8_000,
-    });
-
-    const frameToken = "frame-390x844";
-    const mainToken = "main-390x844";
-    await stampNode(page, FRAME_SELECTOR, frameToken);
-    await stampNode(page, MAIN_SELECTOR, mainToken);
-
-    let contract = await expectNoScrollContract(page, "initial hub");
-    expect(contract.hubCount, "initial hub: exactly one hub mounted").toBe(1);
-    expect(contract.workspaceCount, "initial hub: no module workspace mounted").toBe(0);
-
-    // Hub -> operaciones via the real horizontal nav (same path desktop uses;
-    // Clinic has no separate mobile-only nav component, unlike Admin's
-    // dedicated bottom nav).
-    await navItem(page, "Resumen").click();
-    await expect(
-      page.locator('[data-dashboard-module-workspace="operaciones"]'),
-    ).toBeVisible({ timeout: 8_000 });
-    expect(
-      await readStampedToken(page, FRAME_SELECTOR),
-      "operaciones: app-shell frame node persisted (no remount)",
-    ).toBe(frameToken);
-    expect(
-      await readStampedToken(page, MAIN_SELECTOR),
-      "operaciones: dashboard-main node persisted (no remount)",
-    ).toBe(mainToken);
-    contract = await expectNoScrollContract(page, "operaciones");
-    expect(contract.hubCount, "operaciones: hub unmounted").toBe(0);
-    expect(contract.workspaceCount, "operaciones: exactly one workspace mounted").toBe(1);
-
-    // operaciones -> tokens: the previous module must be fully gone, not just
-    // covered.
-    await navItem(page, "Tokens").click();
-    await expect(
-      page.locator('[data-dashboard-module-workspace="tokens"]'),
-    ).toBeVisible({ timeout: 8_000 });
-    await expect(
-      page.locator('[data-dashboard-module-workspace="operaciones"]'),
-    ).toHaveCount(0);
-    expect(
-      await readStampedToken(page, FRAME_SELECTOR),
-      "tokens: app-shell frame node persisted",
-    ).toBe(frameToken);
-    expect(
-      await readStampedToken(page, MAIN_SELECTOR),
-      "tokens: dashboard-main node persisted",
-    ).toBe(mainToken);
-    await expectNoScrollContract(page, "tokens");
-
-    // tokens -> perfil
-    await navItem(page, "Perfil").click();
-    await expect(
-      page.locator('[data-dashboard-module-workspace="perfil"]'),
-    ).toBeVisible({ timeout: 8_000 });
-    await expect(
-      page.locator('[data-dashboard-module-workspace="tokens"]'),
-    ).toHaveCount(0);
-    expect(
-      await readStampedToken(page, FRAME_SELECTOR),
-      "perfil: app-shell frame node persisted",
-    ).toBe(frameToken);
-    expect(
-      await readStampedToken(page, MAIN_SELECTOR),
-      "perfil: dashboard-main node persisted",
-    ).toBe(mainToken);
-    await expectNoScrollContract(page, "perfil");
-
-    // perfil -> hub via the workspace "Vista general" back control (Clinic's
-    // nav has no item that targets the bare hub).
-    await page
-      .locator('[data-dashboard-module-workspace="perfil"]')
-      .locator('button[aria-label="Vista general"]')
-      .click();
-    await expect(page.locator('[data-dashboard-module-hub="true"]')).toBeVisible({
-      timeout: 8_000,
-    });
-    contract = await expectNoScrollContract(page, "hub after round trip");
-    expect(contract.hubCount, "hub after round trip: exactly one hub mounted").toBe(1);
-    expect(
-      contract.workspaceCount,
-      "hub after round trip: no stale module workspace left mounted",
-    ).toBe(0);
-    expect(
-      await readStampedToken(page, FRAME_SELECTOR),
-      "hub after round trip: app-shell frame node persisted",
-    ).toBe(frameToken);
-    expect(
-      await readStampedToken(page, MAIN_SELECTOR),
-      "hub after round trip: dashboard-main node persisted",
-    ).toBe(mainToken);
-
-    const screenshotDirectory = resolve(
-      testInfo.config.rootDir,
-      "..",
-      "test-results",
-      "dashboard-clinic-mobile-nav-stage-parity",
+    expect(contract.navOverflowX, `${label}: bottom nav overflow`).toBeLessThanOrEqual(
+      TOLERANCE,
     );
-    await mkdir(screenshotDirectory, { recursive: true });
-    await page.screenshot({
-      path: resolve(screenshotDirectory, "390x844-hub-after-round-trip.png"),
-      animations: "disabled",
-      fullPage: false,
-    });
-  });
+    expect(contract.stageCount, `${label}: clinic stage mounted`).toBe(1);
+  }).toPass({ timeout: 10_000 });
+}
 
-  test("active horizontal nav item stays visible through the round trip (Resumen/Tokens/Perfil) — 390x844", async ({
+async function expectWorkspace(page: Page, moduleId: ClinicModule) {
+  await expect(
+    page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+  ).toBeVisible({ timeout: 8_000 });
+  await expect(page.locator('[data-dashboard-module-hub="true"]')).toHaveCount(0);
+}
+
+test.describe("clinic mobile bottom nav/stage parity (PR-CL7)", () => {
+  test("mobile 390x844 mounts ClinicMobileBottomNav and never AdminMobileBottomNav", async ({
     page,
   }) => {
     await page.setViewportSize(VIEWPORT);
     await setClinicSession(page);
-    await page.goto("/dashboard?module=operaciones");
+    await page.goto("/dashboard");
     await suppressNextDevIndicator(page);
+
+    await expect(bottomNav(page)).toBeVisible({ timeout: 8_000 });
+    await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toHaveCount(0);
     await expect(
-      page.locator('[data-dashboard-module-workspace="operaciones"]'),
-    ).toBeVisible({ timeout: 8_000 });
+      page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    ).toBeHidden();
+    await expect(bottomNav(page).locator('[data-clinic-mobile-bottom-nav-item="true"]')).toHaveCount(6);
 
-    for (const [label, moduleId] of [
-      ["Resumen", "operaciones"],
-      ["Informes", "informes"],
-      ["Logística", "logistica"],
-      ["Tokens", "tokens"],
-      ["Perfil", "perfil"],
-    ] as const) {
-      await navItem(page, label).click();
-      await expect(
-        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
-      ).toBeVisible({ timeout: 8_000 });
+    await expectNoScrollContract(page, "clinic hub");
+  });
 
-      const item = navItem(page, label);
-      await expect(item).toHaveAttribute("aria-current", "page");
-      const box = await item.boundingBox();
-      expect(box, `${label}: nav item has a bounding box`).not.toBeNull();
-      expect(box!.x, `${label}: nav item left edge in viewport`).toBeGreaterThanOrEqual(
-        -TOLERANCE,
+  test("bottom nav reaches the five clinic modules and keeps aria-current", async ({
+    page,
+  }) => {
+    await page.setViewportSize(VIEWPORT);
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    await suppressNextDevIndicator(page);
+    await expect(bottomNav(page)).toBeVisible({ timeout: 8_000 });
+
+    for (const { label, moduleId } of MODULES) {
+      await bottomNavItem(page, label).click();
+      await expectWorkspace(page, moduleId);
+      await expect(bottomNavItem(page, label)).toHaveAttribute(
+        "aria-current",
+        "page",
       );
-      expect(
-        box!.x + box!.width,
-        `${label}: nav item right edge in viewport`,
-      ).toBeLessThanOrEqual(VIEWPORT.width + TOLERANCE);
+      await expectNoScrollContract(page, moduleId);
     }
   });
 
-  // PR-CL4 resolved CL-GAP-7: the horizontal nav items for Informes/Logística
-  // now resolve to their canonical `?module=` workspace, so they are
-  // reachable and verifiable via the same real nav click used for
-  // Resumen/Tokens/Perfil above.
-  for (const [label, moduleId] of [
-    ["Informes", "informes"],
-    ["Logística", "logistica"],
-  ] as const) {
-    test(`${moduleId} module leaves no stale previous module mounted — 390x844`, async ({
-      page,
-    }) => {
-      await page.setViewportSize(VIEWPORT);
-      await setClinicSession(page);
-      await page.goto("/dashboard?module=operaciones");
-      await suppressNextDevIndicator(page);
-      await expect(
-        page.locator('[data-dashboard-module-workspace="operaciones"]'),
-      ).toBeVisible({ timeout: 8_000 });
+  test("hub reset returns to cockpit inside the same clinic stage", async ({
+    page,
+  }) => {
+    await page.setViewportSize(VIEWPORT);
+    await setClinicSession(page);
+    await page.goto("/dashboard?module=tokens");
+    await suppressNextDevIndicator(page);
+    await expectWorkspace(page, "tokens");
 
-      await navItem(page, label).click();
-      await expect(
-        page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
-      ).toBeVisible({ timeout: 8_000 });
-      await expect(
-        page.locator('[data-dashboard-module-workspace="operaciones"]'),
-      ).toHaveCount(0);
-      await expect(page.locator('[data-dashboard-module-hub="true"]')).toHaveCount(0);
-      await expect(navItem(page, label)).toHaveAttribute("aria-current", "page");
-
-      const contract = await expectNoScrollContract(page, moduleId);
-      expect(contract.workspaceCount, `${moduleId}: exactly one workspace mounted`).toBe(1);
+    const stage = page.locator(
+      '[data-dashboard-module-stage="true"][data-clinic-dashboard-stage="true"]',
+    );
+    await stage.evaluate((element) => {
+      (element as HTMLElement).dataset.e2eStageToken = "mobile-clinic-stage";
     });
-  }
+
+    await bottomNavItem(page, "Inicio").click();
+    await expect(page.locator('[data-clinic-cockpit="true"]')).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.locator("[data-dashboard-module-workspace]")).toHaveCount(0);
+    await expect(bottomNavItem(page, "Inicio")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    await expect(
+      page.locator(
+        '[data-dashboard-module-stage="true"][data-clinic-dashboard-stage="true"][data-e2e-stage-token="mobile-clinic-stage"]',
+      ),
+    ).toBeVisible();
+    await expectNoScrollContract(page, "hub reset");
+  });
+
+  test("desktop horizontal nav still syncs to the clinic controller", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setClinicSession(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(bottomNav(page)).toBeHidden();
+
+    for (const { label, moduleId } of MODULES) {
+      const itemLabel = label === "Operaciones" ? "Resumen" : label;
+      await horizontalNavItem(page, itemLabel).click();
+      await expectWorkspace(page, moduleId);
+      await expect(horizontalNavItem(page, itemLabel)).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    }
+  });
+
+  test("admin dashboard keeps AdminMobileBottomNav and does not mount clinic nav", async ({
+    page,
+  }) => {
+    await page.setViewportSize(VIEWPORT);
+    await setAdminSession(page);
+    await page.goto("/dashboard/admin");
+
+    await expect(page.locator('[data-admin-mobile-bottom-nav="true"]')).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(bottomNav(page)).toHaveCount(0);
+  });
 });

--- a/frontend/e2e/dashboard-clinic-module-state-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-module-state-parity.spec.ts
@@ -1,22 +1,8 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
 
-// CL-GAP-6 evidence (docs/audit/clinic-dashboard-admin-structure-parity-audit.md).
-//
-// `operaciones`/`informes`/`logistica` get their data from `page.tsx` (a Server
-// Component): the fetch happens in the Next.js server process, so Playwright's
-// `page.route` cannot intercept it. Their loading/empty/error states are only
-// reachable through the two session fixtures the e2e API server already
-// recognizes (`e2e_test_clinic_session` / `e2e_populated_clinic_session`) — see
-// `frontend/e2e/fixtures/admin-populated-api-server.mjs`. No session value
-// today produces a genuine empty-but-succeeded response for reports/visits, and
-// `/api/logistics/route-plans` has no handler at all, so `statsLoadError` is
-// unconditionally `true` for every clinic session in this fixture. This file
-// audits exactly what that leaves observable; it does not add a new fixture
-// branch to manufacture states that aren't reachable today.
-//
-// `tokens` and `perfil` (`ClinicParticularTokensCard`, `ClinicPublicProfileCard`,
-// `PasswordChangePanel`) fetch client-side via `useEffect`, so their states are
-// fully reachable with `page.route` mocks below.
+// PR-CL7 state parity. `operaciones`/`informes`/`logistica` get SSR data from
+// page.tsx, so their recovery action is a client `router.refresh()` button.
+// `tokens` and `perfil` fetch client-side and expose direct retry/reload paths.
 
 const TOLERANCE = 2;
 const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
@@ -129,7 +115,7 @@ const BLANK_PROFILE = {
 };
 
 test.describe("clinic operaciones/informes/logistica SSR module state parity (CL-GAP-6)", () => {
-  test("default session: operaciones surfaces stats/reports/visits load errors with no retry control", async ({
+  test("default session: operaciones surfaces stats/reports/visits load errors with retry controls", async ({
     page,
   }) => {
     await setClinicSession(page);
@@ -138,25 +124,34 @@ test.describe("clinic operaciones/informes/logistica SSR module state parity (CL
     const commandCenter = page.locator('[data-clinic-command-center="true"]');
     await expect(commandCenter).toBeVisible({ timeout: 8_000 });
 
+    const metricsAlert = commandCenter
+      .getByRole("alert")
+      .filter({ hasText: "métricas operativas" });
+    await expect(metricsAlert).toBeVisible();
     await expect(
-      commandCenter.getByRole("alert").filter({ hasText: "métricas operativas" }),
+      metricsAlert.getByRole("button", { name: "Reintentar" }),
     ).toBeVisible();
 
     await commandCenter.getByRole("tab", { name: "Recientes" }).click();
+    const reportsAlert = commandCenter
+      .getByRole("alert")
+      .filter({ hasText: "informes recientes" });
+    const visitsAlert = commandCenter
+      .getByRole("alert")
+      .filter({ hasText: "visitas de campo recientes" });
+    await expect(reportsAlert).toBeVisible();
     await expect(
-      commandCenter.getByRole("alert").filter({ hasText: "informes recientes" }),
+      reportsAlert.getByRole("button", { name: "Reintentar" }),
     ).toBeVisible();
+    await expect(visitsAlert).toBeVisible();
     await expect(
-      commandCenter.getByRole("alert").filter({ hasText: "visitas de campo recientes" }),
+      visitsAlert.getByRole("button", { name: "Reintentar" }),
     ).toBeVisible();
 
     await commandCenter.getByRole("tab", { name: "Estado" }).click();
     await expect(
       commandCenter.locator('[data-clinic-command-continuity="true"]'),
     ).toContainText("Estado degradado");
-
-    // No SSR-sourced error banner in this module has an associated retry control.
-    await expect(page.getByRole("button", { name: /reintentar|recargar/i })).toHaveCount(0);
   });
 
   test("default session: informes workspace shows the load error, not the empty state", async ({
@@ -170,9 +165,10 @@ test.describe("clinic operaciones/informes/logistica SSR module state parity (CL
     ).toBeVisible({ timeout: 8_000 });
 
     const card = page.locator('[aria-label="Informes recientes de la clínica"]');
-    await expect(card.getByRole("alert")).toHaveText(
+    await expect(card.getByRole("alert")).toContainText(
       "No se pudieron cargar los informes recientes. Intente nuevamente.",
     );
+    await expect(card.getByRole("button", { name: "Reintentar" })).toBeVisible();
     await expect(card.getByText("Sin informes recientes")).toHaveCount(0);
   });
 
@@ -187,9 +183,10 @@ test.describe("clinic operaciones/informes/logistica SSR module state parity (CL
     ).toBeVisible({ timeout: 8_000 });
 
     const card = page.locator('[aria-label="Visitas de campo recientes de la clínica"]');
-    await expect(card.getByRole("alert")).toHaveText(
+    await expect(card.getByRole("alert")).toContainText(
       "No se pudieron cargar las visitas de campo. Intente nuevamente.",
     );
+    await expect(card.getByRole("button", { name: "Reintentar" })).toBeVisible();
     await expect(card.getByText("Sin visitas recientes")).toHaveCount(0);
   });
 
@@ -291,7 +288,7 @@ test.describe("clinic tokens module state parity (client-driven, CL-GAP-6)", () 
     await expect(refreshButton).toHaveText("Actualizar", { timeout: 4_000 });
   });
 
-  test("empty: zero tokens renders a plain message, not the shared EmptyState component", async ({
+  test("empty: zero tokens renders the shared EmptyState pattern", async ({
     page,
   }) => {
     await setClinicSession(page);
@@ -315,6 +312,7 @@ test.describe("clinic tokens module state parity (client-driven, CL-GAP-6)", () 
     await expect(
       card.getByText("No hay tokens particulares generados por esta clínica."),
     ).toBeVisible();
+    await expect(card.getByText("Sin tokens particulares")).toBeVisible();
     await expect(
       card.getByRole("button", { name: "Generar token particular", exact: true }),
     ).toBeEnabled();
@@ -430,7 +428,7 @@ test.describe("clinic tokens module state parity (client-driven, CL-GAP-6)", () 
 });
 
 test.describe("clinic perfil → perfil público module state parity (client-driven, CL-GAP-6)", () => {
-  test("loading: the only observable cue is the 'Sin cargar' badge, no spinner or text", async ({
+  test("loading: profile load exposes explicit loading copy", async ({
     page,
   }) => {
     await setClinicSession(page);
@@ -446,13 +444,12 @@ test.describe("clinic perfil → perfil público module state parity (client-dri
     const editor = page.locator('[data-clinic-profile-editor="true"]');
     await expect(editor).toBeVisible();
 
-    await expect(editor.getByText("Sin cargar")).toBeVisible();
-    await expect(editor.getByText(/cargando/i)).toHaveCount(0);
+    await expect(editor.getByText("Cargando perfil público...")).toBeVisible();
 
     await expect(editor.getByText("Borrador privado")).toBeVisible({ timeout: 4_000 });
   });
 
-  test("error: failed profile load shows an alert with no in-app retry control", async ({
+  test("error: failed profile load shows an alert with in-app retry control", async ({
     page,
   }) => {
     await setClinicSession(page);
@@ -466,13 +463,10 @@ test.describe("clinic perfil → perfil público module state parity (client-dri
     await page.getByRole("tab", { name: "Perfil público", exact: true }).first().click();
 
     const editor = page.locator('[data-clinic-profile-editor="true"]');
-    await expect(editor.getByRole("alert")).toHaveText("No se pudo cargar el perfil.");
-
-    // Gap: unlike tokens' "Actualizar", nothing in this card re-invokes
-    // loadProfile() — the only recovery path is a full page reload.
+    await expect(editor.getByRole("alert")).toContainText("No se pudo cargar el perfil.");
     await expect(
-      editor.getByRole("button", { name: /actualizar|recargar|reintentar/i }),
-    ).toHaveCount(0);
+      editor.getByRole("button", { name: "Reintentar carga", exact: true }),
+    ).toBeVisible();
 
     await expectNoHorizontalOverflow(page);
     await expectMainNotScrollContainer(page);

--- a/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
+++ b/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
@@ -20,6 +20,23 @@ async function setClinicSession(page: Page) {
   ]);
 }
 
+async function expectClinicMobileBottomNav(page: Page, label: string) {
+  const clinicNav = page.locator('[data-clinic-mobile-bottom-nav="true"]');
+  await expect(clinicNav, `${label}: clinic bottom nav visible`).toBeVisible();
+  await expect(
+    clinicNav.locator('[data-clinic-mobile-bottom-nav-item="true"]'),
+    `${label}: clinic bottom nav item count`,
+  ).toHaveCount(6);
+  await expect(
+    page.locator('[data-admin-mobile-bottom-nav="true"]'),
+    `${label}: admin bottom nav absent`,
+  ).toHaveCount(0);
+  await expect(
+    page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    `${label}: horizontal nav hidden on clinic mobile`,
+  ).toBeHidden();
+}
+
 async function mockClinicProfile(page: Page) {
   await page.route("**/api/clinic/profile**", async (route) => {
     if (route.request().method() !== "GET") return route.continue();
@@ -87,6 +104,7 @@ for (const viewport of VIEWPORTS) {
 
     const editor = page.locator('[data-clinic-profile-editor="true"]');
     await expect(editor).toBeVisible();
+    await expectClinicMobileBottomNav(page, viewport.name);
 
     await expect(async () => {
       await editor.getByRole("tab", { name: "Datos", exact: true }).click();

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -67,6 +67,23 @@ async function setClinicSession(page: Page) {
   ]);
 }
 
+async function expectClinicMobileBottomNav(page: Page, label: string) {
+  const clinicNav = page.locator('[data-clinic-mobile-bottom-nav="true"]');
+  await expect(clinicNav, `${label}: clinic bottom nav visible`).toBeVisible();
+  await expect(
+    clinicNav.locator('[data-clinic-mobile-bottom-nav-item="true"]'),
+    `${label}: clinic bottom nav item count`,
+  ).toHaveCount(6);
+  await expect(
+    page.locator('[data-admin-mobile-bottom-nav="true"]'),
+    `${label}: admin bottom nav absent`,
+  ).toHaveCount(0);
+  await expect(
+    page.locator('[data-dashboard-horizontal-nav-shell="true"]'),
+    `${label}: horizontal nav hidden on clinic mobile`,
+  ).toBeHidden();
+}
+
 async function mockClinicTokens(page: Page) {
   await page.route(
     (url) => url.pathname === "/api/particular-tokens",
@@ -203,6 +220,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await expect(async () => {
       await expect(workspace).toBeVisible();
       await expect(card).toBeVisible();
+      await expectClinicMobileBottomNav(page, viewport.name);
       await expect(tokenRows).toHaveCount(4);
 
       for (let index = 0; index < 4; index += 1) {

--- a/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
+++ b/frontend/e2e/dashboard-mobile-shell-nav-contract.spec.ts
@@ -93,11 +93,13 @@ type ShellNavContract = {
   bodyClientWidth: number;
   topbarVisible: boolean;
   horizontalNavVisible: boolean;
-  bottomNavVisible: boolean;
+  adminBottomNavVisible: boolean;
+  clinicBottomNavVisible: boolean;
   clippedTopbarControls: ShellNavMetric[];
   undersizedShellControls: ShellNavMetric[];
   activeHorizontalNavItemVisible: boolean;
-  activeBottomNavItemVisible: boolean;
+  activeAdminBottomNavItemVisible: boolean;
+  activeClinicBottomNavItemVisible: boolean;
 };
 
 async function readShellNavContract(page: Page): Promise<ShellNavContract> {
@@ -154,8 +156,11 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
     const nav = document.querySelector(
       "[data-dashboard-horizontal-nav-shell='true']",
     );
-    const bottomNav = document.querySelector(
+    const adminBottomNav = document.querySelector(
       "[data-admin-mobile-bottom-nav='true']",
+    );
+    const clinicBottomNav = document.querySelector(
+      "[data-clinic-mobile-bottom-nav='true']",
     );
 
     const topbarControls = Array.from(
@@ -166,7 +171,7 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
 
     const shellControls = Array.from(
       document.querySelectorAll(
-        "header[aria-label='Barra superior del dashboard'] a, header[aria-label='Barra superior del dashboard'] button, [data-admin-mobile-bottom-nav='true'] button",
+        "header[aria-label='Barra superior del dashboard'] a, header[aria-label='Barra superior del dashboard'] button, [data-admin-mobile-bottom-nav='true'] button, [data-clinic-mobile-bottom-nav='true'] a, [data-clinic-mobile-bottom-nav='true'] button",
       ),
     ).filter(isVisible);
 
@@ -193,8 +198,11 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
     const activeHorizontalNavItem = document.querySelector(
       "[data-dashboard-horizontal-nav-shell='true'] [aria-current='page']",
     );
-    const activeBottomNavItem = document.querySelector(
+    const activeAdminBottomNavItem = document.querySelector(
       "[data-admin-mobile-bottom-nav='true'] [aria-current='page']",
+    );
+    const activeClinicBottomNavItem = document.querySelector(
+      "[data-clinic-mobile-bottom-nav='true'] [aria-current='page']",
     );
 
     let activeHorizontalNavItemVisible = false;
@@ -208,11 +216,22 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
         rect.bottom <= viewportHeight + tolerance;
     }
 
-    let activeBottomNavItemVisible = false;
-    if (activeBottomNavItem) {
-      const rect = (activeBottomNavItem as HTMLElement).getBoundingClientRect();
-      activeBottomNavItemVisible =
-        isVisible(activeBottomNavItem) &&
+    let activeAdminBottomNavItemVisible = false;
+    if (activeAdminBottomNavItem) {
+      const rect = (activeAdminBottomNavItem as HTMLElement).getBoundingClientRect();
+      activeAdminBottomNavItemVisible =
+        isVisible(activeAdminBottomNavItem) &&
+        rect.left >= -tolerance &&
+        rect.right <= viewportWidth + tolerance &&
+        rect.top >= -tolerance &&
+        rect.bottom <= viewportHeight + tolerance;
+    }
+
+    let activeClinicBottomNavItemVisible = false;
+    if (activeClinicBottomNavItem) {
+      const rect = (activeClinicBottomNavItem as HTMLElement).getBoundingClientRect();
+      activeClinicBottomNavItemVisible =
+        isVisible(activeClinicBottomNavItem) &&
         rect.left >= -tolerance &&
         rect.right <= viewportWidth + tolerance &&
         rect.top >= -tolerance &&
@@ -226,11 +245,13 @@ async function readShellNavContract(page: Page): Promise<ShellNavContract> {
       bodyClientWidth: body.clientWidth,
       topbarVisible: topbar ? isVisible(topbar) : false,
       horizontalNavVisible: nav ? isVisible(nav) : false,
-      bottomNavVisible: bottomNav ? isVisible(bottomNav) : false,
+      adminBottomNavVisible: adminBottomNav ? isVisible(adminBottomNav) : false,
+      clinicBottomNavVisible: clinicBottomNav ? isVisible(clinicBottomNav) : false,
       clippedTopbarControls,
       undersizedShellControls,
       activeHorizontalNavItemVisible,
-      activeBottomNavItemVisible,
+      activeAdminBottomNavItemVisible,
+      activeClinicBottomNavItemVisible,
     };
   }, TOLERANCE);
 }
@@ -247,20 +268,22 @@ function assertShellNavContract(
       contract.horizontalNavVisible,
       `${label}: legacy horizontal nav hidden`,
     ).toBe(false);
-    expect(contract.bottomNavVisible, `${label}: bottom nav visible`).toBe(true);
+    expect(contract.adminBottomNavVisible, `${label}: admin bottom nav visible`).toBe(true);
+    expect(contract.clinicBottomNavVisible, `${label}: clinic bottom nav absent`).toBe(false);
     expect(
-      contract.activeBottomNavItemVisible,
-      `${label}: active bottom nav item visible`,
+      contract.activeAdminBottomNavItemVisible,
+      `${label}: active admin bottom nav item visible`,
     ).toBe(true);
   } else {
     expect(
       contract.horizontalNavVisible,
-      `${label}: clinic horizontal nav visible`,
-    ).toBe(true);
-    expect(contract.bottomNavVisible, `${label}: no Admin bottom nav`).toBe(false);
+      `${label}: clinic horizontal nav hidden on mobile`,
+    ).toBe(false);
+    expect(contract.adminBottomNavVisible, `${label}: admin bottom nav absent`).toBe(false);
+    expect(contract.clinicBottomNavVisible, `${label}: clinic bottom nav visible`).toBe(true);
     expect(
-      contract.activeHorizontalNavItemVisible,
-      `${label}: active clinic nav item visible`,
+      contract.activeClinicBottomNavItemVisible,
+      `${label}: active clinic bottom nav item visible`,
     ).toBe(true);
   }
 

--- a/frontend/src/app/dashboard/ClinicCommandCenter.tsx
+++ b/frontend/src/app/dashboard/ClinicCommandCenter.tsx
@@ -4,6 +4,7 @@ import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
+import { DashboardRefreshButton } from "@/components/dashboard/DashboardRefreshButton";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ClipboardList, Route } from "lucide-react";
 import { formatDate } from "@/lib/utils";
@@ -127,9 +128,13 @@ export function ClinicCommandCenter({
       }
     >
       {statsLoadError ? (
-        <p role="alert" className="clinical-alert-warning shrink-0">
-          No se pudieron cargar las métricas operativas. Intente nuevamente.
-        </p>
+        <div
+          role="alert"
+          className="clinical-alert-warning flex shrink-0 flex-wrap items-center justify-between gap-2"
+        >
+          <span>No se pudieron cargar las métricas operativas. Intente nuevamente.</span>
+          <DashboardRefreshButton />
+        </div>
       ) : null}
       <ModuleTabs
         ariaLabel="Secciones del centro operativo clínica"
@@ -175,9 +180,15 @@ export function ClinicCommandCenter({
                   </CardHeader>
                   <CardContent className="min-h-0 flex-1 space-y-1.5">
                     {reportsLoadError ? (
-                      <p role="alert" className="clinical-alert-warning">
-                        No se pudieron cargar los informes recientes. Intente nuevamente.
-                      </p>
+                      <div
+                        role="alert"
+                        className="clinical-alert-warning flex flex-wrap items-center justify-between gap-2"
+                      >
+                        <span>
+                          No se pudieron cargar los informes recientes. Intente nuevamente.
+                        </span>
+                        <DashboardRefreshButton />
+                      </div>
                     ) : recentReports.length ? (
                       recentReports.map((report) => (
                         <div
@@ -221,9 +232,15 @@ export function ClinicCommandCenter({
                   </CardHeader>
                   <CardContent className="min-h-0 flex-1 space-y-1.5">
                     {visitsLoadError ? (
-                      <p role="alert" className="clinical-alert-warning">
-                        No se pudieron cargar las visitas de campo recientes. Intente nuevamente.
-                      </p>
+                      <div
+                        role="alert"
+                        className="clinical-alert-warning flex flex-wrap items-center justify-between gap-2"
+                      >
+                        <span>
+                          No se pudieron cargar las visitas de campo recientes. Intente nuevamente.
+                        </span>
+                        <DashboardRefreshButton />
+                      </div>
                     ) : recentVisits.length ? (
                       recentVisits.map((visit) => (
                         <div

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -5,6 +5,7 @@ import type { Report } from "@/types";
 import { ClipboardList, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
+import { DashboardRefreshButton } from "@/components/dashboard/DashboardRefreshButton";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
@@ -57,9 +58,13 @@ export function ClinicInformesWorkspaceSummary({
       }
     >
       {reportsLoadError ? (
-        <p role="alert" className="clinical-alert-warning">
-          No se pudieron cargar los informes recientes. Intente nuevamente.
-        </p>
+        <div
+          role="alert"
+          className="clinical-alert-warning flex flex-wrap items-center justify-between gap-2"
+        >
+          <span>No se pudieron cargar los informes recientes. Intente nuevamente.</span>
+          <DashboardRefreshButton />
+        </div>
       ) : recentReports.length ? (
         <div className="dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82">
             <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -5,6 +5,7 @@ import type { FieldVisit } from "@/types";
 import { Route as RouteIcon, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
+import { DashboardRefreshButton } from "@/components/dashboard/DashboardRefreshButton";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
@@ -57,9 +58,13 @@ export function ClinicLogisticaWorkspaceSummary({
       }
     >
       {visitsLoadError ? (
-        <p role="alert" className="clinical-alert-warning">
-          No se pudieron cargar las visitas de campo. Intente nuevamente.
-        </p>
+        <div
+          role="alert"
+          className="clinical-alert-warning flex flex-wrap items-center justify-between gap-2"
+        >
+          <span>No se pudieron cargar las visitas de campo. Intente nuevamente.</span>
+          <DashboardRefreshButton />
+        </div>
       ) : recentVisits.length ? (
         <div className="dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82">
             <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
 import { ClinicDashboardWorkspaceController } from "@/components/dashboard/ClinicDashboardWorkspaceController";
 import type { ClinicModule } from "@/components/dashboard/ClinicDashboardWorkspaceController";
+import { ClinicMobileModuleFrame } from "@/components/dashboard/ClinicMobileModuleFrame";
 import { ClinicCommandCenter } from "./ClinicCommandCenter";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
@@ -115,6 +116,12 @@ export default async function DashboardPage({
         <Suspense>
           <ClinicDashboardWorkspaceController
             initialModule={initialModule}
+            stats={stats}
+            statsLoadError={statsLoadError}
+            recentReports={recentReports}
+            reportsLoadError={reportsLoadError}
+            recentVisits={recentVisits}
+            visitsLoadError={visitsLoadError}
             pendingReports={pendingReports}
             activeVisits={activeVisits}
             pageHeader={
@@ -125,45 +132,57 @@ export default async function DashboardPage({
             }
             workspaces={{
               operaciones: (
-                <ClinicCommandCenter
-                  stats={stats}
-                  statsLoadError={statsLoadError}
-                  recentReports={recentReports}
-                  recentVisits={recentVisits}
-                  reportsLoadError={reportsLoadError}
-                  visitsLoadError={visitsLoadError}
-                />
+                <ClinicMobileModuleFrame moduleId="operaciones">
+                  <ClinicCommandCenter
+                    stats={stats}
+                    statsLoadError={statsLoadError}
+                    recentReports={recentReports}
+                    recentVisits={recentVisits}
+                    reportsLoadError={reportsLoadError}
+                    visitsLoadError={visitsLoadError}
+                  />
+                </ClinicMobileModuleFrame>
               ),
               informes: (
-                <ClinicInformesWorkspaceSummary
-                  recentReports={recentReports}
-                  reportsLoadError={reportsLoadError}
-                />
+                <ClinicMobileModuleFrame moduleId="informes">
+                  <ClinicInformesWorkspaceSummary
+                    recentReports={recentReports}
+                    reportsLoadError={reportsLoadError}
+                  />
+                </ClinicMobileModuleFrame>
               ),
               logistica: (
-                <ClinicLogisticaWorkspaceSummary
-                  recentVisits={recentVisits}
-                  visitsLoadError={visitsLoadError}
-                />
+                <ClinicMobileModuleFrame moduleId="logistica">
+                  <ClinicLogisticaWorkspaceSummary
+                    recentVisits={recentVisits}
+                    visitsLoadError={visitsLoadError}
+                  />
+                </ClinicMobileModuleFrame>
               ),
               perfil: (
-                <ModuleTabs
-                  ariaLabel="Secciones de perfil"
-                  tabs={[
-                    {
-                      id: "acceso",
-                      label: "Acceso",
-                      content: <PasswordChangePanel variant="clinic" />,
-                    },
-                    {
-                      id: "perfil-publico",
-                      label: "Perfil público",
-                      content: <ClinicPublicProfileCard />,
-                    },
-                  ]}
-                />
+                <ClinicMobileModuleFrame moduleId="perfil">
+                  <ModuleTabs
+                    ariaLabel="Secciones de perfil"
+                    tabs={[
+                      {
+                        id: "acceso",
+                        label: "Acceso",
+                        content: <PasswordChangePanel variant="clinic" />,
+                      },
+                      {
+                        id: "perfil-publico",
+                        label: "Perfil público",
+                        content: <ClinicPublicProfileCard />,
+                      },
+                    ]}
+                  />
+                </ClinicMobileModuleFrame>
               ),
-              tokens: <ClinicParticularTokensCard />,
+              tokens: (
+                <ClinicMobileModuleFrame moduleId="tokens">
+                  <ClinicParticularTokensCard />
+                </ClinicMobileModuleFrame>
+              ),
             }}
           />
         </Suspense>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3034,7 +3034,8 @@
    destroyed per-module layer. No fixed-position descendant lives inside the
    stage (the bottom nav, app bar, menus and Radix dialogs render outside it), so
    the new containing block is inert. Scoped to Admin mobile (<=767px); desktop
-   and Clinic keep the stage as a transparent flex passthrough. */
+   stays a transparent flex passthrough. Clinic parity has its own scoped stage
+   contract below. */
 @media (max-width: 767px) {
   [data-vetneb-app-shell-surface="admin"] [data-dashboard-module-stage="true"] {
     isolation: isolate;
@@ -3044,3 +3045,172 @@
   }
 }
 /* admin-mobile-stage-layer:end */
+/* clinic-admin-structure-parity:start */
+@layer components {
+  .clinic-mobile-module-frame {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .clinic-cockpit-hub {
+    min-height: 0;
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 767px) {
+  html:has([data-vetneb-app-shell-surface="clinic"]),
+  body:has([data-vetneb-app-shell-surface="clinic"]) {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] {
+    width: 100%;
+    height: 100vh;
+    height: 100svh;
+    min-height: 0;
+    max-height: 100svh;
+    overflow: hidden;
+    overscroll-behavior: none;
+    isolation: isolate;
+    --clinic-mobile-shell-gutter: clamp(0.45rem, 0.34rem + 0.45svw, 0.62rem);
+    --clinic-mobile-bottom-nav-h: clamp(3.15rem, 0.3rem + 0.45svh, 3.5rem);
+    --clinic-mobile-bottom-nav-gap: clamp(0.1rem, 0.08rem + 0.08svw, 0.16rem);
+    --clinic-mobile-type-2xs: clamp(0.56rem, 0.48rem + 0.22svw, 0.64rem);
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    > [data-vetneb-app-shell-frame="true"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] [data-dashboard-topbar-polish="true"] {
+    --tw-backdrop-blur: none !important;
+    background: hsl(var(--card)) !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-dashboard-horizontal-nav-shell="true"] {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] .dashboard-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+    padding: var(--clinic-mobile-shell-gutter);
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] [data-dashboard-module-stage="true"] {
+    isolation: isolate;
+    background: hsl(var(--card));
+    transform: translateZ(0);
+    overscroll-behavior: none;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] [data-dashboard-module-workspace],
+  [data-vetneb-app-shell-surface="clinic"] [data-dashboard-module-hub] {
+    background: hsl(var(--card));
+    isolation: isolate;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-dashboard-module-back-button="true"] {
+    display: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] .clinic-mobile-bottom-nav {
+    position: relative;
+    z-index: 65;
+    display: flex !important;
+    width: 100%;
+    height: calc(var(--clinic-mobile-bottom-nav-h) + env(safe-area-inset-bottom));
+    min-height: 0;
+    flex: 0 0 auto;
+    align-items: stretch;
+    overflow: hidden;
+    padding-bottom: env(safe-area-inset-bottom);
+    border-top: 1px solid hsl(var(--vetneb-line));
+    background: hsl(var(--card));
+    isolation: isolate;
+    overscroll-behavior: none;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    transform: none !important;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] .clinic-mobile-bottom-nav-item {
+    display: inline-flex;
+    min-width: 0;
+    min-height: 0;
+    flex: 1 1 16.666%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--clinic-mobile-bottom-nav-gap);
+    overflow: hidden;
+    padding: 0.24rem 0.05rem;
+    border-radius: 0;
+    background: hsl(var(--card));
+    color: hsl(var(--muted-foreground));
+    font-size: var(--clinic-mobile-type-2xs);
+    font-weight: 650;
+    line-height: 1;
+    white-space: nowrap;
+    touch-action: manipulation;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    .clinic-mobile-bottom-nav-item-active {
+    color: hsl(var(--vetneb-navy));
+    background: hsl(var(--vetneb-surface-muted));
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    .clinic-mobile-bottom-nav-item:focus-visible {
+    outline: none;
+    box-shadow:
+      inset 0 0 0 2px hsl(var(--ring) / 0.85),
+      inset 0 0 0 4px hsl(var(--card));
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] .clinic-cockpit-hub {
+    gap: 0.45rem;
+    padding: 0.5rem;
+    border-radius: 0.75rem;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-clinic-cockpit="true"]
+    .surface-soft {
+    padding: 0.5rem;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-clinic-cockpit="true"]
+    .dashboard-kpi-pill {
+    padding: 0.45rem 0.55rem;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-clinic-cockpit-primary-actions="true"]
+    button {
+    min-height: 2rem;
+    font-size: var(--clinic-mobile-type-2xs);
+  }
+}
+/* clinic-admin-structure-parity:end */

--- a/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
+++ b/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
@@ -9,8 +9,6 @@ import {
   LayoutDashboard,
   Route,
 } from "lucide-react";
-import { DashboardHubHero } from "./DashboardHubHero";
-import { DashboardModuleHub } from "./DashboardModuleHub";
 import { DashboardModuleWorkspace } from "./DashboardModuleWorkspace";
 import { ROUTES } from "@/lib/routes";
 import {
@@ -18,6 +16,12 @@ import {
   readDashboardLastModule,
   writeDashboardLastModule,
 } from "@/lib/dashboard-last-module";
+import {
+  subscribeClinicHubReset,
+  subscribeClinicModuleActivate,
+} from "@/lib/clinic-hub-reset";
+import { formatDate } from "@/lib/utils";
+import type { DashboardStats, FieldVisit, Report } from "@/types";
 
 const CLINIC_MODULE_VALUES = [
   "operaciones",
@@ -51,6 +55,12 @@ type ClinicWorkspaceSlots = {
 
 type ClinicDashboardWorkspaceControllerProps = {
   initialModule?: ClinicModule | null;
+  stats: DashboardStats | null;
+  statsLoadError: boolean;
+  recentReports: Report[];
+  reportsLoadError: boolean;
+  recentVisits: FieldVisit[];
+  visitsLoadError: boolean;
   pendingReports: number;
   activeVisits: number;
   workspaces: ClinicWorkspaceSlots;
@@ -84,8 +94,308 @@ const MODULE_META: Record<
   },
 };
 
+type ClinicDashboardCockpitProps = {
+  stats: DashboardStats | null;
+  statsLoadError: boolean;
+  recentReports: Report[];
+  reportsLoadError: boolean;
+  recentVisits: FieldVisit[];
+  visitsLoadError: boolean;
+  pendingReports: number;
+  activeVisits: number;
+  activateModule: (moduleId: ClinicModule) => void;
+};
+
+function getActivityTime(value: string | null | undefined): number {
+  if (!value) return 0;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+function getLatestActivity(
+  recentReports: Report[],
+  recentVisits: FieldVisit[],
+) {
+  const latestReport = recentReports[0];
+  const latestVisit = recentVisits[0];
+
+  const reportTime = latestReport
+    ? getActivityTime(latestReport.updatedAt ?? latestReport.uploadDate)
+    : 0;
+  const visitTime = latestVisit
+    ? getActivityTime(latestVisit.scheduledAt)
+    : 0;
+
+  if (latestReport && reportTime >= visitTime) {
+    return {
+      title: latestReport.patientName ?? "Informe sin nombre",
+      detail: `${latestReport.studyType ?? "Estudio"} · ${formatDate(latestReport.uploadDate)}`,
+    };
+  }
+
+  if (latestVisit) {
+    return {
+      title: latestVisit.clinicName ?? `Clínica #${latestVisit.clinicId}`,
+      detail: `Visita de campo · ${formatDate(latestVisit.scheduledAt)}`,
+    };
+  }
+
+  return null;
+}
+
+function ClinicDashboardCockpit({
+  stats,
+  statsLoadError,
+  recentReports,
+  reportsLoadError,
+  recentVisits,
+  visitsLoadError,
+  pendingReports,
+  activeVisits,
+  activateModule,
+}: ClinicDashboardCockpitProps) {
+  const latestActivity = getLatestActivity(recentReports, recentVisits);
+  const hasAnyError = statsLoadError || reportsLoadError || visitsLoadError;
+  const attentionItems = [
+    pendingReports > 0
+      ? `${pendingReports} informe(s) pendiente(s) de entrega.`
+      : null,
+    activeVisits > 0
+      ? `${activeVisits} visita(s) activa(s) o programada(s).`
+      : null,
+    statsLoadError ? "Métricas operativas degradadas." : null,
+    reportsLoadError ? "Informes recientes no disponibles." : null,
+    visitsLoadError ? "Continuidad logística no disponible." : null,
+  ].filter(Boolean);
+
+  const moduleItems: Array<{
+    moduleId: ClinicModule;
+    label: string;
+    detail: string;
+    icon: typeof LayoutDashboard;
+  }> = [
+    {
+      moduleId: "operaciones",
+      label: "Operaciones",
+      detail: "Métricas y continuidad del día",
+      icon: LayoutDashboard,
+    },
+    {
+      moduleId: "informes",
+      label: "Informes",
+      detail: `${recentReports.length} reciente(s)`,
+      icon: FileText,
+    },
+    {
+      moduleId: "logistica",
+      label: "Logística",
+      detail: `${recentVisits.length} visita(s) reciente(s)`,
+      icon: Route,
+    },
+    {
+      moduleId: "perfil",
+      label: "Perfil",
+      detail: "Publicación y datos visibles",
+      icon: Building2,
+    },
+    {
+      moduleId: "tokens",
+      label: "Tokens",
+      detail: "Accesos particulares",
+      icon: KeyRound,
+    },
+  ];
+
+  return (
+    <section
+      data-dashboard-module-hub="true"
+      data-clinic-cockpit="true"
+      aria-label="Cockpit operativo de clínica"
+      className="clinic-cockpit-hub dashboard-module-surface rounded-xl border border-vetneb-line/75 bg-card/92 p-3 shadow-[0_16px_42px_rgba(15,45,62,0.08)] sm:p-4"
+    >
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+        <div
+          data-clinic-cockpit-status="true"
+          className="surface-soft flex min-h-0 flex-col justify-between gap-3 overflow-hidden"
+        >
+          <div className="min-w-0">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-vetneb-navy/80">
+              Estado operativo clínica
+            </p>
+            <h2 className="mt-1 text-xl font-semibold leading-tight text-vetneb-ink">
+              {hasAnyError ? "Operación con señales degradadas" : "Operación al día"}
+            </h2>
+            <p className="mt-1 line-clamp-3 text-sm text-muted-foreground">
+              {hasAnyError
+                ? "Revise métricas, informes o visitas antes de continuar la agenda diagnóstica."
+                : "Informes y logística están sincronizados para continuar la operación."}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div className="dashboard-kpi-pill" data-tone="critical">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                Pendientes
+              </p>
+              <p className="mt-1 text-xl font-bold leading-none">
+                {statsLoadError ? "—" : pendingReports}
+              </p>
+            </div>
+            <div className="dashboard-kpi-pill" data-tone="focus">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-wide">
+                Visitas
+              </p>
+              <p className="mt-1 text-xl font-bold leading-none">
+                {statsLoadError ? "—" : activeVisits}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid min-h-0 grid-cols-1 gap-3 lg:grid-rows-[auto_1fr]">
+          <div className="grid min-h-0 grid-cols-1 gap-3 sm:grid-cols-3">
+            <div
+              data-clinic-cockpit-attention="true"
+              className="surface-soft min-h-0 overflow-hidden"
+            >
+              <p className="text-sm font-semibold text-vetneb-ink">
+                Atención requerida
+              </p>
+              {attentionItems.length ? (
+                <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+                  {attentionItems.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Sin pendientes operativos detectados.
+                </p>
+              )}
+            </div>
+
+            <div
+              data-clinic-cockpit-continuity="true"
+              className="surface-soft min-h-0 overflow-hidden"
+            >
+              <p className="text-sm font-semibold text-vetneb-ink">
+                Continuidad logística
+              </p>
+              <p className="mt-1 line-clamp-3 text-xs text-muted-foreground">
+                {visitsLoadError
+                  ? "No se pudo confirmar la continuidad logística reciente."
+                  : activeVisits > 0
+                    ? "Hay visitas activas para sostener seguimiento de campo."
+                    : "Sin visitas activas registradas en la lectura actual."}
+              </p>
+            </div>
+
+            <div
+              data-clinic-cockpit-activity="true"
+              className="surface-soft min-h-0 overflow-hidden"
+            >
+              <p className="text-sm font-semibold text-vetneb-ink">
+                Actividad reciente
+              </p>
+              {latestActivity ? (
+                <p className="mt-1 line-clamp-3 text-xs text-muted-foreground">
+                  <span className="font-semibold text-foreground/85">
+                    {latestActivity.title}
+                  </span>{" "}
+                  · {latestActivity.detail}
+                </p>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Sin actividad reciente disponible.
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid min-h-0 grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.82fr)]">
+            <div
+              data-clinic-cockpit-modules="true"
+              className="dashboard-inline-list rounded-lg border border-vetneb-line/75 bg-card/82"
+            >
+              <div className="shrink-0 border-b border-vetneb-line/70 px-3 py-2">
+                <h3 className="text-sm font-semibold text-vetneb-ink">
+                  Módulos clínicos
+                </h3>
+                <p className="dashboard-section-description line-clamp-1">
+                  Acceso operativo dentro del stage del dashboard.
+                </p>
+              </div>
+              <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 p-2 sm:grid-cols-2">
+                {moduleItems.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <button
+                      key={item.moduleId}
+                      type="button"
+                      data-clinic-cockpit-module-card={item.moduleId}
+                      onClick={() => activateModule(item.moduleId)}
+                      className="dashboard-card-interactive flex min-h-12 min-w-0 items-center gap-2 rounded-lg border border-vetneb-line/70 bg-vetneb-surface-muted/55 px-3 py-2 text-left"
+                    >
+                      <span className="dashboard-cockpit-tile-icon h-8 w-8">
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-semibold text-vetneb-ink">
+                          {item.label}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {item.detail}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div
+              data-clinic-cockpit-primary-actions="true"
+              className="surface-soft flex min-h-0 flex-col justify-center gap-2 overflow-hidden"
+            >
+              <p className="text-sm font-semibold text-vetneb-ink">
+                Acciones principales
+              </p>
+              <div className="grid grid-cols-1 gap-2">
+                {moduleItems.map((item) => (
+                  <button
+                    key={item.moduleId}
+                    type="button"
+                    onClick={() => activateModule(item.moduleId)}
+                    className="dashboard-btn-interactive flex min-h-9 items-center justify-between rounded-md border border-vetneb-line/70 bg-card/90 px-3 text-sm font-semibold text-vetneb-navy"
+                  >
+                    <span>
+                      {item.moduleId === "tokens"
+                        ? "Generar o abrir tokens"
+                        : `Abrir ${item.label.toLowerCase()}`}
+                    </span>
+                    <span aria-hidden="true">&gt;</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span className="sr-only">
+        {stats ? "Métricas disponibles" : "Métricas no disponibles"}
+      </span>
+    </section>
+  );
+}
+
 export function ClinicDashboardWorkspaceController({
   initialModule,
+  stats,
+  statsLoadError,
+  recentReports,
+  reportsLoadError,
+  recentVisits,
+  visitsLoadError,
   pendingReports,
   activeVisits,
   workspaces,
@@ -103,6 +413,26 @@ export function ClinicDashboardWorkspaceController({
   useEffect(() => {
     setActiveModule(parseModuleFromUrl(searchParams.get("module")));
   }, [searchParams]);
+
+  useEffect(
+    () =>
+      subscribeClinicHubReset(() => {
+        setActiveModule(null);
+        setHasManuallyReturnedToHub(true);
+      }),
+    [],
+  );
+
+  useEffect(
+    () =>
+      subscribeClinicModuleActivate((moduleId) => {
+        const parsed = parseModuleFromUrl(moduleId);
+        if (!parsed) return;
+        setHasManuallyReturnedToHub(false);
+        setActiveModule(parsed);
+      }),
+    [],
+  );
 
   useEffect(() => {
     if (!activeModule) return;
@@ -136,116 +466,44 @@ export function ClinicDashboardWorkspaceController({
     router.replace(ROUTES.dashboard, { scroll: false });
   }, [router]);
 
-  const clinicHero = (
-    <DashboardHubHero
-      variant="clinic"
-      icon={LayoutDashboard}
-      eyebrow="Workspace operativo · Clínica"
-      title="Centro de operaciones clínica"
-      description="Resumen accionable de informes y logística antes de abrir cada módulo."
-      statusLabel={pendingReports > 0 ? "Atención requerida" : "Operación al día"}
-      statusTone={pendingReports > 0 ? "warn" : "ok"}
-      metrics={[
-        {
-          label: "Informes pendientes",
-          value: pendingReports,
-          hint: pendingReports > 0 ? "Requieren atención" : "Sin pendientes",
-        },
-        {
-          label: "Visitas activas",
-          value: activeVisits,
-          hint: activeVisits > 0 ? "En curso o programadas" : "Sin visitas activas",
-        },
-      ]}
-      primaryActionLabel="Abrir centro de operaciones"
-      onPrimaryAction={() => activateModule("operaciones")}
-    />
-  );
-
-  const clinicCards = [
-    {
-      icon: LayoutDashboard,
-      title: "Centro de operaciones",
-      description: "Métricas operativas, informes recientes y visitas activas.",
-      moduleId: "operaciones",
-      onClick: () => activateModule("operaciones"),
-      badge:
-        pendingReports > 0 ? (
-          <span
-            className="inline-flex items-center rounded-full bg-destructive px-2 py-0.5 text-xs font-semibold text-destructive-foreground"
-            aria-label={`${pendingReports} informes pendientes`}
-          >
-            {pendingReports}
-          </span>
-        ) : null,
-      actionLabel: "Ver resumen",
-    },
-    {
-      icon: FileText,
-      title: "Informes",
-      description: "Consultar, filtrar y descargar informes veterinarios.",
-      moduleId: "informes",
-      onClick: () => activateModule("informes"),
-      actionLabel: "Abrir informes",
-    },
-    {
-      icon: Route,
-      title: "Logística",
-      description: "Visitas de campo, planes de ruta y métricas de cumplimiento.",
-      moduleId: "logistica",
-      onClick: () => activateModule("logistica"),
-      badge:
-        activeVisits > 0 ? (
-          <span
-            className="inline-flex items-center rounded-full bg-primary px-2 py-0.5 text-xs font-semibold text-primary-foreground"
-            aria-label={`${activeVisits} visitas activas`}
-          >
-            {activeVisits}
-          </span>
-        ) : null,
-      actionLabel: "Ver logística",
-    },
-    {
-      icon: Building2,
-      title: "Perfil público",
-      description: "Publicar y actualizar el perfil en el banco de especialidades.",
-      moduleId: "perfil",
-      onClick: () => activateModule("perfil"),
-      actionLabel: "Editar perfil",
-    },
-    {
-      icon: KeyRound,
-      title: "Tokens particulares",
-      description: "Generar y gestionar tokens de acceso para pacientes.",
-      moduleId: "tokens",
-      onClick: () => activateModule("tokens"),
-      actionLabel: "Gestionar tokens",
-    },
-  ];
-
   if (activeModule) {
     const meta = MODULE_META[activeModule];
     return (
-      <DashboardModuleWorkspace
-        title={meta.title}
-        description={meta.description}
-        moduleId={activeModule}
-        onBack={backToHub}
+      <div
+        data-dashboard-module-stage="true"
+        data-clinic-dashboard-stage="true"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden dashboard-module-stage"
       >
-        {workspaces[activeModule]}
-      </DashboardModuleWorkspace>
+        <DashboardModuleWorkspace
+          title={meta.title}
+          description={meta.description}
+          moduleId={activeModule}
+          onBack={backToHub}
+        >
+          {workspaces[activeModule]}
+        </DashboardModuleWorkspace>
+      </div>
     );
   }
 
   return (
-    <>
+    <div
+      data-dashboard-module-stage="true"
+      data-clinic-dashboard-stage="true"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden dashboard-module-stage"
+    >
       {pageHeader}
-      <DashboardModuleHub
-        heading="Módulos operativos"
-        description="Acceso rápido a informes, logística, perfil público y tokens de la clínica."
-        cards={clinicCards}
-        hero={clinicHero}
+      <ClinicDashboardCockpit
+        stats={stats}
+        statsLoadError={statsLoadError}
+        recentReports={recentReports}
+        reportsLoadError={reportsLoadError}
+        recentVisits={recentVisits}
+        visitsLoadError={visitsLoadError}
+        pendingReports={pendingReports}
+        activeVisits={activeVisits}
+        activateModule={activateModule}
       />
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/dashboard/ClinicMobileBottomNav.tsx
+++ b/frontend/src/components/dashboard/ClinicMobileBottomNav.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Building2,
+  FileText,
+  Home,
+  KeyRound,
+  LayoutDashboard,
+  Route,
+} from "lucide-react";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import {
+  requestClinicHubReset,
+  requestClinicModuleActivate,
+  subscribeClinicHubReset,
+  subscribeClinicModuleActivate,
+} from "@/lib/clinic-hub-reset";
+import {
+  CLINIC_LAST_MODULE_STORAGE_KEY,
+  writeDashboardLastModule,
+} from "@/lib/dashboard-last-module";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+import type { ClinicModule } from "./ClinicDashboardWorkspaceController";
+
+const CLINIC_DESTINATIONS: Array<{
+  label: string;
+  shortLabel: string;
+  moduleId: ClinicModule;
+  icon: typeof Home;
+}> = [
+  {
+    label: "Operaciones",
+    shortLabel: "Ops",
+    moduleId: "operaciones",
+    icon: LayoutDashboard,
+  },
+  { label: "Informes", shortLabel: "Info", moduleId: "informes", icon: FileText },
+  { label: "Logística", shortLabel: "Log", moduleId: "logistica", icon: Route },
+  { label: "Perfil", shortLabel: "Perfil", moduleId: "perfil", icon: Building2 },
+  { label: "Tokens", shortLabel: "Tokens", moduleId: "tokens", icon: KeyRound },
+];
+
+function parseClinicModuleFromLocation(): ClinicModule | null {
+  if (typeof window === "undefined") return null;
+  const value = new URLSearchParams(window.location.search).get("module");
+  return CLINIC_DESTINATIONS.some((item) => item.moduleId === value)
+    ? (value as ClinicModule)
+    : null;
+}
+
+export function ClinicMobileBottomNav() {
+  const [activeModule, setActiveModule] = useState<ClinicModule | null>(null);
+
+  useEffect(() => {
+    function syncModuleFromLocation() {
+      setActiveModule(parseClinicModuleFromLocation());
+    }
+
+    syncModuleFromLocation();
+    window.addEventListener("popstate", syncModuleFromLocation);
+    return () => window.removeEventListener("popstate", syncModuleFromLocation);
+  }, []);
+
+  useEffect(
+    () =>
+      subscribeClinicModuleActivate((moduleId) => {
+        const destination = CLINIC_DESTINATIONS.find(
+          (item) => item.moduleId === moduleId,
+        );
+        if (!destination) return;
+        setActiveModule(destination.moduleId);
+      }),
+    [],
+  );
+
+  useEffect(
+    () =>
+      subscribeClinicHubReset(() => {
+        setActiveModule(null);
+      }),
+    [],
+  );
+
+  const resetToHub = useCallback(() => {
+    writeDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY, "");
+    setActiveModule(null);
+    requestClinicHubReset();
+  }, []);
+
+  return (
+    <nav
+      aria-label="Navegación móvil de clínica"
+      data-clinic-mobile-bottom-nav="true"
+      className="clinic-mobile-bottom-nav md:hidden"
+    >
+      <PublicRouteControl
+        href={ROUTES.dashboard}
+        prefetch={false}
+        variant="bare"
+        aria-label="Inicio"
+        aria-current={!activeModule ? "page" : undefined}
+        data-clinic-mobile-bottom-nav-item="true"
+        onClick={resetToHub}
+        className={cn(
+          "clinic-mobile-bottom-nav-item",
+          !activeModule && "clinic-mobile-bottom-nav-item-active",
+        )}
+      >
+        <Home className="h-4 w-4" aria-hidden="true" />
+        <span>Inicio</span>
+      </PublicRouteControl>
+
+      {CLINIC_DESTINATIONS.map((destination) => {
+        const Icon = destination.icon;
+        const isActive = activeModule === destination.moduleId;
+        return (
+          <PublicRouteControl
+            key={destination.moduleId}
+            href={`${ROUTES.dashboard}?module=${destination.moduleId}`}
+            prefetch={false}
+            variant="bare"
+            aria-label={destination.label}
+            aria-current={isActive ? "page" : undefined}
+            data-clinic-mobile-bottom-nav-item="true"
+            onClick={() => {
+              setActiveModule(destination.moduleId);
+              requestClinicModuleActivate(destination.moduleId);
+            }}
+            className={cn(
+              "clinic-mobile-bottom-nav-item",
+              isActive && "clinic-mobile-bottom-nav-item-active",
+            )}
+          >
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            <span>{destination.shortLabel}</span>
+          </PublicRouteControl>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/dashboard/ClinicMobileModuleFrame.tsx
+++ b/frontend/src/components/dashboard/ClinicMobileModuleFrame.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import type { ClinicModule } from "./ClinicDashboardWorkspaceController";
+
+type ClinicMobileModuleFrameProps = {
+  moduleId: ClinicModule;
+  children: ReactNode;
+};
+
+export function ClinicMobileModuleFrame({
+  moduleId,
+  children,
+}: ClinicMobileModuleFrameProps) {
+  return (
+    <section
+      data-clinic-mobile-module={moduleId}
+      className="clinic-mobile-module-frame"
+    >
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { CompactPager } from "@/components/dashboard/CompactPager";
+import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import {
@@ -754,12 +755,23 @@ export function ClinicParticularTokensCard() {
                 />
               </>
             ) : (
-              <p className="surface-empty m-4">
-                {isLoadingTokens
-                  ? "Cargando tokens particulares..."
-                  : "No hay tokens particulares generados por esta clínica."}
-                </p>
-              )}
+              <div className="m-4 flex min-h-0 flex-1">
+                <EmptyState
+                  title={
+                    isLoadingTokens
+                      ? "Cargando tokens particulares..."
+                      : "Sin tokens particulares"
+                  }
+                  description={
+                    isLoadingTokens
+                      ? "Consultando los últimos tokens generados por la clínica."
+                      : "No hay tokens particulares generados por esta clínica."
+                  }
+                  size="sm"
+                  className="w-full"
+                />
+              </div>
+            )}
           </div>
         </section>
       </CardContent>

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -260,6 +260,9 @@ export function ClinicPublicProfileCard() {
   const [isAvatarDeleting, setIsAvatarDeleting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [profileLoadErrorMessage, setProfileLoadErrorMessage] = useState<
+    string | null
+  >(null);
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
   const avatarObjectUrlRef = useRef<string | null>(null);
 
@@ -285,6 +288,7 @@ export function ClinicPublicProfileCard() {
   async function loadProfile() {
     setIsLoading(true);
     setErrorMessage(null);
+    setProfileLoadErrorMessage(null);
 
     try {
       const snapshot = await getClinicPublicProfile();
@@ -292,7 +296,7 @@ export function ClinicPublicProfileCard() {
       setProfile(snapshot.profile);
       setFormState(toFormState(snapshot.profile));
     } catch (error) {
-      setErrorMessage(
+      setProfileLoadErrorMessage(
         error instanceof Error
           ? error.message
           : "No se pudo cargar el perfil público de la clínica.",
@@ -770,6 +774,30 @@ export function ClinicPublicProfileCard() {
       </CardHeader>
       <CardContent className="flex min-h-0 flex-1 flex-col px-5 py-3">
         <form className="flex min-h-0 flex-1 flex-col gap-3" onSubmit={handleSubmit}>
+          {isLoading ? (
+            <p className="clinical-alert-info px-3 py-2" role="status">
+              Cargando perfil público...
+            </p>
+          ) : null}
+
+          {profileLoadErrorMessage ? (
+            <div
+              className="clinical-alert-error flex flex-wrap items-center justify-between gap-2 px-3 py-2"
+              role="alert"
+            >
+              <span>{profileLoadErrorMessage}</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void loadProfile()}
+                disabled={isWorking}
+              >
+                Reintentar carga
+              </Button>
+            </div>
+          ) : null}
+
           <ModuleTabs
             ariaLabel="Edición de perfil público"
             tabs={[

--- a/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
+++ b/frontend/src/components/dashboard/DashboardHorizontalNav.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
@@ -113,6 +114,7 @@ function DashboardHorizontalNavInner() {
       <div ref={navScrollerRef} className="flex min-w-0 flex-1 scroll-px-2 items-center gap-1 overflow-x-auto overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {items.map((item) => {
           const active = isItemActive(item, pathname, activeModule);
+          const itemModule = getModuleFromHref(item.href);
 
           return (
             <PublicRouteControl
@@ -122,6 +124,10 @@ function DashboardHorizontalNavInner() {
               variant="bare"
               aria-label={item.label}
               aria-current={active ? "page" : undefined}
+              onClick={() => {
+                if (surface !== "clinic" || !itemModule) return;
+                requestClinicModuleActivate(itemModule);
+              }}
               className={cn(
                 "inline-flex min-h-10 shrink-0 items-center whitespace-nowrap rounded-md border-b-2 border-transparent px-2.5 py-1.5 text-[0.8125rem] font-semibold dashboard-nav-interactive focus-visible:ring-offset-2 sm:min-h-[1.85rem] sm:py-1",
                 active
@@ -158,7 +164,7 @@ export function DashboardHorizontalNav() {
       role="navigation"
       aria-label="Navegación principal"
       data-dashboard-horizontal-nav-shell="true"
-      className="shrink-0 border-t border-vetneb-line/70 bg-card/85"
+      className="hidden shrink-0 border-t border-vetneb-line/70 bg-card/85 md:block"
     >
       <Suspense fallback={<div className="min-h-[2.75rem] sm:min-h-[2.25rem]" aria-hidden="true" />}>
         <DashboardHorizontalNavInner />

--- a/frontend/src/components/dashboard/DashboardRefreshButton.tsx
+++ b/frontend/src/components/dashboard/DashboardRefreshButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type DashboardRefreshButtonProps = {
+  label?: string;
+  className?: string;
+};
+
+export function DashboardRefreshButton({
+  label = "Reintentar",
+  className,
+}: DashboardRefreshButtonProps) {
+  const router = useRouter();
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => router.refresh()}
+      className={className}
+    >
+      <RefreshCw className="h-4 w-4" aria-hidden="true" />
+      {label}
+    </Button>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardShellRouter.tsx
+++ b/frontend/src/components/dashboard/DashboardShellRouter.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/app-shell-release";
 import { AdminMobileBottomNav } from "./AdminMobileBottomNav";
 import { BackForwardCacheGuard } from "./BackForwardCacheGuard";
+import { ClinicMobileBottomNav } from "./ClinicMobileBottomNav";
 
 export function DashboardShellRouter({
   children,
@@ -34,7 +35,9 @@ export function DashboardShellRouter({
       </div>
       {isAdminDashboard ? (
         <AdminMobileBottomNav />
-      ) : null}
+      ) : (
+        <ClinicMobileBottomNav />
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/clinic-hub-reset.ts
+++ b/frontend/src/lib/clinic-hub-reset.ts
@@ -1,0 +1,35 @@
+type ClinicHubResetListener = () => void;
+
+const hubResetListeners = new Set<ClinicHubResetListener>();
+
+export function requestClinicHubReset(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  hubResetListeners.forEach((listener) => listener());
+}
+
+export function subscribeClinicHubReset(
+  listener: ClinicHubResetListener,
+): () => void {
+  hubResetListeners.add(listener);
+  return () => hubResetListeners.delete(listener);
+}
+
+type ClinicModuleActivateListener = (moduleId: string) => void;
+
+const moduleActivateListeners = new Set<ClinicModuleActivateListener>();
+
+export function requestClinicModuleActivate(moduleId: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  moduleActivateListeners.forEach((listener) => listener(moduleId));
+}
+
+export function subscribeClinicModuleActivate(
+  listener: ClinicModuleActivateListener,
+): () => void {
+  moduleActivateListeners.add(listener);
+  return () => moduleActivateListeners.delete(listener);
+}

--- a/test/frontend-dashboard-horizontal-nav.test.ts
+++ b/test/frontend-dashboard-horizontal-nav.test.ts
@@ -84,6 +84,15 @@ test("clinic horizontal nav resolves all 5 modules via ?module= (PR-CL4)", () =>
   assert.ok(source.includes('`${ROUTES.dashboard}?module=perfil`'));
 });
 
+test("clinic horizontal nav notifies the controller before route navigation", () => {
+  const source = read(HORIZONTAL_NAV_PATH);
+
+  assert.ok(source.includes('import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";'));
+  assert.ok(source.includes("const itemModule = getModuleFromHref(item.href);"));
+  assert.ok(source.includes('if (surface !== "clinic" || !itemModule) return;'));
+  assert.ok(source.includes("requestClinicModuleActivate(itemModule);"));
+});
+
 test("horizontal nav resolves admin/clinic surface from the route", () => {
   const source = read(HORIZONTAL_NAV_PATH);
 
@@ -120,9 +129,14 @@ test("topbar embeds the horizontal nav and drops the decorative eyebrow", () => 
 test("shell router no longer renders a vertical sidebar as primary navigation", () => {
   const source = read(SHELL_ROUTER_PATH);
 
+  assert.ok(source.includes('import { AdminMobileBottomNav } from "./AdminMobileBottomNav";'));
+  assert.ok(source.includes('import { ClinicMobileBottomNav } from "./ClinicMobileBottomNav";'));
   assert.equal(source.includes("AdminDashboardSidebar"), false);
   assert.equal(source.includes("ClinicDashboardSidebar"), false);
   assert.equal(source.includes("<aside"), false);
   assert.ok(source.includes("flex flex-col h-dvh overflow-hidden"));
   assert.ok(source.includes("data-vetneb-app-shell-surface={surface}"));
+  assert.ok(source.includes("isAdminDashboard ? ("));
+  assert.ok(source.includes("<AdminMobileBottomNav />"));
+  assert.ok(source.includes("<ClinicMobileBottomNav />"));
 });

--- a/test/frontend-dashboard-hub-hero.test.ts
+++ b/test/frontend-dashboard-hub-hero.test.ts
@@ -101,15 +101,23 @@ test("DashboardModuleHub renders the hero slot outside the module-card section",
 
 // ── Clinic controller wiring ─────────────────────────────────────────────────
 
-test("clinic controller renders a clinic hero with live operational metrics", () => {
+test("clinic controller renders a clinic cockpit with live operational metrics", () => {
   const source = read(CLINIC_CONTROLLER_PATH);
 
-  assert.ok(source.includes('import { DashboardHubHero } from "./DashboardHubHero";'));
-  assert.ok(source.includes('variant="clinic"'));
-  assert.ok(source.includes("value: pendingReports,"));
-  assert.ok(source.includes("value: activeVisits,"));
-  assert.ok(source.includes('onPrimaryAction={() => activateModule("operaciones")}'));
-  assert.ok(source.includes("hero={clinicHero}"));
+  assert.equal(source.includes('import { DashboardHubHero } from "./DashboardHubHero";'), false);
+  assert.equal(source.includes('import { DashboardModuleHub } from "./DashboardModuleHub";'), false);
+  assert.ok(source.includes('data-clinic-cockpit="true"'));
+  assert.ok(source.includes('data-clinic-cockpit-status="true"'));
+  assert.ok(source.includes('data-clinic-cockpit-attention="true"'));
+  assert.ok(source.includes('data-clinic-cockpit-continuity="true"'));
+  assert.ok(source.includes('data-clinic-cockpit-activity="true"'));
+  assert.ok(source.includes('data-clinic-cockpit-modules="true"'));
+  assert.ok(source.includes('data-clinic-cockpit-primary-actions="true"'));
+  assert.ok(source.includes("{statsLoadError ? \"—\" : pendingReports}"));
+  assert.ok(source.includes("{statsLoadError ? \"—\" : activeVisits}"));
+  assert.ok(source.includes("onClick={() => activateModule(item.moduleId)}"));
+  assert.ok(source.includes('data-dashboard-module-stage="true"'));
+  assert.ok(source.includes('data-clinic-dashboard-stage="true"'));
   assert.equal(source.includes('variant="admin"'), false);
 });
 


### PR DESCRIPTION
## Summary
- Aligns the private Clinic dashboard structure with the Admin dashboard benchmark.
- Adds Clinic cockpit hub, persistent stage, dedicated mobile bottom navigation, clinic-specific module sync, mobile-operable module frames, improved loading/empty/error/retry states, and E2E/native coverage.
- Preserves existing full Clinic routes.

## Scope
- Private Clinic dashboard frontend.
- Clinic dashboard E2E and native tests.
- Implementation evidence in docs/implementation.

## Out of scope
- Backend/API/auth/DB/migrations.
- Dependencies/lockfiles.
- CI/workflows.
- Public /clinicas.
- Admin productive behavior.

## Validations reported by Codex
- pnpm typecheck:test
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm test
- pnpm security:public-surface
- pnpm build
- pnpm --dir frontend build
- Playwright Clinic/dashboard shell specs: 83 tests passed
- git diff --check