### PR TITLE
refactor(dashboard): introduce adaptive items per page foundation

### DIFF
--- a/docs/implementation/adaptive-items-per-page-foundation.md
+++ b/docs/implementation/adaptive-items-per-page-foundation.md
@@ -1,0 +1,161 @@
+# PR-CORE-1 — Adaptive items per page foundation
+
+## Estado base
+
+- Fecha: 2026-07-01.
+- Rama base esperada: `main`.
+- HEAD base esperado y confirmado: `865e784 test(dashboard): add global adaptive contract baseline (#1214)`.
+- Rama de trabajo: `refactor/adaptive-items-per-page-foundation`.
+- Working tree inicial: limpio.
+- PRs abiertos al inicio: 0.
+- Ramas locales al inicio: solo `main`.
+- Ramas remotas no mergeadas contra `origin/main`: 0.
+
+## Scope incluido
+
+- Hook global reusable `useAdaptiveItemsPerPage`.
+- `useAdaptiveRowsPerPage` conservado como wrapper semántico compatible.
+- Source-contract de Clínica Tokens actualizado para cubrir la fundación global.
+- Documentación de implementación de PR-CORE-1.
+- Actualización del documento previo de Clínica Tokens.
+
+## Scope excluido
+
+- No se migran nuevos módulos.
+- No se toca Admin productivo.
+- No se toca Particular productivo.
+- No se toca backend, API, auth, DB, migraciones, cookies, CORS, CSP, rate limits, CI, workflows, dependencias, lockfiles ni snapshots.
+- No se cambia CSS, UI, fetch, paginación visible ni copy funcional de Clínica Tokens.
+
+## Auditoría previa
+
+Documentos obligatorios leídos:
+
+- `docs/implementation/global-adaptive-dashboard-contract-baseline.md`.
+- `docs/audit/global-zero-scroll-adaptive-dashboard-matrix.md`.
+- `docs/implementation/clinic-tokens-adaptive-rows-per-page.md`.
+- `docs/audit/vetneb-enterprise-operational-platform-extreme-excellence-advisory.md`.
+
+Documentos relacionados leídos:
+
+- `docs/implementation/dashboard-internal-no-scroll-contract.md`.
+- `docs/implementation/dashboard-global-masked-master-detail.md`.
+- `docs/implementation/dashboard-global-viewport-zoom-adaptability.md`.
+- `docs/audit/dashboard-masked-master-detail-no-scroll-audit.md`.
+- `docs/implementation/admin-enterprise-density-closeout.md`.
+- `docs/implementation/clinic-enterprise-density-closeout.md`.
+- `docs/audit/admin-enterprise-density-completion-audit.md`.
+- `docs/audit/pr-vis-10-visual-regression-matrix.md`.
+
+`docs/architecture` no existe en la base auditada.
+
+## Por qué se crea `useAdaptiveItemsPerPage`
+
+La matriz global zero-scroll define que la cardinalidad de filas/cards debe derivarse del contenedor real y no de constantes fijas, `matchMedia` o `window`. Clínica Tokens ya tenía un hook funcional pero semánticamente nombrado como filas. PR-CORE-1 extrae esa lógica a una fundación neutral para tablas, listas y cards, sin acoplarla a Tokens, Admin ni Particular.
+
+## Problemas globales que resuelve
+
+- Evita que cada módulo vuelva a implementar medición con `ResizeObserver`.
+- Mantiene las constantes actuales como fallback inicial, no como verdad de cardinalidad.
+- Permite medir el contenedor real con instalación tardía cuando el nodo aparece después de una carga async.
+- Protege contra mediciones inválidas (`0`, negativos, `NaN`, `Infinity`) conservando el último valor válido.
+- Mantiene `requestAnimationFrame` para desacoplar el cálculo del callback de resize.
+- No escribe estilos, no introduce scroll y no usa `matchMedia` para cardinalidad.
+
+## Relación con auditorías rectoras
+
+- `global-adaptive-dashboard-contract-baseline.md`: PR-CORE-1 sigue la baseline vigente y no migra módulos; prepara una fundación reusable para próximos PRs.
+- `global-zero-scroll-adaptive-dashboard-matrix.md`: implementa la pieza técnica `useAdaptiveItemsPerPage` descrita en el contrato global y deja `pageSize` fijo como fallback.
+- `clinic-tokens-adaptive-rows-per-page.md`: conserva el comportamiento observable del piloto; `useAdaptiveRowsPerPage` pasa a delegar en la fundación global.
+- `vetneb-enterprise-operational-platform-extreme-excellence-advisory.md`: cumple la Wave 1 de adaptive foundation sin adelantar registries, acciones enterprise ni Admin servidor.
+
+## Contrato técnico
+
+`useAdaptiveItemsPerPage` recibe:
+
+- `containerNode`: nodo real medido.
+- `fallbackItems`: cardinalidad inicial/fallback.
+- `itemHeightPx`: altura real o estimada del ítem.
+- `headerHeightPx`: descuento opcional.
+- `safetyGapPx`: margen de seguridad opcional.
+- `minItems` / `maxItems`: límites.
+- `enabled`: activación opcional.
+
+Retorna:
+
+- `itemsPerPage`.
+
+El hook:
+
+- observa `containerNode` con `ResizeObserver`;
+- agenda medición con `requestAnimationFrame`;
+- se instala cuando `containerNode` pasa de `null` a nodo real;
+- conserva el último valor válido ante mediciones inválidas;
+- sanitiza fallback, límites, alturas y descuentos;
+- no depende de `window`, `matchMedia`, breakpoints ni estilos escritos desde JS.
+
+## Wrapper semántico
+
+`useAdaptiveRowsPerPage` queda como wrapper fino para preservar el contrato público de módulos que hablan de filas:
+
+- mantiene `fallbackRows`, `rowHeightPx`, `minRows`, `maxRows` y `rowsPerPage`;
+- delega en `useAdaptiveItemsPerPage`;
+- preserva `minRows` default efectivo en `2`, como el piloto previo.
+
+## Límites de este PR
+
+- Clínica Tokens sigue usando `useAdaptiveRowsPerPage`.
+- `TOKENS_PAGE_SIZE` sigue siendo fallback.
+- `usePagedRows(filteredTokens, rowsPerPage)` se preserva.
+- No se toca la medición real de filas/cards en `ClinicParticularTokensCard`.
+- No se agregan primitivas visuales ni cambios CSS.
+
+## Riesgos residuales
+
+- La fundación no migra por sí sola los módulos Admin/Clínica/Particular pendientes.
+- Admin servidor sigue bloqueado hasta PR-SRV-0 por estrategia `limit/offset`.
+- Los próximos consumidores deberán elegir correctamente el contenedor real a medir.
+- Los e2e de resize y visual regression siguen siendo necesarios para cada módulo migrado.
+
+## Próximos PRs derivados
+
+- PR-CORE-2: primitiva `AdaptivePaginatedRegion` / `AdaptiveModuleSurface`, si el segundo consumidor lo justifica.
+- PR-CLIENT-1: segundo módulo cliente Clínica, respetando master-detail.
+- PR-SRV-0: estrategia servidor antes de cualquier Admin `limit/offset`.
+- PR-CLEAN-1: eliminar `PAGE_SIZE`, `MOBILE_PAGE_SIZE` y `matchMedia` como fuente de cardinalidad después de migraciones controladas.
+
+## Archivos modificados
+
+- `frontend/src/hooks/useAdaptiveItemsPerPage.ts`.
+- `frontend/src/hooks/useAdaptiveRowsPerPage.ts`.
+- `test/frontend-dashboard-clinic-tokens.test.ts`.
+- `docs/implementation/adaptive-items-per-page-foundation.md`.
+- `docs/implementation/clinic-tokens-adaptive-rows-per-page.md`.
+
+## Validaciones
+
+Ejecutadas con PNPM 10.8.1 explícito (`C:\Program Files\nodejs\pnpm.CMD`) porque el PNPM del PATH reportó `11.7.0` y el repo declara `packageManager: pnpm@10.8.1`.
+
+- `node --test test/frontend-dashboard-clinic-tokens.test.ts` — pasó: 14/14.
+- `pnpm test` — pasó: 2906/2906.
+- `pnpm typecheck:test` — pasó.
+- `pnpm build` — pasó.
+- `pnpm security:public-surface` — pasó; reportó sólo marcadores server-only esperados en `frontend/src/proxy.ts`.
+- `pnpm --dir frontend lint` — pasó.
+- `pnpm --dir frontend typecheck` — pasó.
+- `pnpm --dir frontend build` — pasó.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-viewport-zoom-adaptability.spec.ts` — primer intento no ejecutó asserts porque el `webServer` de Playwright resolvió PNPM 11 del PATH; reintento con `C:\Program Files\nodejs` prepended al PATH pasó: 60/60.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` — pasó: 3/3.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts` — pasó: 8/8.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-global-masked-master-detail.spec.ts` — pasó: 16/16.
+- `git diff --check` — pasó, sin salida.
+
+`frontend/next-env.d.ts` fue regenerado por Next/Playwright durante las validaciones y se restauró antes del diff review porque está fuera de scope.
+
+## Resultado
+
+PR-CORE-1 crea la fundación global de cardinalidad adaptativa y mantiene Clínica Tokens como consumidor semántico por filas, sin cambios observables esperados.
+
+## Estado final
+
+Pendiente de stage/commit/push/PR por Nico. No se avanzó al PR siguiente.

