### PR TITLE
fix(clinic): activate adaptive token row measurement

### DIFF
--- a/docs/implementation/clinic-tokens-adaptive-rows-per-page.md
+++ b/docs/implementation/clinic-tokens-adaptive-rows-per-page.md
@@ -127,3 +127,169 @@ efectos en backend, datos ni otros módulos.
 
 Este PR no toca backend, API, auth, DB, migrations, Admin, Particular, CI,
 dependencias, lockfiles, snapshots visuales, ni specs de e2e existentes.
+
+## PR-FIX-1 — Activation fix
+
+### Bug detectado por PR-PILOT-2
+
+Al redactar el e2e de PR-PILOT-2 (cobertura de resize dinámico, comparando
+filas visibles entre viewport alto y bajo) se detectó que `rowsPerPage` nunca
+se movía de `TOKENS_PAGE_SIZE = 4`, sin importar la altura real del
+contenedor. Medido directamente en runtime (sin recargar la página, sólo
+cambiando `setViewportSize`): el contenedor pasó de 632px → 56px → 1542px de
+alto y la cantidad de filas renderizadas se mantuvo en 4 en los tres casos.
+
+### Causa raíz
+
+`tokens` arranca en `[]`; mientras `tokens.length === 0` se renderiza
+`ParticularTokensEmptyPanel`, no el panel real, así que el nodo del
+contenedor (`panelBodyRef.current`, antes un `useRef`) y los nodos del probe
+de altura de fila y del `<thead>` eran `null` en el primer commit. Los tres
+`useLayoutEffect` que dependían de esos refs corrían una única vez contra un
+ref todavía `null` y hacían early-return:
+
+- Los dos efectos locales del componente (probe de fila, `<thead>`) tenían
+  array de dependencias `[]` — nunca se re-ejecutaban.
+- El efecto de `useAdaptiveRowsPerPage` dependía de `containerRef` (el mismo
+  objeto `ref` siempre — React compara por identidad, no por `.current`),
+  `headerHeightPx` y `rowHeightPx` (ambos nunca cambiaban porque dependían de
+  los otros dos efectos, ya rotos). Ningún valor del array de dependencias
+  cambiaba jamás entre el render inicial (contenedor `null`) y el render
+  donde `tokens` se poblaba y el panel real se montaba, así que el
+  `ResizeObserver` nunca llegaba a instalarse.
+
+### Por qué `useRef` + `useLayoutEffect` no alcanzaba
+
+Un `useRef` tiene identidad estable durante toda la vida del componente;
+asignar `.current` no dispara re-render ni re-ejecuta efectos. Un
+`useLayoutEffect` con dependencias `[]` (o con dependencias que nunca
+cambian) sólo ve el valor de `.current` que existía en el primer commit. Si
+el nodo real se monta en un commit posterior (como acá, detrás de un fetch
+async), el efecto ya corrió y nunca vuelve a intentarlo.
+
+### Por qué callback ref + `useState` corrige el problema
+
+Reemplazando `useRef` por `useState<HTMLElement | null>(null)` y pasando el
+setter como `ref` (patrón nativo de callback ref), React re-renderiza en el
+momento exacto en que el nodo pasa de no existir a existir. Incluyendo ese
+valor de estado en el array de dependencias del efecto, el
+`useLayoutEffect` se re-ejecuta cuando el nodo real aparece, e instala el
+`ResizeObserver` contra el contenedor correcto.
+
+- `useAdaptiveRowsPerPage.ts`: la opción `containerRef: RefObject<...>` pasó
+  a ser `containerNode: HTMLElement | null`; el efecto depende de
+  `containerNode` en vez de un objeto `ref` estable.
+- `ClinicParticularTokensCard.tsx`: `panelBodyRef`, `rowHeightProbeRef` y
+  `tableHeaderRef` (los tres `useRef`) pasaron a ser `panelBodyNode`,
+  `rowHeightProbeNode`/`tableHeaderNode` (más tarde reemplazados también, ver
+  sección siguiente) respaldados por `useState`, con `ref={setXNode}` en el
+  JSX.
+
+## PR-FIX-1 — Mobile row height precision fix
+
+### Segundo bug detectado
+
+Al validar el fix de activación contra los e2e dirigidos existentes
+(`dashboard-clinic-tokens-mobile-parity.spec.ts`), el viewport más angosto
+(360×740, con contenido de tutor/paciente intencionalmente largo) mostró
+overflow real dentro de la lista: contenedor de 282.9px de alto, contenido
+de 372px (~89px de clipping), con 6 cards mobile de ~62px cada una.
+
+### Causa raíz
+
+`rowHeightPx` se medía con un único probe invisible atado al token CSS
+`--dash-row-h` (pensado para una fila de tabla desktop de una sola línea,
+~37-44px). Ese mismo valor se usaba para calcular cuántas filas entraban
+tanto en la tabla desktop como en la lista de cards mobile. La card mobile
+real, con nombre de tutor/paciente largo, envuelve a 2-3 líneas y mide
+~62px real — el hook subestimaba ~20-25px por fila en mobile, calculaba más
+filas de las que entraban, y el contenido desbordaba el contenedor. Este
+riesgo ya estaba documentado como residual en el diseño original de
+PR-PILOT-1 ("rowHeightPx es una aproximación única compartida... puede
+quedar levemente conservador o levemente generoso"), pero nunca se había
+observado en un e2e porque el hook estaba inactivo (bug de activación).
+
+### Solución: medición real por layout, sin breakpoints hardcodeados
+
+Se eliminó el probe sintético de `--dash-row-h` y se reemplazó por
+medición directa de la primera fila/card real ya renderizada:
+
+- `firstDesktopRowNode`: ref (callback + `useState`) sobre el primer `<tr>`
+  de la tabla (`pagedTokens.pageItems[0]`).
+- `firstMobileRowNode`: ref sobre la primera card mobile
+  (`pagedTokens.pageItems[0]`).
+- Un único `useLayoutEffect` observa ambos nodos con `ResizeObserver` y usa
+  `Math.max(desktopHeight, mobileHeight)` como `rowHeightPx`.
+
+Como el layout inactivo vive detrás de una clase Tailwind `hidden`/`md:hidden`
+(`display: none` en su ancestro), su fila mide `0` en `getBoundingClientRect()`
+— tomar el máximo de las dos mediciones da siempre la altura real del
+layout visible, sin decidir por un breakpoint hardcodeado ni por
+`matchMedia`.
+
+### Archivos tocados (PR-FIX-1 completo)
+
+- `frontend/src/hooks/useAdaptiveRowsPerPage.ts`
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` (contrato
+  rígido `toHaveCount(4)` reemplazado por conteo adaptativo asentado —
+  helper `waitForSettledRowCount` — con relaciones: positivo, acotado por el
+  dataset mockeado, texto de paginación y estado de "Siguiente" derivados
+  del conteo observado, no de un literal)
+- `frontend/e2e/dashboard-global-masked-master-detail.spec.ts` (mismo
+  patrón, mismo helper duplicado localmente en el archivo)
+- `docs/implementation/clinic-tokens-adaptive-rows-per-page.md` (esta
+  sección)
+
+`test/frontend-dashboard-clinic-tokens.test.ts` no requirió cambios: no
+pineaba `containerRef`/`containerNode` ni los nombres de refs internos, sólo
+`useAdaptiveRowsPerPage`, `fallbackRows: TOKENS_PAGE_SIZE` y
+`usePagedRows(filteredTokens, rowsPerPage)`, que se preservan.
+
+### Por qué el conteo pasó de "4" a un valor asentado distinto en los e2e
+
+`toHaveCount(4)` en los specs existentes validaba, sin saberlo, el valor
+congelado del bug de activación (que coincidía numéricamente con
+`TOKENS_PAGE_SIZE`). Con el hook activo, la medición real toma dos renders
+en converger: un primer commit calcula con `rowHeightPx`/`headerHeightPx`
+todavía en su valor de fallback (antes de que los efectos hermanos
+actualicen esos estados), y un commit siguiente recalcula con los valores
+reales ya medidos. Los e2e ajustados esperan explícitamente a que el
+conteo se asiente (3 lecturas idénticas consecutivas) antes de tomarlo como
+válido, en vez de fijar un número.
+
+### Validaciones ejecutadas
+
+- `pnpm test` — 2905/2905.
+- `pnpm typecheck:test` — sin errores.
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm --dir frontend build` — build de producción exitoso.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` — 3/3 (repetido 3 veces, estable).
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts` — 8/8.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts` — 16/16.
+- `node --test test/frontend-dashboard-clinic-tokens.test.ts` — 13/13.
+- `frontend/next-env.d.ts`, regenerado por el dev server de Playwright
+  durante las corridas de e2e, revertido antes de cada `pnpm test`.
+
+### Riesgos residuales
+
+- La medición mobile depende de que la primera card de la página actual sea
+  representativa del resto (misma estructura de contenido); un token
+  particular con contenido drásticamente más largo/corto que el resto de la
+  página podría hacer que `rowsPerPage` quede levemente conservador o
+  generoso hasta el próximo `ResizeObserver` tick, pero nunca deja de
+  converger (no hay overflow sostenido observado en los e2e dirigidos).
+- El primer commit tras cargar los tokens sigue mostrando un valor
+  transitorio (calculado con el fallback) antes de asentarse; no afecta al
+  usuario final (son milisegundos dentro de un mismo frame de React) pero
+  cualquier e2e nuevo sobre este módulo debe esperar a que el conteo se
+  asiente en vez de leerlo una sola vez.
+- PR-PILOT-2 (cobertura e2e de resize dinámico) queda pausado; se retoma
+  desde `main` limpio una vez mergeado este PR-FIX-1.
+
+### Rollback
+
+Revertir el/los commits de PR-FIX-1 restaura el estado de PR-PILOT-1: hook
+inactivo (`rowsPerPage` clavado en `TOKENS_PAGE_SIZE = 4`), sin efectos en
+backend, datos ni otros módulos. No requiere rollback de datos ni de
+configuración.

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -249,6 +249,36 @@ async function expectFooterBottomRightAligned(
   ).toBeLessThanOrEqual(18);
 }
 
+// `useAdaptiveRowsPerPage` now actually reacts to the measured container
+// (PR-FIX-1). Right after the list mounts it can briefly compute a transient
+// value from not-yet-updated sub-measurements (row height / header height)
+// before a follow-up render settles on the real value, so a naive read can
+// catch that transient instead of the converged count. Wait until the count
+// stops changing for a few consecutive polls before trusting it.
+async function waitForSettledRowCount(
+  locator: Locator,
+  label: string,
+): Promise<number> {
+  let previousCount = -1;
+  let stableReads = 0;
+
+  await expect(async () => {
+    const currentCount = await locator.count();
+    if (currentCount === previousCount) {
+      stableReads += 1;
+    } else {
+      previousCount = currentCount;
+      stableReads = 0;
+    }
+    expect(
+      stableReads,
+      `${label}: adaptive row count must settle (currently ${currentCount})`,
+    ).toBeGreaterThanOrEqual(3);
+  }).toPass({ timeout: 8_000, intervals: [50] });
+
+  return previousCount;
+}
+
 for (const viewport of MOBILE_VIEWPORTS) {
   test(`clinic Tokens mobile parity at ${viewport.name}`, async ({ page }) => {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
@@ -297,14 +327,6 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(workspace).toBeVisible();
       await expect(card).toBeVisible();
       await expectClinicMobileBottomNav(page, viewport.name);
-      await expect(tokenRows).toHaveCount(4);
-      await expect(detailButtons).toHaveCount(4);
-
-      for (let index = 0; index < 4; index += 1) {
-        await expect(tokenRows.nth(index)).toBeVisible();
-        await expect(detailButtons.nth(index)).toBeVisible();
-      }
-
       await expect(refreshButton).toBeVisible();
       await expect(refreshButton).toBeEnabled();
       await expect(createButton).toBeVisible();
@@ -312,14 +334,45 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(pager).toBeVisible();
       await expect(previousButton).toBeVisible();
       await expect(nextButton).toBeVisible();
-      await expect(nextButton).toBeEnabled();
-      await expect(pager.getByText("Página 1 / 2")).toBeVisible();
-      await expect(card.getByText(/1[\u2013-]4 de \d+ tokens/)).toHaveCount(0);
+      await expect(card.getByText(/1[–-]4 de \d+ tokens/)).toHaveCount(0);
       await expect(futureSlots).toBeVisible();
       await expect(card.getByText("Usuarios y roles")).toHaveCount(0);
       await expect(card.getByText("Auditoría")).toHaveCount(0);
       await expect(card.getByText("Mantenimiento")).toHaveCount(0);
     }).toPass({ timeout: 12_000 });
+
+    // `rowsPerPage` is adaptive (useAdaptiveRowsPerPage), not the historical
+    // fixed TOKENS_PAGE_SIZE=4 -- assert the observable contract instead of a
+    // literal: a positive, settled row count bounded by the mocked dataset,
+    // wired consistently to the detail buttons and the pagination footer.
+    const rowCount = await waitForSettledRowCount(
+      tokenRows,
+      `${viewport.name}: initial list`,
+    );
+    expect(
+      rowCount,
+      `${viewport.name}: adaptive row count must be positive`,
+    ).toBeGreaterThan(0);
+    expect(
+      rowCount,
+      `${viewport.name}: adaptive row count must not exceed the mocked dataset`,
+    ).toBeLessThanOrEqual(MOCK_TOKENS.length);
+    await expect(detailButtons).toHaveCount(rowCount);
+
+    for (let index = 0; index < rowCount; index += 1) {
+      await expect(tokenRows.nth(index)).toBeVisible();
+      await expect(detailButtons.nth(index)).toBeVisible();
+    }
+
+    const expectedPageCount = Math.ceil(MOCK_TOKENS.length / rowCount);
+    await expect(
+      pager.getByText(`Página 1 / ${expectedPageCount}`),
+    ).toBeVisible();
+    if (expectedPageCount > 1) {
+      await expect(nextButton).toBeEnabled();
+    } else {
+      await expect(nextButton).toBeDisabled();
+    }
 
     await expectHorizontallyUnclipped(
       refreshButton,
@@ -374,7 +427,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await detailButtons.nth(1).click();
 
     await expect(async () => {
-      await expect(tokenRows).toHaveCount(4);
+      await expect(tokenRows).toHaveCount(rowCount);
       await expect(tokenRows.nth(0)).toBeVisible();
       await expect(tokenRows.nth(1)).toBeVisible();
       await expect(

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Global inline/masked Master-Detail / no-scroll contract for BOTH dashboards.
@@ -247,6 +247,36 @@ async function readScrollContract(page: Page): Promise<ScrollContract> {
   });
 }
 
+// `useAdaptiveRowsPerPage` (PR-FIX-1) reacts to the measured container/row
+// instead of a fixed page size. Right after the list mounts it can briefly
+// compute a transient value from not-yet-updated sub-measurements before a
+// follow-up render settles on the real value, so a naive read can catch that
+// transient instead of the converged count. Wait until the count stops
+// changing for a few consecutive polls before trusting it.
+async function waitForSettledRowCount(
+  locator: Locator,
+  label: string,
+): Promise<number> {
+  let previousCount = -1;
+  let stableReads = 0;
+
+  await expect(async () => {
+    const currentCount = await locator.count();
+    if (currentCount === previousCount) {
+      stableReads += 1;
+    } else {
+      previousCount = currentCount;
+      stableReads = 0;
+    }
+    expect(
+      stableReads,
+      `${label}: adaptive row count must settle (currently ${currentCount})`,
+    ).toBeGreaterThanOrEqual(3);
+  }).toPass({ timeout: 8_000, intervals: [50] });
+
+  return previousCount;
+}
+
 function assertNoInternalScroll(metrics: ScrollContract, label: string) {
   expect(metrics.hasMain, `${label}: main.dashboard-main present`).toBe(true);
 
@@ -365,7 +395,20 @@ test("clinic Tokens desktop limits the list and opens detail dialog without shel
   await expect(workspace).toBeVisible({
     timeout: 12_000,
   });
-  await expect(card.locator('[data-clinic-access-table-row="true"]')).toHaveCount(4);
+  // `rowsPerPage` is adaptive (useAdaptiveRowsPerPage, PR-FIX-1), not a fixed
+  // literal -- assert a settled, bounded row count instead of TOKENS_PAGE_SIZE.
+  const desktopRowCount = await waitForSettledRowCount(
+    card.locator('[data-clinic-access-table-row="true"]'),
+    "desktop clinic Tokens initial list",
+  );
+  expect(
+    desktopRowCount,
+    "desktop clinic Tokens: adaptive row count must be positive",
+  ).toBeGreaterThan(0);
+  expect(
+    desktopRowCount,
+    "desktop clinic Tokens: adaptive row count must not exceed the mocked dataset",
+  ).toBeLessThanOrEqual(MOCK_TOKENS.length);
   await expect(
     card.locator('[data-clinic-access-pagination-footer="true"]'),
   ).toBeVisible();
@@ -379,7 +422,9 @@ test("clinic Tokens desktop limits the list and opens detail dialog without shel
   await expect(
     card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
   ).toHaveCount(0);
-  await expect(card.locator('[data-clinic-access-table-row="true"]')).toHaveCount(4);
+  await expect(
+    card.locator('[data-clinic-access-table-row="true"]'),
+  ).toHaveCount(desktopRowCount);
   const detailDialog = page.locator('[data-clinic-access-detail-dialog="true"]');
   await expect(detailDialog).toBeVisible();
   await expect(detailDialog).toContainText("Paciente 2 · Tutor 2");
@@ -404,8 +449,25 @@ test("clinic Tokens mobile keeps the list and opens the selected detail dialog",
   });
   await expect(card.locator('[data-clinic-access-mobile-row="true"]').first()).toBeVisible();
 
+  // `rowsPerPage` is adaptive (useAdaptiveRowsPerPage, PR-FIX-1), not a fixed
+  // literal -- assert a settled, bounded row count instead of TOKENS_PAGE_SIZE.
+  const mobileRowCount = await waitForSettledRowCount(
+    card.locator('[data-clinic-access-mobile-row="true"]'),
+    "mobile clinic Tokens initial list",
+  );
+  expect(
+    mobileRowCount,
+    "mobile clinic Tokens: adaptive row count must be positive",
+  ).toBeGreaterThan(0);
+  expect(
+    mobileRowCount,
+    "mobile clinic Tokens: adaptive row count must not exceed the mocked dataset",
+  ).toBeLessThanOrEqual(MOCK_TOKENS.length);
+
   await card.getByRole("button", { name: "Ver detalle", exact: true }).nth(1).click();
-  await expect(card.locator('[data-clinic-access-mobile-row="true"]')).toHaveCount(4);
+  await expect(
+    card.locator('[data-clinic-access-mobile-row="true"]'),
+  ).toHaveCount(mobileRowCount);
   await expect(
     card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
   ).toHaveCount(0);

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { FormEvent, useEffect, useLayoutEffect, useState } from "react";
 
 import { Filter } from "lucide-react";
 import { useAdaptiveRowsPerPage } from "@/hooks/useAdaptiveRowsPerPage";
@@ -70,7 +70,7 @@ type ClinicParticularTokenFilterState = {
 /** Fallback tokens visible per page, used until the list body can be measured. */
 const TOKENS_PAGE_SIZE = 4;
 
-/** Row height fallback (px) before the `--dash-row-h` probe resolves. */
+/** Row height fallback (px) before the first real row/card can be measured. */
 const TOKENS_ROW_HEIGHT_FALLBACK_PX = 44;
 
 const CREATE_TOKEN_STEP_ORDER = ["contact", "patient", "sample"] as const;
@@ -364,51 +364,76 @@ export function ClinicParticularTokensCard() {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const panelBodyRef = useRef<HTMLDivElement | null>(null);
-  const rowHeightProbeRef = useRef<HTMLDivElement | null>(null);
-  const tableHeaderRef = useRef<HTMLTableSectionElement | null>(null);
+  // Callback-ref state (not `useRef`): these nodes sit behind the
+  // `tokens.length` conditional and only mount once `loadTokens()` resolves,
+  // on a render after this component's first commit. A `useRef` object's
+  // identity never changes, so an effect depending on it would never re-run
+  // once the node actually mounts; `useState` re-renders (and therefore
+  // re-runs dependent effects) exactly when the node appears.
+  const [panelBodyNode, setPanelBodyNode] = useState<HTMLDivElement | null>(null);
+  const [firstDesktopRowNode, setFirstDesktopRowNode] =
+    useState<HTMLTableRowElement | null>(null);
+  const [firstMobileRowNode, setFirstMobileRowNode] =
+    useState<HTMLDivElement | null>(null);
+  const [tableHeaderNode, setTableHeaderNode] =
+    useState<HTMLTableSectionElement | null>(null);
   const [rowHeightPx, setRowHeightPx] = useState(TOKENS_ROW_HEIGHT_FALLBACK_PX);
   const [tableHeaderHeightPx, setTableHeaderHeightPx] = useState(0);
 
+  // Desktop table rows and mobile cards render at different real heights
+  // (the mobile card can wrap tutor/patient text across multiple lines), so
+  // a single synthetic probe underestimates one of the two layouts. Measure
+  // the first row of each list directly instead: exactly one is visible at
+  // a time (the other's ancestor is `display: none` via the `md:` classes,
+  // which collapses it to a zero-height rect), so the max of the two is
+  // always the real height of whichever layout is currently on screen —
+  // without deciding by a hardcoded breakpoint.
   useLayoutEffect(() => {
-    const probe = rowHeightProbeRef.current;
-    if (!probe) {
+    if (!firstDesktopRowNode && !firstMobileRowNode) {
       return;
     }
 
     const measureRowHeight = () => {
-      const height = probe.getBoundingClientRect().height;
+      const desktopHeight =
+        firstDesktopRowNode?.getBoundingClientRect().height ?? 0;
+      const mobileHeight =
+        firstMobileRowNode?.getBoundingClientRect().height ?? 0;
+      const height = Math.max(desktopHeight, mobileHeight);
       if (height > 0) {
         setRowHeightPx(height);
       }
     };
 
     const observer = new ResizeObserver(measureRowHeight);
-    observer.observe(probe);
+    if (firstDesktopRowNode) {
+      observer.observe(firstDesktopRowNode);
+    }
+    if (firstMobileRowNode) {
+      observer.observe(firstMobileRowNode);
+    }
     measureRowHeight();
 
     return () => observer.disconnect();
-  }, []);
+  }, [firstDesktopRowNode, firstMobileRowNode]);
 
   useLayoutEffect(() => {
-    const header = tableHeaderRef.current;
-    if (!header) {
+    if (!tableHeaderNode) {
       return;
     }
 
     const measureHeaderHeight = () => {
-      setTableHeaderHeightPx(header.getBoundingClientRect().height);
+      setTableHeaderHeightPx(tableHeaderNode.getBoundingClientRect().height);
     };
 
     const observer = new ResizeObserver(measureHeaderHeight);
-    observer.observe(header);
+    observer.observe(tableHeaderNode);
     measureHeaderHeight();
 
     return () => observer.disconnect();
-  }, []);
+  }, [tableHeaderNode]);
 
   const { rowsPerPage } = useAdaptiveRowsPerPage({
-    containerRef: panelBodyRef,
+    containerNode: panelBodyNode,
     fallbackRows: TOKENS_PAGE_SIZE,
     rowHeightPx,
     headerHeightPx: tableHeaderHeightPx,
@@ -908,16 +933,10 @@ export function ClinicParticularTokensCard() {
                 </ParticularTokensPanelHeader>
 
                 <ParticularTokensPanelBody
-                  ref={panelBodyRef}
+                  ref={setPanelBodyNode}
                   data-clinic-access-list-body="true"
                   className="relative"
                 >
-                  <div
-                    aria-hidden="true"
-                    ref={rowHeightProbeRef}
-                    className="pointer-events-none absolute -z-10 w-px opacity-0"
-                    style={{ height: "var(--dash-row-h)" }}
-                  />
                   {filteredTokens.length ? (
                     <>
                       <div
@@ -926,7 +945,7 @@ export function ClinicParticularTokensCard() {
                       >
                         <table className="w-full table-fixed text-[0.8125rem]">
                           <thead
-                            ref={tableHeaderRef}
+                            ref={setTableHeaderNode}
                             className="border-b border-vetneb-line/65 bg-vetneb-surface-muted/65 text-xs font-semibold uppercase text-muted-foreground"
                           >
                             <tr>
@@ -940,9 +959,10 @@ export function ClinicParticularTokensCard() {
                             </tr>
                           </thead>
                           <tbody className="divide-y divide-vetneb-line/60">
-                            {pagedTokens.pageItems.map((token) => (
+                            {pagedTokens.pageItems.map((token, index) => (
                               <tr
                                 key={token.id}
+                                ref={index === 0 ? setFirstDesktopRowNode : undefined}
                                 data-clinic-access-table-row="true"
                                 className="hover:bg-vetneb-cyan/8"
                               >
@@ -995,13 +1015,14 @@ export function ClinicParticularTokensCard() {
                         data-clinic-access-mobile-list="true"
                         className="flex min-h-0 shrink-0 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
                       >
-                        {pagedTokens.pageItems.map((token) => {
+                        {pagedTokens.pageItems.map((token, index) => {
                           const trackingCase = trackingCasesByTokenId[token.id];
 
                           return (
                             <div
                               key={token.id}
                               id={`clinic-particular-token-${token.id}`}
+                              ref={index === 0 ? setFirstMobileRowNode : undefined}
                               data-clinic-access-mobile-row="true"
                               className="grid min-h-11 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5"
                             >

--- a/frontend/src/hooks/useAdaptiveRowsPerPage.ts
+++ b/frontend/src/hooks/useAdaptiveRowsPerPage.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 export type UseAdaptiveRowsPerPageOptions = {
-  containerRef: RefObject<HTMLElement | null>;
+  containerNode: HTMLElement | null;
   fallbackRows: number;
   rowHeightPx: number;
   headerHeightPx?: number;
@@ -26,9 +26,15 @@ function clamp(value: number, min: number, max: number): number {
  * Derives how many rows fit a measured container instead of a fixed page
  * size. Falls back to `fallbackRows` until a valid measurement is available,
  * and keeps the last valid value whenever the container can't be measured.
+ *
+ * `containerNode` must be the actual DOM node (e.g. via a `useState` callback
+ * ref), not a `useRef` object: the node commonly mounts on a later render
+ * than the hook's first commit (it sits behind a conditional/async-loaded
+ * branch), and a plain ref's identity never changes, so an effect keyed off
+ * the ref object would never re-run once the node appears.
  */
 export function useAdaptiveRowsPerPage({
-  containerRef,
+  containerNode,
   fallbackRows,
   rowHeightPx,
   headerHeightPx = 0,
@@ -42,12 +48,7 @@ export function useAdaptiveRowsPerPage({
   const rowsPerPageRef = useRef(fallbackRows);
 
   useLayoutEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const container = containerRef.current;
-    if (!container) {
+    if (!enabled || !containerNode) {
       return;
     }
 
@@ -56,7 +57,7 @@ export function useAdaptiveRowsPerPage({
     const measure = () => {
       frame = null;
 
-      const containerHeight = container.getBoundingClientRect().height;
+      const containerHeight = containerNode.getBoundingClientRect().height;
       if (containerHeight <= 0 || rowHeightPx <= 0) {
         return;
       }
@@ -89,7 +90,7 @@ export function useAdaptiveRowsPerPage({
     };
 
     const observer = new ResizeObserver(scheduleMeasure);
-    observer.observe(container);
+    observer.observe(containerNode);
     scheduleMeasure();
 
     return () => {
@@ -99,7 +100,7 @@ export function useAdaptiveRowsPerPage({
       }
     };
   }, [
-    containerRef,
+    containerNode,
     enabled,
     headerHeightPx,
     maxRows,


### PR DESCRIPTION
## Summary
- Fixes the PR-PILOT-1 activation bug where `useAdaptiveRowsPerPage` stayed permanently stuck on `TOKENS_PAGE_SIZE=4`: the measured DOM nodes were `null` during the hook's only effect run (they mount later, behind an async token fetch), and a plain `useRef`'s stable identity never re-triggered the effect once the real nodes appeared. Switched to callback-ref state (`useState<HTMLElement | null>`) so the `ResizeObserver` installs when the container/probe nodes actually mount.
- Activating the hook surfaced a second real bug: a single row-height probe (tuned for a single-line desktop table row, ~37-44px) underestimated the real mobile card height (~62px with long tutor/patient text), causing the hook to compute more rows than fit and clip content on narrow viewports (confirmed at 360×740: 372px of content in a 283px container). Replaced the synthetic probe with direct measurement of the first real desktop row and first real mobile card, taking whichever is actually visible (`display:none` collapses the inactive one to zero height, so no hardcoded breakpoint logic is needed).
- Two existing e2e specs (`dashboard-clinic-tokens-mobile-parity.spec.ts`, `dashboard-global-masked-master-detail.spec.ts`) had `toHaveCount(4)` hardcoded, which accidentally validated the frozen fallback value instead of real adaptive behavior. Updated both to wait for the row count to settle and assert a positive, dataset-bounded count instead of a literal.
- No production code beyond the two files above; no backend, API, auth, DB, Admin, Particular, CI, dependencies, lockfiles, or visual snapshots touched.

## Test plan
- [x] `pnpm test` — 2905/2905
- [x] `pnpm typecheck:test` — clean
- [x] `pnpm --dir frontend lint` — clean
- [x] `pnpm --dir frontend build` — production build succeeds
- [x] `playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` — 3/3 (re-run 3x, stable)
- [x] `playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts` — 8/8
- [x] `playwright test e2e/dashboard-global-masked-master-detail.spec.ts` — 16/16
- [x] `node --test test/frontend-dashboard-clinic-tokens.test.ts` — 13/13 (source-contract test needed no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)