### PR TITLE
test(dashboard): add global adaptive contract baseline

### DIFF
--- a/docs/implementation/global-adaptive-dashboard-contract-baseline.md
+++ b/docs/implementation/global-adaptive-dashboard-contract-baseline.md
@@ -1,0 +1,105 @@
+# PR-QA-GLOBAL-0: Global adaptive dashboard contract baseline
+
+## Estado base
+
+- Fecha: 2026-07-01.
+- Rama base: `main`.
+- HEAD base: `c7e3ed5 fix(clinic): activate adaptive token row measurement (#1213)`.
+- Rama de trabajo: `test/global-adaptive-dashboard-contract-baseline`.
+- Working tree inicial: limpio.
+- PRs abiertos al inicio: 0.
+- Ramas locales al inicio: solo `main`.
+- Ramas remotas no mergeadas contra `origin/main`: 0.
+
+## Scope incluido
+
+- Baseline e2e global en `frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts`.
+- Documento de entrega en `docs/implementation/global-adaptive-dashboard-contract-baseline.md`.
+- Validación observable de contrato global en superficies reales ya cubiertas por e2e:
+  - Clínica: hub, Informes, Tokens particulares, Logística y rutas full-page de Informes/Logística.
+  - Admin: hub, Resumen/Alertas, Mantenimiento y Usuarios/Roles.
+  - Particular: entrada pública token-gated de `/particulares` en estado no autenticado.
+
+## Scope excluido
+
+- No se migra ningún módulo.
+- No se toca producción TSX, hooks, CSS, backend, API, auth, DB, migraciones, CI, dependencias, lockfiles, snapshots ni tests unitarios.
+- No se adapta Admin servidor ni se modifica `limit/offset`.
+- No se trata Particular como dashboard paginado.
+- No se agregan fixtures de sesión particular autenticada sin contrato previo confirmado.
+
+## Auditoría previa
+
+- Se leyeron los documentos rectores:
+  - `docs/audit/global-zero-scroll-adaptive-dashboard-matrix.md`.
+  - `docs/audit/vetneb-enterprise-operational-platform-extreme-excellence-advisory.md`.
+  - `docs/implementation/clinic-tokens-adaptive-rows-per-page.md`.
+- Se confirmaron scripts nativos disponibles:
+  - `pnpm test`.
+  - `pnpm typecheck:test`.
+  - `pnpm --dir frontend lint`.
+  - `pnpm --dir frontend build`.
+- Se confirmaron los e2e dirigidos indicados:
+  - `frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts`.
+  - `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts`.
+  - `frontend/e2e/dashboard-internal-no-scroll-contract.spec.ts`.
+  - `frontend/e2e/dashboard-global-masked-master-detail.spec.ts`.
+- Se identificó cobertura Admin poblada existente, pero PR-QA-GLOBAL-0 se mantuvo en el spec global permitido para no ampliar scope.
+- Se identificó `/particulares` con selectores `data-particulares-*`; no se confirmó fixture e2e de sesión particular token-gated autenticada.
+
+## Cambios
+
+- `dashboard-viewport-zoom-adaptability.spec.ts` ahora mide, además del scroll global, el peor scroll vertical interno real dentro de `main.dashboard-main`.
+- El hub Clínica queda marcado como deuda observada para scroll interno medido: en la primera corrida estricta aparecieron `dashboard-inline-list` con 12px de overflow en tablet 768x1024 y 238px en mobile 390x844. PR-QA-GLOBAL-0 no lo transforma en gate porque no migra módulos.
+- Clínica Tokens agrega baseline específico:
+  - filas/cards visibles asentadas;
+  - pager/footer visible;
+  - body sin scroll vertical interno;
+  - filas/cards dentro de la región medida;
+  - gap controlado cuando hay más datos que filas visibles;
+  - comparación entre viewport alto y viewport efectivo compacto para verificar cardinalidad adaptativa observable.
+- Admin queda cubierto por las superficies existentes del spec global, reforzadas con detección de scroll vertical interno medido.
+- Particular agrega baseline público de entrada token-gated:
+  - panel primario visible en primer viewport;
+  - input de token visible;
+  - acción `Ingresar` visible;
+  - estado de próximos pasos visible;
+  - sin overflow horizontal;
+  - sin scroll vertical interno dentro del panel primario;
+  - pliegue controlado de primer viewport en 1280x720 efectivo, sin exigir sesión autenticada.
+
+## Archivos modificados
+
+- `frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts`.
+- `docs/implementation/global-adaptive-dashboard-contract-baseline.md`.
+
+## Validaciones
+
+Ejecutadas con PNPM 10.8.1 explícito (`C:\Program Files\nodejs\pnpm.CMD`) porque el PNPM 11 del runtime Codex ignora `pnpm.overrides` de `package.json` y falla contra el lockfile congelado.
+
+- `pnpm test` — pasó: 2905/2905.
+- `pnpm typecheck:test` — pasó.
+- `pnpm build` — pasó.
+- `pnpm security:public-surface` — pasó sin hallazgos públicos; reportó sólo marcadores server-only esperados en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint` — pasó.
+- `pnpm --dir frontend typecheck` — pasó.
+- `pnpm --dir frontend build` — pasó.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-viewport-zoom-adaptability.spec.ts` — pasó: 60/60.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` — pasó: 3/3.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts` — primer intento 7/8 por `net::ERR_NO_BUFFER_SPACE`; reintento pasó: 8/8.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts` — pasó: 16/16.
+
+## Resultado
+
+Baseline global agregado y validado. No se migraron módulos ni se cambió producción.
+
+## Riesgo residual
+
+- Particular autenticado queda `NO CONFIRMADO / requiere fixture`: este PR sólo valida la entrada pública token-gated en estado no autenticado.
+- Admin servidor queda como deuda observada: el spec valida fit/no-scroll/no-clipping medible, pero no cambia `PAGE_SIZE`, `MOBILE_PAGE_SIZE`, `matchMedia` ni `limit/offset`.
+- Hub Clínica en tablet/mobile conserva deuda de scroll interno medido en `dashboard-inline-list`; documentado como deuda para PR posterior, no corregido en este PR.
+- El baseline de Tokens depende de medición real de filas/cards en Chromium; la corrida dirigida pasó estable en este PR.
+
+## Estado final
+
+Pendiente de stage/commit/push/PR por Nico según protocolo local.

--- a/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
+++ b/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
@@ -19,6 +19,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 type Page = import("@playwright/test").Page;
+type Locator = import("@playwright/test").Locator;
 
 const TOLERANCE = 2;
 
@@ -56,6 +57,8 @@ type SurfaceCase = {
   ready: string;
   /** Whether the clinic Tokens API must be mocked for this surface. */
   mockTokens?: boolean;
+  /** Existing debt documented by the baseline; do not make PR-QA-GLOBAL-0 a migration gate. */
+  allowMeasuredInternalScroll?: boolean;
 };
 
 const CORE_SURFACES: SurfaceCase[] = [
@@ -64,6 +67,7 @@ const CORE_SURFACES: SurfaceCase[] = [
     surface: "clinic",
     path: "/dashboard",
     ready: "main.dashboard-main",
+    allowMeasuredInternalScroll: true,
   },
   {
     label: "clinic Informes (in-shell master-detail)",
@@ -130,7 +134,7 @@ const FULL_PAGE_DEEPLINKS: SurfaceCase[] = [
   },
 ];
 
-const MOCK_TOKENS = Array.from({ length: 6 }, (_, index) => {
+const MOCK_TOKENS = Array.from({ length: 10 }, (_, index) => {
   const id = index + 1;
   return {
     id,
@@ -176,6 +180,21 @@ async function mockClinicTokens(page: Page) {
   );
 }
 
+async function mockParticularLoggedOut(page: Page) {
+  await page.route(
+    (url) => url.pathname === "/api/particular/auth/me",
+    async (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          error: "Particular no autenticado",
+        }),
+      }),
+  );
+}
+
 async function applySession(page: Page, surface: Surface) {
   await page.context().addCookies([
     {
@@ -197,6 +216,40 @@ type ScrollContract = {
   hasMain: boolean;
   navVisible: boolean;
   topbarVisible: boolean;
+};
+
+type InternalScrollContract = {
+  selector: string | null;
+  overflowY: number;
+};
+
+type TokensRegionContract = {
+  bodyPresent: boolean;
+  bodyClientHeight: number;
+  bodyScrollHeight: number;
+  bodyOverflowY: string;
+  footerPresent: boolean;
+  footerTop: number;
+  visibleRowCount: number;
+  maxRowHeight: number;
+  lastRowBottom: number;
+  rowsInsideBody: boolean;
+};
+
+type PublicParticularContract = {
+  htmlScrollWidth: number;
+  htmlClientWidth: number;
+  bodyScrollWidth: number;
+  bodyClientWidth: number;
+  primaryPresent: boolean;
+  primaryTop: number;
+  primaryBottom: number;
+  primaryHeight: number;
+  viewportHeight: number;
+  primaryOverflowY: number;
+  tokenInputPresent: boolean;
+  submitPresent: boolean;
+  nextStepPresent: boolean;
 };
 
 async function readScrollContract(page: Page): Promise<ScrollContract> {
@@ -226,6 +279,239 @@ async function readScrollContract(page: Page): Promise<ScrollContract> {
       topbarVisible: isVisible(topbar),
     };
   });
+}
+
+async function readWorstInternalVerticalScroll(
+  page: Page,
+): Promise<InternalScrollContract> {
+  return page.evaluate(() => {
+    const main = document.querySelector("main.dashboard-main");
+    const worst = {
+      selector: null as string | null,
+      overflowY: 0,
+    };
+
+    const describeElement = (element: HTMLElement) => {
+      const className =
+        typeof element.className === "string"
+          ? element.className.split(/\s+/).filter(Boolean).slice(0, 3).join(".")
+          : "";
+      return `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ""}${
+        className ? `.${className}` : ""
+      }`;
+    };
+
+    main?.querySelectorAll<HTMLElement>("*").forEach((element) => {
+      const style = window.getComputedStyle(element);
+      if (style.overflowY !== "auto" && style.overflowY !== "scroll") {
+        return;
+      }
+
+      const overflowY = element.scrollHeight - element.clientHeight;
+      if (overflowY > worst.overflowY) {
+        worst.selector = describeElement(element);
+        worst.overflowY = overflowY;
+      }
+    });
+
+    return worst;
+  });
+}
+
+function assertNoMeasuredInternalVerticalScroll(
+  metrics: InternalScrollContract,
+  label: string,
+) {
+  expect(
+    metrics.overflowY,
+    `${label}: internal vertical scroll on ${metrics.selector ?? "none"}`,
+  ).toBeLessThanOrEqual(TOLERANCE);
+}
+
+async function readVisibleCount(page: Page, selector: string): Promise<number> {
+  return page.locator(selector).evaluateAll((elements) =>
+    elements.filter((element) => {
+      const rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }).length,
+  );
+}
+
+async function waitForSettledVisibleCount(
+  page: Page,
+  selector: string,
+  label: string,
+): Promise<number> {
+  let previousCount = -1;
+  let stableReads = 0;
+
+  await expect(async () => {
+    const currentCount = await readVisibleCount(page, selector);
+    if (currentCount === previousCount) {
+      stableReads += 1;
+    } else {
+      previousCount = currentCount;
+      stableReads = 0;
+    }
+
+    expect(
+      stableReads,
+      `${label}: visible count must settle (currently ${currentCount})`,
+    ).toBeGreaterThanOrEqual(3);
+  }).toPass({ timeout: 8_000, intervals: [50] });
+
+  return previousCount;
+}
+
+async function readTokensRegionContract(page: Page): Promise<TokensRegionContract> {
+  return page.evaluate(() => {
+    const tolerance = 2;
+    const body = document.querySelector<HTMLElement>(
+      '[data-clinic-access-list-body="true"]',
+    );
+    const footer = document.querySelector<HTMLElement>(
+      '[data-clinic-access-pagination-footer="true"]',
+    );
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        [
+          '[data-clinic-access-table-row="true"]',
+          '[data-clinic-access-mobile-row="true"]',
+        ].join(","),
+      ),
+    )
+      .map((row) => row.getBoundingClientRect())
+      .filter((rect) => rect.width > 0 && rect.height > 0);
+
+    const bodyRect = body?.getBoundingClientRect();
+    const footerRect = footer?.getBoundingClientRect();
+    const maxRowHeight = rows.reduce(
+      (maxHeight, rect) => Math.max(maxHeight, rect.height),
+      0,
+    );
+    const lastRow = rows.at(-1);
+
+    return {
+      bodyPresent: body !== null,
+      bodyClientHeight: body?.clientHeight ?? 0,
+      bodyScrollHeight: body?.scrollHeight ?? 0,
+      bodyOverflowY: body ? window.getComputedStyle(body).overflowY : "missing",
+      footerPresent: footer !== null && Boolean(footerRect?.width && footerRect.height),
+      footerTop: footerRect?.top ?? 0,
+      visibleRowCount: rows.length,
+      maxRowHeight,
+      lastRowBottom: lastRow?.bottom ?? 0,
+      rowsInsideBody:
+        Boolean(bodyRect) &&
+        rows.every(
+          (rect) =>
+            rect.top >= bodyRect!.top - tolerance &&
+            rect.bottom <= bodyRect!.bottom + tolerance,
+        ),
+    };
+  });
+}
+
+function assertTokensRegionContract(
+  metrics: TokensRegionContract,
+  label: string,
+) {
+  expect(metrics.bodyPresent, `${label}: tokens list body present`).toBe(true);
+  expect(metrics.footerPresent, `${label}: tokens pager/footer visible`).toBe(true);
+  expect(metrics.visibleRowCount, `${label}: visible token rows/cards`).toBeGreaterThan(0);
+  expect(
+    metrics.visibleRowCount,
+    `${label}: visible rows/cards bounded by fixture dataset`,
+  ).toBeLessThanOrEqual(MOCK_TOKENS.length);
+  expect(
+    metrics.bodyScrollHeight,
+    `${label}: tokens body must not clip hidden overflow`,
+  ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+  expect(
+    ["auto", "scroll"],
+    `${label}: tokens body must not expose vertical scroll`,
+  ).not.toContain(metrics.bodyOverflowY);
+  expect(metrics.rowsInsideBody, `${label}: token rows/cards inside body`).toBe(true);
+
+  if (metrics.visibleRowCount < MOCK_TOKENS.length) {
+    const gap = metrics.footerTop - metrics.lastRowBottom;
+    expect(gap, `${label}: list-to-footer gap must not overlap`).toBeGreaterThanOrEqual(
+      -TOLERANCE,
+    );
+    expect(gap, `${label}: list-to-footer gap controlled`).toBeLessThanOrEqual(
+      Math.max(metrics.maxRowHeight + 24, 72),
+    );
+  }
+}
+
+async function expectInsideViewport(locator: Locator, label: string) {
+  await expect(locator, `${label}: visible`).toBeVisible();
+  await expect(locator, `${label}: inside viewport`).toBeInViewport();
+}
+
+async function readPublicParticularContract(
+  page: Page,
+): Promise<PublicParticularContract> {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const primary = document.querySelector<HTMLElement>(
+      '[data-particulares-primary-action="true"]',
+    );
+    const tokenInput = document.querySelector<HTMLElement>("#particular-token");
+    const submit = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim() === "Ingresar",
+    );
+    const nextStep = document.querySelector<HTMLElement>(
+      '[data-particulares-next-step-zone="true"]',
+    );
+    const primaryRect = primary?.getBoundingClientRect();
+
+    return {
+      htmlScrollWidth: html.scrollWidth,
+      htmlClientWidth: html.clientWidth,
+      bodyScrollWidth: body.scrollWidth,
+      bodyClientWidth: body.clientWidth,
+      primaryPresent: primary !== null,
+      primaryTop: primaryRect?.top ?? 0,
+      primaryBottom: primaryRect?.bottom ?? 0,
+      primaryHeight: primaryRect?.height ?? 0,
+      viewportHeight: window.innerHeight,
+      primaryOverflowY: primary ? primary.scrollHeight - primary.clientHeight : 0,
+      tokenInputPresent: tokenInput !== null && tokenInput.getBoundingClientRect().height > 0,
+      submitPresent: submit !== undefined && submit.getBoundingClientRect().height > 0,
+      nextStepPresent: nextStep !== null && nextStep.getBoundingClientRect().height > 0,
+    };
+  });
+}
+
+function assertPublicParticularContract(
+  metrics: PublicParticularContract,
+  label: string,
+) {
+  expect(
+    metrics.htmlScrollWidth,
+    `${label}: documentElement horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.htmlClientWidth + TOLERANCE);
+  expect(
+    metrics.bodyScrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(metrics.bodyClientWidth + TOLERANCE);
+  expect(metrics.primaryPresent, `${label}: token gate panel present`).toBe(true);
+  expect(metrics.tokenInputPresent, `${label}: token input present`).toBe(true);
+  expect(metrics.submitPresent, `${label}: submit action present`).toBe(true);
+  expect(metrics.nextStepPresent, `${label}: next step state present`).toBe(true);
+  expect(
+    metrics.primaryOverflowY,
+    `${label}: token gate panel internal vertical overflow`,
+  ).toBeLessThanOrEqual(TOLERANCE);
+  expect(metrics.primaryTop, `${label}: token gate top inside viewport`).toBeGreaterThanOrEqual(
+    -TOLERANCE,
+  );
+  expect(
+    metrics.primaryBottom,
+    `${label}: token gate bottom stays within controlled first-viewport fold`,
+  ).toBeLessThanOrEqual(metrics.viewportHeight + 48);
 }
 
 function assertAdaptiveNoScroll(
@@ -288,6 +574,13 @@ for (const viewport of ALL_VIEWPORTS) {
             `${viewport.name} ${surface.label}`,
             viewport.width,
           );
+          if (!surface.allowMeasuredInternalScroll) {
+            const internalScroll = await readWorstInternalVerticalScroll(page);
+            assertNoMeasuredInternalVerticalScroll(
+              internalScroll,
+              `${viewport.name} ${surface.label}`,
+            );
+          }
         }).toPass({ timeout: 10_000 });
       });
     }
