### PR TITLE
test(admin): add high-volume users fixture pagination

### DIFF
--- a/frontend/e2e/admin-users-fixture-pagination.spec.ts
+++ b/frontend/e2e/admin-users-fixture-pagination.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const API_BASE_URL = "http://127.0.0.1:3107";
+const POPULATED_ADMIN_COOKIE = "admin_session_id=e2e_populated_admin_session";
+
+type AdminUsersFixtureItem = {
+  userType: "admin" | "clinic";
+  userId: number;
+  username: string;
+  role: "admin" | "clinic_owner" | "clinic_staff";
+  status?: string;
+};
+
+type AdminUsersFixtureBody = {
+  success: true;
+  users: AdminUsersFixtureItem[];
+  total: number;
+  totalPages: number;
+  limit: number;
+  offset: number;
+  totals: {
+    adminUsers: number;
+    clinicUsers: number;
+  };
+};
+
+async function readAdminUsersFixture(
+  request: APIRequestContext,
+  path: string,
+): Promise<AdminUsersFixtureBody> {
+  const response = await request.get(`${API_BASE_URL}${path}`, {
+    headers: { Cookie: POPULATED_ADMIN_COOKIE },
+  });
+
+  expect(response.ok()).toBe(true);
+  return (await response.json()) as AdminUsersFixtureBody;
+}
+
+test.describe("admin users populated fixture pagination (CAP-A1)", () => {
+  test("/api/admin/users-roles returns a 5000-user deterministic paginated dataset", async ({
+    request,
+  }) => {
+    const body = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&limit=10&offset=0",
+    );
+
+    expect(body.total).toBe(5000);
+    expect(body.totalPages).toBe(500);
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(0);
+    expect(body.users).toHaveLength(10);
+    expect(body.users.map((user) => user.username).slice(0, 3)).toEqual([
+      "admin_operaciones",
+      "usuario_clinica_01",
+      "usuario_clinica_02",
+    ]);
+    expect(body.totals).toEqual({ adminUsers: 250, clinicUsers: 4750 });
+  });
+
+  test("/api/admin/users-roles caps oversized limits and offset changes the slice", async ({
+    request,
+  }) => {
+    const firstPage = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&limit=250&offset=0",
+    );
+    const secondPage = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&limit=250&offset=100",
+    );
+
+    expect(firstPage.limit).toBe(100);
+    expect(firstPage.totalPages).toBe(50);
+    expect(firstPage.users).toHaveLength(100);
+    expect(secondPage.limit).toBe(100);
+    expect(secondPage.offset).toBe(100);
+    expect(secondPage.users).toHaveLength(100);
+    expect(secondPage.users[0].userId).not.toBe(firstPage.users[0].userId);
+  });
+
+  test("/api/admin/users-roles honors userType and role filters", async ({
+    request,
+  }) => {
+    const body = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&userType=clinic&role=clinic_owner&limit=7&offset=7",
+    );
+
+    expect(body.total).toBe(2375);
+    expect(body.totalPages).toBe(340);
+    expect(body.limit).toBe(7);
+    expect(body.offset).toBe(7);
+    expect(body.users).toHaveLength(7);
+    for (const user of body.users) {
+      expect(user.userType).toBe("clinic");
+      expect(user.role).toBe("clinic_owner");
+    }
+  });
+
+  test("/api/admin/users-roles honors query/search and status filters", async ({
+    request,
+  }) => {
+    const queryBody = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&query=usuario_clinica_fixture_0100&limit=5&offset=0",
+    );
+    const searchBody = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&search=Cl%C3%ADnica%20Fixture%200100&limit=5&offset=0",
+    );
+    const statusBody = await readAdminUsersFixture(
+      request,
+      "/api/admin/users-roles?dataset=high-volume&status=locked&limit=6&offset=0",
+    );
+
+    expect(queryBody.total).toBe(1);
+    expect(queryBody.totalPages).toBe(1);
+    expect(queryBody.users).toHaveLength(1);
+    expect(queryBody.users[0].username).toBe("usuario_clinica_fixture_0100");
+
+    expect(searchBody.total).toBe(1);
+    expect(searchBody.users).toHaveLength(1);
+    expect(searchBody.users[0].username).toBe("usuario_clinica_fixture_0100");
+
+    expect(statusBody.total).toBeGreaterThan(0);
+    expect(statusBody.totalPages).toBe(Math.ceil(statusBody.total / 6));
+    expect(statusBody.users).toHaveLength(6);
+    for (const user of statusBody.users) {
+      expect(user.status).toBe("locked");
+    }
+  });
+});

