### PR TITLE
docs(audit): audit remaining frontend dependencies

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -303,6 +303,19 @@ deploy roto ni auth rota en el estado actual.
   `test/package-scripts-contract.test.ts` dejó de exigir esas 5 dependencias.
   No se tocaron Radix, dependencias `UNKNOWN`, runtime frontend/backend, DB,
   migraciones, workflows, Render ni secrets.
+- **Estado PR-CLEAN7B / remanente P2-B:** **AUDITORÍA DOCS-ONLY COMPLETADA**
+  (2026-06-29, rama `audit/frontend-dependencies-radix-tooling`, HEAD
+  `1ac86d0`). Ver
+  [`docs/audit/frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
+  Resultado: 0 imports reales `from`/`require`/`import()` para los 9 paquetes
+  auditados. `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`,
+  `@radix-ui/react-label`, `@radix-ui/react-select` y
+  `@radix-ui/react-tabs` quedan `SUSPECT unused`; `@radix-ui/react-toast` y
+  `@radix-ui/react-tooltip` quedan `DEFER keep` por roadmap explícito de
+  dashboard premium; `@eslint/eslintrc` y la dependencia directa
+  `@next/eslint-plugin-next` quedan `UNKNOWN keep` para PR tooling dedicado.
+  No se tocaron `frontend/package.json`, `pnpm-lock.yaml`, runtime
+  frontend/backend, DB, migraciones, workflows, Render ni secrets.
 
 #### P2-C · `docs/notes/todo.md` contradictorio con la arquitectura actual
 - **Tipo:** docs · **Riesgo:** Bajo.
@@ -367,11 +380,11 @@ deploy roto ni auth rota en el estado actual.
 | 5 | `legacy/drizzle-old/` (3 archivos) | cleanup | README lo marca "archaeology only" | PR-CLEAN6 |
 | 6 | `scripts/generate-pwa-icons.py` | cleanup | 0 refs; Python prohibido por skill | PR-CLEAN6 |
 | 7 | `scripts/maintenance/FUSION_POR_COMANDO.sh` | cleanup | 0 refs; artefacto de fusión histórica | PR-CLEAN6 |
-| 8 | `@tanstack/react-query` (dep frontend) | dependencias | 0 refs en `frontend/` | PR-CLEAN7 |
-| 9 | `@tanstack/react-table` (dep frontend) | dependencias | 0 refs | PR-CLEAN7 |
-| 10 | `echarts` + `echarts-for-react` (deps) | dependencias | 0 refs | PR-CLEAN7 |
-| 11 | `react-hook-form` (dep frontend) | dependencias | 0 refs | PR-CLEAN7 |
-| 12 | `@radix-ui/react-tooltip` (dep frontend) | dependencias | 0 refs | PR-CLEAN7 |
+| 8 | `@tanstack/react-query` (dep frontend) | dependencias | removida por PR-CLEAN7A (#1175) | cerrado |
+| 9 | `@tanstack/react-table` (dep frontend) | dependencias | removida por PR-CLEAN7A (#1175) | cerrado |
+| 10 | `echarts` + `echarts-for-react` (deps) | dependencias | removidas por PR-CLEAN7A (#1175) | cerrado |
+| 11 | `react-hook-form` (dep frontend) | dependencias | removida por PR-CLEAN7A (#1175) | cerrado |
+| 12 | Radix remanente no importado | dependencias | `avatar`, `dropdown-menu`, `label`, `select`, `tabs` `SUSPECT unused`; `toast`/`tooltip` `DEFER keep` por roadmap | PR-CLEAN7D |
 | 13 | `docs/notes/todo.md` (parte tRPC/Sheets) | docs | contradice arquitectura real | PR-CLEAN1 |
 
 ---
@@ -389,7 +402,7 @@ deploy roto ni auth rota en el estado actual.
 | `legacy/drizzle-old/*` | "archaeology only" (su README) | P3 | Bajo | archivar/eliminar | PR-CLEAN6 |
 | `scripts/generate-pwa-icons.py` | 0 refs; Python prohibido | P3 | Bajo | eliminar | PR-CLEAN6 |
 | `scripts/maintenance/FUSION_POR_COMANDO.sh` | 0 refs; fusión histórica | P3 | Bajo | eliminar | PR-CLEAN6 |
-| `frontend/package.json` (6 deps) | 0 refs (ver §4 #8-12) | P2 | Medio | investigar+remover | PR-CLEAN7 |
+| `frontend/package.json` (Radix/tooling remanente) | 0 imports reales para los 9 paquetes auditados; `toast`/`tooltip` tienen roadmap, tooling queda `UNKNOWN` | P2 | Medio | docs cerrados; decidir PR-CLEAN7C/7D | PR-CLEAN7 |
 | `docs/notes/todo.md` | tRPC/Google Sheets inexistentes | P2 | Bajo | archivar/reescribir | PR-CLEAN1 |
 | `docs/audit/` + `docs/audits/` | taxonomía duplicada | P2 | Bajo | unificar | PR-CLEAN2 |
 | `IMPLEMENTATION_NOTES/` (raíz, 34) | notas en 3 ubicaciones | P2 | Bajo | consolidar bajo `docs/` | PR-CLEAN2 |
@@ -582,7 +595,7 @@ serían altas nuevas (fuera de alcance de limpieza).
 | Tema | Estado | Acción |
 | --- | --- | --- |
 | Code splitting frontend | `gsap`/`ScrollTrigger` lazy (`PublicScrollReveal.tsx:112-114`); `next/dynamic` en `AdminClinicsManagementCard`, `ParticularesContent` | OK |
-| Deps pesadas sin uso | `echarts`/`echarts-for-react`/`react-query`/`react-table`/`react-hook-form` con 0 refs | remover (PR-CLEAN7) |
+| Deps pesadas sin uso | `echarts`/`echarts-for-react`/`react-query`/`react-table`/`react-hook-form` con 0 refs | cerrado por PR-CLEAN7A (#1175) |
 | `no-store` en privados | hook global `applySensitiveApiNoStoreHeaders` (`fastify-app.ts:362`) sobre `/api/*` excepto `/api/public/*` | OK |
 | Cold start backend | build esbuild bundle ESM; `host 0.0.0.0`/`PORT` correctos (no auditado a fondo aquí) | sin hallazgo |
 | Logging | 56 `console.*` en server; sin redacción estructurada | observabilidad (P2-E) |
@@ -1001,12 +1014,17 @@ exige build+E2E). El resto está saludable.
     `@tanstack/react-table`, `echarts`, `echarts-for-react` y
     `react-hook-form`; actualizar `test/package-scripts-contract.test.ts`;
     regenerar lock.
-  - **PR-CLEAN7B:** decidir/remover Radix declarados sin import
-    (`avatar`, `dropdown-menu`, `label`, `select`, `tabs`, `toast`, `tooltip`)
-    o adoptarlos explícitamente si siguen en roadmap.
+  - **PR-CLEAN7B (AUDITORÍA DOCS-ONLY COMPLETADA 2026-06-29):** auditar
+    remanente Radix/tooling sin tocar manifests, lockfile ni runtime. Documento:
+    [`frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
   - **PR-CLEAN7C opcional:** revisar tooling ESLint (`@eslint/eslintrc` y
     dependencia directa `@next/eslint-plugin-next`) sólo si `lint` confirma que
-    son prescindibles.
+    son prescindibles. Mantener como `UNKNOWN keep` si hay fallo o duda de
+    resolución.
+  - **PR-CLEAN7D opcional:** tratar Radix por grupos. Candidatos
+    `SUSPECT unused`: `avatar`, `dropdown-menu`, `label`, `select`, `tabs`.
+    Mantener `toast`/`tooltip` como `DEFER keep` mientras siga vigente el
+    roadmap de dashboard premium; si se descarta, eliminarlos en PR separado.
 - **Validación:** `pnpm install`; `pnpm --dir frontend lint`; `pnpm --dir frontend typecheck`;
   `pnpm --dir frontend build`; E2E (`e2e:smoke`,`e2e:admin-mobile`,`e2e:visual-contract`,`e2e:public-clinic`).
 - **Rollback:** revertir el PR (restaura deps + lock).
@@ -1071,8 +1089,9 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
 - [~] PR-CLEAN6 (dead-code/artefactos): porción `shared/` (P2-A) ejecutada
   (rama `clean/remove-dead-shared-module`); artefactos P3 (`legacy/drizzle-old/`,
   `generate-pwa-icons.py`, `FUSION_POR_COMANDO.sh`) pendientes.
-- [~] PR-CLEAN7 (deps sin uso): PR-CLEAN7A ejecutado; Radix no usados,
-  tooling `UNKNOWN` y E2E completa siguen pendientes.
+- [~] PR-CLEAN7 (deps sin uso): PR-CLEAN7A ejecutado; PR-CLEAN7B docs-only
+  completado; quedan decisiones opcionales PR-CLEAN7C tooling y PR-CLEAN7D
+  Radix por grupos, más E2E completa si se toca manifest/lock.
 - [ ] `.env.example` y `frontend/.env.example` documentan **todas** las vars usadas.
 - [ ] `docs/notes/todo.md` ya no contradice la arquitectura real.
 - [ ] Taxonomía `docs/` unificada (sin `audit`+`audits`, sin `pr-*.md` sueltos).

--- a/docs/audit/frontend-dependencies-usage-audit.md
+++ b/docs/audit/frontend-dependencies-usage-audit.md
@@ -62,7 +62,7 @@ Lectura aplicada:
 
 | Paquete | Clasificación | Evidencia principal | Nota |
 | --- | --- | --- | --- |
-| `@radix-ui/react-avatar` | SUSPECT unused | Solo `frontend/package.json` y `test/package-scripts-contract.test.ts` | Sin import directo ni componente local `Avatar`. |
+| `@radix-ui/react-avatar` | SUSPECT unused | Solo `frontend/package.json` y `test/package-scripts-contract.test.ts` | Sin import directo ni componente local `Avatar`; confirmado post-PR-CLEAN7A. |
 | `@radix-ui/react-dialog` | LIVE runtime | `frontend/src/app/dashboard/admin/ClinicEditDrawer.tsx:4`; `frontend/src/components/dashboard/ModuleDialog.tsx:4` | Usado para drawer/dialog. |
 | `@radix-ui/react-dropdown-menu` | SUSPECT unused | Solo manifest/test de manifest; docs históricas | Sin import directo. |
 | `@radix-ui/react-label` | SUSPECT unused | Solo manifest/test de manifest | Sin import directo. |
@@ -70,8 +70,8 @@ Lectura aplicada:
 | `@radix-ui/react-separator` | LIVE runtime | `frontend/src/components/ui/separator.tsx:4` | Primitiva UI usada. |
 | `@radix-ui/react-slot` | LIVE runtime | `frontend/src/components/ui/button.tsx:2` | Primitiva `Button asChild`. |
 | `@radix-ui/react-tabs` | SUSPECT unused | Solo manifest/test de manifest | El dashboard usa `ModuleTabs` propio, no Radix Tabs. |
-| `@radix-ui/react-toast` | SUSPECT unused | Solo manifest/test de manifest; docs proponen adoptarlo | No hay provider/componente toast runtime. |
-| `@radix-ui/react-tooltip` | SUSPECT unused | Solo manifest/test de manifest; docs proponen adoptarlo | Confirma y amplía el P2-B rector. |
+| `@radix-ui/react-toast` | DEFER keep por roadmap/estandarización UI | Solo manifest/test de manifest; docs proponen adoptarlo | No hay provider/componente toast runtime, pero hay roadmap explícito en `docs/audit-premium-dashboard-interaction-value.md`. |
+| `@radix-ui/react-tooltip` | DEFER keep por roadmap/estandarización UI | Solo manifest/test de manifest; docs proponen adoptarlo | No hay provider/componente tooltip runtime, pero hay roadmap explícito en `docs/audit-premium-dashboard-interaction-value.md`. |
 | `@tanstack/react-query` | SUSPECT unused | Solo manifest/test de manifest y docs históricas | Sin `QueryClient`, `useQuery`, `useMutation` ni imports. |
 | `@tanstack/react-table` | SUSPECT unused | Tests verifican que no se importe; manifest/test de manifest | Sin `useReactTable`; guardrails lo prohíben en layout/públicas. |
 | `class-variance-authority` | LIVE runtime | `frontend/src/components/ui/badge.tsx:2`; `frontend/src/components/ui/button.tsx:3` | Usado por variantes UI. |
@@ -92,8 +92,8 @@ Lectura aplicada:
 
 | Paquete | Clasificación | Evidencia principal | Nota |
 | --- | --- | --- | --- |
-| `@eslint/eslintrc` | UNKNOWN needs manual verification | `pnpm --dir frontend why` muestra dependencia directa solamente | No hay import directo en `eslint.config.mjs`; validar con PR dedicado si se quiere remover. |
-| `@next/eslint-plugin-next` | UNKNOWN needs manual verification | Directa `16.2.7` y transitiva `16.2.9` vía `eslint-config-next` | Posible duplicado/version skew; no tocar sin lint verde. |
+| `@eslint/eslintrc` | UNKNOWN keep | `corepack pnpm --dir frontend why` muestra dependencia directa solamente | No hay import directo en `eslint.config.mjs`; validar con PR tooling dedicado si se quiere remover. |
+| `@next/eslint-plugin-next` | UNKNOWN keep | Directa `16.2.7` y transitiva `16.2.9` vía `eslint-config-next` | Posible duplicado/version skew; no tocar sin lint verde. |
 | `@playwright/test` | LIVE tests | 70+ imports en `frontend/e2e/*.spec.ts`; `frontend/playwright.config.ts:1` | Tooling E2E activo. |
 | `@tailwindcss/postcss` | LIVE build/config/tooling | `frontend/postcss.config.mjs:4` | Plugin PostCSS de Tailwind 4. |
 | `@types/node` | LIVE build/config/tooling | TS/config usa APIs Node en configs (`createRequire`, `process`) | Tipos necesarios para configs y e2e. |
@@ -250,7 +250,13 @@ Antes de moverlo/removerlo hay que revisar si debe vivir en root, frontend o amb
 
 ## 6. Recomendación concreta para el siguiente PR
 
-Siguiente PR recomendado: **PR-CLEAN7A · frontend deps pesadas sin uso**.
+> **Actualización 2026-06-29:** PR-CLEAN7A ya fue ejecutado y mergeado como
+> `1ac86d0 chore(frontend): remove unused core dependencies (#1175)`. El
+> remanente P2-B queda auditado en
+> [`frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
+
+Siguiente PR recomendado originalmente: **PR-CLEAN7A · frontend deps pesadas sin
+uso**.
 
 Alcance propuesto:
 
@@ -266,6 +272,18 @@ Motivo: es el grupo más claro, con evidencia reiterada en auditorías previas,
 guardrails explícitos de no-import para `echarts`/`react-table` y bajo riesgo de
 UX inmediato. Radix conviene tratarlo después porque hay documentos que proponen
 adoptar `toast`/`tooltip`.
+
+Recomendación post-PR-CLEAN7A:
+
+- **PR-CLEAN7B:** docs-only audit del remanente Radix/tooling; no tocar
+  manifests ni runtime.
+- **PR-CLEAN7C:** tooling ESLint únicamente (`@eslint/eslintrc` y directa
+  `@next/eslint-plugin-next`), si Nico autoriza cambio de dependencias y con
+  `pnpm --dir frontend lint` antes/después.
+- **PR-CLEAN7D:** Radix por grupos. Candidatos `SUSPECT unused`:
+  `avatar`, `dropdown-menu`, `label`, `select`, `tabs`. Mantener
+  `toast`/`tooltip` como `DEFER keep` mientras siga vigente el roadmap de
+  dashboard premium.
 
 ---
 
@@ -296,3 +314,23 @@ Cambios de alcance PR-CLEAN7A:
   exigían esas 5 dependencias.
 - No se tocaron Radix, dependencias `UNKNOWN`, runtime frontend/backend, DB,
   migraciones, workflows, Render ni secrets.
+
+## 9. Nota final PR-CLEAN7B
+
+**Estado:** auditoría docs-only completada el 2026-06-29 en la rama
+`audit/frontend-dependencies-radix-tooling`, base HEAD `1ac86d0`.
+
+Documento dedicado:
+[`docs/audit/frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
+
+Clasificación remanente:
+
+- `SUSPECT unused`: `@radix-ui/react-avatar`,
+  `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`,
+  `@radix-ui/react-select`, `@radix-ui/react-tabs`.
+- `DEFER keep por roadmap/estandarización UI`: `@radix-ui/react-toast`,
+  `@radix-ui/react-tooltip`.
+- `UNKNOWN keep`: `@eslint/eslintrc`, `@next/eslint-plugin-next`.
+
+No se modificaron `frontend/package.json`, `pnpm-lock.yaml`, runtime
+frontend/backend, DB, migraciones, workflows, Render ni secrets.

--- a/docs/audit/frontend-radix-tooling-dependencies-audit.md
+++ b/docs/audit/frontend-radix-tooling-dependencies-audit.md
@@ -1,0 +1,186 @@
+# Auditoría P2-B remanente · Radix y tooling frontend
+
+> **Modo:** auditoría documental y técnica / docs-only.
+> **Fecha:** 2026-06-29.
+> **Scope:** remanente P2-B posterior a PR-CLEAN7A:
+> `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`,
+> `@radix-ui/react-label`, `@radix-ui/react-select`,
+> `@radix-ui/react-tabs`, `@radix-ui/react-toast`,
+> `@radix-ui/react-tooltip`, `@eslint/eslintrc`,
+> `@next/eslint-plugin-next`.
+> **No se modificó:** `frontend/package.json`, `pnpm-lock.yaml`, runtime
+> frontend, runtime backend, DB, migraciones, workflows, Render ni secrets.
+
+---
+
+## 1. Estado base
+
+| Ítem | Observado |
+| --- | --- |
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama | `audit/frontend-dependencies-radix-tooling` |
+| HEAD | `1ac86d0 chore(frontend): remove unused core dependencies (#1175)` |
+| Working tree inicial | limpio |
+| PRs abiertos | no verificado por `gh`; el protocolo local no autoriza comandos `gh` en esta auditoría |
+
+Documentos rectores leídos:
+
+- `docs/audit/final-repo-cleanup-engineering-audit.md`
+- `docs/audit/frontend-dependencies-usage-audit.md`
+- `docs/implementation/frontend-unused-deps-clean7a.md`
+
+`frontend/package.json` post-PR-CLEAN7A declara 20 `dependencies` y 12
+`devDependencies`. Las cinco dependencias core removidas por PR-CLEAN7A ya no
+están presentes. Radix remanente y tooling `UNKNOWN` siguen declarados.
+
+---
+
+## 2. Método reproducible
+
+Comandos principales:
+
+```powershell
+git status --short --untracked-files=all
+git branch --show-current
+git log -1 --oneline
+Get-Content -Raw frontend/package.json
+
+git grep -n "@radix-ui/react-avatar\|@radix-ui/react-dropdown-menu\|@radix-ui/react-label\|@radix-ui/react-select\|@radix-ui/react-tabs\|@radix-ui/react-toast\|@radix-ui/react-tooltip\|@eslint/eslintrc\|@next/eslint-plugin-next" -- frontend test scripts docs package.json frontend/package.json
+
+rg -n '@radix-ui/react-(avatar|dropdown-menu|label|select|tabs|toast|tooltip)|@eslint/eslintrc|@next/eslint-plugin-next' frontend/src frontend/e2e frontend/eslint.config.mjs frontend/next.config.ts frontend/package.json test/helpers/clean7a-dependency-cleanup-scope.ts test/package-scripts-contract.test.ts
+
+rg -n 'from [''"](@radix-ui/react-avatar|@radix-ui/react-dropdown-menu|@radix-ui/react-label|@radix-ui/react-select|@radix-ui/react-tabs|@radix-ui/react-toast|@radix-ui/react-tooltip|@eslint/eslintrc|@next/eslint-plugin-next)[''"]' frontend test scripts docs package.json frontend/package.json
+rg -n 'require\([''"](@radix-ui/react-avatar|@radix-ui/react-dropdown-menu|@radix-ui/react-label|@radix-ui/react-select|@radix-ui/react-tabs|@radix-ui/react-toast|@radix-ui/react-tooltip|@eslint/eslintrc|@next/eslint-plugin-next)[''"]\)' frontend test scripts docs package.json frontend/package.json
+rg -n 'import\([''"](@radix-ui/react-avatar|@radix-ui/react-dropdown-menu|@radix-ui/react-label|@radix-ui/react-select|@radix-ui/react-tabs|@radix-ui/react-toast|@radix-ui/react-tooltip|@eslint/eslintrc|@next/eslint-plugin-next)[''"]\)' frontend test scripts docs package.json frontend/package.json
+
+corepack pnpm --dir frontend why @eslint/eslintrc
+corepack pnpm --dir frontend why @next/eslint-plugin-next
+```
+
+Lectura aplicada:
+
+- `frontend/package.json` y `pnpm-lock.yaml` prueban declaración, no uso.
+- `test/package-scripts-contract.test.ts` prueba contrato del manifest, no uso
+  runtime.
+- `test/helpers/clean7a-dependency-cleanup-scope.ts` prueba que PR-CLEAN7A
+  preservó Radix y `UNKNOWN`, no que estén vivos.
+- `docs/**` se considera referencia histórica, auditoría o roadmap; no uso
+  runtime.
+- Imports `from`, `require()` o `import()` en `frontend/src`, `frontend/e2e`,
+  configs o scripts sí contarían como uso real.
+
+---
+
+## 3. Evidencia por paquete
+
+| Paquete | Evidencia técnica | Roadmap/docs | Clasificación |
+| --- | --- | --- | --- |
+| `@radix-ui/react-avatar` | `frontend/package.json`, `pnpm-lock.yaml`, `test/package-scripts-contract.test.ts`, `test/helpers/clean7a-dependency-cleanup-scope.ts`; 0 imports `from`/`require`/`import()` | Sin adopción funcional detectada; menciones de auditoría | `SUSPECT unused` |
+| `@radix-ui/react-dropdown-menu` | Manifest/lock/test/helper; 0 imports reales | Doc histórico de bump #1027; no roadmap funcional vigente | `SUSPECT unused` |
+| `@radix-ui/react-label` | Manifest/lock/test/helper; 0 imports reales | Sin adopción funcional detectada | `SUSPECT unused` |
+| `@radix-ui/react-select` | Manifest/lock/test/helper; 0 imports reales | Sin adopción funcional detectada | `SUSPECT unused` |
+| `@radix-ui/react-tabs` | Manifest/lock/test/helper; 0 imports reales; UI actual usa `ModuleTabs` propio | Sin adopción funcional detectada | `SUSPECT unused` |
+| `@radix-ui/react-toast` | Manifest/lock/test/helper; 0 imports reales | `docs/audit-premium-dashboard-interaction-value.md` propone adoptar `ui/toast.tsx` + provider dashboard | `DEFER keep por roadmap/estandarización UI` |
+| `@radix-ui/react-tooltip` | Manifest/lock/test/helper; 0 imports reales | `docs/audit-premium-dashboard-interaction-value.md` propone adoptar `ui/tooltip.tsx` y reemplazar `title=` en sidebar | `DEFER keep por roadmap/estandarización UI` |
+| `@eslint/eslintrc` | Manifest/lock/test; 0 imports en `frontend/eslint.config.mjs`; `corepack pnpm --dir frontend why` lo muestra como dependencia directa solamente | Sin roadmap funcional; tooling | `UNKNOWN keep` |
+| `@next/eslint-plugin-next` | Manifest/lock/helper; 0 import directo en config; `eslint-config-next@16.2.9` lo trae transitivamente como `16.2.9`; directa está fijada en `16.2.7` | Posible duplicado/version skew; tooling | `UNKNOWN keep` |
+
+Resultado de patrones de carga:
+
+```text
+rg "from ... paquete"    -> 0 resultados
+rg "require(...)"        -> 0 resultados
+rg "import(...)"         -> 0 resultados
+```
+
+Resultado de configs:
+
+```text
+frontend/eslint.config.mjs -> importa `eslint-config-next/core-web-vitals`, no `@eslint/eslintrc` ni `@next/eslint-plugin-next`
+frontend/next.config.ts    -> importa `next`, no los paquetes auditados
+```
+
+Resultado de `pnpm why`:
+
+```text
+@eslint/eslintrc
+-> devDependency directa solamente
+
+@next/eslint-plugin-next
+-> devDependency directa 16.2.7
+-> transitiva 16.2.9 vía eslint-config-next 16.2.9
+```
+
+---
+
+## 4. Clasificación final
+
+| Clasificación | Paquetes | Decisión |
+| --- | --- | --- |
+| `LIVE` | ninguno dentro del scope remanente | No hay imports reales ni config directa. |
+| `SUSPECT unused` | `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`, `@radix-ui/react-select`, `@radix-ui/react-tabs` | Candidatos a eliminación futura en PR chico, si Nico decide no preservarlos como estándar UI. |
+| `UNKNOWN keep` | `@eslint/eslintrc`, `@next/eslint-plugin-next` | Mantener hasta PR tooling dedicado que pruebe lint antes/después sin tocar runtime. |
+| `DEFER keep por roadmap/estandarización UI` | `@radix-ui/react-toast`, `@radix-ui/react-tooltip` | Mantener por ahora por roadmap explícito de dashboard premium; decidir en PR de UI o cerrar como eliminación si se descarta el roadmap. |
+
+---
+
+## 5. Recomendación de PRs chicos
+
+### PR-CLEAN7B · docs-only audit
+
+**Recomendado como este cierre documental.**
+
+- Documentar evidencia remanente P2-B.
+- No modificar manifest, lockfile ni runtime.
+- Dejar estrategia de eliminación/adopción explícita.
+
+### PR-CLEAN7C · tooling ESLint
+
+**Recomendado sólo si Nico autoriza cambio de dependencias.**
+
+- Alcance único: `@eslint/eslintrc` y dependencia directa
+  `@next/eslint-plugin-next`.
+- Hipótesis: `@eslint/eslintrc` podría no ser necesario en flat config actual;
+  `@next/eslint-plugin-next` directa parece duplicada por `eslint-config-next`,
+  con version skew `16.2.7` vs `16.2.9`.
+- Validación obligatoria: `pnpm --dir frontend lint` antes/después,
+  `pnpm --dir frontend typecheck`, `pnpm --dir frontend build`, `pnpm test`.
+- Si falla lint o resolución de config, revertir y cerrar como `UNKNOWN keep`.
+
+### PR-CLEAN7D · Radix por grupos
+
+**No mezclar con tooling.**
+
+Orden sugerido:
+
+1. Eliminar sólo `avatar`, `dropdown-menu`, `label`, `select`, `tabs` si se
+   confirma que no forman parte del estándar UI próximo.
+2. Mantener `toast` y `tooltip` como `DEFER keep` hasta ejecutar o descartar el
+   roadmap `docs/audit-premium-dashboard-interaction-value.md`.
+3. Si se descarta ese roadmap, eliminar `toast` y `tooltip` en PR separado.
+4. Si se adopta, crear `ui/toast.tsx` / `ui/tooltip.tsx` en un PR de UI con
+   tests a11y, sin mezclar limpieza de manifest.
+
+---
+
+## 6. Riesgo residual
+
+- Riesgo principal: `test/package-scripts-contract.test.ts` y guardrails de
+  scope fijan que Radix y `UNKNOWN` existan; cualquier eliminación futura debe
+  actualizar esos tests en el mismo PR.
+- `@next/eslint-plugin-next` tiene duplicidad directa/transitiva; eliminar la
+  directa puede ser correcto, pero debe probarse con lint real.
+- `toast`/`tooltip` no están vivos hoy, pero sí tienen roadmap funcional
+  explícito. Borrarlos sin decisión de producto puede crear churn.
+
+---
+
+## 7. Estado final
+
+- Auditoría P2-B remanente completada.
+- No se eliminó ninguna dependencia.
+- No se modificó `frontend/package.json`.
+- No se modificó `pnpm-lock.yaml`.
+- No se tocó runtime frontend/backend, DB, migraciones, workflows, Render ni
+  secrets.
+- No commit, no push, no PR.


### PR DESCRIPTION
PR-CLEAN7B docs-only audit for the remaining P2-B frontend dependency cleanup scope after PR-CLEAN7A.

Scope:
- Audits remaining Radix suspects:
  - @radix-ui/react-avatar
  - @radix-ui/react-dropdown-menu
  - @radix-ui/react-label
  - @radix-ui/react-select
  - @radix-ui/react-tabs
  - @radix-ui/react-toast
  - @radix-ui/react-tooltip
- Audits remaining UNKNOWN tooling:
  - @eslint/eslintrc
  - @next/eslint-plugin-next
- Adds a dedicated audit document:
  - docs/audit/frontend-radix-tooling-dependencies-audit.md
- Updates the existing cleanup/audit docs with the final classification and next-PR strategy.

Classification:
- SUSPECT unused:
  - @radix-ui/react-avatar
  - @radix-ui/react-dropdown-menu
  - @radix-ui/react-label
  - @radix-ui/react-select
  - @radix-ui/react-tabs
- DEFER keep by roadmap/UI standardization:
  - @radix-ui/react-toast
  - @radix-ui/react-tooltip
- UNKNOWN keep:
  - @eslint/eslintrc
  - @next/eslint-plugin-next
- LIVE:
  - none among the remaining audited packages.

Evidence:
- No real runtime/test/script import, require, or dynamic import found for the 9 audited packages.
- toast/tooltip have explicit roadmap references in docs/audit-premium-dashboard-interaction-value.md.
- @next/eslint-plugin-next remains direct and also appears transitively through eslint-config-next, so tooling is deferred to a dedicated PR.

Preserved scope:
- Docs-only.
- No frontend/package.json changes.
- No pnpm-lock.yaml changes.
- No root package.json changes.
- No frontend runtime changes.
- No backend runtime changes.
- No DB/migration/workflow/Render/secrets changes.

Validation:
- Direct pnpm wrapper aborted before scripts due ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY.
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm security:public-surface passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.

Recommended follow-ups:
- PR-CLEAN7C: tooling ESLint only, if dependency changes are authorized.
- PR-CLEAN7D: Radix cleanup by groups, starting with avatar/dropdown-menu/label/select/tabs; keep toast/tooltip deferred unless explicitly authorized.
