### PR TITLE
fix(email): use explicit public site url for portal links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,16 +27,22 @@ SESSION_TTL_HOURS=24
 
 # Producción: origen exacto del frontend sin trailing slash.
 # Nota conceptual: CORS_ORIGIN es la allowlist de seguridad de orígenes autorizados a
-# llamar al backend, NO la URL pública canónica del sitio. Hoy server/lib/email.ts deriva
-# la URL del portal en los mails de token particular desde el primer origen https de
-# CORS_ORIGIN (ENV.corsOrigins), lo que acopla dos conceptos distintos. No reordenar
-# CORS_ORIGIN asumiendo que el primer https sea el dominio público canónico.
-# Seguimiento (PR-CLEAN2/PR-CLEAN3): introducir variable explícita PUBLIC_SITE_URL /
-# FRONTEND_URL para los links de email, con fallback al comportamiento actual.
+# llamar al backend, NO la URL pública canónica del sitio. Para los links de los mails
+# de token particular usar PUBLIC_SITE_URL (abajo); CORS_ORIGIN solo es el fallback de
+# compatibilidad si PUBLIC_SITE_URL no está configurada. No reordenar CORS_ORIGIN
+# asumiendo que el primer https sea el dominio público canónico.
 # TRUST_PROXY=1 es el valor correcto en Render (reverse proxy).
 # TRUST_PROXY=true rompe el startup; no usar.
 CORS_ORIGIN=https://vetneb.com.ar
 TRUST_PROXY=1
+
+# URL pública canónica del portal (sin trailing slash). Es la base para construir los
+# links de los emails de token particular (server/lib/email.ts). Concepto DISTINTO de
+# CORS_ORIGIN: aunque CORS_ORIGIN tenga varios orígenes, el mail siempre apunta a este
+# dominio. Si no se define, el backend cae al comportamiento anterior (primer origen
+# https de CORS_ORIGIN). Producción: https://vetneb.com.ar. En development/test se
+# admite http://localhost. Valor inválido (no https en prod) => fail-fast en el startup.
+PUBLIC_SITE_URL=https://vetneb.com.ar
 
 GMAIL_API_CLIENT_ID=<google-oauth-client-id>
 GMAIL_API_CLIENT_SECRET=<google-oauth-client-secret>

--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -532,6 +532,22 @@ exige build+E2E). El resto está saludable.
   usa la var con **fallback** a `CORS_ORIGIN`; documentar en `.env.example`.
 - **Validación:** test de link con/sin la var; `pnpm test -- logger-and-email`; `pnpm typecheck`.
 - **Rollback:** quitar la var → fallback automático; sin cambio de contrato.
