### PR TITLE
fix(dashboard): align shell frame insets and viewport fit

### DIFF
--- a/docs/implementation/dashboard-shell-frame-inset-parity.md
+++ b/docs/implementation/dashboard-shell-frame-inset-parity.md
@@ -1,0 +1,83 @@
+# Dashboard Shell Frame Inset Parity
+
+## Estado base
+
+- Rama auditada: `fix/dashboard-shell-frame-inset-parity`.
+- HEAD inicial: `9b834a1 feat(clinic): align dashboard structure with admin benchmark (#1142)`.
+- Estado inicial: `git status --short` limpio.
+- Entorno usado: Windows, PowerShell, PNPM.
+
+## Scope incluido
+
+- Frame/layout del dashboard privado compartido.
+- Inset inferior del `main.dashboard-main` alineado con el inset lateral.
+- Contencion del stage persistente `data-dashboard-module-stage`.
+- Cobertura E2E para Admin y Clinica en desktop/mobile.
+- Modulos criticos Clinica cubiertos: Resumen (`operaciones`), Informes y Tokens.
+
+## Scope excluido
+
+- Backend, API, DB, Drizzle, migraciones y schema.
+- Auth, cookies, sesiones, CSRF, CORS, CSP y rate limits.
+- Dependencias, `package.json`, lockfiles, CI y workflows.
+- Pagina publica `/clinicas` y marketing publico.
+- Refactors globales o redisenos de modulos fuera del frame privado.
+
+## Auditoria previa
+
+- Se confirmo rama esperada y base limpia.
+- Se revisaron `globals.css`, `DashboardShellRouter`, `DashboardModuleWorkspace`, `DashboardModuleHub`, `ModuleSurface`, `ClinicMobileModuleFrame`, controllers Admin/Clinica y specs dashboard shell/layout/no-scroll.
+- Se buscaron referencias legacy de `dashboard-main`, `dashboard-module-stage`, `overflow-y-auto`, `ModuleSurface` y contratos no-scroll.
+- Riesgo identificado: el shell es compartido por Admin y Clinica; el cambio se dejo en tokens CSS del app shell y un contrato E2E por rectangulos reales.
+
+## Problema corregido
+
+El padding vertical del frame usaba el mismo token para top/bottom (`--dash-pad-y`), mientras el lateral usaba `--dash-pad-x`. En desktop esto dejaba el borde inferior visualmente mas pegado que los laterales. El stage compartido tampoco tenia un contrato CSS explicito de maximo ancho/alto como hijo flex contenido.
+
+## Cambios
+
+- `--dash-frame-inset-inline`, `--dash-frame-inset-block-start` y `--dash-frame-inset-block-end` separan ritmo vertical de inset visual.
+- `padding-block-end` de `dashboard-main` ahora usa el mismo token que el lateral.
+- `data-dashboard-module-stage` queda blindado como hijo flex contenido con `min/max`, `flex: 1 1 auto` y `overflow: hidden`.
+- `dashboard-workspace-layout-polish.spec.ts` mide:
+  - no overflow horizontal,
+  - no overflow vertical efectivo en `main`,
+  - paridad left/right/bottom entre `main` y stage,
+  - stage y superficie dentro del viewport,
+  - Admin y Clinica en desktop/mobile,
+  - Clinica Resumen, Informes y Tokens.
+
+## Archivos modificados
+
+- `frontend/src/app/globals.css`
+- `frontend/e2e/dashboard-workspace-layout-polish.spec.ts`
+- `docs/implementation/dashboard-shell-frame-inset-parity.md`
+
+## Validaciones
+
+- `git diff --check`: ejecutado, paso.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts`: ejecutado, paso; 16 passed.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts`: ejecutado, paso; 4 passed.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts`: ejecutado, paso; 25 passed.
+- `pnpm --dir frontend lint`: ejecutado, paso.
+- `pnpm typecheck:test`: ejecutado, paso.
+- `pnpm --dir frontend typecheck`: ejecutado, paso.
+- `pnpm --dir frontend build`: ejecutado, paso.
+- `pnpm test`: ejecutado, paso; 2840 passed.
+- `pnpm security:public-surface`: ejecutado, paso; reporto solo hallazgos server-only esperados en `frontend/src/proxy.ts`.
+- `pnpm build`: ejecutado, paso.
+
+## Resultado
+
+El dashboard privado queda con inset inferior alineado al lateral y el stage compartido queda contenido dentro del viewport sin convertir `main` en scroll container. Admin y Clinica conservan el contrato no-scroll y los modulos criticos de Clinica quedan cubiertos por E2E.
+
+## Riesgo residual
+
+- La evidencia visual mobile corresponde a Chromium/Playwright con viewports emulados; no reemplaza smoke fisico en dispositivos reales.
+- Cambios futuros en `globals.css`, `DashboardShellRouter`, controllers de workspace o bottom nav deben reejecutar los specs de shell/no-scroll.
+
+## Estado final
+
+- Implementacion completada dentro del scope solicitado.
+- Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI, cookies ni paginas publicas.
+- Sin commit, push ni PR.

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from "@playwright/test";
 
 type Page = import("@playwright/test").Page;
 
+const TOLERANCE = 2;
+
 async function setClinicSession(page: Page) {
   await page.context().addCookies([
     {
@@ -20,6 +22,220 @@ async function setAdminSession(page: Page) {
       url: "http://127.0.0.1:3000",
     },
   ]);
+}
+
+type Surface = "clinic" | "admin";
+
+type FrameRouteCase = {
+  label: string;
+  surface: Surface;
+  path: string;
+  ready: string;
+};
+
+const FRAME_VIEWPORTS = [
+  { name: "desktop-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+const FRAME_ROUTES: FrameRouteCase[] = [
+  {
+    label: "clinic resumen",
+    surface: "clinic",
+    path: "/dashboard?module=operaciones",
+    ready: '[data-dashboard-module-workspace="operaciones"]',
+  },
+  {
+    label: "clinic informes",
+    surface: "clinic",
+    path: "/dashboard?module=informes",
+    ready: '[data-dashboard-module-workspace="informes"]',
+  },
+  {
+    label: "clinic tokens",
+    surface: "clinic",
+    path: "/dashboard?module=tokens",
+    ready: '[data-dashboard-module-workspace="tokens"]',
+  },
+  {
+    label: "admin resumen",
+    surface: "admin",
+    path: "/dashboard/admin?module=admin",
+    ready: '[data-dashboard-module-workspace="admin"]',
+  },
+];
+
+type RectMetric = {
+  present: boolean;
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+type FrameFitMetrics = {
+  viewportWidth: number;
+  viewportHeight: number;
+  htmlScrollWidth: number;
+  htmlClientWidth: number;
+  bodyScrollWidth: number;
+  bodyClientWidth: number;
+  mainScrollHeight: number;
+  mainClientHeight: number;
+  mainScrollWidth: number;
+  mainClientWidth: number;
+  mainOverflowY: string;
+  mainPaddingLeft: string;
+  mainPaddingRight: string;
+  mainPaddingBottom: string;
+  main: RectMetric;
+  stage: RectMetric;
+  surface: RectMetric;
+};
+
+async function applySession(page: Page, surface: Surface) {
+  if (surface === "clinic") {
+    await setClinicSession(page);
+  } else {
+    await setAdminSession(page);
+  }
+}
+
+async function readFrameFitMetrics(page: Page): Promise<FrameFitMetrics> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const stage = document.querySelector<HTMLElement>(
+      '[data-dashboard-module-stage="true"]',
+    );
+    const workspace = document.querySelector<HTMLElement>(
+      "[data-dashboard-module-workspace]",
+    );
+    const hub = document.querySelector<HTMLElement>(
+      '[data-dashboard-module-hub="true"]',
+    );
+    const surfaceRoot = workspace ?? hub;
+    const surface =
+      surfaceRoot?.querySelector<HTMLElement>(
+        '[data-dashboard-module-surface="true"], .dashboard-surface, [data-module-tabs="true"]',
+      ) ?? surfaceRoot;
+    const mainStyle = main ? window.getComputedStyle(main) : null;
+
+    const rectFor = (element: Element | null): RectMetric => {
+      if (!element) {
+        return {
+          present: false,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          width: 0,
+          height: 0,
+        };
+      }
+
+      const rect = element.getBoundingClientRect();
+
+      return {
+        present: true,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      };
+    };
+
+    return {
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      htmlScrollWidth: html.scrollWidth,
+      htmlClientWidth: html.clientWidth,
+      bodyScrollWidth: body.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      mainScrollHeight: main?.scrollHeight ?? 0,
+      mainClientHeight: main?.clientHeight ?? 0,
+      mainScrollWidth: main?.scrollWidth ?? 0,
+      mainClientWidth: main?.clientWidth ?? 0,
+      mainOverflowY: mainStyle?.overflowY ?? "missing",
+      mainPaddingLeft: mainStyle?.paddingLeft ?? "0px",
+      mainPaddingRight: mainStyle?.paddingRight ?? "0px",
+      mainPaddingBottom: mainStyle?.paddingBottom ?? "0px",
+      main: rectFor(main),
+      stage: rectFor(stage),
+      surface: rectFor(surface ?? null),
+    };
+  });
+}
+
+function assertDashboardFrameFit(metrics: FrameFitMetrics, label: string) {
+  expect(metrics.main.present, `${label}: main present`).toBe(true);
+  expect(metrics.stage.present, `${label}: dashboard stage present`).toBe(true);
+  expect(metrics.surface.present, `${label}: dashboard surface present`).toBe(true);
+
+  expect(
+    metrics.htmlScrollWidth,
+    `${label}: documentElement horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.htmlClientWidth + TOLERANCE);
+  expect(
+    metrics.bodyScrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.bodyClientWidth + TOLERANCE);
+  expect(
+    metrics.mainScrollWidth,
+    `${label}: main horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.mainClientWidth + TOLERANCE);
+  expect(
+    metrics.mainScrollHeight,
+    `${label}: main vertical overflow`,
+  ).toBeLessThanOrEqual(metrics.mainClientHeight + TOLERANCE);
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main must not become operational scroll`,
+  ).not.toBe("auto");
+  expect(
+    metrics.mainOverflowY,
+    `${label}: main must not become operational scroll`,
+  ).not.toBe("scroll");
+
+  const inlineStartInset = metrics.stage.left - metrics.main.left;
+  const inlineEndInset = metrics.main.right - metrics.stage.right;
+  const blockEndInset = metrics.main.bottom - metrics.stage.bottom;
+
+  expect(
+    Math.abs(inlineStartInset - inlineEndInset),
+    `${label}: left/right frame inset parity`,
+  ).toBeLessThanOrEqual(TOLERANCE);
+  expect(
+    Math.abs(blockEndInset - inlineStartInset),
+    `${label}: bottom frame inset must match lateral inset (left=${inlineStartInset}, bottom=${blockEndInset}, css bottom=${metrics.mainPaddingBottom}, css left=${metrics.mainPaddingLeft})`,
+  ).toBeLessThanOrEqual(TOLERANCE);
+  expect(
+    Math.abs(blockEndInset - inlineEndInset),
+    `${label}: bottom frame inset must match lateral inset (right=${inlineEndInset}, bottom=${blockEndInset}, css bottom=${metrics.mainPaddingBottom}, css right=${metrics.mainPaddingRight})`,
+  ).toBeLessThanOrEqual(TOLERANCE);
+
+  expect(metrics.stage.left, `${label}: stage clipped left`).toBeGreaterThanOrEqual(
+    metrics.main.left - TOLERANCE,
+  );
+  expect(metrics.stage.right, `${label}: stage clipped right`).toBeLessThanOrEqual(
+    metrics.main.right + TOLERANCE,
+  );
+  expect(metrics.stage.bottom, `${label}: stage clipped bottom`).toBeLessThanOrEqual(
+    metrics.main.bottom + TOLERANCE,
+  );
+  expect(
+    metrics.surface.bottom,
+    `${label}: module surface clipped by viewport bottom`,
+  ).toBeLessThanOrEqual(metrics.viewportHeight + TOLERANCE);
+  expect(
+    metrics.surface.right,
+    `${label}: module surface clipped by viewport right`,
+  ).toBeLessThanOrEqual(metrics.viewportWidth + TOLERANCE);
 }
 
 test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