--- a/docs/implementation/clinic-tokens-adaptive-rows-per-page.md
+++ b/docs/implementation/clinic-tokens-adaptive-rows-per-page.md
@@ -293,3 +293,26 @@ Revertir el/los commits de PR-FIX-1 restaura el estado de PR-PILOT-1: hook
 inactivo (`rowsPerPage` clavado en `TOKENS_PAGE_SIZE = 4`), sin efectos en
 backend, datos ni otros módulos. No requiere rollback de datos ni de
 configuración.
+
+## PR-CORE-1 — Adaptive items foundation
+
+`useAdaptiveRowsPerPage` pasa a apoyarse en la fundación global
+`useAdaptiveItemsPerPage`. El wrapper conserva el lenguaje semántico de filas
+para Clínica Tokens y mantiene los nombres públicos del contrato previo:
+`fallbackRows`, `rowHeightPx`, `headerHeightPx`, `minRows`, `maxRows` y
+`rowsPerPage`.
+
+El comportamiento observable de Clínica Tokens no cambia:
+
+- `ClinicParticularTokensCard` sigue importando y usando
+  `useAdaptiveRowsPerPage`.
+- `TOKENS_PAGE_SIZE` se preserva como `fallbackRows`.
+- `usePagedRows(filteredTokens, rowsPerPage)` se preserva.
+- Los fixes de activación por `containerNode` y medición mobile por fila/card
+  real se preservan.
+- No se migra ningún módulo adicional.
+
+PR-CORE-1 no toca UI, CSS, fetch, paginación visible, backend, auth, DB,
+dependencias, CI ni snapshots. Su único objetivo es extraer la lógica genérica
+para que próximos PRs puedan migrar otras familias del contrato adaptive sin
+copiar la implementación del piloto.

