### PR TITLE
docs(env): document version gate env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,12 @@ TRUST_PROXY=1
 # admite http://localhost. Valor inválido (no https en prod) => fail-fast en el startup.
 PUBLIC_SITE_URL=https://vetneb.com.ar
 
+# Version gate. Usar el mismo token no secreto en frontend y backend.
+# APP_VERSION gobierna /api/app-version; CLIENT_MIN_VERSION activa el gate 426.
+# Para desarmar el gate 426, dejar CLIENT_MIN_VERSION vacío/no configurado.
+APP_VERSION=<version-token>
+CLIENT_MIN_VERSION=<version-token>
+
 GMAIL_API_CLIENT_ID=<google-oauth-client-id>
 GMAIL_API_CLIENT_SECRET=<google-oauth-client-secret>
 GMAIL_API_REFRESH_TOKEN=<google-oauth-refresh-token>

--- a/docs/audit/final-cleanup-current-status-snapshot.md
+++ b/docs/audit/final-cleanup-current-status-snapshot.md
@@ -21,6 +21,7 @@
 - Marcar P1-B como cerrado por #1162.
 - Marcar P2-A `shared/` como cerrado por #1173.
 - Marcar P2-B dependencias frontend como cerrado por #1175-#1179.
+- Marcar P2-F env version vars como cerrado por documentación explícita en env examples.
 - Mantener trazabilidad histórica sin que las tablas recomienden PRs ya ejecutados.
 
 ## Scope excluido
@@ -40,6 +41,7 @@
 | P1-B email public URL | Cerrado | #1162, `PUBLIC_SITE_URL` explícita con fallback conservador |
 | P2-A `shared/` | Cerrado | #1173, eliminado `shared/` y `test/shared-const-and-errors.test.ts` |
 | P2-B frontend dependencies | Cerrado | #1175, #1176, #1177, #1178, #1179 |
+| P2-F env version vars | Cerrado | `APP_VERSION`/`CLIENT_MIN_VERSION` en `.env.example`; `NEXT_PUBLIC_APP_VERSION` en `frontend/.env.example` |
 | Tooling `UNKNOWN` frontend | Cerrado | #1177 |
 | Radix PR-CLEAN7D | Cerrado | #1178 |
 
@@ -50,7 +52,6 @@
 | P2-C | `docs/notes/todo.md` contradictorio | Pendiente |
 | P2-D | Taxonomía documental fragmentada | Pendiente |
 | P2-E | Logger/console observability | Pendiente |
-| P2-F | Env vars no documentadas (`APP_VERSION`, `CLIENT_MIN_VERSION`, `NEXT_PUBLIC_APP_VERSION`) | Pendiente |
 | P3 | Artefactos históricos/orfanados (`legacy/drizzle-old/`, `scripts/generate-pwa-icons.py`, `scripts/maintenance/FUSION_POR_COMANDO.sh`) | Pendiente |
 | P3-G | `backend-ci.yml` `paths-ignore` opcional | Pendiente opcional |
 
@@ -64,7 +65,8 @@ Estas dependencias no se clasifican como deuda activa accidental en este corte.
 ## Riesgo residual
 
 - Bajo y documental: el riesgo principal era que el rector siguiera induciendo a
-  ejecutar PRs ya cerrados.
+  ejecutar PRs ya cerrados o que el version gate siguiera sin variables listadas
+  explícitamente en los env examples.
 - Cualquier cambio futuro sobre pendientes reales debe abrir PR dedicado y
   mantener el protocolo de validación del repo.
 
@@ -72,4 +74,5 @@ Estas dependencias no se clasifican como deuda activa accidental en este corte.
 
 - Snapshot creado para lectura rápida del estado vigente.
 - Scope docs-only respetado.
+- P2-F cerrado sin secretos, sin lógica y sin cambios de runtime.
 - Sin commit, push ni PR.

--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -66,12 +66,9 @@ La deuda activa real queda limitada a:
    ~31 `pr-*.md` sueltos en la raíz de `docs/`). *(P2.)*
 3. **P2-E · Logger/console observability**: logger mínimo y mezcla de
    `console.*`/logger en backend. *(P2.)*
-4. **P2-F · Gaps menores de documentación de env vars** (`APP_VERSION`,
-   `CLIENT_MIN_VERSION`, `NEXT_PUBLIC_APP_VERSION` usados pero no listados en
-   `.env.example`). *(P2.)*
-5. **P3 · Artefactos históricos/orfanados**: `legacy/drizzle-old/`,
+4. **P3 · Artefactos históricos/orfanados**: `legacy/drizzle-old/`,
    `scripts/generate-pwa-icons.py`, `scripts/maintenance/FUSION_POR_COMANDO.sh`. *(P3.)*
