### PR TITLE
fix(clinic): align tokens footer pagination

### DIFF
--- a/docs/implementation/clinic-tokens-footer-pagination-parity.md
+++ b/docs/implementation/clinic-tokens-footer-pagination-parity.md
@@ -1,0 +1,83 @@
+# Clinic Tokens Footer Pagination Parity
+
+## Estado base
+
+- Rama: `fix/clinic-tokens-footer-pagination-parity`.
+- HEAD inicial auditado: `11b4880 fix(clinic): match admin table action structure for reports and tokens (#1145)`.
+- Estado inicial: `git status --short --untracked-files=all` limpio.
+- Entorno usado: Windows, PowerShell, PNPM.
+
+## Scope incluido
+
+- Ajustar solo Tokens Clinica para que la paginacion cierre el modulo como footer inferior.
+- Eliminar el conteo inferior izquierdo del listado de Tokens Clinica.
+- Agregar continuidad visual del listado para futuras cargas mediante slots estructurales vacios.
+- Mantener lista/tabla compacta con boton `Ver detalle`.
+- Actualizar tests relacionados con el contrato visual y no-scroll.
+
+## Scope excluido
+
+- Backend, API, DB, Drizzle, migraciones, schema y endpoints.
+- Auth, cookies, CORS, CSP, rate limits y seguridad de sesiones.
+- Dependencias, `package.json`, lockfiles, CI y workflows.
+- Cambios productivos en dashboard Admin; Admin se uso solo como referencia de lectura.
+- Reintroduccion de master-detail inline o scroll interno visible.
+
+## Auditoria previa
+
+- Se confirmo rama esperada y base limpia.
+- Se leyeron `ClinicParticularTokensCard`, `globals.css`, `CompactPager`, `ModuleSurface`, e2e indicados, test nativo de Tokens Clinica y la nota `clinic-table-action-parity.md`.
+- Se confirmaron scripts reales: `pnpm test`, `pnpm typecheck:test`, `pnpm --dir frontend lint`, `pnpm --dir frontend build` y e2e Playwright solicitados.
+- Se uso `AdminParticularTokensCard` solo como referencia de lectura para footer inferior y paginacion.
+- Referencia legacy detectada: `dashboard-global-masked-master-detail.spec.ts` todavia esperaba el rango visible `1-4 de 6 tokens`.
+
+## Cambios
+
+- `ClinicParticularTokensCard`:
+  - Reemplaza el `CompactPager` visible de Tokens Clinica por un footer integrado al borde inferior del panel.
+  - Ubica controles `Anterior`, `Pagina N / M` y `Siguiente` abajo a la derecha.
+  - Elimina el texto de rango `1-4 de N tokens`.
+  - Conserva columnas `Token / Paciente`, `Estado`, `Informe`, `Ultimo acceso o creado`, `Accion`.
+  - Conserva botones superiores `Actualizar` y `Generar token particular`.
+  - Mantiene `Ver detalle` por fila y detalle en `ModuleDialog`.
+- `globals.css`:
+  - Agrega CSS scoped a superficie Clinica para pintar slots estructurales vacios debajo de las filas.
+  - Mantiene `overflow: hidden` y no crea scroll containers.
+- Tests:
+  - El e2e movil valida footer inferior, controles a la derecha, slots estructurales, ausencia del rango y no-scroll.
+  - El e2e global relacionado deja de exigir el rango legacy.
+  - El test nativo actualiza el contrato fuente de Tokens Clinica.
+
+## Archivos modificados
+
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/app/globals.css`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`
+- `frontend/e2e/dashboard-global-masked-master-detail.spec.ts`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `docs/implementation/clinic-tokens-footer-pagination-parity.md`
+
+## Validaciones
+
+- `git diff --check`: paso. Git informo solo warnings de normalizacion LF/CRLF en archivos ya tocados.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`: paso, 3/3.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts`: paso, 8/8.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts`: paso, 18/18.
+- `pnpm --dir frontend lint`: paso.
+- `pnpm typecheck:test`: paso.
+- `pnpm --dir frontend build`: paso.
+- `pnpm test`: paso, 2841/2841.
+- Validacion adicional por test tocado: `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts`: paso, 16/16.
+
+Nota de ejecucion: el `pnpm` primero en PATH era el wrapper del runtime de Codex y fallo al intentar `install` sin TTY. Las validaciones se ejecutaron con el PNPM del sistema (`C:\Program Files\nodejs\pnpm.CMD`) y PATH ajustado para que el webServer de Playwright use el mismo binario.
+
+## Riesgo residual
+
+- Bajo: cambio acotado a presentacion y tests de Tokens Clinica.
+- La referencia Admin no se modifica.
+- No se tocan rutas, contratos API, auth, DB, dependencias ni CI.
+
+## Estado final
+
+- Working tree sin stage, con cambios acotados a frontend/test/doc del scope.
+- Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI ni Admin productivo.

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -218,6 +218,37 @@ async function expectHorizontallyUnclipped(
   );
 }
 
+async function expectFooterBottomRightAligned(
+  footer: Locator,
+  controls: Locator,
+  panel: Locator,
+  label: string,
+) {
+  await expect(footer, `${label}: footer visible`).toBeVisible();
+  await expect(controls, `${label}: controls visible`).toBeVisible();
+
+  const footerBox = await footer.boundingBox();
+  const controlsBox = await controls.boundingBox();
+  const panelBox = await panel.boundingBox();
+
+  expect(footerBox, `${label}: footer box`).not.toBeNull();
+  expect(controlsBox, `${label}: controls box`).not.toBeNull();
+  expect(panelBox, `${label}: panel box`).not.toBeNull();
+
+  expect(
+    Math.abs(footerBox!.y + footerBox!.height - (panelBox!.y + panelBox!.height)),
+    `${label}: footer sits on panel bottom edge`,
+  ).toBeLessThanOrEqual(TOLERANCE);
+  expect(
+    panelBox!.x + panelBox!.width - (controlsBox!.x + controlsBox!.width),
+    `${label}: controls align to the right side of the footer`,
+  ).toBeGreaterThanOrEqual(0);
+  expect(
+    panelBox!.x + panelBox!.width - (controlsBox!.x + controlsBox!.width),
+    `${label}: controls stay close to the right side of the footer`,
+  ).toBeLessThanOrEqual(18);
+}
+
 for (const viewport of MOBILE_VIEWPORTS) {
   test(`clinic Tokens mobile parity at ${viewport.name}`, async ({ page }) => {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
@@ -230,6 +261,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
       .locator('[data-dashboard-module-workspace="tokens"]')
       .first();
     const card = page.locator("#clinic-particular-tokens");
+    const listPanel = card.locator('[data-clinic-access-list-panel="true"]');
     const tokenRows = card.locator('[data-clinic-access-mobile-row="true"]');
     const detailButtons = card.getByRole("button", {
       name: "Ver detalle",
@@ -243,7 +275,15 @@ for (const viewport of MOBILE_VIEWPORTS) {
       name: "Generar token particular",
       exact: true,
     });
-    const pager = card.locator('[data-dashboard-compact-pager="true"]');
+    const pager = card.locator(
+      '[data-clinic-access-pagination-footer="true"]',
+    );
+    const pagerControls = card.locator(
+      '[data-clinic-access-pagination-controls="true"]',
+    );
+    const futureSlots = card.locator(
+      '[data-clinic-access-future-slots="true"]',
+    );
     const previousButton = pager.getByRole("button", {
       name: "Página anterior",
       exact: true,
@@ -273,6 +313,9 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(previousButton).toBeVisible();
       await expect(nextButton).toBeVisible();
       await expect(nextButton).toBeEnabled();
+      await expect(pager.getByText("Página 1 / 2")).toBeVisible();
+      await expect(card.getByText(/1[\u2013-]4 de \d+ tokens/)).toHaveCount(0);
+      await expect(futureSlots).toBeVisible();
       await expect(card.getByText("Usuarios y roles")).toHaveCount(0);
       await expect(card.getByText("Auditoría")).toHaveCount(0);
       await expect(card.getByText("Mantenimiento")).toHaveCount(0);
@@ -294,6 +337,11 @@ for (const viewport of MOBILE_VIEWPORTS) {
       `${viewport.name}: paginador`,
     );
     await expectHorizontallyUnclipped(
+      pagerControls,
+      viewport.width,
+      `${viewport.name}: controles de paginación`,
+    );
+    await expectHorizontallyUnclipped(
       previousButton,
       viewport.width,
       `${viewport.name}: Página anterior`,
@@ -302,6 +350,12 @@ for (const viewport of MOBILE_VIEWPORTS) {
       nextButton,
       viewport.width,
       `${viewport.name}: Página siguiente`,
+    );
+    await expectFooterBottomRightAligned(
+      pager,
+      pagerControls,
+      listPanel,
+      `${viewport.name}: footer de paginación`,
     );
 
     await expect(card.locator('[data-clinic-access-table="true"]')).toBeHidden();

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -366,7 +366,14 @@ test("clinic Tokens desktop limits the list and opens detail dialog without shel
     timeout: 12_000,
   });
   await expect(card.locator('[data-clinic-access-table-row="true"]')).toHaveCount(4);
-  await expect(page.getByText(/1.4 de 6 tokens/)).toBeVisible();
+  await expect(
+    card.locator('[data-clinic-access-pagination-footer="true"]'),
+  ).toBeVisible();
+  await expect(
+    card.locator('[data-clinic-access-pagination-controls="true"]'),
+  ).toBeVisible();
+  await expect(card.locator('[data-clinic-access-future-slots="true"]')).toBeVisible();
+  await expect(card.getByText(/1[\u2013-]4 de \d+ tokens/)).toHaveCount(0);
 
   await card.getByRole("button", { name: "Ver detalle", exact: true }).nth(1).click();
   await expect(

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3090,6 +3090,22 @@
     overflow: hidden;
     overscroll-behavior: none;
   }
+
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-future-slots="true"] {
+    flex: 1 1 auto;
+    min-height: 0;
+    border-top: 1px solid hsl(var(--vetneb-line) / 0.42);
+    pointer-events: none;
+    background:
+      repeating-linear-gradient(
+        to bottom,
+        hsl(var(--vetneb-surface-muted) / 0.24) 0,
+        hsl(var(--vetneb-surface-muted) / 0.24) 2.35rem,
+        hsl(var(--vetneb-line) / 0.42) 2.35rem,
+        hsl(var(--vetneb-line) / 0.42) calc(2.35rem + 1px)
+      ),
+      hsl(var(--card) / 0.78);
+  }
 }
 
 @media (max-width: 767px) {

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -5,7 +5,6 @@ import { FormEvent, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { CompactPager } from "@/components/dashboard/CompactPager";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
@@ -41,7 +40,7 @@ type GeneratedTokenDetails = {
   tutorLastName: string;
 };
 
-/** Maximum tokens visible per page in the master list (rest via CompactPager). */
+/** Maximum tokens visible per page in the master list (rest via footer pager). */
 const TOKENS_PAGE_SIZE = 4;
 
 const CREATE_TOKEN_STEP_ORDER = ["contact", "patient", "sample"] as const;
@@ -574,7 +573,7 @@ export function ClinicParticularTokensCard() {
             <div className="flex min-h-0 flex-1 flex-col">
               <div
                 data-clinic-access-list-panel="true"
-                className="min-h-0 flex-1 overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
+                className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
               >
                 <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2">
                   <div className="min-w-0">
@@ -600,11 +599,11 @@ export function ClinicParticularTokensCard() {
 
                 <div
                   data-clinic-access-list-body="true"
-                  className="min-h-0 flex-1 overflow-hidden"
+                  className="flex min-h-0 flex-1 flex-col overflow-hidden"
                 >
                   <div
                     data-clinic-access-table="true"
-                    className="hidden min-h-0 flex-1 overflow-hidden md:block"
+                    className="hidden min-h-0 shrink-0 overflow-hidden md:block"
                   >
                     <table className="w-full table-fixed text-[0.8125rem]">
                       <thead className="border-b border-vetneb-line/65 bg-vetneb-surface-muted/65 text-xs font-semibold uppercase text-muted-foreground">
@@ -672,7 +671,7 @@ export function ClinicParticularTokensCard() {
 
                   <div
                     data-clinic-access-mobile-list="true"
-                    className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
+                    className="flex min-h-0 shrink-0 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
                   >
                     {pagedTokens.pageItems.map((token) => {
                       const trackingCase = trackingCasesByTokenId[token.id];
@@ -714,27 +713,57 @@ export function ClinicParticularTokensCard() {
                       );
                     })}
                   </div>
+
+                  <div
+                    aria-hidden="true"
+                    data-clinic-access-future-slots="true"
+                  />
                 </div>
 
-                <CompactPager
-                  className="shrink-0"
-                  page={pagedTokens.page}
-                  pageCount={pagedTokens.pageCount}
-                  rangeStart={pagedTokens.rangeStart}
-                  rangeEnd={pagedTokens.rangeEnd}
-                  total={pagedTokens.total}
-                  hasPrev={pagedTokens.hasPrev}
-                  hasNext={pagedTokens.hasNext}
-                  onPrev={() => {
-                    setSelectedTokenId(null);
-                    pagedTokens.goPrev();
-                  }}
-                  onNext={() => {
-                    setSelectedTokenId(null);
-                    pagedTokens.goNext();
-                  }}
-                  itemLabel="tokens"
-                />
+                <div
+                  data-clinic-access-pagination-footer="true"
+                  className="flex min-h-10 shrink-0 items-center justify-end border-t border-vetneb-line/65 px-3 py-2 text-xs text-muted-foreground"
+                >
+                  <div
+                    data-clinic-access-pagination-controls="true"
+                    className="flex items-center justify-end gap-1.5"
+                  >
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2 text-xs"
+                      disabled={!pagedTokens.hasPrev || isLoadingTokens}
+                      onClick={() => {
+                        setSelectedTokenId(null);
+                        pagedTokens.goPrev();
+                      }}
+                      aria-label="Página anterior"
+                    >
+                      Anterior
+                    </Button>
+                    <span
+                      data-clinic-access-pagination-status="true"
+                      className="min-w-16 text-center"
+                    >
+                      Página {pagedTokens.page + 1} / {pagedTokens.pageCount}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2 text-xs"
+                      disabled={!pagedTokens.hasNext || isLoadingTokens}
+                      onClick={() => {
+                        setSelectedTokenId(null);
+                        pagedTokens.goNext();
+                      }}
+                      aria-label="Página siguiente"
+                    >
+                      Siguiente
+                    </Button>
+                  </div>
+                </div>
               </div>
             </div>
           ) : (

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -83,7 +83,6 @@ test("clinic tokens uses table/list row actions with dialog detail and step dial
 
   assert.ok(source.includes("const TOKENS_PAGE_SIZE = 4;"));
   assert.ok(source.includes("usePagedRows(tokens, TOKENS_PAGE_SIZE)"));
-  assert.ok(source.includes("<CompactPager"));
   assert.ok(source.includes("selectedTokenId"));
   assert.ok(source.includes("ModuleSurface"));
   assert.ok(source.includes('data-clinic-access-table="true"'));
@@ -91,6 +90,16 @@ test("clinic tokens uses table/list row actions with dialog detail and step dial
   assert.ok(source.includes('data-clinic-access-mobile-list="true"'));
   assert.ok(source.includes('data-clinic-access-mobile-row="true"'));
   assert.ok(source.includes('data-clinic-access-list-body="true"'));
+  assert.ok(source.includes('data-clinic-access-future-slots="true"'));
+  assert.ok(source.includes('data-clinic-access-pagination-footer="true"'));
+  assert.ok(source.includes('data-clinic-access-pagination-controls="true"'));
+  assert.ok(source.includes('aria-label="Página anterior"'));
+  assert.ok(source.includes('aria-label="Página siguiente"'));
+  assert.ok(source.includes("Página {pagedTokens.page + 1} / {pagedTokens.pageCount}"));
+  assert.equal(source.includes("<CompactPager"), false);
+  assert.equal(source.includes("rangeStart={pagedTokens.rangeStart}"), false);
+  assert.equal(source.includes("rangeEnd={pagedTokens.rangeEnd}"), false);
+  assert.equal(source.includes('itemLabel="tokens"'), false);
   assert.ok(source.includes("Ver detalle"));
   assert.ok(source.includes("openTokenDetail"));
   assert.ok(source.includes('data-clinic-access-detail-dialog="true"'));


### PR DESCRIPTION
## Summary
- Aligns Clinic Tokens pagination with the module footer.
- Removes the lower-left range text from the Tokens module.
- Uses the remaining space as structural continuation for future token rows while preserving the table/list with per-row 'Ver detalle'.

## Scope
- Private Clinic Tokens layout.
- E2E/native tests for Tokens footer and no-scroll behavior.
- Implementation evidence in docs/implementation.

## Out of scope
- Admin productive code.
- Backend/API/auth/DB/migrations.
- Dependencies/lockfiles.
- CI/workflows.
- Public /clinicas.

## Validations
- git diff --check
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts
- pnpm --dir frontend exec playwright test e2e/dashboard-workspace-layout-polish.spec.ts
- pnpm --dir frontend lint
- pnpm typecheck:test
- pnpm --dir frontend build
- pnpm test