### PR TITLE
fix(admin): correct desktop users filter select clipping

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -499,7 +499,7 @@ export function AdminUsersRolesReadOnlyCard() {
           <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48 md:gap-0.5">
             Tipo usuario
             <select
-              className="field-select h-8 text-xs md:h-7"
+              className="field-select h-8 py-1 text-xs leading-none md:h-7"
               value={userType}
               disabled={disableUserActions}
               onChange={(event) => {
@@ -517,7 +517,7 @@ export function AdminUsersRolesReadOnlyCard() {
           <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48 md:gap-0.5">
             Rol
             <select
-              className="field-select h-8 text-xs md:h-7"
+              className="field-select h-8 py-1 text-xs leading-none md:h-7"
               value={role}
               disabled={disableUserActions}
               onChange={(event) => {


### PR DESCRIPTION
## Summary
- Fix desktop select text clipping in Admin Users/Roles filters.
- Override the inherited field-select vertical padding locally for the Tipo usuario and Rol selects.
- Add `leading-none` so the md:h-7 desktop height has enough content-box for the text line.
- Resolve QA1 known finding F1 with `selectClipsMaxPx: 0`.

## Scope
- One production file only:
  - frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
- No backend/API/auth/DB changes.
- No dependency/lockfile/CI changes.
- No docs/audit or PNG changes.
- No docs/product changes.
- No globals.css changes.
- No frontend/next-env.d.ts changes.

## Validation
- pnpm --dir frontend exec playwright test e2e/admin-users-visual-quality-gate.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-mobile-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "admin users and roles populated fits without external or internal scroll"
- pnpm test
- pnpm build
- pnpm security:public-surface