### PR TITLE
refactor(cors): share helper in auth routes

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -695,6 +695,42 @@ exige build+E2E). El resto está saludable.
     **definiciones** (`security-production-invariants.test.ts`, `logistics-*-api.test.ts`) para verificar el
     `import` en vez de la definición local. `public-professionals.fastify.ts` permanece fuera (CORS y mensaje
     distintos).
+- **Nota de seguimiento (ejecución real — PR-CORS3A, rama `clean/backend-cors-helper-auth-routes`, 2026-06-29):**
+  se ejecutó la subfase **auth** de PR-CORS3, separada de logística y de rutas *block-null* para mantener el
+  diff chico y el contrato exacto. El helper `server/lib/cors-headers.ts` **no se modificó**: ya exportaba
+  `UNSAFE_METHODS`, `normalizeOrigin`, `getAllowedOrigins`, `getOriginHeader`, `getAllowedOriginForCors`,
+  `getRequestOrigin` y `enforceTrustedOrigin`.
+  - **Rutas migradas (3):** `server/routes/auth.fastify.ts`,
+    `server/routes/admin-auth.fastify.ts` y `server/routes/particular-auth.fastify.ts`.
+    Las tres reemplazan las definiciones locales de `getAllowedOrigins`, `normalizeOrigin`,
+    `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin`, `enforceTrustedOrigin` y el
+    `const UNSAFE_METHODS` local por imports desde `../lib/cors-headers.ts`.
+  - **`applyCorsHeaders` se mantiene local** en las tres rutas, con el mismo cuerpo y los mismos headers
+    (`vary`, `access-control-allow-origin`, `access-control-allow-credentials` y
+    `LOGIN_RATE_LIMIT_EXPOSED_HEADERS`). La guardia de `api-production-session-contract.test.ts` que fija
+    `function applyCorsHeaders` sigue vigente y pasa sin cambios.
+  - **Contrato preservado:** misma variante *allow-null* para métodos inseguros sin `Origin`/`Referer`,
+    mismo bloqueo 403 con `{ success: false, error: "Origen no permitido" }`, mismo preflight
+    `GET,POST,OPTIONS`, mismo reflejo de `Origin` permitido y sin wildcard con credenciales.
+  - **Tests actualizados:** `test/security-production-invariants.test.ts` dejó de exigir definiciones locales
+    en el trío auth y ahora verifica que el contrato vive en `server/lib/cors-headers.ts`, que las rutas
+    importan `enforceTrustedOrigin`, `getAllowedOriginForCors`, `getAllowedOrigins` y `getRequestOrigin`, y
+    que no reintroducen las copias locales. `applyCorsHeaders` continúa exigido localmente.
+  - **Fuera de alcance respetado:** no se tocaron logística (`logistics-*`), rutas *block-null*
+    (`particular-study-tracking`, `study-tracking`), `public-professionals.fastify.ts`, frontend runtime, DB,
+    migraciones, dependencias, lockfiles, workflows, Render ni secrets.
+  - **Validación ejecutada:** `pnpm typecheck`, `pnpm typecheck:test`, helper CORS (10/10),
+    `security-trusted-origin-cors-boundaries` (4/4), `security-production-invariants` (11/11),
+    `api-production-session-contract` (4/4), `global-auth-boundary-contract` (5/5), bloque auth específico
+    encontrado por grep (167/167), `pnpm build`, `pnpm security:public-surface`,
+    `pnpm --dir frontend lint`, `pnpm --dir frontend typecheck` y `pnpm --dir frontend build` verdes.
+    `pnpm test` completo fue ejecutado: 2885/2893 pasaron y 8 fallaron por guardas históricas de PRs frontend
+    que inspeccionan el `git diff` y prohíben cambios backend (`server/routes/admin-auth.fastify.ts`,
+    `server/routes/auth.fastify.ts`), no por regresión CORS/auth.
+  - **Pendiente → PR-CORS3B recomendado:** abordar logística y *block-null* por separado. Para logística,
+    actualizar primero `logistics-*-api.test.ts` para verificar import/uso del helper compartido. Para
+    `particular-study-tracking` y `study-tracking`, preservar explícitamente el contrato *block-null* con una
+    variante o wrapper dedicado; no reutilizar el helper *allow-null* sin adaptar contrato.
 
 ### PR-CLEAN6 · dead-code & artefactos
 - **Alcance:** eliminar `shared/` + `test/shared-const-and-errors.test.ts`;

