### PR TITLE
refactor(cors): share admin route origin helpers

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -595,6 +595,55 @@ exige build+E2E). El resto está saludable.
   `contact-route.test.ts`, `trusted-origin*.test.ts`, `public-*`); `pnpm build`.
 - **Rollback:** revertir el PR (cambio mecánico, sin cambio de semántica).
 - **Sugerencia:** dividir en 2-3 sub-PRs por familia (admin / particular / public+logistics) si el diff es grande.
+- **Nota de seguimiento (ejecución real — PR-CORS1, rama `clean/backend-cors-helper-consolidation`, 2026-06-28):**
+  se ejecutó la **fase 1** de la consolidación (la sugerencia de sub-PR por familia se adoptó: este PR migra la **familia admin**).
+  - **Helper creado:** `server/lib/cors-headers.ts` exporta `UNSAFE_METHODS`, `getAllowedOrigins`,
+    `normalizeOrigin`, `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin` y
+    `enforceTrustedOrigin`, copiados **verbatim** de la variante dominante (mismo contrato:
+    misma allowlist `ENV.corsOrigins`, mismos status/headers, mismo `"Origen no permitido"`).
+  - **`applyCorsHeaders` NO se consolidó** (corrección a la lista del alcance original): su cuerpo
+    **varía por ruta** en `access-control-expose-headers` (rate-limit / `Retry-After`), por lo que
+    se mantiene **local** en cada archivo. Consolidarlo exigiría parametrizar y cambiar firmas/call-sites.
+  - **Rutas migradas (14, familia admin):** `admin-audit`, `admin-clinics`, `admin-failed-login-alerts`,
+    `admin-particular-tokens`, `admin-pricing`, `admin-report-access-tokens`, `admin-report-workflow`,
+    `admin-reports`, `admin-sessions`, `admin-study-tracking`, `admin-system-health`,
+    `admin-system-maintenance`, `admin-system-schema-health`, `admin-users-roles`. Se reemplazaron
+    las definiciones locales por `import … from "../lib/cors-headers.ts"` y se eliminó el `const UNSAFE_METHODS`
+    local (sólo lo usaba `enforceTrustedOrigin`). Net ≈ **−1.180 líneas** (1.262 borradas / 80 nuevas).
+  - **Hallazgo que acota el alcance (no estaba en la auditoría original):** `enforceTrustedOrigin` tiene
+    **dos clases de comportamiento** ante método inseguro **sin Origin ni Referer**: *allow-null* (lo
+    permite; el hook global `requireTrustedOriginForFastify` cubre el cookie-forgery) vs *block-null*
+    (responde 403). **Toda la familia admin es uniformemente *allow-null***, por lo que el canónico
+    *allow-null* preserva el comportamiento exacto. Las rutas *block-null* (`particular-study-tracking`,
+    `study-tracking`) **quedan fuera** para no alterar su contrato. `getAllowedOrigins` canónico conserva
+    el fallback dev (inalcanzable, P3-D); `admin-clinics` tenía una variante simplificada sin fallback,
+    **equivalente** porque `ENV.corsOrigins` nunca está vacío (`env.ts:166-173`).
+  - **Sin cambios en tests de contrato existentes:** la fase 1 evita deliberadamente los archivos cuyos
+    tests fijan **definiciones** (no call-sites): el trío auth (`security-production-invariants.test.ts`
+    fija `function normalizeOrigin/getRequestOrigin/enforceTrustedOrigin`) y el trío logística
+    (`logistics-*-api.test.ts` fija `function enforceTrustedOrigin`, además de uso *inline* de `UNSAFE_METHODS`).
+    `api-production-session-contract.test.ts` fija `function applyCorsHeaders` en 10 rutas — satisfecho
+    porque `applyCorsHeaders` se mantiene local. El resto de la suite sólo fija **call-sites**
+    (`enforceTrustedOrigin(request, reply, allowedOrigins)`), preservados intactos.
+  - **Test nuevo:** `test/cors-headers-shared-helper.test.ts` (10 casos: normalización, allowlist,
+    Origin>Referer, `enforceTrustedOrigin` allow-null + 403, `getAllowedOrigins`=`ENV.corsOrigins`, `UNSAFE_METHODS`).
+  - **Validación ejecutada (verde):** `pnpm typecheck`, `pnpm typecheck:test`,
+    `node --experimental-strip-types --test test/security-trusted-origin-cors-boundaries.test.ts` (4/4) y
+    además `security-production-invariants` (11), `api-production-session-contract` (4),
+    `security-csrf-mutating-route-coverage` (17), `security-audit-logging-phase-boundaries` (9),
+    `security-boundary-suite-completeness` (6), `security-mutation-permission-surface` (5),
+    `clinic-management-route-policy` (3), `trusted-origin-router-policy` (2), `reports-suite-completeness` (7),
+    `report-write-surface-ownership` (5), los **14** `admin-*` route tests (138) y el helper nuevo (10). La
+    suite completa `pnpm test`/`pnpm build` no se corrió (requiere Postgres, igual que la auditoría original — §11/§15).
+  - **Pendiente → PR-CORS2:** migrar la familia **clínica/particular/público no fijada por definiciones**
+    (`contact`, `clinic-public-profile`, `particular-tokens`, `report-access-tokens`, `reports-status`,
+    `reports`, `public-report-access`, `admin-auth` queda en el grupo auth) manteniendo `applyCorsHeaders` local.
+  - **Pendiente → PR-CORS3 (requiere tocar tests de contrato en el mismo PR):** trío **auth**
+    (`auth`/`admin-auth`/`particular-auth`) y trío **logística** + rutas **block-null**; implica actualizar
+    `security-production-invariants.test.ts`, `logistics-*-api.test.ts` y la guardia `function applyCorsHeaders`
+    de `api-production-session-contract.test.ts` para verificar el `import` + uso en vez de la definición local.
+    `public-professionals.fastify.ts` **no** entra en la consolidación: su CORS es distinto (responde 403,
+    mensaje `"Origin no permitido"`, expone rate-limit headers).
 
 ### PR-CLEAN6 · dead-code & artefactos
 - **Alcance:** eliminar `shared/` + `test/shared-const-and-errors.test.ts`;

