### PR TITLE
fix(dashboard): remove workspace header divider

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1234,9 +1234,9 @@
   }
 
   .dashboard-workspace-header {
-    border-bottom: 1px solid hsl(var(--vetneb-line) / 0.68);
-    padding-bottom: 1rem;
-    margin-bottom: 1rem;
+    border-bottom: 0;
+    padding-bottom: 0;
+    margin-bottom: 0;
   }
 
   .dashboard-master-panel {

--- a/test/frontend-dashboard-workspace-layout-polish.test.ts
+++ b/test/frontend-dashboard-workspace-layout-polish.test.ts
@@ -100,23 +100,25 @@ test("PR-2 globals.css reduced-motion disables dashboard-workspace-enter animati
 
 // ── Workspace header separator ────────────────────────────────────────────────
 
-test("PR-2 globals.css defines .dashboard-workspace-header with border separator", () => {
+test("PR-2 globals.css defines .dashboard-workspace-header without border separator", () => {
   const source = read(GLOBALS_CSS_PATH);
   assert.ok(
     source.includes(".dashboard-workspace-header {"),
     "globals.css must define .dashboard-workspace-header",
   );
+  const headerIdx = source.indexOf(".dashboard-workspace-header {");
+  const headerRule = source.slice(headerIdx, source.indexOf("}", headerIdx));
   assert.ok(
-    source.includes("border-bottom: 1px solid"),
-    ".dashboard-workspace-header must define a border-bottom separator",
+    headerRule.includes("border-bottom: 0;"),
+    ".dashboard-workspace-header must not render a border-bottom separator",
   );
   assert.ok(
-    source.includes("padding-bottom: 1rem;"),
-    ".dashboard-workspace-header must define padding-bottom",
+    headerRule.includes("padding-bottom: 0;"),
+    ".dashboard-workspace-header must not reserve padding-bottom",
   );
   assert.ok(
-    source.includes("margin-bottom: 1rem;"),
-    ".dashboard-workspace-header must define margin-bottom",
+    headerRule.includes("margin-bottom: 0;"),
+    ".dashboard-workspace-header must not reserve margin-bottom",
   );
 });
 


### PR DESCRIPTION
Visual density fix for dashboard workspace headers.

Scope:
- Removes the horizontal divider below dashboard module headers.
- Removes the associated bottom padding/margin so lower content moves up.
- Applies through shared `.dashboard-workspace-header`, used by both Admin and Clinic dashboard workspaces.
- Updates the visual/layout contract test that previously pinned the old divider.

Files:
- frontend/src/app/globals.css
- test/frontend-dashboard-workspace-layout-polish.test.ts

Contract:
- Admin dashboard: divider removed.
- Clinic dashboard: divider removed.
- Content below the header moves up and reuses the freed vertical space.
- No new copy/text.
- No logic changes.
- No backend changes.
- No DB/migration changes.
- No package/lock changes.
- No workflow changes.
- No docs/audit changes.
- No new scroll introduced.

Validation:
- pnpm --dir frontend lint passed.
- pnpm --dir frontend typecheck passed.
- pnpm --dir frontend build passed.
- pnpm typecheck passed.
- pnpm typecheck:test passed.
- pnpm test passed: 2890/2890.
- git diff --check passed.
- Scope guard returned no sensitive paths.
