### PR TITLE
fix(clinic): port admin dashboard layout metrics to clinic modules

### DIFF
--- a/docs/implementation/clinic-port-admin-layout-metrics.md
+++ b/docs/implementation/clinic-port-admin-layout-metrics.md
@@ -1,0 +1,147 @@
+# Clinic Port Admin Layout Metrics
+
+## Estado base
+
+- Rama: `fix/clinic-port-admin-layout-metrics`.
+- HEAD inicial auditado: `102eebc fix(dashboard): align shell frame insets and viewport fit (#1143)`.
+- Estado inicial: `git status --short --untracked-files=all` limpio.
+- Entorno usado: Windows, PowerShell, PNPM.
+
+## Scope incluido
+
+- Portar metricas estructurales del dashboard Admin a modulos Clinica.
+- Reestructurar Tokens Clinica sin duplicar funciones Admin.
+- Reestructurar Perfil Clinica sin convertirlo en formulario largo con scroll.
+- Mantener funciones clinicas actuales: operaciones, informes, tokens particulares, logistica y perfil publico.
+- Reforzar tests e2e y tests nativos del contrato no-scroll y de estructura.
+
+## Scope excluido
+
+- Backend, API, DB, Drizzle, migraciones, schema y endpoints.
+- Auth, cookies, CORS, CSP, rate limits y seguridad de sesiones.
+- Dependencias, `package.json`, lockfiles, CI y workflows.
+- Pagina publica `/clinicas`.
+- Cambios productivos en dashboard Admin; Admin se uso solo como referencia de lectura.
+- Copia de textos, permisos, modulos o funciones administrativas en Clinica.
+
+## Auditoria previa
+
+- Se confirmo base limpia, rama esperada y ultimo commit.
+- Se confirmaron scripts reales en `package.json` y `frontend/package.json`.
+- Se leyeron referencias Admin: `DashboardModuleWorkspace`, `ModuleSurface`, `ModuleTabs`, `AdminDashboardWorkspaceController`, `AdminCommandCenter`, `AdminParticularTokensCard` y `globals.css`.
+- Se leyeron superficies Clinica: controller, Tokens, Perfil, mobile frame, command center, Informes y Logistica.
+- Se revisaron specs e2e indicados y tests fuente relacionados.
+- Referencias legacy detectadas en el scope: `dashboard-inline-scroll` en Tokens Clinica y `overflow-y-auto` en Perfil Clinica.
+
+## Metricas Admin extraidas
+
+- Stage/frame: `dashboard-main` usa `--dash-frame-inset-inline`, `--dash-frame-inset-block-start` y `--dash-frame-inset-block-end`.
+- Padding base: `--dash-pad-x: clamp(0.75rem, 0.45rem + 1vw, 2rem)`.
+- Padding vertical base: `--dash-pad-y: clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem)`.
+- Rhythm entre secciones: `--dash-rhythm: clamp(0.6rem, 0.4rem + 0.7vh, 1.5rem)`.
+- Gap de modulo: `--dash-gap: clamp(0.55rem, 0.35rem + 0.55vh, 1rem)`.
+- Superficie de modulo: `dashboard-module-surface` es `flex`, `min-height: 0`, `flex: 1 1 auto`, `overflow: hidden`.
+- Toolbar: `dashboard-module-toolbar` es fija, `flex-wrap`, `gap: 0.5rem 0.75rem`.
+- Body: `dashboard-module-body` crece con `flex: 1 1 auto`, `min-height: 0` y `overflow: hidden`.
+- Tabs: `dashboard-module-tabs` y `dashboard-module-tabpanel` mantienen `flex: 1 1 auto`, `min-height: 0`.
+- Altura tabs: `--dash-tab-h: clamp(1.9rem, 1.6rem + 0.7vh, 2.25rem)`.
+- Paneles: `--dash-panel-min: clamp(6rem, 1rem + 18vh, 18rem)`.
+- Densidad de filas: `--dash-list-pad-y: clamp(0.4rem, 0.3rem + 0.25vh, 0.65rem)`.
+- Footer/paginacion: `dashboard-compact-pager` queda `flex-shrink: 0` y visible en el cuerpo del modulo.
+
+## Valores portados a Clinica
+
+- Tokens y Perfil ahora usan `ModuleSurface`, por lo tanto heredan `dashboard-module-surface`, `dashboard-module-toolbar`, `dashboard-module-body`, `--dash-gap` y la cadena `min-h-0 + overflow hidden`.
+- `globals.css` agrega reglas acotadas a `[data-vetneb-app-shell-surface="clinic"]` para toolbar de Tokens/Perfil y cuerpos no-scroll.
+- Tokens reemplaza lista scrollable por lista paginada bounded con `data-clinic-access-list-body`.
+- Perfil reemplaza formulario largo por tabs internos `Estado`, `Datos`, `Contacto` y `Contenido`.
+- Las acciones primarias quedan en toolbar: `Generar token particular`, `Actualizar` y `Guardar perfil publico`.
+- La paginacion de Tokens queda visible con `CompactPager`.
+
+## Cambios
+
+- `ClinicParticularTokensCard`:
+  - Migra de `Card` a `ModuleSurface`.
+  - Mueve metricas y acciones a toolbar compacta.
+  - Elimina `dashboard-inline-scroll`.
+  - Separa lista paginada y detalle compacto.
+  - Conserva alta de token en `ModuleDialog`.
+  - Conserva estado activo/inactivo, informe vinculado, seguimiento, detalle y paginacion.
+- `ClinicPublicProfileCard`:
+  - Migra de `Card` a `ModuleSurface`.
+  - Mueve `Guardar perfil publico` a toolbar del modulo.
+  - Divide campos en tabs compactos para evitar scroll largo.
+  - Elimina `overflow-y-auto`.
+  - Conserva avatar/logo, visibilidad, calidad, datos, contenido y guardado.
+- `globals.css`:
+  - Agrega reglas Clinica scoped para toolbars y cuerpos bounded no-scroll.
+- Tests:
+  - Tokens mobile valida lista sin scroll interno, toolbar, accion primaria, paginador y ausencia de modulos Admin.
+  - Perfil mobile valida tabs, accion primaria visible y cero contenedores scroll internos.
+  - Layout polish e internal no-scroll cubren `perfil` y `tokens`.
+  - Tests fuente actualizan contratos de Tokens y Perfil.
+
+## Archivos modificados
+
+- `frontend/src/app/globals.css`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ClinicPublicProfileCard.tsx`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts`
+- `frontend/e2e/dashboard-workspace-layout-polish.spec.ts`
+- `frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `test/frontend-clinic-public-profile.test.ts`
+- `docs/implementation/clinic-port-admin-layout-metrics.md`
+
+## Funciones clinicas preservadas
+
+- Generar token particular.
+- Actualizar tokens.
+- Listar tokens de la clinica.
+- Ver estado activo/inactivo.
+- Ver si el token tiene informe.
+- Ver detalle y seguimiento del token clinico.
+- Paginacion de tokens.
+- Publicar/actualizar perfil publico.
+- Estado de visibilidad, calidad/completitud, avatar/logo, datos, contenido y guardado.
+
+## Confirmacion de no duplicar Admin
+
+- No se importaron helpers Admin en Clinica.
+- No se agregaron permisos, modulos ni textos administrativos a Clinica.
+- No se copiaron acciones Admin como eliminar tokens, gestionar clinicas, usuarios, auditoria, precios, sesiones o mantenimiento.
+- Los tests e2e verifican ausencia de `Usuarios y roles`, `Auditoria` y `Mantenimiento` en Tokens/Perfil Clinica.
+
+## Scroll eliminado
+
+- Tokens Clinica: se removio `dashboard-inline-scroll` del modulo.
+- Perfil Clinica: se removio `overflow-y-auto` de los paneles.
+- Se agregaron assertions e2e para detectar `overflow-y: auto/scroll` dentro de Tokens y Perfil.
+- `body`, `html` y `main.dashboard-main` siguen bajo contrato no-scroll.
+
+## Validaciones
+
+- `git diff --check`: ejecutado, paso; solo avisos CRLF de Git en Windows.
+- `pnpm --dir frontend typecheck`: ejecutado, paso.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`: ejecutado, paso; 3/3.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-perfil-mobile-operability.spec.ts`: ejecutado, paso; 3/3.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts`: ejecutado, paso; 18/18.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts`: ejecutado, paso; 8/8.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts`: ejecutado, paso; 4/4.
+- `pnpm --dir frontend lint`: ejecutado, paso.
+- `pnpm typecheck:test`: ejecutado, paso.
+- `pnpm --dir frontend build`: ejecutado, paso.
+- `pnpm test`: ejecutado, paso; 2840/2840.
+- `pnpm security:public-surface`: ejecutado, paso; solo reporto hallazgos `server-only` existentes en `frontend/src/proxy.ts`.
+- `pnpm build`: ejecutado, paso.
+
+## Riesgo residual
+
+- La evidencia visual/no-scroll depende de Playwright Chromium; no reemplaza smoke en dispositivo fisico.
+- Informes y Logistica conservan `dashboard-inline-scroll` existente porque el pedido duro de eliminacion aplica a Tokens y Perfil; cambiarlos globalmente podria romper contratos fuera del scope.
+
+## Estado final
+
+- Implementacion completada y validada.
+- Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI ni workflows.

