### PR TITLE
ci(backend): skip docs-only pull requests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   push:
     branches:
       - main

--- a/docs/audit/final-cleanup-current-status-snapshot.md
+++ b/docs/audit/final-cleanup-current-status-snapshot.md
@@ -52,13 +52,13 @@
 | --- | --- | --- |
 | P2-D | Taxonomía documental fragmentada | Pendiente |
 | P2-E | Logger/console observability | Pendiente |
-| P3-G | `backend-ci.yml` `paths-ignore` opcional | Pendiente opcional |
 
 ## Bloques cerrados (actualización 2026-06-29)
 
 | Bloque | Estado actual | Evidencia |
 | --- | --- | --- |
 | P3 artefactos históricos/orfanados | Cerrado | `clean/remove-orphaned-historical-artifacts`; eliminados `legacy/drizzle-old/`, `scripts/generate-pwa-icons.py`, `scripts/maintenance/FUSION_POR_COMANDO.sh` tras revalidar 0 referencias operativas |
+| P3-G `backend-ci.yml` `paths-ignore` opcional | Cerrado | `ci/backend-paths-ignore-docs-only`; `paths-ignore: ['docs/**', '**/*.md']` agregado sólo al trigger `pull_request` de `.github/workflows/backend-ci.yml`; `push` y `frontend-ci.yml` sin cambios; ver `docs/implementation/backend-ci-paths-ignore-docs-only.md` |
 
 ## Dependencias diferidas
 

--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -435,7 +435,7 @@ deploy roto ni auth rota en el estado actual.
 | P3-D | `trusted-origin.ts` conserva helper/fallback propio | Middleware global fuera de `server/routes`; mantiene contrato de protección global y no fue tocado por #1164–#1170 | mantener como remanente intencional salvo PR dedicado |
 | P3-E | `AXIOS_TIMEOUT_MS` (`@deprecated`) | residuo histórico de `shared/const.ts`; eliminado junto con P2-A por #1173 | cerrado |
 | P3-F | Split `zod` v3 (backend `^3.25.76`) vs v4 (frontend `^4`) | `package.json` vs `frontend/package.json` | documentar (intencional: paquetes separados); revisar a futuro |
-| P3-G | `backend-ci.yml` sin `paths:` → corre en PRs de solo-docs/frontend | `.github/workflows/backend-ci.yml:3-16` | evaluar `paths-ignore` (ver §10) |
+| P3-G | `backend-ci.yml` sin `paths:` → corre en PRs de solo-docs/frontend | `.github/workflows/backend-ci.yml:3-16` | Cerrado: `paths-ignore` (`docs/**`, `**/*.md`) en `pull_request` (ver §10) |
 | P3-H | Residual CORS local resuelto en `logistics-sla.fastify.ts` | Cerrado por #1170 / `clean/backend-cors-helper-logistics-sla`: la ruta GET-only importa `getAllowedOrigins`, `getAllowedOriginForCors` y `getRequestOrigin` desde `server/lib/cors-headers.ts`; `applyCorsHeaders` queda local | cerrado |
 
 ---
@@ -623,16 +623,24 @@ de URL pública ya fue cerrado por #1162 / PR-CLEAN3.
 
 | Workflow | Estado | Observación |
 | --- | --- | --- |
-| `backend-ci.yml` | sólido | **Sin `paths:`** → corre full (postgres+migraciones+test+build, ~15 min) también en PRs de solo-docs o solo-frontend. `pnpm audit`/`pnpm audit --prod` pueden romper CI por advisories de devDeps. |
+| `backend-ci.yml` | sólido | `pull_request` tiene `paths-ignore: docs/**, **/*.md` (P3-G, cerrado) → no corre en PRs estrictamente docs-only; sigue corriendo full (postgres+migraciones+test+build, ~15 min) ante cambios en `server/**`, `test/**`, `package.json`, `pnpm-lock.yaml`, `.github/workflows/**`, `drizzle/**`, `scripts/**`, `.env.example` o cualquier archivo no-docs. `push` queda sin `paths-ignore` (sin cambio). `pnpm audit`/`pnpm audit --prod` pueden romper CI por advisories de devDeps. |
 | `frontend-ci.yml` | sólido | `paths:` correctos; E2E en 4 grupos; `concurrency` con cancel. |
 | `app-version-force-update.yml` | excelente | `workflow_dispatch` only, validación dura de input, sin imprimir secretos, orden frontend→backend, smoke con polling. **No tocar.** |
 
 **Triggers / duplicación:** `backend-ci` corre en `push` (a `main` y muchas ramas
 `feat/**,fix/**,…`) **y** `pull_request` a `main`. Un push a una rama con PR
 abierto dispara el workflow dos veces; `concurrency: cancel-in-progress` mitiga
