### PR TITLE
chore(frontend): remove redundant eslint tooling deps

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -284,8 +284,9 @@ deploy roto ni auth rota en el estado actual.
 - **Riesgo de eliminación:** `test/package-scripts-contract.test.ts` fija varias
   dependencias como contrato de manifest; cualquier PR de eliminación debe
   actualizar ese test junto con `frontend/package.json` y `pnpm-lock.yaml`.
-  `@eslint/eslintrc` y la dependencia directa `@next/eslint-plugin-next` quedan
-  como `UNKNOWN needs manual verification`, no como eliminación de runtime.
+  PR-CLEAN7C cerró el remanente tooling: `@eslint/eslintrc` y la dependencia
+  directa `@next/eslint-plugin-next` fueron eliminadas de forma acotada tras
+  validar `lint`; no eran eliminación de runtime.
 - **Impacto:** no inflan el bundle servido (Next no las bundlea si no se importan)
   pero sí el `node_modules`, tiempo de install, superficie de `pnpm audit` y ruido
   de actualizaciones. `echarts` en especial es pesado.
@@ -313,9 +314,22 @@ deploy roto ni auth rota en el estado actual.
   `@radix-ui/react-tabs` quedan `SUSPECT unused`; `@radix-ui/react-toast` y
   `@radix-ui/react-tooltip` quedan `DEFER keep` por roadmap explícito de
   dashboard premium; `@eslint/eslintrc` y la dependencia directa
-  `@next/eslint-plugin-next` quedan `UNKNOWN keep` para PR tooling dedicado.
+  `@next/eslint-plugin-next` fueron resueltas luego por PR-CLEAN7C.
   No se tocaron `frontend/package.json`, `pnpm-lock.yaml`, runtime
-  frontend/backend, DB, migraciones, workflows, Render ni secrets.
+  frontend/backend, DB, migraciones, workflows, Render ni secrets en PR-CLEAN7B.
+- **Estado PR-CLEAN7C / tooling ESLint:** **EJECUTADO** (2026-06-29, rama
+  `clean/frontend-eslint-tooling-deps`, base HEAD `7626865`). Se removieron sólo
+  `@eslint/eslintrc` y la dependencia directa `@next/eslint-plugin-next` de
+  `frontend/package.json` con
+  `corepack pnpm --dir frontend remove @eslint/eslintrc @next/eslint-plugin-next`,
+  regenerando `pnpm-lock.yaml`. La decisión se basó en que no existe uso de
+  `FlatCompat` ni import de `@eslint/eslintrc` en `frontend/eslint.config.mjs`,
+  y en que `eslint-config-next@16.2.9` ya trae transitivamente
+  `@next/eslint-plugin-next@16.2.9`. Se actualizó
+  `test/package-scripts-contract.test.ts` y el guard histórico
+  `test/helpers/clean7a-dependency-cleanup-scope.ts`. No se tocó Radix, runtime
+  frontend/backend, DB, migraciones, workflows, Render, secrets ni
+  `package.json` raíz.
 
 #### P2-C · `docs/notes/todo.md` contradictorio con la arquitectura actual
 - **Tipo:** docs · **Riesgo:** Bajo.
@@ -402,7 +416,7 @@ deploy roto ni auth rota en el estado actual.
 | `legacy/drizzle-old/*` | "archaeology only" (su README) | P3 | Bajo | archivar/eliminar | PR-CLEAN6 |
 | `scripts/generate-pwa-icons.py` | 0 refs; Python prohibido | P3 | Bajo | eliminar | PR-CLEAN6 |
 | `scripts/maintenance/FUSION_POR_COMANDO.sh` | 0 refs; fusión histórica | P3 | Bajo | eliminar | PR-CLEAN6 |
