### PR TITLE
docs(notes): archive legacy todo architecture

### DIFF
--- a/docs/archive/legacy-trpc-sheets-todo.md
+++ b/docs/archive/legacy-trpc-sheets-todo.md
@@ -1,0 +1,86 @@
+# Histórico — TODO original tRPC/Google Sheets (pre-Fastify/Supabase)
+
+> **Estado:** archivado. **No usar como fuente de arquitectura vigente.**
+> **Motivo del archivo:** P2-C en
+> [`docs/audit/final-repo-cleanup-engineering-audit.md`](../audit/final-repo-cleanup-engineering-audit.md).
+> Para arquitectura real, ver `docs/SOURCES_OF_TRUTH.md`.
+
+Este documento conserva el contenido original de `docs/notes/todo.md` referido a
+una arquitectura **tRPC + Google Sheets** que nunca correspondió al sistema real
+(Fastify REST + Supabase/Postgres + Drizzle + Next.js App Router). Se preserva
+únicamente como registro histórico de la planificación inicial del proyecto.
+
+---
+
+## Autenticación y Autorización
+
+- [x] Sistema de login con credenciales de clínica (usuario/contraseña)
+- [x] Validación de credenciales contra base de datos local
+- [x] Generación de token de sesión y almacenamiento en SESIONES_ACTIVAS
+- [x] Protección de rutas y procedimientos tRPC con autenticación
+- [x] Logout y limpieza de sesión
+
+## Integración con Google Sheets
+
+- [x] Opción 1: Sincronización automática mediante Google Sheets API (sin credenciales)
+- [x] Opción 2: Carga manual de datos desde archivos Excel/CSV
+- [x] Sincronización de datos de CONTROL_CLINICAS (clínicas y usuarios)
+- [x] Sincronización de datos de REGISTRO_INFORMES (informes médicos)
+- [x] Endpoint para cargar datos manualmente
+- [ ] Función de actualización periódica de datos
+- [ ] Sincronización de SESIONES_ACTIVAS (tokens activos)
+
+## Base de Datos
+
+- [x] Crear tabla de clínicas (clinics)
+- [x] Crear tabla de usuarios/credenciales (clinic_users)
+- [x] Crear tabla de informes (reports)
+- [x] Crear tabla de sesiones activas (active_sessions)
+- [ ] Índices para búsqueda rápida
+
+## API y Procedimientos tRPC
+
+- [x] Procedimiento de login (validar credenciales)
+- [x] Procedimiento de logout
+- [x] Procedimiento para obtener informes por clínica
+- [x] Procedimiento para buscar/filtrar informes
+- [x] Procedimiento para obtener URL de descarga de archivo
+- [x] Procedimiento para sincronizar datos de Google Sheets
+
+## Interfaz de Usuario
+
+- [x] Layout de una sola página con panel lateral y área principal
+- [x] Componente de login/autenticación
+- [x] Panel lateral con lista de informes
+- [x] Área principal con visor de PDF
+- [x] Barra de búsqueda y filtros
+- [x] Indicadores de carga y estados
+- [x] Diseño responsivo (mobile, tablet, desktop)
+
+## Visor de PDF y Descargas
+
+- [x] Integración de iframe para visualizar PDFs desde Google Drive
+- [x] Función de descarga directa de archivos
+- [x] Manejo de errores en carga de PDFs
+- [ ] Indicador de progreso de carga
+
+## Búsqueda y Filtrado
+
+- [x] Búsqueda por nombre de paciente
+- [x] Filtro por tipo de estudio
+- [ ] Filtro por fecha de subida
+- [x] Búsqueda en tiempo real
+- [x] Ordenamiento de resultados
+
+## Pruebas
+
+- [x] Pruebas unitarias de procedimientos tRPC
+- [x] Pruebas de autenticación
+- [ ] Pruebas de filtrado y búsqueda
+- [ ] Pruebas de integración con Google Sheets
+
+## Despliegue y Entrega
+
+- [ ] Verificar funcionamiento en navegador
+- [ ] Documentación de uso
+- [ ] Instrucciones de configuración

