### PR TITLE
feat(app): enforce client version gate

### DIFF
--- a/docs/implementation/APP_VERSION_GATE.md
+++ b/docs/implementation/APP_VERSION_GATE.md
@@ -1,33 +1,127 @@
 # App version gate
 
-> **Estado: PARCIAL / NO DEFINITIVO.** Este guard es *frontend-polling* y solo
-> protege a clientes que ya están ejecutando el frontend nuevo. Una PWA/app
-> instalada vieja o cacheada ejecuta el frontend viejo, que **no contiene este
-> guard**, por lo que nunca consulta `/api/app-version` ni se bloquea. Por lo
-> tanto **no resuelve** el caso real de "Origen no permitido" en apps viejas.
->
-> La solución definitiva (pendiente, en rama limpia separada) es enforcement de
-> backend: header `X-VETNEB-Client-Version` validado en los endpoints de auth
-> (`login`/`me`) respondiendo `426 CLIENT_VERSION_UNSUPPORTED` cuando la versión
-> falta o es menor a la mínima aceptada. Este guard frontend solo mejora la UX
-> del bloqueo, no sustituye al contrato backend.
+> **Estado: ENFORCEMENT BACKEND IMPLEMENTADO.** Además del guard de frontend
+> (que solo protege a clientes que ya ejecutan el bundle nuevo), el backend
+> valida en cada request de auth relevante el header
+> `X-VETNEB-Client-Version` y responde `426 CLIENT_VERSION_UNSUPPORTED`
+> cuando falta o es una versión menor a la mínima aceptada
+> (`CLIENT_MIN_VERSION`). Esto es lo que efectivamente bloquea a una
+> PWA/app instalada vieja: aunque ese cliente nunca cargue el JS nuevo y
+> nunca consulte `/api/app-version`, en el momento en que intenta
+> `login`/`me` el backend lo rechaza.
 
-El frontend consulta `/api/app-version` y compara `NEXT_PUBLIC_APP_VERSION` contra la versión vigente publicada por backend. Si no coincide, bloquea el uso de la aplicación y exige actualizar.
+## Por qué frontend-only no alcanza
 
-## Variables recomendadas
+Una PWA/app instalada vieja sigue ejecutando el bundle de frontend con el
+que fue instalada. Ese bundle viejo no contiene el guard nuevo, así que
+nunca va a consultar `/api/app-version` ni a bloquearse solo. El único
+punto de contacto que un cliente viejo **siempre** atraviesa es la llamada
+de red a backend (`login` o `me`). Por eso la validación real tiene que
+vivir en backend, en esos endpoints.
 
-- `APP_VERSION`: versión vigente del backend. En Render puede ser el commit SHA de despliegue.
-- `NEXT_PUBLIC_APP_VERSION`: misma versión embebida en el build frontend.
-- `CLIENT_MIN_VERSION`: reservado para endurecer política de compatibilidad mínima.
+## Contrato
 
-## Comportamiento
+Frontend (vía el cliente API centralizado `frontend/src/lib/api.ts`) envía
+en **todas** las requests:
 
-- El endpoint de versión usa `cache-control: no-store`.
-- El guard corre globalmente desde `RootLayout`.
-- En producción verifica al iniciar y cada 60 segundos. No usa `visibilitychange` (prohibido por el contrato de persistencia de sesión `auth-cookie-persistence-contract`).
-- Si detecta versión vieja, muestra un `alertdialog` bloqueante.
-- El botón de actualización intenta activar el service worker nuevo, limpia caches `portal-vetneb-*` y recarga.
+```
+X-VETNEB-Client-Version: <NEXT_PUBLIC_APP_VERSION>
+```
 
-## Límite operativo
+Backend valida ese header con un hook global (`onRequest`) instalado en
+`server/fastify-app.ts`, antes del registro de rutas, igual que el guard de
+origen confiable. El hook (`server/middlewares/version-gate.ts`)
+solo actúa sobre estas rutas:
 