-6. **P3-G · Backend CI `paths-ignore` opcional** para evitar runs pesados en PRs
+5. **P3-G · Backend CI `paths-ignore` opcional** para evitar runs pesados en PRs
    estrictamente docs-only/frontend, previa verificación de tests de contrato.
 
 Las eliminaciones o cambios restantes se proponen como **PRs chicos, con prueba
@@ -414,7 +411,14 @@ deploy roto ni auth rota en el estado actual.
   logger con niveles. No bloqueante para el cierre.
 
 #### P2-F · `APP_VERSION` / `CLIENT_MIN_VERSION` / `NEXT_PUBLIC_APP_VERSION` no documentadas en `.env.example`
-- **Tipo:** env / docs · **Riesgo:** Bajo. Ver §8.
+- **Tipo:** env / docs · **Riesgo:** Bajo.
+- **Estado actualizado (2026-06-29):** **cerrado** por la rama
+  `docs/env-version-vars-contract`. `.env.example` documenta `APP_VERSION` y
+  `CLIENT_MIN_VERSION`; `frontend/.env.example` documenta
+  `NEXT_PUBLIC_APP_VERSION`. El cambio fue docs/env-example comments only: no
+  se tocó runtime frontend/backend, lógica del version gate, `CORS_ORIGIN`,
+  URLs públicas, secretos, dependencias, lockfile, DB, migraciones, workflows ni
+  Render. Ver [`docs/implementation/env-version-vars-docs.md`](../implementation/env-version-vars-docs.md).
 
 ### P3 — Bajo (cosmético / archaeology / nice-to-have)
 
@@ -471,7 +475,7 @@ deploy roto ni auth rota en el estado actual.
 | `docs/audit/` + `docs/audits/` | taxonomía duplicada | P2 | Bajo | unificar | PR-CLEAN2 |
 | `IMPLEMENTATION_NOTES/` (raíz, 34) | notas en 3 ubicaciones | P2 | Bajo | consolidar bajo `docs/` | PR-CLEAN2 |
 | ~31 `docs/pr-*.md` sueltos | deberían ir en `pr-history/` | P2 | Bajo | mover | PR-CLEAN2 |
-| `.env.example` / `frontend/.env.example` | faltan `APP_VERSION`,`CLIENT_MIN_VERSION`,`NEXT_PUBLIC_APP_VERSION` | P2/P3 | Bajo | documentar (comentario) | PR-CLEAN1 |
+| `.env.example` / `frontend/.env.example` | `APP_VERSION`, `CLIENT_MIN_VERSION` y `NEXT_PUBLIC_APP_VERSION` documentadas con token no secreto | P2 cerrado | Bajo | cerrado docs-only | P2-F |
 | `server/lib/logger.ts` + 56 `console.*` | logger mínimo, mezcla cruda | P2 | Bajo | documentar/unificar (opcional) | — |
 
 ---
@@ -544,10 +548,10 @@ SMTP_*, GMAIL_API_*, CONTACT_TO, APP_VERSION, RENDER_GIT_COMMIT, CLIENT_MIN_VERS
 
 | Variable | Usada | En `.env.example` | Observación |
 | --- | --- | --- | --- |
-| `APP_VERSION` | sí (`env.ts:98,152`) | **no** | gestionada por force-update workflow; documentar como comentario |
-| `CLIENT_MIN_VERSION` | sí (`env.ts:100,163-164`) | **no** | arma el gate 426; borrarla apaga el gate (ver memoria) — documentar |
+| `APP_VERSION` | sí (`env.ts:98,152`) | **sí** | documentada en `.env.example` como token no secreto del version gate |
+| `CLIENT_MIN_VERSION` | sí (`env.ts:100,163-164`) | **sí** | documentada en `.env.example`; arma el gate 426 y vaciarla/no configurarla lo desarma |
 | `RENDER_GIT_COMMIT` | sí (fallback de `appVersion`) | **no** | inyectada por Render; aceptable no documentar |
-| `NEXT_PUBLIC_APP_VERSION` | sí (`frontend/src/lib/app-version.ts:8`) | **no** (en `frontend/.env.example`) | build-time, set en Render; documentar |
+| `NEXT_PUBLIC_APP_VERSION` | sí (`frontend/src/lib/app-version.ts:8`) | **sí** (en `frontend/.env.example`) | build-time; debe moverse con `APP_VERSION`/`CLIENT_MIN_VERSION` y requiere rebuild |
 | `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_SITE_URL` | sí | sí | consistentes (`api.vetneb.com.ar` / `vetneb.com.ar`) |
 | `CORS_ORIGIN` | sí | sí (`https://vetneb.com.ar`) | allowlist CORS; el doble uso como fuente primaria de URL de email fue cerrado por #1162 con `PUBLIC_SITE_URL` (ver §9) |
 