--- a/docs/implementation/clinic-port-admin-layout-metrics.md
+++ b/docs/implementation/clinic-port-admin-layout-metrics.md
@@ -145,3 +145,91 @@
 
 - Implementacion completada y validada.
 - Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI ni workflows.
+
+## Fix CI Tokens mobile inline detail
+
+### Estado base
+
+- Fecha: 2026-06-26.
+- Rama: `fix/clinic-port-admin-layout-metrics`.
+- HEAD auditado: `0ae6fa4 fix(clinic): port admin dashboard layout metrics to clinic modules`.
+- Estado inicial del fix: `git status --short --untracked-files=all` limpio.
+- Entorno: Windows, PowerShell, PNPM 10.8.1.
+
+### Scope incluido
+
+- Corregir exclusivamente Tokens Clinica mobile para mantener visible la lista al seleccionar un token.
+- Mantener visibles `#clinic-particular-token-1` y `#clinic-particular-token-2` despues de abrir el detalle de token 2.
+- Compactar lista y detalle dentro de `ModuleSurface` sin scroll interno visible.
+- Reforzar tests e2e y nativo del contrato de lista visible.
+- Actualizar esta evidencia de implementacion.
+
+### Scope excluido
+
+- Dashboard Admin productivo, salvo lectura y validacion opcional.
+- Backend, API, auth, DB, migraciones, dependencias, lockfiles, CI y workflows.
+- Cambios globales de CSS o refactors fuera del modulo Tokens Clinica.
+
+### Auditoria previa
+
+- Base limpia y rama esperada confirmadas.
+- Scripts reales confirmados: `pnpm test`, `pnpm build`, `pnpm security:public-surface`, `pnpm --dir frontend lint`, `pnpm --dir frontend typecheck`, `pnpm --dir frontend build`, `pnpm typecheck:test`.
+- Archivos leidos del scope: componente Tokens Clinica, `globals.css`, specs e2e indicados, test nativo de Tokens y este documento.
+- Referencia legacy vinculada al fallo: el componente aplicaba `hasOpenDetail && !isSelected && "hidden sm:block"` en cada fila no seleccionada.
+
+### Causa raiz
+
+- Al abrir detalle mobile, Tokens Clinica ocultaba las filas no seleccionadas para reducir altura.
+- Eso dejaba `#clinic-particular-token-1` en estado hidden despues de seleccionar `#clinic-particular-token-2`, rompiendo el contrato de lista visible.
+
+### Cambios
+
+- `ClinicParticularTokensCard`:
+  - Reemplaza el ocultamiento mobile de filas no seleccionadas por una compactacion visual (`opacity-90`).
+  - Mantiene la lista en flujo con 4 filas visibles y `min-h-[12rem]` mobile en el cuerpo de lista.
+  - Ajusta panel de lista y detalle a `flex-none` en mobile y `sm:flex-1` en viewports mayores.
+  - Compacta el detalle mobile: menos padding/gap, heading menor, badges densos y grilla de 3 columnas.
+  - No agrega `overflow-y-auto`, `overflow-y: auto`, `overflow-y: scroll` ni `dashboard-inline-scroll`.
+- Specs e2e:
+  - `dashboard-global-masked-master-detail.spec.ts` ahora verifica que token 2 tambien siga visible tras el click.
+  - `dashboard-clinic-tokens-mobile-parity.spec.ts` ahora verifica token 1 y token 2 visibles con detalle abierto.
+- Test nativo:
+  - `frontend-dashboard-clinic-tokens.test.ts` blinda que no vuelva el patron `hidden sm:block` para filas no seleccionadas.
+
+### Archivos modificados
+
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/e2e/dashboard-global-masked-master-detail.spec.ts`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `docs/implementation/clinic-port-admin-layout-metrics.md`
+
+### Validaciones
+
+- `git diff --check`: ejecutado, paso; solo avisos CRLF de Git en Windows.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts`: ejecutado, paso; 16/16.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts`: ejecutado, paso; 45/45.
+- `pnpm --dir frontend lint`: ejecutado, paso.
+- `pnpm typecheck:test`: ejecutado, paso.
+- `pnpm --dir frontend build`: ejecutado, paso.
+- `pnpm test`: ejecutado, paso; 2840/2840.
+- `pnpm --dir frontend typecheck`: ejecutado, paso.
+- `pnpm security:public-surface`: ejecutado, paso; sin exposicion publica, solo findings informativos `server-only` existentes en `frontend/src/proxy.ts`.
+- `pnpm build`: ejecutado, paso.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts`: ejecutado, paso; 4/4.
+
+### Resultado
+
+- Tokens Clinica mobile mantiene la lista visible al seleccionar token 2.
+- `#clinic-particular-token-1` y `#clinic-particular-token-2` quedan visibles con detalle abierto.
+- El detalle sigue inline compacto dentro del modulo.
+- No se restauro scroll interno visible.
+
+### Riesgo residual
+
+- La evidencia visual/no-scroll se valido en Chromium Playwright; no reemplaza prueba manual en dispositivo fisico.
+
+### Estado final del fix
+
+- Implementacion completada y validada.
+- Sin cambios en Admin productivo, backend, API, auth, DB, migraciones, dependencias, lockfiles, CI ni workflows.

