### PR TITLE
feat(ui): add select textarea label primitives

### DIFF
--- a/docs/audit/pr-vis-5-implementation.md
+++ b/docs/audit/pr-vis-5-implementation.md
@@ -1,0 +1,71 @@
+# PR-VIS-5 implementation report
+
+## Scope exacto aplicado
+
+PR-VIS-5 implementa las primitivas frontend `ui/select`, `ui/textarea` y `ui/label` para cerrar VIS-P1-006 f1. El alcance queda limitado a componentes UI reutilizables, test nativo de contrato y este reporte de auditoría.
+
+No se migraron call-sites existentes y no se cambió ninguna pantalla.
+
+## Archivos modificados
+
+- `frontend/src/components/ui/select.tsx`
+- `frontend/src/components/ui/textarea.tsx`
+- `frontend/src/components/ui/label.tsx`
+- `test/frontend-form-primitives.test.ts`
+- `docs/audit/pr-vis-5-implementation.md`
+
+## Tokens y contratos visuales usados
+
+- `border-input`
+- `bg-card/96`
+- `text-foreground`
+- `text-muted-foreground`
+- `text-vetneb-ink`
+- `hover:border-vetneb-teal/35`
+- `focus-visible:ring-ring/85`
+- `ring-offset-background`
+- Disabled states consistentes con `Input`
+
+Se preservaron los contratos de PR-VIS-0 a PR-VIS-4: gobernanza DS, theme único sin dark mode muerto, badge tokenizado, scoping de selección al chrome y tokens visuales existentes.
+
+## Qué se evitó tocar explícitamente
+
+- No se migraron formularios existentes.
+- No se tocó `globals.css`.
+- No se tocaron layouts, dashboard, mobile shell, filtros, tablas ni rutas.
+- No se introdujo texto visible nuevo en UI.
+- No se agregaron tokens duplicados ni un segundo sistema visual.
+- No se modificaron dependencias ni lockfiles.
+
+## Validaciones ejecutadas
+
+Ejecutadas:
+
+- `pnpm --filter frontend lint`: no efectivo; PNPM informó `No projects matched the filters in "C:\PORTAL-VETNEB"`.
+- `pnpm --filter frontend typecheck`: no efectivo; PNPM informó `No projects matched the filters in "C:\PORTAL-VETNEB"`.
+- `pnpm --filter frontend test`: no efectivo; PNPM informó `No projects matched the filters in "C:\PORTAL-VETNEB"`.
+- `pnpm --filter portal-vetneb-frontend lint`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm --filter portal-vetneb-frontend typecheck`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm --filter portal-vetneb-frontend test`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm lint` en `frontend`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm typecheck` en `frontend`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm test`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm build`: falló antes de ejecutar el script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `frontend/node_modules/.bin/eslint.CMD .` en `frontend`: PASS.
+- `frontend/node_modules/.bin/next.CMD build` en `frontend`: PASS.
+- `frontend/node_modules/.bin/tsc.CMD --noEmit` en `frontend`: PASS al re-ejecutar después de `next build`. El primer intento directo corrió en paralelo con `next build` y falló por `.next/types/validator.ts` sin `routes.js`.
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-form-primitives.test.ts`: PASS, 4/4.
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts`: PASS, 2901/2901.
+- `git diff --check`: PASS.
+
+## Resultado
+
+PR-VIS-5 queda implementado con primitivas nuevas, test nativo de contrato y sin migración de pantallas existentes. Los comandos PNPM quedaron bloqueados por estado local de `node_modules`/TTY antes de ejecutar scripts; no se forzó instalación ni purga para evitar tocar dependencias o lockfiles.
+
+## Riesgos residuales
+
+Bajo. Las primitivas nuevas no están conectadas a pantallas existentes, por lo que no deberían producir cambios visuales en runtime hasta que PRs posteriores migren call-sites de forma controlada.
+
+## Confirmación de no backend/API/auth/DB/migrations/deps/lockfiles/CI
+
+Confirmado: este PR no modifica backend, API, auth, DB, migraciones, dependencias, lockfiles, workflows ni CI.

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <label
+        className={cn(
+          "text-sm font-semibold leading-none text-vetneb-ink peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Label.displayName = "Label";
+
+export { Label };

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  wrapperClassName?: string;
+}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, wrapperClassName, children, ...props }, ref) => {
+    return (
+      <div className={cn("relative w-full", wrapperClassName)}>
+        <select
+          className={cn(
+            "flex h-10 w-full appearance-none rounded-md border border-input bg-card/96 px-3 py-2 pr-10 text-sm text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] ring-offset-background transition-[border-color,box-shadow,background-color] hover:border-vetneb-teal/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-55",
+            className,
+          )}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </select>
+        <ChevronDown
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+      </div>
+    );
+  },
+);
+Select.displayName = "Select";
+
+export { Select };

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-24 w-full resize-y rounded-md border border-input bg-card/96 px-3 py-2 text-sm text-foreground shadow-[0_1px_2px_rgba(15,45,62,0.05)] ring-offset-background transition-[border-color,box-shadow,background-color] placeholder:text-muted-foreground hover:border-vetneb-teal/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-55",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/test/frontend-form-primitives.test.ts
+++ b/test/frontend-form-primitives.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const SELECT_PATH = "frontend/src/components/ui/select.tsx";
+const TEXTAREA_PATH = "frontend/src/components/ui/textarea.tsx";
+const LABEL_PATH = "frontend/src/components/ui/label.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("select primitive uses native select semantics and shared tokenized styling", () => {
+  const source = read(SELECT_PATH);
+
+  assert.ok(source.includes('import * as React from "react";'));
+  assert.ok(source.includes('import { ChevronDown } from "lucide-react";'));
+  assert.ok(source.includes('import { cn } from "@/lib/utils";'));
+  assert.ok(source.includes("export interface SelectProps"));
+  assert.ok(source.includes("extends React.SelectHTMLAttributes<HTMLSelectElement>"));
+  assert.ok(source.includes("wrapperClassName?: string;"));
+  assert.ok(source.includes("const Select = React.forwardRef<HTMLSelectElement, SelectProps>("));
+  assert.ok(source.includes("<select"));
+  assert.ok(source.includes("ref={ref}"));
+  assert.ok(source.includes("{...props}"));
+  assert.ok(source.includes("{children}"));
+});
+
+test("select primitive keeps accessible icon treatment and focus contract", () => {
+  const source = read(SELECT_PATH);
+
+  assert.ok(source.includes('aria-hidden="true"'));
+  assert.ok(source.includes("pointer-events-none absolute right-3 top-1/2 size-4"));
+  assert.ok(source.includes("appearance-none rounded-md border border-input bg-card/96"));
+  assert.ok(source.includes("hover:border-vetneb-teal/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"));
+  assert.ok(source.includes("disabled:cursor-not-allowed disabled:opacity-55"));
+  assert.ok(source.includes('Select.displayName = "Select";'));
+  assert.ok(source.includes("export { Select };"));
+});
+
+test("textarea primitive uses native textarea semantics and shared tokenized styling", () => {
+  const source = read(TEXTAREA_PATH);
+
+  assert.ok(source.includes('import * as React from "react";'));
+  assert.ok(source.includes('import { cn } from "@/lib/utils";'));
+  assert.ok(source.includes("export interface TextareaProps"));
+  assert.ok(source.includes("extends React.TextareaHTMLAttributes<HTMLTextAreaElement>"));
+  assert.ok(source.includes("const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>("));
+  assert.ok(source.includes("<textarea"));
+  assert.ok(source.includes("ref={ref}"));
+  assert.ok(source.includes("{...props}"));
+  assert.ok(source.includes("min-h-24 w-full resize-y rounded-md border border-input bg-card/96"));
+  assert.ok(source.includes("placeholder:text-muted-foreground hover:border-vetneb-teal/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"));
+  assert.ok(source.includes('Textarea.displayName = "Textarea";'));
+  assert.ok(source.includes("export { Textarea };"));
+});
+
+test("label primitive uses native label semantics and accessible disabled styling", () => {
+  const source = read(LABEL_PATH);
+
+  assert.ok(source.includes('import * as React from "react";'));
+  assert.ok(source.includes('import { cn } from "@/lib/utils";'));
+  assert.ok(source.includes("export interface LabelProps"));
+  assert.ok(source.includes("extends React.LabelHTMLAttributes<HTMLLabelElement>"));
+  assert.ok(source.includes("const Label = React.forwardRef<HTMLLabelElement, LabelProps>("));
+  assert.ok(source.includes("<label"));
+  assert.ok(source.includes("ref={ref}"));
+  assert.ok(source.includes("{...props}"));
+  assert.ok(source.includes("text-sm font-semibold leading-none text-vetneb-ink"));
+  assert.ok(source.includes("peer-disabled:cursor-not-allowed peer-disabled:opacity-70"));
+  assert.ok(source.includes('Label.displayName = "Label";'));
+  assert.ok(source.includes("export { Label };"));
+});