-Un cliente que ya estaba ejecutando código viejo antes de desplegar este guard no puede recibir este comportamiento hasta hacer una recarga. Desde el primer despliegue con este guard, los despliegues posteriores sí quedan protegidos.
+- `POST /api/auth/login`
+- `GET /api/auth/me`
+- `POST /api/admin/auth/login`
+- `GET /api/admin/auth/me`
+- `POST /api/particular/auth/login`
+- `GET /api/particular/auth/me`
+
+El resto de la superficie (incluyendo `/api/contact`, `/api/health`,
+`/api/app-version`, logout, change-password, etc.) no se toca.
+
+Si falta el header o la versión es menor a `CLIENT_MIN_VERSION`, responde:
+
+```json
+HTTP 426 Upgrade Required
+{
+  "success": false,
+  "code": "CLIENT_VERSION_UNSUPPORTED",
+  "message": "Tu aplicación está desactualizada. Actualizá o reinstalá VETNEB para continuar.",
+  "minimumClientVersion": "...",
+  "clientVersion": "..."
+}
+```
+
+Si la versión es válida (igual o, cuando ambos lados son semver punteado
+como `1.2.3`, superior a la mínima), el comportamiento existente del
+endpoint se preserva sin cambios.
+
+### Comparación de versiones
+
+`APP_VERSION`/`CLIENT_MIN_VERSION` en Render pueden ser un commit SHA, no
+necesariamente semver. Por eso la comparación:
+
+1. Si `clientVersion === minimumClientVersion`, es válida (cubre el caso
+   de versiones tipo SHA).
+2. Si ambas son versiones punteadas numéricas (`"1.2.3"`), se comparan
+   segmento a segmento y se acepta cualquier versión `>=` a la mínima.
+3. En cualquier otro caso (formatos no comparables y distintos), se
+   considera no soportada.
+
+## Activación (importante para soporte y despliegue)
+
+El enforcement queda **inactivo por defecto** (modo seguro) hasta que se
+configure explícitamente `CLIENT_MIN_VERSION` en el entorno de backend.
+Esto es intencional: hoy nada fija `NEXT_PUBLIC_APP_VERSION` en el build de
+frontend, así que activar el bloqueo sin coordinar el build rompería el
+login de todos los clientes actuales. Antes de armar el gate en
+producción:
+
+1. Configurar `NEXT_PUBLIC_APP_VERSION` en el build de frontend (Render) con
+   el valor de versión/commit a exigir.
+2. Configurar `APP_VERSION` y `CLIENT_MIN_VERSION` en el backend (Render)
+   con el mismo valor.
+3. Desplegar backend y frontend juntos.
+4. Verificar `pnpm test` (incluye `test/client-version-gate-contract.test.ts`)
+   antes y después del despliegue.
+
+Mientras `CLIENT_MIN_VERSION` no esté seteado, todas las rutas funcionan
+exactamente igual que antes de este cambio.
+
+## Guard de frontend (UX, no sustituye al backend)
+
+El frontend sigue exponiendo dos bloqueos visuales, montados globalmente
+desde `RootLayout` vía `AppVersionGate`:
+
+- **Polling propio** (`/api/app-version`, cada 60s en producción): mejora
+  la UX para sesiones ya abiertas con el bundle nuevo.
+- **Reactivo a `CLIENT_VERSION_UNSUPPORTED`**: cuando cualquier llamada del
+  cliente API centralizado recibe el `426` de backend (por ejemplo, al
+  intentar login o refrescar `me`), se publica una señal global
+  (`frontend/src/lib/client-version-error.ts`) y `AppVersionGate` muestra
+  un bloqueo con el título **"Actualización requerida"** y el mensaje
+  **"Estás usando una versión anterior de VETNEB. Para proteger tu sesión
+  y evitar errores, actualizá o reinstalá la app."**, con la acción
+  **"Actualizar ahora"**. No se permite continuar login/dashboard mientras
+  esta señal esté activa.
+
+## Exclusiones explícitas de este cambio
+
+- Sin cambios de base de datos ni migraciones.
+- Sin dependencias nuevas ni cambios de lockfile.
+- Sin cambios de CI.
+- Sin ampliar `CORS_ORIGIN` ni el contrato de origen confiable.
+- Sin reescribir auth/sesión: el hook corre antes de los handlers de
+  login/me y no toca cookies, tokens ni lógica de autenticación.
+
+## Checklist de soporte (cliente reporta error de versión o sesión rota)
+
+1. Cerrar completamente la app/PWA.
+2. Abrir `https://vetneb.com.ar` desde el navegador.
+3. Si el problema persiste, borrar caché del sitio/navegador.
+4. Desinstalar y reinstalar la PWA.
+5. Volver a validar el login.

