### PR TITLE
feat(clinic): adapt token rows to viewport height

### DIFF
--- a/docs/implementation/clinic-tokens-adaptive-rows-per-page.md
+++ b/docs/implementation/clinic-tokens-adaptive-rows-per-page.md
@@ -1,0 +1,129 @@
+# PR-PILOT-1: Clinic Tokens adaptive rows per page
+
+## Estado base
+
+- Rama: `feat/clinic-tokens-adaptive-rows`, creada desde `main` en `17a8df0`.
+- Working tree limpio antes de iniciar, sin PRs abiertos, sin ramas locales adicionales.
+- Documentos de gobernanza ya mergeados: `docs/audit/vetneb-enterprise-operational-platform-extreme-excellence-advisory.md`
+  y `docs/audit/global-zero-scroll-adaptive-dashboard-matrix.md`.
+
+## Problema
+
+`ClinicParticularTokensCard` paginaba la lista de tokens con una cardinalidad fija
+(`TOKENS_PAGE_SIZE = 4`) sin relación con el espacio real disponible en el
+contenedor de filas/cards. En viewports altos sobraba espacio vacío; en viewports
+bajos el valor fijo podía seguir siendo más grande de lo que el contenedor podía
+mostrar sin comprometer el contrato de no-scroll.
+
+## Scope incluido
+
+- Hook nuevo `useAdaptiveRowsPerPage` (cliente, genérico, sin dependencias del
+  dominio Clínica).
+- Integración exclusiva en `ClinicParticularTokensCard` (tabla desktop + lista
+  mobile comparten el mismo `rowsPerPage`).
+- `ParticularTokensPanelBody` acepta ahora `ref` (prop nativa de React 19, sin
+  `forwardRef`) para exponer el nodo medido.
+- Token CSS `--dash-row-h` agregado a la capa de densidad existente del App
+  Shell (`.dashboard-app-shell`), con valores por tier (base/compact/dense/
+  ultra-compact), igual que el resto de los tokens `--dash-*`.
+- Test de contrato de fuente actualizado para reflejar `rowsPerPage` en lugar
+  de `TOKENS_PAGE_SIZE` pasado directo a `usePagedRows`.
+
+## Scope excluido
+
+- No se tocó backend, API, auth, DB, migrations.
+- No se tocó Admin ni Particular.
+- No se tocó CI, workflows, dependencias, lockfiles ni snapshots visuales.
+- No se generalizó el patrón a otros módulos del dashboard.
+- No se modificaron specs de e2e (solo se ejecutaron los tres e2e dirigidos ya
+  existentes, sin editarlos).
+- No se cambió la firma de `usePagedRows`, el fetch (`limit: 10`), el footer/
+  pager, los flujos de alta/filtros/detalle/diálogos, ni los `data-clinic-access-*`
+  existentes.
+
+## Diseño técnico
+
+`useAdaptiveRowsPerPage` (`frontend/src/hooks/useAdaptiveRowsPerPage.ts`):
+
+- Estado inicial = `fallbackRows` (`TOKENS_PAGE_SIZE`).
+- `useLayoutEffect` + `ResizeObserver` sobre `containerRef.current`, con el
+  cálculo real desacoplado vía `requestAnimationFrame`.
+- Fórmula: `rowsPerPage = clamp(floor((containerHeight - headerHeightPx - safetyGapPx) / rowHeightPx), minRows, maxRows)`.
+- Nunca retorna `0`, negativo, `NaN` ni `Infinity`; conserva el último valor
+  válido si el contenedor no existe, mide `0`, o `rowHeightPx <= 0`.
+- `minRows` default `2`, `maxRows` default `50`, `safetyGapPx` default `6`.
+- No escribe estilos, no usa `matchMedia`, no lee `window` como fuente de
+  verdad para decidir cardinalidad.
+
+Integración en `ClinicParticularTokensCard`:
+
+- `panelBodyRef` se pasa a `ParticularTokensPanelBody` (nodo con
+  `data-clinic-access-list-body="true"`), que es el `containerRef` del hook.
+- `rowHeightPx` se obtiene midiendo un probe invisible (`aria-hidden`,
+  `pointer-events-none`, `opacity-0`, `position: absolute`) cuya altura es
+  `var(--dash-row-h)`, vía su propio `ResizeObserver`. Esto resuelve el valor
+  computado real del token CSS (los custom properties no se resuelven al leer
+  `getComputedStyle` directamente sobre el elemento).
+- `headerHeightPx` se obtiene midiendo el `<thead>` de la tabla desktop. En
+  mobile ese `<thead>` vive dentro de un contenedor `hidden md:block`, por lo
+  que su altura medida es `0` automáticamente y no se descuenta nada — cumple
+  el requisito de no descontar header de tabla en mobile sin lógica adicional.
+- `usePagedRows(filteredTokens, rowsPerPage)` reemplaza el uso directo de
+  `TOKENS_PAGE_SIZE`; la firma de `usePagedRows` no cambia.
+- `TOKENS_PAGE_SIZE = 4` permanece en el archivo como `fallbackRows`.
+- `setPage(0)` en cambios de filtros (`applyAdvancedFilters`,
+  `clearAdvancedFilters`) se preserva sin modificaciones.
+
+CSS (`frontend/src/app/globals.css`):
+
+- `--dash-row-h` se agrega junto a `--dash-list-pad-y` dentro del bloque base
+  de `.dashboard-app-shell` y se ajusta en los tres media queries de altura ya
+  existentes (`max-height: 860px / 760px / 680px`), siguiendo el mismo patrón
+  fluido (`clamp()`) que el resto de los tokens de densidad. No se creó un
+  sistema de breakpoints nuevo.
+
+## Archivos modificados
+
+- `frontend/src/hooks/useAdaptiveRowsPerPage.ts` (nuevo)
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx`
+- `frontend/src/app/globals.css`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `docs/implementation/clinic-tokens-adaptive-rows-per-page.md` (nuevo)
+
+## Validaciones
+
+- `pnpm test` — 2905 tests, 0 fallos.
+- `pnpm typecheck:test` — sin errores.
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm --dir frontend build` — build de producción exitoso.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` — 3/3 passed.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts` — 8/8 passed.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts` — 16/16 passed.
+- `frontend/next-env.d.ts`, regenerado por el dev server de Playwright durante
+  la corrida de e2e, fue revertido antes del commit (ver `[[feedback_next_env_regeneration]]`).
+
+## Riesgos residuales
+
+- El `rowHeightPx` medido vía probe con `var(--dash-row-h)` es una
+  aproximación única para fila desktop (tabla) y fila mobile (card); ambos
+  layouts tienen alturas ligeramente distintas en la práctica, por lo que
+  `rowsPerPage` puede quedar levemente conservador o levemente generoso según
+  el layout activo. No se detectó overflow en los e2e dirigidos.
+- `maxRows` queda en el default del hook (`50`); dado que `loadTokens` sigue
+  pidiendo `limit: 10`, el techo práctico visible sigue acotado por el fetch,
+  no por el hook.
+- No se agregó cobertura e2e nueva que fuerce específicamente el
+  redimensionamiento del contenedor para validar el recálculo dinámico de
+  `rowsPerPage` (reservado explícitamente para PR-PILOT-2).
+
+## Rollback
+
+Revertir el commit del PR restaura `usePagedRows(filteredTokens, TOKENS_PAGE_SIZE)`
+como cardinalidad fija, elimina el hook nuevo y el token `--dash-row-h`, sin
+efectos en backend, datos ni otros módulos.
+
+## Confirmación de scope
+
+Este PR no toca backend, API, auth, DB, migrations, Admin, Particular, CI,
+dependencias, lockfiles, snapshots visuales, ni specs de e2e existentes.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2138,6 +2138,7 @@
     /* Hub + lists density. */
     --dash-cockpit-gap: clamp(0.5rem, 0.3rem + 0.6vh, 1.15rem);
     --dash-list-pad-y: clamp(0.4rem, 0.3rem + 0.25vh, 0.65rem);
+    --dash-row-h: clamp(2.5rem, 2.2rem + 0.5vh, 3rem);
 
     /* Secondary text size used only by the compact tiers. */
     --dash-secondary-font: 0.75rem;
@@ -2153,6 +2154,7 @@
       --dash-card-pad: clamp(0.6rem, 0.45rem + 0.4vw, 0.9rem);
       --dash-panel-min: clamp(5rem, 0.5rem + 16vh, 13rem);
       --dash-cockpit-gap: clamp(0.5rem, 0.3rem + 0.5vh, 0.9rem);
+      --dash-row-h: clamp(2.35rem, 2.1rem + 0.4vh, 2.75rem);
     }
   }
 
@@ -2166,6 +2168,7 @@
       --dash-panel-min: clamp(4.5rem, 0.5rem + 14vh, 11rem);
       --dash-tab-h: clamp(1.85rem, 1.6rem + 0.5vh, 2.1rem);
       --dash-list-pad-y: clamp(0.35rem, 0.25rem + 0.2vh, 0.55rem);
+      --dash-row-h: clamp(2.2rem, 2rem + 0.35vh, 2.5rem);
     }
   }
 
@@ -2180,6 +2183,7 @@
       --dash-panel-min: 4rem;
       --dash-cockpit-gap: 0.45rem;
       --dash-secondary-font: 0.7rem;
+      --dash-row-h: 2.1rem;
     }
   }
 

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { Filter } from "lucide-react";
+import { useAdaptiveRowsPerPage } from "@/hooks/useAdaptiveRowsPerPage";
 import {
   dashboardFilterActionClassName,
   dashboardFilterControlClassName,
@@ -66,8 +67,11 @@ type ClinicParticularTokenFilterState = {
   to: string;
 };
 
-/** Maximum tokens visible per page in the master list (rest via footer pager). */
+/** Fallback tokens visible per page, used until the list body can be measured. */
 const TOKENS_PAGE_SIZE = 4;
+
+/** Row height fallback (px) before the `--dash-row-h` probe resolves. */
+const TOKENS_ROW_HEIGHT_FALLBACK_PX = 44;
 
 const CREATE_TOKEN_STEP_ORDER = ["contact", "patient", "sample"] as const;
 type CreateTokenStep = (typeof CREATE_TOKEN_STEP_ORDER)[number];
@@ -360,10 +364,60 @@ export function ClinicParticularTokensCard() {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  const panelBodyRef = useRef<HTMLDivElement | null>(null);
+  const rowHeightProbeRef = useRef<HTMLDivElement | null>(null);
+  const tableHeaderRef = useRef<HTMLTableSectionElement | null>(null);
+  const [rowHeightPx, setRowHeightPx] = useState(TOKENS_ROW_HEIGHT_FALLBACK_PX);
+  const [tableHeaderHeightPx, setTableHeaderHeightPx] = useState(0);
+
+  useLayoutEffect(() => {
+    const probe = rowHeightProbeRef.current;
+    if (!probe) {
+      return;
+    }
+
+    const measureRowHeight = () => {
+      const height = probe.getBoundingClientRect().height;
+      if (height > 0) {
+        setRowHeightPx(height);
+      }
+    };
+
+    const observer = new ResizeObserver(measureRowHeight);
+    observer.observe(probe);
+    measureRowHeight();
+
+    return () => observer.disconnect();
+  }, []);
+
+  useLayoutEffect(() => {
+    const header = tableHeaderRef.current;
+    if (!header) {
+      return;
+    }
+
+    const measureHeaderHeight = () => {
+      setTableHeaderHeightPx(header.getBoundingClientRect().height);
+    };
+
+    const observer = new ResizeObserver(measureHeaderHeight);
+    observer.observe(header);
+    measureHeaderHeight();
+
+    return () => observer.disconnect();
+  }, []);
+
+  const { rowsPerPage } = useAdaptiveRowsPerPage({
+    containerRef: panelBodyRef,
+    fallbackRows: TOKENS_PAGE_SIZE,
+    rowHeightPx,
+    headerHeightPx: tableHeaderHeightPx,
+  });
+
   const filteredTokens = tokens.filter((token) =>
     matchesClinicParticularTokenFilters(token, appliedFilters),
   );
-  const pagedTokens = usePagedRows(filteredTokens, TOKENS_PAGE_SIZE);
+  const pagedTokens = usePagedRows(filteredTokens, rowsPerPage);
   const selectedToken =
     selectedTokenId === null
       ? null
@@ -854,8 +908,16 @@ export function ClinicParticularTokensCard() {
                 </ParticularTokensPanelHeader>
 
                 <ParticularTokensPanelBody
+                  ref={panelBodyRef}
                   data-clinic-access-list-body="true"
+                  className="relative"
                 >
+                  <div
+                    aria-hidden="true"
+                    ref={rowHeightProbeRef}
+                    className="pointer-events-none absolute -z-10 w-px opacity-0"
+                    style={{ height: "var(--dash-row-h)" }}
+                  />
                   {filteredTokens.length ? (
                     <>
                       <div
@@ -863,7 +925,10 @@ export function ClinicParticularTokensCard() {
                         className="hidden min-h-0 shrink-0 overflow-hidden md:block"
                       >
                         <table className="w-full table-fixed text-[0.8125rem]">
-                          <thead className="border-b border-vetneb-line/65 bg-vetneb-surface-muted/65 text-xs font-semibold uppercase text-muted-foreground">
+                          <thead
+                            ref={tableHeaderRef}
+                            className="border-b border-vetneb-line/65 bg-vetneb-surface-muted/65 text-xs font-semibold uppercase text-muted-foreground"
+                          >
                             <tr>
                               <th className="w-[32%] px-3 py-2 text-left">Token / Paciente</th>
                               <th className="w-[13%] px-3 py-2 text-left">Estado</th>

--- a/frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
+++ b/frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ComponentPropsWithRef, ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -87,7 +87,7 @@ export function ParticularTokensPanelHeader({
 export function ParticularTokensPanelBody({
   className,
   ...props
-}: ComponentPropsWithoutRef<"div">) {
+}: ComponentPropsWithRef<"div">) {
   return (
     <div
       className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", className)}

--- a/frontend/src/hooks/useAdaptiveRowsPerPage.ts
+++ b/frontend/src/hooks/useAdaptiveRowsPerPage.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState, type RefObject } from "react";
+
+export type UseAdaptiveRowsPerPageOptions = {
+  containerRef: RefObject<HTMLElement | null>;
+  fallbackRows: number;
+  rowHeightPx: number;
+  headerHeightPx?: number;
+  safetyGapPx?: number;
+  minRows?: number;
+  maxRows?: number;
+  enabled?: boolean;
+};
+
+export type UseAdaptiveRowsPerPageResult = {
+  rowsPerPage: number;
+  isMeasured: boolean;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Derives how many rows fit a measured container instead of a fixed page
+ * size. Falls back to `fallbackRows` until a valid measurement is available,
+ * and keeps the last valid value whenever the container can't be measured.
+ */
+export function useAdaptiveRowsPerPage({
+  containerRef,
+  fallbackRows,
+  rowHeightPx,
+  headerHeightPx = 0,
+  safetyGapPx = 6,
+  minRows = 2,
+  maxRows = 50,
+  enabled = true,
+}: UseAdaptiveRowsPerPageOptions): UseAdaptiveRowsPerPageResult {
+  const [rowsPerPage, setRowsPerPage] = useState(fallbackRows);
+  const [isMeasured, setIsMeasured] = useState(false);
+  const rowsPerPageRef = useRef(fallbackRows);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const measure = () => {
+      frame = null;
+
+      const containerHeight = container.getBoundingClientRect().height;
+      if (containerHeight <= 0 || rowHeightPx <= 0) {
+        return;
+      }
+
+      const availableRowsHeight =
+        containerHeight - headerHeightPx - safetyGapPx;
+      const nextRows = clamp(
+        Math.floor(availableRowsHeight / rowHeightPx),
+        minRows,
+        maxRows,
+      );
+
+      if (!Number.isFinite(nextRows) || nextRows <= 0) {
+        return;
+      }
+
+      setIsMeasured(true);
+
+      if (nextRows !== rowsPerPageRef.current) {
+        rowsPerPageRef.current = nextRows;
+        setRowsPerPage(nextRows);
+      }
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) {
+        return;
+      }
+      frame = requestAnimationFrame(measure);
+    };
+
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(container);
+    scheduleMeasure();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [
+    containerRef,
+    enabled,
+    headerHeightPx,
+    maxRows,
+    minRows,
+    rowHeightPx,
+    safetyGapPx,
+  ]);
+
+  return { rowsPerPage, isMeasured };
+}

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -82,7 +82,10 @@ test("clinic tokens uses table/list row actions with dialog detail and step dial
   const source = read(CLINIC_TOKENS_CARD_PATH);
 
   assert.ok(source.includes("const TOKENS_PAGE_SIZE = 4;"));
-  assert.ok(source.includes("usePagedRows(filteredTokens, TOKENS_PAGE_SIZE)"));
+  assert.ok(source.includes("useAdaptiveRowsPerPage"));
+  assert.ok(source.includes("fallbackRows: TOKENS_PAGE_SIZE"));
+  assert.equal(source.includes("usePagedRows(filteredTokens, TOKENS_PAGE_SIZE)"), false);
+  assert.ok(source.includes("usePagedRows(filteredTokens, rowsPerPage)"));
   assert.ok(source.includes("selectedTokenId"));
   assert.ok(source.includes("ModuleSurface"));
   assert.ok(source.includes('data-clinic-access-table="true"'));
@@ -141,7 +144,7 @@ test("clinic tokens exposes advanced filters over visible token fields", () => {
   assert.ok(source.includes("token.lastLoginAt ?? token.createdAt"));
   assert.ok(source.includes("matchesTokenVisibleDateRange(token, filters.from, filters.to)"));
   assert.ok(source.includes("const filteredTokens = tokens.filter((token) =>"));
-  assert.ok(source.includes("usePagedRows(filteredTokens, TOKENS_PAGE_SIZE)"));
+  assert.ok(source.includes("usePagedRows(filteredTokens, rowsPerPage)"));
   assert.ok(source.includes('data-clinic-access-filter-bar={mobile ? "advanced-mobile" : "advanced"}'));
   assert.ok(source.includes('title="Filtrar tokens"'));
   assert.ok(source.includes("Sin tokens para los filtros aplicados"));


### PR DESCRIPTION
Implements the PR-PILOT-1 adaptive rows pilot for Clinic particular tokens. Keeps TOKENS_PAGE_SIZE as fallback, derives rowsPerPage from the measured list body, preserves the existing footer/pager and source-contract invariants, and adds implementation docs. No backend, API, admin, particular, CI, dependencies, lockfiles, snapshots, or e2e files changed.