### PR TITLE
fix(admin): prevent users date cell clipping

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -554,8 +554,8 @@ export function AdminUsersRolesReadOnlyCard() {
                     <TableHead className="w-[10%]">Tipo</TableHead>
                     <TableHead className="w-[14%]">Rol</TableHead>
                     <TableHead>Clínica</TableHead>
-                    <TableHead className="hidden w-[9.5rem] xl:table-cell">Creado</TableHead>
-                    <TableHead className="w-[9.5rem]">Actualizado</TableHead>
+                    <TableHead className="hidden w-[10.5rem] xl:table-cell">Creado</TableHead>
+                    <TableHead className="w-[10.5rem]">Actualizado</TableHead>
                     <TableHead className="w-[8.5rem] text-right">Acción</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -597,10 +597,10 @@ export function AdminUsersRolesReadOnlyCard() {
                             </p>
                           ) : null}
                         </TableCell>
-                        <TableCell className="hidden truncate text-xs text-muted-foreground xl:table-cell">
+                        <TableCell className="hidden truncate text-xs tabular-nums text-muted-foreground xl:table-cell">
                           {formatDateTime(user.createdAt)}
                         </TableCell>
-                        <TableCell className="truncate text-xs text-muted-foreground">
+                        <TableCell className="truncate text-xs tabular-nums text-muted-foreground">
                           {formatDateTime(user.updatedAt)}
                         </TableCell>
                         <TableCell className="text-right">


### PR DESCRIPTION
## Summary
- Prevent random ellipsis in Admin Users/Roles desktop CREADO/ACTUALIZADO date cells.
- Add tabular numeric rendering to date cells.
- Increase date column width from 9.5rem to 10.5rem so timestamps fit without clipping.
- Keep the table no-scroll contract intact by taking space from the flexible Clínica column.

## Scope
- One production file only:
  - frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
- No backend/API/auth/DB changes.
- No dependency/lockfile/CI changes.
- No docs/audit or PNG changes.
- No docs/product changes.
- No globals.css changes.
- No frontend/next-env.d.ts changes.

## Validation
- pnpm --dir frontend exec playwright test e2e/admin-users-visual-quality-gate.spec.ts --project=chromium
  - F1 remains resolved: selectClipsMaxPx 0
  - F2 resolved: dateCellClipCount 0
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-mobile-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "admin users and roles populated fits without external or internal scroll"
- pnpm test
- pnpm build
- pnpm --dir frontend build
- pnpm security:public-surface