### PR TITLE
docs(audit): close documentation taxonomy cleanup

### DIFF
--- a/docs/audit/documentation-taxonomy-fragmentation-audit.md
+++ b/docs/audit/documentation-taxonomy-fragmentation-audit.md
@@ -1,0 +1,200 @@
+# Auditoría P2-D · Taxonomía documental fragmentada — fase 0 (docs-only)
+
+> **Modo:** AUDITORÍA. No se movió, renombró ni borró ningún archivo. No se
+> tocó runtime, tests, `package.json`, `pnpm-lock.yaml`, workflows, DB,
+> migraciones, Render ni secretos. No commit, no push, no PR.
+>
+> **Rama:** `docs/audit-documentation-taxonomy-plan`.
+> **HEAD base:** `1b6f6b0 docs(audit): document backend observability debt (#1185)`.
+> **Fecha:** 2026-06-29.
+
+---
+
+## 1. Resumen ejecutivo
+
+**Hallazgo principal: la fragmentación documental que describe P2-D ya fue
+resuelta en disco.** PR `#1163` (`af5cd28 docs: consolidate historical
+documentation structure`, 2026-06-28) ejecutó el move-only completo:
+
+- `docs/audits/` → `docs/audit/` (10 archivos unificados, sin colisión).
+- `IMPLEMENTATION_NOTES/` (raíz, 34 archivos) → `docs/implementation/`.
+- `docs/implementation-history/` (13 archivos) → `docs/implementation/`.
+- ~31 `docs/pr-*.md` sueltos en la raíz → `docs/pr-history/`.
+
+El inventario actual confirma que **ninguna de las cuatro ubicaciones
+duplicadas/fragmentadas existe hoy**:
+
+```
+docs/audits/                 → no existe
+IMPLEMENTATION_NOTES/        → no existe
+docs/implementation-history/ → no existe
+docs/pr-*.md (raíz)          → 0 archivos
+```
+
+Lo que queda pendiente **no es mover archivos** (ya se hizo), sino **cerrar
+documentalmente** dos documentos rectores que todavía presentan P2-D como
+"deuda activa pendiente" cuando en realidad ya fue ejecutada:
+
+1. `docs/audit/final-repo-cleanup-engineering-audit.md` — §1 (línea 62-64) y
+   §3 P2-D (línea 398-407) describen evidencia con conteos viejos
+   (`docs/audit/` 62 / `docs/audits/` 10) como si la duplicación siguiera
+   vigente, aunque el mismo documento, más abajo en la nota de seguimiento de
+   **PR-CLEAN2** (línea 790-821), ya registra la ejecución real del
+   2026-06-28.
+2. `docs/audit/final-cleanup-current-status-snapshot.md` — tabla "Pendientes
+   reales" (línea 49-53) lista `P2-D | Taxonomía documental fragmentada |
+   Pendiente`, contradiciendo el estado real en disco.
+
+No se detectaron referencias de alto riesgo rotas: ningún test, script ni
+workflow lee hoy una ruta bajo `docs/audits/`, `IMPLEMENTATION_NOTES/` o
+`docs/implementation-history/`.
+
+---
+
+## 2. Inventario actual por carpeta (`docs/` + raíz)
+
+```
+99  docs/implementation
+62  docs/pr-history
+58  docs/audit
+21  docs/audit/evidence/dashboard-runtime-post-ux1
+14  docs/ (archivos sueltos en raíz, no pr-*.md)
+ 6  docs/security
+ 6  docs/ops
+ 5  docs/release
+ 5  docs/governance
+ 4  docs/logistics
+ 3  docs/qa
+ 3  docs/notes
+ 3  docs/changelog
+ 1  docs/protocol
+ 1  docs/product
+ 1  docs/archive
+```
+
+Carpetas/archivos mencionados por P2-D como fragmentados, verificados ausentes:
+
+| Ruta histórica | Estado en disco | Verificación |
+| --- | --- | --- |
+| `docs/audits/` | **no existe** | `Get-ChildItem docs/audits` → error de ruta |
+| `IMPLEMENTATION_NOTES/` (raíz) | **no existe** | `Get-ChildItem IMPLEMENTATION_NOTES` → error de ruta |
+| `docs/implementation-history/` | **no existe** | `Get-ChildItem docs/implementation-history` → error de ruta |
+| `docs/pr-*.md` sueltos en raíz de `docs/` | **0 archivos** | `Get-ChildItem docs -File -Filter "pr-*.md"` → vacío |
+| `docs/pr-history/` | **62 archivos** (destino consolidado) | existe, poblada |
+| `docs/implementation/` | **99 archivos** (destino consolidado) | existe, poblada |
+| `docs/audit/` | **58 archivos** en raíz + 21 en `evidence/dashboard-runtime-post-ux1/` (destino consolidado) | existe, poblada |
+
+**Commit responsable de la consolidación:** `af5cd28 docs: consolidate
+historical documentation structure (#1163)`. Confirmado vía:
+```
+git log --oneline --all -- docs/audits docs/implementation-history IMPLEMENTATION_NOTES docs/pr-history
+```
+
+---
+
+## 3. Referencias detectadas (`git grep`)
+
+### 3.1 Referencias a rutas viejas (`docs/audits/`, `IMPLEMENTATION_NOTES/`, `docs/implementation-history/`)
+
+Todas las apariciones encontradas son **prosa histórica** (notas de
+implementación y auditorías que narran el move-only ya ejecutado, o
+documentos índice como `docs/HISTORICAL_DOCUMENTATION.md` y
+`docs/SOURCES_OF_TRUTH.md` que documentan correctamente "ex-`docs/audits/`,
+ahora en `docs/audit/`"). **Ninguna es una referencia de código activo, test
+ni script** que intente leer esas rutas hoy. Archivos relevantes:
+
+- `AGENTS.md`
+- `docs/HISTORICAL_DOCUMENTATION.md`
+- `docs/SOURCES_OF_TRUTH.md`
+- `docs/audit/README.md`
+- `docs/audit/repository-operational-ordering-audit.md`
+- `docs/implementation/chore-docs-organize-audit-implementation-notes.md`
+- `docs/implementation/audit-auth-password-change-security-contracts.md`
+- `docs/implementation/feat-auth-dashboard-password-change-ui.md`
+- `docs/implementation/feat-auth-password-change-api-clients.md`
+- `docs/implementation/feat-dashboard-no-scroll-premium-redesign.md`
+- `docs/implementation/feat-dashboard-premium-visual-shell.md`
+- `docs/implementation/fix-dashboard-clear-last-module-on-logout.md`
+- `docs/implementation/fix-dashboard-surface-password-change-panel.md`
+
+Estas no requieren cambio: reescribirlas reescribiría historia documental ya
+cerrada (precedente explícito en
+`docs/audit/repository-operational-ordering-audit.md` §3/§4/§8: "no se
+reescribe historia").
+
+### 3.2 Tests/scripts que leen rutas exactas de `docs/` (alto riesgo si se mueve algo)
+
+```
+test/admin-docs-operational-contract.test.ts        → docs/staging-smoke-runbook.md, docs/release-readiness.md
+test/frontend-dashboard-filter-drawer-sticky-filters.test.ts → docs/pr-history/pr-6-dashboard-filter-drawer-sticky-filters.md
+test/global-e2e-production-readiness-contract.test.ts → docs/audit/global-e2e-extreme-production-audit.md,
+                                                          docs/pr-history/pr-826-global-e2e-extreme-production-readiness.md
+test/helpers/clean7a-dependency-cleanup-scope.ts     → docs/implementation/frontend-unused-deps-clean7a.md
+test/production-readiness.test.ts                    → docs/implementation/IMPLEMENTATION_PRODUCTION_OBSERVABILITY_READINESS.md
+test/public-staging-config-contract.test.ts          → docs/staging-smoke-runbook.md, docs/release-readiness.md
+test/security-docs-matrix-drift-guard.test.ts        → docs/security/security-sessions-tenant-rls-audit.md,
+                                                          docs/security/rls-enforcement-matrix.md,
+                                                          docs/security/RBAC_MATRIX.md,
+                                                          docs/security/ENDPOINT_PERMISSION_MATRIX.md,
+                                                          docs/security/ENDPOINT_TEST_MATRIX.md,
+                                                          docs/ops/CROSS_TENANT_SMOKE_EVIDENCE_RUNBOOK.md
+test/security-production-invariants.test.ts          → docs/security/csp-reporting-rollout.md
+test/smoke-env-contract.test.ts                      → docs/smoke-local.md
+test/smoke-local-contract.test.ts                    → docs/smoke-local.md
+```
+
+**Ninguno** de estos tests referencia `docs/audits/`, `IMPLEMENTATION_NOTES/`
+ni `docs/implementation-history/`. Todas las rutas fijadas ya apuntan a la
+taxonomía consolidada (`docs/audit/`, `docs/implementation/`,
+`docs/pr-history/`, `docs/security/`, `docs/ops/`, raíz `docs/`). Esto
+confirma que la consolidación de #1163 ya actualizó estos guards en su
+momento (precedente: tests de scope alineados in-PR, mencionado en el
+documento rector §13).
+
+---
+
+## 4. Qué queda realmente pendiente de P2-D
+
+No queda trabajo de **movimiento de archivos**. Queda únicamente:
+
+1. **Cerrar documentalmente** la sección P2-D en
+   `docs/audit/final-repo-cleanup-engineering-audit.md` (actualizar evidencia
+   con los conteos reales y remover la recomendación de ejecutar PR-CLEAN2,
+   que ya fue ejecutado).
+2. **Actualizar** la tabla "Pendientes reales" en
+   `docs/audit/final-cleanup-current-status-snapshot.md` para mover P2-D de
+   `Pendiente` a `Cerrado` (referenciando #1163).
+3. Opcional, no bloqueante: revisar si conviene un índice de navegación
+   adicional (`docs/audit/README.md` ya cumple ese rol para `docs/audit/`,
+   y `docs/SOURCES_OF_TRUTH.md` / `docs/HISTORICAL_DOCUMENTATION.md` ya
+   documentan el mapa completo).
+
+No se proponen fases de movimiento porque no hay movimiento que hacer. Las
+fases A-D originalmente previstas en el brief (consolidar `audits→audit`,
+mover `pr-*.md`, decidir `IMPLEMENTATION_NOTES` vs `implementation-history`,
+crear índice) **ya fueron ejecutadas por #1163** salvo el cierre documental
+del punto 4 (índice), que ya existe en `docs/SOURCES_OF_TRUTH.md` y
+`docs/HISTORICAL_DOCUMENTATION.md`.
+
+| Fase prevista en el brief | Estado real |
+| --- | --- |
+| Fase A: `docs/audits` → `docs/audit` | **Ejecutada** por #1163 |
+| Fase B: `docs/pr-*.md` → `docs/pr-history/` | **Ejecutada** por #1163 |
+| Fase C: `IMPLEMENTATION_NOTES/` vs `docs/implementation-history/` | **Ejecutada** por #1163 (ambas absorbidas en `docs/implementation/`) |
+| Fase D: índice de navegación / SOURCES_OF_TRUTH | **Ya existe**: `docs/SOURCES_OF_TRUTH.md`, `docs/HISTORICAL_DOCUMENTATION.md`, `docs/audit/README.md` |
+
+**No se ejecutan moves en esta fase 0** (no hay ninguno pendiente que
+ejecutar; el hallazgo de esta auditoría es que el move-only ya había
+ocurrido y los documentos rectores no se habían actualizado para reflejarlo).
+
+---
+
+## 5. Confirmación docs-only
+
+- No se movió, renombró ni borró ningún archivo.
+- No se tocó runtime frontend/backend, tests, `package.json`,
+  `pnpm-lock.yaml`, workflows, DB, migraciones, Render ni secretos.
+- Cambios de esta auditoría: este documento nuevo +
+  actualización de estado en `final-repo-cleanup-engineering-audit.md` y
+  `final-cleanup-current-status-snapshot.md` + nota en
+  `docs/implementation/documentation-taxonomy-audit.md`.

--- a/docs/audit/final-cleanup-current-status-snapshot.md
+++ b/docs/audit/final-cleanup-current-status-snapshot.md
@@ -48,9 +48,13 @@
 
 ## Pendientes reales
 
-| Id | Pendiente | Estado |
+_(Ninguno relativo a P2-D: ver actualización 2026-06-29 más abajo.)_
+
+## Bloques cerrados (actualización 2026-06-29 · auditoría fase 0 P2-D)
+
+| Bloque | Estado actual | Evidencia |
 | --- | --- | --- |
-| P2-D | Taxonomía documental fragmentada | Pendiente |
+| P2-D | Taxonomía documental fragmentada — **cerrado**, ya ejecutado por `#1163` (2026-06-28) | `docs/audits/`, `IMPLEMENTATION_NOTES/` y `docs/implementation-history/` ya no existen en disco; `docs/pr-*.md` sueltos = 0. Auditoría de re-verificación en [`docs/audit/documentation-taxonomy-fragmentation-audit.md`](documentation-taxonomy-fragmentation-audit.md). El documento rector listaba P2-D como pendiente por desactualización, no porque el trabajo siguiera abierto. |
 
 ## Bloques cerrados (actualización 2026-06-29)
 

--- a/docs/audit/final-repo-cleanup-engineering-audit.md
+++ b/docs/audit/final-repo-cleanup-engineering-audit.md
@@ -59,9 +59,13 @@ cerrados en este corte:
 
 La deuda activa real queda limitada a:
 
-1. **P2-D · Taxonomía documental fragmentada**: ~233 docs con taxonomía
-   fragmentada (`audit/` + `audits/`, notas de implementación en 3 lugares,
-   ~31 `pr-*.md` sueltos en la raíz de `docs/`). *(P2.)*
+1. **P2-D · Taxonomía documental fragmentada**: **auditado y planificado, no
+   pendiente de ejecución** (2026-06-29) — el move-only ya fue ejecutado por
+   `#1163` (2026-06-28); la duplicación `audit/`+`audits/`, las 3 ubicaciones
+   de notas de implementación y los `pr-*.md` sueltos **ya no existen en
+   disco**. Ver auditoría de fase 0
+   [`documentation-taxonomy-fragmentation-audit.md`](documentation-taxonomy-fragmentation-audit.md).
+   *(P2, auditado.)*
 2. **P2-E · Logger/console observability**: logger mínimo y mezcla de
    `console.*`/logger en backend. *(P2.)* **Cerrado documentalmente
    (2026-06-29)** — ver detalle más abajo y
@@ -397,14 +401,28 @@ deploy roto ni auth rota en el estado actual.
 
 #### P2-D · Taxonomía documental fragmentada
 - **Tipo:** docs · **Riesgo:** Bajo.
-- **Evidencia:**
+- **Estado actualizado (2026-06-29):** **ejecutado por `#1163`
+  (2026-06-28, `docs: consolidate historical documentation structure`)**. El
+  move-only ya ocurrió: `docs/audits/`, `IMPLEMENTATION_NOTES/` (raíz) y
+  `docs/implementation-history/` **ya no existen**; `docs/pr-*.md` sueltos en
+  la raíz de `docs/` = 0. Lo que la sección de evidencia original describía
+  (duplicación `audit/`+`audits/`, 3 hogares de implementation notes, `pr-*.md`
+  sueltos) es **histórico**, no deuda activa. Auditoría de fase 0 (re-verificó
+  el estado en disco, `git grep` de referencias y tests de contrato) en
+  [`docs/audit/documentation-taxonomy-fragmentation-audit.md`](documentation-taxonomy-fragmentation-audit.md).
+- **Evidencia original (previa a #1163, conservada por trazabilidad):**
   - `docs/audit/` (62) **y** `docs/audits/` (10): dos taxonomías casi idénticas.
   - Notas de implementación en **3 lugares**: `docs/implementation/` (39),
     `docs/implementation-history/` (13) y `IMPLEMENTATION_NOTES/` en la raíz (34).
   - `docs/pr-history/` (32) **y** ~31 `pr-*.md` sueltos en la raíz de `docs/`
     (`pr-1…pr-10`, `pr-815…pr-826`, `pr0…pr5b`).
-- **Acción:** **consolidar** taxonomía (unificar `audit`/`audits`; mover notas a un
-  único árbol; recolectar `pr-*.md` en `pr-history/`). PR de solo-docs **PR-CLEAN2**.
+- **Acción histórica:** consolidar taxonomía (unificar `audit`/`audits`; mover
+  notas a un único árbol; recolectar `pr-*.md` en `pr-history/`). PR de
+  solo-docs **PR-CLEAN2**, ejecutado por `#1163`.
+- **Acción actual:** **cerrado**. No listar P2-D como pendiente de movimiento;
+  el único seguimiento posible es cosmético (índices ya existentes en
+  `docs/SOURCES_OF_TRUTH.md` / `docs/HISTORICAL_DOCUMENTATION.md` /
+  `docs/audit/README.md`).
 
 #### P2-E · Logger mínimo y mezcla `console.*` / logger
 - **Tipo:** observability · **Riesgo:** Bajo.
@@ -493,9 +511,9 @@ deploy roto ni auth rota en el estado actual.
 | `scripts/maintenance/FUSION_POR_COMANDO.sh` | 0 refs; fusión histórica; eliminado | P3 cerrado | Bajo | cerrado | `clean/remove-orphaned-historical-artifacts` |
 | `frontend/package.json` (Radix remanente) | Tooling ESLint cerrado por PR-CLEAN7C; Radix `avatar`, `dropdown-menu`, `label`, `select`, `tabs` cerrado por PR-CLEAN7D/#1178; `toast`/`tooltip` quedan `DEFER keep` por roadmap | P2 cerrado | Medio | cerrado; no recomendar PR-CLEAN7D como pendiente | #1178 / #1179 |
 | `docs/notes/todo.md` | tRPC/Google Sheets inexistentes | P2 cerrado | Bajo | cerrado; archivado en `docs/archive/legacy-trpc-sheets-todo.md` | PR-CLEAN1 |
-| `docs/audit/` + `docs/audits/` | taxonomía duplicada | P2 | Bajo | unificar | PR-CLEAN2 |
-| `IMPLEMENTATION_NOTES/` (raíz, 34) | notas en 3 ubicaciones | P2 | Bajo | consolidar bajo `docs/` | PR-CLEAN2 |
-| ~31 `docs/pr-*.md` sueltos | deberían ir en `pr-history/` | P2 | Bajo | mover | PR-CLEAN2 |
+| `docs/audit/` + `docs/audits/` | unificado por #1163; `docs/audits/` ya no existe | P2 cerrado | Bajo | cerrado | #1163 / PR-CLEAN2 |
+| `IMPLEMENTATION_NOTES/` (raíz, 34) | consolidado por #1163; ya no existe | P2 cerrado | Bajo | cerrado | #1163 / PR-CLEAN2 |
+| ~31 `docs/pr-*.md` sueltos | movidos a `pr-history/` por #1163; 0 sueltos hoy | P2 cerrado | Bajo | cerrado | #1163 / PR-CLEAN2 |
 | `.env.example` / `frontend/.env.example` | `APP_VERSION`, `CLIENT_MIN_VERSION` y `NEXT_PUBLIC_APP_VERSION` documentadas con token no secreto | P2 cerrado | Bajo | cerrado docs-only | P2-F |
 | `server/lib/logger.ts` + 56 `console.*` | logger mínimo, mezcla cruda | P2 | Bajo | documentar/unificar (opcional) | — |
 

--- a/docs/implementation/documentation-taxonomy-audit.md
+++ b/docs/implementation/documentation-taxonomy-audit.md
@@ -1,0 +1,48 @@
+# Nota de implementación · auditoría P2-D taxonomía documental (fase 0)
+
+> **Rama:** `docs/audit-documentation-taxonomy-plan`.
+> **HEAD base:** `1b6f6b0 docs(audit): document backend observability debt (#1185)`.
+> **Modo:** docs-only, sin moves.
+
+## Qué se hizo
+
+Auditoría de re-verificación de P2-D (taxonomía documental fragmentada),
+listada en `docs/audit/final-repo-cleanup-engineering-audit.md` como deuda
+activa pendiente. El hallazgo: **la fragmentación ya no existe en disco**.
+El move-only fue ejecutado por `#1163` (`af5cd28 docs: consolidate
+historical documentation structure`, 2026-06-28), antes de esta auditoría.
+Los documentos rectores no se habían actualizado para reflejarlo.
+
+## Qué se verificó
+
+- Inventario de `docs/` por carpeta (`Get-ChildItem`/`find` recursivo).
+- Confirmación de que `docs/audits/`, `IMPLEMENTATION_NOTES/` (raíz) y
+  `docs/implementation-history/` no existen.
+- Confirmación de que no quedan `docs/pr-*.md` sueltos en la raíz de `docs/`.
+- `git log` sobre las rutas viejas para identificar el commit de
+  consolidación (`#1163`).
+- `git grep` de referencias a las rutas viejas: solo prosa histórica en notas
+  de implementación/auditoría e índices (`docs/SOURCES_OF_TRUTH.md`,
+  `docs/HISTORICAL_DOCUMENTATION.md`), ninguna referencia de código activo.
+- `git grep` de tests/scripts que leen rutas exactas de `docs/`: todos
+  apuntan a la taxonomía ya consolidada (`docs/audit/`, `docs/implementation/`,
+  `docs/pr-history/`, `docs/security/`, `docs/ops/`, raíz `docs/`). Ninguno
+  referencia las rutas eliminadas.
+
+## Qué se cambió
+
+- Nuevo: `docs/audit/documentation-taxonomy-fragmentation-audit.md`
+  (auditoría completa con inventario, referencias y tabla de fases).
+- Actualizado: `docs/audit/final-repo-cleanup-engineering-audit.md` — §1 y
+  §3 P2-D y tabla maestra §5, marcando P2-D como cerrado/ejecutado por
+  `#1163`, preservando la evidencia original como histórico.
+- Actualizado: `docs/audit/final-cleanup-current-status-snapshot.md` —
+  movió P2-D de "Pendientes reales" a bloque cerrado.
+- Nuevo: este archivo.
+
+## Qué NO se hizo
+
+- No se movió, renombró ni borró ningún archivo.
+- No se tocó runtime frontend/backend, tests, `package.json`,
+  `pnpm-lock.yaml`, workflows, DB, migraciones, Render ni secretos.
+- No commit, no push, no PR.


### PR DESCRIPTION
Docs-only closure for P2-D documentation taxonomy fragmentation.

Scope:
- Adds documentation taxonomy fragmentation audit:
  - docs/audit/documentation-taxonomy-fragmentation-audit.md
- Adds implementation note:
  - docs/implementation/documentation-taxonomy-audit.md
- Updates final cleanup audit/current-status docs.

Finding:
- P2-D fragmentation no longer exists on disk.
- The move-only consolidation was already completed by PR #1163.
- Current disk state is consolidated:
  - docs/audits/ does not exist.
  - root IMPLEMENTATION_NOTES/ does not exist.
  - docs/implementation-history/ does not exist.
  - docs/pr-*.md loose files in docs root: 0.
  - docs/audit/, docs/implementation/, and docs/pr-history/ are the active consolidated destinations.

Reference check:
- No active code/test/script references point to old documentation paths.
- Historical prose references remain only as historical notes.
- 9 tests read exact docs paths, and all point to consolidated current paths.

Contract:
- Docs-only.
- No moves.
- No renames.
- No deletes.
- No runtime frontend/backend changes.
- No tests changes.
- No package/lock changes.
- No workflows changes.
- No DB/migration/Render/secrets changes.

Validation:
- corepack pnpm typecheck passed.
- corepack pnpm typecheck:test passed.
- corepack pnpm test passed: 2890/2890.
- corepack pnpm build passed.
- corepack pnpm --dir frontend lint passed.
- corepack pnpm --dir frontend typecheck passed.
- corepack pnpm --dir frontend build passed.
- git diff --check passed.
- Forbidden scope guard returned no files.