--- a/frontend/src/hooks/useAdaptiveItemsPerPage.ts
+++ b/frontend/src/hooks/useAdaptiveItemsPerPage.ts
@@ -1,0 +1,145 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+
+export type AdaptiveItemsPerPageOptions = {
+  containerNode: HTMLElement | null;
+  fallbackItems: number;
+  itemHeightPx: number;
+  headerHeightPx?: number;
+  safetyGapPx?: number;
+  minItems?: number;
+  maxItems?: number;
+  enabled?: boolean;
+};
+
+export type AdaptiveItemsPerPageResult = {
+  itemsPerPage: number;
+};
+
+function toPositiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
+function toNonNegativeFinite(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return value;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function resolveBounds(minItems: number | undefined, maxItems: number | undefined) {
+  const min = toPositiveInteger(minItems, 1);
+  const max = Math.max(min, toPositiveInteger(maxItems, 50));
+
+  return { min, max };
+}
+
+function resolveFallbackItems(
+  fallbackItems: number,
+  minItems: number,
+  maxItems: number,
+): number {
+  const fallback = toPositiveInteger(fallbackItems, minItems);
+
+  return clamp(fallback, minItems, maxItems);
+}
+
+/**
+ * Derives how many items fit in a real measured container. The fixed
+ * per-module page size remains only the initial fallback; ResizeObserver plus
+ * requestAnimationFrame provide the container-aware value after mount.
+ */
+export function useAdaptiveItemsPerPage({
+  containerNode,
+  fallbackItems,
+  itemHeightPx,
+  headerHeightPx = 0,
+  safetyGapPx = 6,
+  minItems,
+  maxItems,
+  enabled = true,
+}: AdaptiveItemsPerPageOptions): AdaptiveItemsPerPageResult {
+  const { min, max } = resolveBounds(minItems, maxItems);
+  const initialItems = resolveFallbackItems(fallbackItems, min, max);
+  const [itemsPerPage, setItemsPerPage] = useState(initialItems);
+  const itemsPerPageRef = useRef(initialItems);
+
+  useLayoutEffect(() => {
+    if (!enabled || !containerNode) {
+      return;
+    }
+
+    const rowHeight = toNonNegativeFinite(itemHeightPx, 0);
+    if (rowHeight <= 0) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const measure = () => {
+      frame = null;
+
+      const containerHeight = containerNode.getBoundingClientRect().height;
+      if (!Number.isFinite(containerHeight) || containerHeight <= 0) {
+        return;
+      }
+
+      const availableItemsHeight =
+        containerHeight -
+        toNonNegativeFinite(headerHeightPx, 0) -
+        toNonNegativeFinite(safetyGapPx, 0);
+      if (!Number.isFinite(availableItemsHeight) || availableItemsHeight <= 0) {
+        return;
+      }
+
+      const nextItems = clamp(Math.floor(availableItemsHeight / rowHeight), min, max);
+      if (!Number.isFinite(nextItems) || nextItems <= 0) {
+        return;
+      }
+
+      if (nextItems !== itemsPerPageRef.current) {
+        itemsPerPageRef.current = nextItems;
+        setItemsPerPage(nextItems);
+      }
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) {
+        return;
+      }
+
+      frame = requestAnimationFrame(measure);
+    };
+
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(containerNode);
+    scheduleMeasure();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [
+    containerNode,
+    enabled,
+    headerHeightPx,
+    itemHeightPx,
+    max,
+    min,
+    safetyGapPx,
+  ]);
+
+  return { itemsPerPage };
+}

--- a/frontend/src/hooks/useAdaptiveRowsPerPage.ts
+++ b/frontend/src/hooks/useAdaptiveRowsPerPage.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState } from "react";
+import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";
 
