### PR TITLE
docs(audit): close frontend dependencies cleanup

### DIFF
--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -42,14 +42,16 @@ La deuda activa restante sigue enfocada en ordenamiento y documentación:
    (`resolveParticularPortalUrl`): la URL del portal en mails de token sale del
    primer origen `https` del allowlist CORS, conflando dos conceptos distintos. *(P1.)*
 2. **Módulo `shared/` muerto** (3 archivos) consumido solo por su propio test. *(P2.)*
-3. **Dependencias de frontend aparentemente sin uso**: auditoría documental
-   dedicada confirma como `SUSPECT unused` el grupo original
-   (`@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
-   `echarts-for-react`, `react-hook-form`, `@radix-ui/react-tooltip`) y amplía
-   la señal a Radix no importados (`avatar`, `dropdown-menu`, `label`, `select`,
-   `tabs`, `toast`). Ver
-   [`frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md).
-   *(P2.)*
+3. **Dependencias de frontend P2-B**: bloque cerrado documentalmente post
+   PR-CLEAN7A/#1175, PR-CLEAN7B/#1176, PR-CLEAN7C/#1177 y PR-CLEAN7D/#1178.
+   Se removieron las dependencias sin uso confirmadas y el tooling `UNKNOWN`;
+   `@radix-ui/react-toast` y `@radix-ui/react-tooltip` quedan diferidas
+   intencionalmente por roadmap/UI. Ver
+   [`frontend-dependencies-cleanup-closeout.md`](frontend-dependencies-cleanup-closeout.md),
+   [`frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md)
+   y
+   [`frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
+   *(P2 cerrado con deuda diferida documentada.)*
 4. **Deuda documental de organización**: ~233 docs con taxonomía fragmentada
    (`audit/` + `audits/`, notas de implementación en 3 lugares, ~31 `pr-*.md`
    sueltos en la raíz de `docs/`) y al menos un doc **contradictorio**
@@ -262,7 +264,8 @@ deploy roto ni auth rota en el estado actual.
   `scripts/maintenance/FUSION_POR_COMANDO.sh`) **siguen pendientes**.
 
 #### P2-B · Dependencias de frontend sin uso
-- **Tipo:** dependencias / performance-surface · **Riesgo:** Medio (verificar build/E2E).
+- **Tipo:** dependencias / performance-surface · **Estado:** cerrado
+  documentalmente post-#1178; queda defer roadmap/UI para `toast`/`tooltip`.
 - **Snapshot documental dedicado (2026-06-29, rama
   `audit/frontend-dependencies-usage`, HEAD `d958c63`):**
   [`docs/audit/frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md).
@@ -330,6 +333,19 @@ deploy roto ni auth rota en el estado actual.
   `test/helpers/clean7a-dependency-cleanup-scope.ts`. No se tocó Radix, runtime
   frontend/backend, DB, migraciones, workflows, Render, secrets ni
   `package.json` raíz.
+- **Estado PR-CLEAN7D / Radix unused:** **EJECUTADO** (2026-06-29, rama
+  `clean/frontend-radix-unused-core`, mergeado como #1178; HEAD esperado post
+  merge `327253e`). Se removieron sólo `@radix-ui/react-avatar`,
+  `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`,
+  `@radix-ui/react-select` y `@radix-ui/react-tabs`. Permanecen
+  `@radix-ui/react-toast` y `@radix-ui/react-tooltip` como `DEFER keep` por
+  roadmap/estandarización UI.
+- **Cierre P2-B (2026-06-29):** **CERRADO DOCUMENTALMENTE** en
+  [`docs/audit/frontend-dependencies-cleanup-closeout.md`](frontend-dependencies-cleanup-closeout.md).
+  El bloque quedó cerrado por #1175, #1176, #1177 y #1178; el tooling `UNKNOWN`
+  quedó resuelto; no hubo cambios runtime/API/backend/DB/workflows en este
+  closeout docs-only; no se tocaron `frontend/package.json`, `pnpm-lock.yaml`,
+  `package.json` raíz ni runtime.
 
 #### P2-C · `docs/notes/todo.md` contradictorio con la arquitectura actual
 - **Tipo:** docs · **Riesgo:** Bajo.
@@ -1019,10 +1035,13 @@ exige build+E2E). El resto está saludable.
 - **Rollback:** revertir (historia preservada en git).
 
 ### PR-CLEAN7 · dependencias frontend sin uso
-- **Estado documental:** auditoría dedicada completada en
-  [`docs/audit/frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md).
-  PR-CLEAN7A ya eliminó el primer grupo probado; Radix no usados y tooling
-  `UNKNOWN` permanecen pendientes.
+- **Estado documental:** **bloque P2-B cerrado post-PR-CLEAN7D/#1178**. Cierre
+  dedicado en
+  [`docs/audit/frontend-dependencies-cleanup-closeout.md`](frontend-dependencies-cleanup-closeout.md).
+  Auditorías base:
+  [`frontend-dependencies-usage-audit.md`](frontend-dependencies-usage-audit.md)
+  y
+  [`frontend-radix-tooling-dependencies-audit.md`](frontend-radix-tooling-dependencies-audit.md).
 - **Alcance recomendado por fases:**
   - **PR-CLEAN7A (EJECUTADO 2026-06-29):** remover `@tanstack/react-query`,
     `@tanstack/react-table`, `echarts`, `echarts-for-react` y
