### PR TITLE
docs(audit): audit frontend dependency usage

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -42,9 +42,14 @@ La deuda activa restante sigue enfocada en ordenamiento y documentación:
    (`resolveParticularPortalUrl`): la URL del portal en mails de token sale del
    primer origen `https` del allowlist CORS, conflando dos conceptos distintos. *(P1.)*
 2. **Módulo `shared/` muerto** (3 archivos) consumido solo por su propio test. *(P2.)*
-3. **6 dependencias de frontend sin uso** (`@tanstack/react-query`,
-   `@tanstack/react-table`, `echarts`, `echarts-for-react`, `react-hook-form`,
-   `@radix-ui/react-tooltip`). *(P2.)*
+3. **Dependencias de frontend aparentemente sin uso**: auditoría documental
+   dedicada confirma como `SUSPECT unused` el grupo original
+   (`@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
+   `echarts-for-react`, `react-hook-form`, `@radix-ui/react-tooltip`) y amplía
+   la señal a Radix no importados (`avatar`, `dropdown-menu`, `label`, `select`,
+   `tabs`, `toast`). Ver
+   [`frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md).
+   *(P2.)*
 4. **Deuda documental de organización**: ~233 docs con taxonomía fragmentada
    (`audit/` + `audits/`, notas de implementación en 3 lugares, ~31 `pr-*.md`
    sueltos en la raíz de `docs/`) y al menos un doc **contradictorio**
@@ -258,20 +263,38 @@ deploy roto ni auth rota en el estado actual.
 
 #### P2-B · Dependencias de frontend sin uso
 - **Tipo:** dependencias / performance-surface · **Riesgo:** Medio (verificar build/E2E).
-- **Evidencia** (`git grep` por nombre literal en `frontend/src`, `frontend/e2e`, configs → 0 refs):
-  | Paquete | Refs en código |
-  | --- | --- |
-  | `@tanstack/react-query` | 0 (sin `QueryClient/useQuery/useMutation`) |
-  | `@tanstack/react-table` | 0 (sin `useReactTable`) |
-  | `echarts` | 0 |
-  | `echarts-for-react` | 0 |
-  | `react-hook-form` | 0 (formularios usan `useState`/`onSubmit`; 26 componentes) |
-  | `@radix-ui/react-tooltip` | 0 (sin `Tooltip`) |
+- **Snapshot documental dedicado (2026-06-29, rama
+  `audit/frontend-dependencies-usage`, HEAD `d958c63`):**
+  [`docs/audit/frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md).
+  Inventario completo de `frontend/package.json`: 25 `dependencies` y 12
+  `devDependencies`, con búsquedas reproducibles en `frontend/src`,
+  `frontend/e2e`, `test`, `scripts`, configs y `docs` como referencia.
+- **Evidencia principal:** el grupo original sigue sin imports runtime/config:
+  `@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
+  `echarts-for-react`, `react-hook-form`, `@radix-ui/react-tooltip`.
+  La auditoría amplía el set `SUSPECT unused` a Radix declarados pero no
+  importados: `@radix-ui/react-avatar`,
+  `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`,
+  `@radix-ui/react-select`, `@radix-ui/react-tabs`,
+  `@radix-ui/react-toast`.
+- **Falsos positivos descartados:** `gsap` sí está vivo por imports dinámicos en
+  `frontend/src/components/public/PublicScrollReveal.tsx`; `@radix-ui/react-dialog`,
+  `@radix-ui/react-separator` y `@radix-ui/react-slot` sí tienen imports runtime;
+  Tailwind/PostCSS/Next/React/Playwright/TypeScript son tooling o runtime vivo.
+- **Riesgo de eliminación:** `test/package-scripts-contract.test.ts` fija varias
+  dependencias como contrato de manifest; cualquier PR de eliminación debe
+  actualizar ese test junto con `frontend/package.json` y `pnpm-lock.yaml`.
+  `@eslint/eslintrc` y la dependencia directa `@next/eslint-plugin-next` quedan
+  como `UNKNOWN needs manual verification`, no como eliminación de runtime.
 - **Impacto:** no inflan el bundle servido (Next no las bundlea si no se importan)
   pero sí el `node_modules`, tiempo de install, superficie de `pnpm audit` y ruido
   de actualizaciones. `echarts` en especial es pesado.
-- **Acción:** **investigar y remover** vía PR con build + E2E + lint verdes
-  (**PR-CLEAN7**). **No tocar `package.json`/lock en esta auditoría.**
+- **Acción:** no remover masivamente. Recomendar PRs chicos por grupo. Primer PR
+  sugerido: **PR-CLEAN7A** para `@tanstack/react-query`,
+  `@tanstack/react-table`, `echarts`, `echarts-for-react` y
+  `react-hook-form`, dejando Radix no usados para un PR posterior porque existen
+  docs/roadmap que proponen adoptar `toast`/`tooltip`. **No tocar
+  `package.json`/lock en esta auditoría.**
 
 #### P2-C · `docs/notes/todo.md` contradictorio con la arquitectura actual
 - **Tipo:** docs · **Riesgo:** Bajo.
@@ -961,9 +984,20 @@ exige build+E2E). El resto está saludable.
 - **Rollback:** revertir (historia preservada en git).
 
 ### PR-CLEAN7 · dependencias frontend sin uso