@@ -120,3 +336,29 @@ test.describe("dashboard workspace layout polish — smoke (PR-2)", () => {
     expect(overflow).toBeLessThanOrEqual(5);
   });
 });
+
+for (const viewport of FRAME_VIEWPORTS) {
+  test.describe(`dashboard frame inset parity — ${viewport.name}`, () => {
+    for (const routeCase of FRAME_ROUTES) {
+      test(`${routeCase.label} keeps contained frame`, async ({ page }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await applySession(page, routeCase.surface);
+        await page.goto(routeCase.path);
+        await expect(page.locator(routeCase.ready).first()).toBeVisible({
+          timeout: 12_000,
+        });
+
+        await expect(async () => {
+          const metrics = await readFrameFitMetrics(page);
+          assertDashboardFrameFit(
+            metrics,
+            `${viewport.name} ${routeCase.label}`,
+          );
+        }).toPass({ timeout: 10_000 });
+      });
+    }
+  });
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2083,6 +2083,9 @@
     --dash-pad-x: clamp(0.75rem, 0.45rem + 1vw, 2rem);
     --dash-pad-y: clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem);
     --dash-rhythm: clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem);
+    --dash-frame-inset-inline: var(--dash-pad-x);
+    --dash-frame-inset-block-start: var(--dash-pad-y);
+    --dash-frame-inset-block-end: var(--dash-pad-x);
 
     /* Panels / cards: gap between panels, internal card padding, master/detail
        floor (replaces the rigid 18rem that forced 36rem in single-column). */