--- a/frontend/src/components/app-version/AppVersionGate.tsx
+++ b/frontend/src/components/app-version/AppVersionGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 
 import {
   CLIENT_APP_VERSION,
@@ -8,6 +8,11 @@ import {
   isClientVersionOutdated,
   type AppVersionSnapshot,
 } from "@/lib/app-version";
+import {
+  getClientVersionUnsupportedServerSnapshot,
+  getClientVersionUnsupportedSnapshot,
+  subscribeClientVersionUnsupported,
+} from "@/lib/client-version-error";
 
 const VERSION_CHECK_INTERVAL_MS = 60_000;
 
@@ -46,6 +51,11 @@ export function AppVersionGate() {
   const [isUpdateRequired, setIsUpdateRequired] = useState(false);
   const [isReloading, setIsReloading] = useState(false);
   const [checkFailed, setCheckFailed] = useState(false);
+  const clientVersionUnsupported = useSyncExternalStore(
+    subscribeClientVersionUnsupported,
+    getClientVersionUnsupportedSnapshot,
+    getClientVersionUnsupportedServerSnapshot,
+  );
 
   const evaluateSnapshot = useCallback((snapshot: AppVersionSnapshot) => {
     setLatestVersion(snapshot.appVersion);
@@ -90,6 +100,44 @@ export function AppVersionGate() {
     } finally {
       window.location.reload();
     }
+  }
+
+  if (clientVersionUnsupported) {
+    return (
+      <div
+        className="fixed inset-0 z-[2147483647] flex items-center justify-center bg-vetneb-navy/82 px-4 py-6 backdrop-blur-sm"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="client-version-unsupported-title"
+        aria-describedby="client-version-unsupported-description"
+        data-app-version-gate="true"
+        data-client-version-unsupported="true"
+      >
+        <div className="w-full max-w-lg rounded-2xl border border-vetneb-line/80 bg-card p-6 shadow-2xl">
+          <h2
+            id="client-version-unsupported-title"
+            className="text-2xl font-semibold text-vetneb-ink"
+          >
+            Actualización requerida
+          </h2>
+          <p
+            id="client-version-unsupported-description"
+            className="mt-3 text-sm leading-6 text-muted-foreground"
+          >
+            Estás usando una versión anterior de VETNEB. Para proteger tu
+            sesión y evitar errores, actualizá o reinstalá la app.
+          </p>
+          <button
+            type="button"
+            className="mt-5 inline-flex w-full items-center justify-center rounded-lg bg-vetneb-teal px-4 py-3 text-sm font-semibold text-vetneb-navy transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-70"
+            onClick={() => void handleUpdateNow()}
+            disabled={isReloading}
+          >
+            {isReloading ? "Actualizando..." : "Actualizar ahora"}
+          </button>
+        </div>
+      </div>
+    );
   }
 
   if (!isUpdateRequired) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,10 @@ import {
 } from "@/lib/api-error";
 import { ApiResponseError } from "@/lib/api-error";
 import { publishAdminAccessErrorStatus } from "@/lib/admin-access-error";
+import { CLIENT_APP_VERSION, CLIENT_VERSION_HEADER } from "@/lib/app-version";
+import { publishClientVersionUnsupported } from "@/lib/client-version-error";
+
+const CLIENT_VERSION_UNSUPPORTED_CODE = "CLIENT_VERSION_UNSUPPORTED";
 
 const LOCAL_DEVELOPMENT_API_BASE_URL = "http://localhost:3000";
 const SAME_ORIGIN_API_BASE_URL = "";
@@ -236,6 +240,10 @@ async function apiFetch<T>(
     headers.set("Content-Type", "application/json");
   }
 
+  if (!headers.has(CLIENT_VERSION_HEADER)) {
+    headers.set(CLIENT_VERSION_HEADER, CLIENT_APP_VERSION);
+  }
+
   let res: Response;
 
   try {
@@ -271,6 +279,9 @@ async function apiFetch<T>(
     const body = (await res.json().catch(() => ({}))) as {
       error?: unknown;
       message?: unknown;
+      code?: unknown;
+      minimumClientVersion?: unknown;
+      clientVersion?: unknown;
       retryAfterSeconds?: unknown;
       retryAfter?: unknown;
     };
@@ -280,6 +291,20 @@ async function apiFetch<T>(
         : typeof body.message === "string" && body.message.trim()
           ? body.message
           : null;
+
+    if (
+      res.status === 426 &&
+      body.code === CLIENT_VERSION_UNSUPPORTED_CODE
+    ) {
+      publishClientVersionUnsupported({
+        minimumClientVersion:
+          typeof body.minimumClientVersion === "string"
+            ? body.minimumClientVersion
+            : "",
+        clientVersion:
+          typeof body.clientVersion === "string" ? body.clientVersion : "",
+      });
+    }
 
     if (res.status === 429) {
       const retryAfterSeconds = readRetryAfterSeconds(res.headers, body);

--- a/frontend/src/lib/app-version.ts
+++ b/frontend/src/lib/app-version.ts
@@ -1,3 +1,5 @@
+export const CLIENT_VERSION_HEADER = "x-vetneb-client-version";
+
 export const CLIENT_APP_VERSION =
   process.env.NEXT_PUBLIC_APP_VERSION?.trim() || "missing-client-version";
 

--- a/frontend/src/lib/client-version-error.ts
+++ b/frontend/src/lib/client-version-error.ts
@@ -1,0 +1,35 @@
+export type ClientVersionUnsupportedState = {
+  minimumClientVersion: string;
+  clientVersion: string;
+};
+
+type ClientVersionErrorListener = () => void;
+
+let browserClientVersionUnsupported: ClientVersionUnsupportedState | null = null;
+const browserClientVersionErrorListeners = new Set<ClientVersionErrorListener>();
+
+export function publishClientVersionUnsupported(
+  state: ClientVersionUnsupportedState,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  browserClientVersionUnsupported = state;
+  browserClientVersionErrorListeners.forEach((listener) => listener());
+}
+
+export function subscribeClientVersionUnsupported(
+  listener: ClientVersionErrorListener,
+): () => void {
+  browserClientVersionErrorListeners.add(listener);
+  return () => browserClientVersionErrorListeners.delete(listener);
+}
+
+export function getClientVersionUnsupportedSnapshot(): ClientVersionUnsupportedState | null {
+  return browserClientVersionUnsupported;
+}
+
+export function getClientVersionUnsupportedServerSnapshot(): null {
+  return null;
+}

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -145,6 +145,7 @@ import {
   type LogisticsSlaNativeRoutesOptions,
 } from "./routes/logistics-sla.fastify.ts";
 import { requireTrustedOriginForFastify } from "./middlewares/trusted-origin.ts";
+import { requireMinimumClientVersionForFastify } from "./middlewares/version-gate.ts";
 import { applySensitiveApiNoStoreHeaders } from "./lib/sensitive-response-cache.ts";
 import { applyApiSecurityHeaders } from "./lib/api-response-security.ts";
 import {
@@ -353,6 +354,7 @@ export async function createFastifyApp(
   });
 
   app.addHook("onRequest", requireTrustedOriginForFastify);
+  app.addHook("onRequest", requireMinimumClientVersionForFastify);
 
   app.addHook(
     "onSend",

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -161,6 +161,7 @@ export const ENV = {
   databaseMaxConnections,
   appVersion,
   clientMinVersion: rawEnv.CLIENT_MIN_VERSION ?? appVersion,
+  clientVersionGateEnforced: Boolean(rawEnv.CLIENT_MIN_VERSION),
   supabaseUrl: rawEnv.SUPABASE_URL,
   supabaseAnonKey: rawEnv.SUPABASE_ANON_KEY,
   supabaseServiceRoleKey: rawEnv.SUPABASE_SERVICE_ROLE_KEY,

--- a/server/middlewares/version-gate.ts
+++ b/server/middlewares/version-gate.ts
@@ -1,0 +1,111 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { ENV } from "../lib/env.ts";
+
+export const CLIENT_VERSION_HEADER = "x-vetneb-client-version";
+export const CLIENT_VERSION_UNSUPPORTED_CODE = "CLIENT_VERSION_UNSUPPORTED";
+export const CLIENT_VERSION_UNSUPPORTED_MESSAGE =
+  "Tu aplicación está desactualizada. Actualizá o reinstalá VETNEB para continuar.";
+
+type GatedRoute = {
+  method: "GET" | "POST";
+  path: string;
+};
+
+// Solo se protegen los endpoints de auth donde una PWA vieja primero toca
+// backend: si una de estas llamadas pasa, el cliente queda con sesión activa.
+const GATED_ROUTES: readonly GatedRoute[] = [
+  { method: "POST", path: "/api/auth/login" },
+  { method: "GET", path: "/api/auth/me" },
+  { method: "POST", path: "/api/admin/auth/login" },
+  { method: "GET", path: "/api/admin/auth/me" },
+  { method: "POST", path: "/api/particular/auth/login" },
+  { method: "GET", path: "/api/particular/auth/me" },
+];
+
+function getRequestPath(request: FastifyRequest): string {
+  const url = request.url ?? "";
+  const queryIndex = url.indexOf("?");
+
+  return queryIndex === -1 ? url : url.slice(0, queryIndex);
+}
+
+function isGatedRoute(request: FastifyRequest): boolean {
+  const path = getRequestPath(request);
+  const method = request.method.toUpperCase();
+
+  return GATED_ROUTES.some(
+    (route) => route.method === method && route.path === path,
+  );
+}
+
+function getClientVersionHeader(request: FastifyRequest): string | null {
+  const raw = request.headers[CLIENT_VERSION_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseVersionParts(version: string): number[] | null {
+  const parts = version.split(".").map((part) => Number(part));
+
+  if (parts.length === 0 || parts.some((part) => !Number.isInteger(part) || part < 0)) {
+    return null;
+  }
+
+  return parts;
+}
+
+// Cuando APP_VERSION/CLIENT_MIN_VERSION son SHAs de despliegue (no semver),
+// la única comparación válida es igualdad exacta; el orden numérico solo
+// aplica si ambos lados son versiones punteadas como "1.2.3".
+export function isClientVersionSupported(
+  clientVersion: string,
+  minimumVersion: string,
+): boolean {
+  if (clientVersion === minimumVersion) {
+    return true;
+  }
+
+  const clientParts = parseVersionParts(clientVersion);
+  const minimumParts = parseVersionParts(minimumVersion);
+
+  if (!clientParts || !minimumParts) {
+    return false;
+  }
+
+  const length = Math.max(clientParts.length, minimumParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const clientPart = clientParts[index] ?? 0;
+    const minimumPart = minimumParts[index] ?? 0;
+
+    if (clientPart > minimumPart) return true;
+    if (clientPart < minimumPart) return false;
+  }
+
+  return true;
+}
+
+export async function requireMinimumClientVersionForFastify(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  if (!ENV.clientVersionGateEnforced || !isGatedRoute(request)) {
+    return undefined;
+  }
+
+  const clientVersion = getClientVersionHeader(request);
+  const minimumClientVersion = ENV.clientMinVersion;
+
+  if (clientVersion && isClientVersionSupported(clientVersion, minimumClientVersion)) {
+    return undefined;
+  }
+
+  return reply.code(426).send({
+    success: false,
+    code: CLIENT_VERSION_UNSUPPORTED_CODE,
+    message: CLIENT_VERSION_UNSUPPORTED_MESSAGE,
+    minimumClientVersion,
+    clientVersion: clientVersion ?? "",
+  });
+}

--- a/test/app-version-gate-contract.test.ts
+++ b/test/app-version-gate-contract.test.ts
@@ -49,6 +49,49 @@ test("app version gate blocks usage and clears PWA caches before reload", () => 
   assert.ok(gate.includes("window.location.reload();"));
 });
 
+test("frontend api client sends the client version header on every request", () => {
+  const api = read("frontend/src/lib/api.ts");
+
+  assert.ok(
+    api.includes(
+      'import { CLIENT_APP_VERSION, CLIENT_VERSION_HEADER } from "@/lib/app-version";',
+    ),
+  );
+  assert.ok(
+    api.includes("headers.set(CLIENT_VERSION_HEADER, CLIENT_APP_VERSION);"),
+  );
+});
+
+test("frontend api client publishes a blocking signal on CLIENT_VERSION_UNSUPPORTED", () => {
+  const api = read("frontend/src/lib/api.ts");
+
+  assert.ok(
+    api.includes(
+      'import { publishClientVersionUnsupported } from "@/lib/client-version-error";',
+    ),
+  );
+  assert.ok(api.includes('const CLIENT_VERSION_UNSUPPORTED_CODE = "CLIENT_VERSION_UNSUPPORTED";'));
+  assert.ok(api.includes("res.status === 426 &&"));
+  assert.ok(api.includes("body.code === CLIENT_VERSION_UNSUPPORTED_CODE"));
+  assert.ok(api.includes("publishClientVersionUnsupported({"));
+});
+
+test("app version gate blocks usage on CLIENT_VERSION_UNSUPPORTED with the required copy", () => {
+  const gate = read("frontend/src/components/app-version/AppVersionGate.tsx");
+
+  assert.ok(gate.includes('data-client-version-unsupported="true"'));
+  assert.ok(gate.includes("Actualización requerida"));
+  assert.ok(
+    gate.includes(
+      "Estás usando una versión anterior de VETNEB. Para proteger tu",
+    ),
+  );
+  assert.ok(gate.includes("Actualizar ahora"));
+  assert.ok(
+    gate.includes("subscribeClientVersionUnsupported"),
+  );
+});
+
 test("service worker cache namespace changes for the version gate deployment", () => {
   const sw = read("frontend/public/sw.js");
 

--- a/test/client-version-gate-contract.test.ts
+++ b/test/client-version-gate-contract.test.ts
@@ -1,0 +1,197 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+process.env.NODE_ENV ??= "test";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const {
+  isClientVersionSupported,
+  CLIENT_VERSION_HEADER,
+  CLIENT_VERSION_UNSUPPORTED_CODE,
+} = await import("../server/middlewares/version-gate.ts");
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+type GateScenarioResult = {
+  result: unknown;
+  statusCode: number | null;
+  payload: Record<string, unknown> | null;
+};
+
+function runGateScenario(
+  envOverrides: Record<string, string>,
+  scenario: {
+    method: string;
+    path: string;
+    headers?: Record<string, string>;
+  },
+): GateScenarioResult {
+  const env = {
+    ...process.env,
+    NODE_ENV: "test",
+    SUPABASE_URL: "https://example.supabase.co",
+    SUPABASE_ANON_KEY: "test-anon-key",
+    SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+    DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/postgres",
+    SUPABASE_DB_URL: "postgresql://postgres:postgres@127.0.0.1:5432/postgres",
+    CLIENT_MIN_VERSION: "",
+    APP_VERSION: "",
+    ...envOverrides,
+  };
+
+  const script = [
+    'const { requireMinimumClientVersionForFastify } = await import("./server/middlewares/version-gate.ts");',
+    `const request = ${JSON.stringify({
+      method: scenario.method,
+      url: scenario.path,
+      headers: scenario.headers ?? {},
+    })};`,
+    "let statusCode = null;",
+    "let payload = null;",
+    "const reply = { code(code) { statusCode = code; return this; }, send(body) { payload = body; return this; } };",
+    "const result = await requireMinimumClientVersionForFastify(request, reply);",
+    "process.stdout.write(JSON.stringify({ result: result === undefined ? null : result, statusCode, payload }));",
+  ].join("\n");
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--experimental-strip-types",
+      "--experimental-specifier-resolution=node",
+      "--input-type=module",
+      "-e",
+      script,
+    ],
+    {
+      cwd: resolve(process.cwd()),
+      env,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+
+  return JSON.parse(result.stdout) as GateScenarioResult;
+}
+
+test("isClientVersionSupported compara versiones punteadas y exige igualdad exacta para shas", () => {
+  assert.equal(isClientVersionSupported("1.2.0", "1.2.0"), true);
+  assert.equal(isClientVersionSupported("1.3.0", "1.2.0"), true);
+  assert.equal(isClientVersionSupported("1.1.9", "1.2.0"), false);
+  assert.equal(isClientVersionSupported("abc123", "abc123"), true);
+  assert.equal(isClientVersionSupported("abc123", "def456"), false);
+});
+
+test("gate armado: header de version faltante en login bloquea con 426 CLIENT_VERSION_UNSUPPORTED", () => {
+  const { statusCode, payload } = runGateScenario(
+    { CLIENT_MIN_VERSION: "1.2.0", APP_VERSION: "1.2.0" },
+    { method: "POST", path: "/api/auth/login" },
+  );
+
+  assert.equal(statusCode, 426);
+  assert.deepEqual(payload, {
+    success: false,
+    code: CLIENT_VERSION_UNSUPPORTED_CODE,
+    message:
+      "Tu aplicación está desactualizada. Actualizá o reinstalá VETNEB para continuar.",
+    minimumClientVersion: "1.2.0",
+    clientVersion: "",
+  });
+});
+
+test("gate armado: version menor a la minima bloquea con 426 en auth/me admin", () => {
+  const { statusCode, payload } = runGateScenario(
+    { CLIENT_MIN_VERSION: "1.2.0", APP_VERSION: "1.2.0" },
+    {
+      method: "GET",
+      path: "/api/admin/auth/me",
+      headers: { [CLIENT_VERSION_HEADER]: "1.1.9" },
+    },
+  );
+
+  assert.equal(statusCode, 426);
+  assert.equal(payload?.code, CLIENT_VERSION_UNSUPPORTED_CODE);
+  assert.equal(payload?.clientVersion, "1.1.9");
+  assert.equal(payload?.minimumClientVersion, "1.2.0");
+});
+
+test("gate armado: version valida o superior preserva comportamiento existente", () => {
+  const exact = runGateScenario(
+    { CLIENT_MIN_VERSION: "1.2.0", APP_VERSION: "1.2.0" },
+    {
+      method: "POST",
+      path: "/api/particular/auth/login",
+      headers: { [CLIENT_VERSION_HEADER]: "1.2.0" },
+    },
+  );
+
+  assert.equal(exact.statusCode, null);
+  assert.equal(exact.result, null);
+
+  const higher = runGateScenario(
+    { CLIENT_MIN_VERSION: "1.2.0", APP_VERSION: "1.2.0" },
+    {
+      method: "GET",
+      path: "/api/particular/auth/me",
+      headers: { [CLIENT_VERSION_HEADER]: "1.3.0" },
+    },
+  );
+
+  assert.equal(higher.statusCode, null);
+  assert.equal(higher.result, null);
+});
+
+test("gate armado: rutas publicas como contact y health nunca se bloquean", () => {
+  const contact = runGateScenario(
+    { CLIENT_MIN_VERSION: "1.2.0", APP_VERSION: "1.2.0" },
+    { method: "POST", path: "/api/contact" },
+  );
+  const health = runGateScenario(
+    { CLIENT_MIN_VERSION: "1.2.0", APP_VERSION: "1.2.0" },
+    { method: "GET", path: "/api/health" },
+  );
+
+  assert.equal(contact.statusCode, null);
+  assert.equal(health.statusCode, null);
+});
+
+test("gate desarmado por defecto: sin CLIENT_MIN_VERSION configurado no bloquea aunque falte el header", () => {
+  const { statusCode, result } = runGateScenario(
+    {},
+    { method: "POST", path: "/api/auth/login" },
+  );
+
+  assert.equal(statusCode, null);
+  assert.equal(result, null);
+});
+
+test("client-version-gate hook esta instalado globalmente antes del registro de rutas", () => {
+  const fastifyApp = read("server/fastify-app.ts");
+  const trustedOriginIndex = fastifyApp.indexOf(
+    'app.addHook("onRequest", requireTrustedOriginForFastify);',
+  );
+  const versionGateIndex = fastifyApp.indexOf(
+    'app.addHook("onRequest", requireMinimumClientVersionForFastify);',
+  );
+  const firstRouteRegistrationIndex = fastifyApp.indexOf(
+    "await app.register(appVersionNativeRoutes",
+  );
+
+  assert.notEqual(trustedOriginIndex, -1);
+  assert.notEqual(versionGateIndex, -1);
+  assert.notEqual(firstRouteRegistrationIndex, -1);
+  assert.ok(trustedOriginIndex < versionGateIndex);
+  assert.ok(versionGateIndex < firstRouteRegistrationIndex);
+});

--- a/test/helpers/report-foreign-access-scope.ts
+++ b/test/helpers/report-foreign-access-scope.ts
@@ -9,6 +9,9 @@ const SHARED_BACKEND_SCOPE_EXCEPTIONS = new Set([
   "server/routes/reports-status.fastify.ts",
   "server/routes/reports.fastify.ts",
   "server/routes/study-tracking.fastify.ts",
+  "server/fastify-app.ts",
+  "server/lib/env.ts",
+  "server/middlewares/version-gate.ts",
 ]);
 
 export function isSharedBackendScopeException(file: string): boolean {


### PR DESCRIPTION
Implements server-side client version enforcement for stale installed/PWA app versions.

Summary:
- Adds backend version gate for auth/app endpoints.
- Sends X-VETNEB-Client-Version from frontend apiFetch.
- Returns 426 CLIENT_VERSION_UNSUPPORTED for missing or outdated clients when CLIENT_MIN_VERSION is explicitly configured.
- Shows blocking update-required UX on frontend.
- Keeps contact/health public endpoints unblocked.
- Documents activation checklist and production guardrails.

Validation:
- pnpm test: 2865/2865 passing
- pnpm typecheck: passing
- frontend pnpm lint: passing

Notes:
- Enforcement is production-safe by default and only arms when CLIENT_MIN_VERSION is explicitly set.
- No DB, migrations, dependencies, lockfiles, CI, broad CORS changes, or auth/session rewrites.