--- a/server/lib/cors-headers.ts
+++ b/server/lib/cors-headers.ts
@@ -1,0 +1,116 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import { ENV } from "./env.ts";
+
+/**
+ * Helpers CORS / trusted-origin compartidos por las rutas Fastify.
+ *
+ * Consolida el boilerplate que vivía duplicado por ruta (auditoría final,
+ * hallazgo P1-A / PR-CLEAN5). El comportamiento es idéntico al de las copias
+ * previas: misma allowlist (`ENV.corsOrigins`), misma normalización de origen,
+ * mismos status/headers y mismo mensaje `"Origen no permitido"`.
+ *
+ * `applyCorsHeaders` NO se consolida aquí a propósito: cada ruta expone un set
+ * distinto de `access-control-expose-headers` (rate-limit, Retry-After, etc.),
+ * por lo que se mantiene local en cada archivo.
+ */
+
+export const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function getAllowedOrigins(): string[] {
+  const configuredOrigins = ENV.corsOrigins.map((origin) =>
+    origin.trim().toLowerCase(),
+  );
+
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  if (ENV.isDevelopment) {
+    return [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:3001",
+      "http://127.0.0.1:3001",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ];
+  }
+
+  return [];
+}
+
+export function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin.trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function getOriginHeader(request: FastifyRequest): string {
+  return typeof request.headers.origin === "string"
+    ? request.headers.origin.trim()
+    : "";
+}
+
+export function getAllowedOriginForCors(
+  request: FastifyRequest,
+  allowedOrigins: ReadonlySet<string>,
+): string | null {
+  const rawOrigin = getOriginHeader(request);
+
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const normalizedOrigin = normalizeOrigin(rawOrigin);
+
+  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
+    return null;
+  }
+
+  return rawOrigin;
+}
+
+export function getRequestOrigin(request: FastifyRequest): string | null {
+  const originHeader = getOriginHeader(request);
+
+  if (originHeader) {
+    return normalizeOrigin(originHeader);
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string"
+      ? request.headers.referer.trim()
+      : "";
+
+  if (refererHeader) {
+    return normalizeOrigin(refererHeader);
+  }
+
+  return null;
+}
+
+export function enforceTrustedOrigin(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+): boolean {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}

--- a/server/routes/admin-audit.fastify.ts
+++ b/server/routes/admin-audit.fastify.ts
@@ -5,6 +5,11 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import {
   buildAdminAuditCsv as defaultBuildAdminAuditCsv,
@@ -127,81 +132,6 @@ async function authenticateAdminUser(
     hashSessionToken: deps.hashSessionToken,
     now,
   });
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
 }
 
 function applyCorsHeaders(

--- a/server/routes/admin-clinics.fastify.ts
+++ b/server/routes/admin-clinics.fastify.ts
@@ -7,6 +7,12 @@ import type {
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
+import {
   authenticateFastifyAdmin,
   type FastifyAuthenticatedAdmin,
 } from "../lib/fastify-admin-auth.ts";
@@ -19,8 +25,6 @@ import type {
   AdminClinicUpdateInput,
 } from "../db-admin-clinics.ts";
 import type { ClinicUserRole } from "../../drizzle/schema.ts";
-
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type AdminSessionRecord = {
   id?: number;
@@ -67,10 +71,6 @@ type AdminClinicDeleteBody = {
 type AdminClinicParams = {
   clinicId: string;
 };
-
-function getAllowedOrigins() {
-  return ENV.corsOrigins.map((origin) => origin.trim().toLowerCase());
-}
 
 export type AdminClinicsNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
@@ -209,54 +209,6 @@ function parseClinicUserRole(value: unknown): ClinicUserRole | null {
   return null;
 }
 
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest): string {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-): string | null {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  return refererHeader ? normalizeOrigin(refererHeader) : null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -271,29 +223,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseRequiredString(input: {

--- a/server/routes/admin-failed-login-alerts.fastify.ts
+++ b/server/routes/admin-failed-login-alerts.fastify.ts
@@ -5,6 +5,11 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type {
   AdminFailedLoginAlertReason,
@@ -244,81 +249,6 @@ function parseFailedLoginAlertsQuery(
     limit,
     offset,
   };
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
 }
 
 function applyCorsHeaders(

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -11,6 +11,12 @@ import type {
   StudyTrackingNotification,
 } from "../../drizzle/schema.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import {
   adminCreateParticularTokenSchema,
@@ -144,8 +150,6 @@ export type AdminParticularTokensNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminParticularTokensRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 type AdminParticularTokensFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
@@ -218,81 +222,6 @@ async function loadDefaultDeps(): Promise<NativeAdminParticularTokensDeps> {
   return defaultDepsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -307,33 +236,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function getSafeErrorName(error: unknown) {

--- a/server/routes/admin-pricing.fastify.ts
+++ b/server/routes/admin-pricing.fastify.ts
@@ -5,6 +5,12 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { clearPublicPricingCache } from "../lib/public-pricing-cache.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
@@ -12,8 +18,6 @@ import type {
   PricingItem,
   UpdatePricingItemInput,
 } from "../db-pricing.ts";
-
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type AdminSessionRecord = {
   id: number;
@@ -143,81 +147,6 @@ async function authenticateAdminUser(
   });
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -232,29 +161,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parsePositiveInteger(value: unknown): number | null {

--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -7,6 +7,12 @@ import type {
 import type { Report, ReportAccessToken } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import {
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
@@ -117,8 +123,6 @@ export type AdminReportAccessTokensNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminReportAccessTokensRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 type AdminReportAccessTokensFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
@@ -176,81 +180,6 @@ async function loadDefaultDeps(): Promise<NativeAdminReportAccessTokensDeps> {
   return defaultDepsPromise!;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -269,33 +198,6 @@ function applyCorsHeaders(
     "access-control-expose-headers",
     "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
   );
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function setMutationRateLimitHeaders(

--- a/server/routes/admin-report-workflow.fastify.ts
+++ b/server/routes/admin-report-workflow.fastify.ts
@@ -11,9 +11,14 @@ import {
 import type { AdminReportWorkflowItem } from "../db-report-workflow.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  normalizeOrigin,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const MAX_PAGE_SIZE = 20;
 const WORKFLOW_STAGE_SET = new Set<string>(REPORT_WORKFLOW_STAGES);
 
@@ -115,55 +120,6 @@ async function loadDefaultDeps(): Promise<NativeAdminReportWorkflowDeps> {
   return defaultDepsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const origin =
-    typeof request.headers.origin === "string"
-      ? request.headers.origin.trim()
-      : "";
-
-  if (origin) {
-    return normalizeOrigin(origin);
-  }
-
-  const referer =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  return referer ? normalizeOrigin(referer) : null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -182,29 +138,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", rawOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parsePositiveInteger(value: unknown): number | null {

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -15,6 +15,12 @@ import type {
 import type { Multer } from "multer";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import { ALLOWED_MIME_TYPES } from "../lib/supabase.ts";
 import {
@@ -146,8 +152,6 @@ export type AdminReportsNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminReportsRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 type AdminReportsFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
@@ -315,81 +319,6 @@ async function resolveDeps(
   };
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -404,29 +333,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 

--- a/server/routes/admin-sessions.fastify.ts
+++ b/server/routes/admin-sessions.fastify.ts
@@ -5,6 +5,12 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type {
   AdminSessionsQuery,
@@ -60,8 +66,6 @@ type CreateSessionAuditLogInput = {
   entity?: string | null;
   entityId?: number | null;
 };
-
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 export type AdminSessionsNativeRoutesOptions = {
   deleteAdminSession?: (tokenHash: string) => Promise<void>;
@@ -150,81 +154,6 @@ async function authenticateAdminUser(
     : null;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -239,29 +168,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseSessionType(

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -12,6 +12,12 @@ import type {
 } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import {
   adminCreateStudyTrackingSchema,
@@ -189,8 +195,6 @@ export type AdminStudyTrackingNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminStudyTrackingRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 type AdminStudyTrackingFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
 };
@@ -269,81 +273,6 @@ async function loadDefaultDeps(): Promise<NativeAdminStudyTrackingDeps> {
   return defaultDepsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -358,33 +287,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 

--- a/server/routes/admin-system-health.fastify.ts
+++ b/server/routes/admin-system-health.fastify.ts
@@ -5,6 +5,11 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 
 type AdminSessionRecord = {
@@ -227,81 +232,6 @@ function buildServiceChecksPayload(checks: unknown) {
     cors_has_local_or_lan_origins: corsReadiness.hasLocalOrLanOrigins,
     node_env: ENV.nodeEnv,
   };
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
 }
 
 function applyCorsHeaders(

--- a/server/routes/admin-system-maintenance.fastify.ts
+++ b/server/routes/admin-system-maintenance.fastify.ts
@@ -5,10 +5,14 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type { MaintenancePurgeDryRunSnapshot } from "../db-maintenance.ts";
-
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type AdminSessionRecord = {
   adminUserId: number;
@@ -95,81 +99,6 @@ async function authenticateAdminUser(
   });
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -184,29 +113,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 export const adminSystemMaintenanceNativeRoutes: FastifyPluginAsync<

--- a/server/routes/admin-system-schema-health.fastify.ts
+++ b/server/routes/admin-system-schema-health.fastify.ts
@@ -5,6 +5,11 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type { SchemaHealthSnapshot } from "../lib/schema-health.ts";
 
@@ -88,81 +93,6 @@ async function authenticateAdminUser(
     hashSessionToken: deps.hashSessionToken,
     now,
   });
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
 }
 
 function applyCorsHeaders(

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -5,6 +5,12 @@ import type {
 } from "fastify";
 
 import { ENV } from "../lib/env.ts";
+import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} from "../lib/cors-headers.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type {
@@ -19,8 +25,6 @@ import type {
   AdminClinicUserCredentialsUpdateInput,
   AdminClinicUserCredentialsUpdateResult,
 } from "../db-admin-clinics.ts";
-
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type AdminClinicUserRole = Exclude<AdminRoleUserRole, "admin">;
 
@@ -153,81 +157,6 @@ async function authenticateAdminUser(
   });
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -242,29 +171,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseUserType(value: string | undefined): AdminRoleUserType | undefined | null {

--- a/test/cors-headers-shared-helper.test.ts
+++ b/test/cors-headers-shared-helper.test.ts
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+process.env.CORS_ORIGIN ??= "https://vetneb.com.ar";
+
+const { ENV } = await import("../server/lib/env.ts");
+const {
+  UNSAFE_METHODS,
+  getAllowedOrigins,
+  normalizeOrigin,
+  getOriginHeader,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+  enforceTrustedOrigin,
+} = await import("../server/lib/cors-headers.ts");
+
+// ---------------------------------------------------------------------------
+// Fakes mínimos: las funciones sólo leen method/headers y, para
+// enforceTrustedOrigin, usan reply.code(n).send(body).
+// ---------------------------------------------------------------------------
+
+function fakeRequest(
+  headers: Record<string, string | undefined>,
+  method = "GET",
+): FastifyRequest {
+  return { method, headers, url: "/" } as unknown as FastifyRequest;
+}
+
+function fakeReply() {
+  const state: { statusCode: number | null; body: unknown } = {
+    statusCode: null,
+    body: undefined,
+  };
+  const reply = {
+    code(n: number) {
+      state.statusCode = n;
+      return reply;
+    },
+    send(body: unknown) {
+      state.body = body;
+      return reply;
+    },
+  };
+  return { reply: reply as unknown as FastifyReply, state };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeOrigin
+// ---------------------------------------------------------------------------
+
+test("normalizeOrigin devuelve el origen en minúsculas y null para valores inválidos", () => {
+  assert.equal(
+    normalizeOrigin("HTTPS://VetNeb.com.AR/particulares"),
+    "https://vetneb.com.ar",
+  );
+  assert.equal(normalizeOrigin("http://localhost:3000"), "http://localhost:3000");
+  assert.equal(normalizeOrigin("no-es-una-url"), null);
+  assert.equal(normalizeOrigin(""), null);
+});
+
+// ---------------------------------------------------------------------------
+// getOriginHeader
+// ---------------------------------------------------------------------------
+
+test("getOriginHeader recorta el header Origin y devuelve '' cuando no es string", () => {
+  assert.equal(
+    getOriginHeader(fakeRequest({ origin: "  https://vetneb.com.ar  " })),
+    "https://vetneb.com.ar",
+  );
+  assert.equal(getOriginHeader(fakeRequest({})), "");
+});
+
+// ---------------------------------------------------------------------------
+// getAllowedOriginForCors
+// ---------------------------------------------------------------------------
+
+test("getAllowedOriginForCors refleja el Origin crudo sólo si está en la allowlist", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+
+  assert.equal(
+    getAllowedOriginForCors(
+      fakeRequest({ origin: "https://vetneb.com.ar" }),
+      allowed,
+    ),
+    "https://vetneb.com.ar",
+  );
+  // Origin no permitido → null (no se refleja)
+  assert.equal(
+    getAllowedOriginForCors(
+      fakeRequest({ origin: "https://evil.example" }),
+      allowed,
+    ),
+    null,
+  );
+  // Sin Origin → null
+  assert.equal(getAllowedOriginForCors(fakeRequest({}), allowed), null);
+});
+
+// ---------------------------------------------------------------------------
+// getRequestOrigin (Origin tiene prioridad sobre Referer)
+// ---------------------------------------------------------------------------
+
+test("getRequestOrigin prioriza Origin y cae a Referer; sino null", () => {
+  assert.equal(
+    getRequestOrigin(
+      fakeRequest({
+        origin: "https://vetneb.com.ar",
+        referer: "https://otro.example/x",
+      }),
+    ),
+    "https://vetneb.com.ar",
+  );
+  assert.equal(
+    getRequestOrigin(fakeRequest({ referer: "https://vetneb.com.ar/ruta" })),
+    "https://vetneb.com.ar",
+  );
+  assert.equal(getRequestOrigin(fakeRequest({})), null);
+});
+
+// ---------------------------------------------------------------------------
+// enforceTrustedOrigin (variante allow-null: sin Origin/Referer en método
+// inseguro → permitido; el hook global de fastify-app cubre cookie-forgery)
+// ---------------------------------------------------------------------------
+
+test("enforceTrustedOrigin permite métodos seguros sin tocar la respuesta", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOrigin(
+    fakeRequest({ origin: "https://evil.example" }, "GET"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, true);
+  assert.equal(state.statusCode, null);
+});
+
+test("enforceTrustedOrigin permite método inseguro con Origin de la allowlist", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOrigin(
+    fakeRequest({ origin: "https://vetneb.com.ar" }, "POST"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, true);
+  assert.equal(state.statusCode, null);
+});
+
+test("enforceTrustedOrigin permite método inseguro sin Origin ni Referer (allow-null)", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOrigin(fakeRequest({}, "POST"), reply, allowed);
+
+  assert.equal(result, true);
+  assert.equal(state.statusCode, null);
+});
+
+test("enforceTrustedOrigin bloquea método inseguro con Origin externo: 403 'Origen no permitido'", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOrigin(
+    fakeRequest({ origin: "https://evil.example" }, "POST"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, false);
+  assert.equal(state.statusCode, 403);
+  assert.deepEqual(state.body, {
+    success: false,
+    error: "Origen no permitido",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAllowedOrigins + UNSAFE_METHODS
+// ---------------------------------------------------------------------------
+
+test("getAllowedOrigins refleja ENV.corsOrigins normalizado y nunca está vacío", () => {
+  const origins = getAllowedOrigins();
+
+  assert.ok(origins.length > 0);
+  // Todos en minúsculas y sin espacios
+  for (const origin of origins) {
+    assert.equal(origin, origin.trim().toLowerCase());
+  }
+  // Coincide con la allowlist central de ENV (mismo contrato)
+  assert.deepEqual(
+    origins,
+    ENV.corsOrigins.map((o) => o.trim().toLowerCase()),
+  );
+});
+
+test("UNSAFE_METHODS cubre exactamente POST/PUT/PATCH/DELETE", () => {
+  for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+    assert.ok(UNSAFE_METHODS.has(method), `falta ${method}`);
+  }
+  assert.equal(UNSAFE_METHODS.has("GET"), false);
+  assert.equal(UNSAFE_METHODS.has("OPTIONS"), false);
+  assert.equal(UNSAFE_METHODS.size, 4);
+});


### PR DESCRIPTION
PR-CORS1 from the final repository cleanup audit.

Scope:
- Adds a shared backend CORS helper for repeated origin utilities.
- Migrates the admin route family that uses the allow-null trusted-origin behavior.
- Keeps applyCorsHeaders local because expose-headers differ by route.
- Preserves HTTP behavior, status codes, response bodies, headers, and the Origen no permitido message.
- Leaves auth/logistics/block-null/public-professionals routes for follow-up PRs due to intentionally different contracts.

No frontend runtime changes.
No DB changes.
No migrations.
No dependencies.
No lockfile changes.
No workflow changes.
No Render/secrets changes.

Validation:
- pnpm typecheck passed.
- pnpm typecheck:test passed.
- security trusted origin CORS boundaries passed.
- security production invariants passed.
- api production session contract passed.
- CSRF/mutation/security boundary tests passed.
- 14 admin route test files passed.
- new shared helper test passed.

Full pnpm test/build not run locally because they require Postgres; affected tests were run directly.