### PR TITLE
test(frontend): add axe accessibility checks for key routes

### DIFF
--- a/docs/audit/pr-vis-8-implementation.md
+++ b/docs/audit/pr-vis-8-implementation.md
@@ -1,0 +1,108 @@
+# PR-VIS-8 implementation report
+
+## Scope exacto detectado
+
+PR-VIS-8 corresponde a VIS-P1-007: agregar scanning automatizado de accesibilidad con axe-core en rutas clave, registrando contraste mediante axe y sin cambios visuales salvo hallazgo concreto.
+
+Rutas cubiertas:
+
+- `/`
+- `/login`
+- `/dashboard`
+- `/dashboard/admin`
+
+Cada ruta se valida en desktop `1440x900` y mobile `390x844`.
+
+## Criterio de razonamiento usado
+
+MEDIO.
+
+El alcance estuvo explícito en `docs/audit/total-engineering-roadmap.md` y `docs/audit/total-visual-engineering-audit.md`. No se subió a ALTO porque no hubo corrección visual ni decisión UX subjetiva; axe quedó verde en las rutas cubiertas.
+
+## IA usada
+
+Codex.
+
+## Archivos modificados
+
+- `frontend/package.json`
+- `pnpm-lock.yaml`
+- `frontend/e2e/accessibility-axe-key-routes.spec.ts`
+- `docs/audit/pr-vis-8-implementation.md`
+
+## Tokens/contratos visuales usados
+
+No se agregaron tokens ni colores. El PR sólo introduce medición axe sobre la UI existente y preserva:
+
+- contrato de design system governance PR-VIS-0,
+- theme único sin dark mode muerto PR-VIS-1,
+- badges tokenizados PR-VIS-2,
+- tokens visuales PR-VIS-3,
+- selección limitada al chrome PR-VIS-4,
+- primitivas `Select`, `Textarea`, `Label` PR-VIS-5,
+- contrato `FilterBar`/`FilterField` PR-VIS-6,
+- primitivas `ParticularTokensCardPrimitives` PR-VIS-7.
+
+## Componentes/primitivas
+
+Creado:
+
+- Spec e2e `accessibility-axe-key-routes.spec.ts`.
+
+Usado:
+
+- `@axe-core/playwright` con `AxeBuilder`.
+- Playwright existente.
+
+No se crearon primitivas UI nuevas. No se migraron call-sites visuales.
+
+## Qué se evitó tocar
+
+- Backend.
+- API.
+- Auth.
+- DB.
+- Migraciones.
+- CI/workflows.
+- Rutas funcionales.
+- Query params.
+- Permisos.
+- Contratos de datos.
+- CSS global.
+- Tokens visuales.
+- Copy visible de UI.
+- Correcciones de contraste sin hallazgo axe.
+
+## Validaciones ejecutadas
+
+- `git branch --show-current`: pasó, rama `chore/pr-vis-8-visual-roadmap-next`.
+- `git status --short`: base inicial limpia.
+- `git log -1 --oneline`: pasó, `f288c80 refactor(dashboard): extract particular token card primitives (#1203)`.
+- `pnpm --filter portal-vetneb-frontend add -D @axe-core/playwright`: falló por `ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF`.
+- `pnpm --filter portal-vetneb-frontend add -D @axe-core/playwright --lockfile-only`: ejecutó con PNPM 11, pero se descartó por drift de lockfile no mínimo.
+- `corepack pnpm --filter portal-vetneb-frontend add -D @axe-core/playwright --lockfile-only`: pasó con PNPM 10.8.1 y dejó diff mínimo.
+- `corepack pnpm install --frozen-lockfile`: pasó; sincronizó instalación local sin cambiar lockfile.
+- `pnpm --dir frontend dev --hostname 127.0.0.1`: falló por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` usando PNPM global 11; no se forzó purga de `node_modules`.
+- `corepack pnpm --dir frontend exec playwright test e2e/accessibility-axe-key-routes.spec.ts`: pasó, 8/8 tests.
+- `corepack pnpm --filter portal-vetneb-frontend lint`: pasó.
+- `corepack pnpm --filter portal-vetneb-frontend typecheck`: pasó.
+- `corepack pnpm --filter portal-vetneb-frontend run test`: script no disponible en `frontend/package.json`; el comando no ejecutó suite.
+- `corepack pnpm --filter portal-vetneb-frontend build`: pasó.
+- `corepack pnpm test`: pasó, 2905/2905 tests.
+- `corepack pnpm build`: pasó.
+- `corepack pnpm security:public-surface`: pasó, sin findings de exposición pública; reportó notas server-only existentes para `CLINIC_SESSION_COOKIE_NAME` y `ADMIN_SESSION_COOKIE_NAME` en `frontend/src/proxy.ts`.
+- `git diff --check`: pasó.
+
+## Resultado
+
+PR-VIS-8 queda implementado como red e2e axe en rutas clave. No hubo violaciones axe en las rutas y viewports cubiertos. No se hicieron cambios visuales.
+
+## Riesgos residuales
+
+- La cobertura axe inicial queda limitada a Chromium, igual que el proyecto Playwright actual. Cross-browser sigue fuera de scope y corresponde a PR-VIS-10.
+- No se agregó gate CI porque CI/workflows quedó fuera de scope.
+- Axe automatiza parte de WCAG; no reemplaza revisión manual completa con lector de pantalla.
+
+## Confirmación de exclusiones críticas
+
+No se tocó backend, API, auth, DB, migraciones, dependencias no autorizadas, lockfiles fuera de la actualización permitida ni CI/workflows.

--- a/frontend/e2e/accessibility-axe-key-routes.spec.ts
+++ b/frontend/e2e/accessibility-axe-key-routes.spec.ts
@@ -1,0 +1,115 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+type SessionSurface = "admin" | "clinic";
+
+type RouteCase = {
+  label: string;
+  path: string;
+  ready: string;
+  mobileReady?: string;
+  session?: SessionSurface;
+};
+
+const routeCases: RouteCase[] = [
+  {
+    label: "public home",
+    path: "/",
+    ready: "main",
+  },
+  {
+    label: "login",
+    path: "/login",
+    ready: 'form[aria-label="Formulario de inicio de sesión"]',
+  },
+  {
+    label: "clinic dashboard hub",
+    path: "/dashboard",
+    ready: '[data-dashboard-module-hub="true"]',
+    session: "clinic",
+  },
+  {
+    label: "admin dashboard hub",
+    path: "/dashboard/admin",
+    ready: '[data-dashboard-module-hub="true"]',
+    mobileReady: '[data-admin-mobile-hub-launcher="true"]',
+    session: "admin",
+  },
+];
+
+const viewports = [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+] as const;
+
+async function applySession(page: Page, surface: SessionSurface | undefined) {
+  if (!surface) {
+    return;
+  }
+
+  await page.context().addCookies([
+    {
+      name: surface === "admin" ? "admin_session_id" : "app_session_id",
+      value:
+        surface === "admin"
+          ? "e2e_populated_admin_session"
+          : "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+function formatViolations(
+  violations: Awaited<ReturnType<AxeBuilder["analyze"]>>["violations"],
+) {
+  return violations
+    .map((violation) => {
+      const targets = violation.nodes
+        .flatMap((node) => node.target)
+        .slice(0, 3)
+        .join(", ");
+
+      return `${violation.id} (${violation.impact ?? "unknown"}): ${violation.help} — ${targets}`;
+    })
+    .join("\n");
+}
+
+test.describe("PR-VIS-8 axe accessibility on key routes", () => {
+  for (const viewport of viewports) {
+    for (const routeCase of routeCases) {
+      test(`${routeCase.label} has no axe violations on ${viewport.name}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await applySession(page, routeCase.session);
+
+        const response = await page.goto(routeCase.path, {
+          waitUntil: "domcontentloaded",
+        });
+
+        expect(
+          response?.ok(),
+          `${routeCase.path} should return a successful response`,
+        ).toBeTruthy();
+        await expect(
+          page
+            .locator(
+              viewport.name === "mobile" && routeCase.mobileReady
+                ? routeCase.mobileReady
+                : routeCase.ready,
+            )
+            .first(),
+        ).toBeVisible({ timeout: 8_000 });
+
+        const results = await new AxeBuilder({ page })
+          .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+          .analyze();
+
+        expect(results.violations, formatViolations(results.violations)).toEqual([]);
+      });
+    }
+  }
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "zod": "^4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "^25.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
         specifier: ^4
         version: 4.4.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.61.0)
       '@playwright/test':
         specifier: ^1.61.0
         version: 1.61.0
