### PR TITLE
fix(app): improve stale version update flow

### DIFF
--- a/docs/implementation/APP_VERSION_GATE.md
+++ b/docs/implementation/APP_VERSION_GATE.md
@@ -109,6 +109,63 @@ desde `RootLayout` vía `AppVersionGate`:
   **"Actualizar ahora"**. No se permite continuar login/dashboard mientras
   esta señal esté activa.
 
+## Versión técnica vs. versión comercial (UI)
+
+`appVersion` y `clientMinVersion` son **técnicos**: en Render suelen ser un
+commit SHA (`RENDER_GIT_COMMIT`) y existen solo para que backend/frontend
+comparen igualdad exacta o tests/diagnóstico los citen. **Nunca** deben
+renderizarse tal cual en pantalla, y tampoco el sentinel interno
+`CLIENT_APP_VERSION_FALLBACK` (`"missing-client-version"`) que usa el
+frontend cuando `NEXT_PUBLIC_APP_VERSION` no está configurado en el build.
+
+Para usuario final existe una versión **comercial** separada,
+`displayVersion`/`toSafeDisplayVersion`:
+
+- Backend (`server/routes/app-version.fastify.ts`) calcula
+  `displayVersion` a partir de `process.env.npm_package_version` (el mismo
+  mecanismo que ya usa `admin-system-health.fastify.ts` para el chequeo de
+  salud), formateado como `Portal VETNEB v<version>` — hoy
+  `Portal VETNEB v2.1.0` porque la raíz del repo está en `2.1.0`. Si el
+  `major` de `package.json` pasa a `3.x`, este mismo código produce
+  `Portal VETNEB v3.x.x` automáticamente, sin tocar el formateo.
+- Frontend (`frontend/src/lib/app-version.ts`) expone
+  `toSafeDisplayVersion(raw)`, que normaliza cualquier valor técnico a una
+  etiqueta segura:
+  - sentinel `missing-client-version`, vacío o no reconocible → `"anterior
+    / no detectada"`;
+  - SHA de commit (hex largo) → `"anterior / no detectada"` (nunca se
+    imprime el hash);
+  - semver puntuado (`"2.1.0"`) → `"Portal VETNEB v2.1.0"`;
+  - valor ya formateado (`"Portal VETNEB v…"`) → se devuelve sin cambios.
+- `AppVersionGate.tsx` usa `toSafeDisplayVersion` tanto para la "Versión
+  instalada" (cliente, `CLIENT_APP_VERSION`) como para la "Versión
+  vigente" (backend, `displayVersion ?? appVersion`). Ningún componente de
+  UI debe interpolar `CLIENT_APP_VERSION` o `snapshot.appVersion` crudos.
+
+## Recuperación al tocar "Actualizar ahora"
+
+Antes, el botón solo llamaba `registration.update()` + `reload()`. Si el
+service worker viejo seguía controlando la pestaña, el reload podía volver
+a servir el mismo shell desactualizado y el cartel reaparecía sin
+resolver nada. Ahora `handleUpdateNow` en `AppVersionGate.tsx` hace, en
+orden:
+
+1. `unregisterServiceWorkers()`: desregistra (no solo actualiza) todos los
+   `ServiceWorkerRegistration` de este origen.
+2. `clearPortalCaches()`: borra únicamente las Cache Storage con prefijo
+   `portal-vetneb-` (las que usa `frontend/public/sw.js`).
+3. `clearAppVersionLocalState()`: borra únicamente claves de
+   `localStorage` con prefijo `vetneb:app-version:`, si existieran. Nunca
+   toca otras claves (tema, último módulo de dashboard, etc.).
+4. `navigateToFreshAppShell()`: navega con `window.location.replace(...)`
+   a `"/"` con un parámetro `?vetnebUpdate=<timestamp>` como cache-buster,
+   sin dejar la pantalla de bloqueo en el historial.
+
+Si el aviso persiste después de esto, la UI muestra una nota secundaria
+fija (no es un link, es texto plano: el frontend no usa `<a>`/`next/link`)
+indicando cerrar la app, eliminar el acceso directo instalado y abrir
+`https://vetneb.com.ar` desde el navegador.
+
 ## Exclusiones explícitas de este cambio
 
 - Sin cambios de base de datos ni migraciones.