### PR DESCRIPTION
## Summary

Adds the PR-VIS-5 frontend form primitives required by the visual roadmap:

- Select
- Textarea
- Label

This PR creates the primitives only. It does not migrate existing call-sites and does not introduce visible screen changes.

## Scope

- Adds tokenized UI primitives under rontend/src/components/ui.
- Adds a native contract test for the new form primitives.
- Adds the required implementation report at docs/audit/pr-vis-5-implementation.md.

## Validation

Effective validations executed by Codex:

- rontend/node_modules/.bin/eslint.CMD . — PASS
- rontend/node_modules/.bin/tsc.CMD --noEmit — PASS after 
ext build
- rontend/node_modules/.bin/next.CMD build — PASS
- 
ode --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-form-primitives.test.ts — PASS 4/4
- 
ode --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts — PASS 2901/2901
- git diff --check — PASS

PNPM note:

- pnpm --filter frontend lint/typecheck/test was not effective because rontend does not match a workspace package.
- pnpm --filter portal-vetneb-frontend ..., pnpm test, and pnpm build were blocked before script execution by ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY.
- No install, purge, dependency update, or lockfile change was forced.

## Explicitly not touched

- Backend
- API
- Auth
- Database
- Migrations
- Dependencies
- Lockfiles
- CI / workflows

## Protocol

- One branch / one PR.
- Git operations performed manually.
- Codex limited to implementation and tests.
