### PR TITLE
refactor(cors): share public route origin helpers

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -644,6 +644,57 @@ exige build+E2E). El resto está saludable.
     de `api-production-session-contract.test.ts` para verificar el `import` + uso en vez de la definición local.
     `public-professionals.fastify.ts` **no** entra en la consolidación: su CORS es distinto (responde 403,
     mensaje `"Origin no permitido"`, expone rate-limit headers).
+- **Nota de seguimiento (ejecución real — PR-CORS2, rama `clean/backend-cors-helper-route-family-2`, 2026-06-28):**
+  se ejecutó la **fase 2** de la consolidación sobre la **segunda familia segura** identificada por PR-CORS1
+  (rutas *allow-null* y *header-only* cuyo contrato **no** está fijado por tests de definición). El helper
+  `server/lib/cors-headers.ts` **no se modificó** (ya exportaba los 7 símbolos); sólo se reemplazaron las
+  definiciones locales por `import … from "../lib/cors-headers.ts"` y se eliminó el `const UNSAFE_METHODS`
+  local donde quedaba sin uso. `applyCorsHeaders` se mantiene **local** en las 7 rutas (sus
+  `access-control-expose-headers` varían: `contact` incluye `Retry-After`; `report-access-tokens` y
+  `public-report-access` exponen rate-limit sin `Retry-After`; `clinic-public-profile`, `particular-tokens`,
+  `reports-status` y `reports` no exponen headers extra).
+  - **Rutas migradas (7):**
+    - **Allow-null con `enforceTrustedOrigin` (5):** `contact`, `clinic-public-profile`, `particular-tokens`,
+      `report-access-tokens`, `reports-status`. Importan `enforceTrustedOrigin` + `getAllowedOrigins` +
+      `getAllowedOriginForCors` (+ `getRequestOrigin` salvo `clinic-public-profile`, ver abajo) y se borró el
+      `const UNSAFE_METHODS` local (sólo lo usaba `enforceTrustedOrigin`). Las dos formas locales del cuerpo
+      (`!o || allowed.has(o)` en `contact`; `if(!o) …; if(allowed.has(o)) …` en las otras 4) son **equivalentes**
+      al canónico *allow-null* — comportamiento exacto preservado.
+    - **GET-only sin `enforceTrustedOrigin` (1):** `reports`. Importa `getAllowedOrigins` +
+      `getAllowedOriginForCors` + `getRequestOrigin` (este último se usa *inline* en el `optionsHandler`).
+    - **Header-only (1):** `public-report-access`. No tiene `getRequestOrigin` ni `enforceTrustedOrigin` ni
+      `"Origen no permitido"`; importa sólo `getAllowedOrigins` + `getAllowedOriginForCors`.
+  - **Matiz de imports (verificado por uso real, no por nombre):** `clinic-public-profile` **no** importa
+    `getRequestOrigin` porque su única referencia vivía dentro del `enforceTrustedOrigin` local (ahora
+    importado); el resto sí lo usa en su `optionsHandler` de preflight. `normalizeOrigin`/`getOriginHeader`
+    quedan en **0** referencias directas en las 7 rutas (sólo se invocan dentro del helper compartido).
+  - **`import { ENV }` sin uso en `contact` y `public-report-access`:** tras migrar, `ENV` sólo lo usaba el
+    `getAllowedOrigins` local. Se **deja el import** para replicar exactamente el patrón de PR-CORS1 (las 14
+    rutas admin migradas también conservan el `import { ENV }` sin uso; `tsconfig.json` no activa
+    `noUnusedLocals`, por lo que `typecheck` lo tolera). Candidato menor a limpieza futura, fuera de alcance.
+  - **Sin cambios en tests de contrato:** ningún test fija las **definiciones** de estas 7 rutas; el resto de
+    la suite sólo fija **call-sites** (`enforceTrustedOrigin(request, reply, allowedOrigins)`) y
+    `function applyCorsHeaders` (satisfecho porque sigue local). No se añadieron ni modificaron tests.
+  - **Diff:** net **−605 líneas** (38 nuevas / 643 borradas) en 7 archivos; sin tocar frontend, DB,
+    migraciones, dependencias, lockfiles, workflows ni env.
+  - **Validación ejecutada (verde):** `pnpm typecheck`, `pnpm typecheck:test`,
+    `node --experimental-strip-types --test test/cors-headers-shared-helper.test.ts` (10/10) y
+    `…/security-trusted-origin-cors-boundaries.test.ts` (4/4); además los tests dedicados por ruta
+    (`contact-route`, `contact-rate-limit`, `clinic-public-profile.fastify`, `particular-tokens.fastify`,
+    `report-access-tokens.fastify`, `reports-status.fastify`, `reports.fastify`, `public-report-access.fastify`,
+    `public-report-access-rate-limit`) y los contratos acoplados (`trusted-origin-router-policy`,
+    `security-csrf-mutating-route-coverage`, `security-critical-route-surface-registry`,
+    `security-boundary-suite-completeness`, `reports-suite-completeness`, los `*-runtime-timing-contract` y
+    `*-session-last-access-contract` de las rutas migradas, `report-management-route-policy`,
+    `clinic-management-route-policy`, `report-write-surface-ownership`, `global-auth-boundary-contract`,
+    `backend-api-no-store-cache-contract`, `fastify-app`). Total ejecutado: typecheck ×2 + **≈205** casos en
+    verde, fail 0. `pnpm test`/`pnpm build` completos no se corrieron (requieren Postgres — §11/§15).
+  - **Pendiente → PR-CORS3 (sin cambios respecto a PR-CORS1):** trío **auth**
+    (`auth`/`admin-auth`/`particular-auth`) y trío **logística** + rutas **block-null**
+    (`particular-study-tracking`, `study-tracking`); requiere actualizar en el mismo PR los tests que fijan
+    **definiciones** (`security-production-invariants.test.ts`, `logistics-*-api.test.ts`) para verificar el
+    `import` en vez de la definición local. `public-professionals.fastify.ts` permanece fuera (CORS y mensaje
+    distintos).
 
 ### PR-CLEAN6 · dead-code & artefactos
 - **Alcance:** eliminar `shared/` + `test/shared-const-and-errors.test.ts`;