--- a/docs/audit/final-cleanup-current-status-snapshot.md
+++ b/docs/audit/final-cleanup-current-status-snapshot.md
@@ -42,6 +42,7 @@
 | P2-A `shared/` | Cerrado | #1173, eliminado `shared/` y `test/shared-const-and-errors.test.ts` |
 | P2-B frontend dependencies | Cerrado | #1175, #1176, #1177, #1178, #1179 |
 | P2-F env version vars | Cerrado | `APP_VERSION`/`CLIENT_MIN_VERSION` en `.env.example`; `NEXT_PUBLIC_APP_VERSION` en `frontend/.env.example` |
+| P2-C `docs/notes/todo.md` contradictorio | Cerrado | histórico tRPC/Google Sheets archivado en `docs/archive/legacy-trpc-sheets-todo.md`; logística vigente preservada |
 | Tooling `UNKNOWN` frontend | Cerrado | #1177 |
 | Radix PR-CLEAN7D | Cerrado | #1178 |
 
@@ -49,7 +50,6 @@
 
 | Id | Pendiente | Estado |
 | --- | --- | --- |
-| P2-C | `docs/notes/todo.md` contradictorio | Pendiente |
 | P2-D | Taxonomía documental fragmentada | Pendiente |
 | P2-E | Logger/console observability | Pendiente |
 | P3 | Artefactos históricos/orfanados (`legacy/drizzle-old/`, `scripts/generate-pwa-icons.py`, `scripts/maintenance/FUSION_POR_COMANDO.sh`) | Pendiente |

--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -59,16 +59,14 @@ cerrados en este corte:
 
 La deuda activa real queda limitada a:
 
-1. **P2-C · `docs/notes/todo.md` contradictorio**: describe tRPC + Google
-   Sheets, que ya no corresponden a la arquitectura real. *(P2.)*
-2. **P2-D · Taxonomía documental fragmentada**: ~233 docs con taxonomía
+1. **P2-D · Taxonomía documental fragmentada**: ~233 docs con taxonomía
    fragmentada (`audit/` + `audits/`, notas de implementación en 3 lugares,
    ~31 `pr-*.md` sueltos en la raíz de `docs/`). *(P2.)*
-3. **P2-E · Logger/console observability**: logger mínimo y mezcla de
+2. **P2-E · Logger/console observability**: logger mínimo y mezcla de
    `console.*`/logger en backend. *(P2.)*
-4. **P3 · Artefactos históricos/orfanados**: `legacy/drizzle-old/`,
+3. **P3 · Artefactos históricos/orfanados**: `legacy/drizzle-old/`,
    `scripts/generate-pwa-icons.py`, `scripts/maintenance/FUSION_POR_COMANDO.sh`. *(P3.)*
-5. **P3-G · Backend CI `paths-ignore` opcional** para evitar runs pesados en PRs
+4. **P3-G · Backend CI `paths-ignore` opcional** para evitar runs pesados en PRs
    estrictamente docs-only/frontend, previa verificación de tests de contrato.
 
 Las eliminaciones o cambios restantes se proponen como **PRs chicos, con prueba
@@ -380,13 +378,17 @@ deploy roto ni auth rota en el estado actual.
 
 #### P2-C · `docs/notes/todo.md` contradictorio con la arquitectura actual
 - **Tipo:** docs · **Riesgo:** Bajo.
-- **Evidencia:** el archivo describe "procedimientos **tRPC**", "Sincronización con
+- **Evidencia:** el archivo describía "procedimientos **tRPC**", "Sincronización con
   **Google Sheets API**", `CONTROL_CLINICAS`, `REGISTRO_INFORMES`, carga Excel/CSV
   y `SESIONES_ACTIVAS` — una arquitectura que **no corresponde** al sistema real
   (Fastify REST + Supabase/Postgres + Drizzle). La sección de logística al final sí
   es vigente.
