### PR TITLE
refactor(cors): share helper in logistics routes

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -731,6 +731,46 @@ exige build+E2E). El resto está saludable.
     actualizar primero `logistics-*-api.test.ts` para verificar import/uso del helper compartido. Para
     `particular-study-tracking` y `study-tracking`, preservar explícitamente el contrato *block-null* con una
     variante o wrapper dedicado; no reutilizar el helper *allow-null* sin adaptar contrato.
+- **Nota de seguimiento (ejecución real — PR-CORS3B, rama `clean/backend-cors-helper-logistics-routes`, 2026-06-29):**
+  se ejecutó la subfase **logística** de PR-CORS3, separada de rutas *block-null* y de
+  `public-professionals.fastify.ts` para preservar contratos distintos. El helper
+  `server/lib/cors-headers.ts` **no se modificó**: ya exportaba `UNSAFE_METHODS`, `normalizeOrigin`,
+  `getAllowedOrigins`, `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin` y
+  `enforceTrustedOrigin`.
+  - **Rutas migradas (3):** `server/routes/logistics-field-visits.fastify.ts`,
+    `server/routes/logistics-route-events.fastify.ts` y `server/routes/logistics-route-plans.fastify.ts`.
+    Las tres reemplazan las definiciones locales de `getAllowedOrigins`, `normalizeOrigin`,
+    `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin`, `enforceTrustedOrigin` y el
+    `const UNSAFE_METHODS` local por imports desde `../lib/cors-headers.ts`. A diferencia del trío auth,
+    logística conserva uso directo de `UNSAFE_METHODS` para guardias RBAC de métodos inseguros, por lo que
+    también importa ese símbolo desde el helper compartido.
+  - **`applyCorsHeaders` se mantiene local** en las tres rutas, con el mismo cuerpo y los mismos headers
+    (`vary`, `access-control-allow-origin`, `access-control-allow-credentials`). No se parametrizó ni se
+    consolidó en este PR.
+  - **Contrato preservado:** misma variante *allow-null* para métodos inseguros sin `Origin`/`Referer`,
+    mismo bloqueo 403 con `{ success: false, error: "Origen no permitido" }`, mismo comportamiento
+    `Origin`/`Referer`, mismos preflight por ruta (`field-visits`: `GET,POST,PUT,PATCH,OPTIONS`;
+    `route-events`: `GET,POST,OPTIONS`; `route-plans`: `GET,POST,PATCH,OPTIONS`) y sin wildcard con
+    credenciales.
+  - **Tests actualizados:** `test/logistics-field-visits-api.test.ts`,
+    `test/logistics-route-events-api.test.ts`, `test/logistics-route-plans-api.test.ts` y
+    `test/security-production-invariants.test.ts` dejaron de exigir definiciones locales y ahora verifican
+    import/uso del helper compartido, `applyCorsHeaders` local y ausencia de copias CORS.
+  - **Fuera de alcance respetado:** no se tocaron `particular-study-tracking`, `study-tracking`,
+    `public-professionals.fastify.ts`, frontend runtime, DB, migraciones, dependencias, lockfiles,
+    workflows, Render ni secrets.
+  - **Validación ejecutada:** `corepack pnpm typecheck`, `corepack pnpm typecheck:test`, helper CORS
+    (10/10), `security-trusted-origin-cors-boundaries` (4/4), `security-production-invariants` (11/11),
+    los tres contratos logísticos migrados (17/17, 11/11, 23/23), todo `test/logistics-*.test.ts`
+    encontrado por grep (219/219), `corepack pnpm build`, `corepack pnpm security:public-surface`,
+    `corepack pnpm --dir frontend lint`, `corepack pnpm --dir frontend typecheck` y
+    `corepack pnpm --dir frontend build` verdes. `corepack pnpm test` completo fue ejecutado:
+    2885/2893 pasaron y 8 fallaron por guardas históricas de PRs frontend que inspeccionan `git diff` y
+    prohíben cambios backend (`server/routes/logistics-*.fastify.ts`), no por regresión CORS/logística.
+  - **Pendiente → PR-CORS3C recomendado:** abordar sólo rutas *block-null*
+    (`particular-study-tracking`, `study-tracking`) con variante/wrapper dedicado que preserve el bloqueo
+    de métodos inseguros sin `Origin` ni `Referer`. `public-professionals.fastify.ts` sigue fuera porque su
+    CORS y mensaje son distintos.
 
 ### PR-CLEAN6 · dead-code & artefactos
 - **Alcance:** eliminar `shared/` + `test/shared-const-and-errors.test.ts`;