-| `frontend/package.json` (Radix/tooling remanente) | 0 imports reales para los 9 paquetes auditados; `toast`/`tooltip` tienen roadmap, tooling queda `UNKNOWN` | P2 | Medio | docs cerrados; decidir PR-CLEAN7C/7D | PR-CLEAN7 |
+| `frontend/package.json` (Radix remanente) | Tooling ESLint cerrado por PR-CLEAN7C; Radix tiene 0 imports reales, con `toast`/`tooltip` en roadmap | P2 | Medio | decidir PR-CLEAN7D | PR-CLEAN7 |
 | `docs/notes/todo.md` | tRPC/Google Sheets inexistentes | P2 | Bajo | archivar/reescribir | PR-CLEAN1 |
 | `docs/audit/` + `docs/audits/` | taxonomía duplicada | P2 | Bajo | unificar | PR-CLEAN2 |
 | `IMPLEMENTATION_NOTES/` (raíz, 34) | notas en 3 ubicaciones | P2 | Bajo | consolidar bajo `docs/` | PR-CLEAN2 |
@@ -1017,10 +1031,9 @@ exige build+E2E). El resto está saludable.
   - **PR-CLEAN7B (AUDITORÍA DOCS-ONLY COMPLETADA 2026-06-29):** auditar
     remanente Radix/tooling sin tocar manifests, lockfile ni runtime. Documento:
     [`frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
-  - **PR-CLEAN7C opcional:** revisar tooling ESLint (`@eslint/eslintrc` y
-    dependencia directa `@next/eslint-plugin-next`) sólo si `lint` confirma que
-    son prescindibles. Mantener como `UNKNOWN keep` si hay fallo o duda de
-    resolución.
+  - **PR-CLEAN7C (EJECUTADO 2026-06-29):** remover tooling ESLint directo
+    `@eslint/eslintrc` y dependencia directa `@next/eslint-plugin-next`, con
+    lint antes/después y validaciones completas.
   - **PR-CLEAN7D opcional:** tratar Radix por grupos. Candidatos
     `SUSPECT unused`: `avatar`, `dropdown-menu`, `label`, `select`, `tabs`.
     Mantener `toast`/`tooltip` como `DEFER keep` mientras siga vigente el
@@ -1090,7 +1103,7 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
   (rama `clean/remove-dead-shared-module`); artefactos P3 (`legacy/drizzle-old/`,
   `generate-pwa-icons.py`, `FUSION_POR_COMANDO.sh`) pendientes.
 - [~] PR-CLEAN7 (deps sin uso): PR-CLEAN7A ejecutado; PR-CLEAN7B docs-only
-  completado; quedan decisiones opcionales PR-CLEAN7C tooling y PR-CLEAN7D
+  completado; PR-CLEAN7C tooling ejecutado; queda decisión opcional PR-CLEAN7D
   Radix por grupos, más E2E completa si se toca manifest/lock.
 - [ ] `.env.example` y `frontend/.env.example` documentan **todas** las vars usadas.
 - [ ] `docs/notes/todo.md` ya no contradice la arquitectura real.

--- a/docs/audit/frontend-dependencies-usage-audit.md
+++ b/docs/audit/frontend-dependencies-usage-audit.md
@@ -92,8 +92,8 @@ Lectura aplicada:
 
 | Paquete | Clasificación | Evidencia principal | Nota |
 | --- | --- | --- | --- |
-| `@eslint/eslintrc` | UNKNOWN keep | `corepack pnpm --dir frontend why` muestra dependencia directa solamente | No hay import directo en `eslint.config.mjs`; validar con PR tooling dedicado si se quiere remover. |
-| `@next/eslint-plugin-next` | UNKNOWN keep | Directa `16.2.7` y transitiva `16.2.9` vía `eslint-config-next` | Posible duplicado/version skew; no tocar sin lint verde. |
+| `@eslint/eslintrc` | REMOVED en PR-CLEAN7C | `corepack pnpm --dir frontend why` mostraba dependencia directa solamente | Sin `FlatCompat` ni import directo en `eslint.config.mjs`; lint pasó antes/después de remover. |
+| `@next/eslint-plugin-next` | REMOVED directo en PR-CLEAN7C | Directa `16.2.7` y transitiva `16.2.9` vía `eslint-config-next` | La directa era redundante; permanece la transitiva de `eslint-config-next`. |
 | `@playwright/test` | LIVE tests | 70+ imports en `frontend/e2e/*.spec.ts`; `frontend/playwright.config.ts:1` | Tooling E2E activo. |
 | `@tailwindcss/postcss` | LIVE build/config/tooling | `frontend/postcss.config.mjs:4` | Plugin PostCSS de Tailwind 4. |
 | `@types/node` | LIVE build/config/tooling | TS/config usa APIs Node en configs (`createRequire`, `process`) | Tipos necesarios para configs y e2e. |
@@ -224,9 +224,10 @@ pnpm --dir frontend why @next/eslint-plugin-next
 -> directa 16.2.7 y transitiva 16.2.9 por eslint-config-next
 ```
 
-Interpretación: ambos son candidatos de auditoría de tooling, no de eliminación
-junto con runtime deps. `@next/eslint-plugin-next` muestra posible duplicado,
-pero remover la directa puede depender de cómo resuelva ESLint/Next el plugin.
+Interpretación post-PR-CLEAN7C: ambos candidatos de tooling fueron eliminados
+de forma acotada tras validar `lint`. `@eslint/eslintrc` no era necesario por
+`FlatCompat`; `@next/eslint-plugin-next` directo era redundante porque
+`eslint-config-next@16.2.9` conserva su dependencia transitiva.
 
 ---
 
@@ -240,7 +241,7 @@ eliminación.
 | --- | --- | --- | --- |
 | Charts/table/query/forms | `@tanstack/react-query`, `@tanstack/react-table`, `echarts`, `echarts-for-react`, `react-hook-form` | Medio: cambio en manifest/lock y test de contrato; `echarts` pesado pero no importado | `pnpm install`; `pnpm --dir frontend lint`; `pnpm --dir frontend typecheck`; `pnpm --dir frontend build`; E2E frontend relevante |
 | Radix no usados | `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`, `@radix-ui/react-select`, `@radix-ui/react-tabs`, `@radix-ui/react-toast`, `@radix-ui/react-tooltip` | Medio-bajo: posible roadmap UX pendiente; test de contrato debe actualizarse | Mismas validaciones + revisar docs/roadmap antes de borrar |
-| Tooling ESLint | `@eslint/eslintrc`, directa `@next/eslint-plugin-next` | Medio: puede romper `pnpm --dir frontend lint` por resolución de plugin/config | PR separado, sólo tooling; lint antes/después |
+| Tooling ESLint | `@eslint/eslintrc`, directa `@next/eslint-plugin-next` | Cerrado por PR-CLEAN7C | Removidos con pnpm; lint antes/después verde. |
 
 `zod` queda fuera de candidatos por ahora: está en el manifest frontend, pero el
 uso detectado está en tests raíz (`api-contract-smoke`, `production-env-contracts`).
@@ -278,8 +279,8 @@ Recomendación post-PR-CLEAN7A:
 - **PR-CLEAN7B:** docs-only audit del remanente Radix/tooling; no tocar
   manifests ni runtime.
 - **PR-CLEAN7C:** tooling ESLint únicamente (`@eslint/eslintrc` y directa
-  `@next/eslint-plugin-next`), si Nico autoriza cambio de dependencias y con
-  `pnpm --dir frontend lint` antes/después.
+  `@next/eslint-plugin-next`) ejecutado el 2026-06-29. Se removieron ambas
+  entradas directas de `frontend/package.json` y se regeneró `pnpm-lock.yaml`.
 - **PR-CLEAN7D:** Radix por grupos. Candidatos `SUSPECT unused`:
   `avatar`, `dropdown-menu`, `label`, `select`, `tabs`. Mantener
   `toast`/`tooltip` como `DEFER keep` mientras siga vigente el roadmap de
@@ -330,7 +331,36 @@ Clasificación remanente:
   `@radix-ui/react-select`, `@radix-ui/react-tabs`.
 - `DEFER keep por roadmap/estandarización UI`: `@radix-ui/react-toast`,
   `@radix-ui/react-tooltip`.
-- `UNKNOWN keep`: `@eslint/eslintrc`, `@next/eslint-plugin-next`.
+- `REMOVED en PR-CLEAN7C`: `@eslint/eslintrc`, dependencia directa
+  `@next/eslint-plugin-next`.
 
 No se modificaron `frontend/package.json`, `pnpm-lock.yaml`, runtime
 frontend/backend, DB, migraciones, workflows, Render ni secrets.
+
+## 10. Nota final PR-CLEAN7C
+
+**Estado:** ejecutado el 2026-06-29 en la rama
+`clean/frontend-eslint-tooling-deps`, base HEAD `7626865`.
+
+Se eliminaron únicamente las dependencias directas de tooling ESLint
+`@eslint/eslintrc` y `@next/eslint-plugin-next` con
+`corepack pnpm --dir frontend remove @eslint/eslintrc @next/eslint-plugin-next`.
+
+Decisiones:
+
+- `@eslint/eslintrc`: removido porque no hay `FlatCompat` en
+  `frontend/eslint.config.mjs`, no hay imports directos y `why` lo mostró como
+  dependencia directa solamente.
+- `@next/eslint-plugin-next`: removida la directa porque
+  `eslint-config-next@16.2.9` ya aporta `@next/eslint-plugin-next@16.2.9`
+  transitivamente.
+
+Cambios de alcance PR-CLEAN7C:
+
+- `frontend/package.json`: removidas sólo esas dos devDependencies directas.
+- `pnpm-lock.yaml`: lockfile regenerado por pnpm.
+- `test/package-scripts-contract.test.ts`: dejó de exigir `@eslint/eslintrc`.
+- `test/helpers/clean7a-dependency-cleanup-scope.ts`: actualizó el guard
+  histórico para aceptar que CLEAN7C removió las dos dependencias `UNKNOWN`.
+- No se tocó Radix, runtime frontend/backend, DB, migraciones, workflows,
+  Render, secrets ni `package.json` raíz.

--- a/docs/audit/frontend-radix-tooling-dependencies-audit.md
+++ b/docs/audit/frontend-radix-tooling-dependencies-audit.md
@@ -82,8 +82,8 @@ Lectura aplicada:
 | `@radix-ui/react-tabs` | Manifest/lock/test/helper; 0 imports reales; UI actual usa `ModuleTabs` propio | Sin adopción funcional detectada | `SUSPECT unused` |
 | `@radix-ui/react-toast` | Manifest/lock/test/helper; 0 imports reales | `docs/audit-premium-dashboard-interaction-value.md` propone adoptar `ui/toast.tsx` + provider dashboard | `DEFER keep por roadmap/estandarización UI` |
 | `@radix-ui/react-tooltip` | Manifest/lock/test/helper; 0 imports reales | `docs/audit-premium-dashboard-interaction-value.md` propone adoptar `ui/tooltip.tsx` y reemplazar `title=` en sidebar | `DEFER keep por roadmap/estandarización UI` |
-| `@eslint/eslintrc` | Manifest/lock/test; 0 imports en `frontend/eslint.config.mjs`; `corepack pnpm --dir frontend why` lo muestra como dependencia directa solamente | Sin roadmap funcional; tooling | `UNKNOWN keep` |
-| `@next/eslint-plugin-next` | Manifest/lock/helper; 0 import directo en config; `eslint-config-next@16.2.9` lo trae transitivamente como `16.2.9`; directa está fijada en `16.2.7` | Posible duplicado/version skew; tooling | `UNKNOWN keep` |
+| `@eslint/eslintrc` | Antes de PR-CLEAN7C: manifest/lock/test; 0 imports en `frontend/eslint.config.mjs`; `corepack pnpm --dir frontend why` lo mostró como dependencia directa solamente | Sin `FlatCompat`; tooling directo prescindible | `REMOVED en PR-CLEAN7C` |
+| `@next/eslint-plugin-next` | Antes de PR-CLEAN7C: manifest/lock/helper; 0 import directo en config; `eslint-config-next@16.2.9` lo traía transitivamente como `16.2.9`; directa fijada en `16.2.7` | Duplicado/version skew directo | `REMOVED directo en PR-CLEAN7C` |
 
 Resultado de patrones de carga:
 
@@ -119,7 +119,7 @@ Resultado de `pnpm why`:
 | --- | --- | --- |
 | `LIVE` | ninguno dentro del scope remanente | No hay imports reales ni config directa. |
 | `SUSPECT unused` | `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`, `@radix-ui/react-select`, `@radix-ui/react-tabs` | Candidatos a eliminación futura en PR chico, si Nico decide no preservarlos como estándar UI. |
-| `UNKNOWN keep` | `@eslint/eslintrc`, `@next/eslint-plugin-next` | Mantener hasta PR tooling dedicado que pruebe lint antes/después sin tocar runtime. |
+| `REMOVED en PR-CLEAN7C` | `@eslint/eslintrc`, dependencia directa `@next/eslint-plugin-next` | `@eslint/eslintrc` no era necesario por `FlatCompat` ni por grafo transitivo; `@next/eslint-plugin-next` directo era redundante porque `eslint-config-next@16.2.9` lo trae transitivamente. |
 | `DEFER keep por roadmap/estandarización UI` | `@radix-ui/react-toast`, `@radix-ui/react-tooltip` | Mantener por ahora por roadmap explícito de dashboard premium; decidir en PR de UI o cerrar como eliminación si se descarta el roadmap. |
 
 ---
@@ -136,16 +136,22 @@ Resultado de `pnpm why`:
 
 ### PR-CLEAN7C · tooling ESLint
 
-**Recomendado sólo si Nico autoriza cambio de dependencias.**
+**Ejecutado el 2026-06-29 en la rama `clean/frontend-eslint-tooling-deps`.**
 
 - Alcance único: `@eslint/eslintrc` y dependencia directa
   `@next/eslint-plugin-next`.
-- Hipótesis: `@eslint/eslintrc` podría no ser necesario en flat config actual;
-  `@next/eslint-plugin-next` directa parece duplicada por `eslint-config-next`,
-  con version skew `16.2.7` vs `16.2.9`.
-- Validación obligatoria: `pnpm --dir frontend lint` antes/después,
-  `pnpm --dir frontend typecheck`, `pnpm --dir frontend build`, `pnpm test`.
-- Si falla lint o resolución de config, revertir y cerrar como `UNKNOWN keep`.
+- Decisión `@eslint/eslintrc`: eliminado. `frontend/eslint.config.mjs` no usa
+  `FlatCompat`, `corepack pnpm --dir frontend why @eslint/eslintrc` lo mostró
+  como dependencia directa solamente y `lint` pasó antes de la remoción.
+- Decisión `@next/eslint-plugin-next`: eliminada sólo la dependencia directa.
+  `corepack pnpm --dir frontend why @next/eslint-plugin-next` mostró directa
+  `16.2.7` y transitiva `16.2.9` vía `eslint-config-next@16.2.9`.
+- Remoción aplicada con
+  `corepack pnpm --dir frontend remove @eslint/eslintrc @next/eslint-plugin-next`.
+- Se actualizó el contrato de tests que exigía `@eslint/eslintrc` y el helper
+  histórico de CLEAN7A que preservaba ambas dependencias `UNKNOWN`.
+- No se tocó Radix, runtime frontend/backend, DB, migraciones, workflows,
+  Render, secrets ni `package.json` raíz.
 
 ### PR-CLEAN7D · Radix por grupos
 
@@ -165,11 +171,11 @@ Orden sugerido:
 
 ## 6. Riesgo residual
 
-- Riesgo principal: `test/package-scripts-contract.test.ts` y guardrails de
-  scope fijan que Radix y `UNKNOWN` existan; cualquier eliminación futura debe
+- Riesgo principal restante: `test/package-scripts-contract.test.ts` y guardrails
+  de scope siguen fijando Radix; cualquier eliminación futura de Radix debe
   actualizar esos tests en el mismo PR.
-- `@next/eslint-plugin-next` tiene duplicidad directa/transitiva; eliminar la
-  directa puede ser correcto, pero debe probarse con lint real.
+- El riesgo de tooling ESLint se cerró en PR-CLEAN7C con lint antes/después y
+  validaciones completas.
 - `toast`/`tooltip` no están vivos hoy, pero sí tienen roadmap funcional
   explícito. Borrarlos sin decisión de producto puede crear churn.
 
@@ -177,10 +183,11 @@ Orden sugerido:
 
 ## 7. Estado final
 
-- Auditoría P2-B remanente completada.
-- No se eliminó ninguna dependencia.
-- No se modificó `frontend/package.json`.
-- No se modificó `pnpm-lock.yaml`.
+- Auditoría P2-B remanente actualizada post-PR-CLEAN7C.
+- Se eliminaron sólo `@eslint/eslintrc` y la dependencia directa
+  `@next/eslint-plugin-next`.
+- `frontend/package.json` y `pnpm-lock.yaml` cambiaron sólo por esa remoción
+  vía pnpm.
 - No se tocó runtime frontend/backend, DB, migraciones, workflows, Render ni
   secrets.
 - No commit, no push, no PR.

--- a/docs/implementation/frontend-eslint-tooling-clean7c.md
+++ b/docs/implementation/frontend-eslint-tooling-clean7c.md
@@ -1,0 +1,117 @@
+# PR-CLEAN7C · frontend ESLint tooling dependencies
+
+## Estado base
+
+- Repo: `C:\PORTAL-VETNEB`.
+- Rama: `clean/frontend-eslint-tooling-deps`.
+- HEAD: `7626865 docs(audit): audit remaining frontend dependencies (#1176)`.
+- Working tree inicial: limpio.
+
+## Scope incluido
+
+- Analizar sólo `@eslint/eslintrc` y la dependencia directa
+  `@next/eslint-plugin-next` en `frontend/package.json`.
+- Remover dependencias directas de tooling ESLint sólo si la evidencia y `lint`
+  lo permiten.
+- Regenerar `pnpm-lock.yaml` con pnpm.
+- Ajustar contratos de test que exigían explícitamente los paquetes removidos.
+- Actualizar documentación rectora en `docs/audit`.
+
+## Scope excluido
+
+- Radix.
+- Runtime frontend.
+- Runtime backend.
+- DB, migraciones, workflows, Render, secrets y auth.
+- `package.json` raíz.
+- Commit, push y PR.
+
+## Auditoría previa
+
+- Base limpia en la rama esperada y HEAD esperado.
+- `frontend/eslint.config.mjs` importa `eslint-config-next/core-web-vitals`.
+- No existe `FlatCompat` ni import de `@eslint/eslintrc`.
+- `frontend/next.config.ts` no usa los paquetes auditados.
+- `package.json` raíz no declara estos paquetes.
+- `pnpm-lock.yaml` mostraba `@next/eslint-plugin-next@16.2.7` directo y
+  `@next/eslint-plugin-next@16.2.9` transitivo por `eslint-config-next@16.2.9`.
+
+## Evidencia
+
+```text
+corepack pnpm --dir frontend why @eslint/eslintrc
+-> devDependencies:
+-> @eslint/eslintrc 3.3.5
+
+corepack pnpm --dir frontend why @next/eslint-plugin-next
+-> devDependencies:
+-> @next/eslint-plugin-next 16.2.7
+-> eslint-config-next 16.2.9
+-> └── @next/eslint-plugin-next 16.2.9
+
+corepack pnpm --dir frontend why eslint-config-next
+-> devDependencies:
+-> eslint-config-next 16.2.9
+```
+
+`git grep` encontró referencias en docs, manifest, lockfile,
+`frontend/eslint.config.mjs`, `test/package-scripts-contract.test.ts` y
+`test/helpers/clean7a-dependency-cleanup-scope.ts`; no encontró uso runtime ni
+`FlatCompat`.
+
+## Cambios
+
+- Se ejecutó:
+  `corepack pnpm --dir frontend remove @eslint/eslintrc @next/eslint-plugin-next`.
+- `frontend/package.json` dejó de declarar esas dos devDependencies directas.
+- `pnpm-lock.yaml` fue regenerado por pnpm.
+- `test/package-scripts-contract.test.ts` dejó de exigir `@eslint/eslintrc`.
+- `test/helpers/clean7a-dependency-cleanup-scope.ts` dejó de preservar esas dos
+  dependencias `UNKNOWN` y ahora fija su ausencia para CLEAN7C.
+- Docs actualizados:
+  `docs/audit/final-repo-cleanup-engineering-audit.md`,
+  `docs/audit/frontend-dependencies-usage-audit.md`,
+  `docs/audit/frontend-radix-tooling-dependencies-audit.md`.
+
+## Decisiones
+
+- `@eslint/eslintrc`: removido. No era necesario por `FlatCompat`; el grafo lo
+  mostraba como dependencia directa solamente y `lint` pasó antes de remover.
+- `@next/eslint-plugin-next`: removida sólo la dependencia directa. La copia
+  necesaria queda transitiva vía `eslint-config-next@16.2.9`.
+
+## Validaciones
+
+- `corepack pnpm --dir frontend lint` baseline antes de remover: pasó.
+- `node --experimental-strip-types --test test/package-scripts-contract.test.ts`:
+  pasó 10/10 tras los ajustes de contrato.
+- `corepack pnpm typecheck`: pasó.
+- `corepack pnpm typecheck:test`: pasó.
+- `node --experimental-strip-types --test test/package-scripts-contract.test.ts`:
+  pasó 10/10.
+- `corepack pnpm test`: pasó 2890/2890.
+- `corepack pnpm build`: pasó.
+- `corepack pnpm security:public-surface`: pasó; mantuvo notas informativas
+  existentes sobre identificadores uppercase en `frontend/src/proxy.ts`.
+- `corepack pnpm --dir frontend lint`: pasó.
+- `corepack pnpm --dir frontend typecheck`: pasó.
+- `corepack pnpm --dir frontend build`: pasó.
+
+## Resultado
+
+- Remoción acotada de tooling ESLint directo.
+- Radix queda sin cambios.
+- Runtime frontend/backend queda sin cambios.
+- `package.json` raíz queda sin cambios.
+
+## Riesgo residual
+
+- Riesgo bajo-medio propio de cambio de manifest/lockfile.
+- Persisten warnings peer existentes de `eslint-config-next` con ESLint 10; no
+  bloquearon pnpm ni lint.
+
+## Estado final
+
+- Sin commit.
+- Sin push.
+- Sin PR.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,8 +41,6 @@
     "zod": "^4"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.5",
-    "@next/eslint-plugin-next": "16.2.7",
     "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "^25.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,12 +129,6 @@ importers:
         specifier: ^4
         version: 4.4.3
     devDependencies:
-      '@eslint/eslintrc':
-        specifier: ^3.3.5
-        version: 3.3.5
-      '@next/eslint-plugin-next':
-        specifier: 16.2.7
-        version: 16.2.7
       '@playwright/test':
         specifier: ^1.61.0
         version: 1.61.0
@@ -440,10 +434,6 @@ packages:
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/eslintrc@3.3.5':
-    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -666,9 +656,6 @@ packages:
 
   '@next/env@16.2.7':
     resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
-
-  '@next/eslint-plugin-next@16.2.7':
-    resolution: {integrity: sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==}
 
   '@next/eslint-plugin-next@16.2.9':
     resolution: {integrity: sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==}
@@ -1573,9 +1560,6 @@ packages:
     resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
     engines: {node: '>=16.17.0'}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -1697,10 +1681,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
@@ -2047,10 +2027,6 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2064,10 +2040,6 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
-
-  espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
@@ -2214,10 +2186,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
   globals@16.4.0:
     resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
     engines: {node: '>=18'}
@@ -2280,10 +2248,6 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
-
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2422,10 +2386,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2730,10 +2690,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2927,10 +2883,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -3104,10 +3056,6 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -3538,20 +3486,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
-    dependencies:
-      ajv: 6.15.0
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.2.0
-      minimatch: 3.1.5
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@eslint/object-schema@3.0.5': {}
 
   '@eslint/plugin-kit@0.7.2':
@@ -3739,10 +3673,6 @@ snapshots:
     optional: true
 
   '@next/env@16.2.7': {}
-
-  '@next/eslint-plugin-next@16.2.7':
-    dependencies:
-      fast-glob: 3.3.1
 
   '@next/eslint-plugin-next@16.2.9':
     dependencies:
@@ -4599,8 +4529,6 @@ snapshots:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
 
-  argparse@2.0.1: {}
-
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -4747,8 +4675,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
 
@@ -5151,8 +5077,6 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.1: {}
-
   eslint-visitor-keys@5.0.1: {}
 
   eslint@10.5.0(jiti@2.7.0):
@@ -5191,12 +5115,6 @@ snapshots:
       jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
-
-  espree@10.4.0:
-    dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
@@ -5369,8 +5287,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  globals@14.0.0: {}
-
   globals@16.4.0: {}
 
   globalthis@1.0.4:
@@ -5420,11 +5336,6 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
-
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
 
@@ -5569,10 +5480,6 @@ snapshots:
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 
@@ -5864,10 +5771,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6063,8 +5966,6 @@ snapshots:
       set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
-
-  resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -6299,8 +6200,6 @@ snapshots:
       safe-buffer: 5.2.1
 
   strip-bom@3.0.0: {}
-
-  strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:

--- a/test/helpers/clean7a-dependency-cleanup-scope.ts
+++ b/test/helpers/clean7a-dependency-cleanup-scope.ts
@@ -26,7 +26,7 @@ const RADIX_DEPENDENCIES_LEFT_UNTOUCHED = [
   "@radix-ui/react-tooltip",
 ] as const;
 
-const UNKNOWN_DEV_DEPENDENCIES_LEFT_UNTOUCHED = [
+const CLEAN7C_REMOVED_DEV_DEPENDENCIES = [
   "@eslint/eslintrc",
   "@next/eslint-plugin-next",
 ] as const;
@@ -92,10 +92,11 @@ export function assertClean7aDependencyCleanupScope(): void {
     );
   }
 
-  for (const dependency of UNKNOWN_DEV_DEPENDENCIES_LEFT_UNTOUCHED) {
-    assert.ok(
+  for (const dependency of CLEAN7C_REMOVED_DEV_DEPENDENCIES) {
+    assert.equal(
       devDependencies[dependency],
-      `PR-CLEAN7A must not remove UNKNOWN tooling dependency ${dependency}`,
+      undefined,
+      `PR-CLEAN7C must remove only the approved ESLint tooling dependency ${dependency}`,
     );
   }
 

--- a/test/package-scripts-contract.test.ts
+++ b/test/package-scripts-contract.test.ts
@@ -144,7 +144,6 @@ test("frontend package keeps development dependency surface", () => {
   assert.ok(devDependencies.typescript);
   assert.ok(devDependencies.eslint);
   assert.ok(devDependencies["eslint-config-next"]);
-  assert.ok(devDependencies["@eslint/eslintrc"]);
   assert.ok(devDependencies["@playwright/test"]);
   assert.ok(devDependencies["@types/node"]);
   assert.ok(devDependencies["@types/react"]);


### PR DESCRIPTION
PR-CLEAN7C for the remaining P2-B frontend dependency cleanup scope.

Scope:
- Removes only two direct frontend devDependencies:
  - @eslint/eslintrc
  - @next/eslint-plugin-next
- Keeps eslint-config-next as the source for Next ESLint config.
- Keeps @next/eslint-plugin-next transitively via eslint-config-next.
- Updates package/lockfile contracts and audit documentation.
- Adds implementation note:
  - docs/implementation/frontend-eslint-tooling-clean7c.md

Decision:
- @eslint/eslintrc removed because frontend/eslint.config.mjs does not use FlatCompat and there is no direct import/use.
- @next/eslint-plugin-next direct dependency removed because eslint-config-next already provides it transitively.
- Radix dependencies are untouched and remain deferred/separate from this PR.

Preserved scope:
- No Radix changes.
- No frontend runtime changes.
- No backend runtime changes.
- No root package.json changes.
- No DB changes.
- No migrations.
- No workflow changes.
- No Render/secrets changes.
- No additional dependencies removed.

Evidence:
- grep found no runtime usage or FlatCompat usage for @eslint/eslintrc.
- pnpm why showed @eslint/eslintrc as direct-only before removal and absent after removal.
- pnpm why showed @next/eslint-plugin-next as direct + transitive before removal, and only transitive via eslint-config-next after removal.
- frontend lint passed after removal.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- node --experimental-strip-types --test test/package-scripts-contract.test.ts passed: 10/10.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm security:public-surface passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.

Residual:
- Existing peer warnings around eslint-config-next and ESLint 10 remain informational; lint/build/test passed.
