### PR TITLE
feat(admin): add users roles search UI

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -8,9 +8,10 @@ import {
   useState,
   useTransition,
 } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Search } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
@@ -168,6 +169,8 @@ export function AdminUsersRolesReadOnlyCard() {
   const [snapshot, setSnapshot] = useState<AdminUsersRolesSnapshot | null>(null);
   const [userType, setUserType] = useState<AdminRoleUserType | "all">("all");
   const [role, setRole] = useState<AdminRoleUserRole | "all">("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [offset, setOffset] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [roleChangeMessage, setRoleChangeMessage] = useState<string | null>(null);
@@ -282,14 +285,34 @@ export function AdminUsersRolesReadOnlyCard() {
   // superset ceiling. The hook already clamps to [1, USERS_ROLES_SUPERSET_CAP].
   const effectiveLimit = rowsPerPage;
 
+  // 300ms debounce (matches the AdminClinicsManagementCard search pattern) so
+  // a fast typist doesn't fire one request per keystroke against 5000 rows.
+  // Skips the mount run: firing on mount would reset offset to 0 shortly after
+  // load and race a page-2 navigation that happens within the debounce window.
+  const isFirstSearchRender = useRef(true);
+  useEffect(() => {
+    if (isFirstSearchRender.current) {
+      isFirstSearchRender.current = false;
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchQuery.trim());
+      setOffset(0);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
   const query = useMemo(
     () => ({
       ...(userType !== "all" ? { userType } : {}),
       ...(role !== "all" ? { role } : {}),
+      ...(debouncedSearch ? { search: debouncedSearch } : {}),
       limit: effectiveLimit,
       offset,
     }),
-    [effectiveLimit, offset, role, userType],
+    [debouncedSearch, effectiveLimit, offset, role, userType],
   );
 
   const isMutatingRole = changingUserKey !== null;
@@ -496,6 +519,27 @@ export function AdminUsersRolesReadOnlyCard() {
           className="flex min-h-12 shrink-0 items-end gap-2 border-b border-vetneb-line/70 bg-muted/15 px-3 py-2 sm:px-4 md:min-h-10 md:py-1"
           aria-label="Filtros de usuarios y roles"
         >
+          <label className="grid min-w-0 flex-[2] gap-1 text-[11px] font-medium text-muted-foreground md:gap-0.5">
+            Buscar
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                className="h-8 pl-7 text-xs leading-none md:h-7"
+                placeholder="Buscar usuario o clínica"
+                value={searchQuery}
+                disabled={disableUserActions}
+                onChange={(event) => {
+                  resetFiltersFeedback();
+                  setSearchQuery(event.target.value);
+                }}
+                aria-label="Buscar usuario o clínica"
+              />
+            </div>
+          </label>
+
           <label className="grid min-w-0 flex-1 gap-1 text-[11px] font-medium text-muted-foreground sm:max-w-48 md:gap-0.5">
             Tipo usuario
             <select
@@ -715,6 +759,29 @@ export function AdminUsersRolesReadOnlyCard() {
             Actualizar
           </Button>
         </header>
+
+        <div className="shrink-0 border-b border-vetneb-line/70 bg-muted/15 px-2 py-1">
+          <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">
+            Buscar
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                className="h-9 pl-7 text-xs leading-none"
+                placeholder="Buscar usuario o clínica"
+                value={searchQuery}
+                disabled={disableUserActions}
+                onChange={(event) => {
+                  resetFiltersFeedback();
+                  setSearchQuery(event.target.value);
+                }}
+                aria-label="Buscar usuario o clínica"
+              />
+            </div>
+          </label>
+        </div>
 
         <div className="grid min-h-12 shrink-0 grid-cols-2 gap-2 overflow-hidden border-b border-vetneb-line/70 bg-muted/15 px-2 py-1">
           <label className="grid min-w-0 gap-0.5 text-[10px] font-medium text-muted-foreground">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1863,6 +1863,10 @@ export async function getAdminUsersRoles(
     query.set("role", params.role);
   }
 
+  if (params.search && params.search.trim()) {
+    query.set("search", params.search.trim());
+  }
+
   if (typeof params.limit === "number") {
     query.set("limit", String(params.limit));
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -286,6 +286,7 @@ export type AdminRoleUserSummary =
 export type AdminUsersRolesQuery = {
   userType?: AdminRoleUserType;
   role?: AdminRoleUserRole;
+  search?: string;
   limit?: number;
   offset?: number;
 };

--- a/test/frontend-admin-users-roles-card.test.ts
+++ b/test/frontend-admin-users-roles-card.test.ts
@@ -122,7 +122,7 @@ test("admin users roles card builds query and disables actions during mutations"
   assert.ok(source.includes("useAdaptiveItemsPerPage"));
   assert.ok(source.includes("const effectiveLimit = rowsPerPage;"));
   assert.ok(source.includes("offset"));
-  assert.ok(source.includes("[effectiveLimit, offset, role, userType]"));
+  assert.ok(source.includes("[debouncedSearch, effectiveLimit, offset, role, userType]"));
   assert.ok(source.includes("const isMutatingRole = changingUserKey !== null;"));
   assert.ok(source.includes("const disableUserActions = isPending || isMutatingRole;"));
 });

--- a/test/frontend-dashboard-action-feedback-focus-polish.test.ts
+++ b/test/frontend-dashboard-action-feedback-focus-polish.test.ts
@@ -132,7 +132,7 @@ test("PR-4 AdminSchemaHealthStatusCard Reintentar button has aria-busy and spinn
 test("PR-4 AdminUsersRolesReadOnlyCard Actualizar button has aria-busy and spinner", () => {
   const source = read(ADMIN_USERS_ROLES_CARD_PATH);
   assert.ok(source.includes("aria-busy={isPending ? true : undefined}"));
-  assert.ok(source.includes('import { Loader2 } from "lucide-react";'));
+  assert.ok(source.includes('import { Loader2, Search } from "lucide-react";'));
   assert.ok(source.includes('"Actualizando..."'));
 });
 


### PR DESCRIPTION
## Summary
- Add a compact Admin Users/Roles search control for desktop and mobile.
- Wire the search input to the already-merged `GET /api/admin/users-roles?search=...` backend support.
- Debounce search updates by 300ms, matching the Admin Clinics search pattern.
- Reset pagination offset to 0 when search changes.
- Omit empty/trimmed search from the request.
- Keep existing `userType`, `role`, `limit`, and `offset` behavior.

## Scope
- Frontend UI/client only.
- No backend/server changes.
- No DB schema or migrations.
- No auth/session changes.
- No dependency, lockfile, or CI changes.
- No docs/audit or docs/product changes.
- No status implementation.
- No jump-to-page implementation.
- No frontend/next-env.d.ts changes.

## Files
- frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
- frontend/src/lib/api.ts
- frontend/src/types/index.ts
- test/frontend-admin-users-roles-card.test.ts
- test/frontend-dashboard-action-feedback-focus-polish.test.ts

## Validation
- pnpm --dir frontend exec playwright test e2e/admin-users-visual-quality-gate.spec.ts --project=chromium
  - selectClipsMaxPx 0
  - dateCellClipCount 0
  - duplicateChipItems 0
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/admin-users-workspace-mobile-5000.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts --project=chromium --grep "admin users and roles populated fits without external or internal scroll"
- pnpm test
  - 2928 passed / 0 failed
- pnpm build
- pnpm --dir frontend build
- pnpm security:public-surface
  - PASS: no public devtools exposure findings

## Notes
- UI search integration depends on backend search API merged in #1259.
- Search is intentionally limited to text search only.
- Status and jump-to-page remain deferred.