--- a/docs/implementation/backend-cors-helper-logistics-routes.md
+++ b/docs/implementation/backend-cors-helper-logistics-routes.md
@@ -1,0 +1,114 @@
+# PR-CORS3B - backend logistics CORS helper
+
+## Estado base
+
+- Rama: `clean/backend-cors-helper-logistics-routes`.
+- HEAD inicial: `9f2e4af refactor(cors): share helper in auth routes (#1166)`.
+- Working tree inicial: limpio.
+- PRs abiertos: no verificado con `gh` por protocolo local; no se ejecuto ningun comando `gh`.
+- Nota de paridad: `pnpm` directo resolvia `11.7.0` y fallo antes de scripts por mismatch de overrides/lockfile; se uso `corepack pnpm` para respetar `packageManager: pnpm@10.8.1`.
+
+## Scope incluido
+
+- Migrar solo el trio logistico real al helper CORS compartido:
+  - `server/routes/logistics-field-visits.fastify.ts`
+  - `server/routes/logistics-route-events.fastify.ts`
+  - `server/routes/logistics-route-plans.fastify.ts`
+- Mantener `applyCorsHeaders` local en cada ruta.
+- Actualizar tests de contrato que fijaban definiciones locales en esas rutas.
+- Actualizar el documento rector de auditoria final con la ejecucion real PR-CORS3B.
+
+## Scope excluido
+
+- Frontend runtime.
+- DB, Drizzle, migraciones, dependencias, lockfiles, workflows, Render y secrets.
+- Contratos HTTP: status codes, bodies, headers y mensajes.
+- `particular-study-tracking`, `study-tracking` y `public-professionals.fastify.ts`.
+- Commits, push y PR.
+
+## Auditoria previa
+
+- Base limpia confirmada con `git status --short --untracked-files=all`.
+- Rama y HEAD confirmados con `git branch --show-current` y `git log -1 --oneline`.
+- `git fetch --prune` no dejo ramas remotas no mergeadas contra `origin/main`.
+- Los paths del brief `server/routes/logistics.fastify.ts`, `server/routes/logistics-admin.fastify.ts` y `server/routes/logistics-public.fastify.ts` no existen en el repo actual.
+- Los archivos reales identificados por el documento rector y por `rg --files server/routes | rg "logistics"` son `logistics-field-visits`, `logistics-route-events` y `logistics-route-plans`.
+- `server/lib/cors-headers.ts` ya exportaba `UNSAFE_METHODS`, `normalizeOrigin`, `getAllowedOrigins`, `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin` y `enforceTrustedOrigin`.
+- Las tres rutas logisticas tenian definiciones locales compatibles *allow-null* de `getAllowedOrigins`, `normalizeOrigin`, `getRequestOrigin` y `enforceTrustedOrigin`.
+- Las tres rutas logisticas usan `UNSAFE_METHODS` tambien fuera de CORS para guardias RBAC de metodos inseguros, por lo que ese simbolo debe importarse desde el helper compartido.
+- `applyCorsHeaders` no se migro: queda local y conserva los mismos headers.
+- Los tests reales que fijaban definiciones locales eran `test/logistics-field-visits-api.test.ts`, `test/logistics-route-events-api.test.ts`, `test/logistics-route-plans-api.test.ts` y la guardia ampliada en `test/security-production-invariants.test.ts`.
+- Los tests nombrados en el brief `test/logistics-api.test.ts`, `test/logistics-admin-api.test.ts` y `test/logistics-public-api.test.ts` no existen en el repo actual.
+
+## Cambios
+
+- Las tres rutas logisticas importan desde `../lib/cors-headers.ts`:
+  - `UNSAFE_METHODS`
+  - `enforceTrustedOrigin`
+  - `getAllowedOriginForCors`
+  - `getAllowedOrigins`
+  - `getRequestOrigin`
+- Se eliminaron de esas rutas las copias locales de:
+  - `UNSAFE_METHODS`
+  - `getAllowedOrigins`
+  - `normalizeOrigin`
+  - `getOriginHeader`
+  - `getAllowedOriginForCors`
+  - `getRequestOrigin`
+  - `enforceTrustedOrigin`
+- `applyCorsHeaders` queda local y mantiene `vary`, `access-control-allow-origin` y `access-control-allow-credentials`.
+- Los tres tests `logistics-*-api.test.ts` ahora verifican import/uso del helper compartido y ausencia de definiciones locales.
+- `test/security-production-invariants.test.ts` incorpora las rutas logisticas al contrato del helper compartido.
+
+## Archivos modificados
+
+- `server/routes/logistics-field-visits.fastify.ts`
+- `server/routes/logistics-route-events.fastify.ts`
+- `server/routes/logistics-route-plans.fastify.ts`
+- `test/logistics-field-visits-api.test.ts`
+- `test/logistics-route-events-api.test.ts`
+- `test/logistics-route-plans-api.test.ts`
+- `test/security-production-invariants.test.ts`
+- `docs/audit/final-repo-cleanup-engineering-audit.md`
+- `docs/implementation/backend-cors-helper-logistics-routes.md`
+
+## Validaciones
+
+- `corepack pnpm install --frozen-lockfile`: paso; restauro `node_modules` con lock congelado despues de que `pnpm 11.7.0` intentara purgarlo sin TTY.
+- `corepack pnpm typecheck`: paso.
+- `corepack pnpm typecheck:test`: paso.
+- `node --experimental-strip-types --test test/cors-headers-shared-helper.test.ts`: paso, 10/10.
+- `node --experimental-strip-types --test test/security-trusted-origin-cors-boundaries.test.ts`: paso, 4/4.
+- `node --experimental-strip-types --test test/security-production-invariants.test.ts`: paso, 11/11.
+- `node --experimental-strip-types --test test/logistics-field-visits-api.test.ts`: paso, 17/17.
+- `node --experimental-strip-types --test test/logistics-route-events-api.test.ts`: paso, 11/11.
+- `node --experimental-strip-types --test test/logistics-route-plans-api.test.ts`: paso, 23/23.
+- `node --experimental-strip-types --test test/logistics-*.test.ts` encontrado por `rg`: paso, 219/219.
+- `corepack pnpm test`: ejecutado; 2885/2893 pasaron y 8 fallaron por guardas historicas de PRs frontend que inspeccionan `git diff` y prohiben cambios backend, no por regresion CORS/logistica.
+- `corepack pnpm build`: paso.
+- `corepack pnpm security:public-surface`: paso; mantuvo findings informativos existentes sobre identificadores uppercase server-only en `frontend/src/proxy.ts`.
+- `corepack pnpm --dir frontend lint`: paso.
+- `corepack pnpm --dir frontend typecheck`: paso.
+- `corepack pnpm --dir frontend build`: paso.
+
+## Resultado
+
+PR-CORS3B queda implementado para el trio logistico real. El comportamiento *allow-null*, `Origin`/`Referer`, preflight, mensaje `"Origen no permitido"`, headers CORS con credenciales y guardias RBAC con `UNSAFE_METHODS` quedan cubiertos por tests.
+
+## Riesgo residual
+
+- `corepack pnpm test` completo no queda verde mientras existan guardas frontend PR-especificas que fallan ante cualquier cambio backend en el working tree.
+- `applyCorsHeaders` sigue local por contrato; su consolidacion queda fuera de este PR.
+- Las rutas *block-null* siguen sin migrar porque requieren variante o wrapper dedicado para no cambiar comportamiento sin `Origin`/`Referer`.
+
+## Recomendacion PR-CORS3C
+
+- Migrar `particular-study-tracking` y `study-tracking` por separado.
+- Preservar explicitamente el contrato *block-null* para metodos inseguros sin `Origin` ni `Referer`.
+- No reutilizar el helper *allow-null* actual sin adaptar contrato.
+- Mantener `public-professionals.fastify.ts` fuera porque su CORS y mensaje son distintos.
+
+## Estado final
+
+- Sin commit, sin push, sin PR.
+- Sin cambios en frontend runtime, DB, migraciones, dependencias, lockfiles, workflows, Render ni secrets.