--- a/server/routes/clinic-public-profile.fastify.ts
+++ b/server/routes/clinic-public-profile.fastify.ts
@@ -7,6 +7,11 @@ import multer from "multer";
 
 import { ENV } from "../lib/env.ts";
 import {
+  enforceTrustedOrigin,
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+} from "../lib/cors-headers.ts";
+import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
@@ -146,7 +151,6 @@ export type ClinicPublicProfileNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__clinicPublicProfileRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const MAX_DISPLAY_NAME = 255;
 const MAX_EMAIL = 255;
 const MAX_PHONE = 50;
@@ -260,81 +264,6 @@ async function loadDefaultDeps(): Promise<NativeClinicPublicProfileDeps> {
   return defaultDepsPromise!;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -349,33 +278,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/server/routes/contact.fastify.ts
+++ b/server/routes/contact.fastify.ts
@@ -14,6 +14,12 @@ import {
 } from "../lib/contact-rate-limit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  enforceTrustedOrigin,
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
+import {
   createMemoryRateLimitStore,
   getOrCreateRateLimitEntry,
   incrementRateLimitEntry,
@@ -63,8 +69,6 @@ const contactSchema = z.object({
   message: z.string().trim().min(10).max(4000),
 });
 
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 let defaultDepsPromise:
   | Promise<ContactNativeRouteDeps>
   | undefined;
@@ -96,81 +100,6 @@ async function resolveDeps(
   };
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -189,29 +118,6 @@ function applyCorsHeaders(
     "access-control-expose-headers",
     "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
   );
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function normalizeOptionalText(value: string | null | undefined) {

--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -7,6 +7,12 @@ import type {
 import type { ParticularToken, Report, StudyTrackingCase } from "../../drizzle/schema.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  enforceTrustedOrigin,
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
+import {
   buildValidationError,
   clinicCreateParticularTokenSchema,
   parseEntityId,
@@ -138,7 +144,6 @@ export type ParticularTokensNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__particularTokensRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type ParticularTokensFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -206,81 +211,6 @@ async function loadDefaultDeps(): Promise<NativeParticularTokensDeps> {
   return defaultDepsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -295,33 +225,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/server/routes/public-report-access.fastify.ts
+++ b/server/routes/public-report-access.fastify.ts
@@ -33,6 +33,10 @@ import {
 } from "../lib/supabase.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+} from "../lib/cors-headers.ts";
+import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
 } from "../middlewares/request-logger.ts";
@@ -126,62 +130,6 @@ async function loadDefaultDeps(): Promise<NativePublicReportAccessDeps> {
   }
 
   return defaultDepsPromise;
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
 }
 
 function applyCorsHeaders(

--- a/server/routes/report-access-tokens.fastify.ts
+++ b/server/routes/report-access-tokens.fastify.ts
@@ -8,6 +8,12 @@ import type { Report, ReportAccessToken } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  enforceTrustedOrigin,
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
+import {
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_ERROR_MESSAGE,
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_MAX_ATTEMPTS,
   REPORT_ACCESS_TOKEN_MUTATION_RATE_LIMIT_WINDOW_MS,
@@ -145,7 +151,6 @@ export type ReportAccessTokensNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__reportAccessTokensRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type ReportAccessTokensFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -208,81 +213,6 @@ async function loadDefaultDeps(): Promise<NativeReportAccessTokensDeps> {
   return defaultDepsPromise!;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -301,33 +231,6 @@ function applyCorsHeaders(
     "access-control-expose-headers",
     "RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset",
   );
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -8,6 +8,12 @@ import type { Report, ReportStatus } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  enforceTrustedOrigin,
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
+import {
   normalizeOptionalNote,
   parseReportId,
   parseReportStatus,
@@ -100,7 +106,6 @@ export type ReportsStatusNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__reportsStatusRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type ReportsStatusFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -203,81 +208,6 @@ async function resolveDeps(
   };
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -292,33 +222,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -8,6 +8,11 @@ import type {
 import type { Report, ReportStatus } from "../../drizzle/schema.ts";
 import { ENV } from "../lib/env.ts";
 import {
+  getAllowedOrigins,
+  getAllowedOriginForCors,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
+import {
   getReadClinicScope,
   normalizeSearchText,
   parseOffset,
@@ -216,81 +221,6 @@ async function resolveDeps(
       options.createSignedReportDownloadUrl ??
       defaultDeps!.createSignedReportDownloadUrl,
   };
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
 }
 
 function applyCorsHeaders(


### PR DESCRIPTION
PR-CORS2 from the final repository cleanup audit.

Scope:
- Migrates the second safe route family to the shared backend CORS helper from PR #1164.
- Migrated routes:
  - contact
  - clinic-public-profile
  - particular-tokens
  - report-access-tokens
  - reports-status
  - reports
  - public-report-access
- Keeps applyCorsHeaders local because expose-headers differ by route.
- Preserves HTTP behavior, status codes, response bodies, headers, and the Origen no permitido message.
- Leaves auth/logistics/block-null/public-professionals routes for follow-up PRs due to intentionally different or pinned contracts.

No frontend runtime changes.
No DB changes.
No migrations.
No dependencies.
No lockfile changes.
No workflow changes.
No Render/secrets changes.

Validation:
- pnpm typecheck passed.
- pnpm typecheck:test passed.
- shared CORS helper test passed.
- security trusted origin CORS boundaries passed.
- route-specific tests for migrated routes passed.
- security/policy/session/cache/app-wiring related tests passed.

Full pnpm test/build not run locally because they require Postgres; affected tests were run directly.