@@ -150,6 +153,11 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1488,6 +1496,10 @@ packages:
 
   axe-core@4.11.4:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -3119,6 +3131,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.0)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.0
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -4339,6 +4356,8 @@ snapshots:
     optional: true
 
   axe-core@4.11.4: {}
+
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
## Summary

Adds axe accessibility checks for PR-VIS-8 / VIS-P1-007.

This PR adds @axe-core/playwright and an e2e accessibility spec for key routes:

- /
- /login
- /dashboard
- /dashboard/admin

The checks run across desktop and mobile viewports. Axe found no violations, so no visual/token changes were needed.

## Scope

- Adds @axe-core/playwright as a frontend dev dependency.
- Updates pnpm-lock.yaml through the repo-pinned PNPM version via Corepack.
- Adds rontend/e2e/accessibility-axe-key-routes.spec.ts.
- Adds docs/audit/pr-vis-8-implementation.md.

## Validation

- corepack pnpm --dir frontend exec playwright test e2e/accessibility-axe-key-routes.spec.ts — PASS 8/8
- corepack pnpm --filter portal-vetneb-frontend lint — PASS
- corepack pnpm --filter portal-vetneb-frontend typecheck — PASS
- corepack pnpm --filter portal-vetneb-frontend run test — script not available in rontend/package.json
- corepack pnpm --filter portal-vetneb-frontend build — PASS
- corepack pnpm test — PASS 2905/2905
- corepack pnpm build — PASS
- corepack pnpm security:public-surface — PASS
- git diff --check — PASS

## Notes

The global pnpm v11 attempted to touch 
ode_modules and failed with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY. This PR used corepack pnpm 10.8.1, matching the package manager pinned by the repo.

## Explicitly not touched

- Backend
- API
- Auth
- Database
- Migrations
- CI / workflows

## Protocol

- Dependency/lockfile modification was explicitly authorized for PR-VIS-8 only.
- One branch / one PR.
- Git operations performed manually.
- Codex limited to implementation and tests.
