### PR TITLE
docs(admin): close users roles quality search block

### DIFF
--- a/docs/implementation/admin-users-roles-quality-search-closeout.md
+++ b/docs/implementation/admin-users-roles-quality-search-closeout.md
@@ -1,0 +1,46 @@
+# Closeout — Admin Users/Roles Quality + Search
+
+Estado: **cerrado**. Base validada: `main @ 4374b37` (feat(admin): add users roles search UI, #1260).
+
+## 1. Estado final del bloque
+
+El bloque de calidad visual + búsqueda para Admin Users/Roles quedó resuelto y mergeado a `main`. No hay PRs abiertos pendientes de este bloque.
+
+## 2. PRs cerrados
+
+| PR | Título | Alcance |
+|---|---|---|
+| #1254 | PR-CAP-QA1 | Visual quality gate |
+| #1255 | PR-CAP-V1 | Desktop select clipping |
+| #1256 | PR-CAP-V2 | Date cell clipping/ellipsis |
+| #1257 | PR-CAP-V3 | Adaptive first paint desktop stability |
+| #1258 | PR-CAP-V4 | Mobile Admin/Admin duplicate chip |
+| #1259 | PR-CAP-T1a-BE | Backend search API |
+| #1260 | PR-CAP-T1a-UI | Frontend search UI |
+
+## 3. Qué quedó resuelto
+
+- `selectClipsMaxPx` = 0
+- `dateCellClipCount` = 0
+- `duplicateChipItems` = 0
+- First-paint desktop settle estabilizado
+- Búsqueda textual backend + UI conectada end-to-end
+- Contratos no-scroll (App Shell) preservados
+
+## 4. Qué queda diferido
+
+- T3 jump-to-page
+- Búsqueda avanzada/por status (si se decide abordar más adelante)
+- Cualquier settle residual mobile preexistente, si se decide tratarlo como bloque propio
+
+## 5. Validación final
+
+- `main @ 4374b37`
+- Backend CI: success (push a main)
+- Frontend CI: success (push a main)
+- Working tree: limpio
+- PRs abiertos del bloque: 0
+
+## 6. Scope del documento
+
+Closeout docs-only. Sin cambios funcionales, de código, tests, frontend, backend, dependencias, CI ni assets.


### PR DESCRIPTION
## Summary
- Add a docs-only closeout for the Admin Users/Roles quality and search block.
- Document completed PRs #1254–#1260.
- Record resolved visual quality findings:
  - selectClipsMaxPx 0
  - dateCellClipCount 0
  - duplicateChipItems 0
  - desktop first-paint settle stabilized
  - backend + UI text search connected
- Record deferred follow-ups:
  - T3 jump-to-page
  - possible advanced search/status work
  - possible residual mobile settle follow-up if treated as its own block

## Scope
- Docs-only.
- One new file:
  - docs/implementation/admin-users-roles-quality-search-closeout.md
- No code changes.
- No tests changes.
- No frontend/backend changes.
- No dependency, lockfile, CI, DB, migration, or PNG changes.

## Validation
- git diff --check
- staged scope guard confirms only the closeout document is included