### PR TITLE
fix(admin): stabilize users adaptive first paint

### DIFF
--- a/frontend/src/hooks/useAdaptiveItemsPerPage.ts
+++ b/frontend/src/hooks/useAdaptiveItemsPerPage.ts
@@ -123,7 +123,13 @@ export function useAdaptiveItemsPerPage({
 
     const observer = new ResizeObserver(scheduleMeasure);
     observer.observe(containerNode);
-    scheduleMeasure();
+    // The very first measurement runs synchronously (not through rAF) so it
+    // lands within this same layout-effect pass, before the browser paints.
+    // Deferring it to requestAnimationFrame left the fallback-sized first
+    // paint visible for one extra frame, then corrected on the next frame —
+    // the F3 settle. Later ResizeObserver-driven remeasures still go through
+    // scheduleMeasure to stay rAF-throttled against resize thrashing.
+    measure();
 
     return () => {
       observer.disconnect();


### PR DESCRIPTION
## Summary
- Stabilize the first desktop paint for the Admin Users/Roles adaptive row limit.
- Measure immediately inside the layout effect instead of scheduling the first measurement one frame later.
- Keep later ResizeObserver-driven re-measurements throttled through requestAnimationFrame.
- Preserve floor/cap behavior and no-scroll contracts.

## Scope
- One production hook only:
  - frontend/src/hooks/useAdaptiveItemsPerPage.ts
- No backend/API/auth/DB changes.
- No dependency/lockfile/CI changes.
- No docs/audit or PNG changes.
- No docs/product changes.
- No globals.css changes.
- No frontend/next-env.d.ts changes.

## Validation
- pnpm --dir frontend exec playwright test e2e/admin-users-visual-quality-gate.spec.ts --project=chromium
  - F1 remains resolved: selectClipsMaxPx 0
  - F2 remains resolved: dateCellClipCount 0
  - desktop 1440x900 settleDelta 0 in audited states
  - mobile residual settle remains a preexisting known finding and is not introduced by this PR
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-mobile-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "admin users and roles populated fits without external or internal scroll"
- pnpm test
- pnpm build
- pnpm security:public-surface

## Notes
- This PR closes the original desktop F3 first-paint settle from the visual audit.
- Mobile first-paint settle is explicitly left as a separate follow-up candidate if needed.