+- **Nota de seguimiento (ejecución real, rama `clean/email-public-site-url-contract`):**
+  implementado con el nombre canónico **`PUBLIC_SITE_URL`** (coherente con
+  `NEXT_PUBLIC_SITE_URL` del frontend), no `PUBLIC_PORTAL_URL`. (a) `server/lib/env.ts`
+  agrega `PUBLIC_SITE_URL` al schema y expone `ENV.publicSiteUrl`, resuelto por
+  `resolvePublicSiteUrl()`: normaliza al **origen** (sin trailing slash), exige `https`
+  en producción (admite `http://localhost`/`127.0.0.1` en development/test) y hace
+  **fail-fast** en el startup ante un valor inválido. (b) `server/lib/email.ts`:
+  `resolveParticularPortalUrl(ENV.publicSiteUrl, ENV.corsOrigins)` prioriza
+  `PUBLIC_SITE_URL` y mantiene el **fallback** al primer origen `https` de `CORS_ORIGIN`
+  (cero ruptura si Render aún no define la var). (c) `.env.example` documenta
+  `PUBLIC_SITE_URL=https://vetneb.com.ar` y la diferencia conceptual con `CORS_ORIGIN`.
+  (d) Tests: `test/email-html-templates.test.ts` cubre A (usa `PUBLIC_SITE_URL`),
+  B (trailing slash no duplica barra), C (fallback a CORS), D (onrender de CORS no gana)
+  y E (token no se imprime en logs); `test/env.test.ts` cubre `resolvePublicSiteUrl`
+  (normalización, https requerido, localhost en dev/test, fail-fast). **Acción manual
+  post-merge:** agregar `PUBLIC_SITE_URL=https://vetneb.com.ar` en el backend de Render.
 
 ### PR-CLEAN4 · (reservado) www/CORS topology
 - **Alcance (investigar):** decidir si `CORS_ORIGIN` incluye `www.vetneb.com.ar`

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -633,7 +633,17 @@ function buildVetnebEmailHtml(input: { title: string; body: string }): string {
 </html>`;
 }
 
-function resolveParticularPortalUrl(corsOrigins: string[]): string | null {
+function resolveParticularPortalUrl(
+  publicSiteUrl: string | undefined,
+  corsOrigins: string[],
+): string | null {
+  // URL pública canónica explícita (PUBLIC_SITE_URL) tiene prioridad. Se normaliza
+  // el trailing slash de forma defensiva para no duplicar la barra del path.
+  if (publicSiteUrl) {
+    return `${publicSiteUrl.replace(/\/+$/, "")}/particulares`;
+  }
+
+  // Fallback de compatibilidad: primer origen https del allowlist CORS.
   const httpsOrigin = corsOrigins.find((o) => /^https:\/\//.test(o));
   return httpsOrigin ? `${httpsOrigin}/particulares` : null;
 }
@@ -903,7 +913,7 @@ export async function sendParticularTokenEmail(input: {
     return { sent: false, reason: "no_recipients" as const };
   }
 
-  const portalUrl = resolveParticularPortalUrl(ENV.corsOrigins);
+  const portalUrl = resolveParticularPortalUrl(ENV.publicSiteUrl, ENV.corsOrigins);
 
   const delivery = await sendConfiguredEmailMessage({
     to: recipients,

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -36,6 +36,44 @@ function parseDatabaseMaxConnections(value: string | undefined): number {
 
   return Math.min(Math.max(Math.trunc(parsed), 1), 10);
 }
+
+// URL pública canónica del portal para los links de email (token particular).
+// Concepto distinto de CORS_ORIGIN (allowlist de seguridad). Normaliza al origen
+// (sin trailing slash, sin path) y valida el esquema: https en producción;
+// http://localhost o http://127.0.0.1 solo se admite en development/test.
+// Devuelve undefined si no está configurada (el consumidor cae al fallback CORS).
+export function resolvePublicSiteUrl(
+  rawValue: string | undefined,
+  env: "development" | "test" | "production",
+): string | undefined {
+  if (!rawValue) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawValue);
+  } catch {
+    throw new Error(
+      "PUBLIC_SITE_URL debe ser una URL absoluta válida (ej: https://vetneb.com.ar)",
+    );
+  }
+
+  const isHttps = parsed.protocol === "https:";
+  const isLocalHttp =
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1");
+
+  const allowed = env === "production" ? isHttps : isHttps || isLocalHttp;
+
+  if (!allowed) {
+    throw new Error(
+      "PUBLIC_SITE_URL debe usar https (http://localhost solo se admite en development/test)",
+    );
+  }
+
+  return parsed.origin;
+}
 const envSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
   PORT: z.coerce.number().int().positive().optional(),
@@ -59,6 +97,7 @@ const envSchema = z.object({
     z.string().min(1).optional(),
   ),
   CORS_ORIGIN: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
+  PUBLIC_SITE_URL: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
   TRUST_PROXY: z.coerce.number().int().min(0).max(10).optional(),
   OWNER_OPEN_ID: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
   LAB_UPLOAD_USERNAMES: z.preprocess(
@@ -133,6 +172,8 @@ const corsOrigins =
     ? configuredCorsOrigins
     : Array.from(new Set([...configuredCorsOrigins, ...LOCAL_CORS_ORIGINS]));
 
+const publicSiteUrl = resolvePublicSiteUrl(rawEnv.PUBLIC_SITE_URL, nodeEnv);
+
 const smtpEnabled = Boolean(
   rawEnv.SMTP_HOST &&
     rawEnv.SMTP_PORT &&
@@ -171,6 +212,7 @@ export const ENV = {
   particularCookieName:
     rawEnv.PARTICULAR_COOKIE_NAME ?? "particular_session_id",
   corsOrigins,
+  publicSiteUrl,
   trustProxy: rawEnv.TRUST_PROXY ?? 1,
   cookieSecure: nodeEnv === "production",
   cookieSameSite: (nodeEnv === "production" ? "none" : "lax") as

--- a/test/email-html-templates.test.ts
+++ b/test/email-html-templates.test.ts
@@ -26,6 +26,7 @@ type EnvSnapshot = {
   isProduction: boolean;
   contactTo: string[];
   corsOrigins: string[];
+  publicSiteUrl: string | undefined;
   smtp: typeof ENV.smtp;
   gmailApi: typeof ENV.gmailApi;
 };
@@ -35,6 +36,7 @@ function snapshotEnv(): EnvSnapshot {
     isProduction: ENV.isProduction,
     contactTo: [...ENV.contactTo],
     corsOrigins: [...ENV.corsOrigins],
+    publicSiteUrl: ENV.publicSiteUrl,
     smtp: { ...ENV.smtp },
     gmailApi: { ...ENV.gmailApi },
   };
@@ -44,6 +46,7 @@ function restoreEnv(snap: EnvSnapshot): void {
   (ENV as any).isProduction = snap.isProduction;
   (ENV as any).contactTo = snap.contactTo;
   (ENV as any).corsOrigins = snap.corsOrigins;
+  (ENV as any).publicSiteUrl = snap.publicSiteUrl;
   for (const k of Object.keys(snap.smtp) as (keyof typeof ENV.smtp)[]) {
     (ENV.smtp as any)[k] = snap.smtp[k];
   }
@@ -580,6 +583,195 @@ test("seguridad: token no aparece en ningun href del HTML particular", async () 
     html.includes(`/particulares/${token}`),
     false,
     "token no debe estar en path de href",
+  );
+});
+
+// ─── Contrato PUBLIC_SITE_URL: URL pública desacoplada de CORS_ORIGIN ─────────
+
+test("PUBLIC_SITE_URL definido: el link usa ese dominio y no el de CORS_ORIGIN", async () => {
+  const snap = snapshotEnv();
+  const originalCreateTransport = nodemailer.createTransport;
+  const sendMailCalls: Array<Record<string, unknown>> = [];
+
+  enableSmtp();
+  // Host único: el transporter se cachea por host/port/user (evita colisión entre tests).
+  (ENV.smtp as any).host = "smtp-psu-defined.test";
+  (ENV as any).publicSiteUrl = "https://vetneb.com.ar";
+  // CORS_ORIGIN apunta a un host distinto (staging onrender): NO debe ganar.
+  (ENV as any).corsOrigins = [
+    "https://portal-vetneb-frontend-staging.onrender.com",
+  ];
+
+  (nodemailer as any).createTransport = () => ({
+    sendMail: async (p: Record<string, unknown>) => {
+      sendMailCalls.push(p);
+      return { messageId: "psu-test" };
+    },
+  });
+
+  try {
+    await sendParticularTokenEmail({
+      to: "tutor@example.com",
+      token: "TOKEN-PSU",
+      tutorLastName: "Diaz",
+      petName: "Mia",
+    });
+  } finally {
+    (nodemailer as any).createTransport = originalCreateTransport;
+    restoreEnv(snap);
+  }
+
+  assert.equal(sendMailCalls.length, 1);
+  const html = String(sendMailCalls[0].html);
+  const text = String(sendMailCalls[0].text);
+
+  assert.ok(
+    html.includes('href="https://vetneb.com.ar/particulares"'),
+    "href debe usar PUBLIC_SITE_URL",
+  );
+  assert.ok(
+    text.includes("https://vetneb.com.ar/particulares"),
+    "text/plain debe usar PUBLIC_SITE_URL",
+  );
+  // Escenario D: el origen onrender de CORS no gana con PUBLIC_SITE_URL definido.
+  assert.equal(
+    html.includes("onrender.com"),
+    false,
+    "no debe usar el origen onrender de CORS_ORIGIN",
+  );
+});
+
+test("PUBLIC_SITE_URL con trailing slash: el link no duplica la barra", async () => {
+  const snap = snapshotEnv();
+  const originalCreateTransport = nodemailer.createTransport;
+  const sendMailCalls: Array<Record<string, unknown>> = [];
+
+  enableSmtp();
+  (ENV.smtp as any).host = "smtp-psu-slash.test";
+  (ENV as any).publicSiteUrl = "https://vetneb.com.ar/";
+  (ENV as any).corsOrigins = ["https://portal.vetneb.com"];
+
+  (nodemailer as any).createTransport = () => ({
+    sendMail: async (p: Record<string, unknown>) => {
+      sendMailCalls.push(p);
+      return { messageId: "psu-slash-test" };
+    },
+  });
+
+  try {
+    await sendParticularTokenEmail({
+      to: "tutor@example.com",
+      token: "TOKEN-SLASH",
+      tutorLastName: "Ruiz",
+      petName: "Toby",
+    });
+  } finally {
+    (nodemailer as any).createTransport = originalCreateTransport;
+    restoreEnv(snap);
+  }
+
+  assert.equal(sendMailCalls.length, 1);
+  const html = String(sendMailCalls[0].html);
+
+  assert.ok(
+    html.includes('href="https://vetneb.com.ar/particulares"'),
+    "href debe normalizar el trailing slash",
+  );
+  assert.equal(
+    html.includes("https://vetneb.com.ar//particulares"),
+    false,
+    "no debe duplicar la barra del path",
+  );
+});
+
+test("PUBLIC_SITE_URL ausente: el link cae al primer https de CORS_ORIGIN", async () => {
+  const snap = snapshotEnv();
+  const originalCreateTransport = nodemailer.createTransport;
+  const sendMailCalls: Array<Record<string, unknown>> = [];
+
+  enableSmtp();
+  (ENV.smtp as any).host = "smtp-psu-fallback.test";
+  (ENV as any).publicSiteUrl = undefined;
+  (ENV as any).corsOrigins = [
+    "http://localhost:3000",
+    "https://vetneb.com.ar",
+    "https://segundo.example.com",
+  ];
+
+  (nodemailer as any).createTransport = () => ({
+    sendMail: async (p: Record<string, unknown>) => {
+      sendMailCalls.push(p);
+      return { messageId: "fallback-test" };
+    },
+  });
+
+  try {
+    await sendParticularTokenEmail({
+      to: "tutor@example.com",
+      token: "TOKEN-FALLBACK",
+      tutorLastName: "Vega",
+      petName: "Kira",
+    });
+  } finally {
+    (nodemailer as any).createTransport = originalCreateTransport;
+    restoreEnv(snap);
+  }
+
+  assert.equal(sendMailCalls.length, 1);
+  const html = String(sendMailCalls[0].html);
+
+  assert.ok(
+    html.includes('href="https://vetneb.com.ar/particulares"'),
+    "fallback debe usar el primer origen https de CORS_ORIGIN",
+  );
+  assert.equal(
+    html.includes("segundo.example.com"),
+    false,
+    "no debe usar un origen https posterior",
+  );
+});
+
+test("seguridad: el envío con PUBLIC_SITE_URL no imprime el token en logs", async () => {
+  const snap = snapshotEnv();
+  const originalCreateTransport = nodemailer.createTransport;
+  const originalInfo = console.info;
+  const logged: string[] = [];
+
+  enableSmtp();
+  (ENV.smtp as any).host = "smtp-psu-logs.test";
+  (ENV as any).publicSiteUrl = "https://vetneb.com.ar";
+
+  (nodemailer as any).createTransport = () => ({
+    sendMail: async () => ({ messageId: "log-test" }),
+  });
+  console.info = (...args: unknown[]) => {
+    logged.push(
+      args
+        .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+        .join(" "),
+    );
+  };
+
+  const token = "SECRET-LOG-TOKEN-123";
+
+  try {
+    await sendParticularTokenEmail({
+      to: "tutor@example.com",
+      token,
+      tutorLastName: "Soto",
+      petName: "Nina",
+    });
+  } finally {
+    console.info = originalInfo;
+    (nodemailer as any).createTransport = originalCreateTransport;
+    restoreEnv(snap);
+  }
+
+  const all = logged.join("\n");
+  assert.equal(all.includes(token), false, "el token no debe aparecer en logs");
+  assert.ok(
+    all.includes("particular_token sent"),
+    "debe loguear el envío sin exponer el token",
   );
 });
 

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -10,7 +10,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV, resolvePublicSiteUrl } = await import("../server/lib/env.ts");
 
 function readGmailApiEnvFromChild(overrides: Record<string, string>) {
   const env = {
@@ -175,6 +175,51 @@ test("ENV.gmailApi queda habilitado cuando las variables requeridas estan comple
     refreshToken: "google-refresh-token",
     from: "lab.vetneb@gmail.com",
   });
+});
+
+// PUBLIC_SITE_URL contract ──────────────────────────────────────────────────────
+
+test("resolvePublicSiteUrl devuelve undefined cuando no está configurada", () => {
+  assert.equal(resolvePublicSiteUrl(undefined, "production"), undefined);
+  assert.equal(resolvePublicSiteUrl("", "production"), undefined);
+});
+
+test("resolvePublicSiteUrl normaliza al origen y elimina el trailing slash", () => {
+  assert.equal(
+    resolvePublicSiteUrl("https://vetneb.com.ar/", "production"),
+    "https://vetneb.com.ar",
+  );
+  // origin normaliza host y descarta path/query sobrantes.
+  assert.equal(
+    resolvePublicSiteUrl("https://VETNEB.com.ar", "production"),
+    "https://vetneb.com.ar",
+  );
+});
+
+test("resolvePublicSiteUrl exige https en producción", () => {
+  assert.throws(
+    () => resolvePublicSiteUrl("http://vetneb.com.ar", "production"),
+    /https/,
+  );
+  assert.throws(
+    () => resolvePublicSiteUrl("http://localhost:3001", "production"),
+    /https/,
+  );
+});
+
+test("resolvePublicSiteUrl admite http://localhost solo en development/test", () => {
+  assert.equal(
+    resolvePublicSiteUrl("http://localhost:3001", "development"),
+    "http://localhost:3001",
+  );
+  assert.equal(
+    resolvePublicSiteUrl("http://127.0.0.1:3000/", "test"),
+    "http://127.0.0.1:3000",
+  );
+});
+
+test("resolvePublicSiteUrl hace fail-fast ante un valor inválido", () => {
+  assert.throws(() => resolvePublicSiteUrl("no-es-una-url", "production"), /URL/);
 });
 
 test("ENV exige CORS_ORIGIN explícito en producción", () => {


### PR DESCRIPTION
PR-CLEAN3 from the final repository cleanup audit.

Scope:
- Adds PUBLIC_SITE_URL as the explicit canonical public portal URL for email links.
- Keeps fallback to existing CORS_ORIGIN behavior when PUBLIC_SITE_URL is absent.
- Normalizes the configured URL and rejects invalid production values.
- Updates particular-token email link generation to prefer PUBLIC_SITE_URL.
- Adds env/email contract tests.
- Documents post-merge Render configuration.

Manual post-merge Render step:
- Backend service: set PUBLIC_SITE_URL=https://vetneb.com.ar
- Redeploy backend.
- Generate a new particular token email and confirm the link starts with https://vetneb.com.ar/particulares

No DB changes.
No migrations.
No dependencies.
No lockfile changes.
No workflow changes.
No Render/secrets changes in repo.

Validation:
- pnpm typecheck passed.
- pnpm typecheck:test passed.
- pnpm build passed.
- email template tests passed.
- env tests passed.
- production env contracts passed.
- public staging config contract passed.
- related email/auth/source-reading tests passed.