@@ -1034,7 +1053,7 @@ exige build+E2E). El resto está saludable.
   - **PR-CLEAN7C (EJECUTADO 2026-06-29):** remover tooling ESLint directo
     `@eslint/eslintrc` y dependencia directa `@next/eslint-plugin-next`, con
     lint antes/después y validaciones completas.
-  - **PR-CLEAN7D opcional:** tratar Radix por grupos. Candidatos
+  - **PR-CLEAN7D (EJECUTADO 2026-06-29, #1178):** remover Radix
     `SUSPECT unused`: `avatar`, `dropdown-menu`, `label`, `select`, `tabs`.
     Mantener `toast`/`tooltip` como `DEFER keep` mientras siga vigente el
     roadmap de dashboard premium; si se descarta, eliminarlos en PR separado.
@@ -1102,10 +1121,11 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
 - [~] PR-CLEAN6 (dead-code/artefactos): porción `shared/` (P2-A) ejecutada
   (rama `clean/remove-dead-shared-module`); artefactos P3 (`legacy/drizzle-old/`,
   `generate-pwa-icons.py`, `FUSION_POR_COMANDO.sh`) pendientes.
-- [~] PR-CLEAN7 (deps sin uso): PR-CLEAN7A ejecutado; PR-CLEAN7B docs-only
+- [x] PR-CLEAN7 / P2-B (deps sin uso): PR-CLEAN7A ejecutado; PR-CLEAN7B docs-only
   completado; PR-CLEAN7C tooling ejecutado; PR-CLEAN7D Radix `SUSPECT unused`
   ejecutado para `avatar`, `dropdown-menu`, `label`, `select` y `tabs`.
-  `toast`/`tooltip` quedan diferidos por roadmap.
+  `toast`/`tooltip` quedan diferidos por roadmap y el cierre docs-only queda en
+  `docs/audit/frontend-dependencies-cleanup-closeout.md`.
 - [ ] `.env.example` y `frontend/.env.example` documentan **todas** las vars usadas.
 - [ ] `docs/notes/todo.md` ya no contradice la arquitectura real.
 - [ ] Taxonomía `docs/` unificada (sin `audit`+`audits`, sin `pr-*.md` sueltos).

--- a/docs/audit/frontend-dependencies-cleanup-closeout.md
+++ b/docs/audit/frontend-dependencies-cleanup-closeout.md
@@ -1,0 +1,136 @@
+# Cierre P2-B · frontend dependencies cleanup
+
+> **Modo:** cierre documental / docs-only.
+> **Fecha:** 2026-06-29.
+> **Base esperada:** rama `docs/closeout-frontend-deps-cleanup`, HEAD
+> `327253e chore(frontend): remove unused radix core deps (#1178)`.
+> **Scope:** cerrar documentalmente el bloque P2-B posterior a PR-CLEAN7A,
+> PR-CLEAN7B, PR-CLEAN7C y PR-CLEAN7D.
+
+---
+
+## 1. Estado base
+
+| Item | Estado |
+| --- | --- |
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama esperada | `docs/closeout-frontend-deps-cleanup` |
+| HEAD esperado | `327253e chore(frontend): remove unused radix core deps (#1178)` |
+| Working tree inicial | limpio |
+| Modo | docs-only |
+
+Documentos rectores:
+
+- `docs/audit/final-repo-cleanup-engineering-audit.md`
+- `docs/audit/frontend-dependencies-usage-audit.md`
+- `docs/audit/frontend-radix-tooling-dependencies-audit.md`
+- `docs/implementation/frontend-unused-deps-clean7a.md`
+- `docs/implementation/frontend-eslint-tooling-clean7c.md`
+- `docs/implementation/frontend-radix-clean7d.md`
+
+---
+
+## 2. Scope incluido
+
+- Cerrar documentalmente P2-B como bloque completado por PR-CLEAN7A/#1175,
+  PR-CLEAN7B/#1176, PR-CLEAN7C/#1177 y PR-CLEAN7D/#1178.
+- Actualizar los documentos rectores de auditoría para reflejar el estado
+  posterior a #1178.
+- Crear este documento de closeout dedicado.
+- Registrar dependencias removidas, dependencias diferidas, cierre de tooling
+  `UNKNOWN` y exclusiones de runtime/API/backend/DB/workflows.
+
+---
+
+## 3. Scope excluido
+
+- No tocar `frontend/package.json`.
+- No tocar `pnpm-lock.yaml`.
+- No tocar `package.json` raíz.
+- No tocar runtime frontend.
+- No tocar runtime backend ni API.
+- No tocar tests.
+- No tocar DB, Drizzle ni migraciones.
+- No tocar workflows, Render ni secrets.
+- No hacer commit, push ni PR.
+
+---
+
+## 4. Auditoría previa
+
+- PR-CLEAN7A/#1175 cerró el grupo core sin imports reales:
+  `@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
+  `echarts-for-react` y `react-hook-form`.
+- PR-CLEAN7B/#1176 auditó docs-only el remanente Radix/tooling y confirmó 0
+  imports reales `from`/`require()`/`import()` para los paquetes auditados.
+- PR-CLEAN7C/#1177 cerró el remanente tooling `UNKNOWN`:
+  `@eslint/eslintrc` fue removido por ausencia de `FlatCompat`/uso directo, y
+  la dependencia directa `@next/eslint-plugin-next` fue removida porque
+  `eslint-config-next` mantiene el plugin como transitivo.
+- PR-CLEAN7D/#1178 removió el grupo Radix `SUSPECT unused`:
+  `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`,
+  `@radix-ui/react-label`, `@radix-ui/react-select` y
+  `@radix-ui/react-tabs`.
+- `@radix-ui/react-toast` y `@radix-ui/react-tooltip` permanecen declarados de
+  forma intencional como `DEFER keep` por roadmap/estandarización UI.
+
+---
+
+## 5. Cambios documentales
+
+- `docs/audit/final-repo-cleanup-engineering-audit.md`: P2-B pasa a estado
+  cerrado post-#1178, con referencia a este closeout.
+- `docs/audit/frontend-dependencies-usage-audit.md`: se agrega cierre final
+  del bloque P2-B y se vincula este documento.
+- `docs/audit/frontend-radix-tooling-dependencies-audit.md`: se actualiza el
+  estado final para reflejar cierre post-PR-CLEAN7D/#1178.
+- `docs/audit/frontend-dependencies-cleanup-closeout.md`: nuevo documento de
+  cierre documental.
+
+---
+
+## 6. Resultado
+
+P2-B queda cerrado documentalmente.
+
+Dependencias removidas por el bloque:
+
+- PR-CLEAN7A/#1175:
+  `@tanstack/react-query`, `@tanstack/react-table`, `echarts`,
+  `echarts-for-react`, `react-hook-form`.
+- PR-CLEAN7C/#1177:
+  `@eslint/eslintrc`, dependencia directa `@next/eslint-plugin-next`.
+- PR-CLEAN7D/#1178:
+  `@radix-ui/react-avatar`, `@radix-ui/react-dropdown-menu`,
+  `@radix-ui/react-label`, `@radix-ui/react-select`,
+  `@radix-ui/react-tabs`.
+
+Dependencias diferidas:
+
+- `@radix-ui/react-toast`: diferida por roadmap/estandarización UI de
+  notificaciones/toast.
+- `@radix-ui/react-tooltip`: diferida por roadmap/estandarización UI de
+  ayudas contextuales/tooltip.
+
+El estado `UNKNOWN` tooling queda resuelto por PR-CLEAN7C. No queda paquete
+P2-B clasificado como `UNKNOWN`.
+
+---
+
+## 7. Riesgo residual
+
+- Riesgo residual bajo y documental: `toast`/`tooltip` no tienen uso runtime
+  actual, pero se preservan intencionalmente por roadmap/UI. Su adopción o
+  remoción debe ocurrir en PR separado y explícito.
+- Este closeout no modifica manifests, lockfiles, runtime, API, backend, DB,
+  migraciones, workflows, Render ni secrets.
+
+---
+
+## 8. Estado final
+
+- Bloque P2-B cerrado documentalmente.
+- Scope docs-only respetado.
+- Sin commit.
+- Sin push.
+- Sin PR.

--- a/docs/audit/frontend-dependencies-usage-audit.md
+++ b/docs/audit/frontend-dependencies-usage-audit.md
@@ -295,6 +295,10 @@ Recomendación post-PR-CLEAN7A:
 - `frontend/package.json` y `pnpm-lock.yaml` permanecen sin cambios.
 - No commit, no push, no PR.
 
+> **Actualización de cierre P2-B (2026-06-29):** el bloque completo quedó
+> cerrado documentalmente post-PR-CLEAN7D/#1178. Ver
+> [`frontend-dependencies-cleanup-closeout.md`](frontend-dependencies-cleanup-closeout.md).
+
 ## 8. Nota final PR-CLEAN7A
 
 **Estado:** ejecutado el 2026-06-29 en la rama
@@ -390,3 +394,28 @@ Cambios de alcance PR-CLEAN7D:
 - `@radix-ui/react-toast` y `@radix-ui/react-tooltip` permanecen declarados.
 - No se toco runtime frontend/backend, DB, migraciones, workflows, Render,
   secrets, `package.json` raiz ni otras dependencias.
+
+## 12. Cierre P2-B post-PR-CLEAN7D
+
+**Estado:** cerrado documentalmente el 2026-06-29 sobre la base
+`327253e chore(frontend): remove unused radix core deps (#1178)`.
+
+El bloque P2-B queda cerrado por:
+
+- PR-CLEAN7A/#1175: removió `@tanstack/react-query`,
+  `@tanstack/react-table`, `echarts`, `echarts-for-react` y
+  `react-hook-form`.
+- PR-CLEAN7B/#1176: auditó docs-only el remanente Radix/tooling.
+- PR-CLEAN7C/#1177: removió `@eslint/eslintrc` y la dependencia directa
+  `@next/eslint-plugin-next`; el tooling `UNKNOWN` queda resuelto.
+- PR-CLEAN7D/#1178: removió `@radix-ui/react-avatar`,
+  `@radix-ui/react-dropdown-menu`, `@radix-ui/react-label`,
+  `@radix-ui/react-select` y `@radix-ui/react-tabs`.
+
+`@radix-ui/react-toast` y `@radix-ui/react-tooltip` quedan diferidos
+intencionalmente como roadmap/UI. Este cierre no toca `frontend/package.json`,
+`pnpm-lock.yaml`, runtime frontend/backend, API, DB, migraciones, workflows,
+Render ni secrets.
+
+Documento de cierre:
+[`docs/audit/frontend-dependencies-cleanup-closeout.md`](frontend-dependencies-cleanup-closeout.md).

--- a/docs/audit/frontend-radix-tooling-dependencies-audit.md
+++ b/docs/audit/frontend-radix-tooling-dependencies-audit.md
@@ -200,11 +200,15 @@ Orden sugerido:
 
 ## 7. Estado final
 
-- Auditoría P2-B remanente actualizada post-PR-CLEAN7C.
-- Se eliminaron sólo `@eslint/eslintrc` y la dependencia directa
+- Auditoría P2-B remanente actualizada post-PR-CLEAN7D/#1178.
+- Se eliminaron en PR-CLEAN7C sólo `@eslint/eslintrc` y la dependencia directa
   `@next/eslint-plugin-next`.
 - PR-CLEAN7D elimino despues solo `avatar`, `dropdown-menu`, `label`, `select`
   y `tabs`; `toast`/`tooltip` siguen preservados.
+- El tooling `UNKNOWN` queda resuelto; no queda paquete remanente P2-B en esa
+  clasificación.
+- Cierre documental dedicado:
+  [`frontend-dependencies-cleanup-closeout.md`](frontend-dependencies-cleanup-closeout.md).
 - No se tocó runtime frontend/backend, DB, migraciones, workflows, Render ni
   secrets.
 - No commit, no push, no PR.


### PR DESCRIPTION
Docs-only closeout for the P2-B frontend dependencies cleanup block.

Scope:
- Closes P2-B after PR-CLEAN7A through PR-CLEAN7D:
  - #1175 removed core unused dependencies.
  - #1176 audited remaining Radix/UNKNOWN dependencies.
  - #1177 removed redundant direct ESLint tooling dependencies.
  - #1178 removed unused Radix core dependencies.
- Adds dedicated closeout document:
  - docs/audit/frontend-dependencies-cleanup-closeout.md
- Updates audit docs:
  - docs/audit/final-repo-cleanup-engineering-audit.md
  - docs/audit/frontend-dependencies-usage-audit.md
  - docs/audit/frontend-radix-tooling-dependencies-audit.md

Result:
- P2-B is documented as closed.
- Removed dependency groups are recorded.
- UNKNOWN tooling is documented as resolved.
- @radix-ui/react-toast and @radix-ui/react-tooltip remain intentionally deferred by roadmap/UI standardization.

Preserved scope:
- Docs-only.
- No frontend/package.json changes.
- No pnpm-lock.yaml changes.
- No root package.json changes.
- No frontend runtime changes.
- No backend runtime/API changes.
- No tests changes.
- No DB/migration/workflow/Render/secrets changes.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm security:public-surface passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.
- Forbidden scope guard returned no files.