--- a/server/routes/logistics-field-visits.fastify.ts
+++ b/server/routes/logistics-field-visits.fastify.ts
@@ -23,6 +23,13 @@ import type {
   UpsertVisitLocationInput,
   VisitLocation,
 } from "../db-logistics.ts";
+import {
+  UNSAFE_METHODS,
+  enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   getClinicPermissions,
@@ -109,8 +116,6 @@ type NativeLogisticsFieldVisitsDeps = Required<
   >
 >;
 
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 let defaultDepsPromise: Promise<NativeLogisticsFieldVisitsDeps> | undefined;
 
 async function loadDefaultDeps(): Promise<NativeLogisticsFieldVisitsDeps> {
@@ -151,81 +156,6 @@ async function loadDefaultDeps(): Promise<NativeLogisticsFieldVisitsDeps> {
   return depsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest): string {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-): string | null {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -241,34 +171,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
 }
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-): boolean {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
-}
-
 
 function enforceLogisticsPermission(
   reply: FastifyReply,

--- a/server/routes/logistics-route-events.fastify.ts
+++ b/server/routes/logistics-route-events.fastify.ts
@@ -16,6 +16,13 @@ import type {
   ListRouteEventsParams,
   RouteEvent,
 } from "../db-logistics.ts";
+import {
+  UNSAFE_METHODS,
+  enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   AUDIT_EVENTS,
@@ -96,8 +103,6 @@ type NativeLogisticsRouteEventsDeps = Required<
   >
 >;
 
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-
 let defaultDepsPromise: Promise<NativeLogisticsRouteEventsDeps> | undefined;
 
 async function loadDefaultDeps(): Promise<NativeLogisticsRouteEventsDeps> {
@@ -137,81 +142,6 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRouteEventsDeps> {
   return depsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest): string {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-): string | null {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -227,34 +157,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
 }
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-): boolean {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
-}
-
 
 function enforceLogisticsPermission(
   reply: FastifyReply,

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -28,6 +28,13 @@ import type {
   UpdateRoutePlanInput,
   UpdateRouteStopInput,
 } from "../db-logistics.ts";
+import {
+  UNSAFE_METHODS,
+  enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   AUDIT_EVENTS,
@@ -145,7 +152,6 @@ type NativeLogisticsRoutePlansDeps = Required<
   >
 >;
 
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const MAX_ROUTE_PLAN_FIELD_VISIT_IDS = 100;
 const LOGISTICS_CACHE_STATUS_HEADER = "X-Logistics-Cache";
 
@@ -264,81 +270,6 @@ async function loadDefaultDeps(): Promise<NativeLogisticsRoutePlansDeps> {
   return depsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest): string {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-): string | null {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -354,34 +285,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
 }
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-): boolean {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin) {
-    return true;
-  }
-
-  if (allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
-}
-
 
 function enforceLogisticsPermission(
   reply: FastifyReply,

--- a/test/logistics-field-visits-api.test.ts
+++ b/test/logistics-field-visits-api.test.ts
@@ -58,8 +58,18 @@ test("logistics field visit API validates contracts and pagination before callin
 });
 
 test("logistics field visit API keeps unsafe methods behind trusted-origin checks", () => {
-  assert.match(routeSource, /const UNSAFE_METHODS = new Set\(\["POST", "PUT", "PATCH", "DELETE"\]\)/);
-  assert.match(routeSource, /function enforceTrustedOrigin/);
+  assert.match(routeSource, /from "\.\.\/lib\/cors-headers\.ts";/);
+  assert.match(routeSource, /UNSAFE_METHODS,/);
+  assert.match(routeSource, /enforceTrustedOrigin,/);
+  assert.match(routeSource, /getAllowedOriginForCors,/);
+  assert.match(routeSource, /getAllowedOrigins,/);
+  assert.match(routeSource, /getRequestOrigin,/);
+  assert.match(routeSource, /function applyCorsHeaders/);
+  assert.doesNotMatch(routeSource, /const UNSAFE_METHODS = new Set\(\["POST", "PUT", "PATCH", "DELETE"\]\)/);
+  assert.doesNotMatch(routeSource, /function getAllowedOrigins/);
+  assert.doesNotMatch(routeSource, /function normalizeOrigin/);
+  assert.doesNotMatch(routeSource, /function getRequestOrigin/);
+  assert.doesNotMatch(routeSource, /function enforceTrustedOrigin/);
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /Origen no permitido/);
 });

--- a/test/logistics-route-events-api.test.ts
+++ b/test/logistics-route-events-api.test.ts
@@ -88,8 +88,18 @@ test("logistics route events API serializes route events with stable public shap
 });
 
 test("logistics route events API keeps event writes behind trusted-origin checks", () => {
-  assert.match(routeSource, /const UNSAFE_METHODS = new Set\(\["POST", "PUT", "PATCH", "DELETE"\]\)/);
-  assert.match(routeSource, /function enforceTrustedOrigin/);
+  assert.match(routeSource, /from "\.\.\/lib\/cors-headers\.ts";/);
+  assert.match(routeSource, /UNSAFE_METHODS,/);
+  assert.match(routeSource, /enforceTrustedOrigin,/);
+  assert.match(routeSource, /getAllowedOriginForCors,/);
+  assert.match(routeSource, /getAllowedOrigins,/);
+  assert.match(routeSource, /getRequestOrigin,/);
+  assert.match(routeSource, /function applyCorsHeaders/);
+  assert.doesNotMatch(routeSource, /const UNSAFE_METHODS = new Set\(\["POST", "PUT", "PATCH", "DELETE"\]\)/);
+  assert.doesNotMatch(routeSource, /function getAllowedOrigins/);
+  assert.doesNotMatch(routeSource, /function normalizeOrigin/);
+  assert.doesNotMatch(routeSource, /function getRequestOrigin/);
+  assert.doesNotMatch(routeSource, /function enforceTrustedOrigin/);
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /Origen no permitido/);
 });

--- a/test/logistics-route-plans-api.test.ts
+++ b/test/logistics-route-plans-api.test.ts
@@ -101,8 +101,18 @@ test("logistics route plans API serializes route plans and stops with stable pub
 });
 
 test("logistics route plans API keeps unsafe methods behind trusted-origin checks", () => {
-  assert.match(routeSource, /const UNSAFE_METHODS = new Set\(\["POST", "PUT", "PATCH", "DELETE"\]\)/);
-  assert.match(routeSource, /function enforceTrustedOrigin/);
+  assert.match(routeSource, /from "\.\.\/lib\/cors-headers\.ts";/);
+  assert.match(routeSource, /UNSAFE_METHODS,/);
+  assert.match(routeSource, /enforceTrustedOrigin,/);
+  assert.match(routeSource, /getAllowedOriginForCors,/);
+  assert.match(routeSource, /getAllowedOrigins,/);
+  assert.match(routeSource, /getRequestOrigin,/);
+  assert.match(routeSource, /function applyCorsHeaders/);
+  assert.doesNotMatch(routeSource, /const UNSAFE_METHODS = new Set\(\["POST", "PUT", "PATCH", "DELETE"\]\)/);
+  assert.doesNotMatch(routeSource, /function getAllowedOrigins/);
+  assert.doesNotMatch(routeSource, /function normalizeOrigin/);
+  assert.doesNotMatch(routeSource, /function getRequestOrigin/);
+  assert.doesNotMatch(routeSource, /function enforceTrustedOrigin/);
   assert.match(routeSource, /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)/);
   assert.match(routeSource, /Origen no permitido/);
 });

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -27,6 +27,12 @@ const authRouteFiles = [
   "server/routes/particular-auth.fastify.ts",
 ] as const;
 