-- **Alcance:** remover `@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
-  `echarts-for-react`, `react-hook-form`, `@radix-ui/react-tooltip` de
-  `frontend/package.json` (regenerar lock).
+- **Estado documental:** auditoría dedicada completada en
+  [`docs/audit/frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md).
+  No se eliminó ninguna dependencia.
+- **Alcance recomendado por fases:**
+  - **PR-CLEAN7A:** remover `@tanstack/react-query`,
+    `@tanstack/react-table`, `echarts`, `echarts-for-react` y
+    `react-hook-form`; actualizar `test/package-scripts-contract.test.ts`;
+    regenerar lock.
+  - **PR-CLEAN7B:** decidir/remover Radix declarados sin import
+    (`avatar`, `dropdown-menu`, `label`, `select`, `tabs`, `toast`, `tooltip`)
+    o adoptarlos explícitamente si siguen en roadmap.
+  - **PR-CLEAN7C opcional:** revisar tooling ESLint (`@eslint/eslintrc` y
+    dependencia directa `@next/eslint-plugin-next`) sólo si `lint` confirma que
+    son prescindibles.
 - **Validación:** `pnpm install`; `pnpm --dir frontend lint`; `pnpm --dir frontend typecheck`;
   `pnpm --dir frontend build`; E2E (`e2e:smoke`,`e2e:admin-mobile`,`e2e:visual-contract`,`e2e:public-clinic`).
 - **Rollback:** revertir el PR (restaura deps + lock).