--- a/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
+++ b/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
@@ -77,6 +77,57 @@ async function mockClinicProfile(page: Page) {
   });
 }
 
+async function expectNoProfileInternalScroll(page: Page, label: string) {
+  const scrollState = await page.evaluate(() => {
+    const editor = document.querySelector<HTMLElement>(
+      '[data-clinic-profile-editor="true"]',
+    );
+    const fields = document.querySelector<HTMLElement>(
+      '[data-clinic-profile-fields="true"]',
+    );
+    const scrollContainers = editor
+      ? [editor, ...Array.from(editor.querySelectorAll<HTMLElement>("*"))].flatMap(
+          (element) => {
+            const style = window.getComputedStyle(element);
+            return ["auto", "scroll"].includes(style.overflowY)
+              ? [
+                  {
+                    tag: element.tagName,
+                    overflowY: style.overflowY,
+                  },
+                ]
+              : [];
+          },
+        )
+      : [];
+    const fieldStyle = fields ? window.getComputedStyle(fields) : null;
+
+    return {
+      hasEditor: editor !== null,
+      hasFields: fields !== null,
+      fieldOverflowY: fieldStyle?.overflowY ?? "missing",
+      fieldScrollHeight: fields?.scrollHeight ?? 0,
+      fieldClientHeight: fields?.clientHeight ?? 0,
+      scrollContainers,
+    };
+  });
+
+  expect(scrollState.hasEditor, `${label}: profile editor present`).toBe(true);
+  expect(scrollState.hasFields, `${label}: active profile fields present`).toBe(true);
+  expect(
+    ["auto", "scroll"],
+    `${label}: active fields must not expose vertical scroll`,
+  ).not.toContain(scrollState.fieldOverflowY);
+  expect(
+    scrollState.fieldScrollHeight,
+    `${label}: active fields must fit without hidden clipping`,
+  ).toBeLessThanOrEqual(scrollState.fieldClientHeight + TOLERANCE);
+  expect(
+    scrollState.scrollContainers,
+    `${label}: profile editor must not contain internal scroll containers`,
+  ).toEqual([]);
+}
+
 for (const viewport of VIEWPORTS) {
   test(`clinic perfil public editor is operable at ${viewport.name}`, async ({
     page,
@@ -115,6 +166,7 @@ for (const viewport of VIEWPORTS) {
 
     const fields = editor.locator('[data-clinic-profile-fields="true"]');
     await expect(fields).toBeVisible();
+    await expectNoProfileInternalScroll(page, `${viewport.name}: datos tab`);
 
     const shellMetrics = await page.evaluate(() => {
       const main = document.querySelector<HTMLElement>("main.dashboard-main");
@@ -157,8 +209,10 @@ for (const viewport of VIEWPORTS) {
       shellMetrics.main!.clientHeight + TOLERANCE,
     );
 
+    await editor.getByRole("tab", { name: "Contacto", exact: true }).click();
+    await expectNoProfileInternalScroll(page, `${viewport.name}: contacto tab`);
+
     const mapLink = page.locator("#clinic-profile-map-link");
-    await mapLink.scrollIntoViewIfNeeded();
     await expect(mapLink).toBeVisible();
     const mapLinkBox = await mapLink.boundingBox();
     expect(mapLinkBox).not.toBeNull();
@@ -181,5 +235,8 @@ for (const viewport of VIEWPORTS) {
     expect(saveButtonBox!.y + saveButtonBox!.height).toBeLessThanOrEqual(
       viewport.height + TOLERANCE,
     );
+    await expect(editor.getByText("Usuarios y roles")).toHaveCount(0);
+    await expect(editor.getByText("Auditoría")).toHaveCount(0);
+    await expect(editor.getByText("Mantenimiento")).toHaveCount(0);
   });
 }

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -53,6 +53,9 @@ type LayoutContract = {
   mainClientHeight: number;
   mainOverflowY: string;
   listClientHeight: number;
+  listScrollHeight: number;
+  listOverflowY: string;
+  moduleScrollContainers: Array<{ tag: string; overflowY: string }>;
   hasMain: boolean;
   hasList: boolean;
 };
@@ -118,7 +121,21 @@ async function readLayoutContract(page: Page): Promise<LayoutContract> {
     const html = document.documentElement;
     const body = document.body;
     const main = document.querySelector<HTMLElement>("main.dashboard-main");
-    const list = document.querySelector<HTMLElement>(".dashboard-inline-scroll");
+    const card = document.querySelector<HTMLElement>("#clinic-particular-tokens");
+    const list = document.querySelector<HTMLElement>(
+      '[data-clinic-access-list-body="true"]',
+    );
+    const moduleScrollContainers = card
+      ? [card, ...Array.from(card.querySelectorAll<HTMLElement>("*"))].flatMap(
+          (element) => {
+            const style = window.getComputedStyle(element);
+            return ["auto", "scroll"].includes(style.overflowY)
+              ? [{ tag: element.tagName, overflowY: style.overflowY }]
+              : [];
+          },
+        )
+      : [];
+    const listStyle = list ? window.getComputedStyle(list) : null;
 
     return {
       htmlScrollWidth: html.scrollWidth,
@@ -133,6 +150,9 @@ async function readLayoutContract(page: Page): Promise<LayoutContract> {
       mainClientHeight: main?.clientHeight ?? 0,
       mainOverflowY: main ? window.getComputedStyle(main).overflowY : "none",
       listClientHeight: list?.clientHeight ?? 0,
+      listScrollHeight: list?.scrollHeight ?? 0,
+      listOverflowY: listStyle?.overflowY ?? "missing",
+      moduleScrollContainers,
       hasMain: main !== null,
       hasList: list !== null,
     };
@@ -169,6 +189,18 @@ function assertNoGlobalOverflow(metrics: LayoutContract, label: string) {
     metrics.listClientHeight,
     `${label}: inline list must keep an operable height`,
   ).toBeGreaterThanOrEqual(44);
+  expect(
+    metrics.listScrollHeight,
+    `${label}: token list must not clip hidden overflow`,
+  ).toBeLessThanOrEqual(metrics.listClientHeight + TOLERANCE);
+  expect(
+    ["auto", "scroll"],
+    `${label}: token list must not expose vertical scroll`,
+  ).not.toContain(metrics.listOverflowY);
+  expect(
+    metrics.moduleScrollContainers,
+    `${label}: tokens module must not contain internal scroll containers`,
+  ).toEqual([]);
 }
 
 async function expectHorizontallyUnclipped(
@@ -235,6 +267,9 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(previousButton).toBeVisible();
       await expect(nextButton).toBeVisible();
       await expect(nextButton).toBeEnabled();
+      await expect(card.getByText("Usuarios y roles")).toHaveCount(0);
+      await expect(card.getByText("Auditoría")).toHaveCount(0);
+      await expect(card.getByText("Mantenimiento")).toHaveCount(0);
     }).toPass({ timeout: 12_000 });
 
     await expectHorizontallyUnclipped(

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -309,6 +309,8 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await secondToken.click();
 
     await expect(async () => {
+      await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
+      await expect(secondToken).toBeVisible();
       await expect(secondToken).toHaveAttribute(
         "aria-expanded",
         "true",

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -394,6 +394,7 @@ test("clinic Tokens mobile keeps the list and expands the selected detail inline
 
   await page.locator("#clinic-particular-token-2").click();
   await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
+  await expect(page.locator("#clinic-particular-token-2")).toBeVisible();
   await expect(page.locator("#clinic-particular-token-2")).toHaveAttribute(
     "aria-expanded",
     "true",

--- a/frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts
+++ b/frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts
@@ -52,6 +52,18 @@ const SHELLS: ShellCase[] = [
     ready: '[data-dashboard-module-hub="true"]',
   },
   {
+    label: "clinic tokens module",
+    surface: "clinic",
+    path: "/dashboard?module=tokens",
+    ready: '[data-dashboard-module-workspace="tokens"]',
+  },
+  {
+    label: "clinic perfil module",
+    surface: "clinic",
+    path: "/dashboard?module=perfil",
+    ready: '[data-dashboard-module-workspace="perfil"]',
+  },
+  {
     label: "admin dashboard shell",
     surface: "admin",
     path: "/dashboard/admin",

--- a/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
+++ b/frontend/e2e/dashboard-workspace-layout-polish.spec.ts
@@ -58,6 +58,12 @@ const FRAME_ROUTES: FrameRouteCase[] = [
     ready: '[data-dashboard-module-workspace="tokens"]',
   },
   {
+    label: "clinic perfil",
+    surface: "clinic",
+    path: "/dashboard?module=perfil",
+    ready: '[data-dashboard-module-workspace="perfil"]',
+  },
+  {
     label: "admin resumen",
     surface: "admin",
     path: "/dashboard/admin?module=admin",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3074,6 +3074,22 @@
     min-height: 0;
     overflow: hidden;
   }
+
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-toolbar="true"],
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-profile-toolbar="true"] {
+    min-width: 0;
+    max-width: 100%;
+    gap: var(--dash-gap);
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-list-body="true"],
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-list-panel="true"],
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-profile-fields="true"] {
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
 }
 
 @media (max-width: 767px) {

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -571,7 +571,7 @@ export function ClinicParticularTokensCard() {
             <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
               <div
                 data-clinic-access-list-panel="true"
-                className="dashboard-master-panel dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82"
+                className="dashboard-master-panel dashboard-inline-list min-h-0 flex-none rounded-lg border border-vetneb-line/75 bg-card/82 sm:flex-1"
               >
                 <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2">
                   <div className="min-w-0">
@@ -597,7 +597,7 @@ export function ClinicParticularTokensCard() {
 
                 <div
                   data-clinic-access-list-body="true"
-                  className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden"
+                  className="min-h-[12rem] flex-none divide-y divide-vetneb-line/60 overflow-hidden sm:min-h-0 sm:flex-1"
                 >
                   {pagedTokens.pageItems.map((token) => {
                     const isSelected = selectedToken?.id === token.id;
@@ -608,7 +608,7 @@ export function ClinicParticularTokensCard() {
                         key={token.id}
                         className={cn(
                           "min-w-0",
-                          hasOpenDetail && !isSelected && "hidden sm:block",
+                          hasOpenDetail && !isSelected && "opacity-90",
                         )}
                       >
                         <button
@@ -680,16 +680,17 @@ export function ClinicParticularTokensCard() {
 
               {selectedToken ? (
                 <div
+                  data-clinic-access-detail="true"
                   data-detail-state="selected"
-                  className="dashboard-detail-panel dashboard-inline-detail flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/92"
+                  className="dashboard-detail-panel dashboard-inline-detail flex min-h-0 flex-none flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/92 sm:flex-1"
                 >
-                  <div className="flex min-h-0 flex-1 flex-col gap-2 p-3">
-                    <div className="flex shrink-0 flex-col gap-2 border-b border-vetneb-line/70 pb-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex min-h-0 flex-1 flex-col gap-1.5 p-2 sm:gap-2 sm:p-3">
+                    <div className="flex shrink-0 flex-col gap-1.5 border-b border-vetneb-line/70 pb-1.5 sm:flex-row sm:items-start sm:justify-between sm:gap-2 sm:pb-2">
                       <div className="min-w-0">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
                           Detalle del token
                         </p>
-                        <h3 className="mt-0.5 truncate text-base font-semibold text-vetneb-ink">
+                        <h3 className="mt-0.5 truncate text-sm font-semibold text-vetneb-ink sm:text-base">
                           {selectedToken.petName} · {selectedToken.tutorLastName}
                         </h3>
                         <p className="mt-0.5 text-xs text-muted-foreground">
@@ -699,6 +700,7 @@ export function ClinicParticularTokensCard() {
                       <div className="flex flex-wrap gap-1.5">
                         <Badge
                           variant={selectedToken.isActive ? "default" : "outline"}
+                          className="h-5 px-1.5 text-[0.6875rem]"
                         >
                           {selectedToken.isActive ? "Activo" : "Inactivo"}
                         </Badge>
@@ -706,6 +708,7 @@ export function ClinicParticularTokensCard() {
                           variant={
                             selectedToken.hasLinkedReport ? "default" : "outline"
                           }
+                          className="h-5 px-1.5 text-[0.6875rem]"
                         >
                           {selectedToken.hasLinkedReport
                             ? "Informe vinculado"
@@ -714,8 +717,8 @@ export function ClinicParticularTokensCard() {
                       </div>
                     </div>
 
-                    <div className="grid min-h-0 flex-1 grid-cols-2 gap-1.5 sm:gap-2 xl:grid-cols-3">
-                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                    <div className="grid min-h-0 flex-1 grid-cols-3 gap-1 sm:gap-2">
+                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                           Paciente
                         </p>
@@ -728,7 +731,7 @@ export function ClinicParticularTokensCard() {
                         </p>
                       </div>
 
-                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                           Muestra
                         </p>
@@ -740,7 +743,7 @@ export function ClinicParticularTokensCard() {
                         </p>
                       </div>
 
-                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                           Fechas
                         </p>
@@ -752,7 +755,7 @@ export function ClinicParticularTokensCard() {
                         </p>
                       </div>
 
-                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                           Publicación
                         </p>
@@ -770,7 +773,7 @@ export function ClinicParticularTokensCard() {
                         </p>
                       </div>
 
-                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                           Vínculo
                         </p>
@@ -782,7 +785,7 @@ export function ClinicParticularTokensCard() {
                         </p>
                       </div>
 
-                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
                           Seguimiento
                         </p>

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -4,11 +4,11 @@ import { FormEvent, useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { CompactPager } from "@/components/dashboard/CompactPager";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import {
   createClinicParticularToken,
@@ -254,11 +254,12 @@ export function ClinicParticularTokensCard() {
   const pagedTokens = usePagedRows(tokens, TOKENS_PAGE_SIZE);
   const selectedToken =
     selectedTokenId === null
-      ? (tokens[0] ?? null)
-      : (tokens.find((token) => token.id === selectedTokenId) ?? tokens[0] ?? null);
+      ? null
+      : (tokens.find((token) => token.id === selectedTokenId) ?? null);
   const selectedTrackingCase = selectedToken
     ? trackingCasesByTokenId[selectedToken.id]
     : undefined;
+  const hasOpenDetail = selectedToken !== null;
 
   const activeTokensCount = tokens.filter((token) => token.isActive).length;
   const linkedReportsCount = tokens.filter((token) => token.hasLinkedReport).length;
@@ -277,7 +278,7 @@ export function ClinicParticularTokensCard() {
       setSelectedTokenId((current) =>
         current && nextTokens.some((token) => token.id === current)
           ? current
-          : nextTokens[0]?.id ?? null,
+          : null,
       );
 
       if (nextTokens.length === 0) {
@@ -487,57 +488,69 @@ export function ClinicParticularTokensCard() {
   }
 
   return (
-    <Card
+    <section
       id="clinic-particular-tokens"
-      className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
     >
-      <CardHeader className="shrink-0 border-b border-vetneb-line/70 p-4 sm:p-6">
-        <div className="flex flex-col gap-2 sm:gap-3 xl:flex-row xl:items-start xl:justify-between">
-          <div className="min-w-0">
-            <CardTitle className="text-base">Generación de tokens particulares</CardTitle>
-            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground sm:line-clamp-none">
-              Gestión compacta: generar token en una capa dedicada, seleccionar de la
-              lista y revisar el seguimiento solo desde el detalle.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-3 gap-2 text-sm xl:min-w-[20rem]">
-            <div className="surface-soft px-3 py-2">
-              <p className="text-xs text-muted-foreground">Tokens</p>
-              <p className="mt-0.5 font-semibold text-vetneb-ink">{tokens.length}</p>
-            </div>
-            <div className="surface-soft px-3 py-2">
-              <p className="text-xs text-muted-foreground">Activos</p>
-              <p className="mt-0.5 font-semibold text-vetneb-ink">
-                {activeTokensCount}
-              </p>
-            </div>
-            <div className="surface-soft px-3 py-2">
-              <p className="text-xs text-muted-foreground">Informes</p>
-              <p className="mt-0.5 font-semibold text-vetneb-ink">
-                {linkedReportsCount}
-              </p>
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="flex min-h-0 flex-1 flex-col gap-2 px-4 pb-4 pt-3 sm:gap-4 sm:px-6 sm:pb-6 sm:pt-4">
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
-          <p className="line-clamp-2 text-xs text-muted-foreground sm:line-clamp-none">
-            Lista limitada con paginación compacta. La generación abre una capa
-            dedicada y no apila el formulario sobre la lista.
-          </p>
-          <Button
-            type="button"
-            size="sm"
-            onClick={() => setIsCreateDialogOpen(true)}
-            disabled={generatedToken !== null}
+      <ModuleSurface
+        ariaLabel="Tokens particulares de la clínica"
+        toolbar={
+          <div
+            data-clinic-access-toolbar="true"
+            className="flex w-full flex-wrap items-center justify-between gap-2"
           >
-            Generar token particular
-          </Button>
-        </div>
+            <div className="min-w-0">
+              <h3 className="dashboard-section-heading">
+                Tokens particulares
+              </h3>
+              <p className="dashboard-section-description line-clamp-1">
+                Generación, actualización, estado y detalle clínico en un módulo
+                compacto.
+              </p>
+            </div>
 
+            <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+              <div
+                className="grid grid-cols-3 divide-x divide-vetneb-line/70 rounded-md border border-vetneb-line/75 bg-vetneb-surface-muted/45 text-center"
+                aria-label="Métricas de tokens particulares"
+              >
+                {[
+                  ["Tokens", tokens.length],
+                  ["Activos", activeTokensCount],
+                  ["Informes", linkedReportsCount],
+                ].map(([label, value]) => (
+                  <div key={label} className="min-w-[4.25rem] px-2 py-1">
+                    <p className="text-[0.6875rem] text-muted-foreground">
+                      {label}
+                    </p>
+                    <p className="text-sm font-semibold leading-tight text-vetneb-ink">
+                      {value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void loadTokens()}
+                disabled={isLoadingTokens}
+              >
+                {isLoadingTokens ? "Actualizando..." : "Actualizar"}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => setIsCreateDialogOpen(true)}
+                disabled={generatedToken !== null}
+              >
+                Generar token particular
+              </Button>
+            </div>
+          </div>
+        }
+      >
         {errorMessage ? (
           <p className="clinical-alert-error shrink-0 px-3 py-2" role="alert">
             {errorMessage}
@@ -554,42 +567,50 @@ export function ClinicParticularTokensCard() {
           aria-label="Tokens particulares de la clínica"
           className="flex min-h-0 flex-1 flex-col"
         >
-          <div className="dashboard-master-panel dashboard-inline-list min-h-0 flex-1 rounded-xl border border-vetneb-line/75 bg-card/82">
-            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2 sm:px-4 sm:py-3">
-              <div>
-                <h3 className="text-sm font-semibold text-vetneb-ink">
-                  Últimos tokens de la clínica
-                </h3>
-                <p className="dashboard-section-description line-clamp-1 sm:line-clamp-none">
-                  Seleccionar un token despliega el detalle dentro del propio token.
-                </p>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => void loadTokens()}
-                disabled={isLoadingTokens}
+          {tokens.length ? (
+            <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
+              <div
+                data-clinic-access-list-panel="true"
+                className="dashboard-master-panel dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82"
               >
-                {isLoadingTokens ? "Actualizando..." : "Actualizar"}
-              </Button>
-            </div>
+                <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2">
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-semibold text-vetneb-ink">
+                      Últimos tokens de la clínica
+                    </h3>
+                    <p className="dashboard-section-description line-clamp-1">
+                      Lista paginada sin scroll interno.
+                    </p>
+                    {trackingLoadError ? (
+                      <p
+                        className="line-clamp-1 text-[0.68rem] text-amber-700"
+                        role="alert"
+                      >
+                        Seguimiento parcial: {trackingLoadError}
+                      </p>
+                    ) : null}
+                  </div>
+                  <Badge variant="outline" className="shrink-0">
+                    Pág. {pagedTokens.page + 1}
+                  </Badge>
+                </div>
 
-            {trackingLoadError ? (
-              <p className="clinical-alert-warning m-3 px-3 py-2 text-sm" role="alert">
-                {trackingLoadError}
-              </p>
-            ) : null}
-
-            {tokens.length ? (
-              <>
-                <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
+                <div
+                  data-clinic-access-list-body="true"
+                  className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden"
+                >
                   {pagedTokens.pageItems.map((token) => {
                     const isSelected = selectedToken?.id === token.id;
                     const trackingCase = trackingCasesByTokenId[token.id];
 
                     return (
-                      <div key={token.id} className="min-w-0">
+                      <div
+                        key={token.id}
+                        className={cn(
+                          "min-w-0",
+                          hasOpenDetail && !isSelected && "hidden sm:block",
+                        )}
+                      >
                         <button
                           type="button"
                           id={`clinic-particular-token-${token.id}`}
@@ -597,7 +618,8 @@ export function ClinicParticularTokensCard() {
                           aria-pressed={isSelected}
                           aria-expanded={isSelected}
                           className={cn(
-                            "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                            "block w-full px-3 py-1.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset sm:py-2",
+                            hasOpenDetail && "py-1 sm:py-2",
                             isSelected && "bg-vetneb-cyan/12",
                           )}
                         >
@@ -609,137 +631,38 @@ export function ClinicParticularTokensCard() {
                               <p className="mt-0.5 truncate text-xs text-muted-foreground">
                                 Token ****{token.tokenLast4}
                               </p>
-                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              <p className="hidden truncate text-xs text-muted-foreground sm:mt-0.5 sm:block">
                                 {trackingCase
                                   ? getTrackingStageLabel(trackingCase.currentStage)
                                   : "Sin seguimiento vinculado"}
                               </p>
                             </div>
-                            <div className="flex shrink-0 flex-col items-end gap-1">
-                              <Badge variant={token.isActive ? "default" : "outline"}>
+                            <div
+                              className={cn(
+                                "flex shrink-0 flex-col items-end gap-1",
+                                hasOpenDetail && "hidden sm:flex",
+                              )}
+                            >
+                              <Badge
+                                variant={token.isActive ? "default" : "outline"}
+                                className="h-5 px-1.5 text-[0.6875rem]"
+                              >
                                 {token.isActive ? "Activo" : "Inactivo"}
                               </Badge>
-                              <Badge variant={token.hasLinkedReport ? "default" : "outline"}>
+                              <Badge
+                                variant={token.hasLinkedReport ? "default" : "outline"}
+                                className="h-5 px-1.5 text-[0.6875rem]"
+                              >
                                 {token.hasLinkedReport ? "Informe" : "Sin informe"}
                               </Badge>
                             </div>
                           </div>
                         </button>
-
-                        {isSelected && selectedToken ? (
-                          <div
-                            data-detail-state="selected"
-                            className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
-                          >
-                            <div className="space-y-3 p-4">
-                              <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-3 lg:flex-row lg:items-start lg:justify-between">
-                                <div className="min-w-0">
-                                  <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                    Detalle del token
-                                  </p>
-                                  <h3 className="mt-1 text-lg font-semibold text-vetneb-ink">
-                                    {selectedToken.petName} · {selectedToken.tutorLastName}
-                                  </h3>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Token ****{selectedToken.tokenLast4}
-                                  </p>
-                                </div>
-                                <div className="flex flex-wrap gap-2">
-                                  <Badge variant={selectedToken.isActive ? "default" : "outline"}>
-                                    {selectedToken.isActive ? "Activo" : "Inactivo"}
-                                  </Badge>
-                                  <Badge variant={selectedToken.hasLinkedReport ? "default" : "outline"}>
-                                    {selectedToken.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
-                                  </Badge>
-                                </div>
-                              </div>
-
-                              <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                    Paciente
-                                  </p>
-                                  <p className="mt-1 text-xs text-vetneb-ink">
-                                    {selectedToken.petSpecies} · {selectedToken.petBreed} · {selectedToken.petSex}
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">Edad: {selectedToken.petAge}</p>
-                                </div>
-
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                    Muestra
-                                  </p>
-                                  <p className="mt-1 text-xs text-vetneb-ink">{selectedToken.sampleLocation}</p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Evolución: {selectedToken.sampleEvolution}
-                                  </p>
-                                </div>
-
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                    Fechas
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Extracción: {formatDate(selectedToken.extractionDate)}
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Envío: {formatDate(selectedToken.shippingDate)}
-                                  </p>
-                                </div>
-
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                    Publicación
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Informe: {selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Último acceso: {selectedToken.lastLoginAt ? formatDate(selectedToken.lastLoginAt) : "—"}
-                                  </p>
-                                </div>
-
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                    Vínculo
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Tutor: {selectedToken.tutorLastName}
-                                  </p>
-                                  <p className="mt-1 text-xs text-muted-foreground">
-                                    Origen: {formatTokenSource(selectedToken)}
-                                  </p>
-                                </div>
-
-                                <div className="clinical-muted-band rounded-lg px-3 py-2">
-                                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                    Seguimiento
-                                  </p>
-                                  {selectedTrackingCase ? (
-                                    <>
-                                      <p className="mt-1 text-xs text-vetneb-ink">
-                                        Etapa: {getTrackingStageLabel(selectedTrackingCase.currentStage)}
-                                      </p>
-                                      <p className="mt-1 text-xs text-muted-foreground">
-                                        {selectedTrackingCase.specialStainRequired
-                                          ? "Alerta: Solicitud de tinción especial"
-                                          : "Sin alerta de tinción especial"}
-                                      </p>
-                                    </>
-                                  ) : (
-                                    <p className="mt-1 text-xs text-muted-foreground">
-                                      Sin seguimiento vinculado.
-                                    </p>
-                                  )}
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        ) : null}
                       </div>
                     );
                   })}
                 </div>
+
                 <CompactPager
                   className="shrink-0"
                   page={pagedTokens.page}
@@ -753,28 +676,161 @@ export function ClinicParticularTokensCard() {
                   onNext={pagedTokens.goNext}
                   itemLabel="tokens"
                 />
-              </>
-            ) : (
-              <div className="m-4 flex min-h-0 flex-1">
-                <EmptyState
-                  title={
-                    isLoadingTokens
-                      ? "Cargando tokens particulares..."
-                      : "Sin tokens particulares"
-                  }
-                  description={
-                    isLoadingTokens
-                      ? "Consultando los últimos tokens generados por la clínica."
-                      : "No hay tokens particulares generados por esta clínica."
-                  }
-                  size="sm"
-                  className="w-full"
-                />
               </div>
-            )}
-          </div>
+
+              {selectedToken ? (
+                <div
+                  data-detail-state="selected"
+                  className="dashboard-detail-panel dashboard-inline-detail flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/92"
+                >
+                  <div className="flex min-h-0 flex-1 flex-col gap-2 p-3">
+                    <div className="flex shrink-0 flex-col gap-2 border-b border-vetneb-line/70 pb-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                          Detalle del token
+                        </p>
+                        <h3 className="mt-0.5 truncate text-base font-semibold text-vetneb-ink">
+                          {selectedToken.petName} · {selectedToken.tutorLastName}
+                        </h3>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Token ****{selectedToken.tokenLast4}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-1.5">
+                        <Badge
+                          variant={selectedToken.isActive ? "default" : "outline"}
+                        >
+                          {selectedToken.isActive ? "Activo" : "Inactivo"}
+                        </Badge>
+                        <Badge
+                          variant={
+                            selectedToken.hasLinkedReport ? "default" : "outline"
+                          }
+                        >
+                          {selectedToken.hasLinkedReport
+                            ? "Informe vinculado"
+                            : "Sin informe"}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    <div className="grid min-h-0 flex-1 grid-cols-2 gap-1.5 sm:gap-2 xl:grid-cols-3">
+                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                          Paciente
+                        </p>
+                        <p className="mt-1 line-clamp-1 text-xs text-vetneb-ink">
+                          {selectedToken.petSpecies} · {selectedToken.petBreed} ·{" "}
+                          {selectedToken.petSex}
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Edad: {selectedToken.petAge}
+                        </p>
+                      </div>
+
+                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                          Muestra
+                        </p>
+                        <p className="mt-1 line-clamp-1 text-xs text-vetneb-ink">
+                          {selectedToken.sampleLocation}
+                        </p>
+                        <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                          Evolución: {selectedToken.sampleEvolution}
+                        </p>
+                      </div>
+
+                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                          Fechas
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Extracción: {formatDate(selectedToken.extractionDate)}
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Envío: {formatDate(selectedToken.shippingDate)}
+                        </p>
+                      </div>
+
+                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                          Publicación
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Informe:{" "}
+                          {selectedToken.reportId
+                            ? `#${selectedToken.reportId}`
+                            : "—"}
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Último acceso:{" "}
+                          {selectedToken.lastLoginAt
+                            ? formatDate(selectedToken.lastLoginAt)
+                            : "—"}
+                        </p>
+                      </div>
+
+                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                          Vínculo
+                        </p>
+                        <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                          Tutor: {selectedToken.tutorLastName}
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          Origen: {formatTokenSource(selectedToken)}
+                        </p>
+                      </div>
+
+                      <div className="clinical-muted-band rounded-md px-2 py-1.5 sm:px-2.5 sm:py-2">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
+                          Seguimiento
+                        </p>
+                        {selectedTrackingCase ? (
+                          <>
+                            <p className="mt-1 line-clamp-1 text-xs text-vetneb-ink">
+                              Etapa:{" "}
+                              {getTrackingStageLabel(
+                                selectedTrackingCase.currentStage,
+                              )}
+                            </p>
+                            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                              {selectedTrackingCase.specialStainRequired
+                                ? "Alerta: Solicitud de tinción especial"
+                                : "Sin alerta de tinción especial"}
+                            </p>
+                          </>
+                        ) : (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Sin seguimiento vinculado.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82 p-3">
+              <EmptyState
+                title={
+                  isLoadingTokens
+                    ? "Cargando tokens particulares..."
+                    : "Sin tokens particulares"
+                }
+                description={
+                  isLoadingTokens
+                    ? "Consultando los últimos tokens generados por la clínica."
+                    : "No hay tokens particulares generados por esta clínica."
+                }
+                size="sm"
+                className="w-full"
+              />
+            </div>
+          )}
         </section>
-      </CardContent>
+      </ModuleSurface>
 
       <ModuleDialog
         open={isCreateDialogOpen}
@@ -1184,6 +1240,6 @@ export function ClinicParticularTokensCard() {
           </div>
         </div>
       </ModuleDialog>
-    </Card>
+    </section>
   );
 }

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -5,13 +5,6 @@ import NextImage from "next/image";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
   getClinicPublicProfile,
@@ -21,6 +14,7 @@ import {
   type ClinicPublicProfile,
   type ClinicPublicProfileUpdatePayload,
 } from "@/lib/api";
+import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
 
 type ProfileFormState = {
@@ -485,9 +479,9 @@ export function ClinicPublicProfileCard() {
   const statusTab = (
     <div
       data-clinic-profile-fields="true"
-      className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
+      className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden"
     >
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
         <div className="surface-soft">
           <p className="text-xs text-muted-foreground">Estado</p>
           <Badge className="mt-2" variant={getPublicationVariant(profile)}>
@@ -521,7 +515,7 @@ export function ClinicPublicProfileCard() {
         <label htmlFor="clinic-profile-avatar" className="field-label">
           Avatar o logo
         </label>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <div className="flex h-12 w-12 sm:h-16 sm:w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-vetneb-line/70 bg-white">
             {profileAvatarSrc ? (
               <NextImage
@@ -578,9 +572,9 @@ export function ClinicPublicProfileCard() {
   const detailsTab = (
     <div
       data-clinic-profile-fields="true"
-      className="min-h-0 flex-1 overflow-y-auto lg:overflow-y-visible"
+      className="min-h-0 flex-1 overflow-hidden"
     >
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
         <div>
           <label htmlFor="clinic-profile-display-name" className="field-label">
             Nombre visible
@@ -641,7 +635,16 @@ export function ClinicPublicProfileCard() {
             disabled={isWorking}
           />
         </div>
+      </div>
+    </div>
+  );
 
+  const contactTab = (
+    <div
+      data-clinic-profile-fields="true"
+      className="min-h-0 flex-1 overflow-hidden"
+    >
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
         <div>
           <label htmlFor="clinic-profile-email" className="field-label">
             Email público
@@ -707,9 +710,9 @@ export function ClinicPublicProfileCard() {
   const contentTab = (
     <div
       data-clinic-profile-fields="true"
-      className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
+      className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden"
     >
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
         <div>
           <label htmlFor="clinic-profile-services" className="field-label">
             Servicios
@@ -717,7 +720,7 @@ export function ClinicPublicProfileCard() {
           <textarea
             id="clinic-profile-services"
             name="servicesText"
-            className="field-textarea h-24 min-h-0"
+            className="field-textarea h-20 min-h-0"
             value={formState.servicesText}
             onChange={(event) => updateField("servicesText", event.target.value)}
             disabled={isWorking}
@@ -732,7 +735,7 @@ export function ClinicPublicProfileCard() {
           <textarea
             id="clinic-profile-about"
             name="aboutText"
-            className="field-textarea h-24 min-h-0"
+            className="field-textarea h-20 min-h-0"
             value={formState.aboutText}
             onChange={(event) => updateField("aboutText", event.target.value)}
             disabled={isWorking}
@@ -741,7 +744,7 @@ export function ClinicPublicProfileCard() {
         </div>
       </div>
 
-      <label className="clinical-muted-band flex items-start gap-3 rounded-lg px-3 py-2 text-sm text-vetneb-navy">
+      <label className="clinical-muted-band flex items-start gap-3 rounded-lg px-3 py-2 text-xs text-vetneb-navy sm:text-sm">
         <input
           type="checkbox"
           className="mt-1"
@@ -760,73 +763,95 @@ export function ClinicPublicProfileCard() {
   );
 
   return (
-    <Card
+    <form
       id="clinic-public-profile"
       data-clinic-profile-editor="true"
-      className="dashboard-surface flex min-h-0 flex-1 flex-col"
+      className="flex min-h-0 flex-1 flex-col"
+      onSubmit={handleSubmit}
     >
-      <CardHeader className="shrink-0 border-b border-vetneb-line/70 px-5 py-3">
-        <CardTitle className="text-base">Perfil para banco de especialidades</CardTitle>
-        <CardDescription>
-          Complete y publique el perfil de la clínica para aparecer en el banco
-          público de especialidades y profesionales.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex min-h-0 flex-1 flex-col px-5 py-3">
-        <form className="flex min-h-0 flex-1 flex-col gap-3" onSubmit={handleSubmit}>
-          {isLoading ? (
-            <p className="clinical-alert-info px-3 py-2" role="status">
-              Cargando perfil público...
+      <ModuleSurface
+        ariaLabel="Perfil público de la clínica"
+        toolbar={
+          <div
+            data-clinic-profile-toolbar="true"
+            className="flex w-full flex-wrap items-center justify-between gap-2"
+          >
+            <div className="min-w-0">
+              <h3 className="dashboard-section-heading">
+                Perfil para banco de especialidades
+              </h3>
+              <p className="dashboard-section-description line-clamp-1">
+                Publicación, calidad, avatar y datos visibles en tabs compactos.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Badge variant={getPublicationVariant(profile)}>
+                {getPublicationLabel(profile)}
+              </Badge>
+              <Button type="submit" size="sm" disabled={isWorking}>
+                {isSubmitting ? "Guardando..." : "Guardar perfil público"}
+              </Button>
+            </div>
+          </div>
+        }
+      >
+        {isLoading ? (
+          <p className="clinical-alert-info shrink-0 px-3 py-2" role="status">
+            Cargando perfil público...
+          </p>
+        ) : null}
+
+        {profileLoadErrorMessage ? (
+          <div
+            className="clinical-alert-error flex shrink-0 flex-wrap items-center justify-between gap-2 px-3 py-2"
+            role="alert"
+          >
+            <span>{profileLoadErrorMessage}</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadProfile()}
+              disabled={isWorking}
+            >
+              Reintentar carga
+            </Button>
+          </div>
+        ) : null}
+
+        <ModuleTabs
+          ariaLabel="Edición de perfil público"
+          tabs={[
+            { id: "estado", label: "Estado", content: statusTab },
+            { id: "datos", label: "Datos", content: detailsTab },
+            { id: "contacto", label: "Contacto", content: contactTab },
+            { id: "contenido", label: "Contenido", content: contentTab },
+          ]}
+        />
+
+        <div
+          data-clinic-profile-footer="true"
+          className="flex min-h-8 shrink-0 flex-wrap items-center gap-2 border-t border-vetneb-line/65 pt-2 text-xs"
+        >
+          {errorMessage ? (
+            <p className="clinical-alert-error px-3 py-1.5" role="alert">
+              {errorMessage}
             </p>
           ) : null}
 
-          {profileLoadErrorMessage ? (
-            <div
-              className="clinical-alert-error flex flex-wrap items-center justify-between gap-2 px-3 py-2"
-              role="alert"
-            >
-              <span>{profileLoadErrorMessage}</span>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => void loadProfile()}
-                disabled={isWorking}
-              >
-                Reintentar carga
-              </Button>
-            </div>
+          {statusMessage ? (
+            <p className="clinical-alert-success px-3 py-1.5">
+              {statusMessage}
+            </p>
           ) : null}
 
-          <ModuleTabs
-            ariaLabel="Edición de perfil público"
-            tabs={[
-              { id: "estado", label: "Estado", content: statusTab },
-              { id: "datos", label: "Datos", content: detailsTab },
-              { id: "contenido", label: "Contenido", content: contentTab },
-            ]}
-          />
-
-          <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-vetneb-line/65 pt-3">
-            <div className="min-h-5 text-sm">
-              {errorMessage ? (
-                <p className="clinical-alert-error px-3 py-2" role="alert">
-                  {errorMessage}
-                </p>
-              ) : null}
-
-              {statusMessage ? (
-                <p className="clinical-alert-success px-3 py-2">
-                  {statusMessage}
-                </p>
-              ) : null}
-            </div>
-            <Button type="submit" disabled={isWorking}>
-              {isSubmitting ? "Guardando perfil..." : "Guardar perfil público"}
-            </Button>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+          {!errorMessage && !statusMessage ? (
+            <p className="text-muted-foreground">
+              Cambios del perfil se guardan desde la acción principal del módulo.
+            </p>
+          ) : null}
+        </div>
+      </ModuleSurface>
+    </form>
   );
 }

--- a/test/frontend-clinic-public-profile.test.ts
+++ b/test/frontend-clinic-public-profile.test.ts
@@ -73,9 +73,14 @@ test("clinic public profile editor keeps mobile fields operable", () => {
 
   assert.ok(source.includes('data-clinic-profile-editor="true"'));
   assert.ok(source.includes('data-clinic-profile-fields="true"'));
+  assert.ok(source.includes('data-clinic-profile-toolbar="true"'));
+  assert.ok(source.includes('data-clinic-profile-footer="true"'));
+  assert.ok(source.includes("ModuleSurface"));
+  assert.ok(source.includes('label: "Contacto"'));
   assert.ok(source.includes("h-12 w-12 sm:h-16 sm:w-16"));
   assert.ok(source.includes("text-xl sm:text-2xl"));
-  assert.ok(source.includes("min-h-0 flex-1 overflow-y-auto"));
+  assert.ok(source.includes("min-h-0 flex-1 overflow-hidden"));
+  assert.equal(source.includes("overflow-y-auto"), false);
 });
 
 test("frontend api exposes clinic public profile helpers", () => {

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -94,6 +94,7 @@ test("clinic tokens uses inline master-detail with paged list and step dialogs",
   assert.ok(source.includes('data-detail-state="selected"'));
   assert.equal(source.includes("isMobileDetailOpen"), false);
   assert.equal(source.includes("Volver a la lista"), false);
+  assert.equal(source.includes('hasOpenDetail && !isSelected && "hidden sm:block"'), false);
   assert.equal(source.includes('xl:grid-cols-[0.82fr_1.46fr]'), false);
   assert.equal(source.includes("dashboard-inline-scroll"), false);
   assert.ok(source.includes("CREATE_TOKEN_STEP_ORDER"));

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -85,14 +85,17 @@ test("clinic tokens uses inline master-detail with paged list and step dialogs",
   assert.ok(source.includes("usePagedRows(tokens, TOKENS_PAGE_SIZE)"));
   assert.ok(source.includes("<CompactPager"));
   assert.ok(source.includes("selectedTokenId"));
+  assert.ok(source.includes("ModuleSurface"));
   assert.ok(source.includes("dashboard-inline-list"));
-  assert.ok(source.includes("dashboard-inline-scroll"));
+  assert.ok(source.includes('data-clinic-access-list-body="true"'));
   assert.ok(source.includes("dashboard-inline-detail"));
+  assert.ok(source.includes("dashboard-detail-panel"));
   assert.ok(source.includes("aria-expanded={isSelected}"));
   assert.ok(source.includes('data-detail-state="selected"'));
   assert.equal(source.includes("isMobileDetailOpen"), false);
   assert.equal(source.includes("Volver a la lista"), false);
   assert.equal(source.includes('xl:grid-cols-[0.82fr_1.46fr]'), false);
+  assert.equal(source.includes("dashboard-inline-scroll"), false);
   assert.ok(source.includes("CREATE_TOKEN_STEP_ORDER"));
   assert.ok(source.includes("createStep"));
   assert.ok(source.includes("Siguiente"));


### PR DESCRIPTION
## Summary
- Ports Admin dashboard layout metrics and structural patterns to Clinic modules without duplicating Admin functions.
- Reworks Clinic Tokens and Perfil into bounded ModuleSurface layouts with compact toolbars, visible primary actions, compact detail panels, and no visible internal vertical scroll.
- Preserves Clinic domain functions and verifies Admin remains unaffected.

## Scope
- Private Clinic dashboard Tokens and Perfil layout.
- Clinic scoped CSS.
- E2E and native tests for no-scroll, operability, and source contracts.
- Implementation evidence in docs/implementation.

## Out of scope
- Dashboard Admin productive code.
- Backend/API/auth/DB/migrations.
- Dependencies/lockfiles.
- CI/workflows.
- Public /clinicas.

## Validations
- git diff --check
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-mobile-bottom-navigation-no-scroll.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
- pnpm test