-- **Acción:** **archivar o reescribir** (separar la parte de logística vigente del
-  TODO histórico tRPC/Sheets). **PR-CLEAN1**.
+- **Acción:** **CERRADO DOCUMENTALMENTE.** El histórico tRPC/Sheets se archivó en
+  [`docs/archive/legacy-trpc-sheets-todo.md`](../archive/legacy-trpc-sheets-todo.md);
+  `docs/notes/todo.md` quedó solo con la sección de logística vigente y una nota
+  que referencia el archivo y `docs/SOURCES_OF_TRUTH.md`. Detalle en
+  [`docs/implementation/legacy-todo-note-cleanup.md`](../implementation/legacy-todo-note-cleanup.md).
+  Docs-only, sin cambios en runtime/dependencias/DB. **PR-CLEAN1**.
 
 #### P2-D · Taxonomía documental fragmentada
 - **Tipo:** docs · **Riesgo:** Bajo.
@@ -453,7 +455,7 @@ deploy roto ni auth rota en el estado actual.
 | 10 | `echarts` + `echarts-for-react` (deps) | dependencias | removidas por PR-CLEAN7A (#1175) | cerrado |
 | 11 | `react-hook-form` (dep frontend) | dependencias | removida por PR-CLEAN7A (#1175) | cerrado |
 | 12 | Radix remanente no importado | dependencias | `avatar`, `dropdown-menu`, `label`, `select`, `tabs` removidos por PR-CLEAN7D/#1178; `toast`/`tooltip` `DEFER keep` por roadmap | cerrado |
-| 13 | `docs/notes/todo.md` (parte tRPC/Sheets) | docs | contradice arquitectura real | PR-CLEAN1 |
+| 13 | `docs/notes/todo.md` (parte tRPC/Sheets) | docs | archivada en `docs/archive/legacy-trpc-sheets-todo.md` | cerrado |
 
 ---
 
@@ -471,7 +473,7 @@ deploy roto ni auth rota en el estado actual.
 | `scripts/generate-pwa-icons.py` | 0 refs; Python prohibido | P3 | Bajo | eliminar | PR-CLEAN6 |
 | `scripts/maintenance/FUSION_POR_COMANDO.sh` | 0 refs; fusión histórica | P3 | Bajo | eliminar | PR-CLEAN6 |
 | `frontend/package.json` (Radix remanente) | Tooling ESLint cerrado por PR-CLEAN7C; Radix `avatar`, `dropdown-menu`, `label`, `select`, `tabs` cerrado por PR-CLEAN7D/#1178; `toast`/`tooltip` quedan `DEFER keep` por roadmap | P2 cerrado | Medio | cerrado; no recomendar PR-CLEAN7D como pendiente | #1178 / #1179 |
-| `docs/notes/todo.md` | tRPC/Google Sheets inexistentes | P2 | Bajo | archivar/reescribir | PR-CLEAN1 |
+| `docs/notes/todo.md` | tRPC/Google Sheets inexistentes | P2 cerrado | Bajo | cerrado; archivado en `docs/archive/legacy-trpc-sheets-todo.md` | PR-CLEAN1 |
 | `docs/audit/` + `docs/audits/` | taxonomía duplicada | P2 | Bajo | unificar | PR-CLEAN2 |
 | `IMPLEMENTATION_NOTES/` (raíz, 34) | notas en 3 ubicaciones | P2 | Bajo | consolidar bajo `docs/` | PR-CLEAN2 |
 | ~31 `docs/pr-*.md` sueltos | deberían ir en `pr-history/` | P2 | Bajo | mover | PR-CLEAN2 |
@@ -509,8 +511,10 @@ deploy roto ni auth rota en el estado actual.
 - **Histórico útil (archivar, no borrar):** `docs/audit/*` y `docs/audits/*` de
   bloques cerrados (admin-mobile density, dashboard redesign, backend incident
   P0), `docs/pr-history/*`, `docs/implementation-history/*`, `IMPLEMENTATION_NOTES/*`.
-- **Obsoleto / contradictorio:** `docs/notes/todo.md` (tRPC + Google Sheets;
-  contradice Fastify/Supabase). Revisar `docs/notes/PENDIENTE_NORMALIZACION_CLINICS.md`.
+- **Obsoleto / contradictorio (cerrado):** `docs/notes/todo.md` (tRPC + Google
+  Sheets; contradecía Fastify/Supabase) — histórico archivado en
+  `docs/archive/legacy-trpc-sheets-todo.md`. Revisar
+  `docs/notes/PENDIENTE_NORMALIZACION_CLINICS.md`.
 - **Candidato a reorganizar:** ~31 `pr-*.md` sueltos en raíz de `docs/`;
   duplicidad `audit/` vs `audits/`; notas de implementación en 3 árboles.
 
@@ -740,6 +744,14 @@ exige build+E2E). El resto está saludable.
   `NEXT_PUBLIC_APP_VERSION` en `frontend/.env.example`, usando sólo placeholders
   no secretos. No se tocaron `docs/notes/todo.md`, runtime, dependencias,
   lockfiles, DB, migraciones, workflows, Render ni lógica del version gate.
+- **Nota de seguimiento P2-C (ejecución real, rama
+  `docs/cleanup-legacy-todo-note`, 2026-06-29):** el histórico tRPC/Google Sheets
+  de `docs/notes/todo.md` se movió a
+  `docs/archive/legacy-trpc-sheets-todo.md`; `docs/notes/todo.md` quedó con la
+  sección de logística vigente y una nota que apunta al archivo y a
+  `docs/SOURCES_OF_TRUTH.md`. Detalle en
+  `docs/implementation/legacy-todo-note-cleanup.md`. Docs-only, sin tocar
+  runtime, dependencias, lockfiles, DB, migraciones ni workflows.
 
 ### PR-CLEAN2 · reorganización documental (solo-docs)
 - **Alcance:** unificar `docs/audits/` → `docs/audit/`; mover `pr-*.md` sueltos a
@@ -1165,8 +1177,9 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
 
 ## 17. Checklist final de cierre de proyecto
 
-- [~] PR-CLEAN1 (docs/env comments): P2-F cerrado por
-  `docs/env-version-vars-contract`; P2-C `docs/notes/todo.md` sigue pendiente.
+- [x] PR-CLEAN1 (docs/env comments): P2-F cerrado por
+  `docs/env-version-vars-contract`; P2-C `docs/notes/todo.md` cerrado, histórico
+  archivado en `docs/archive/legacy-trpc-sheets-todo.md`.
 - [ ] PR-CLEAN2 (reorg docs) mergeado, `git grep` de rutas movidas sin huérfanos.
 - [x] PR-CLEAN3 / P1-B (email URL contract) cerrado por #1162; `PUBLIC_SITE_URL`
   separa URL pública de `CORS_ORIGIN` con fallback conservador.
@@ -1184,7 +1197,7 @@ git grep -n "<simbolo-o-paquete>" -- frontend/src frontend/e2e server shared
   `docs/audit/frontend-dependencies-cleanup-closeout.md`.
 - [x] `.env.example` y `frontend/.env.example` documentan las vars del version
   gate (`APP_VERSION`, `CLIENT_MIN_VERSION`, `NEXT_PUBLIC_APP_VERSION`).
-- [ ] `docs/notes/todo.md` ya no contradice la arquitectura real.
+- [x] `docs/notes/todo.md` ya no contradice la arquitectura real.
 - [ ] Taxonomía `docs/` unificada (sin `audit`+`audits`, sin `pr-*.md` sueltos).
 - [ ] `main` limpio, CI verde (backend + frontend), 0 PRs abiertos.
 - [ ] `pnpm typecheck` + `pnpm --dir frontend typecheck` verdes (hoy: ✅).

--- a/docs/implementation/legacy-todo-note-cleanup.md
+++ b/docs/implementation/legacy-todo-note-cleanup.md
@@ -1,0 +1,47 @@
+# Cierre P2-C — `docs/notes/todo.md` contradictorio con la arquitectura actual
+
+> **Modo:** docs-only.
+> **Fecha:** 2026-06-29.
+> **Rama:** `docs/cleanup-legacy-todo-note`.
+> **HEAD base:** `509a465 docs(env): document version gate env examples (#1181)`.
+> **Documento rector:** `docs/audit/final-repo-cleanup-engineering-audit.md` (P2-C).
+
+## Hallazgo
+
+`docs/notes/todo.md` mezclaba contenido histórico de una arquitectura
+**tRPC + Google Sheets** (`CONTROL_CLINICAS`, `REGISTRO_INFORMES`, carga
+Excel/CSV, `SESIONES_ACTIVAS`) que nunca correspondió al sistema real
+(Fastify REST + Supabase/Postgres + Drizzle + Next.js App Router) con una
+sección de logística operativa vigente.
+
+## Acción
+
+- Se creó [`docs/archive/legacy-trpc-sheets-todo.md`](../archive/legacy-trpc-sheets-todo.md)
+  con el contenido histórico completo (autenticación, Google Sheets, base de
+  datos, API tRPC, UI, visor de PDF, búsqueda/filtrado, pruebas, despliegue),
+  marcado explícitamente como **archivado / no usar como fuente vigente**.
+- `docs/notes/todo.md` quedó reducido a:
+  - una nota breve que referencia el archivo histórico y `docs/SOURCES_OF_TRUTH.md`;
+  - la sección **Logística operativa**, sin modificaciones de contenido.
+- Se actualizó `docs/audit/final-repo-cleanup-engineering-audit.md` (secciones
+  §3, §4, §5, §7, §14, §17) marcando P2-C como cerrado y referenciando el
+  archivo nuevo.
+- Se actualizó `docs/audit/final-cleanup-current-status-snapshot.md` moviendo
+  P2-C de "Pendientes reales" a "Bloques cerrados".
+
+## Verificación de referencias
+
+`git grep` confirmó que ninguna ruta de código, test, workflow o script
+referenciaba `docs/notes/todo.md` por contenido tRPC/Sheets antes del cambio.
+La única referencia activa a `docs/notes/todo.md` fuera de los documentos de
+auditoría es `docs/logistics/ROLLING_ROADMAP.md:39` ("Reference in
+`docs/notes/todo.md`"), que sigue siendo válida porque la sección de
+logística se preservó sin cambios de contenido.
+
+## Scope
+
+- Docs-only.
+- No se tocó runtime frontend/backend, `package.json`, `pnpm-lock.yaml`, DB,
+  migraciones, workflows, Render ni secrets.
+- No se eliminó contenido histórico sin archivarlo.
+- No commit, no push, no PR.

--- a/docs/notes/todo.md
+++ b/docs/notes/todo.md
@@ -1,77 +1,11 @@
 # Portal VETNEB - TODO
 
-## Autenticación y Autorización
-
-- [x] Sistema de login con credenciales de clínica (usuario/contraseña)
-- [x] Validación de credenciales contra base de datos local
-- [x] Generación de token de sesión y almacenamiento en SESIONES_ACTIVAS
-- [x] Protección de rutas y procedimientos tRPC con autenticación
-- [x] Logout y limpieza de sesión
-
-## Integración con Google Sheets
-
-- [x] Opción 1: Sincronización automática mediante Google Sheets API (sin credenciales)
-- [x] Opción 2: Carga manual de datos desde archivos Excel/CSV
-- [x] Sincronización de datos de CONTROL_CLINICAS (clínicas y usuarios)
-- [x] Sincronización de datos de REGISTRO_INFORMES (informes médicos)
-- [x] Endpoint para cargar datos manualmente
-- [ ] Función de actualización periódica de datos
-- [ ] Sincronización de SESIONES_ACTIVAS (tokens activos)
-
-## Base de Datos
-
-- [x] Crear tabla de clínicas (clinics)
-- [x] Crear tabla de usuarios/credenciales (clinic_users)
-- [x] Crear tabla de informes (reports)
-- [x] Crear tabla de sesiones activas (active_sessions)
-- [ ] Índices para búsqueda rápida
-
-## API y Procedimientos tRPC
-
-- [x] Procedimiento de login (validar credenciales)
-- [x] Procedimiento de logout
-- [x] Procedimiento para obtener informes por clínica
-- [x] Procedimiento para buscar/filtrar informes
-- [x] Procedimiento para obtener URL de descarga de archivo
-- [x] Procedimiento para sincronizar datos de Google Sheets
-
-## Interfaz de Usuario
-
-- [x] Layout de una sola página con panel lateral y área principal
-- [x] Componente de login/autenticación
-- [x] Panel lateral con lista de informes
-- [x] Área principal con visor de PDF
-- [x] Barra de búsqueda y filtros
-- [x] Indicadores de carga y estados
-- [x] Diseño responsivo (mobile, tablet, desktop)
-
-## Visor de PDF y Descargas
-
-- [x] Integración de iframe para visualizar PDFs desde Google Drive
-- [x] Función de descarga directa de archivos
-- [x] Manejo de errores en carga de PDFs
-- [ ] Indicador de progreso de carga
-
-## Búsqueda y Filtrado
-
-- [x] Búsqueda por nombre de paciente
-- [x] Filtro por tipo de estudio
-- [ ] Filtro por fecha de subida
-- [x] Búsqueda en tiempo real
-- [x] Ordenamiento de resultados
-
-## Pruebas
-
-- [x] Pruebas unitarias de procedimientos tRPC
-- [x] Pruebas de autenticación
-- [ ] Pruebas de filtrado y búsqueda
-- [ ] Pruebas de integración con Google Sheets
-
-## Despliegue y Entrega
-
-- [ ] Verificar funcionamiento en navegador
-- [ ] Documentación de uso
-- [ ] Instrucciones de configuración
+> El TODO original de este archivo describía una arquitectura **tRPC + Google
+> Sheets** que nunca correspondió al sistema real. Ese contenido histórico se
+> archivó en
+> [`docs/archive/legacy-trpc-sheets-todo.md`](../archive/legacy-trpc-sheets-todo.md).
+> La arquitectura vigente es **Fastify REST + Supabase/Postgres + Drizzle +
+> Next.js App Router** — ver `docs/SOURCES_OF_TRUTH.md`.
 
 ## Logística operativa
 


### PR DESCRIPTION
Docs-only cleanup for P2-C legacy todo note.

Scope:
- Archives obsolete tRPC / Google Sheets / CONTROL_CLINICAS / REGISTRO_INFORMES / SESIONES_ACTIVAS / Excel-CSV todo content.
- Preserves active logistics content in docs/notes/todo.md unchanged.
- Updates audit/current-status docs to mark P2-C as closed.
- Adds implementation note:
  - docs/implementation/legacy-todo-note-cleanup.md

Files:
- docs/archive/legacy-trpc-sheets-todo.md
- docs/notes/todo.md
- docs/audit/final-repo-cleanup-engineering-audit.md
- docs/audit/final-cleanup-current-status-snapshot.md
- docs/implementation/legacy-todo-note-cleanup.md

Contract:
- Docs-only.
- Historical content was archived, not lost.
- docs/notes/todo.md now points to the archived historical note and current sources of truth.
- Logistics operational section remains intact.
- No runtime frontend/backend changes.
- No package/lock changes.
- No tests changes.
- No DB/migration/workflow/Render/secrets changes.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.
- Forbidden scope guard returned no files.

Reference check:
- git grep found the remaining active reference in docs/logistics/ROLLING_ROADMAP.md:39, which remains valid because logistics content was preserved.
