### PR TITLE
refactor(cors): share block-null helper in study tracking routes

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -771,6 +771,45 @@ exige build+E2E). El resto está saludable.
     (`particular-study-tracking`, `study-tracking`) con variante/wrapper dedicado que preserve el bloqueo
     de métodos inseguros sin `Origin` ni `Referer`. `public-professionals.fastify.ts` sigue fuera porque su
     CORS y mensaje son distintos.
+- **Nota de seguimiento (ejecución real — PR-CORS3C, rama `clean/backend-cors-helper-block-null-routes`, 2026-06-29):**
+  se ejecutó la subfase **block-null** de PR-CORS3, limitada a las dos rutas que bloquean métodos inseguros
+  sin `Origin` ni `Referer`. El helper `server/lib/cors-headers.ts` ahora exporta
+  `enforceTrustedOriginRequired`, variante explícita *block-null* que reutiliza `UNSAFE_METHODS` y
+  `getRequestOrigin`, preserva métodos seguros y responde 403 con `{ success: false, error: "Origen no permitido" }`
+  cuando el origen falta o no pertenece a la allowlist. La variante *allow-null* `enforceTrustedOrigin` no se
+  modificó.
+  - **Rutas migradas (2):** `server/routes/particular-study-tracking.fastify.ts` y
+    `server/routes/study-tracking.fastify.ts`. Ambas reemplazan las definiciones locales de
+    `getAllowedOrigins`, `normalizeOrigin`, `getOriginHeader`, `getAllowedOriginForCors`, `getRequestOrigin`,
+    `enforceTrustedOrigin` y el `const UNSAFE_METHODS` local por imports desde `../lib/cors-headers.ts`. Para
+    conservar call-sites y guardas existentes, importan `enforceTrustedOriginRequired as enforceTrustedOrigin`.
+  - **`applyCorsHeaders` se mantiene local** en ambas rutas, con el mismo cuerpo y los mismos headers
+    (`vary`, `access-control-allow-origin`, `access-control-allow-credentials`).
+  - **Contrato preservado:** métodos inseguros sin `Origin` ni `Referer` siguen devolviendo 403,
+    `Origin` permitido no falla por origen, `Origin` no permitido devuelve 403, el mensaje exacto sigue siendo
+    `"Origen no permitido"`, y los preflight `OPTIONS` conservan sus allow-methods por ruta.
+  - **Tests actualizados:** `test/cors-headers-shared-helper.test.ts` cubre la variante *block-null*;
+    `test/security-production-invariants.test.ts` exige import/uso del helper compartido y ausencia de copias
+    CORS locales en las dos rutas; `test/study-tracking.fastify.test.ts` y
+    `test/particular-study-tracking.fastify.test.ts` fijan los casos runtime de `Origin` permitido, faltante y
+    no permitido.
+  - **Fuera de alcance respetado:** no se tocó `public-professionals.fastify.ts`, frontend runtime, DB,
+    migraciones, dependencias, lockfiles, workflows, Render ni secrets.
+  - **Validación ejecutada:** `pnpm typecheck` y `pnpm typecheck:test` directos fallaron antes de ejecutar
+    scripts por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`; los equivalentes `corepack pnpm typecheck` y
+    `corepack pnpm typecheck:test` pasaron. Pasaron también helper CORS (14/14),
+    `security-trusted-origin-cors-boundaries` (4/4), `security-production-invariants` (11/11), las dos rutas
+    migradas (11/11 y 12/12), contratos CSRF/mutación/management, suite study-tracking, runtime timing,
+    `fastify-app`, seguridad cross-auth/sesiones/ownership/audit y report/status/access-token específicos
+    ejecutados. `corepack pnpm build`, `corepack pnpm security:public-surface`,
+    `corepack pnpm --dir frontend lint`, `corepack pnpm --dir frontend build` y un segundo
+    `corepack pnpm --dir frontend typecheck` pasaron; el primer frontend typecheck falló por
+    `.next/types/routes.js` faltante antes del build y pasó luego de regenerar `.next`. `corepack pnpm test`
+    completo fue ejecutado: 2890/2898 pasaron y 8 fallaron por guardas históricas de PRs frontend que
+    inspeccionan `git diff` y prohíben cambios backend (`server/lib/cors-headers.ts` y rutas backend), no por
+    regresión CORS/study-tracking.
+  - **Recomendación restante:** mantener `public-professionals.fastify.ts` fuera de esta consolidación salvo PR
+    dedicado, porque conserva contrato CORS y mensaje propio (`"Origin no permitido"`).
 
 ### PR-CLEAN6 · dead-code & artefactos
 - **Alcance:** eliminar `shared/` + `test/shared-const-and-errors.test.ts`;

--- a/docs/implementation/backend-cors-helper-block-null-routes.md
+++ b/docs/implementation/backend-cors-helper-block-null-routes.md
@@ -1,0 +1,112 @@
+# PR-CORS3C - backend block-null CORS helper
+
+## Estado base
+
+- Rama: `clean/backend-cors-helper-block-null-routes`.
+- HEAD inicial: `bef63a1 refactor(cors): share helper in logistics routes (#1167)`.
+- Working tree inicial: limpio.
+- PRs abiertos: no verificado con `gh` por protocolo local; no se ejecuto ningun comando `gh`.
+- `pnpm` directo falla antes de scripts por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`; se usaron equivalentes `corepack pnpm` para respetar el `packageManager` del repo.
+
+## Scope incluido
+
+- Migrar solo las rutas CORS *block-null*:
+  - `server/routes/particular-study-tracking.fastify.ts`
+  - `server/routes/study-tracking.fastify.ts`
+- Agregar helper compartido explicito para metodos inseguros que requieren `Origin` o `Referer`.
+- Mantener `applyCorsHeaders` local en ambas rutas.
+- Actualizar tests de contrato y runtime de las dos rutas.
+- Actualizar el documento rector de auditoria final con la ejecucion real PR-CORS3C.
+
+## Scope excluido
+
+- `server/routes/public-professionals.fastify.ts`.
+- Frontend runtime.
+- DB, Drizzle, migraciones, dependencias, lockfiles, workflows, Render y secrets.
+- Contratos HTTP: status codes, bodies, headers y mensajes.
+- Cambios en `CORS_ORIGIN` o env.
+- Commits, push y PR.
+
+## Auditoria previa
+
+- Base limpia confirmada con `git status --short`.
+- Rama y HEAD confirmados con `git branch --show-current` y `git log -1 --oneline`.
+- `server/lib/cors-headers.ts` tenia `enforceTrustedOrigin` con contrato *allow-null*: metodos inseguros sin `Origin` ni `Referer` pasan.
+- `particular-study-tracking` y `study-tracking` tenian contrato *block-null*: metodos inseguros sin `Origin` ni `Referer` responden 403.
+- Los `git grep` obligatorios confirmaron copias locales en ambas rutas de `getAllowedOrigins`, `normalizeOrigin`, `getRequestOrigin`, `enforceTrustedOrigin`, `UNSAFE_METHODS`, `applyCorsHeaders` y `"Origen no permitido"`.
+- Tests relacionados encontrados: `test/cors-headers-shared-helper.test.ts`, `test/security-production-invariants.test.ts`, `test/study-tracking.fastify.test.ts`, `test/particular-study-tracking.fastify.test.ts`, `test/security-trusted-origin-cors-boundaries.test.ts`, `test/security-csrf-mutating-route-coverage.test.ts`, `test/security-mutation-permission-surface.test.ts`, `test/study-tracking-suite-completeness.test.ts` y contratos de sesion/audit/report-status/access-token.
+- `public-professionals.fastify.ts` queda fuera porque usa contrato CORS y mensaje propio: `"Origin no permitido"`.
+
+## Cambios
+
+- `server/lib/cors-headers.ts` exporta `enforceTrustedOriginRequired`.
+- El nuevo helper reutiliza `UNSAFE_METHODS` y `getRequestOrigin`.
+- `enforceTrustedOriginRequired` conserva metodos seguros y bloquea metodos inseguros cuando:
+  - falta `Origin` y falta `Referer`;
+  - el origen normalizado no esta en `allowedOrigins`.
+- El bloqueo preserva 403 y body exacto `{ success: false, error: "Origen no permitido" }`.
+- Las dos rutas importan desde `../lib/cors-headers.ts`:
+  - `enforceTrustedOriginRequired as enforceTrustedOrigin`
+  - `getAllowedOriginForCors`
+  - `getAllowedOrigins`
+  - `getRequestOrigin`
+- Se eliminaron de ambas rutas las copias locales de:
+  - `UNSAFE_METHODS`
+  - `getAllowedOrigins`
+  - `normalizeOrigin`
+  - `getOriginHeader`
+  - `getAllowedOriginForCors`
+  - `getRequestOrigin`
+  - `enforceTrustedOrigin`
+- `applyCorsHeaders` queda local y mantiene los mismos headers.
+
+## Archivos modificados
+
+- `server/lib/cors-headers.ts`
+- `server/routes/particular-study-tracking.fastify.ts`
+- `server/routes/study-tracking.fastify.ts`
+- `test/cors-headers-shared-helper.test.ts`
+- `test/particular-study-tracking.fastify.test.ts`
+- `test/security-production-invariants.test.ts`
+- `test/study-tracking.fastify.test.ts`
+- `docs/audit/final-repo-cleanup-engineering-audit.md`
+- `docs/implementation/backend-cors-helper-block-null-routes.md`
+
+## Validaciones
+
+- `pnpm typecheck`: fallo antes de ejecutar scripts por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm typecheck:test`: fallo antes de ejecutar scripts por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `corepack pnpm typecheck`: paso.
+- `corepack pnpm typecheck:test`: paso.
+- `node --experimental-strip-types --test test/cors-headers-shared-helper.test.ts`: paso, 14/14.
+- `node --experimental-strip-types --test test/security-trusted-origin-cors-boundaries.test.ts`: paso, 4/4.
+- `node --experimental-strip-types --test test/security-production-invariants.test.ts`: paso, 11/11.
+- `node --experimental-strip-types --test test/particular-study-tracking.fastify.test.ts`: paso, 12/12.
+- `node --experimental-strip-types --test test/study-tracking.fastify.test.ts`: paso, 11/11.
+- Contratos adicionales encontrados por grep: CSRF, mutacion/permisos, management, suite study-tracking, runtime timing, `fastify-app`, cross-auth/sesiones, ownership, response disclosure, audit/write attribution y report/status/access-token: pasaron.
+- `corepack pnpm build`: paso.
+- `corepack pnpm security:public-surface`: paso; sin findings publicos, con notas server-only existentes en `frontend/src/proxy.ts`.
+- `corepack pnpm --dir frontend lint`: paso.
+- `corepack pnpm --dir frontend typecheck`: primer intento fallo por `.next/types/routes.js` faltante antes del build; segundo intento paso despues de `frontend build`.
+- `corepack pnpm --dir frontend build`: paso.
+- `corepack pnpm test`: ejecutado; 2890/2898 pasaron y 8 fallaron por guardas historicas de PRs frontend que inspeccionan `git diff` y prohiben cambios backend.
+
+## Resultado
+
+PR-CORS3C queda implementado para las dos rutas *block-null*. El helper *allow-null* existente no cambio. El comportamiento 403 ante metodos inseguros sin `Origin` ni `Referer`, el mensaje exacto `"Origen no permitido"` y los headers/preflight de cada ruta quedan preservados y cubiertos por tests.
+
+## Riesgo residual
+
+- `corepack pnpm test` completo no queda verde mientras existan guardas frontend PR-especificas que fallan ante cambios backend en el working tree.
+- El primer `frontend typecheck` puede fallar si `.next/types/routes.js` no existe; `frontend build` lo regenera y el typecheck posterior pasa.
+- `applyCorsHeaders` sigue local por contrato; su consolidacion queda fuera de este PR.
+
+## Recomendacion public-professionals
+
+- No migrar `public-professionals.fastify.ts` dentro del helper actual.
+- Si se decide consolidarlo, hacerlo en PR dedicado porque conserva contrato y mensaje propio: `"Origin no permitido"`.
+
+## Estado final
+
+- Sin commit, sin push, sin PR.
+- Sin cambios en frontend runtime, DB, migraciones, dependencias, lockfiles, workflows, Render ni secrets.

--- a/server/lib/cors-headers.ts
+++ b/server/lib/cors-headers.ts
@@ -10,6 +10,10 @@ import { ENV } from "./env.ts";
  * previas: misma allowlist (`ENV.corsOrigins`), misma normalización de origen,
  * mismos status/headers y mismo mensaje `"Origen no permitido"`.
  *
+ * `enforceTrustedOrigin` conserva el contrato allow-null. Las rutas que deben
+ * bloquear métodos inseguros sin Origin/Referer usan
+ * `enforceTrustedOriginRequired`.
+ *
  * `applyCorsHeaders` NO se consolida aquí a propósito: cada ruta expone un set
  * distinto de `access-control-expose-headers` (rate-limit, Retry-After, etc.),
  * por lo que se mantiene local en cada archivo.
@@ -104,6 +108,29 @@ export function enforceTrustedOrigin(
   const requestOrigin = getRequestOrigin(request);
 
   if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
+    return true;
+  }
+
+  reply.code(403).send({
+    success: false,
+    error: "Origen no permitido",
+  });
+
+  return false;
+}
+
+export function enforceTrustedOriginRequired(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  allowedOrigins: ReadonlySet<string>,
+): boolean {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
+    return true;
+  }
+
+  const requestOrigin = getRequestOrigin(request);
+
+  if (requestOrigin && allowedOrigins.has(requestOrigin)) {
     return true;
   }
 

