### PR TITLE
feat(clinic): redesign logistics master-detail workspace

### DIFF
--- a/docs/implementation/clinic-logistics-master-detail-workspace.md
+++ b/docs/implementation/clinic-logistics-master-detail-workspace.md
@@ -1,0 +1,93 @@
+# PR-LOGISTICA-REDESIGN-1 — Rediseño master-detail de Logística clínica
+
+## PR
+
+`feat(clinic): redesign logistics master-detail workspace`
+
+Rama: `feat/clinic-logistics-master-detail-redesign`
+
+## Base
+
+`main @ 83b2ac0` — `docs(dashboard): document blocked master-detail scope (#1218)`
+
+## Scope
+
+Rediseñar únicamente la superficie `ClinicLogisticaWorkspaceSummary` del dashboard clínico para
+eliminar la dependencia de `.dashboard-inline-scroll` y del detalle inline expandido, sin clipping
+en mobile, sin scroll global y sin tocar CSS global.
+
+Fuera de scope (no tocado): `MasterDetailWorkspace.tsx`, rutas full-page de informes/logística,
+backend, API, auth, DB, CI, deps, lockfiles, snapshots, `globals.css`.
+
+## Skills elegidas
+
+- **Principal:** `vetneb-production-web-optimization-engineer`.
+- **Complementarias:** `vetneb-briefing-planificacion-diseno-desarrollo-pruebas`,
+  `vetneb-web-end-to-end-global`, `vetneb-staff-senior-full-stack-engineer`.
+- **Guardrail:** `vetneb-security-production-invariants`.
+- **Modelo:** Claude Opus 4.8 (`claude-opus-4-8`), esfuerzo alto.
+
+## Archivos modificados
+
+1. `frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx`
+2. `frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts`
+3. `docs/implementation/clinic-logistics-master-detail-workspace.md`
+4. `test/frontend-dashboard-home.test.ts` — sólo el test de contrato de Logística
+   (líneas 233-248), alineado al nuevo contrato `ModuleDialog` con autorización explícita
+   (precedente #958). No se tocó ningún otro test del archivo.
+
+## Cambio de contrato visual
+
+Antes:
+
+- Lista con inner-scroll (`.dashboard-inline-scroll`).
+- Detalle renderizado inline debajo de la fila seleccionada
+  (`.dashboard-inline-detail` / `[data-detail-state="selected"]`).
+- `selectedVisitId` inicial apuntaba a la primera visita, abriendo detalle al render.
+
+Ahora:
+
+- Lista compacta fija dentro de `[data-clinic-logistics-list-panel="true"]` /
+  `[data-clinic-logistics-list-body="true"]`, sin inner-scroll y sin clipping.
+- Cada fila es un botón `[data-clinic-logistics-row="true"]`, operable por teclado, con
+  `aria-haspopup="dialog"` y `aria-label` claro.
+- Detalle movido a `ModuleDialog` controlado (`[data-clinic-logistics-detail-dialog="true"]`),
+  renderizado vía portal (no debajo de la fila).
+- `selectedVisitId` inicial `null`: no abre detalle en el render inicial.
+- El detalle muestra: clínica, estado, fecha programada, fecha completada (si existe), dirección
+  y la acción “Abrir visitas en módulo completo”.
+- Cierre del dialog limpia `selectedVisitId`.
+
+Se conserva: `ModuleSurface`, toolbar, CTA “Abrir módulo completo”, error state con
+`DashboardRefreshButton`, empty state y `recentVisits` como fuente única (sin cambios de API ni
+payload).
+
+## Por qué se eligió `ModuleDialog`
+
+Alinea la superficie de Logística con el patrón ya validado en `ClinicInformesWorkspaceSummary`:
+lista compacta fija + detalle en dialog centrado y capado al viewport. Esto elimina el inner-scroll
+y el detalle inline sin reintroducir scroll global ni clipping en mobile, y sin necesidad de
+`MasterDetailWorkspace` (que no tiene consumidor runtime real). El dialog aporta título/descripción
+accesibles y cierre estándar por overlay/escape.
+
+## Validaciones ejecutadas
+
+- `pnpm test` — 2907 pass / 0 fail.
+- `pnpm -C frontend typecheck` — OK.
+- `pnpm -C frontend lint` — OK.
+- `pnpm -C frontend e2e -- e2e/dashboard-clinic-logistica-mobile-parity.spec.ts` — 3 pass
+  (360x740, 390x844, 430x932).
+- `pnpm -C frontend e2e:public-clinic` — 116 pass.
+- `pnpm -C frontend build` — OK.
+
+Nota: `pnpm test` fallaba inicialmente por `frontend/next-env.d.ts` regenerado a path de dev por
+una corrida previa de e2e; se restauró con `git checkout -- frontend/next-env.d.ts` antes de
+validar. El build de producción vuelve a dejar el path de producción.
+
+## Confirmaciones de invariantes
+
+- No se tocó backend, API, auth, DB, CI, deps, lockfiles ni snapshots.
+- No se tocó `globals.css` ni `MasterDetailWorkspace.tsx`.
+- No se tocaron rutas full-page de informes/logística.
+- El ZIP/carpeta de skills no fue copiado, descomprimido, editado ni agregado al repo; sólo se
+  observaron nombres y descripciones para elegir el modo de trabajo.

--- a/frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts
@@ -22,8 +22,12 @@ type LayoutContract = {
   mainScrollHeight: number;
   mainClientHeight: number;
   listClientHeight: number;
+  listScrollHeight: number;
+  listOverflowY: string;
+  moduleScrollContainers: Array<{ tag: string; overflowY: string }>;
   hasMain: boolean;
   hasList: boolean;
+  hasInlineScroll: boolean;
 };
 
 async function setClinicSession(page: Page) {
@@ -58,7 +62,23 @@ async function readLayoutContract(page: Page): Promise<LayoutContract> {
     const html = document.documentElement;
     const body = document.body;
     const main = document.querySelector<HTMLElement>("main.dashboard-main");
-    const list = document.querySelector<HTMLElement>(".dashboard-inline-scroll");
+    const card = document.querySelector<HTMLElement>(
+      '[aria-label="Visitas de campo recientes de la clínica"]',
+    );
+    const list = document.querySelector<HTMLElement>(
+      '[data-clinic-logistics-list-body="true"]',
+    );
+    const moduleScrollContainers = card
+      ? [card, ...Array.from(card.querySelectorAll<HTMLElement>("*"))].flatMap(
+          (element) => {
+            const style = window.getComputedStyle(element);
+            return ["auto", "scroll"].includes(style.overflowY)
+              ? [{ tag: element.tagName, overflowY: style.overflowY }]
+              : [];
+          },
+        )
+      : [];
+    const listStyle = list ? window.getComputedStyle(list) : null;
 
     return {
       htmlScrollWidth: html.scrollWidth,
@@ -72,8 +92,14 @@ async function readLayoutContract(page: Page): Promise<LayoutContract> {
       mainScrollHeight: main?.scrollHeight ?? 0,
       mainClientHeight: main?.clientHeight ?? 0,
       listClientHeight: list?.clientHeight ?? 0,
+      listScrollHeight: list?.scrollHeight ?? 0,
+      listOverflowY: listStyle?.overflowY ?? "missing",
+      moduleScrollContainers,
       hasMain: main !== null,
       hasList: list !== null,
+      hasInlineScroll: card
+        ? card.querySelector(".dashboard-inline-scroll") !== null
+        : false,
     };
   });
 }
@@ -99,11 +125,27 @@ function assertNoGlobalOverflow(metrics: LayoutContract, label: string) {
   expect(metrics.mainScrollHeight, `${label}: dashboard shell scroll`).toBeLessThanOrEqual(
     metrics.mainClientHeight + TOLERANCE,
   );
-  expect(metrics.hasList, `${label}: inline list present`).toBe(true);
+  expect(metrics.hasList, `${label}: compact list present`).toBe(true);
+  expect(
+    metrics.hasInlineScroll,
+    `${label}: logistica card must not use .dashboard-inline-scroll`,
+  ).toBe(false);
   expect(
     metrics.listClientHeight,
-    `${label}: inline list must keep an operable height`,
+    `${label}: visit list must keep an operable height`,
   ).toBeGreaterThanOrEqual(44);
+  expect(
+    metrics.listScrollHeight,
+    `${label}: visit list must not clip hidden overflow`,
+  ).toBeLessThanOrEqual(metrics.listClientHeight + TOLERANCE);
+  expect(
+    ["auto", "scroll"],
+    `${label}: visit list must not expose vertical scroll`,
+  ).not.toContain(metrics.listOverflowY);
+  expect(
+    metrics.moduleScrollContainers,
+    `${label}: logistica module must not contain internal scroll containers`,
+  ).toEqual([]);
 }
 
 async function expectHorizontallyUnclipped(
@@ -136,8 +178,8 @@ for (const viewport of MOBILE_VIEWPORTS) {
     const card = workspace.locator(
       '[aria-label="Visitas de campo recientes de la clínica"]',
     );
-    const inlineList = card.locator(".dashboard-inline-scroll");
-    const visitRows = inlineList.locator('button[aria-pressed]');
+    const listPanel = card.locator('[data-clinic-logistics-list-panel="true"]');
+    const visitRows = card.locator('[data-clinic-logistics-row="true"]');
     const fullModuleButton = card.getByRole("button", {
       name: "Abrir módulo completo de logística",
       exact: true,
@@ -147,6 +189,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(workspace).toBeVisible();
       await expect(card).toBeVisible();
       await expectClinicMobileBottomNav(page, viewport.name);
+      await expect(listPanel).toBeVisible();
       await expect(visitRows).toHaveCount(3);
 
       for (let index = 0; index < 3; index += 1) {
@@ -158,6 +201,10 @@ for (const viewport of MOBILE_VIEWPORTS) {
     }).toPass({ timeout: 12_000 });
 
     await expect(card.locator("table")).toHaveCount(0);
+    await expect(card.locator(".dashboard-inline-scroll")).toHaveCount(0);
+    await expect(
+      card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+    ).toHaveCount(0);
     await expectHorizontallyUnclipped(
       fullModuleButton,
       viewport.width,
@@ -177,19 +224,23 @@ for (const viewport of MOBILE_VIEWPORTS) {
       assertNoGlobalOverflow(metrics, `${viewport.name}: initial layout`);
     }).toPass({ timeout: 10_000 });
 
-    const secondVisit = visitRows.nth(1);
-    await secondVisit.click();
+    await visitRows.nth(1).click();
 
     await expect(async () => {
-      await expect(secondVisit).toHaveAttribute("aria-expanded", "true");
+      await expect(visitRows).toHaveCount(3);
+      await expect(visitRows.nth(1)).toBeVisible();
+      await expect(
+        card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),
+      ).toHaveCount(0);
 
-      const inlineDetail = card.locator('[data-detail-state="selected"]');
-      await expect(inlineDetail).toHaveCount(1);
-      await expect(inlineDetail).toBeVisible();
-      await expect(inlineDetail).toContainText(LONG_VISIT_ADDRESS);
+      const detailDialog = page.locator(
+        '[data-clinic-logistics-detail-dialog="true"]',
+      );
+      await expect(detailDialog).toBeVisible();
+      await expect(detailDialog).toContainText(LONG_VISIT_ADDRESS);
 
       const metrics = await readLayoutContract(page);
-      assertNoGlobalOverflow(metrics, `${viewport.name}: expanded inline detail`);
+      assertNoGlobalOverflow(metrics, `${viewport.name}: modal detail`);
     }).toPass({ timeout: 10_000 });
   });
 }

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -6,10 +6,11 @@ import { Route as RouteIcon, ExternalLink } from "lucide-react";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { DashboardRefreshButton } from "@/components/dashboard/DashboardRefreshButton";
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
-import { cn, formatDate } from "@/lib/utils";
+import { formatDate } from "@/lib/utils";
 
 type Props = {
   recentVisits: FieldVisit[];
@@ -20,13 +21,11 @@ export function ClinicLogisticaWorkspaceSummary({
   recentVisits,
   visitsLoadError,
 }: Props) {
-  const [selectedVisitId, setSelectedVisitId] = useState<number | null>(
-    recentVisits[0]?.id ?? null,
-  );
+  const [selectedVisitId, setSelectedVisitId] = useState<number | null>(null);
   const selectedVisit =
-    recentVisits.find((visit) => visit.id === selectedVisitId) ??
-    recentVisits[0] ??
-    null;
+    selectedVisitId === null
+      ? null
+      : (recentVisits.find((visit) => visit.id === selectedVisitId) ?? null);
 
   const fullModuleLink = (
     <PublicRouteControl
@@ -66,97 +65,38 @@ export function ClinicLogisticaWorkspaceSummary({
           <DashboardRefreshButton />
         </div>
       ) : recentVisits.length ? (
-        <div className="dashboard-inline-list min-h-0 flex-1 rounded-lg border border-vetneb-line/75 bg-card/82">
-            <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
-              {recentVisits.map((visit) => {
-                const isSelected = selectedVisit?.id === visit.id;
-
-                return (
-                  <div key={visit.id} className="min-w-0">
-                    <button
-                      type="button"
-                      onClick={() => setSelectedVisitId(visit.id)}
-                      aria-pressed={isSelected}
-                      aria-expanded={isSelected}
-                      className={cn(
-                        "flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                        isSelected && "bg-vetneb-cyan/12",
-                      )}
-                    >
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-vetneb-ink">
-                          {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {formatDate(visit.scheduledAt)}
-                        </p>
-                      </div>
-                      <StatusBadge status={visit.status} size="sm" className="ml-2 shrink-0" />
-                    </button>
-
-                    {isSelected && selectedVisit ? (
-                      <div
-                        data-detail-state="selected"
-                        className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40 p-4"
-                      >
-                        <div className="space-y-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                Detalle de la visita
-                              </p>
-                              <h4 className="mt-1 break-words text-lg font-semibold text-vetneb-ink">
-                                {selectedVisit.clinicName ?? `Clínica #${selectedVisit.clinicId}`}
-                              </h4>
-                            </div>
-                            <StatusBadge status={selectedVisit.status} size="sm" className="shrink-0" />
-                          </div>
-                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                            <div className="clinical-muted-band rounded-lg px-3 py-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Programada
-                              </p>
-                              <p className="mt-1 text-xs text-vetneb-ink">
-                                {formatDate(selectedVisit.scheduledAt)}
-                              </p>
-                            </div>
-                            <div className="clinical-muted-band rounded-lg px-3 py-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Completada
-                              </p>
-                              <p className="mt-1 text-xs text-muted-foreground">
-                                {selectedVisit.completedAt ? formatDate(selectedVisit.completedAt) : "—"}
-                              </p>
-                            </div>
-                            <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Dirección
-                              </p>
-                              <p className="mt-1 break-words text-xs text-muted-foreground">
-                                {selectedVisit.address ?? "Sin dirección registrada"}
-                              </p>
-                            </div>
-                            <div className="clinical-muted-band rounded-lg px-3 py-2 sm:col-span-2">
-                              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-vetneb-navy">
-                                Acción
-                              </p>
-                              <PublicRouteControl
-                                href={ROUTES.dashboardLogisticaVisitas}
-                                variant="textLink"
-                                className="mt-1 inline-flex text-xs font-semibold text-vetneb-navy hover:text-vetneb-teal"
-                                aria-label="Abrir visitas de campo en el módulo completo"
-                              >
-                                Abrir visitas en módulo completo
-                              </PublicRouteControl>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </div>
+        <div
+          data-clinic-logistics-list-panel="true"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
+        >
+          <div
+            data-clinic-logistics-list-body="true"
+            className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden"
+          >
+            {recentVisits.map((visit) => (
+              <button
+                key={visit.id}
+                type="button"
+                data-clinic-logistics-row="true"
+                onClick={() => setSelectedVisitId(visit.id)}
+                aria-haspopup="dialog"
+                aria-label={`Ver detalle de la visita en ${
+                  visit.clinicName ?? `Clínica #${visit.clinicId}`
+                }`}
+                className="grid min-h-11 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold text-vetneb-ink">
+                    {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {formatDate(visit.scheduledAt)}
+                  </p>
+                </div>
+                <StatusBadge status={visit.status} size="sm" className="shrink-0" />
+              </button>
+            ))}
+          </div>
         </div>
       ) : (
         <EmptyState
@@ -165,6 +105,68 @@ export function ClinicLogisticaWorkspaceSummary({
           icon={RouteIcon}
         />
       )}
+
+      {selectedVisit ? (
+        <ModuleDialog
+          open={selectedVisit !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSelectedVisitId(null);
+            }
+          }}
+          title={selectedVisit.clinicName ?? `Clínica #${selectedVisit.clinicId}`}
+          description="Detalle de la visita de campo programada."
+        >
+          <div
+            data-clinic-logistics-detail-dialog="true"
+            className="flex min-h-0 flex-col gap-3 text-xs"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-[0.6875rem] text-muted-foreground">Clínica</p>
+                <p className="break-words text-sm font-semibold text-vetneb-ink">
+                  {selectedVisit.clinicName ?? `Clínica #${selectedVisit.clinicId}`}
+                </p>
+              </div>
+              <StatusBadge
+                status={selectedVisit.status}
+                size="sm"
+                className="shrink-0"
+              />
+            </div>
+
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-2 rounded-lg border border-vetneb-line/70 px-3 py-2">
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Programada</dt>
+                <dd className="font-medium">{formatDate(selectedVisit.scheduledAt)}</dd>
+              </div>
+              <div>
+                <dt className="text-[0.6875rem] text-muted-foreground">Completada</dt>
+                <dd className="text-muted-foreground">
+                  {selectedVisit.completedAt
+                    ? formatDate(selectedVisit.completedAt)
+                    : "—"}
+                </dd>
+              </div>
+              <div className="col-span-2 min-w-0">
+                <dt className="text-[0.6875rem] text-muted-foreground">Dirección</dt>
+                <dd className="break-words">
+                  {selectedVisit.address ?? "Sin dirección registrada"}
+                </dd>
+              </div>
+            </dl>
+
+            <PublicRouteControl
+              href={ROUTES.dashboardLogisticaVisitas}
+              variant="textLink"
+              className="text-xs"
+              aria-label="Abrir visitas de campo en el módulo completo"
+            >
+              Abrir visitas en módulo completo
+            </PublicRouteControl>
+          </div>
+        </ModuleDialog>
+      ) : null}
     </ModuleSurface>
   );
 }

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -230,21 +230,21 @@ test("clinic informes summary exposes advanced filters over visible report field
   }
 });
 
-test("clinic logistica summary keeps its existing inline master-detail layer", () => {
+test("clinic logistica summary uses compact list with controlled detail dialog", () => {
   const source = read(CLINIC_LOGISTICA_SUMMARY_PATH);
 
   assert.ok(source.includes('"use client";'));
   assert.ok(source.includes("ModuleSurface"));
+  assert.ok(source.includes("ModuleDialog"));
   assert.ok(source.includes("useState"));
-  assert.ok(source.includes("dashboard-inline-list"));
-  assert.ok(source.includes("dashboard-inline-scroll"));
-  assert.ok(source.includes("dashboard-inline-detail"));
-  assert.ok(source.includes("aria-expanded={isSelected}"));
-  assert.ok(source.includes('data-detail-state="selected"'));
-  assert.equal(source.includes("isMobileDetailOpen"), false);
-  assert.equal(source.includes("Volver a la lista"), false);
-  assert.equal(source.includes('xl:grid-cols-[0.85fr_1.15fr]'), false);
-  assert.equal(source.includes("space-y-4"), false);
+  assert.ok(source.includes('data-clinic-logistics-list-panel="true"'));
+  assert.ok(source.includes('data-clinic-logistics-list-body="true"'));
+  assert.ok(source.includes('data-clinic-logistics-row="true"'));
+  assert.ok(source.includes('data-clinic-logistics-detail-dialog="true"'));
+  assert.equal(source.includes("dashboard-inline-scroll"), false);
+  assert.equal(source.includes("dashboard-inline-detail"), false);
+  assert.equal(source.includes("aria-expanded={isSelected}"), false);
+  assert.equal(source.includes('data-detail-state="selected"'), false);
 });
 
 test("dashboard home keeps status badge and date formatting in clinic command center", () => {


### PR DESCRIPTION
## Summary

Redesigns the clinic logistics workspace summary from inline expanded detail to a compact list plus `ModuleDialog` detail contract.

## Changes

- Removes the `dashboard-inline-scroll` / inline expanded detail dependency from `ClinicLogisticaWorkspaceSummary`.
- Opens logistics visit detail in a controlled `ModuleDialog`.
- Updates the mobile parity e2e to the new dialog contract.
- Updates the source-contract test that previously pinned the old inline design.
- Adds implementation documentation.

## Validations

- `pnpm test` — 2907 pass / 0 fail
- `pnpm -C frontend typecheck` — OK
- `pnpm -C frontend lint` — OK
- `pnpm -C frontend e2e -- e2e/dashboard-clinic-logistica-mobile-parity.spec.ts` — 3 pass
- `pnpm -C frontend e2e:public-clinic` — 116 pass
- `pnpm -C frontend build` — OK

## Scope

Touched:
- `frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx`
- `frontend/e2e/dashboard-clinic-logistica-mobile-parity.spec.ts`
- `test/frontend-dashboard-home.test.ts`
- `docs/implementation/clinic-logistics-master-detail-workspace.md`

Not touched:
- backend/API/auth/DB
- CI/workflows
- dependencies/lockfiles
- snapshots
- `globals.css`
- `MasterDetailWorkspace.tsx`
- full-page logística/informes routes