### PR TITLE
docs(env): clarify production domain references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ SUPABASE_SIGNED_URL_EXPIRES_IN_SECONDS=900
 SESSION_TTL_HOURS=24
 
 # Producción: origen exacto del frontend sin trailing slash.
+# Nota conceptual: CORS_ORIGIN es la allowlist de seguridad de orígenes autorizados a
+# llamar al backend, NO la URL pública canónica del sitio. Hoy server/lib/email.ts deriva
+# la URL del portal en los mails de token particular desde el primer origen https de
+# CORS_ORIGIN (ENV.corsOrigins), lo que acopla dos conceptos distintos. No reordenar
+# CORS_ORIGIN asumiendo que el primer https sea el dominio público canónico.
+# Seguimiento (PR-CLEAN2/PR-CLEAN3): introducir variable explícita PUBLIC_SITE_URL /
+# FRONTEND_URL para los links de email, con fallback al comportamiento actual.
 # TRUST_PROXY=1 es el valor correcto en Render (reverse proxy).
 # TRUST_PROXY=true rompe el startup; no usar.
 CORS_ORIGIN=https://vetneb.com.ar

--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -506,6 +506,18 @@ exige build+E2E). El resto está saludable.
   `frontend/.env.example`; marcar dominio productivo (`vetneb.com.ar`) vs staging.
 - **Validación:** `pnpm test -- production-env-contracts` y `public-staging-config-contract`; `pnpm typecheck`.
 - **Rollback:** revertir el PR (solo docs/comentarios; sin runtime).
+- **Nota de seguimiento (ejecución real, rama `clean/docs-env-domain-references`):**
+  este PR ejecuta el subconjunto de **referencias de dominio + nota conceptual de
+  `CORS_ORIGIN`**: (a) `frontend/README.md` usa ahora los dominios productivos
+  canónicos (`https://vetneb.com.ar` / `https://api.vetneb.com.ar`) como ejemplo y
+  marca staging Render (`*.onrender.com`) explícitamente; (b) `.env.example` documenta
+  que `CORS_ORIGIN` no es la URL pública canónica y anota el seguimiento a
+  `PUBLIC_SITE_URL`/`FRONTEND_URL` (PR-CLEAN2/3). **Diferido a un PR posterior** (no es
+  referencia de dominio): la reescritura de `docs/notes/todo.md` (P2-C) y los comentarios
+  de `APP_VERSION`/`CLIENT_MIN_VERSION`/`NEXT_PUBLIC_APP_VERSION` (P2-F). Las apariciones
+  `*-staging.onrender.com` en `docs/release-readiness.md`, `docs/staging-smoke-runbook.md`
+  y `test/*` se **mantienen**: son fixtures de contrato guardadas por
+  `public-staging-config-contract.test.ts` y `admin-docs-operational-contract.test.ts`.
 
 ### PR-CLEAN2 · reorganización documental (solo-docs)
 - **Alcance:** unificar `docs/audits/` → `docs/audit/`; mover `pr-*.md` sueltos a

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,7 +47,7 @@ El frontend corre en `http://localhost:3000` por defecto (o el puerto que config
 > Referencia local/LAN (development-only):
 > - Backend: `http://127.0.0.1:3000` o `http://<LAN-IP>:3000`
 > - Frontend: `http://localhost:3001` o `http://<LAN-IP>:3001`
-> - En staging/prod, `NEXT_PUBLIC_API_URL` debe apuntar explícitamente al backend público (`https://...onrender.com`) y no usar localhost/LAN.
+> - En producción, `NEXT_PUBLIC_API_URL` debe apuntar al backend público canónico (`https://api.vetneb.com.ar`); en staging Render usa `https://...onrender.com`. Nunca localhost/LAN.
 
 ## Variables de entorno
 
@@ -57,10 +57,15 @@ Copiar `frontend/.env.example` a `frontend/.env.local`:
 cp frontend/.env.example frontend/.env.local
 ```
 
-| Variable | Descripción | Default |
+| Variable | Descripción | Ejemplo (producción) |
 |---|---|---|
-| `NEXT_PUBLIC_API_URL` | URL del backend Fastify público | `https://portal-vetneb-backend-staging.onrender.com` |
-| `NEXT_PUBLIC_SITE_URL` | URL pública del frontend | `https://portal-vetneb-frontend-staging.onrender.com` |
+| `NEXT_PUBLIC_API_URL` | URL del backend Fastify público | `https://api.vetneb.com.ar` |
+| `NEXT_PUBLIC_SITE_URL` | URL pública del frontend | `https://vetneb.com.ar` |
+
+> Dominios productivos vigentes: frontend `https://vetneb.com.ar`, backend
+> `https://api.vetneb.com.ar` (fuente de verdad: `frontend/.env.example`). En staging
+> Render los servicios usan `*.onrender.com`; ver `docs/staging-smoke-runbook.md` y
+> `docs/release-readiness.md`.
 
 ## Build de producción
 


### PR DESCRIPTION
PR-CLEAN1 from the final repository cleanup audit.

Scope:
- Docs/env-example only.
- Clarifies production domain examples:
  - Frontend: https://vetneb.com.ar
  - Backend: https://api.vetneb.com.ar
- Marks Render onrender.com references as staging/test fixtures where applicable.
- Documents that CORS_ORIGIN is a security allowlist, not the canonical public site URL.
- Leaves runtime email URL behavior unchanged for a future PR-CLEAN3.

No runtime changes.
No backend/frontend code changes.
No DB, migrations, dependencies, lockfiles, workflows, Render, or secrets changes.

Validation:
- production-env-contracts.test.ts passed.
- public-staging-config-contract.test.ts passed.
- Full typecheck/test intentionally not required for docs/env-example-only changes.