--- a/server/routes/particular-study-tracking.fastify.ts
+++ b/server/routes/particular-study-tracking.fastify.ts
@@ -9,6 +9,12 @@ import type {
   StudyTrackingCase,
   StudyTrackingNotification,
 } from "../../drizzle/schema.ts";
+import {
+  enforceTrustedOriginRequired as enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   parseBooleanQuery,
@@ -80,7 +86,6 @@ export type ParticularStudyTrackingNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__particularStudyTrackingRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type ParticularStudyTrackingFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -184,103 +189,6 @@ async function resolveDeps(
       options.markAllStudyTrackingNotificationsReadScoped ??
       defaultDeps!.markAllStudyTrackingNotificationsReadScoped,
   };
-}
-
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (!requestOrigin || !allowedOrigins.has(requestOrigin)) {
-    reply.code(403).send({
-      success: false,
-      error: "Origen no permitido",
-    });
-    return false;
-  }
-
-  return true;
 }
 
 function applyCorsHeaders(

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -11,6 +11,12 @@ import type {
   StudyTrackingNotification,
 } from "../../drizzle/schema.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
+import {
+  enforceTrustedOriginRequired as enforceTrustedOrigin,
+  getAllowedOriginForCors,
+  getAllowedOrigins,
+  getRequestOrigin,
+} from "../lib/cors-headers.ts";
 import { ENV } from "../lib/env.ts";
 import {
   applyEstimatedDeliveryRules,
@@ -188,7 +194,6 @@ export type StudyTrackingNativeRoutesOptions = {
 };
 
 const REQUEST_TIMER_KEY = "__studyTrackingRequestTimer";
-const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type StudyTrackingFastifyRequest = FastifyRequest & {
   [REQUEST_TIMER_KEY]?: RuntimeTimer;
@@ -272,81 +277,6 @@ async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
   return depsPromise;
 }
 
-function getAllowedOrigins(): string[] {
-  const configuredOrigins = ENV.corsOrigins.map((origin) =>
-    origin.trim().toLowerCase(),
-  );
-
-  if (configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  if (ENV.isDevelopment) {
-    return [
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-      "http://localhost:3001",
-      "http://127.0.0.1:3001",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ];
-  }
-
-  return [];
-}
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin.trim().toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-function getOriginHeader(request: FastifyRequest) {
-  return typeof request.headers.origin === "string"
-    ? request.headers.origin.trim()
-    : "";
-}
-
-function getAllowedOriginForCors(
-  request: FastifyRequest,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  const rawOrigin = getOriginHeader(request);
-
-  if (!rawOrigin) {
-    return null;
-  }
-
-  const normalizedOrigin = normalizeOrigin(rawOrigin);
-
-  if (!normalizedOrigin || !allowedOrigins.has(normalizedOrigin)) {
-    return null;
-  }
-
-  return rawOrigin;
-}
-
-function getRequestOrigin(request: FastifyRequest): string | null {
-  const originHeader = getOriginHeader(request);
-
-  if (originHeader) {
-    return normalizeOrigin(originHeader);
-  }
-
-  const refererHeader =
-    typeof request.headers.referer === "string"
-      ? request.headers.referer.trim()
-      : "";
-
-  if (refererHeader) {
-    return normalizeOrigin(refererHeader);
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -361,29 +291,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function enforceTrustedOrigin(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  allowedOrigins: ReadonlySet<string>,
-) {
-  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) {
-    return true;
-  }
-
-  const requestOrigin = getRequestOrigin(request);
-
-  if (requestOrigin && allowedOrigins.has(requestOrigin)) {
-    return true;
-  }
-
-  reply.code(403).send({
-    success: false,
-    error: "Origen no permitido",
-  });
-
-  return false;
 }
 
 function parseCookies(cookieHeader: string | undefined) {

--- a/test/cors-headers-shared-helper.test.ts
+++ b/test/cors-headers-shared-helper.test.ts
@@ -20,6 +20,7 @@ const {
   getAllowedOriginForCors,
   getRequestOrigin,
   enforceTrustedOrigin,
+  enforceTrustedOriginRequired,
 } = await import("../server/lib/cors-headers.ts");
 
 // ---------------------------------------------------------------------------
@@ -174,6 +175,75 @@ test("enforceTrustedOrigin bloquea método inseguro con Origin externo: 403 'Ori
 
   const result = enforceTrustedOrigin(
     fakeRequest({ origin: "https://evil.example" }, "POST"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, false);
+  assert.equal(state.statusCode, 403);
+  assert.deepEqual(state.body, {
+    success: false,
+    error: "Origen no permitido",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceTrustedOriginRequired (variante block-null: sin Origin/Referer en
+// método inseguro → 403 para rutas con sesión cookie que lo requieren localmente)
+// ---------------------------------------------------------------------------
+
+test("enforceTrustedOriginRequired permite métodos seguros sin tocar la respuesta", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOriginRequired(
+    fakeRequest({ origin: "https://evil.example" }, "GET"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, true);
+  assert.equal(state.statusCode, null);
+});
+
+test("enforceTrustedOriginRequired permite método inseguro con Origin de la allowlist", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOriginRequired(
+    fakeRequest({ origin: "https://vetneb.com.ar" }, "PATCH"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, true);
+  assert.equal(state.statusCode, null);
+});
+
+test("enforceTrustedOriginRequired bloquea método inseguro sin Origin ni Referer: 403 'Origen no permitido'", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOriginRequired(
+    fakeRequest({}, "PATCH"),
+    reply,
+    allowed,
+  );
+
+  assert.equal(result, false);
+  assert.equal(state.statusCode, 403);
+  assert.deepEqual(state.body, {
+    success: false,
+    error: "Origen no permitido",
+  });
+});
+
+test("enforceTrustedOriginRequired bloquea método inseguro con Origin externo: 403 'Origen no permitido'", () => {
+  const allowed = new Set(["https://vetneb.com.ar"]);
+  const { reply, state } = fakeReply();
+
+  const result = enforceTrustedOriginRequired(
+    fakeRequest({ origin: "https://evil.example" }, "PATCH"),
     reply,
     allowed,
   );

--- a/test/particular-study-tracking.fastify.test.ts
+++ b/test/particular-study-tracking.fastify.test.ts
@@ -311,7 +311,7 @@ test("particularStudyTrackingNativeRoutes responde 404 genérico en PATCH /notif
   }
 });
 
-test("particularStudyTrackingNativeRoutes expone PATCH /notifications/read-all scoped por token", async () => {
+test("particularStudyTrackingNativeRoutes expone PATCH /notifications/read-all con Origin permitido", async () => {
   const markAllCalls: Array<Record<string, unknown>> = [];
   const app = await createTestApp({
     markAllStudyTrackingNotificationsReadScoped: async (
@@ -343,7 +343,7 @@ test("particularStudyTrackingNativeRoutes expone PATCH /notifications/read-all s
   }
 });
 
-test("particularStudyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin origin confiable", async () => {
+test("particularStudyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin Origin ni Referer", async () => {
   const app = await createTestApp();
 
   try {
@@ -356,6 +356,38 @@ test("particularStudyTrackingNativeRoutes bloquea PATCH /notifications/read-all 
     });
 
     assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes bloquea PATCH /notifications/read-all con Origin no permitido", async () => {
+  const markAllCalls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    markAllStudyTrackingNotificationsReadScoped: async (
+      params: Record<string, unknown>,
+    ) => {
+      markAllCalls.push(params);
+      return { updatedCount: 3 };
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/api/particular/study-tracking/notifications/read-all",
+      headers: {
+        origin: "https://evil.example",
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(markAllCalls, []);
     assert.deepEqual(JSON.parse(response.body), {
       success: false,
       error: "Origen no permitido",

--- a/test/security-production-invariants.test.ts
+++ b/test/security-production-invariants.test.ts
@@ -33,6 +33,11 @@ const logisticsRouteFiles = [
   "server/routes/logistics-route-plans.fastify.ts",
 ] as const;
 
+const blockNullCorsRouteFiles = [
+  "server/routes/particular-study-tracking.fastify.ts",
+  "server/routes/study-tracking.fastify.ts",
+] as const;
+
 const clinicSessionCookieRouteFiles = [
   "server/routes/auth.fastify.ts",
   "server/routes/clinic-audit.fastify.ts",
@@ -235,6 +240,16 @@ test("origin/CORS bloquea métodos inseguros con Origin no permitido y no usa wi
   );
   assertContains(
     corsHelper,
+    "export function enforceTrustedOriginRequired(",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
+    "if (requestOrigin && allowedOrigins.has(requestOrigin))",
+    "server/lib/cors-headers.ts",
+  );
+  assertContains(
+    corsHelper,
     'error: "Origen no permitido"',
     "server/lib/cors-headers.ts",
   );
@@ -314,6 +329,49 @@ test("origin/CORS bloquea métodos inseguros con Origin no permitido y no usa wi
       "function normalizeOrigin(value: string): string | null",
       file,
     );
+    assertNotContains(
+      source,
+      "function getRequestOrigin(request: FastifyRequest): string | null",
+      file,
+    );
+    assertNotContains(source, "function enforceTrustedOrigin(", file);
+    assertContains(source, 'error: "Origen no permitido"', file);
+    assertContains(source, 'reply.header("vary", "Origin")', file);
+    assertContains(source, 'reply.header("access-control-allow-origin", allowedOrigin)', file);
+    assertContains(source, 'reply.header("access-control-allow-credentials", "true")', file);
+    assertNotContains(source, 'access-control-allow-origin", "*"', file);
+  }
+
+  for (const file of blockNullCorsRouteFiles) {
+    const source = read(file);
+
+    assertContains(
+      source,
+      'from "../lib/cors-headers.ts";',
+      file,
+    );
+    assertContains(source, "  enforceTrustedOriginRequired as enforceTrustedOrigin,", file);
+    assertContains(source, "  getAllowedOriginForCors,", file);
+    assertContains(source, "  getAllowedOrigins,", file);
+    assertContains(source, "  getRequestOrigin,", file);
+    assertContains(source, "function applyCorsHeaders(", file);
+    assertNotContains(
+      source,
+      'const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);',
+      file,
+    );
+    assertNotContains(
+      source,
+      "function getAllowedOrigins(): string[]",
+      file,
+    );
+    assertNotContains(
+      source,
+      "function normalizeOrigin(value: string): string | null",
+      file,
+    );
+    assertNotContains(source, "function getOriginHeader(", file);
+    assertNotContains(source, "function getAllowedOriginForCors(", file);
     assertNotContains(
       source,
       "function getRequestOrigin(request: FastifyRequest): string | null",

--- a/test/study-tracking.fastify.test.ts
+++ b/test/study-tracking.fastify.test.ts
@@ -307,7 +307,7 @@ test("studyTrackingNativeRoutes responde 404 genérico en PATCH /notifications/:
   }
 });
 
-test("studyTrackingNativeRoutes expone PATCH /notifications/read-all clinic-scoped", async () => {
+test("studyTrackingNativeRoutes expone PATCH /notifications/read-all con Origin permitido", async () => {
   const markAllCalls: Array<Record<string, unknown>> = [];
   const app = await createTestApp({
     markAllStudyTrackingNotificationsReadScoped: async (
@@ -339,7 +339,7 @@ test("studyTrackingNativeRoutes expone PATCH /notifications/read-all clinic-scop
   }
 });
 
-test("studyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin origin confiable", async () => {
+test("studyTrackingNativeRoutes bloquea PATCH /notifications/read-all sin Origin ni Referer", async () => {
   const app = await createTestApp();
 
   try {


### PR DESCRIPTION
PR-CORS3C from the final repository cleanup audit.

Scope:
- Adds explicit block-null CORS helper enforceTrustedOriginRequired in server/lib/cors-headers.ts.
- Preserves existing allow-null enforceTrustedOrigin behavior.
- Migrates only block-null study tracking routes:
  - server/routes/particular-study-tracking.fastify.ts
  - server/routes/study-tracking.fastify.ts
- Keeps applyCorsHeaders local.
- Updates tests to cover block-null behavior explicitly.
- Adds implementation note for PR-CORS3C.
- Updates the final repository cleanup audit with real execution notes.

Preserved contracts:
- Unsafe method without Origin or Referer returns 403.
- Unsafe method with disallowed Origin returns 403.
- Error body remains { error: "Origen no permitido" }.
- No HTTP status code changes.
- No response body changes.
- No CORS error message changes.
- No Origin/Referer behavior changes.
- No allow-null behavior changes for previously migrated routes.
- No public-professionals changes.
- No frontend runtime changes.
- No DB changes.
- No migrations.
- No dependencies.
- No lockfile changes.
- No workflow changes.
- No Render/secrets changes.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm build passed.
- corepack pnpm security:public-surface passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed after frontend build regenerated .next types.
- corepack pnpm --dir frontend build passed.
- CORS shared helper test passed.
- trusted-origin CORS boundaries passed.
- security production invariants passed.
- study-tracking route tests passed.
- particular-study-tracking route tests passed.
- related CSRF, auth/session, ownership, audit, report/status/access-token contracts passed.

Full pnpm test:
- Executed locally.
- 2890/2898 passed.
- 8 failures are known diff-scope guard failures from historical frontend PR tests that reject backend route changes in the working diff; they are not CORS/study-tracking regressions.
