### PR TITLE
fix(clinic): request only recent dashboard reports

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -77,7 +77,7 @@ export default async function DashboardPage({
   await Promise.all([
     (async () => {
       try {
-        reports = await getReports(requestOptions, undefined, {
+        reports = await getReports(requestOptions, { limit: 3, offset: 0 }, {
           throwOnError: true,
         });
       } catch (error) {

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -67,7 +67,7 @@ test("dashboard home reads stats reports and field visits through API helpers", 
   assert.ok(source.includes("let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];"));
   assert.ok(source.includes("let visitsLoadError = false;"));
   assert.ok(source.includes("await Promise.all(["));
-  assert.ok(source.includes("getReports(requestOptions, undefined, {"));
+  assert.ok(source.includes("getReports(requestOptions, { limit: 3, offset: 0 }, {"));
   assert.ok(source.includes("getLogisticsFieldVisits(requestOptions, {"));
   assert.ok(source.includes("throwOnError: true,"));
   assert.ok(source.includes("const recentReports = reports.slice(0, 3);"));

--- a/test/frontend-dashboard-live-read-contract.test.ts
+++ b/test/frontend-dashboard-live-read-contract.test.ts
@@ -52,7 +52,11 @@ test("frontend dashboard page uses API client wrappers", () => {
   assertIncludes(source, "let reportsLoadError = false;", dashboardPage);
   assertIncludes(source, "let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];", dashboardPage);
   assertIncludes(source, "let visitsLoadError = false;", dashboardPage);
-  assertIncludes(source, "getReports(requestOptions, undefined, {", dashboardPage);
+  assertIncludes(
+    source,
+    "getReports(requestOptions, { limit: 3, offset: 0 }, {",
+    dashboardPage,
+  );
   assertIncludes(source, "getLogisticsFieldVisits(requestOptions, {", dashboardPage);
   assertIncludes(source, "throwOnError: true,", dashboardPage);
 });


### PR DESCRIPTION
## Summary
- Updates Clínica dashboard to request only the 3 recent reports it displays.
- Keeps reports.slice(0, 3) as a defensive local guard.
- Updates direct source-contract tests for the new getReports call-site.

## Scope
- Changed: frontend/src/app/dashboard/page.tsx
- Changed: test/frontend-dashboard-home.test.ts
- Changed: test/frontend-dashboard-live-read-contract.test.ts
- No backend/API/auth/DB/deps/lockfiles/CI/globals.css changes.
- No changes to ClinicInformesWorkspaceSummary.
- No changes to /dashboard/informes.
- No fixtures 1000.

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface
- git diff --check
- git diff --stat
- git diff --name-only