@@ -568,9 +572,11 @@ pública primaria.
 preflight cross-origin podría fallar (ya señalado en
 `docs/audit/backend-api-global-incident-p0.md`). **Investigar** según hosts reales.
 
-**Acción env pendiente:** **PR-CLEAN1** agrega comentarios documentando `APP_VERSION`,
-`CLIENT_MIN_VERSION`, `NEXT_PUBLIC_APP_VERSION` en los `.env.example` (sin valores
-secretos). El contrato de URL pública ya fue cerrado por #1162 / PR-CLEAN3.
+**Acción env P2-F cerrada (2026-06-29):** `.env.example` documenta
+`APP_VERSION` y `CLIENT_MIN_VERSION`; `frontend/.env.example` documenta
+`NEXT_PUBLIC_APP_VERSION`. Se usó placeholder no secreto (`<version-token>`) y
+no se modificaron URLs, `CORS_ORIGIN`, lógica del gate ni runtime. El contrato
+de URL pública ya fue cerrado por #1162 / PR-CLEAN3.
 
 ---
 
@@ -728,6 +734,12 @@ exige build+E2E). El resto está saludable.
   `*-staging.onrender.com` en `docs/release-readiness.md`, `docs/staging-smoke-runbook.md`
   y `test/*` se **mantienen**: son fixtures de contrato guardadas por
   `public-staging-config-contract.test.ts` y `admin-docs-operational-contract.test.ts`.
+- **Nota de seguimiento P2-F (ejecución real, rama
+  `docs/env-version-vars-contract`, 2026-06-29):** se documentaron
+  `APP_VERSION` y `CLIENT_MIN_VERSION` en `.env.example`, y
+  `NEXT_PUBLIC_APP_VERSION` en `frontend/.env.example`, usando sólo placeholders
+  no secretos. No se tocaron `docs/notes/todo.md`, runtime, dependencias,
+  lockfiles, DB, migraciones, workflows, Render ni lógica del version gate.
 
 ### PR-CLEAN2 · reorganización documental (solo-docs)
 - **Alcance:** unificar `docs/audits/` → `docs/audit/`; mover `pr-*.md` sueltos a
@@ -1153,7 +1165,8 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
 
 ## 17. Checklist final de cierre de proyecto
 
-- [ ] PR-CLEAN1 (docs/env comments) mergeado, contratos de env verdes.
+- [~] PR-CLEAN1 (docs/env comments): P2-F cerrado por
+  `docs/env-version-vars-contract`; P2-C `docs/notes/todo.md` sigue pendiente.
 - [ ] PR-CLEAN2 (reorg docs) mergeado, `git grep` de rutas movidas sin huérfanos.
 - [x] PR-CLEAN3 / P1-B (email URL contract) cerrado por #1162; `PUBLIC_SITE_URL`
   separa URL pública de `CORS_ORIGIN` con fallback conservador.
@@ -1169,7 +1182,8 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
   `label`, `select` y `tabs`.
   `toast`/`tooltip` quedan diferidos por roadmap y el cierre docs-only queda en
   `docs/audit/frontend-dependencies-cleanup-closeout.md`.
-- [ ] `.env.example` y `frontend/.env.example` documentan **todas** las vars usadas.
+- [x] `.env.example` y `frontend/.env.example` documentan las vars del version
+  gate (`APP_VERSION`, `CLIENT_MIN_VERSION`, `NEXT_PUBLIC_APP_VERSION`).
 - [ ] `docs/notes/todo.md` ya no contradice la arquitectura real.
 - [ ] Taxonomía `docs/` unificada (sin `audit`+`audits`, sin `pr-*.md` sueltos).
 - [ ] `main` limpio, CI verde (backend + frontend), 0 PRs abiertos.