--- a/frontend/e2e/fixtures/admin-populated-api-server.mjs
+++ b/frontend/e2e/fixtures/admin-populated-api-server.mjs
@@ -356,13 +356,24 @@ const REPORTS = Array.from({ length: 9 }, (_, index) => ({
   workflowUpdatedAt: "2026-06-18T11:00:00.000Z",
 }));
 
-const USERS = Array.from({ length: 9 }, (_, index) =>
+const ADMIN_USERS_TARGET_TOTAL = 5000;
+const ADMIN_USER_STATUSES = ["active", "inactive", "locked"];
+const ADMIN_USER_LOCALITIES = [
+  "CABA",
+  "Buenos Aires",
+  "Córdoba",
+  "Rosario",
+  "Mendoza",
+];
+
+const LEGACY_USERS = Array.from({ length: 9 }, (_, index) =>
   index === 0
     ? {
         userType: "admin",
         userId: 41,
         username: "admin_operaciones",
         role: "admin",
+        status: "active",
         clinicId: null,
         clinicName: null,
         createdAt: "2025-11-10T10:00:00.000Z",
@@ -373,6 +384,7 @@ const USERS = Array.from({ length: 9 }, (_, index) =>
         userId: 200 + index,
         username: `usuario_clinica_${String(index).padStart(2, "0")}`,
         role: index % 2 === 0 ? "clinic_owner" : "clinic_staff",
+        status: ADMIN_USER_STATUSES[(index - 1) % ADMIN_USER_STATUSES.length],
         clinicId: 11 + index,
         clinicName: `Clínica E2E ${String(index).padStart(2, "0")}`,
         clinicLocality: index % 2 === 0 ? "CABA" : "Buenos Aires",
@@ -380,6 +392,136 @@ const USERS = Array.from({ length: 9 }, (_, index) =>
         updatedAt: "2026-06-17T15:30:00.000Z",
       },
 );
+
+function createSyntheticAdminUser(index) {
+  const createdAt = isoDaysBefore("2026-06-18T10:00:00.000Z", index % 365, 10);
+  const updatedAt = isoDaysBefore("2026-06-18T15:30:00.000Z", index % 90, 15);
+
+  return {
+    userType: "admin",
+    userId: 10_000 + index,
+    username: `admin_fixture_${String(index).padStart(4, "0")}`,
+    role: "admin",
+    status: ADMIN_USER_STATUSES[index % ADMIN_USER_STATUSES.length],
+    clinicId: null,
+    clinicName: null,
+    createdAt,
+    updatedAt,
+  };
+}
+
+function createSyntheticClinicUser(index) {
+  const clinicId = 20_000 + index;
+  const createdAt = isoDaysBefore("2026-06-18T10:00:00.000Z", index % 365, 10);
+  const updatedAt = isoDaysBefore("2026-06-18T15:30:00.000Z", index % 90, 15);
+
+  return {
+    userType: "clinic",
+    userId: 30_000 + index,
+    username: `usuario_clinica_fixture_${String(index).padStart(4, "0")}`,
+    role: index % 2 === 0 ? "clinic_owner" : "clinic_staff",
+    status: ADMIN_USER_STATUSES[index % ADMIN_USER_STATUSES.length],
+    clinicId,
+    clinicName: `Clínica Fixture ${String(index).padStart(4, "0")}`,
+    clinicLocality: ADMIN_USER_LOCALITIES[index % ADMIN_USER_LOCALITIES.length],
+    createdAt,
+    updatedAt,
+  };
+}
+
+const SYNTHETIC_ADMIN_USERS = Array.from({ length: 249 }, (_, index) =>
+  createSyntheticAdminUser(index + 1),
+);
+
+const SYNTHETIC_CLINIC_USERS = Array.from(
+  {
+    length:
+      ADMIN_USERS_TARGET_TOTAL -
+      LEGACY_USERS.length -
+      SYNTHETIC_ADMIN_USERS.length,
+  },
+  (_, index) => createSyntheticClinicUser(index + 1),
+);
+
+const USERS = [
+  ...LEGACY_USERS,
+  ...SYNTHETIC_ADMIN_USERS,
+  ...SYNTHETIC_CLINIC_USERS,
+];
+
+function readAdminUsersPagination(url, total) {
+  const rawLimit = Number(url.searchParams.get("limit"));
+  const rawOffset = Number(url.searchParams.get("offset"));
+  const hasLimit = url.searchParams.has("limit");
+  const limit =
+    hasLimit && Number.isInteger(rawLimit) && rawLimit > 0
+      ? Math.min(rawLimit, 100)
+      : Math.min(total, 9);
+  const offset =
+    Number.isInteger(rawOffset) && rawOffset > 0 ? rawOffset : 0;
+
+  return { limit, offset };
+}
+
+function includesAdminUserText(value, query) {
+  return String(value ?? "").toLowerCase().includes(query);
+}
+
+// CAP-A1 (5000-user dataset) is opt-in via ?dataset=high-volume. Requests
+// without it — i.e. the real AdminUsersRolesReadOnlyCard component, whose
+// adaptive server-page-size can exceed 9 on tall viewports — keep resolving
+// against the 9-user LEGACY_USERS pool, preserving the pre-CAP-A1 no-scroll
+// contract (`expectNinePopulatedRows`) that relies on the dataset itself
+// capping the response at 9 rows regardless of the requested limit.
+function isHighVolumeAdminUsersRequest(url) {
+  return url.searchParams.get("dataset") === "high-volume";
+}
+
+function filterAdminUsers(url) {
+  const query = (
+    url.searchParams.get("query") ??
+    url.searchParams.get("search") ??
+    ""
+  )
+    .trim()
+    .toLowerCase();
+  const userType = url.searchParams.get("userType")?.trim() ?? "";
+  const role = url.searchParams.get("role")?.trim() ?? "";
+  const status = url.searchParams.get("status")?.trim() ?? "";
+  const pool = isHighVolumeAdminUsersRequest(url) ? USERS : LEGACY_USERS;
+
+  return pool.filter((user) => {
+    const matchesQuery =
+      !query ||
+      includesAdminUserText(user.userId, query) ||
+      includesAdminUserText(user.username, query) ||
+      includesAdminUserText(user.role, query) ||
+      includesAdminUserText(user.status, query) ||
+      includesAdminUserText(user.clinicId, query) ||
+      includesAdminUserText(user.clinicName, query) ||
+      includesAdminUserText(user.clinicLocality, query);
+    const matchesUserType = !userType || user.userType === userType;
+    const matchesRole = !role || user.role === role;
+    const matchesStatus = !status || user.status === status;
+
+    return matchesQuery && matchesUserType && matchesRole && matchesStatus;
+  });
+}
+
+function countAdminUsersByType(users) {
+  return users.reduce(
+    (totals, user) => {
+      if (user.userType === "admin") {
+        totals.adminUsers += 1;
+      } else {
+        totals.clinicUsers += 1;
+      }
+
+      return totals;
+    },
+    { adminUsers: 0, clinicUsers: 0 },
+  );
+}
 
 function sendJson(response, status, body) {
   response.writeHead(status, {
@@ -570,21 +712,19 @@ function handlePopulatedRequest(request, response, url) {
   }
 
   if (url.pathname === "/api/admin/users-roles") {
-    const limit = Number(url.searchParams.get("limit") ?? 9);
-    const offset = Number(url.searchParams.get("offset") ?? 0);
-    const userType = url.searchParams.get("userType");
-    const role = url.searchParams.get("role");
-    const filteredUsers = USERS.filter(
-      (user) => (!userType || user.userType === userType) && (!role || user.role === role),
-    );
+    const filteredUsers = filterAdminUsers(url);
+    const total = filteredUsers.length;
+    const { limit, offset } = readAdminUsersPagination(url, total);
+    const totalPages = limit > 0 ? Math.ceil(total / limit) : 0;
 
     sendJson(response, 200, {
       success: true,
       users: filteredUsers.slice(offset, offset + limit),
-      total: filteredUsers.length,
+      total,
+      totalPages,
       limit,
       offset,
-      totals: { adminUsers: 3, clinicUsers: 26 },
+      totals: countAdminUsersByType(filteredUsers),
       checkedBy: { adminUserId: 41, username: "admin_operaciones" },
     });
     return;


### PR DESCRIPTION
## Summary
- Add deterministic 5000-user Admin users/roles fixture data.
- Implement bounded pagination metadata for /api/admin/users-roles.
- Add fixture filters for query/search, status, userType, and role.
- Add a directed Playwright API spec for the high-volume Admin users fixture contract.

## Scope
- Test/fixture only.
- No production dashboard code.
- No frontend/src changes.
- No backend/API/auth/DB/dependency/lockfile/CI changes.
- No globals.css.
- No frontend/next-env.d.ts.

## Validation
- node --check frontend/e2e/fixtures/admin-populated-api-server.mjs
- node --check frontend/e2e/admin-users-fixture-pagination.spec.ts
- pnpm --dir frontend exec playwright test e2e/admin-users-fixture-pagination.spec.ts --project=chromium
- pnpm test
- pnpm build
- pnpm security:public-surface