### PR TITLE
fix(dashboard): move clinic password change into profile tabs

### DIFF
--- a/docs/audit/clinic-profile-change-password-tab-placement.md
+++ b/docs/audit/clinic-profile-change-password-tab-placement.md
@@ -1,0 +1,36 @@
+# Clínica perfil — ubicación de cambiar contraseña
+
+Fecha: 2026-06-26
+
+## Cambio realizado
+
+- Se quitó el selector superior interno `Acceso | Perfil público` del módulo `Perfil` del dashboard Clínica.
+- El módulo `Perfil` renderiza directamente `ClinicPublicProfileCard`.
+- El formulario existente `PasswordChangePanel` queda reutilizado dentro de la navegación interna del perfil público como tab `Cambiar contraseña`.
+- La navegación interna queda: `Estado`, `Datos`, `Contacto`, `Contenido`, `Cambiar contraseña`.
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/page.tsx`
+- `frontend/src/components/dashboard/ClinicPublicProfileCard.tsx`
+- `frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts`
+- `frontend/e2e/dashboard-clinic-module-state-parity.spec.ts`
+- `frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts`
+- `test/frontend-dashboard-password-change-ui.test.ts`
+- `docs/audit/clinic-profile-change-password-tab-placement.md`
+
+## Validaciones ejecutadas
+
+- `corepack pnpm lint` desde `frontend`: falla antes de lint por `ERR_MODULE_NOT_FOUND` resolviendo `eslint-config-next/core-web-vitals` desde `frontend/eslint.config.mjs`; no se modifica configuración por estar fuera de scope.
+- `corepack pnpm typecheck` desde `frontend`: OK.
+- `corepack pnpm build` desde `frontend`: OK.
+- `corepack pnpm e2e -- dashboard-clinic-perfil-mobile-operability.spec.ts` desde `frontend`: OK, 3/3.
+- `corepack pnpm test` desde raíz: OK, 2841/2841. Primer intento falló porque `next build` había regenerado `frontend/next-env.d.ts` hacia `.next/dev`; se restauró el artefacto generado y la repetición pasó.
+- `corepack pnpm build` desde raíz: OK.
+- `corepack pnpm security:public-surface` desde raíz: OK.
+
+## Alcance excluido
+
+- Sin cambios en backend, API, auth, DB, migraciones, dependencias, lockfiles, CI o workflows.
+- Sin cambios de endpoints ni contratos de cookies/sesión.
+- Sin crear tabs `Acceso` o módulos nuevos.

--- a/frontend/e2e/dashboard-clinic-module-state-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-module-state-parity.spec.ts
@@ -439,7 +439,6 @@ test.describe("clinic perfil → perfil público module state parity (client-dri
     });
 
     await page.goto("/dashboard?module=perfil");
-    await page.getByRole("tab", { name: "Perfil público", exact: true }).first().click();
 
     const editor = page.locator('[data-clinic-profile-editor="true"]');
     await expect(editor).toBeVisible();
@@ -460,7 +459,6 @@ test.describe("clinic perfil → perfil público module state parity (client-dri
 
     await page.setViewportSize(MOBILE_VIEWPORT);
     await page.goto("/dashboard?module=perfil");
-    await page.getByRole("tab", { name: "Perfil público", exact: true }).first().click();
 
     const editor = page.locator('[data-clinic-profile-editor="true"]');
     await expect(editor.getByRole("alert")).toContainText("No se pudo cargar el perfil.");
@@ -473,11 +471,12 @@ test.describe("clinic perfil → perfil público module state parity (client-dri
   });
 });
 
-test.describe("clinic perfil → acceso (password) module state parity (CL-GAP-6)", () => {
+test.describe("clinic perfil → cambiar contraseña module state parity (CL-GAP-6)", () => {
   test("validation error is local and needs no network mock", async ({ page }) => {
     await setClinicSession(page);
     await page.goto("/dashboard?module=perfil");
 
+    await page.getByRole("tab", { name: "Cambiar contraseña", exact: true }).click();
     const panel = page.locator("#clinic-password-change");
     await expect(panel).toBeVisible({ timeout: 8_000 });
 
@@ -508,6 +507,7 @@ test.describe("clinic perfil → acceso (password) module state parity (CL-GAP-6
     });
 
     await page.goto("/dashboard?module=perfil");
+    await page.getByRole("tab", { name: "Cambiar contraseña", exact: true }).click();
     const panel = page.locator("#clinic-password-change");
     await expect(panel).toBeVisible({ timeout: 8_000 });
 

--- a/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
+++ b/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
@@ -140,22 +140,46 @@ for (const viewport of VIEWPORTS) {
     await mockClinicProfile(page);
 
     await page.goto("/dashboard?module=perfil");
-    await expect(
-      page.locator('[data-dashboard-module-workspace="perfil"]'),
-    ).toBeVisible({ timeout: 12_000 });
+    const workspace = page.locator('[data-dashboard-module-workspace="perfil"]');
+    await expect(workspace).toBeVisible({ timeout: 12_000 });
 
     await expect(async () => {
-      const publicProfileTab = page
-        .getByRole("tab", { name: "Perfil público", exact: true })
-        .first();
-      await expect(publicProfileTab).toBeVisible();
-      await publicProfileTab.click();
+      await expect(
+        workspace.getByRole("tab", { name: "Acceso", exact: true }),
+      ).toHaveCount(0);
+      await expect(
+        workspace.getByRole("tab", { name: "Perfil público", exact: true }),
+      ).toHaveCount(0);
       await expect(page.locator("#clinic-public-profile")).toBeVisible();
     }).toPass({ timeout: 12_000 });
 
     const editor = page.locator('[data-clinic-profile-editor="true"]');
     await expect(editor).toBeVisible();
     await expectClinicMobileBottomNav(page, viewport.name);
+
+    for (const tabName of [
+      "Estado",
+      "Datos",
+      "Contacto",
+      "Contenido",
+      "Cambiar contraseña",
+    ]) {
+      await expect(
+        editor.getByRole("tab", { name: tabName, exact: true }),
+      ).toBeVisible();
+    }
+    await expect(
+      editor.getByRole("tab", { name: "Acceso", exact: true }),
+    ).toHaveCount(0);
+
+    await editor
+      .getByRole("tab", { name: "Cambiar contraseña", exact: true })
+      .click();
+    const passwordPanel = editor.locator("#clinic-password-change");
+    await expect(passwordPanel).toBeVisible();
+    await expect(passwordPanel.locator('input[name="currentPassword"]')).toBeVisible();
+    await expect(passwordPanel.locator('input[name="newPassword"]')).toBeVisible();
+    await expect(passwordPanel.locator('input[name="confirmPassword"]')).toBeVisible();
 
     await expect(async () => {
       await editor.getByRole("tab", { name: "Datos", exact: true }).click();

--- a/frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
+++ b/frontend/e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts
@@ -714,7 +714,6 @@ for (const viewport of VIEWPORTS) {
       await expect(
         page.locator('[data-dashboard-module-workspace="perfil"]'),
       ).toBeVisible({ timeout: 12_000 });
-      await page.getByRole("tab", { name: /Perfil p.blico/ }).click();
       await expect(page.locator("#clinic-public-profile")).toBeVisible({
         timeout: 12_000,
       });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,8 +9,6 @@ import { ClinicMobileModuleFrame } from "@/components/dashboard/ClinicMobileModu
 import { ClinicCommandCenter } from "./ClinicCommandCenter";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
 import { ClinicPublicProfileCard } from "@/components/dashboard/ClinicPublicProfileCard";
-import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";
-import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
 import { ClinicInformesWorkspaceSummary } from "./ClinicInformesWorkspaceSummary";
 import { ClinicLogisticaWorkspaceSummary } from "./ClinicLogisticaWorkspaceSummary";
 import {
@@ -161,21 +159,7 @@ export default async function DashboardPage({
               ),
               perfil: (
                 <ClinicMobileModuleFrame moduleId="perfil">
-                  <ModuleTabs
-                    ariaLabel="Secciones de perfil"
-                    tabs={[
-                      {
-                        id: "acceso",
-                        label: "Acceso",
-                        content: <PasswordChangePanel variant="clinic" />,
-                      },
-                      {
-                        id: "perfil-publico",
-                        label: "Perfil público",
-                        content: <ClinicPublicProfileCard />,
-                      },
-                    ]}
-                  />
+                  <ClinicPublicProfileCard />
                 </ClinicMobileModuleFrame>
               ),
               tokens: (

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { FormEvent, type ChangeEvent, useEffect, useRef, useState } from "react";
+import {
+  FormEvent,
+  type ChangeEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import NextImage from "next/image";
 
 import { Badge } from "@/components/ui/badge";
@@ -16,6 +23,7 @@ import {
 } from "@/lib/api";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { ModuleTabs } from "@/components/dashboard/ModuleTabs";
+import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";
 
 type ProfileFormState = {
   displayName: string;
@@ -55,6 +63,8 @@ const ALLOWED_AVATAR_MIME_TYPES = new Set([
   "image/png",
   "image/webp",
 ]);
+const PROFILE_FORM_ID = "clinic-public-profile-form";
+const PASSWORD_TAB_ID = "cambiar-contrasena";
 
 const PUBLICATION_FIELD_LABELS: Record<string, string> = {
   displayName: "Nombre visible",
@@ -246,6 +256,7 @@ function getPublicationLabel(profile: ClinicPublicProfile | null) {
 export function ClinicPublicProfileCard() {
   const [profile, setProfile] = useState<ClinicPublicProfile | null>(null);
   const [formState, setFormState] = useState<ProfileFormState>(INITIAL_FORM_STATE);
+  const [activeTabId, setActiveTabId] = useState("estado");
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -762,12 +773,21 @@ export function ClinicPublicProfileCard() {
     </div>
   );
 
+  function renderProfileForm(content: ReactNode) {
+    return (
+      <form id={PROFILE_FORM_ID} className="contents" onSubmit={handleSubmit}>
+        {content}
+      </form>
+    );
+  }
+
+  const isPasswordTabActive = activeTabId === PASSWORD_TAB_ID;
+
   return (
-    <form
+    <div
       id="clinic-public-profile"
       data-clinic-profile-editor="true"
       className="flex min-h-0 flex-1 flex-col"
-      onSubmit={handleSubmit}
     >
       <ModuleSurface
         ariaLabel="Perfil público de la clínica"
@@ -788,9 +808,16 @@ export function ClinicPublicProfileCard() {
               <Badge variant={getPublicationVariant(profile)}>
                 {getPublicationLabel(profile)}
               </Badge>
-              <Button type="submit" size="sm" disabled={isWorking}>
-                {isSubmitting ? "Guardando..." : "Guardar perfil público"}
-              </Button>
+              {!isPasswordTabActive ? (
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={isWorking}
+                  form={PROFILE_FORM_ID}
+                >
+                  {isSubmitting ? "Guardando..." : "Guardar perfil público"}
+                </Button>
+              ) : null}
             </div>
           </div>
         }
@@ -821,37 +848,62 @@ export function ClinicPublicProfileCard() {
 
         <ModuleTabs
           ariaLabel="Edición de perfil público"
+          defaultTabId="estado"
+          onTabChange={setActiveTabId}
           tabs={[
-            { id: "estado", label: "Estado", content: statusTab },
-            { id: "datos", label: "Datos", content: detailsTab },
-            { id: "contacto", label: "Contacto", content: contactTab },
-            { id: "contenido", label: "Contenido", content: contentTab },
+            {
+              id: "estado",
+              label: "Estado",
+              content: renderProfileForm(statusTab),
+            },
+            {
+              id: "datos",
+              label: "Datos",
+              content: renderProfileForm(detailsTab),
+            },
+            {
+              id: "contacto",
+              label: "Contacto",
+              content: renderProfileForm(contactTab),
+            },
+            {
+              id: "contenido",
+              label: "Contenido",
+              content: renderProfileForm(contentTab),
+            },
+            {
+              id: PASSWORD_TAB_ID,
+              label: "Cambiar contraseña",
+              content: <PasswordChangePanel variant="clinic" />,
+            },
           ]}
         />
 
-        <div
-          data-clinic-profile-footer="true"
-          className="flex min-h-8 shrink-0 flex-wrap items-center gap-2 border-t border-vetneb-line/65 pt-2 text-xs"
-        >
-          {errorMessage ? (
-            <p className="clinical-alert-error px-3 py-1.5" role="alert">
-              {errorMessage}
-            </p>
-          ) : null}
+        {!isPasswordTabActive ? (
+          <div
+            data-clinic-profile-footer="true"
+            className="flex min-h-8 shrink-0 flex-wrap items-center gap-2 border-t border-vetneb-line/65 pt-2 text-xs"
+          >
+            {errorMessage ? (
+              <p className="clinical-alert-error px-3 py-1.5" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
 
-          {statusMessage ? (
-            <p className="clinical-alert-success px-3 py-1.5">
-              {statusMessage}
-            </p>
-          ) : null}
+            {statusMessage ? (
+              <p className="clinical-alert-success px-3 py-1.5">
+                {statusMessage}
+              </p>
+            ) : null}
 
-          {!errorMessage && !statusMessage ? (
-            <p className="text-muted-foreground">
-              Cambios del perfil se guardan desde la acción principal del módulo.
-            </p>
-          ) : null}
-        </div>
+            {!errorMessage && !statusMessage ? (
+              <p className="text-muted-foreground">
+                Cambios del perfil se guardan desde la acción principal del módulo.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
       </ModuleSurface>
-    </form>
+    </div>
   );
 }

--- a/test/frontend-dashboard-password-change-ui.test.ts
+++ b/test/frontend-dashboard-password-change-ui.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 const PANEL_PATH =
   "frontend/src/components/dashboard/PasswordChangePanel.tsx";
 const CLINIC_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
+const CLINIC_PROFILE_CARD_PATH =
+  "frontend/src/components/dashboard/ClinicPublicProfileCard.tsx";
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
 const API_CLIENT_PATH = "frontend/src/lib/api.ts";
 
@@ -60,28 +62,37 @@ test("password change panel reuses both merged API clients mapped by variant", (
 });
 
 test("clinic dashboard wires the panel with the clinic variant", () => {
-  const source = read(CLINIC_PAGE_PATH);
+  const pageSource = read(CLINIC_PAGE_PATH);
+  const profileSource = read(CLINIC_PROFILE_CARD_PATH);
+
+  assert.equal(
+    pageSource.includes(
+      'import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";',
+    ),
+    false,
+  );
+  assert.equal(pageSource.includes('ariaLabel="Secciones de perfil"'), false);
+  assert.equal(pageSource.includes('label: "Acceso"'), false);
+  assert.equal(pageSource.includes('label: "Perfil público"'), false);
+  assert.ok(pageSource.includes("<ClinicPublicProfileCard />"));
 
   assert.ok(
-    source.includes(
+    profileSource.includes(
       'import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";',
     ),
   );
-  assert.ok(source.includes('<PasswordChangePanel variant="clinic" />'));
-  // The existing public profile card is preserved in the same workspace.
-  assert.ok(source.includes("<ClinicPublicProfileCard />"));
-
-  // PR #1005: the security panel is surfaced above the public profile card so
-  // it is visible immediately when the perfil workspace opens.
   assert.ok(
-    source.indexOf('<PasswordChangePanel variant="clinic" />') <
-      source.indexOf("<ClinicPublicProfileCard />"),
-    "clinic password panel must render before the public profile card",
+    profileSource.includes(
+      '{ id: PASSWORD_TAB_ID, label: "Cambiar contraseña", content: <PasswordChangePanel variant="clinic" /> }',
+    ) ||
+      profileSource.includes('label: "Cambiar contraseña"'),
   );
+  assert.equal(profileSource.includes('label: "Acceso"'), false);
 
   // No new "Seguridad" module/navigation is introduced; the panel stays inside
   // the existing perfil workspace.
-  assert.equal(source.toLowerCase().includes('"seguridad"'), false);
+  assert.equal(pageSource.toLowerCase().includes('"seguridad"'), false);
+  assert.equal(profileSource.toLowerCase().includes('"seguridad"'), false);
 });
 
 test("admin dashboard wires the panel with the admin variant", () => {


### PR DESCRIPTION
## Summary
- remove redundant Clinic Profile upper switch between Access and Public Profile
- move the existing password change form into the public profile tabs as Cambiar contraseña
- keep profile tabs Estado, Datos, Contacto and Contenido available

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm build
- corepack pnpm exec playwright test e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
- corepack pnpm test
- corepack pnpm build
- corepack pnpm security:public-surface