--- a/docs/implementation/backend-cors-helper-auth-routes.md
+++ b/docs/implementation/backend-cors-helper-auth-routes.md
@@ -1,0 +1,100 @@
+# PR-CORS3A - backend auth CORS helper
+
+## Estado base
+
+- Rama: `clean/backend-cors-helper-auth-routes`.
+- HEAD inicial: `9200bf1 refactor(cors): share public route origin helpers (#1165)`.
+- Working tree inicial: limpio.
+- PRs abiertos: no verificado con `gh` por protocolo local; no se ejecuto ningun comando `gh`.
+
+## Scope incluido
+
+- Migrar solo el trio auth al helper CORS compartido:
+  - `server/routes/auth.fastify.ts`
+  - `server/routes/admin-auth.fastify.ts`
+  - `server/routes/particular-auth.fastify.ts`
+- Mantener `applyCorsHeaders` local en cada ruta.
+- Actualizar el test de contrato que fijaba definiciones locales de CORS en esas rutas.
+- Actualizar el documento rector de auditoria final con la ejecucion real PR-CORS3A.
+
+## Scope excluido
+
+- Frontend runtime.
+- DB, Drizzle, migraciones, dependencias, lockfiles, workflows, Render y secrets.
+- Contratos HTTP: status codes, bodies, headers y mensajes.
+- Logistica, `particular-study-tracking`, `study-tracking` y `public-professionals`.
+- Commits, push y PR.
+
+## Auditoria previa
+
+- Base limpia confirmada con `git status --short`.
+- Rama y HEAD confirmados con `git branch --show-current` y `git log -1 --oneline`.
+- `server/lib/cors-headers.ts` ya exportaba `UNSAFE_METHODS`, `normalizeOrigin`, `getAllowedOrigins`, `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin` y `enforceTrustedOrigin`.
+- Las tres rutas auth tenian definiciones locales de `getAllowedOrigins`, `normalizeOrigin`, `getRequestOrigin`, `enforceTrustedOrigin` y `applyCorsHeaders`.
+- `security-production-invariants.test.ts` fijaba las definiciones locales del trio auth.
+- `api-production-session-contract.test.ts` sigue fijando `applyCorsHeaders`; no se cambio porque `applyCorsHeaders` queda local por alcance.
+
+## Cambios
+
+- Las tres rutas auth importan desde `../lib/cors-headers.ts`:
+  - `enforceTrustedOrigin`
+  - `getAllowedOriginForCors`
+  - `getAllowedOrigins`
+  - `getRequestOrigin`
+- Se eliminaron de esas rutas las copias locales de:
+  - `UNSAFE_METHODS`
+  - `getAllowedOrigins`
+  - `normalizeOrigin`
+  - `getOriginHeader`
+  - `getAllowedOriginForCors`
+  - `getRequestOrigin`
+  - `enforceTrustedOrigin`
+- `applyCorsHeaders` queda local y mantiene los mismos headers.
+- `test/security-production-invariants.test.ts` ahora verifica el helper compartido y exige que las rutas auth importen el helper en vez de redefinirlo.
+
+## Archivos modificados
+
+- `server/routes/auth.fastify.ts`
+- `server/routes/admin-auth.fastify.ts`
+- `server/routes/particular-auth.fastify.ts`
+- `test/security-production-invariants.test.ts`
+- `docs/audit/final-repo-cleanup-engineering-audit.md`
+- `docs/implementation/backend-cors-helper-auth-routes.md`
+
+## Validaciones
+
+- `pnpm typecheck`: paso.
+- `pnpm typecheck:test`: paso.
+- `node --experimental-strip-types --test test/cors-headers-shared-helper.test.ts`: paso, 10/10.
+- `node --experimental-strip-types --test test/security-trusted-origin-cors-boundaries.test.ts`: paso, 4/4.
+- `node --experimental-strip-types --test test/security-production-invariants.test.ts`: paso, 11/11.
+- `node --experimental-strip-types --test test/api-production-session-contract.test.ts`: paso, 4/4.
+- `node --experimental-strip-types --test test/global-auth-boundary-contract.test.ts`: paso, 5/5.
+- Bloque auth especifico encontrado por grep: paso, 167/167.
+- `pnpm build`: paso.
+- `pnpm security:public-surface`: paso.
+- `pnpm --dir frontend lint`: paso.
+- `pnpm --dir frontend typecheck`: paso.
+- `pnpm --dir frontend build`: paso.
+- `pnpm test`: ejecutado; 2885/2893 pasaron y 8 fallaron por guardas historicas de PRs frontend que inspeccionan `git diff` y prohiben cambios en `server/routes/*`. Fallas no vinculadas a comportamiento CORS/auth.
+
+## Resultado
+
+PR-CORS3A queda implementado para el trio auth. El comportamiento allow-null, Origin/Referer, preflight y el mensaje `"Origen no permitido"` quedan cubiertos por tests runtime y de contrato.
+
+## Riesgo residual
+
+- `pnpm test` completo no queda verde mientras existan guardas frontend PR-especificas que fallan ante cualquier cambio backend en el working tree.
+- `applyCorsHeaders` sigue local por contrato; su consolidacion queda fuera de este PR.
+
+## Recomendacion PR-CORS3B
+
+- Separar logistica y block-null en al menos dos pasos.
+- Para logistica: actualizar `logistics-*-api.test.ts` para verificar import/uso del helper compartido antes de migrar rutas.
+- Para `particular-study-tracking` y `study-tracking`: preservar explicitamente el contrato block-null; no reutilizar el helper allow-null sin variante o wrapper dedicado.
+- Mantener `public-professionals.fastify.ts` fuera porque su CORS y mensaje son distintos.
+
+## Estado final
+
+- Sin commit, sin push, sin PR.
+- Sin cambios en frontend runtime, DB, migraciones, dependencias, lockfiles, workflows, Render ni secrets.

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -7,6 +7,12 @@ import { eq } from "drizzle-orm";
 
 import { adminUsers } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS } from "../lib/audit.ts";
