### PR TITLE
fix(clinic): match admin table action structure for reports and tokens

### DIFF
--- a/docs/implementation/clinic-table-action-parity.md
+++ b/docs/implementation/clinic-table-action-parity.md
@@ -1,0 +1,109 @@
+# Clinic Table Action Parity
+
+## Estado base
+
+- Rama: `fix/clinic-table-action-parity`.
+- HEAD inicial auditado: `6670f81 fix(clinic): port admin dashboard layout metrics to clinic modules (#1144)`.
+- Estado inicial: `git status --short` limpio.
+- Entorno usado: Windows, PowerShell, PNPM.
+
+## Scope incluido
+
+- Reestructurar Tokens Clinica como tabla/lista compacta con accion por fila.
+- Reestructurar Informes Clinica como tabla/lista compacta con accion por fila.
+- Mantener funciones clinicas existentes sin convertir Clinica en Admin.
+- Actualizar tests e2e y tests nativos relacionados.
+- Documentar la implementacion en `docs/implementation`.
+
+## Scope excluido
+
+- Backend, API, DB, Drizzle, migraciones, schema y endpoints.
+- Auth, cookies, CORS, CSP, rate limits y seguridad de sesiones.
+- Dependencias, `package.json`, lockfiles, CI y workflows.
+- Pagina publica `/clinicas`.
+- Cambios productivos en dashboard Admin; Admin se uso solo como referencia de lectura.
+- Copia de textos, permisos, modulos, filtros o acciones administrativas en Clinica.
+
+## Auditoria previa
+
+- Se confirmo rama esperada y base limpia.
+- Se confirmaron scripts reales en `package.json` y `frontend/package.json`.
+- Se leyeron referencias Admin: `AdminParticularTokensCard`, `AdminReportsCard`, `DashboardModuleWorkspace`, `ModuleSurface`, `CompactPager` y `globals.css`.
+- Se leyeron superficies Clinica: `ClinicParticularTokensCard`, `ClinicInformesWorkspaceSummary` y `ClinicDashboardWorkspaceController`.
+- Se ubicaron tests e2e obligatorios y tests nativos relacionados.
+- Referencias legacy detectadas en el scope: Tokens e Informes Clinica usaban detalle inline con `dashboard-inline-detail` y `data-detail-state="selected"`.
+
+## Estructura Admin extraida
+
+- Toolbar superior fija con metricas y acciones.
+- Tabla o lista compacta full-width.
+- Filas densas con columnas operativas.
+- Boton de accion por fila.
+- Paginacion o footer visible al pie del modulo.
+- Detalle controlado en dialogo, no expandido dentro de la lista principal.
+
+## Cambios
+
+- `ClinicParticularTokensCard`:
+  - Reemplaza el master-detail inline por tabla desktop y lista mobile.
+  - Agrega boton `Ver detalle` por fila.
+  - Mueve el detalle clinico a `ModuleDialog`.
+  - Conserva generacion de token, actualizacion, listado, estado activo/inactivo, informe vinculado, seguimiento, detalle y paginacion.
+- `ClinicInformesWorkspaceSummary`:
+  - Reemplaza el detalle inline por tabla/lista compacta.
+  - Agrega boton `Ver` por fila.
+  - Mueve el detalle a `ModuleDialog`.
+  - Conserva `Abrir modulo completo`, datos de caso/paciente, estudio, estado, fecha y archivo/informe.
+- Tests:
+  - E2E de Tokens/Informes validan filas compactas, accion por fila, ausencia de detalle inline y footer visible.
+  - El contrato global de no-scroll valida detalle en dialogo para Tokens.
+  - Tests nativos actualizan el contrato fuente de Tokens e Informes Clinica.
+
+## Archivos modificados
+
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-global-masked-master-detail.spec.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `test/frontend-dashboard-home.test.ts`
+- `docs/implementation/clinic-table-action-parity.md`
+
+## Funciones clinicas preservadas
+
+- Tokens: generar token particular, actualizar, listar tokens de la clinica, ver activo/inactivo, ver informe vinculado, ver detalle clinico y paginar.
+- Informes: consultar informes recientes, ver caso/paciente, estudio, estado, fecha, archivo/informe, abrir detalle y abrir el modulo completo.
+
+## Confirmacion de no duplicar Admin
+
+- No se importaron helpers Admin en Clinica.
+- No se agregaron acciones administrativas como eliminar tokens, gestionar clinicas, usuarios, auditoria, sesiones o mantenimiento.
+- No se copiaron filtros, permisos, datos ni textos administrativos.
+- Admin productivo solo se leyo como referencia visual y estructural.
+
+## Validaciones
+
+- `pnpm install --frozen-lockfile --ignore-scripts`: ejecutado como precondicion para restaurar `node_modules`; paso sin modificar lockfile.
+- `git diff --check`: paso. Git informo solo warnings de normalizacion LF/CRLF en dos archivos TSX.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts`: paso, 48/48.
+- `pnpm --dir frontend lint`: paso.
+- `pnpm typecheck:test`: paso.
+- `pnpm --dir frontend typecheck`: paso.
+- `pnpm build`: paso.
+- `pnpm security:public-surface`: paso; el script reporto notas/finding server-only existentes sobre identificadores de cookies en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend build`: paso.
+- `pnpm test`: paso, 2841/2841.
+
+Nota de ejecucion: el `pnpm` primero en PATH era el wrapper del runtime de Codex y bloqueaba la ejecucion por preflight de install. Para validar se uso el PNPM del sistema (`C:\Program Files\nodejs\pnpm.CMD`, version 10.8.1), que coincide con `packageManager`.
+
+## Riesgo residual
+
+- Bajo: el cambio queda acotado a presentacion y tests del dashboard Clinica.
+- El detalle de Informes usa acciones de archivo existentes para scope `clinic`; no agrega endpoints.
+
+## Estado final
+
+- Working tree con cambios solo en archivos frontend/test/doc del scope.
+- Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI ni Admin productivo.
+- `git status --short --untracked-files=all` muestra los archivos modificados y esta nota nueva sin stage.

--- a/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
@@ -22,6 +22,9 @@ type LayoutContract = {
   mainScrollHeight: number;
   mainClientHeight: number;
   listClientHeight: number;
+  listScrollHeight: number;
+  listOverflowY: string;
+  moduleScrollContainers: Array<{ tag: string; overflowY: string }>;
   hasMain: boolean;
   hasList: boolean;
 };