-parcialmente. **Optimización (P3-G):** considerar `paths-ignore` en `backend-ci`
-para PRs de solo-docs (riesgo: algunos tests de contrato leen `.env.example`/docs;
-verificar antes con `git grep`).
+parcialmente. **Optimización (P3-G, cerrado):** se agregó `paths-ignore:
+['docs/**', '**/*.md']` sólo al trigger `pull_request` de `backend-ci.yml`. Se
+verificó con `git grep` que los tests de contrato que leen `.env.example`
+(`test/smoke-env-contract.test.ts`, `test/production-env-contracts.test.ts`,
+etc.) no dependen de archivos `docs/**`/`*.md`, y que GitHub Actions sólo omite
+el job cuando *todos* los archivos del diff caen dentro del `paths-ignore`
+(cualquier archivo en `server/**`, `test/**`, `package.json`,
+`pnpm-lock.yaml`, `.github/workflows/**`, `drizzle/**`, `scripts/**` o
+`.env.example` sigue disparando el job normalmente). El trigger `push` queda
+intacto. Ver
+[`docs/implementation/backend-ci-paths-ignore-docs-only.md`](../implementation/backend-ci-paths-ignore-docs-only.md).
 
 **Secretos requeridos** (force-update): `RENDER_API_KEY`,
 `RENDER_FRONTEND_SERVICE_ID`, `RENDER_BACKEND_SERVICE_ID`,

