### PR TITLE
fix(admin): align mobile users row height fallback

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -42,8 +42,9 @@ const USERS_ROLES_SUPERSET_CAP = 36;
 // Fixed header row height of the desktop table (`[&_th]:h-8`), discounted from
 // the measured region so the row math never counts the header as a data row.
 const USERS_ROLES_TABLE_HEADER_PX = 32;
-// Fallback item height used until a real row is measured.
-const USERS_ROLES_ROW_HEIGHT_FALLBACK_PX = 36;
+// Fallback item height used until a real row is measured. Mobile rows use
+// `min-h-10`, so the pre-measurement limit must not overestimate capacity.
+const USERS_ROLES_ROW_HEIGHT_FALLBACK_PX = 40;
 
 type Measurement = {
   containerNode: HTMLElement | null;


### PR DESCRIPTION
## Summary
- Aligns Admin Users/Roles mobile row-height fallback with the actual mobile row min-height.
- Prevents pre-measurement overestimation of mobile users page capacity.
- Stabilizes the Admin mobile ops users no-scroll contract without weakening the E2E assertion.

## Scope
- Changed: frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
- No CAP-C1 changes.
- No Clínica dashboard reports changes.
- No backend/API/auth/DB/deps/lockfiles/CI/globals.css changes.
- No changes to ClinicInformesWorkspaceSummary or /dashboard/informes.

## Validation
- pnpm test
- pnpm --dir frontend exec playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts --project=chromium
- pnpm build
- pnpm security:public-surface
- git diff --check
- git diff --stat
- git diff --name-only