+const logisticsRouteFiles = [
+  "server/routes/logistics-field-visits.fastify.ts",
+  "server/routes/logistics-route-events.fastify.ts",
+  "server/routes/logistics-route-plans.fastify.ts",
+] as const;
+
 const clinicSessionCookieRouteFiles = [
   "server/routes/auth.fastify.ts",
   "server/routes/clinic-audit.fastify.ts",
@@ -246,6 +252,53 @@ test("origin/CORS bloquea métodos inseguros con Origin no permitido y no usa wi
     assertContains(source, "  getAllowedOrigins,", file);
     assertContains(source, "  getRequestOrigin,", file);
     assertContains(source, "function applyCorsHeaders(", file);
+    assertNotContains(
+      source,
+      'const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);',
+      file,
+    );
+    assertNotContains(
+      source,
+      "function getAllowedOrigins(): string[]",
+      file,
+    );
+    assertNotContains(
+      source,
+      "function normalizeOrigin(value: string): string | null",
+      file,
+    );
+    assertNotContains(
+      source,
+      "function getRequestOrigin(request: FastifyRequest): string | null",
+      file,
+    );
+    assertNotContains(source, "function enforceTrustedOrigin(", file);
+    assertContains(source, 'error: "Origen no permitido"', file);
+    assertContains(source, 'reply.header("vary", "Origin")', file);
+    assertContains(source, 'reply.header("access-control-allow-origin", allowedOrigin)', file);
+    assertContains(source, 'reply.header("access-control-allow-credentials", "true")', file);
+    assertNotContains(source, 'access-control-allow-origin", "*"', file);
+  }
+
+  for (const file of logisticsRouteFiles) {
+    const source = read(file);
+
+    assertContains(
+      source,
+      'from "../lib/cors-headers.ts";',
+      file,
+    );
+    assertContains(source, "  UNSAFE_METHODS,", file);
+    assertContains(source, "  enforceTrustedOrigin,", file);
+    assertContains(source, "  getAllowedOriginForCors,", file);
+    assertContains(source, "  getAllowedOrigins,", file);
+    assertContains(source, "  getRequestOrigin,", file);
+    assertContains(source, "function applyCorsHeaders(", file);
+    assertContains(
+      source,
+      "UNSAFE_METHODS.has(request.method.toUpperCase())",
+      file,
+    );
     assertNotContains(
       source,
       'const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);',


### PR DESCRIPTION
PR-CORS3B from the final repository cleanup audit.

Scope:
- Migrates the real logistics route family to the shared backend CORS helper:
  - server/routes/logistics-field-visits.fastify.ts
  - server/routes/logistics-route-events.fastify.ts
  - server/routes/logistics-route-plans.fastify.ts
- The originally named brief paths logistics.fastify.ts, logistics-admin.fastify.ts, and logistics-public.fastify.ts do not exist in this repository.
- Keeps applyCorsHeaders local because route CORS response headers remain route-specific.
- Updates logistics route tests and security-production-invariants to verify shared helper import/use instead of requiring local helper definitions.
- Adds implementation note for PR-CORS3B.
- Updates the final repository cleanup audit with real execution notes.

Preserved contracts:
- No HTTP status code changes.
- No response body changes.
- No CORS error message changes.
- No Origin/Referer behavior changes.
- No frontend runtime changes.
- No DB changes.
- No migrations.
- No dependencies.
- No lockfile changes.
- No workflow changes.
- No Render/secrets changes.
- No block-null or public-professionals changes.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm build passed.
- corepack pnpm security:public-surface passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- CORS shared helper test passed.
- trusted-origin CORS boundaries passed.
- security production invariants passed.
- logistics direct route tests passed.
- all test/logistics-*.test.ts passed: 219/219.

Full pnpm test:
- Executed locally.
- 2885/2893 passed.
- 8 failures are known diff-scope guard failures from historical frontend PR tests that reject backend route changes in the working diff; they are not CORS/logistics regressions.