### PR TITLE
fix(admin): clarify mobile admin user action state

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -794,7 +794,9 @@ export function AdminUsersRolesReadOnlyCard() {
                       {isChanging ? "Cambiando..." : "Cambiar"}
                     </Button>
                   ) : (
-                    <AdminUserTypeBadge userType={user.userType} />
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      No editable
+                    </span>
                   )}
                 </article>
               );


### PR DESCRIPTION
## Summary
- Remove the duplicated "Admin Admin" chip in Admin Users/Roles mobile rows.
- Keep the primary Admin role chip beside the username.
- Replace the right-side admin action slot with non-interactive "No editable" text, aligned with desktop semantics.
- Resolve QA1 F4 with `duplicateChipItems: 0`.

## Scope
- One production file only:
  - frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
- No backend/API/auth/DB changes.
- No dependency/lockfile/CI changes.
- No docs/audit or PNG changes.
- No docs/product changes.
- No globals.css changes.
- No frontend/next-env.d.ts changes.

## Validation
- pnpm --dir frontend exec playwright test e2e/admin-users-visual-quality-gate.spec.ts --project=chromium
  - F1 remains resolved: selectClipsMaxPx 0
  - F2 remains resolved: dateCellClipCount 0
  - F4 resolved: duplicateChipItems 0
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-mobile-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "admin users and roles populated fits without external or internal scroll"
- pnpm test
- pnpm build
- pnpm security:public-surface