@@ -307,6 +600,11 @@ for (const viewport of DEMANDING_VIEWPORTS) {
             metrics,
             `${viewport.name} ${surface.label}`,
             viewport.width,
+          );
+          const internalScroll = await readWorstInternalVerticalScroll(page);
+          assertNoMeasuredInternalVerticalScroll(
+            internalScroll,
+            `${viewport.name} ${surface.label}`,
           );
         }).toPass({ timeout: 10_000 });
       });
@@ -328,9 +626,81 @@ for (const viewport of DESKTOP_ZOOM_VIEWPORTS) {
             `${viewport.name} ${surface.label}`,
             viewport.width,
           );
+          const internalScroll = await readWorstInternalVerticalScroll(page);
+          assertNoMeasuredInternalVerticalScroll(
+            internalScroll,
+            `${viewport.name} ${surface.label}`,
+          );
         }).toPass({ timeout: 10_000 });
       });
     }
+  });
+}
+
+test("clinic Tokens adaptive rows baseline changes density without internal scroll", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await gotoSurface(page, {
+    label: "clinic Tokens particulares",
+    surface: "clinic",
+    path: "/dashboard?module=tokens",
+    ready: '[data-dashboard-module-workspace="tokens"]',
+    mockTokens: true,
+  });
+
+  const rowSelector = [
+    '[data-clinic-access-table-row="true"]',
+    '[data-clinic-access-mobile-row="true"]',
+  ].join(",");
+  const tallCount = await waitForSettledVisibleCount(
+    page,
+    rowSelector,
+    "clinic Tokens tall viewport",
+  );
+  await expect(async () => {
+    const metrics = await readTokensRegionContract(page);
+    assertTokensRegionContract(metrics, "clinic Tokens tall viewport");
+  }).toPass({ timeout: 10_000 });
+
+  await page.setViewportSize({ width: 1280, height: 700 });
+  const compactCount = await waitForSettledVisibleCount(
+    page,
+    rowSelector,
+    "clinic Tokens compact effective viewport",
+  );
+  await expect(async () => {
+    const metrics = await readTokensRegionContract(page);
+    assertTokensRegionContract(metrics, "clinic Tokens compact effective viewport");
+  }).toPass({ timeout: 10_000 });
+
+  expect(
+    compactCount,
+    `compact viewport (${compactCount}) must render fewer token rows/cards than tall viewport (${tallCount})`,
+  ).toBeLessThan(tallCount);
+});
+
+for (const viewport of DEMANDING_VIEWPORTS) {
+  test(`particular token gate baseline fits primary viewport at ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockParticularLoggedOut(page);
+    await page.goto("/particulares");
+
+    await expectInsideViewport(
+      page.locator('[data-particulares-primary-action="true"]'),
+      `${viewport.name}: particular token gate panel`,
+    );
+    await expectInsideViewport(
+      page.locator("#particular-token"),
+      `${viewport.name}: particular token input`,
+    );
+
+    await expect(async () => {
+      const metrics = await readPublicParticularContract(page);
+      assertPublicParticularContract(metrics, `${viewport.name}: particulares`);
+    }).toPass({ timeout: 10_000 });
   });
 }
 


### PR DESCRIPTION
Adds a global e2e baseline for the Zero-Scroll Adaptive Dashboard contract across Admin, Clinic, and Particular where fixtures are available. Documents uncovered surfaces and known debt, including Particular authenticated coverage requiring a fixture and measured Clinic hub scroll debt. No production code, backend, API, auth, DB, CI, dependencies, lockfiles, or snapshots changed.