--- a/docs/implementation/backend-ci-paths-ignore-docs-only.md
+++ b/docs/implementation/backend-ci-paths-ignore-docs-only.md
@@ -1,0 +1,115 @@
+# Backend CI · `paths-ignore` docs-only (P3-G)
+
+> **Modo:** CI-only + docs.
+> **Fecha:** 2026-06-29.
+> **Rama:** `ci/backend-paths-ignore-docs-only`.
+> **HEAD base:** `def7cd1 chore(cleanup): remove orphaned historical artifacts (#1183)`.
+> **Documento rector:** `docs/audit/final-repo-cleanup-engineering-audit.md` (§10, hallazgo P3-G).
+
+## Problema
+
+`.github/workflows/backend-ci.yml` no tenía `paths:`/`paths-ignore:`, por lo que
+`validate-backend` (postgres + migraciones + typecheck + test + build, ~15 min)
+corría también en PRs estrictamente docs-only (por ejemplo, ediciones de
+`docs/audit/*.md`), generando ruido y consumo de minutos de CI sin valor.
+
+## Cambio aplicado
+
+Se agregó `paths-ignore` únicamente al trigger `pull_request` de
+`.github/workflows/backend-ci.yml`:
+
+```yaml
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  push:
+    branches:
+      - main
+      - chore/**
+      - feat/**
+      - fix/**
+      - refactor/**
+      - ci/**
+      - test/**
+      - codex/**
+```
+
+El trigger `push` **no** se modificó: las ramas de trabajo (`feat/**`, `fix/**`,
+etc.) siguen disparando `backend-ci` en cada push, igual que antes.
+
+## Por qué sólo `docs/**` y `**/*.md`
+
+GitHub Actions omite el job sólo cuando **todos** los archivos del diff del PR
+coinciden con `paths-ignore`. Cualquier archivo fuera de esos dos patrones
+(p. ej. `server/**`, `test/**`, `package.json`, `pnpm-lock.yaml`,
+`.github/workflows/**`, `drizzle/**`, `scripts/**`, `.env.example`,
+`frontend/**`) sigue disparando `validate-backend` con normalidad, incluso si
+el mismo PR también toca `docs/**` o algún `.md`.
+
+Se excluyeron deliberadamente de `paths-ignore`:
+
+- `.env.example` y `frontend/.env.example` — varios tests de contrato backend
+  los leen directamente (`test/smoke-env-contract.test.ts`,
+  `test/production-env-contracts.test.ts`,
+  `test/global-e2e-production-readiness-contract.test.ts`, entre otros).
+- `package.json`, `pnpm-lock.yaml` — cambios de dependencias.
+- `.github/workflows/**` — cambios al propio pipeline de CI.
+- `server/**`, `test/**`, `drizzle/**`, `scripts/**`, `frontend/**` — código y
+  artefactos que `validate-backend` debe seguir cubriendo.
+
+## Verificación de tests de contrato
+
+Se revisó con `git grep` qué tests leen `.env.example`/`docs/` para confirmar
+que ninguno depende de que el job corra a partir de un cambio en `docs/**` o
+`*.md` exclusivamente; todos esos tests corren igual dentro del job cuando éste
+se dispara por cualquier otro archivo (server/test/package/lock/workflow/env),
+y el job nunca se salta si el PR toca algo fuera de `docs/**`/`*.md`.
+
+## Qué sigue disparando `validate-backend` en PRs a `main`
+
+- `server/**`
+- `test/**`
+- `package.json`
+- `pnpm-lock.yaml`
+- `.github/workflows/**`
+- `drizzle/**`
+- `scripts/**`
+- `.env.example`
+- `frontend/**` (y cualquier otro archivo no cubierto por `docs/**`/`**/*.md`)
+
+## Qué deja de disparar `validate-backend`
+
+- PRs a `main` cuyo diff completo está compuesto exclusivamente por archivos
+  bajo `docs/**` y/o archivos `*.md` en cualquier carpeta (por ejemplo, README
+  raíz, `docs/audit/*.md`, `docs/implementation/*.md`).
+
+## `frontend-ci.yml`
+
+Sin cambios. Se leyó sólo como referencia de un `paths:` ya correcto
+(`frontend/**`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `package.json`,
+`.github/workflows/frontend-ci.yml`).
+
+## Validaciones ejecutadas
+
+- `corepack pnpm typecheck` — OK.
+- `corepack pnpm typecheck:test` — OK.
+- `corepack pnpm test` — 2890 tests, 0 fallos.
+- `corepack pnpm build` — OK (`dist/index.js`, 836.8kb).
+- `corepack pnpm --dir frontend lint` — OK.
+- `corepack pnpm --dir frontend typecheck` — OK.
+- `corepack pnpm --dir frontend build` — OK (25 rutas generadas, sin drift en
+  `frontend/next-env.d.ts`).
+- `git diff --check` — sin conflictos de whitespace.
+
+## Alcance respetado
+
+- No se tocó runtime frontend ni backend.
+- No se tocó `package.json` ni `pnpm-lock.yaml`.
+- No se tocó DB ni migraciones.
+- No se tocó Render ni secrets.
+- No se tocó `frontend-ci.yml` ni `app-version-force-update.yml`.
+- Sin commit, sin push, sin PR.


### PR DESCRIPTION
CI-only/docs update for P3-G backend CI paths-ignore.

Scope:
- Adds paths-ignore to Backend CI pull_request trigger.
- Leaves Backend CI push trigger intact.
- Leaves Frontend CI unchanged.
- Updates audit/current-status docs to mark P3-G as closed.
- Adds implementation note:
  - docs/implementation/backend-ci-paths-ignore-docs-only.md

Ignored on Backend CI pull_request:
- docs/**
- **/*.md

Still triggers Backend CI:
- server/**
- test/**
- package.json
- pnpm-lock.yaml
- .github/workflows/**
- drizzle/**
- scripts/**
- .env.example
- frontend/**

Contract:
- GitHub Actions skips the workflow only when the entire PR diff matches ignored paths.
- No runtime frontend/backend changes.
- No package/lock changes.
- No DB/migration changes.
- No Render/secrets changes.
- No frontend-ci.yml changes.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.
- Forbidden scope guard returned no files.