--- a/docs/implementation/env-version-vars-docs.md
+++ b/docs/implementation/env-version-vars-docs.md
@@ -1,0 +1,87 @@
+# Env version vars docs
+
+> **Modo:** docs/env-example comments only.
+> **Fecha:** 2026-06-29.
+> **Rama:** `docs/env-version-vars-contract`.
+> **HEAD base:** `da143ea docs(audit): normalize final cleanup status (#1180)`.
+
+## Estado base
+
+- Working tree inicial limpio.
+- Rama esperada confirmada: `docs/env-version-vars-contract`.
+- HEAD esperado confirmado: `da143ea docs(audit): normalize final cleanup status (#1180)`.
+
+## Scope incluido
+
+- Documentar en `.env.example` las variables backend del version gate:
+  `APP_VERSION` y `CLIENT_MIN_VERSION`.
+- Documentar en `frontend/.env.example` la variable build-time:
+  `NEXT_PUBLIC_APP_VERSION`.
+- Marcar P2-F como cerrado en los documentos de auditoría vigentes.
+
+## Scope excluido
+
+- No runtime frontend.
+- No runtime backend.
+- No lógica del version gate.
+- No `package.json`, `frontend/package.json` ni `pnpm-lock.yaml`.
+- No DB, migraciones, workflows, Render ni secrets.
+- No cambios a `CORS_ORIGIN`, `NEXT_PUBLIC_SITE_URL` ni `NEXT_PUBLIC_API_URL`.
+
+## Auditoría previa
+
+- `server/lib/env.ts` acepta `APP_VERSION` y `CLIENT_MIN_VERSION`.
+- `frontend/src/lib/app-version.ts` lee `NEXT_PUBLIC_APP_VERSION`.
+- Los env examples no listaban explícitamente esas tres variables.
+- Los tests de contrato relevantes inspeccionan `.env.example` y
+  `frontend/.env.example` para evitar URLs o valores activos incorrectos.
+
+## Cambios
+
+- `.env.example` agrega un bloque breve de version gate con placeholders no
+  secretos:
+  `APP_VERSION=<version-token>` y `CLIENT_MIN_VERSION=<version-token>`.
+- `frontend/.env.example` agrega `NEXT_PUBLIC_APP_VERSION=<version-token>` y
+  aclara que es build-time y requiere rebuild al cambiar.
+- Los documentos de auditoría marcan P2-F como cerrado y mantienen P2-C como
+  pendiente separado.
+
+## Archivos modificados
+
+- `.env.example`
+- `frontend/.env.example`
+- `docs/audit/final-repo-cleanup-engineering-audit.md`
+- `docs/audit/final-cleanup-current-status-snapshot.md`
+- `docs/implementation/env-version-vars-docs.md`
+
+## Validaciones
+
+- `corepack pnpm typecheck` -> pasó.
+- `corepack pnpm typecheck:test` -> pasó.
+- `node --experimental-strip-types --test test/production-env-contracts.test.ts` -> pasó.
+- `node --experimental-strip-types --test test/public-staging-config-contract.test.ts` -> pasó.
+- `corepack pnpm test` -> pasó, 2890/2890.
+- `corepack pnpm build` -> pasó.
+- `corepack pnpm security:public-surface` -> pasó.
+- `corepack pnpm --dir frontend lint` -> pasó.
+- `corepack pnpm --dir frontend typecheck` -> pasó.
+- `corepack pnpm --dir frontend build` -> pasó.
+- `git diff --check` -> pasó; Git informó sólo avisos CRLF para `.env.example`
+  y `frontend/.env.example`.
+
+## Resultado
+
+- P2-F queda cerrado como documentación explícita de env examples.
+- No se agregaron secretos ni valores productivos reales nuevos.
+- No se modificó lógica ni runtime.
+
+## Riesgo residual
+
+- Bajo: los placeholders son no secretos y sólo documentan variables ya usadas.
+- El riesgo operativo restante es mantener alineado el mismo token entre
+  frontend build-time y backend runtime durante un force update.
+
+## Estado final
+
+- Cambio acotado a docs/env examples.
+- Sin commit, push ni PR.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,6 +8,10 @@ NEXT_PUBLIC_API_URL=https://api.vetneb.com.ar
 # URL pública del frontend (SEO, canonical, sitemap) — obligatorio en producción.
 NEXT_PUBLIC_SITE_URL=https://vetneb.com.ar
 
+# Version gate. Build-time: requiere rebuild del frontend al cambiar.
+# Debe usar el mismo token no secreto que APP_VERSION/CLIENT_MIN_VERSION del backend.
+NEXT_PUBLIC_APP_VERSION=<version-token>
+
 # Solo desarrollo local (auxiliar)
 # NEXT_PUBLIC_API_URL=http://localhost:3000
 # NEXT_PUBLIC_SITE_URL=http://localhost:3001


### PR DESCRIPTION
Docs/env-example only update for P2-F version gate variables.

Scope:
- Documents APP_VERSION and CLIENT_MIN_VERSION in .env.example.
- Documents NEXT_PUBLIC_APP_VERSION in frontend/.env.example.
- Updates audit/current-status docs to mark P2-F as closed.
- Adds implementation note:
  - docs/implementation/env-version-vars-docs.md

Contract:
- Uses only non-secret placeholder <version-token>.
- Does not change version gate logic.
- Does not change runtime frontend/backend.
- Does not change CORS_ORIGIN.
- Does not change NEXT_PUBLIC_SITE_URL or NEXT_PUBLIC_API_URL.
- Does not touch package/lock files, DB, migrations, workflows, Render, or secrets.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- node --experimental-strip-types --test test/production-env-contracts.test.ts passed: 12/12.
- node --experimental-strip-types --test test/public-staging-config-contract.test.ts passed: 3/3.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm security:public-surface passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.
- Forbidden scope guard returned no files.

Notes:
- Git reported CRLF warnings for .env.example and frontend/.env.example only; no whitespace errors.