@@ -58,7 +61,23 @@ async function readLayoutContract(page: Page): Promise<LayoutContract> {
     const html = document.documentElement;
     const body = document.body;
     const main = document.querySelector<HTMLElement>("main.dashboard-main");
-    const list = document.querySelector<HTMLElement>(".dashboard-inline-scroll");
+    const card = document.querySelector<HTMLElement>(
+      '[aria-label="Informes recientes de la clínica"]',
+    );
+    const list = document.querySelector<HTMLElement>(
+      '[data-clinic-reports-mobile-list="true"]',
+    );
+    const moduleScrollContainers = card
+      ? [card, ...Array.from(card.querySelectorAll<HTMLElement>("*"))].flatMap(
+          (element) => {
+            const style = window.getComputedStyle(element);
+            return ["auto", "scroll"].includes(style.overflowY)
+              ? [{ tag: element.tagName, overflowY: style.overflowY }]
+              : [];
+          },
+        )
+      : [];
+    const listStyle = list ? window.getComputedStyle(list) : null;
 
     return {
       htmlScrollWidth: html.scrollWidth,
@@ -72,6 +91,9 @@ async function readLayoutContract(page: Page): Promise<LayoutContract> {
       mainScrollHeight: main?.scrollHeight ?? 0,
       mainClientHeight: main?.clientHeight ?? 0,
       listClientHeight: list?.clientHeight ?? 0,
+      listScrollHeight: list?.scrollHeight ?? 0,
+      listOverflowY: listStyle?.overflowY ?? "missing",
+      moduleScrollContainers,
       hasMain: main !== null,
       hasList: list !== null,
     };
@@ -102,8 +124,20 @@ function assertNoGlobalOverflow(metrics: LayoutContract, label: string) {
   expect(metrics.hasList, `${label}: inline list present`).toBe(true);
   expect(
     metrics.listClientHeight,
-    `${label}: inline list must keep an operable height`,
+    `${label}: report list must keep an operable height`,
   ).toBeGreaterThanOrEqual(44);
+  expect(
+    metrics.listScrollHeight,
+    `${label}: report list must not clip hidden overflow`,
+  ).toBeLessThanOrEqual(metrics.listClientHeight + TOLERANCE);
+  expect(
+    ["auto", "scroll"],
+    `${label}: report list must not expose vertical scroll`,
+  ).not.toContain(metrics.listOverflowY);
+  expect(
+    metrics.moduleScrollContainers,
+    `${label}: informes module must not contain internal scroll containers`,
+  ).toEqual([]);
 }
 
 async function expectHorizontallyUnclipped(
@@ -136,8 +170,9 @@ for (const viewport of MOBILE_VIEWPORTS) {
     const card = workspace.locator(
       '[aria-label="Informes recientes de la clínica"]',
     );
-    const inlineList = card.locator(".dashboard-inline-scroll");
-    const reportRows = inlineList.locator('button[aria-pressed]');
+    const mobileList = card.locator('[data-clinic-reports-mobile-list="true"]');
+    const reportRows = card.locator('[data-clinic-reports-mobile-row="true"]');
+    const viewButtons = card.getByRole("button", { name: "Ver", exact: true });
     const fullModuleButton = card.getByRole("button", {
       name: "Abrir módulo completo de informes",
       exact: true,
@@ -147,17 +182,23 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(workspace).toBeVisible();
       await expect(card).toBeVisible();
       await expectClinicMobileBottomNav(page, viewport.name);
+      await expect(mobileList).toBeVisible();
       await expect(reportRows).toHaveCount(3);
+      await expect(viewButtons).toHaveCount(3);
 
       for (let index = 0; index < 3; index += 1) {
         await expect(reportRows.nth(index)).toBeVisible();
+        await expect(viewButtons.nth(index)).toBeVisible();
       }
 
       await expect(fullModuleButton).toBeVisible();
       await expect(fullModuleButton).toBeEnabled();
     }).toPass({ timeout: 12_000 });
 
-    await expect(card.locator("table")).toHaveCount(0);
+    await expect(card.locator('[data-clinic-reports-table="true"]')).toBeHidden();
+    await expect(
+      card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+    ).toHaveCount(0);
     await expectHorizontallyUnclipped(
       fullModuleButton,
       viewport.width,
@@ -177,19 +218,23 @@ for (const viewport of MOBILE_VIEWPORTS) {
       assertNoGlobalOverflow(metrics, `${viewport.name}: initial layout`);
     }).toPass({ timeout: 10_000 });
 
-    const secondReport = reportRows.nth(1);
-    await secondReport.click();
+    await viewButtons.nth(1).click();
 
     await expect(async () => {
-      await expect(secondReport).toHaveAttribute("aria-expanded", "true");
+      await expect(reportRows).toHaveCount(3);
+      await expect(reportRows.nth(1)).toBeVisible();
+      await expect(
+        card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+      ).toHaveCount(0);
 
-      const inlineDetail = card.locator('[data-detail-state="selected"]');
-      await expect(inlineDetail).toHaveCount(1);
-      await expect(inlineDetail).toBeVisible();
-      await expect(inlineDetail).toContainText(LONG_PATIENT_NAME);
+      const detailDialog = page.locator(
+        '[data-clinic-reports-detail-dialog="true"]',
+      );
+      await expect(detailDialog).toBeVisible();
+      await expect(detailDialog).toContainText(LONG_PATIENT_NAME);
 
       const metrics = await readLayoutContract(page);
-      assertNoGlobalOverflow(metrics, `${viewport.name}: expanded inline detail`);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: modal detail`);
     }).toPass({ timeout: 10_000 });
   });
 }

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -230,7 +230,11 @@ for (const viewport of MOBILE_VIEWPORTS) {
       .locator('[data-dashboard-module-workspace="tokens"]')
       .first();
     const card = page.locator("#clinic-particular-tokens");
-    const tokenRows = card.locator('[id^="clinic-particular-token-"]');
+    const tokenRows = card.locator('[data-clinic-access-mobile-row="true"]');
+    const detailButtons = card.getByRole("button", {
+      name: "Ver detalle",
+      exact: true,
+    });
     const refreshButton = card.getByRole("button", {
       name: "Actualizar",
       exact: true,
@@ -254,9 +258,11 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(card).toBeVisible();
       await expectClinicMobileBottomNav(page, viewport.name);
       await expect(tokenRows).toHaveCount(4);
+      await expect(detailButtons).toHaveCount(4);
 
       for (let index = 0; index < 4; index += 1) {
         await expect(tokenRows.nth(index)).toBeVisible();
+        await expect(detailButtons.nth(index)).toBeVisible();
       }
 
       await expect(refreshButton).toBeVisible();
@@ -298,34 +304,41 @@ for (const viewport of MOBILE_VIEWPORTS) {
       `${viewport.name}: Página siguiente`,
     );
 
-    await expect(card.locator("table")).toHaveCount(0);
+    await expect(card.locator('[data-clinic-access-table="true"]')).toBeHidden();
+    await expect(
+      card.locator('[data-clinic-access-mobile-list="true"]'),
+    ).toBeVisible();
+    await expect(
+      card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+    ).toHaveCount(0);
 
     await expect(async () => {
       const metrics = await readLayoutContract(page);
       assertNoGlobalOverflow(metrics, `${viewport.name}: initial layout`);
     }).toPass({ timeout: 10_000 });
 
-    const secondToken = page.locator("#clinic-particular-token-2");
-    await secondToken.click();
+    await detailButtons.nth(1).click();
 
     await expect(async () => {
-      await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
-      await expect(secondToken).toBeVisible();
-      await expect(secondToken).toHaveAttribute(
-        "aria-expanded",
-        "true",
-      );
-      const inlineDetail = card.locator('[data-detail-state="selected"]');
-      await expect(inlineDetail).toHaveCount(1);
-      await expect(inlineDetail).toBeVisible();
+      await expect(tokenRows).toHaveCount(4);
+      await expect(tokenRows.nth(0)).toBeVisible();
+      await expect(tokenRows.nth(1)).toBeVisible();
       await expect(
-        inlineDetail.getByRole("heading", {
-          name: /Paciente veterinario 2 .* Apellido compuesto del tutor 2/,
-        }),
+        card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+      ).toHaveCount(0);
+
+      const detailDialog = page.locator(
+        '[data-clinic-access-detail-dialog="true"]',
+      );
+      await expect(detailDialog).toBeVisible();
+      await expect(
+        detailDialog.getByText(
+          /Paciente veterinario 2 .* Apellido compuesto del tutor 2/,
+        ),
       ).toBeVisible();
 
       const metrics = await readLayoutContract(page);
-      assertNoGlobalOverflow(metrics, `${viewport.name}: expanded inline detail`);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: modal detail`);
     }).toPass({ timeout: 10_000 });
   });
 }

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -40,13 +40,13 @@ type ModuleCase = {
 
 const MODULES: ModuleCase[] = [
   {
-    label: "clinic Tokens particulares (inline detail + dialog alta)",
+    label: "clinic Tokens particulares (table actions + dialog alta)",
     surface: "clinic",
     path: "/dashboard?module=tokens",
     moduleId: "tokens",
   },
   {
-    label: "clinic Informes (in-shell master-detail)",
+    label: "clinic Informes (table actions)",
     surface: "clinic",
     path: "/dashboard?module=informes",
     moduleId: "informes",
@@ -352,7 +352,7 @@ for (const viewport of VIEWPORTS) {
   });
 }
 
-test("clinic Tokens desktop limits the list and expands detail inline without shell scroll", async ({
+test("clinic Tokens desktop limits the list and opens detail dialog without shell scroll", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1366, height: 768 });
@@ -360,26 +360,29 @@ test("clinic Tokens desktop limits the list and expands detail inline without sh
   await mockClinicTokens(page);
 
   await page.goto("/dashboard?module=tokens");
-  await expect(page.locator('[data-dashboard-module-workspace="tokens"]').first()).toBeVisible({
+  const workspace = page.locator('[data-dashboard-module-workspace="tokens"]').first();
+  const card = page.locator("#clinic-particular-tokens");
+  await expect(workspace).toBeVisible({
     timeout: 12_000,
   });
-  await expect(page.locator('[id^="clinic-particular-token-"]')).toHaveCount(4);
+  await expect(card.locator('[data-clinic-access-table-row="true"]')).toHaveCount(4);
   await expect(page.getByText(/1.4 de 6 tokens/)).toBeVisible();
 
-  await page.locator("#clinic-particular-token-2").click();
-  await expect(page.locator("#clinic-particular-token-2")).toHaveAttribute(
-    "aria-expanded",
-    "true",
-  );
-  await expect(page.locator('[data-detail-state="selected"]')).toHaveCount(1);
-  await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeVisible();
-  await expect(page.getByText("Alerta: Solicitud de tinción especial")).toBeVisible();
+  await card.getByRole("button", { name: "Ver detalle", exact: true }).nth(1).click();
+  await expect(
+    card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+  ).toHaveCount(0);
+  await expect(card.locator('[data-clinic-access-table-row="true"]')).toHaveCount(4);
+  const detailDialog = page.locator('[data-clinic-access-detail-dialog="true"]');
+  await expect(detailDialog).toBeVisible();
+  await expect(detailDialog).toContainText("Paciente 2 · Tutor 2");
+  await expect(detailDialog.getByText("Alerta: Solicitud de tinción especial")).toBeVisible();
 
   const metrics = await readScrollContract(page);
-  assertNoInternalScroll(metrics, "desktop clinic Tokens selected detail");
+  assertNoInternalScroll(metrics, "desktop clinic Tokens selected dialog");
 });
 
-test("clinic Tokens mobile keeps the list and expands the selected detail inline", async ({
+test("clinic Tokens mobile keeps the list and opens the selected detail dialog", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -387,21 +390,22 @@ test("clinic Tokens mobile keeps the list and expands the selected detail inline
   await mockClinicTokens(page);
 
   await page.goto("/dashboard?module=tokens");
-  await expect(page.locator('[data-dashboard-module-workspace="tokens"]').first()).toBeVisible({
+  const workspace = page.locator('[data-dashboard-module-workspace="tokens"]').first();
+  const card = page.locator("#clinic-particular-tokens");
+  await expect(workspace).toBeVisible({
     timeout: 12_000,
   });
-  await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
+  await expect(card.locator('[data-clinic-access-mobile-row="true"]').first()).toBeVisible();
 
-  await page.locator("#clinic-particular-token-2").click();
-  await expect(page.locator("#clinic-particular-token-1")).toBeVisible();
-  await expect(page.locator("#clinic-particular-token-2")).toBeVisible();
-  await expect(page.locator("#clinic-particular-token-2")).toHaveAttribute(
-    "aria-expanded",
-    "true",
-  );
-  await expect(page.locator('[data-detail-state="selected"]')).toHaveCount(1);
-  await expect(page.getByRole("heading", { name: "Paciente 2 · Tutor 2" })).toBeVisible();
+  await card.getByRole("button", { name: "Ver detalle", exact: true }).nth(1).click();
+  await expect(card.locator('[data-clinic-access-mobile-row="true"]')).toHaveCount(4);
+  await expect(
+    card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+  ).toHaveCount(0);
+  const detailDialog = page.locator('[data-clinic-access-detail-dialog="true"]');
+  await expect(detailDialog).toBeVisible();
+  await expect(detailDialog).toContainText("Paciente 2 · Tutor 2");
 
   const metrics = await readScrollContract(page);
-  assertNoInternalScroll(metrics, "mobile clinic Tokens inline detail");
+  assertNoInternalScroll(metrics, "mobile clinic Tokens selected dialog");
 });

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -3,30 +3,44 @@
 import { useState } from "react";
 import type { Report } from "@/types";
 import { ClipboardList, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CompactPager } from "@/components/dashboard/CompactPager";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { DashboardRefreshButton } from "@/components/dashboard/DashboardRefreshButton";
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
+import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
+import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
-import { cn, formatDate } from "@/lib/utils";
+import { formatDate } from "@/lib/utils";
 
 type Props = {
   recentReports: Report[];
   reportsLoadError: boolean;
 };
 
+const REPORTS_PAGE_SIZE = 3;
+
+function formatReportFile(report: Report): string {
+  if (report.fileName) {
+    return report.fileName;
+  }
+
+  return report.hasFile ? "Con archivo" : "Sin archivo";
+}
+
 export function ClinicInformesWorkspaceSummary({
   recentReports,
   reportsLoadError,
 }: Props) {
-  const [selectedReportId, setSelectedReportId] = useState<number | null>(
-    recentReports[0]?.id ?? null,
-  );
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
+  const pagedReports = usePagedRows(recentReports, REPORTS_PAGE_SIZE);
   const selectedReport =
-    recentReports.find((report) => report.id === selectedReportId) ??
-    recentReports[0] ??
-    null;
+    selectedReportId === null
+      ? null
+      : (recentReports.find((report) => report.id === selectedReportId) ?? null);
 
   const fullModuleLink = (
     <PublicRouteControl
@@ -66,97 +80,128 @@ export function ClinicInformesWorkspaceSummary({
           <DashboardRefreshButton />
         </div>
       ) : recentReports.length ? (
-        <div className="dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82">
-            <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
-              {recentReports.map((report) => {
-                const isSelected = selectedReport?.id === report.id;
-
-                return (
-                  <div key={report.id} className="min-w-0">
-                    <button
-                      type="button"
-                      onClick={() => setSelectedReportId(report.id)}
-                      aria-pressed={isSelected}
-                      aria-expanded={isSelected}
-                      className={cn(
-                        "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                        isSelected && "bg-vetneb-cyan/12",
-                      )}
-                    >
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-vetneb-ink">
-                          {report.patientName ?? "Sin nombre"}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {report.studyType} · {formatDate(report.uploadDate)}
-                        </p>
-                      </div>
-                      <StatusBadge status={report.status} size="sm" className="ml-2 shrink-0" />
-                    </button>
-
-                    {isSelected && selectedReport ? (
-                      <div
-                        data-detail-state="selected"
-                        className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40 p-4"
+        <div
+          data-clinic-reports-list-panel="true"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
+        >
+          <div
+            data-clinic-reports-table="true"
+            className="hidden min-h-0 flex-1 overflow-hidden md:block"
+          >
+            <table className="w-full table-fixed text-[0.8125rem]">
+              <thead className="border-b border-vetneb-line/65 bg-vetneb-surface-muted/65 text-xs font-semibold uppercase text-muted-foreground">
+                <tr>
+                  <th className="w-[26%] px-3 py-2 text-left">Caso / Paciente</th>
+                  <th className="w-[17%] px-3 py-2 text-left">Estudio</th>
+                  <th className="w-[15%] px-3 py-2 text-left">Estado</th>
+                  <th className="w-[14%] px-3 py-2 text-left">Fecha</th>
+                  <th className="w-[18%] px-3 py-2 text-left">Archivo / Informe</th>
+                  <th className="w-[10%] px-3 py-2 text-right">Acción</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-vetneb-line/60">
+                {pagedReports.pageItems.map((report) => (
+                  <tr
+                    key={report.id}
+                    data-clinic-reports-table-row="true"
+                    className="hover:bg-vetneb-cyan/8"
+                  >
+                    <td className="px-3 py-1.5">
+                      <p className="truncate font-semibold text-vetneb-ink">
+                        {report.patientName ?? "Sin nombre"}
+                      </p>
+                      <p className="font-mono text-[0.6875rem] text-muted-foreground">
+                        Informe #{report.id}
+                      </p>
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <span className="block truncate">
+                        {report.studyType ?? "Tipo sin registrar"}
+                      </span>
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <StatusBadge status={report.status} size="sm" />
+                    </td>
+                    <td className="px-3 py-1.5 text-xs text-muted-foreground">
+                      {formatDate(report.uploadDate)}
+                    </td>
+                    <td className="px-3 py-1.5 text-xs text-muted-foreground">
+                      <span className="block truncate">{formatReportFile(report)}</span>
+                    </td>
+                    <td className="px-3 py-1.5 text-right">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => setSelectedReportId(report.id)}
                       >
-                        <div className="space-y-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                Detalle del informe
-                              </p>
-                              <h4 className="mt-1 break-words text-lg font-semibold text-vetneb-ink">
-                                {selectedReport.patientName ?? "Sin nombre"}
-                              </h4>
-                            </div>
-                            <StatusBadge status={selectedReport.status} size="sm" className="shrink-0" />
-                          </div>
-                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                            <div className="clinical-muted-band rounded-lg px-3 py-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Estudio
-                              </p>
-                              <p className="mt-1 text-xs text-vetneb-ink">
-                                {selectedReport.studyType ?? "—"}
-                              </p>
-                            </div>
-                            <div className="clinical-muted-band rounded-lg px-3 py-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Carga
-                              </p>
-                              <p className="mt-1 text-xs text-muted-foreground">
-                                {formatDate(selectedReport.uploadDate)}
-                              </p>
-                            </div>
-                            <div className="clinical-muted-band rounded-lg px-3 py-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Informe
-                              </p>
-                              <p className="mt-1 text-xs text-muted-foreground">
-                                #{selectedReport.id} · {selectedReport.hasFile ? "Con archivo" : "Sin archivo"}
-                              </p>
-                            </div>
-                            <div className="clinical-muted-band rounded-lg px-3 py-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Acción
-                              </p>
-                              <PublicRouteControl
-                                href={`${ROUTES.dashboardInformes}?reportId=${selectedReport.id}`}
-                                variant="textLink"
-                                className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                                aria-label={`Abrir informe ${selectedReport.id} en el módulo completo`}
-                              >
-                                Abrir en módulo completo
-                              </PublicRouteControl>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </div>
+                        Ver
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div
+            data-clinic-reports-mobile-list="true"
+            className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
+          >
+            {pagedReports.pageItems.map((report) => (
+              <div
+                key={report.id}
+                data-clinic-reports-mobile-row="true"
+                className="grid min-h-11 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-semibold text-vetneb-ink">
+                    #{report.id} · {report.patientName ?? "Sin nombre"}
+                  </p>
+                  <p className="truncate text-[0.6875rem] text-muted-foreground">
+                    {report.studyType ?? "Tipo sin registrar"} ·{" "}
+                    {formatDate(report.uploadDate)}
+                  </p>
+                  <p className="truncate text-[0.6875rem] text-muted-foreground">
+                    {formatReportFile(report)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <StatusBadge status={report.status} size="sm" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    onClick={() => setSelectedReportId(report.id)}
+                  >
+                    Ver
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <CompactPager
+            className="shrink-0 px-3 pb-2"
+            page={pagedReports.page}
+            pageCount={pagedReports.pageCount}
+            rangeStart={pagedReports.rangeStart}
+            rangeEnd={pagedReports.rangeEnd}
+            total={pagedReports.total}
+            hasPrev={pagedReports.hasPrev}
+            hasNext={pagedReports.hasNext}
+            onPrev={() => {
+              setSelectedReportId(null);
+              pagedReports.goPrev();
+            }}
+            onNext={() => {
+              setSelectedReportId(null);
+              pagedReports.goNext();
+            }}
+            itemLabel="informes"
+          />
         </div>
       ) : (
         <EmptyState
@@ -165,6 +210,78 @@ export function ClinicInformesWorkspaceSummary({
           icon={ClipboardList}
         />
       )}
+
+      {selectedReport ? (
+        <ModuleDialog
+          open={selectedReport !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSelectedReportId(null);
+            }
+          }}
+          title={`Informe #${selectedReport.id}`}
+          description={selectedReport.patientName ?? "Sin nombre"}
+        >
+          <div
+            data-clinic-reports-detail-dialog="true"
+            className="flex min-h-0 flex-col gap-3 text-xs"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-[0.6875rem] text-muted-foreground">
+                  Caso / Paciente
+                </p>
+                <p className="truncate text-sm font-semibold text-vetneb-ink">
+                  {selectedReport.patientName ?? "Sin nombre"}
+                </p>
+              </div>
+              <StatusBadge
+                status={selectedReport.status}
+                size="sm"
+                className="shrink-0"
+              />
+            </div>
+
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-2 rounded-lg border border-vetneb-line/70 px-3 py-2">
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Estudio</dt>
+                <dd className="truncate font-medium">
+                  {selectedReport.studyType ?? "Tipo sin registrar"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Fecha</dt>
+                <dd>{formatDate(selectedReport.uploadDate)}</dd>
+              </div>
+              <div className="col-span-2 min-w-0">
+                <dt className="text-[0.6875rem] text-muted-foreground">
+                  Archivo / Informe
+                </dt>
+                <dd className="truncate">{formatReportFile(selectedReport)}</dd>
+              </div>
+            </dl>
+
+            <div className="border-t border-vetneb-line/65 pt-2">
+              <p className="mb-1 text-xs font-medium">Documento seguro</p>
+              <ReportFileActions
+                reportId={selectedReport.id}
+                hasFile={selectedReport.hasFile}
+                scope="clinic"
+                align="start"
+              />
+            </div>
+
+            <PublicRouteControl
+              href={`${ROUTES.dashboardInformes}?reportId=${selectedReport.id}`}
+              variant="textLink"
+              className="text-xs"
+              aria-label={`Abrir informe ${selectedReport.id} en el módulo completo`}
+            >
+              Abrir en módulo completo
+            </PublicRouteControl>
+          </div>
+        </ModuleDialog>
+      ) : null}
     </ModuleSurface>
   );
 }

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -259,7 +259,6 @@ export function ClinicParticularTokensCard() {
   const selectedTrackingCase = selectedToken
     ? trackingCasesByTokenId[selectedToken.id]
     : undefined;
-  const hasOpenDetail = selectedToken !== null;
 
   const activeTokensCount = tokens.filter((token) => token.isActive).length;
   const linkedReportsCount = tokens.filter((token) => token.hasLinkedReport).length;
@@ -346,6 +345,10 @@ export function ClinicParticularTokensCard() {
     if (!open) {
       setCreateStep("contact");
     }
+  }
+
+  function openTokenDetail(tokenId: number) {
+    setSelectedTokenId(tokenId);
   }
 
   function goToPreviousCreateStep() {
@@ -568,10 +571,10 @@ export function ClinicParticularTokensCard() {
           className="flex min-h-0 flex-1 flex-col"
         >
           {tokens.length ? (
-            <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
+            <div className="flex min-h-0 flex-1 flex-col">
               <div
                 data-clinic-access-list-panel="true"
-                className="dashboard-master-panel dashboard-inline-list min-h-0 flex-none rounded-lg border border-vetneb-line/75 bg-card/82 sm:flex-1"
+                className="min-h-0 flex-1 overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
               >
                 <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2">
                   <div className="min-w-0">
@@ -597,70 +600,120 @@ export function ClinicParticularTokensCard() {
 
                 <div
                   data-clinic-access-list-body="true"
-                  className="min-h-[12rem] flex-none divide-y divide-vetneb-line/60 overflow-hidden sm:min-h-0 sm:flex-1"
+                  className="min-h-0 flex-1 overflow-hidden"
                 >
-                  {pagedTokens.pageItems.map((token) => {
-                    const isSelected = selectedToken?.id === token.id;
-                    const trackingCase = trackingCasesByTokenId[token.id];
-
-                    return (
-                      <div
-                        key={token.id}
-                        className={cn(
-                          "min-w-0",
-                          hasOpenDetail && !isSelected && "opacity-90",
-                        )}
-                      >
-                        <button
-                          type="button"
-                          id={`clinic-particular-token-${token.id}`}
-                          onClick={() => setSelectedTokenId(token.id)}
-                          aria-pressed={isSelected}
-                          aria-expanded={isSelected}
-                          className={cn(
-                            "block w-full px-3 py-1.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset sm:py-2",
-                            hasOpenDetail && "py-1 sm:py-2",
-                            isSelected && "bg-vetneb-cyan/12",
-                          )}
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="truncate text-sm font-semibold text-vetneb-ink">
+                  <div
+                    data-clinic-access-table="true"
+                    className="hidden min-h-0 flex-1 overflow-hidden md:block"
+                  >
+                    <table className="w-full table-fixed text-[0.8125rem]">
+                      <thead className="border-b border-vetneb-line/65 bg-vetneb-surface-muted/65 text-xs font-semibold uppercase text-muted-foreground">
+                        <tr>
+                          <th className="w-[32%] px-3 py-2 text-left">Token / Paciente</th>
+                          <th className="w-[13%] px-3 py-2 text-left">Estado</th>
+                          <th className="w-[15%] px-3 py-2 text-left">Informe</th>
+                          <th className="w-[24%] px-3 py-2 text-left">
+                            Último acceso o creado
+                          </th>
+                          <th className="w-[16%] px-3 py-2 text-right">Acción</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-vetneb-line/60">
+                        {pagedTokens.pageItems.map((token) => (
+                          <tr
+                            key={token.id}
+                            data-clinic-access-table-row="true"
+                            className="hover:bg-vetneb-cyan/8"
+                          >
+                            <td className="px-3 py-1.5">
+                              <p className="truncate font-mono text-xs font-semibold text-vetneb-ink">
+                                ****{token.tokenLast4}
+                              </p>
+                              <p className="truncate text-[0.6875rem] text-muted-foreground">
                                 {token.petName} · {token.tutorLastName}
                               </p>
-                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                                Token ****{token.tokenLast4}
-                              </p>
-                              <p className="hidden truncate text-xs text-muted-foreground sm:mt-0.5 sm:block">
-                                {trackingCase
-                                  ? getTrackingStageLabel(trackingCase.currentStage)
-                                  : "Sin seguimiento vinculado"}
-                              </p>
-                            </div>
-                            <div
-                              className={cn(
-                                "flex shrink-0 flex-col items-end gap-1",
-                                hasOpenDetail && "hidden sm:flex",
-                              )}
-                            >
+                            </td>
+                            <td className="px-3 py-1.5">
                               <Badge
                                 variant={token.isActive ? "default" : "outline"}
                                 className="h-5 px-1.5 text-[0.6875rem]"
                               >
                                 {token.isActive ? "Activo" : "Inactivo"}
                               </Badge>
-                              <Badge
-                                variant={token.hasLinkedReport ? "default" : "outline"}
-                                className="h-5 px-1.5 text-[0.6875rem]"
+                            </td>
+                            <td className="px-3 py-1.5 text-xs text-muted-foreground">
+                              {token.hasLinkedReport && token.reportId
+                                ? `#${token.reportId}`
+                                : token.hasLinkedReport
+                                  ? "Con informe"
+                                  : "Sin informe"}
+                            </td>
+                            <td className="px-3 py-1.5 text-xs text-muted-foreground">
+                              {token.lastLoginAt
+                                ? `Acceso ${formatDate(token.lastLoginAt)}`
+                                : `Creado ${formatDate(token.createdAt)}`}
+                            </td>
+                            <td className="px-3 py-1.5 text-right">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                onClick={() => openTokenDetail(token.id)}
                               >
-                                {token.hasLinkedReport ? "Informe" : "Sin informe"}
-                              </Badge>
-                            </div>
+                                Ver detalle
+                              </Button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <div
+                    data-clinic-access-mobile-list="true"
+                    className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
+                  >
+                    {pagedTokens.pageItems.map((token) => {
+                      const trackingCase = trackingCasesByTokenId[token.id];
+
+                      return (
+                        <div
+                          key={token.id}
+                          id={`clinic-particular-token-${token.id}`}
+                          data-clinic-access-mobile-row="true"
+                          className="grid min-h-11 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-xs font-semibold text-vetneb-ink">
+                              ****{token.tokenLast4} · {token.petName}
+                            </p>
+                            <p className="truncate text-[0.6875rem] text-muted-foreground">
+                              {token.isActive ? "Activo" : "Inactivo"} ·{" "}
+                              {token.hasLinkedReport ? "Informe" : "Sin informe"} ·{" "}
+                              {token.lastLoginAt
+                                ? formatDate(token.lastLoginAt)
+                                : formatDate(token.createdAt)}
+                            </p>
+                            <p className="truncate text-[0.6875rem] text-muted-foreground">
+                              {trackingCase
+                                ? getTrackingStageLabel(trackingCase.currentStage)
+                                : token.tutorLastName}
+                            </p>
                           </div>
-                        </button>
-                      </div>
-                    );
-                  })}
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-7 px-2 text-xs"
+                            onClick={() => openTokenDetail(token.id)}
+                          >
+                            Ver detalle
+                          </Button>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
 
                 <CompactPager
@@ -672,147 +725,17 @@ export function ClinicParticularTokensCard() {
                   total={pagedTokens.total}
                   hasPrev={pagedTokens.hasPrev}
                   hasNext={pagedTokens.hasNext}
-                  onPrev={pagedTokens.goPrev}
-                  onNext={pagedTokens.goNext}
+                  onPrev={() => {
+                    setSelectedTokenId(null);
+                    pagedTokens.goPrev();
+                  }}
+                  onNext={() => {
+                    setSelectedTokenId(null);
+                    pagedTokens.goNext();
+                  }}
                   itemLabel="tokens"
                 />
               </div>
-
-              {selectedToken ? (
-                <div
-                  data-clinic-access-detail="true"
-                  data-detail-state="selected"
-                  className="dashboard-detail-panel dashboard-inline-detail flex min-h-0 flex-none flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/92 sm:flex-1"
-                >
-                  <div className="flex min-h-0 flex-1 flex-col gap-1.5 p-2 sm:gap-2 sm:p-3">
-                    <div className="flex shrink-0 flex-col gap-1.5 border-b border-vetneb-line/70 pb-1.5 sm:flex-row sm:items-start sm:justify-between sm:gap-2 sm:pb-2">
-                      <div className="min-w-0">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                          Detalle del token
-                        </p>
-                        <h3 className="mt-0.5 truncate text-sm font-semibold text-vetneb-ink sm:text-base">
-                          {selectedToken.petName} · {selectedToken.tutorLastName}
-                        </h3>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Token ****{selectedToken.tokenLast4}
-                        </p>
-                      </div>
-                      <div className="flex flex-wrap gap-1.5">
-                        <Badge
-                          variant={selectedToken.isActive ? "default" : "outline"}
-                          className="h-5 px-1.5 text-[0.6875rem]"
-                        >
-                          {selectedToken.isActive ? "Activo" : "Inactivo"}
-                        </Badge>
-                        <Badge
-                          variant={
-                            selectedToken.hasLinkedReport ? "default" : "outline"
-                          }
-                          className="h-5 px-1.5 text-[0.6875rem]"
-                        >
-                          {selectedToken.hasLinkedReport
-                            ? "Informe vinculado"
-                            : "Sin informe"}
-                        </Badge>
-                      </div>
-                    </div>
-
-                    <div className="grid min-h-0 flex-1 grid-cols-3 gap-1 sm:gap-2">
-                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                          Paciente
-                        </p>
-                        <p className="mt-1 line-clamp-1 text-xs text-vetneb-ink">
-                          {selectedToken.petSpecies} · {selectedToken.petBreed} ·{" "}
-                          {selectedToken.petSex}
-                        </p>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Edad: {selectedToken.petAge}
-                        </p>
-                      </div>
-
-                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                          Muestra
-                        </p>
-                        <p className="mt-1 line-clamp-1 text-xs text-vetneb-ink">
-                          {selectedToken.sampleLocation}
-                        </p>
-                        <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
-                          Evolución: {selectedToken.sampleEvolution}
-                        </p>
-                      </div>
-
-                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                          Fechas
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          Extracción: {formatDate(selectedToken.extractionDate)}
-                        </p>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Envío: {formatDate(selectedToken.shippingDate)}
-                        </p>
-                      </div>
-
-                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                          Publicación
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          Informe:{" "}
-                          {selectedToken.reportId
-                            ? `#${selectedToken.reportId}`
-                            : "—"}
-                        </p>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Último acceso:{" "}
-                          {selectedToken.lastLoginAt
-                            ? formatDate(selectedToken.lastLoginAt)
-                            : "—"}
-                        </p>
-                      </div>
-
-                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                          Vínculo
-                        </p>
-                        <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
-                          Tutor: {selectedToken.tutorLastName}
-                        </p>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          Origen: {formatTokenSource(selectedToken)}
-                        </p>
-                      </div>
-
-                      <div className="clinical-muted-band rounded-md px-1.5 py-1 sm:px-2.5 sm:py-2">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                          Seguimiento
-                        </p>
-                        {selectedTrackingCase ? (
-                          <>
-                            <p className="mt-1 line-clamp-1 text-xs text-vetneb-ink">
-                              Etapa:{" "}
-                              {getTrackingStageLabel(
-                                selectedTrackingCase.currentStage,
-                              )}
-                            </p>
-                            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
-                              {selectedTrackingCase.specialStainRequired
-                                ? "Alerta: Solicitud de tinción especial"
-                                : "Sin alerta de tinción especial"}
-                            </p>
-                          </>
-                        ) : (
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            Sin seguimiento vinculado.
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
             </div>
           ) : (
             <div className="flex min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82 p-3">
@@ -1243,6 +1166,139 @@ export function ClinicParticularTokensCard() {
           </div>
         </div>
       </ModuleDialog>
+
+      {selectedToken ? (
+        <ModuleDialog
+          open={selectedToken !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSelectedTokenId(null);
+            }
+          }}
+          title={`Token ****${selectedToken.tokenLast4}`}
+          description={`${selectedToken.petName} · ${selectedToken.tutorLastName}`}
+        >
+          <div
+            data-clinic-access-detail-dialog="true"
+            className="flex min-h-0 flex-col gap-3 text-xs"
+          >
+            <div className="flex flex-wrap items-center gap-1.5">
+              <Badge
+                variant={selectedToken.isActive ? "default" : "outline"}
+                className="h-5 px-1.5 text-[0.6875rem]"
+              >
+                {selectedToken.isActive ? "Activo" : "Inactivo"}
+              </Badge>
+              <Badge
+                variant={selectedToken.hasLinkedReport ? "default" : "outline"}
+                className="h-5 px-1.5 text-[0.6875rem]"
+              >
+                {selectedToken.hasLinkedReport ? "Informe vinculado" : "Sin informe"}
+              </Badge>
+            </div>
+
+            <dl className="grid grid-cols-1 divide-y divide-vetneb-line/55 rounded-lg border border-vetneb-line/70 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
+              <div className="space-y-1 p-2.5">
+                <dt className="text-[0.6875rem] text-muted-foreground">
+                  Paciente
+                </dt>
+                <dd className="font-medium text-vetneb-ink">
+                  {selectedToken.petName} · {selectedToken.tutorLastName}
+                </dd>
+                <dd className="text-muted-foreground">
+                  {selectedToken.petSpecies} · {selectedToken.petBreed} ·{" "}
+                  {selectedToken.petSex} · {selectedToken.petAge}
+                </dd>
+              </div>
+              <div className="space-y-1 p-2.5">
+                <dt className="text-[0.6875rem] text-muted-foreground">
+                  Vínculo
+                </dt>
+                <dd className="font-medium text-vetneb-ink">
+                  Tutor: {selectedToken.tutorLastName}
+                </dd>
+                <dd className="text-muted-foreground">
+                  Origen: {formatTokenSource(selectedToken)}
+                </dd>
+              </div>
+            </dl>
+
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-2">
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Muestra</dt>
+                <dd className="truncate text-vetneb-ink">
+                  {selectedToken.sampleLocation}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Evolución</dt>
+                <dd className="truncate text-vetneb-ink">
+                  {selectedToken.sampleEvolution}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">
+                  Extracción
+                </dt>
+                <dd>{formatDate(selectedToken.extractionDate)}</dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Envío</dt>
+                <dd>{formatDate(selectedToken.shippingDate)}</dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">
+                  Informe
+                </dt>
+                <dd>{selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}</dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">
+                  Último acceso
+                </dt>
+                <dd>
+                  {selectedToken.lastLoginAt
+                    ? formatDate(selectedToken.lastLoginAt)
+                    : "—"}
+                </dd>
+              </div>
+            </dl>
+
+            {selectedToken.detailsLesion ? (
+              <div className="rounded-lg border border-vetneb-line/65 px-2.5 py-2">
+                <p className="text-[0.6875rem] text-muted-foreground">
+                  Detalle de lesión
+                </p>
+                <p className="line-clamp-2 text-vetneb-ink">
+                  {selectedToken.detailsLesion}
+                </p>
+              </div>
+            ) : null}
+
+            <div className="rounded-lg border border-vetneb-line/65 px-2.5 py-2">
+              <p className="text-[0.6875rem] text-muted-foreground">
+                Seguimiento
+              </p>
+              {selectedTrackingCase ? (
+                <>
+                  <p className="mt-1 font-medium text-vetneb-ink">
+                    {getTrackingStageLabel(selectedTrackingCase.currentStage)}
+                  </p>
+                  <p className="mt-0.5 text-muted-foreground">
+                    {selectedTrackingCase.specialStainRequired
+                      ? "Alerta: Solicitud de tinción especial"
+                      : "Sin alerta de tinción especial"}
+                  </p>
+                </>
+              ) : (
+                <p className="mt-1 text-muted-foreground">
+                  Sin seguimiento vinculado.
+                </p>
+              )}
+            </div>
+          </div>
+        </ModuleDialog>
+      ) : null}
     </section>
   );
 }

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -78,7 +78,7 @@ test("clinic particular tokens card exists and uses clinic helpers", () => {
   assert.equal(source.includes(removedTokenEndpoint), false);
 });
 
-test("clinic tokens uses inline master-detail with paged list and step dialogs", () => {
+test("clinic tokens uses table/list row actions with dialog detail and step dialogs", () => {
   const source = read(CLINIC_TOKENS_CARD_PATH);
 
   assert.ok(source.includes("const TOKENS_PAGE_SIZE = 4;"));
@@ -86,12 +86,18 @@ test("clinic tokens uses inline master-detail with paged list and step dialogs",
   assert.ok(source.includes("<CompactPager"));
   assert.ok(source.includes("selectedTokenId"));
   assert.ok(source.includes("ModuleSurface"));
-  assert.ok(source.includes("dashboard-inline-list"));
+  assert.ok(source.includes('data-clinic-access-table="true"'));
+  assert.ok(source.includes('data-clinic-access-table-row="true"'));
+  assert.ok(source.includes('data-clinic-access-mobile-list="true"'));
+  assert.ok(source.includes('data-clinic-access-mobile-row="true"'));
   assert.ok(source.includes('data-clinic-access-list-body="true"'));
-  assert.ok(source.includes("dashboard-inline-detail"));
-  assert.ok(source.includes("dashboard-detail-panel"));
-  assert.ok(source.includes("aria-expanded={isSelected}"));
-  assert.ok(source.includes('data-detail-state="selected"'));
+  assert.ok(source.includes("Ver detalle"));
+  assert.ok(source.includes("openTokenDetail"));
+  assert.ok(source.includes('data-clinic-access-detail-dialog="true"'));
+  assert.equal(source.includes("dashboard-inline-detail"), false);
+  assert.equal(source.includes("dashboard-detail-panel"), false);
+  assert.equal(source.includes("aria-expanded={isSelected}"), false);
+  assert.equal(source.includes('data-detail-state="selected"'), false);
   assert.equal(source.includes("isMobileDetailOpen"), false);
   assert.equal(source.includes("Volver a la lista"), false);
   assert.equal(source.includes('hasOpenDetail && !isSelected && "hidden sm:block"'), false);

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -144,26 +144,44 @@ test("dashboard home clinic command center presentational props contain operatio
   assert.ok(source.includes("No hay visitas de campo recientes disponibles."));
 });
 
-test("clinic informes and logistica summaries use inline master-detail layers", () => {
-  for (const [context, path] of [
-    ["informes", CLINIC_INFORMES_SUMMARY_PATH],
-    ["logistica", CLINIC_LOGISTICA_SUMMARY_PATH],
-  ] as const) {
-    const source = read(path);
+test("clinic informes summary uses table/list row actions with controlled detail dialog", () => {
+  const source = read(CLINIC_INFORMES_SUMMARY_PATH);
 
-    assert.ok(source.includes('"use client";'), `${context} summary must own state`);
-    assert.ok(source.includes("ModuleSurface"), `${context} summary must use ModuleSurface`);
-    assert.ok(source.includes("useState"), `${context} summary must use selection state`);
-    assert.ok(source.includes("dashboard-inline-list"), `${context} summary must use inline list`);
-    assert.ok(source.includes("dashboard-inline-scroll"), `${context} summary must bound list overflow`);
-    assert.ok(source.includes("dashboard-inline-detail"), `${context} summary must render inline detail`);
-    assert.ok(source.includes("aria-expanded={isSelected}"), `${context} selection must expose expanded state`);
-    assert.ok(source.includes('data-detail-state="selected"'), `${context} detail must remain inside the selected row`);
-    assert.equal(source.includes("isMobileDetailOpen"), false, `${context} summary must not use a replacement layer`);
-    assert.equal(source.includes("Volver a la lista"), false, `${context} summary must keep list and detail together`);
-    assert.equal(source.includes('xl:grid-cols-[0.85fr_1.15fr]'), false, `${context} summary must not use a lateral grid`);
-    assert.equal(source.includes("space-y-4"), false, `${context} summary must not stack teaser blocks`);
-  }
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("ModuleSurface"));
+  assert.ok(source.includes("useState"));
+  assert.ok(source.includes('data-clinic-reports-table="true"'));
+  assert.ok(source.includes('data-clinic-reports-mobile-list="true"'));
+  assert.ok(source.includes('data-clinic-reports-detail-dialog="true"'));
+  assert.ok(source.includes("ReportFileActions"));
+  assert.ok(source.includes("Ver"));
+  assert.ok(source.includes("Abrir módulo completo"));
+  assert.equal(source.includes("dashboard-inline-list"), false);
+  assert.equal(source.includes("dashboard-inline-scroll"), false);
+  assert.equal(source.includes("dashboard-inline-detail"), false);
+  assert.equal(source.includes("aria-expanded={isSelected}"), false);
+  assert.equal(source.includes('data-detail-state="selected"'), false);
+  assert.equal(source.includes("isMobileDetailOpen"), false);
+  assert.equal(source.includes("Volver a la lista"), false);
+  assert.equal(source.includes('xl:grid-cols-[0.85fr_1.15fr]'), false);
+  assert.equal(source.includes("space-y-4"), false);
+});
+
+test("clinic logistica summary keeps its existing inline master-detail layer", () => {
+  const source = read(CLINIC_LOGISTICA_SUMMARY_PATH);
+
+  assert.ok(source.includes('"use client";'));
+  assert.ok(source.includes("ModuleSurface"));
+  assert.ok(source.includes("useState"));
+  assert.ok(source.includes("dashboard-inline-list"));
+  assert.ok(source.includes("dashboard-inline-scroll"));
+  assert.ok(source.includes("dashboard-inline-detail"));
+  assert.ok(source.includes("aria-expanded={isSelected}"));
+  assert.ok(source.includes('data-detail-state="selected"'));
+  assert.equal(source.includes("isMobileDetailOpen"), false);
+  assert.equal(source.includes("Volver a la lista"), false);
+  assert.equal(source.includes('xl:grid-cols-[0.85fr_1.15fr]'), false);
+  assert.equal(source.includes("space-y-4"), false);
 });
 
 test("dashboard home keeps status badge and date formatting in clinic command center", () => {


### PR DESCRIPTION
## Summary
- Aligns Clinic Tokens and Informes with the Admin table/list + per-row action structure.
- Replaces inline master-detail expansion with compact list/table rows and controlled detail dialogs.
- Preserves Clinic-specific functions, actions, data, pagination, and report file actions.

## Scope
- Private Clinic dashboard Tokens and Informes modules.
- E2E/native tests for Clinic table action parity and no inline detail regression.
- Implementation evidence in docs/implementation.

## Out of scope
- Admin productive code.
- Backend/API/auth/DB/migrations.
- Dependencies/lockfiles.
- CI/workflows.
- Public /clinicas.

## Validations
- git diff --check
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/dashboard-global-masked-master-detail.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-workspace-layout-polish.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend typecheck
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend build
- pnpm test