-export type UseAdaptiveRowsPerPageOptions = {
+export type AdaptiveRowsPerPageOptions = {
   containerNode: HTMLElement | null;
   fallbackRows: number;
   rowHeightPx: number;
@@ -13,101 +13,27 @@ export type UseAdaptiveRowsPerPageOptions = {
   enabled?: boolean;
 };
 
-export type UseAdaptiveRowsPerPageResult = {
+export type UseAdaptiveRowsPerPageOptions = AdaptiveRowsPerPageOptions;
+
+export type AdaptiveRowsPerPageResult = {
   rowsPerPage: number;
-  isMeasured: boolean;
 };
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
+export type UseAdaptiveRowsPerPageResult = AdaptiveRowsPerPageResult;
 
-/**
- * Derives how many rows fit a measured container instead of a fixed page
- * size. Falls back to `fallbackRows` until a valid measurement is available,
- * and keeps the last valid value whenever the container can't be measured.
- *
- * `containerNode` must be the actual DOM node (e.g. via a `useState` callback
- * ref), not a `useRef` object: the node commonly mounts on a later render
- * than the hook's first commit (it sits behind a conditional/async-loaded
- * branch), and a plain ref's identity never changes, so an effect keyed off
- * the ref object would never re-run once the node appears.
- */
-export function useAdaptiveRowsPerPage({
-  containerNode,
-  fallbackRows,
-  rowHeightPx,
-  headerHeightPx = 0,
-  safetyGapPx = 6,
-  minRows = 2,
-  maxRows = 50,
-  enabled = true,
-}: UseAdaptiveRowsPerPageOptions): UseAdaptiveRowsPerPageResult {
-  const [rowsPerPage, setRowsPerPage] = useState(fallbackRows);
-  const [isMeasured, setIsMeasured] = useState(false);
-  const rowsPerPageRef = useRef(fallbackRows);
+export function useAdaptiveRowsPerPage(
+  options: AdaptiveRowsPerPageOptions,
+): AdaptiveRowsPerPageResult {
+  const { itemsPerPage } = useAdaptiveItemsPerPage({
+    containerNode: options.containerNode,
+    fallbackItems: options.fallbackRows,
+    itemHeightPx: options.rowHeightPx,
+    headerHeightPx: options.headerHeightPx,
+    safetyGapPx: options.safetyGapPx,
+    minItems: options.minRows ?? 2,
+    maxItems: options.maxRows,
+    enabled: options.enabled,
+  });
 
-  useLayoutEffect(() => {
-    if (!enabled || !containerNode) {
-      return;
-    }
-
-    let frame: number | null = null;
-
-    const measure = () => {
-      frame = null;
-
-      const containerHeight = containerNode.getBoundingClientRect().height;
-      if (containerHeight <= 0 || rowHeightPx <= 0) {
-        return;
-      }
-
-      const availableRowsHeight =
-        containerHeight - headerHeightPx - safetyGapPx;
-      const nextRows = clamp(
-        Math.floor(availableRowsHeight / rowHeightPx),
-        minRows,
-        maxRows,
-      );
-
-      if (!Number.isFinite(nextRows) || nextRows <= 0) {
-        return;
-      }
-
-      setIsMeasured(true);
-
-      if (nextRows !== rowsPerPageRef.current) {
-        rowsPerPageRef.current = nextRows;
-        setRowsPerPage(nextRows);
-      }
-    };
-
-    const scheduleMeasure = () => {
-      if (frame !== null) {
-        return;
-      }
-      frame = requestAnimationFrame(measure);
-    };
-
-    const observer = new ResizeObserver(scheduleMeasure);
-    observer.observe(containerNode);
-    scheduleMeasure();
-
-    return () => {
-      observer.disconnect();
-      if (frame !== null) {
-        cancelAnimationFrame(frame);
-      }
-    };
-  }, [
-    containerNode,
-    enabled,
-    headerHeightPx,
-    maxRows,
-    minRows,
-    rowHeightPx,
-    safetyGapPx,
-  ]);
-
-  return { rowsPerPage, isMeasured };
+  return { rowsPerPage: itemsPerPage };
 }

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -10,6 +10,10 @@ const CLINIC_DASHBOARD_SIDEBAR_PATH =
   "frontend/src/components/dashboard/ClinicDashboardSidebar.tsx";
 const CLINIC_TOKENS_CARD_PATH =
   "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
+const ADAPTIVE_ITEMS_HOOK_PATH =
+  "frontend/src/hooks/useAdaptiveItemsPerPage.ts";
+const ADAPTIVE_ROWS_HOOK_PATH =
+  "frontend/src/hooks/useAdaptiveRowsPerPage.ts";
 const API_PATH = "frontend/src/lib/api.ts";
 
 function read(relativePath: string): string {
@@ -86,6 +90,7 @@ test("clinic tokens uses table/list row actions with dialog detail and step dial
   assert.ok(source.includes("fallbackRows: TOKENS_PAGE_SIZE"));
   assert.equal(source.includes("usePagedRows(filteredTokens, TOKENS_PAGE_SIZE)"), false);
   assert.ok(source.includes("usePagedRows(filteredTokens, rowsPerPage)"));
+  assert.equal(source.includes("useAdaptiveItemsPerPage"), false);
   assert.ok(source.includes("selectedTokenId"));
   assert.ok(source.includes("ModuleSurface"));
   assert.ok(source.includes('data-clinic-access-table="true"'));
@@ -122,6 +127,43 @@ test("clinic tokens uses table/list row actions with dialog detail and step dial
   assert.ok(source.includes('title="Generar token particular"'));
   assert.ok(source.includes('title="Token generado"'));
   assert.equal(source.includes("overflow-y-auto"), false);
+});
+
+test("adaptive rows wrapper delegates to adaptive items foundation", () => {
+  assert.equal(
+    existsSync(resolve(process.cwd(), ADAPTIVE_ITEMS_HOOK_PATH)),
+    true,
+    "adaptive items hook must exist",
+  );
+  assert.equal(
+    existsSync(resolve(process.cwd(), ADAPTIVE_ROWS_HOOK_PATH)),
+    true,
+    "adaptive rows wrapper must exist",
+  );
+
+  const itemsHook = read(ADAPTIVE_ITEMS_HOOK_PATH);
+  const rowsHook = read(ADAPTIVE_ROWS_HOOK_PATH);
+
+  assert.ok(itemsHook.includes("export function useAdaptiveItemsPerPage"));
+  assert.ok(itemsHook.includes("containerNode: HTMLElement | null"));
+  assert.ok(itemsHook.includes("fallbackItems: number"));
+  assert.ok(itemsHook.includes("itemHeightPx: number"));
+  assert.ok(itemsHook.includes("ResizeObserver"));
+  assert.ok(itemsHook.includes("requestAnimationFrame"));
+  assert.equal(itemsHook.includes("matchMedia"), false);
+  assert.equal(itemsHook.includes("overflow-y-auto"), false);
+
+  assert.ok(rowsHook.includes('import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";'));
+  assert.ok(rowsHook.includes("type AdaptiveRowsPerPageOptions"));
+  assert.ok(rowsHook.includes("fallbackRows: number"));
+  assert.ok(rowsHook.includes("rowHeightPx: number"));
+  assert.ok(rowsHook.includes("const { itemsPerPage } = useAdaptiveItemsPerPage({"));
+  assert.ok(rowsHook.includes("fallbackItems: options.fallbackRows"));
+  assert.ok(rowsHook.includes("itemHeightPx: options.rowHeightPx"));
+  assert.ok(rowsHook.includes("minItems: options.minRows ?? 2"));
+  assert.ok(rowsHook.includes("return { rowsPerPage: itemsPerPage };"));
+  assert.equal(rowsHook.includes("matchMedia"), false);
+  assert.equal(rowsHook.includes("overflow-y-auto"), false);
 });
 
 test("clinic tokens exposes advanced filters over visible token fields", () => {


### PR DESCRIPTION
Introduces the reusable useAdaptiveItemsPerPage foundation from the global adaptive dashboard audits while preserving useAdaptiveRowsPerPage as the semantic rows wrapper for Clinic Tokens. No Admin, Particular, backend, API, auth, DB, CI, dependencies, lockfiles, snapshots, CSS, UI, or additional module migrations changed.