+import {
+  enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   authenticateFastifyAdmin,
@@ -133,7 +139,6 @@ export type AdminAuthNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__adminAuthRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const PASSWORD_CHANGE_MIN_LENGTH = 8;
 const PASSWORD_CHANGE_ERROR_MESSAGE = "No se pudo actualizar la credencial.";
 const ADMIN_PASSWORD_CHANGED_AUDIT_EVENT = "auth.admin.password.changed";
@@ -223,81 +228,6 @@ async function loadDefaultDeps(): Promise<NativeAdminAuthDefaultDeps> {
   return defaultDepsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -316,33 +246,6 @@ function applyCorsHeaders(
     "access-control-expose-headers",
     LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   );
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function serializeCookie(input: {

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -5,6 +5,12 @@ import type {
 } from "fastify";
 
 import { AUDIT_EVENTS } from "../lib/audit.ts";
+import {
+  enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   buildLoginRateLimitResponse,
@@ -230,7 +236,6 @@ export type AuthNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__clinicAuthRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const PASSWORD_CHANGE_MIN_LENGTH = 8;
 const PASSWORD_CHANGE_ERROR_MESSAGE = "No se pudo actualizar la credencial.";
 
@@ -336,81 +341,6 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
   return depsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -429,33 +359,6 @@ function applyCorsHeaders(
     "access-control-expose-headers",
     LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   );
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -5,6 +5,12 @@ import type {
 } from "fastify";
 import type { ParticularToken, Report } from "../../drizzle/schema.ts";
 
+import {
+  enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   buildLoginRateLimitResponse,
@@ -110,7 +116,6 @@ export type ParticularAuthNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__particularAuthRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type ParticularAuthFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -186,81 +191,6 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDefaultDeps> {
   return defaultDepsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -279,33 +209,6 @@ function applyCorsHeaders(
     "access-control-expose-headers",
     LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   );
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -194,20 +194,79 @@ test("cada dominio de sesión lee y escribe únicamente su cookie correspondient
 });
 
 test("origin/CORS bloquea métodos inseguros con Origin no permitido y no usa wildcard credentials", () => {
+  const corsHelper = read("server/lib/cors-headers.ts");
+
+  assertContains(
+    corsHelper,
+    'export const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);',
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
+    "export function normalizeOrigin(value: string): string | null",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
+    "new URL(value).origin.trim().toLowerCase()",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
+    "export function getRequestOrigin(request: FastifyRequest): string | null",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
+    "export function enforceTrustedOrigin(",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(corsHelper, "if (!requestOrigin", "server/lib/cors-headers.ts");
+  assertContains(
+    corsHelper,
+    "if (!requestOrigin || allowedOrigins.has(requestOrigin))",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
+    'error: "Origen no permitido"',
+    "server/lib/cors-headers.ts",
+  );
+
   for (const file of authRouteFiles) {
     const source = read(file);
 
     assertContains(
       source,
+      'from "../lib/cors-headers.ts";',
+      file,
+    );
+    assertContains(source, "  enforceTrustedOrigin,", file);
+    assertContains(source, "  getAllowedOriginForCors,", file);
+    assertContains(source, "  getAllowedOrigins,", file);
+    assertContains(source, "  getRequestOrigin,", file);
+    assertContains(source, "function applyCorsHeaders(", file);
+    assertNotContains(
+      source,
       'const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);',
       file,
     );
-    assertContains(source, "function normalizeOrigin(value: string): string | null", file);
-    assertContains(source, "new URL(value).origin.trim().toLowerCase()", file);
-    assertContains(source, "function getRequestOrigin(request: FastifyRequest): string | null", file);
-    assertContains(source, "function enforceTrustedOrigin(", file);
-    assertContains(source, "if (!requestOrigin) {", file);
-    assertContains(source, "if (allowedOrigins.has(requestOrigin))", file);
+    assertNotContains(
+      source,
+      "function getAllowedOrigins(): string[]",
+      file,
+    );
+    assertNotContains(
+      source,
+      "function normalizeOrigin(value: string): string | null",
+      file,
+    );
+    assertNotContains(
+      source,
+      "function getRequestOrigin(request: FastifyRequest): string | null",
+      file,
+    );
+    assertNotContains(source, "function enforceTrustedOrigin(", file);
     assertContains(source, 'error: "Origen no permitido"', file);
     assertContains(source, 'reply.header("vary", "Origin")', file);
     assertContains(source, 'reply.header("access-control-allow-origin", allowedOrigin)', file);


### PR DESCRIPTION
PR-CORS3A from the final repository cleanup audit.

Scope:
- Migrates only the auth route family to the shared backend CORS helper:
  - server/routes/auth.fastify.ts
  - server/routes/admin-auth.fastify.ts
  - server/routes/particular-auth.fastify.ts
- Keeps applyCorsHeaders local because route CORS response headers remain route-specific.
- Updates security-production-invariants to verify shared helper import/use instead of requiring local helper definitions.
- Adds implementation note for PR-CORS3A.
- Updates the final repository cleanup audit with real execution notes.

Preserved contracts:
- No HTTP status code changes.
- No response body changes.
- No CORS error message changes.
- No cookie/session/auth contract changes.
- No Origin/Referer behavior changes.
- No frontend runtime changes.
- No DB changes.
- No migrations.
- No dependencies.
- No lockfile changes.
- No workflow changes.
- No Render/secrets changes.
- No logistics, block-null, or public-professionals changes.

Validation:
- pnpm typecheck passed.
- pnpm typecheck:test passed.
- pnpm build passed.
- pnpm security:public-surface passed.
- pnpm --dir frontend lint passed.
- pnpm --dir frontend typecheck passed.
- pnpm --dir frontend build passed.
- CORS shared helper test passed.
- trusted-origin CORS boundaries passed.
- security production invariants passed.
- API production session contract passed.
- global auth boundary contract passed.
- auth-specific test block passed: 167/167.

Full pnpm test:
- Executed locally.
- 2885/2893 passed.
- 8 failures are known diff-scope guard failures from historical frontend PR tests that reject backend route changes in the working diff; they are not CORS/auth regressions.