@@ -2151,8 +2154,9 @@
 
   /* ── Apply tokens (higher specificity than the base utility rules) ───────── */
   .dashboard-app-shell .dashboard-main {
-    padding-inline: var(--dash-pad-x);
-    padding-block: var(--dash-pad-y);
+    padding-inline: var(--dash-frame-inset-inline);
+    padding-block-start: var(--dash-frame-inset-block-start);
+    padding-block-end: var(--dash-frame-inset-block-end);
   }
 
   .dashboard-app-shell .dashboard-main > :not([hidden]) ~ :not([hidden]) {
@@ -2166,6 +2170,16 @@
     > :not([hidden])
     ~ :not([hidden]) {
     margin-block-start: var(--dash-rhythm);
+  }
+
+  .dashboard-app-shell [data-dashboard-module-stage="true"] {
+    box-sizing: border-box;
+    min-width: 0;
+    min-height: 0;
+    max-width: 100%;
+    max-height: 100%;
+    flex: 1 1 auto;
+    overflow: hidden;
   }
 
   .dashboard-app-shell .dashboard-cockpit {


### PR DESCRIPTION
## Summary
- Aligns private dashboard shell frame insets so bottom spacing matches lateral spacing.
- Keeps Admin and Clinic dashboard surfaces contained in the viewport.
- Preserves no-scroll contracts and updates shell/frame E2E coverage.

## Scope
- Dashboard private shell/frame CSS.
- Dashboard workspace layout E2E coverage.
- Implementation evidence in docs/implementation.

## Out of scope
- Backend/API/auth/DB/migrations.
- Dependencies/lockfiles.
- CI/workflows.
- Public /clinicas.
- Business logic.

## Validations
- pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-mobile-shell-nav-contract.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
- pnpm test