@@ -125,3 +182,13 @@ desde `RootLayout` vía `AppVersionGate`:
 3. Si el problema persiste, borrar caché del sitio/navegador.
 4. Desinstalar y reinstalar la PWA.
 5. Volver a validar el login.
+
+## Checklist de soporte móvil (cartel "Actualización requerida")
+
+1. Tocar **"Actualizar ahora"** (desregistra el service worker, limpia
+   cachés/claves locales propias y navega con cache-buster).
+2. Si el cartel vuelve a aparecer, cerrar la app por completo.
+3. Borrar el acceso directo/PWA instalado en el dispositivo.
+4. Abrir `https://vetneb.com.ar` desde el navegador (no desde el acceso
+   directo viejo).
+5. Reinstalar el acceso directo/PWA si corresponde.

--- a/frontend/src/components/app-version/AppVersionGate.tsx
+++ b/frontend/src/components/app-version/AppVersionGate.tsx
@@ -4,8 +4,10 @@ import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 
 import {
   CLIENT_APP_VERSION,
+  clearAppVersionLocalState,
   getAppVersionSnapshot,
   isClientVersionOutdated,
+  toSafeDisplayVersion,
   type AppVersionSnapshot,
 } from "@/lib/app-version";
 import {
@@ -15,6 +17,9 @@ import {
 } from "@/lib/client-version-error";
 
 const VERSION_CHECK_INTERVAL_MS = 60_000;
+
+const UPDATE_HELP_TEXT =
+  "Si el aviso vuelve a aparecer, cerrá la app, eliminá el acceso directo instalado y abrí https://vetneb.com.ar nuevamente.";
 
 async function clearPortalCaches() {
   if (typeof window === "undefined" || !("caches" in window)) {
@@ -29,7 +34,7 @@ async function clearPortalCaches() {
   );
 }
 
-async function updateServiceWorkers() {
+async function unregisterServiceWorkers() {
   if (
     typeof navigator === "undefined" ||
     !("serviceWorker" in navigator)
@@ -39,10 +44,49 @@ async function updateServiceWorkers() {
 
   const registrations = await navigator.serviceWorker.getRegistrations();
   await Promise.all(
-    registrations.map(async (registration) => {
-      await registration.update();
-      registration.waiting?.postMessage({ type: "VETNEB_SKIP_WAITING" });
-    }),
+    registrations.map((registration) => registration.unregister()),
+  );
+}
+
+// Recarga simple no alcanza: si el SW viejo sigue activo puede re-servir el
+// mismo shell. Por eso reemplazamos la URL (sin dejar la pantalla bloqueada
+// en el historial) y agregamos un cache-buster para forzar red real.
+function navigateToFreshAppShell() {
+  const url = new URL("/", window.location.origin);
+  url.searchParams.set("vetnebUpdate", Date.now().toString());
+  window.location.replace(url.toString());
+}
+
+function VersionsSummary({
+  installedLabel,
+  currentLabel,
+}: {
+  installedLabel: string;
+  currentLabel: string;
+}) {
+  return (
+    <dl className="mt-4 grid gap-2 rounded-lg border border-vetneb-line/70 bg-vetneb-surface/70 p-3 text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+        <dt>Versión instalada</dt>
+        <dd className="break-words text-right font-medium text-vetneb-ink">
+          {installedLabel}
+        </dd>
+      </div>
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+        <dt>Versión vigente</dt>
+        <dd className="break-words text-right font-medium text-vetneb-ink">
+          {currentLabel}
+        </dd>
+      </div>
+    </dl>
+  );
+}
+
+function UpdateHelpNote() {
+  return (
+    <p className="mt-3 break-words text-xs leading-5 text-muted-foreground">
+      {UPDATE_HELP_TEXT}
+    </p>
   );
 }
 
@@ -58,7 +102,7 @@ export function AppVersionGate() {
   );
 
   const evaluateSnapshot = useCallback((snapshot: AppVersionSnapshot) => {
-    setLatestVersion(snapshot.appVersion);
+    setLatestVersion(snapshot.displayVersion ?? snapshot.appVersion);
     setCheckFailed(false);
     setIsUpdateRequired(isClientVersionOutdated(snapshot));
   }, []);
@@ -95,12 +139,16 @@ export function AppVersionGate() {
     setIsReloading(true);
 
     try {
-      await updateServiceWorkers();
+      await unregisterServiceWorkers();
       await clearPortalCaches();
+      clearAppVersionLocalState();
     } finally {
-      window.location.reload();
+      navigateToFreshAppShell();
     }
   }
+
+  const installedVersionLabel = toSafeDisplayVersion(CLIENT_APP_VERSION);
+  const currentVersionLabel = toSafeDisplayVersion(latestVersion);
 
   if (clientVersionUnsupported) {
     return (
@@ -114,6 +162,9 @@ export function AppVersionGate() {
         data-client-version-unsupported="true"
       >
         <div className="w-full max-w-lg rounded-2xl border border-vetneb-line/80 bg-card p-6 shadow-2xl">
+          <p className="mb-2 inline-flex rounded-full bg-vetneb-teal/12 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-vetneb-teal">
+            Nueva versión disponible
+          </p>
           <h2
             id="client-version-unsupported-title"
             className="text-2xl font-semibold text-vetneb-ink"
@@ -127,6 +178,10 @@ export function AppVersionGate() {
             Estás usando una versión anterior de VETNEB. Para proteger tu
             sesión y evitar errores, actualizá o reinstalá la app.
           </p>
+          <VersionsSummary
+            installedLabel={installedVersionLabel}
+            currentLabel={currentVersionLabel}
+          />
           <button
             type="button"
             className="mt-5 inline-flex w-full items-center justify-center rounded-lg bg-vetneb-teal px-4 py-3 text-sm font-semibold text-vetneb-navy transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-70"
@@ -135,6 +190,7 @@ export function AppVersionGate() {
           >
             {isReloading ? "Actualizando..." : "Actualizar ahora"}
           </button>
+          <UpdateHelpNote />
         </div>
       </div>
     );
@@ -171,16 +227,10 @@ export function AppVersionGate() {
           evitar errores de comunicación, permisos, notificaciones o acciones
           incompletas, el uso queda bloqueado hasta cargar la versión vigente.
         </p>
-        <dl className="mt-4 grid gap-2 rounded-lg border border-vetneb-line/70 bg-vetneb-surface/70 p-3 text-xs text-muted-foreground">
-          <div className="flex justify-between gap-3">
-            <dt>Versión actual</dt>
-            <dd className="font-mono text-vetneb-ink">{CLIENT_APP_VERSION}</dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt>Versión vigente</dt>
-            <dd className="font-mono text-vetneb-ink">{latestVersion ?? "—"}</dd>
-          </div>
-        </dl>
+        <VersionsSummary
+          installedLabel={installedVersionLabel}
+          currentLabel={currentVersionLabel}
+        />
         {checkFailed ? (
           <p className="mt-3 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-xs text-amber-900">
             No se pudo verificar nuevamente la versión. Revisá conexión y
@@ -195,6 +245,7 @@ export function AppVersionGate() {
         >
           {isReloading ? "Actualizando..." : "Actualizar ahora"}
         </button>
+        <UpdateHelpNote />
       </div>
     </div>
   );

--- a/frontend/src/lib/app-version.ts
+++ b/frontend/src/lib/app-version.ts
@@ -1,13 +1,18 @@
 export const CLIENT_VERSION_HEADER = "x-vetneb-client-version";
 
+// Sentinel técnico interno: nunca debe llegar a la UI. Para texto visible al
+// usuario, pasar siempre por toSafeDisplayVersion().
+export const CLIENT_APP_VERSION_FALLBACK = "missing-client-version";
+
 export const CLIENT_APP_VERSION =
-  process.env.NEXT_PUBLIC_APP_VERSION?.trim() || "missing-client-version";
+  process.env.NEXT_PUBLIC_APP_VERSION?.trim() || CLIENT_APP_VERSION_FALLBACK;
 
 export type AppVersionSnapshot = {
   success: true;
   appVersion: string;
   clientMinVersion: string;
   forceUpdate: boolean;
+  displayVersion?: string;
 };
 
 export async function getAppVersionSnapshot(): Promise<AppVersionSnapshot> {
@@ -33,4 +38,63 @@ export function isClientVersionOutdated(snapshot: AppVersionSnapshot): boolean {
   }
 
   return CLIENT_APP_VERSION !== snapshot.appVersion;
+}
+
+// Texto fijo cuando no hay una versión comercial detectable. Se usa solo
+// como valor (la etiqueta "Versión instalada"/"Versión vigente" ya aclara
+// de qué se trata), nunca como identificador técnico.
+export const VERSION_NOT_DETECTED_LABEL = "anterior / no detectada";
+
+const PRODUCT_DISPLAY_VERSION_PREFIX = "Portal VETNEB v";
+const SEMVER_LIKE_VERSION_PATTERN = /^v?\d+(\.\d+){1,3}$/i;
+
+// Convierte cualquier identificador técnico (sentinel, SHA de commit,
+// semver) en una etiqueta apta para usuario final. Nunca debe devolver un
+// hash ni el sentinel "missing-client-version" crudo: ver bug donde la
+// pantalla de actualización mostraba esos valores directamente.
+export function toSafeDisplayVersion(
+  rawVersion: string | null | undefined,
+): string {
+  const value = rawVersion?.trim();
+
+  if (!value || value === CLIENT_APP_VERSION_FALLBACK) {
+    return VERSION_NOT_DETECTED_LABEL;
+  }
+
+  if (value.startsWith(PRODUCT_DISPLAY_VERSION_PREFIX)) {
+    return value;
+  }
+
+  if (SEMVER_LIKE_VERSION_PATTERN.test(value)) {
+    return `${PRODUCT_DISPLAY_VERSION_PREFIX}${value.replace(/^v/i, "")}`;
+  }
+
+  return VERSION_NOT_DETECTED_LABEL;
+}
+
+const APP_VERSION_LOCAL_STORAGE_PREFIX = "vetneb:app-version:";
+
+// Defensivo: hoy ninguna clave usa este prefijo, pero "Actualizar ahora"
+// debe limpiarlas si una versión futura las agrega. Nunca toca otras claves
+// (tema, último módulo del dashboard, etc.).
+export function clearAppVersionLocalState(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const keysToRemove: string[] = [];
+
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+
+      if (key && key.startsWith(APP_VERSION_LOCAL_STORAGE_PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+
+    keysToRemove.forEach((key) => window.localStorage.removeItem(key));
+  } catch {
+    // localStorage no disponible (modo privado / deshabilitado) — ignorar.
+  }
 }

--- a/server/routes/app-version.fastify.ts
+++ b/server/routes/app-version.fastify.ts
@@ -5,7 +5,25 @@ import { ENV } from "../lib/env.ts";
 export type AppVersionNativeRoutesOptions = {
   appVersion?: string;
   clientMinVersion?: string;
+  displayVersion?: string;
 };
+
+const PRODUCT_DISPLAY_VERSION_PREFIX = "Portal VETNEB v";
+
+// APP_VERSION/CLIENT_MIN_VERSION son técnicos (SHA de despliegue) y se usan
+// para enforcement; npm_package_version es la versión comercial de
+// package.json (hoy "2.1.0") y solo se usa para mostrarle algo legible al
+// usuario. Si el mayor pasa a 3.x, esto produce "Portal VETNEB v3.x.x" sin
+// cambios de código.
+function resolveProductDisplayVersion(): string | undefined {
+  const packageVersion = process.env.npm_package_version;
+
+  if (!packageVersion || !/^\d+(\.\d+){1,3}$/.test(packageVersion)) {
+    return undefined;
+  }
+
+  return `${PRODUCT_DISPLAY_VERSION_PREFIX}${packageVersion}`;
+}
 
 export const appVersionNativeRoutes: FastifyPluginAsync<
   AppVersionNativeRoutesOptions
@@ -13,6 +31,8 @@ export const appVersionNativeRoutes: FastifyPluginAsync<
   app.get("/", async (_request, reply) => {
     const appVersion = options.appVersion ?? ENV.appVersion;
     const clientMinVersion = options.clientMinVersion ?? ENV.clientMinVersion;
+    const displayVersion =
+      options.displayVersion ?? resolveProductDisplayVersion();
 
     reply.header("cache-control", "no-store, no-cache, must-revalidate, max-age=0");
     reply.header("pragma", "no-cache");
@@ -23,6 +43,7 @@ export const appVersionNativeRoutes: FastifyPluginAsync<
       appVersion,
       clientMinVersion,
       forceUpdate: true,
+      displayVersion,
     });
   });
 };

--- a/test/app-version-gate-contract.test.ts
+++ b/test/app-version-gate-contract.test.ts
@@ -22,6 +22,14 @@ test("backend exposes a no-store app version endpoint", () => {
   assert.ok(app.includes('prefix: "/api/app-version"'));
 });
 
+test("backend derives a commercial displayVersion from npm_package_version, separate from the technical SHA", () => {
+  const route = read("server/routes/app-version.fastify.ts");
+
+  assert.ok(route.includes("displayVersion"));
+  assert.ok(route.includes("process.env.npm_package_version"));
+  assert.ok(route.includes('"Portal VETNEB v'));
+});
+
 test("frontend compares compiled client version against backend version", () => {
   const helper = read("frontend/src/lib/app-version.ts");
 
@@ -30,6 +38,31 @@ test("frontend compares compiled client version against backend version", () => 
   assert.ok(helper.includes('cache: "no-store"'));
   assert.ok(helper.includes('"x-vetneb-client-version": CLIENT_APP_VERSION'));
   assert.ok(helper.includes("CLIENT_APP_VERSION !== snapshot.appVersion"));
+  assert.ok(helper.includes("export function toSafeDisplayVersion"));
+  assert.ok(helper.includes("export function clearAppVersionLocalState"));
+});
+
+test("toSafeDisplayVersion never leaks the missing-client-version sentinel or raw commit hashes", async () => {
+  const { toSafeDisplayVersion } = await import(
+    "../frontend/src/lib/app-version.ts"
+  );
+
+  assert.equal(
+    toSafeDisplayVersion("missing-client-version"),
+    "anterior / no detectada",
+  );
+  assert.equal(
+    toSafeDisplayVersion("f41c8005a98a9b3f24ad3f55bc608ec97464ccf3"),
+    "anterior / no detectada",
+  );
+  assert.equal(toSafeDisplayVersion(null), "anterior / no detectada");
+  assert.equal(toSafeDisplayVersion(undefined), "anterior / no detectada");
+  assert.equal(toSafeDisplayVersion(""), "anterior / no detectada");
+  assert.equal(toSafeDisplayVersion("2.1.0"), "Portal VETNEB v2.1.0");
+  assert.equal(
+    toSafeDisplayVersion("Portal VETNEB v2.1.0"),
+    "Portal VETNEB v2.1.0",
+  );
 });
 
 test("root layout mounts the app version blocker globally", () => {
@@ -39,14 +72,31 @@ test("root layout mounts the app version blocker globally", () => {
   assert.ok(layout.includes("<AppVersionGate />"));
 });
 
-test("app version gate blocks usage and clears PWA caches before reload", () => {
+test("app version gate blocks usage, unregisters service workers, clears PWA state and replaces the URL with a cache-buster", () => {
   const gate = read("frontend/src/components/app-version/AppVersionGate.tsx");
 
   assert.ok(gate.includes('role="alertdialog"'));
   assert.ok(gate.includes('data-app-version-gate="true"'));
   assert.ok(gate.includes("Actualizá Portal VETNEB para continuar"));
   assert.ok(gate.includes('key.startsWith("portal-vetneb-")'));
-  assert.ok(gate.includes("window.location.reload();"));
+  assert.ok(gate.includes("registration.unregister()"));
+  assert.ok(gate.includes("clearAppVersionLocalState()"));
+  assert.ok(gate.includes('new URL("/", window.location.origin)'));
+  assert.ok(gate.includes('searchParams.set("vetnebUpdate"'));
+  assert.ok(gate.includes("window.location.replace("));
+  assert.ok(!gate.includes("window.location.reload();"));
+});
+
+test("app version gate never renders raw technical version identifiers", () => {
+  const gate = read("frontend/src/components/app-version/AppVersionGate.tsx");
+
+  assert.ok(!gate.includes(">{CLIENT_APP_VERSION}<"));
+  assert.ok(!gate.includes("{latestVersion ?? "));
+  assert.ok(gate.includes("toSafeDisplayVersion(CLIENT_APP_VERSION)"));
+  assert.ok(gate.includes("toSafeDisplayVersion(latestVersion)"));
+  assert.ok(gate.includes("Versión instalada"));
+  assert.ok(gate.includes("Versión vigente"));
+  assert.ok(gate.includes("https://vetneb.com.ar"));
 });
 
 test("frontend api client sends the client version header on every request", () => {

--- a/test/auth-cookie-persistence-contract.test.ts
+++ b/test/auth-cookie-persistence-contract.test.ts
@@ -166,6 +166,10 @@ const UI_PREFERENCE_FILES: Array<{ path: string; keyMarkers: string[] }> = [
       "ADMIN_LAST_MODULE_STORAGE_KEY",
     ],
   },
+  {
+    path: "frontend/src/lib/app-version.ts",
+    keyMarkers: ["APP_VERSION_LOCAL_STORAGE_PREFIX"],
+  },
 ];
 
 function matchUiPreferenceFile(

--- a/test/helpers/report-foreign-access-scope.ts
+++ b/test/helpers/report-foreign-access-scope.ts
@@ -12,6 +12,7 @@ const SHARED_BACKEND_SCOPE_EXCEPTIONS = new Set([
   "server/fastify-app.ts",
   "server/lib/env.ts",
   "server/middlewares/version-gate.ts",
+  "server/routes/app-version.fastify.ts",
 ]);
 
 export function isSharedBackendScopeException(file: string): boolean {


### PR DESCRIPTION
Fixes the stale app version update UX after the client version gate.

Summary:
- Adds safe display version for user-facing UI.
- Prevents hashes and missing-client-version from rendering to users.
- Improves update flow by unregistering service workers, clearing portal-vetneb caches, clearing app-version local state, and navigating with a cache-buster.
- Adds backend displayVersion to /api/app-version.
- Updates app version gate documentation and tests.

Validation:
- pnpm test: 2868/2868 passing
- pnpm typecheck: passing
- pnpm --dir frontend typecheck: passing
- pnpm --dir frontend lint: passing

Scope:
- No DB, migrations, dependencies, lockfiles, CI, broad auth/session rewrite, or backend enforcement changes.