--- a/docs/audit/frontend-dependencies-usage-audit.md
+++ b/docs/audit/frontend-dependencies-usage-audit.md
@@ -1,0 +1,277 @@
+# Auditoría de uso de dependencias frontend
+
+> **Modo:** AUDITORÍA DOCUMENTAL / docs-only.
+> **Fecha:** 2026-06-29.
+> **Scope:** inventariar `frontend/package.json` y clasificar uso real de
+> `dependencies` y `devDependencies`.
+> **No se modificó:** `frontend/package.json`, `pnpm-lock.yaml`, runtime
+> frontend, runtime backend, DB, migraciones, workflows, Render ni secrets.
+
+---
+
+## 1. Estado base
+
+| Ítem | Observado |
+| --- | --- |
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama | `audit/frontend-dependencies-usage` |
+| HEAD | `d958c63 refactor(cleanup): remove dead shared module (#1173)` |
+| Working tree antes de editar docs | limpio |
+| Documento rector | `docs/audit/final-repo-cleanup-engineering-audit.md` |
+
+`frontend/package.json` declara 25 `dependencies` y 12 `devDependencies`.
+La app frontend real es Next.js App Router en `frontend/src`; no existen
+`frontend/app`, `frontend/components`, `frontend/lib` ni
+`frontend/test/tests` en la raíz. Sí existe `frontend/e2e`, incluido como
+superficie de test/tooling Playwright.
+
+---
+
+## 2. Método reproducible
+
+Comandos usados por paquete, ajustando `<package-name>`:
+
+```powershell
+git grep -n "<package-name>" -- frontend test scripts docs package.json frontend/package.json
+git grep -n "from ['\"]<package-name>"
+git grep -n "from ['\"]@scope/package"
+git grep -n "require(['\"]<package-name>"
+git grep -n "import(.*<package-name>"
+rg -n "<package-name>|from ['\"]<package-name>|require\\(['\"]<package-name>" frontend test scripts docs
+```
+
+Lectura aplicada:
+
+- `frontend/package.json` prueba declaración, no uso.
+- `test/package-scripts-contract.test.ts` prueba contrato de manifest, no uso
+  runtime. Si se elimina una dependencia, ese test deberá actualizarse en el PR
+  de eliminación.
+- `docs/**` se considera referencia histórica o recomendación, no uso runtime.
+- Imports de `frontend/src` clasifican como `LIVE runtime`.
+- Imports/configs de `frontend/*.config.*`, `frontend/tsconfig.json`,
+  `frontend/e2e` y scripts npm clasifican como `LIVE build/config/tooling` o
+  `LIVE tests`.
+- Paquetes cargados por convención de Next/React/Tailwind/PostCSS/TypeScript se
+  clasifican como tooling aunque no tengan un import directo por nombre.
+
+---
+
+## 3. Inventario y clasificación
+
+### dependencies
+
+| Paquete | Clasificación | Evidencia principal | Nota |
+| --- | --- | --- | --- |
+| `@radix-ui/react-avatar` | SUSPECT unused | Solo `frontend/package.json` y `test/package-scripts-contract.test.ts` | Sin import directo ni componente local `Avatar`. |
+| `@radix-ui/react-dialog` | LIVE runtime | `frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx:4`; `frontend/src/components/dashboard/ModuleDialog.tsx:4` | Usado para drawer/dialog. |
+| `@radix-ui/react-dropdown-menu` | SUSPECT unused | Solo manifest/test de manifest; docs históricas | Sin import directo. |
+| `@radix-ui/react-label` | SUSPECT unused | Solo manifest/test de manifest | Sin import directo. |
+| `@radix-ui/react-select` | SUSPECT unused | Solo manifest/test de manifest | Sin import directo. |
+| `@radix-ui/react-separator` | LIVE runtime | `frontend/src/components/ui/separator.tsx:4` | Primitiva UI usada. |
+| `@radix-ui/react-slot` | LIVE runtime | `frontend/src/components/ui/button.tsx:2` | Primitiva `Button asChild`. |
+| `@radix-ui/react-tabs` | SUSPECT unused | Solo manifest/test de manifest | El dashboard usa `ModuleTabs` propio, no Radix Tabs. |
+| `@radix-ui/react-toast` | SUSPECT unused | Solo manifest/test de manifest; docs proponen adoptarlo | No hay provider/componente toast runtime. |
+| `@radix-ui/react-tooltip` | SUSPECT unused | Solo manifest/test de manifest; docs proponen adoptarlo | Confirma y amplía el P2-B rector. |
+| `@tanstack/react-query` | SUSPECT unused | Solo manifest/test de manifest y docs históricas | Sin `QueryClient`, `useQuery`, `useMutation` ni imports. |
+| `@tanstack/react-table` | SUSPECT unused | Tests verifican que no se importe; manifest/test de manifest | Sin `useReactTable`; guardrails lo prohíben en layout/públicas. |
+| `class-variance-authority` | LIVE runtime | `frontend/src/components/ui/badge.tsx:2`; `frontend/src/components/ui/button.tsx:3` | Usado por variantes UI. |
+| `clsx` | LIVE runtime | `frontend/src/lib/utils.ts:1` | Usado por `cn()`. |
+| `echarts` | SUSPECT unused | Tests verifican que no se importe; manifest/test de manifest; docs históricas | Paquete pesado; sin import runtime. |
+| `echarts-for-react` | SUSPECT unused | Solo manifest/test de manifest y docs históricas | Sin wrapper React en runtime. |
+| `gsap` | LIVE runtime | `frontend/src/components/public/PublicScrollReveal.tsx:113-114` | Carga dinámica `import("gsap")` y `import("gsap/ScrollTrigger")`. |
+| `lucide-react` | LIVE runtime | 80+ imports en `frontend/src`, ej. `ClinicCommandCenter.tsx:9` | Librería de iconos activa. |
+| `next` | LIVE runtime/build | `frontend/next.config.ts:1`; múltiples `Metadata`/`next/*` en `frontend/src` | Framework principal. |
+| `react` | LIVE runtime | múltiples imports de hooks en `frontend/src`; JSX runtime configurado | Framework principal. |
+| `react-dom` | LIVE runtime | `DashboardNotificationsBell.tsx:3`; `UploadReportModal.tsx:4` | `createPortal`. |
+| `react-hook-form` | SUSPECT unused | Solo manifest/test de manifest y guard de home sin formulario | Formularios actuales usan estado/control propio. |
+| `tailwind-merge` | LIVE runtime | `frontend/src/lib/utils.ts:2` | Usado por `cn()`. |
+| `tailwindcss-animate` | LIVE build/config/tooling | `frontend/tailwind.config.ts:85` | Plugin Tailwind activo. |
+| `zod` | LIVE tests / workspace context | `test/api-contract-smoke.test.ts:4`; `test/production-env-contracts.test.ts:5` | En `frontend/package.json`, pero el uso detectado está en tests raíz. Requiere cuidado antes de mover/eliminar. |
+
+### devDependencies
+
+| Paquete | Clasificación | Evidencia principal | Nota |
+| --- | --- | --- | --- |
+| `@eslint/eslintrc` | UNKNOWN needs manual verification | `pnpm --dir frontend why` muestra dependencia directa solamente | No hay import directo en `eslint.config.mjs`; validar con PR dedicado si se quiere remover. |
+| `@next/eslint-plugin-next` | UNKNOWN needs manual verification | Directa `16.2.7` y transitiva `16.2.9` vía `eslint-config-next` | Posible duplicado/version skew; no tocar sin lint verde. |
+| `@playwright/test` | LIVE tests | 70+ imports en `frontend/e2e/*.spec.ts`; `frontend/playwright.config.ts:1` | Tooling E2E activo. |
+| `@tailwindcss/postcss` | LIVE build/config/tooling | `frontend/postcss.config.mjs:4` | Plugin PostCSS de Tailwind 4. |
+| `@types/node` | LIVE build/config/tooling | TS/config usa APIs Node en configs (`createRequire`, `process`) | Tipos necesarios para configs y e2e. |
+| `@types/react` | LIVE build/config/tooling | React 19 + TSX | Tipos React. |
+| `@types/react-dom` | LIVE build/config/tooling | `react-dom` + TS | Tipos `react-dom`. |
+| `eslint` | LIVE build/config/tooling | Script `lint`; `frontend/eslint.config.mjs` | Tooling lint. |
+| `eslint-config-next` | LIVE build/config/tooling | `frontend/eslint.config.mjs:2` | Config Next usada directamente. |
+| `postcss` | LIVE build/config/tooling | `frontend/postcss.config.mjs` | Loader/config PostCSS. |
+| `tailwindcss` | LIVE build/config/tooling | `frontend/src/app/globals.css:1`; `frontend/tailwind.config.ts:2` | Tailwind 4 activo. |
+| `typescript` | LIVE build/config/tooling | Script `typecheck`; `frontend/tsconfig.json` | Tooling TS. |
+
+---
+
+## 4. Evidencia grep por grupo
+
+### LIVE runtime
+
+```text
+git grep -n -F '@radix-ui/react-dialog' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx:4
+-> frontend/src/components/dashboard/ModuleDialog.tsx:4
+
+git grep -n -F '@radix-ui/react-separator' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/components/ui/separator.tsx:4
+
+git grep -n -F '@radix-ui/react-slot' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/components/ui/button.tsx:2
+
+git grep -n -F 'class-variance-authority' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/components/ui/badge.tsx:2
+-> frontend/src/components/ui/button.tsx:3
+
+git grep -n -F 'clsx' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/lib/utils.ts:1
+
+git grep -n -F 'import("gsap"' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/components/public/PublicScrollReveal.tsx:113
+
+git grep -n -F 'import("gsap/ScrollTrigger"' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/components/public/PublicScrollReveal.tsx:114
+
+git grep -n -F 'lucide-react' -- frontend test scripts docs package.json frontend/package.json
+-> 80+ imports en frontend/src
+
+git grep -n -F 'react-dom' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/components/dashboard/DashboardNotificationsBell.tsx:3
+-> frontend/src/components/dashboard/UploadReportModal.tsx:4
+
+git grep -n -F 'tailwind-merge' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/lib/utils.ts:2
+```
+
+### LIVE build/config/tooling/tests
+
+```text
+git grep -n -F 'next' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/next.config.ts:1
+-> múltiples imports type/runtime `next` y `next/*` en frontend/src
+
+git grep -n -F '@playwright/test' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/playwright.config.ts:1
+-> 70+ imports en frontend/e2e
+
+git grep -n -F '@tailwindcss/postcss' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/postcss.config.mjs:4
+
+git grep -n -F 'tailwindcss-animate' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/tailwind.config.ts:85
+
+git grep -n -F 'eslint-config-next' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/eslint.config.mjs:2
+
+git grep -n -F 'tailwindcss' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/src/app/globals.css:1
+-> frontend/tailwind.config.ts:2
+```
+
+### SUSPECT unused
+
+```text
+git grep -n -F '@tanstack/react-query' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/package.json:32
+-> test/package-scripts-contract.test.ts:117
+-> docs históricas/auditoría; 0 imports runtime/config
+
+git grep -n -F '@tanstack/react-table' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/package.json:33
+-> test/frontend-extreme-speed-guardrails.test.ts:141,155-158 (guard de no-import)
+-> test/package-scripts-contract.test.ts:118
+-> docs históricas/auditoría; 0 imports runtime/config
+
+git grep -n -F 'echarts' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/package.json:36-37
+-> test/frontend-extreme-speed-guardrails.test.ts:118,134,141,150
+-> test/package-scripts-contract.test.ts:141-142
+-> docs históricas/auditoría; 0 imports runtime/config
+
+git grep -n -F 'react-hook-form' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/package.json:43
+-> test/frontend-home-page-content.test.ts:467 (guard de ausencia en CTA)
+-> test/package-scripts-contract.test.ts:119
+-> docs históricas/auditoría; 0 imports runtime/config
+
+git grep -n -F '@radix-ui/react-tooltip' -- frontend test scripts docs package.json frontend/package.json
+-> frontend/package.json:31
+-> test/package-scripts-contract.test.ts:140
+-> docs proponen adoptarlo; 0 imports runtime/config
+```
+
+Radix adicionales con la misma señal:
+
+```text
+@radix-ui/react-avatar        -> solo frontend/package.json + test/package-scripts-contract.test.ts
+@radix-ui/react-dropdown-menu -> solo frontend/package.json + test/package-scripts-contract.test.ts + doc histórico
+@radix-ui/react-label         -> solo frontend/package.json + test/package-scripts-contract.test.ts
+@radix-ui/react-select        -> solo frontend/package.json + test/package-scripts-contract.test.ts
+@radix-ui/react-tabs          -> solo frontend/package.json + test/package-scripts-contract.test.ts
+@radix-ui/react-toast         -> solo frontend/package.json + test/package-scripts-contract.test.ts + doc de adopción futura
+```
+
+### UNKNOWN
+
+```text
+pnpm --dir frontend why @eslint/eslintrc
+-> dependencia directa solamente; sin import directo en frontend/eslint.config.mjs
+
+pnpm --dir frontend why @next/eslint-plugin-next
+-> directa 16.2.7 y transitiva 16.2.9 por eslint-config-next
+```
+
+Interpretación: ambos son candidatos de auditoría de tooling, no de eliminación
+junto con runtime deps. `@next/eslint-plugin-next` muestra posible duplicado,
+pero remover la directa puede depender de cómo resuelva ESLint/Next el plugin.
+
+---
+
+## 5. Candidatos a eliminación
+
+No se recomienda eliminación masiva. La lista siguiente es documental y requiere
+PRs chicos, con `package.json` + lockfile + tests ajustados sólo en el PR de
+eliminación.
+
+| Grupo | Paquetes | Riesgo | Validación mínima |
+| --- | --- | --- | --- |
+| Charts/table/query/forms | `@tanstack/react-query`, `@tanstack/react-table`, `echarts`, `echarts-for-react`, `react-hook-form` | Medio: cambio en manifest/lock y test de contrato; `echarts` pesado pero no importado | `pnpm install`; `pnpm --dir frontend lint`; `pnpm --dir frontend typecheck`; `pnpm --dir frontend build`; E2E frontend relevante |
+| Radix no usados | `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`, `@radix-ui/react-select`, `@radix-ui/react-tabs`, `@radix-ui/react-toast`, `@radix-ui/react-tooltip` | Medio-bajo: posible roadmap UX pendiente; test de contrato debe actualizarse | Mismas validaciones + revisar docs/roadmap antes de borrar |
+| Tooling ESLint | `@eslint/eslintrc`, directa `@next/eslint-plugin-next` | Medio: puede romper `pnpm --dir frontend lint` por resolución de plugin/config | PR separado, sólo tooling; lint antes/después |
+
+`zod` queda fuera de candidatos por ahora: está en el manifest frontend, pero el
+uso detectado está en tests raíz (`api-contract-smoke`, `production-env-contracts`).
+Antes de moverlo/removerlo hay que revisar si debe vivir en root, frontend o ambos.
+
+---
+
+## 6. Recomendación concreta para el siguiente PR
+
+Siguiente PR recomendado: **PR-CLEAN7A · frontend deps pesadas sin uso**.
+
+Alcance propuesto:
+
+- Remover sólo `@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
+  `echarts-for-react` y `react-hook-form`.
+- Actualizar `test/package-scripts-contract.test.ts` para que deje de exigir
+  esos paquetes.
+- Regenerar `pnpm-lock.yaml`.
+- No tocar Radix, ESLint tooling, runtime frontend, backend, DB, migraciones ni
+  workflows en ese PR.
+
+Motivo: es el grupo más claro, con evidencia reiterada en auditorías previas,
+guardrails explícitos de no-import para `echarts`/`react-table` y bajo riesgo de
+UX inmediato. Radix conviene tratarlo después porque hay documentos que proponen
+adoptar `toast`/`tooltip`.
+
+---
+
+## 7. Estado final de esta auditoría
+
+- Auditoría docs-only completada.
+- Candidatos documentados; no se removió ninguna dependencia.
+- `frontend/package.json` y `pnpm-lock.yaml` permanecen sin cambios.
+- No commit, no push, no PR.


### PR DESCRIPTION
Docs-only audit for the P2-B frontend dependency usage finding from the final repository cleanup audit.

Scope:
- Audits frontend/package.json dependencies and devDependencies.
- Adds docs/audit/frontend-dependencies-usage-audit.md with reproducible grep evidence.
- Updates docs/audit/final-repo-cleanup-engineering-audit.md with the P2-B snapshot and next-step recommendation.

Findings:
- frontend/package.json contains 25 dependencies and 12 devDependencies.
- No package.json or lockfile changes were made.
- No frontend or backend runtime files were changed.
- No DB, migration, workflow, Render or secret changes were made.

Classified as SUSPECT unused:
- @tanstack/react-query
- @tanstack/react-table
- echarts
- echarts-for-react
- react-hook-form
- @radix-ui/react-tooltip
- @radix-ui/react-avatar
- @radix-ui/react-dropdown-menu
- @radix-ui/react-label
- @radix-ui/react-select
- @radix-ui/react-tabs
- @radix-ui/react-toast

Classified as UNKNOWN:
- @eslint/eslintrc
- direct @next/eslint-plugin-next dependency

False positives dismissed as live:
- gsap
- @radix-ui/react-dialog
- @radix-ui/react-separator
- @radix-ui/react-slot
- lucide-react
- Next/React/Tailwind/PostCSS/Playwright/TypeScript tooling

Recommendation:
- Do not remove everything in one PR.
- Next implementation PR should be PR-CLEAN7A, limited to:
  - @tanstack/react-query
  - @tanstack/react-table
  - echarts
  - echarts-for-react
  - react-hook-form
- Update test/package-scripts-contract.test.ts and regenerate lockfile only in that later implementation PR.
- Keep Radix suspects for a separate follow-up because roadmap/docs mention possible toast/tooltip adoption.

Validation:
- git diff --check passed.
- documentation-only diff reviewed.
- package.json and lockfile diff confirmed empty.
