### PR TITLE
refactor(dashboard): extract particular token card primitives

### DIFF
--- a/docs/audit/pr-vis-7-implementation.md
+++ b/docs/audit/pr-vis-7-implementation.md
@@ -1,0 +1,123 @@
+# PR-VIS-7 implementation report
+
+## Estado base
+
+- Rama: `chore/pr-vis-7-card-primitives-visual-contract`.
+- HEAD base: `eb8764d feat(dashboard): unify filter visual contract (#1202)`.
+- Working tree inicial: limpio.
+
+## Scope exacto detectado
+
+PR-VIS-7 corresponde a VIS-P1-002: extraer primitivas visuales compartidas para cards de tokens particulares admin/clinica, sin cambio visual y sin extraer logica de dominio/hook. La dupla explicita del roadmap es:
+
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`.
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`.
+
+El cambio aplicado se limita a metric strips, paneles/listas/footer/empty panels compartidos para el modulo de tokens particulares.
+
+## Criterio de razonamiento usado
+
+ALTO.
+
+Motivo: el PR toca cards grandes de dashboard admin/clinica, superficies densas, mobile y contrato no-scroll. No se uso razonamiento extremadamente alto porque no hubo layout global, chrome/navegacion, backend, DB, auth, dependencias, CI ni migracion masiva de componentes.
+
+## Scope incluido
+
+- Nueva primitiva visual `ParticularTokensCardPrimitives`.
+- Migracion acotada de wrappers visuales en `AdminParticularTokensCard`.
+- Migracion acotada de wrappers visuales en `ClinicParticularTokensCard`.
+- Test nativo source-based del contrato PR-VIS-7.
+- Este reporte de auditoria.
+
+## Scope excluido
+
+- Backend, API, auth, DB, migraciones, endpoints, cookies, CORS, CSP y rate limits.
+- Dependencias, lockfiles, `package.json`, workflows, CI y Playwright config.
+- PR-DUP-1: no se extrajeron hooks, fetch, filtros, paginacion, permisos ni logica de dominio.
+- Cambios de copy visible, rutas, query params, estados, permisos, handlers o contratos de datos.
+- Cambios globales de CSS, tokens globales, dark mode, badge status, chrome selection o filtros PR-VIS-6.
+
+## Auditoria previa
+
+- Base limpia confirmada con `git branch --show-current`, `git status --short` y `git log -1 --oneline`.
+- Roadmap visual inspeccionado en `docs/audit/total-visual-engineering-audit.md`, `docs/audit/total-engineering-roadmap.md` y `docs/audit/design-system-contract.md`.
+- PR-VIS-5 y PR-VIS-6 revisados para preservar primitivas existentes y contrato de filtros.
+- Referencias legacy/hardcodeadas buscadas con `rg` sobre `docs`, `frontend`, `test` y componentes de tokens.
+- Tests nativos disponibles confirmados en `package.json`, `frontend/package.json` y suite `test/**/*.test.ts`.
+
+## Cambios
+
+- Se agrego `frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx`.
+- Se reemplazo el bloque de metricas y la lista mobile admin por primitivas visuales compartidas.
+- Se reemplazaron metricas, panel de lista, header, body, footer y empty panel de clinica por primitivas visuales compartidas.
+- Se mantuvieron clases visuales equivalentes basadas en tokens existentes.
+
+## Archivos modificados
+
+- `frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx`.
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx`.
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`.
+- `test/frontend-particular-tokens-card-primitives.test.ts`.
+- `docs/audit/pr-vis-7-implementation.md`.
+
+## Que tokens/contratos visuales se usaron
+
+- `border-vetneb-line`.
+- `bg-vetneb-surface-muted`.
+- `bg-card`.
+- `text-muted-foreground`.
+- `text-vetneb-ink`.
+- `divide-vetneb-line`.
+- Contrato single-viewport/no-scroll existente: wrappers `min-h-0`, `flex-1`, `overflow-hidden`.
+- Contrato dashboard operativo: densidad compacta, paginacion y mobile sin overflow horizontal.
+
+## Que componentes/primitivas se crearon, usaron o no se usaron
+
+- Creada: `ParticularTokensCardPrimitives`.
+- Usadas: `ParticularTokensMetricStrip`, `ParticularTokensPanel`, `ParticularTokensPanelHeader`, `ParticularTokensPanelBody`, `ParticularTokensPanelFooter`, `ParticularTokensMobileList`, `ParticularTokensEmptyPanel`.
+- No usadas: primitivas nuevas de form; PR-VIS-7 no modifica formularios ni filtros. Se preservan `FilterBar`, `FilterField`, `Input`, `Select`, `Button`, `Badge`, `Card`, `ModuleDialog`, `ModuleSurface` y `EmptyState` existentes.
+- No se creo un segundo sistema visual ni se agregaron tokens nuevos.
+
+## Que se evito tocar explicitamente
+
+- no backend/API/auth/DB/migrations/deps/lockfiles/CI.
+- No `server/`, `drizzle/`, `frontend/src/lib/api.ts`, `package.json`, `pnpm-lock.yaml`, workflows ni configs.
+- No `globals.css`.
+- No cambios de comportamiento, fetch, handlers, paginacion, permisos, rutas ni query params.
+- No copy visible nuevo fuera de nombres internos de componentes/test/doc.
+
+## Validaciones ejecutadas
+
+- `pnpm --filter portal-vetneb-frontend lint`: no efectivo; PNPM aborto antes del script por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+- `pnpm --filter portal-vetneb-frontend typecheck`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm --filter portal-vetneb-frontend test`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm --dir frontend lint`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm --dir frontend typecheck`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm --dir frontend build`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm test`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm build`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `pnpm security:public-surface`: no efectivo; mismo bloqueo PNPM/no TTY.
+- `frontend/node_modules/.bin/eslint.CMD .`: PASS.
+- `frontend/node_modules/.bin/tsc.CMD --noEmit`: PASS.
+- `frontend/node_modules/.bin/next.CMD build`: PASS.
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-particular-tokens-card-primitives.test.ts test/frontend-admin-particular-tokens.test.ts test/frontend-dashboard-clinic-tokens.test.ts test/admin-tokens-enterprise-density.test.ts`: PASS, 42/42.
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/**/*.test.ts`: PASS, 2905/2905.
+- `node scripts/security/audit-public-devtools-surface.mjs`: PASS; sin findings publicos. Reporto notas server-only existentes por identificadores de cookies en `frontend/src/proxy.ts`.
+- `node_modules/.bin/esbuild.CMD server/index.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/index.js`: PASS.
+
+## Resultado
+
+PR-VIS-7 queda implementado como extraccion visual pequena y composable para cards de tokens particulares admin/clinica, sin modificar logica de dominio ni contratos funcionales.
+
+## Riesgos residuales
+
+- Bajo-medio: al reemplazar wrappers densos, el riesgo principal es una diferencia visual sutil en spacing o clases fusionadas. Mitigacion: primitivas conservan tokens/clases equivalentes y se validan con lint/typecheck/build/tests.
+- Bajo: la deduplicacion de logica queda pendiente para PR-DUP-1 por scope.
+
+## Confirmacion de no backend/API/auth/DB/migrations/deps/lockfiles/CI
+
+Confirmado: este PR no modifica backend, API, auth, DB, migraciones, dependencias, lockfiles, workflows ni CI.
+
+## Estado final
+
+Implementado y validado con equivalentes locales porque PNPM quedo bloqueado por no TTY antes de ejecutar scripts.

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -11,6 +11,10 @@ import {
   type FilterBarDensity,
 } from "@/components/dashboard/FilterBar";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import {
+  ParticularTokensMetricStrip,
+  ParticularTokensMobileList,
+} from "@/components/dashboard/ParticularTokensCardPrimitives";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -1254,21 +1258,17 @@ export function AdminParticularTokensCard() {
               Accesos sensibles, trazabilidad bajo demanda y acciones controladas.
             </p>
           </div>
-          <div className="flex min-h-10 items-center divide-x divide-vetneb-line/70 rounded-lg border border-vetneb-line/75 bg-vetneb-surface-muted/45 md:min-h-8">
-            {[
-              ["En página", filteredTokens.length],
-              ["Activos", activeTokensCount],
-              ["Con informe", linkedReportsCount],
-              ["Página", page + 1],
-            ].map(([label, value]) => (
-              <div key={label} className="min-w-[4.5rem] px-3 py-1 text-center md:px-2 md:py-0.5">
-                <p className="text-[0.6875rem] text-muted-foreground">{label}</p>
-                <p className="text-xl font-semibold leading-5 text-vetneb-ink md:text-base md:leading-4">
-                  {value}
-                </p>
-              </div>
-            ))}
-          </div>
+          <ParticularTokensMetricStrip
+            metrics={[
+              { label: "En página", value: filteredTokens.length },
+              { label: "Activos", value: activeTokensCount },
+              { label: "Con informe", value: linkedReportsCount },
+              { label: "Página", value: page + 1 },
+            ]}
+            className="flex min-h-10 items-center rounded-lg md:min-h-8"
+            itemClassName="min-w-[4.5rem] px-3 py-1 text-center md:px-2 md:py-0.5"
+            valueClassName="text-xl leading-5 md:text-base md:leading-4"
+          />
         </div>
       </CardHeader>
 
@@ -1434,9 +1434,8 @@ export function AdminParticularTokensCard() {
             className="flex h-full min-h-0 flex-1 flex-col gap-1.5 md:hidden"
             data-admin-mobile-core-module="tokens"
           >
-            <div
+            <ParticularTokensMobileList
               data-admin-particulars-mobile-list="true"
-              className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
             >
               {filteredMobileTokens.map((token) => (
                 <div
@@ -1470,7 +1469,7 @@ export function AdminParticularTokensCard() {
                   </Button>
                 </div>
               ))}
-            </div>
+            </ParticularTokensMobileList>
 
             {!filteredMobileTokens.length && isMobileViewport ? (
               <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -17,6 +17,14 @@ import { Select } from "@/components/ui/select";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
+import {
+  ParticularTokensEmptyPanel,
+  ParticularTokensMetricStrip,
+  ParticularTokensPanel,
+  ParticularTokensPanelBody,
+  ParticularTokensPanelFooter,
+  ParticularTokensPanelHeader,
+} from "@/components/dashboard/ParticularTokensCardPrimitives";
 import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import {
   createClinicParticularToken,
@@ -747,25 +755,17 @@ export function ClinicParticularTokensCard() {
             </div>
 
             <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
-              <div
-                className="grid grid-cols-3 divide-x divide-vetneb-line/70 rounded-md border border-vetneb-line/75 bg-vetneb-surface-muted/45 text-center"
+              <ParticularTokensMetricStrip
+                metrics={[
+                  { label: "Tokens", value: tokens.length },
+                  { label: "Activos", value: activeTokensCount },
+                  { label: "Informes", value: linkedReportsCount },
+                ]}
+                className="grid grid-cols-3 rounded-md"
+                itemClassName="min-w-[4.25rem] px-2 py-1"
+                valueClassName="text-sm"
                 aria-label="Métricas de tokens particulares"
-              >
-                {[
-                  ["Tokens", tokens.length],
-                  ["Activos", activeTokensCount],
-                  ["Informes", linkedReportsCount],
-                ].map(([label, value]) => (
-                  <div key={label} className="min-w-[4.25rem] px-2 py-1">
-                    <p className="text-[0.6875rem] text-muted-foreground">
-                      {label}
-                    </p>
-                    <p className="text-sm font-semibold leading-tight text-vetneb-ink">
-                      {value}
-                    </p>
-                  </div>
-                ))}
-              </div>
+              />
 
               <ModuleDialog
                 open={isFilterDialogOpen}
@@ -828,11 +828,10 @@ export function ClinicParticularTokensCard() {
         >
           {tokens.length ? (
             <div className="flex min-h-0 flex-1 flex-col">
-              <div
+              <ParticularTokensPanel
                 data-clinic-access-list-panel="true"
-                className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
               >
-                <div className="flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2">
+                <ParticularTokensPanelHeader>
                   <div className="min-w-0">
                     <h3 className="text-sm font-semibold text-vetneb-ink">
                       Últimos tokens de la clínica
@@ -852,11 +851,10 @@ export function ClinicParticularTokensCard() {
                   <Badge variant="outline" className="shrink-0">
                     Pág. {pagedTokens.page + 1}
                   </Badge>
-                </div>
+                </ParticularTokensPanelHeader>
 
-                <div
+                <ParticularTokensPanelBody
                   data-clinic-access-list-body="true"
-                  className="flex min-h-0 flex-1 flex-col overflow-hidden"
                 >
                   {filteredTokens.length ? (
                     <>
@@ -988,11 +986,10 @@ export function ClinicParticularTokensCard() {
                     aria-hidden="true"
                     data-clinic-access-future-slots="true"
                   />
-                </div>
+                </ParticularTokensPanelBody>
 
-                <div
+                <ParticularTokensPanelFooter
                   data-clinic-access-pagination-footer="true"
-                  className="flex min-h-10 shrink-0 items-center justify-end border-t border-vetneb-line/65 px-3 py-2 text-xs text-muted-foreground"
                 >
                   <div
                     data-clinic-access-pagination-controls="true"
@@ -1033,11 +1030,11 @@ export function ClinicParticularTokensCard() {
                       Siguiente
                     </Button>
                   </div>
-                </div>
-              </div>
+                </ParticularTokensPanelFooter>
+              </ParticularTokensPanel>
             </div>
           ) : (
-            <div className="flex min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82 p-3">
+            <ParticularTokensEmptyPanel>
               <EmptyState
                 title={
                   isLoadingTokens
@@ -1052,7 +1049,7 @@ export function ClinicParticularTokensCard() {
                 size="sm"
                 className="w-full"
               />
-            </div>
+            </ParticularTokensEmptyPanel>
           )}
         </section>
       </ModuleSurface>

--- a/frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
+++ b/frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
@@ -1,0 +1,142 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type ParticularTokensMetric = {
+  label: ReactNode;
+  value: ReactNode;
+};
+
+type ParticularTokensMetricStripProps = ComponentPropsWithoutRef<"div"> & {
+  metrics: ParticularTokensMetric[];
+  itemClassName?: string;
+  labelClassName?: string;
+  valueClassName?: string;
+};
+
+export function ParticularTokensMetricStrip({
+  metrics,
+  className,
+  itemClassName,
+  labelClassName,
+  valueClassName,
+  ...props
+}: ParticularTokensMetricStripProps) {
+  return (
+    <div
+      className={cn(
+        "divide-x divide-vetneb-line/70 border border-vetneb-line/75 bg-vetneb-surface-muted/45 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {metrics.map((metric) => (
+        <div key={String(metric.label)} className={itemClassName}>
+          <p
+            className={cn(
+              "text-[0.6875rem] text-muted-foreground",
+              labelClassName,
+            )}
+          >
+            {metric.label}
+          </p>
+          <p
+            className={cn(
+              "font-semibold leading-tight text-vetneb-ink",
+              valueClassName,
+            )}
+          >
+            {metric.value}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ParticularTokensPanel({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ParticularTokensPanelHeader({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-3 border-b border-vetneb-line/70 px-3 py-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ParticularTokensPanelBody({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", className)}
+      {...props}
+    />
+  );
+}
+
+export function ParticularTokensPanelFooter({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-10 shrink-0 items-center justify-end border-t border-vetneb-line/65 px-3 py-2 text-xs text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ParticularTokensMobileList({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ParticularTokensEmptyPanel({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82 p-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/test/frontend-particular-tokens-card-primitives.test.ts
+++ b/test/frontend-particular-tokens-card-primitives.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const PRIMITIVES_PATH =
+  "frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx";
+const ADMIN_CARD_PATH =
+  "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx";
+const CLINIC_CARD_PATH =
+  "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
+const DOC_PATH = "docs/audit/pr-vis-7-implementation.md";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("PR-VIS-7 exposes small visual-only particular token card primitives", () => {
+  const source = read(PRIMITIVES_PATH);
+
+  for (const exportName of [
+    "ParticularTokensMetricStrip",
+    "ParticularTokensPanel",
+    "ParticularTokensPanelHeader",
+    "ParticularTokensPanelBody",
+    "ParticularTokensPanelFooter",
+    "ParticularTokensMobileList",
+    "ParticularTokensEmptyPanel",
+  ]) {
+    assert.ok(source.includes(`export function ${exportName}`));
+  }
+
+  for (const tokenClass of [
+    "border-vetneb-line/75",
+    "bg-vetneb-surface-muted/45",
+    "text-muted-foreground",
+    "text-vetneb-ink",
+    "bg-card/82",
+    "divide-vetneb-line/60",
+  ]) {
+    assert.ok(source.includes(tokenClass), `missing visual token ${tokenClass}`);
+  }
+
+  assert.equal(source.includes("@/lib/api"), false);
+  assert.equal(source.includes("fetch("), false);
+  assert.equal(source.includes("useState"), false);
+  assert.equal(source.includes("useEffect"), false);
+  assert.equal(source.includes("admin_session_id"), false);
+  assert.equal(source.includes("app_session_id"), false);
+});
+
+test("PR-VIS-7 wires primitives only into admin and clinic token cards", () => {
+  const admin = read(ADMIN_CARD_PATH);
+  const clinic = read(CLINIC_CARD_PATH);
+
+  assert.ok(
+    admin.includes(
+      'from "@/components/dashboard/ParticularTokensCardPrimitives";',
+    ),
+  );
+  assert.ok(admin.includes("<ParticularTokensMetricStrip"));
+  assert.ok(admin.includes("<ParticularTokensMobileList"));
+  assert.ok(admin.includes('data-admin-particulars-mobile-list="true"'));
+
+  assert.ok(
+    clinic.includes(
+      'from "@/components/dashboard/ParticularTokensCardPrimitives";',
+    ),
+  );
+  assert.ok(clinic.includes("<ParticularTokensMetricStrip"));
+  assert.ok(clinic.includes("<ParticularTokensPanel"));
+  assert.ok(clinic.includes("<ParticularTokensPanelHeader"));
+  assert.ok(clinic.includes("<ParticularTokensPanelBody"));
+  assert.ok(clinic.includes("<ParticularTokensPanelFooter"));
+  assert.ok(clinic.includes("<ParticularTokensEmptyPanel"));
+  assert.ok(clinic.includes('data-clinic-access-list-panel="true"'));
+  assert.ok(clinic.includes('data-clinic-access-pagination-footer="true"'));
+});
+
+test("PR-VIS-7 documentation records scope validations and exclusions", () => {
+  const source = read(DOC_PATH);
+
+  assert.ok(source.includes("# PR-VIS-7 implementation report"));
+  assert.ok(source.includes("## Scope exacto detectado"));
+  assert.ok(source.includes("## Criterio de razonamiento usado"));
+  assert.ok(source.includes("## Archivos modificados"));
+  assert.ok(source.includes("## Que tokens/contratos visuales se usaron"));
+  assert.ok(source.includes("## Que componentes/primitivas se crearon, usaron o no se usaron"));
+  assert.ok(source.includes("## Que se evito tocar explicitamente"));
+  assert.ok(source.includes("## Validaciones ejecutadas"));
+  assert.ok(source.includes("## Riesgos residuales"));
+  assert.ok(source.includes("no backend/API/auth/DB/migrations/deps/lockfiles/CI"));
+});


### PR DESCRIPTION
## Summary

Extracts shared visual primitives for particular token cards as PR-VIS-7.

This PR addresses VIS-P1-002 by reducing duplicated visual card structure between:

- Admin particular tokens card
- Clinic particular tokens card

The extraction is visual-only and intentionally small. It does not move domain logic, fetch logic, permissions, routes, query parameters, state handling, or visible functional copy.

## Scope

- Adds frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx.
- Updates admin and clinic particular token cards to use the shared visual primitives.
- Adds source-based contract coverage for the new primitives.
- Adds docs/audit/pr-vis-7-implementation.md.

## Validation

PNPM commands were attempted first, but were not effective due to ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY.

Effective validations executed:

- ESLint — PASS
- TypeScript — PASS
- Next build — PASS
- PR-VIS-7 related tests — PASS 42/42
- Full native Node suite — PASS 2905/2905
- Security public surface — PASS
- Backend esbuild equivalent — PASS
- git diff --check — PASS, with normal Windows CRLF/LF warnings only

## Explicitly not touched

- Backend
- API
- Auth
- Database
- Migrations
- Dependencies
- Lockfiles
- CI / workflows

## Risk

Residual risk is low-medium visual only: dense token card wrappers may have subtle presentation differences. Mitigated by keeping equivalent tokens/classes, avoiding logic movement, and passing contract/build/typecheck/test validations.

## Protocol

- One branch / one PR.
- Git operations performed manually.
- Codex limited to implementation and tests.
