### PR TITLE
feat(admin): add users jump to page

### DIFF
--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -172,6 +172,7 @@ export function AdminUsersRolesReadOnlyCard() {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [offset, setOffset] = useState(0);
+  const [jumpPageInput, setJumpPageInput] = useState("1");
   const [error, setError] = useState<string | null>(null);
   const [roleChangeMessage, setRoleChangeMessage] = useState<string | null>(null);
   const [changingUserKey, setChangingUserKey] = useState<string | null>(null);
@@ -451,6 +452,27 @@ export function AdminUsersRolesReadOnlyCard() {
     setOffset(offset + effectiveLimit);
   }
 
+  function goToPage(targetPage: number) {
+    const clampedPage = Math.min(Math.max(targetPage, 1), pageCount);
+    resetFiltersFeedback();
+    setOffset((clampedPage - 1) * effectiveLimit);
+  }
+
+  function handleJumpToPage() {
+    const parsedPage = Number.parseInt(jumpPageInput, 10);
+    if (!Number.isFinite(parsedPage)) {
+      setJumpPageInput(String(page));
+      return;
+    }
+    goToPage(parsedPage);
+  }
+
+  // Keep the jump input aligned with the current page whenever it changes
+  // externally (Anterior/Siguiente, filters, or a successful jump).
+  useEffect(() => {
+    setJumpPageInput(String(page));
+  }, [page]);
+
   return (
     <>
       <Card className="dashboard-surface hidden min-h-0 flex-1 flex-col overflow-hidden shadow-none hover:shadow-none md:flex">
@@ -716,6 +738,33 @@ export function AdminUsersRolesReadOnlyCard() {
             >
               Siguiente
             </Button>
+            <div className="hidden items-center gap-1 md:flex">
+              <Input
+                type="number"
+                min={1}
+                max={pageCount}
+                value={jumpPageInput}
+                disabled={disableUserActions || pageCount <= 1}
+                onChange={(event) => setJumpPageInput(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    handleJumpToPage();
+                  }
+                }}
+                aria-label="Ir a la página"
+                className="h-7 w-14 px-1.5 text-xs leading-none"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disableUserActions || pageCount <= 1}
+                onClick={handleJumpToPage}
+                className="h-7 px-2 text-xs"
+              >
+                Ir
+              </Button>
+            </div>
           </div>
         </footer>
       </CardContent>

--- a/test/frontend-admin-users-roles-card.test.ts
+++ b/test/frontend-admin-users-roles-card.test.ts
@@ -203,6 +203,32 @@ test("admin users roles card renders rows editable clinic actions and admin non-
   assert.ok(source.includes("No editable"));
 });
 
+test("admin users roles card supports desktop jump-to-page navigation", () => {
+  const source = read(ADMIN_USERS_ROLES_CARD_PATH);
+
+  assert.ok(source.includes('const [jumpPageInput, setJumpPageInput] = useState("1");'));
+  assert.ok(source.includes("function goToPage(targetPage: number)"));
+  assert.ok(
+    source.includes(
+      "const clampedPage = Math.min(Math.max(targetPage, 1), pageCount);",
+    ),
+  );
+  assert.ok(source.includes("resetFiltersFeedback();"));
+  assert.ok(
+    source.includes("setOffset((clampedPage - 1) * effectiveLimit);"),
+  );
+  assert.ok(source.includes("function handleJumpToPage()"));
+  assert.ok(
+    source.includes("const parsedPage = Number.parseInt(jumpPageInput, 10);"),
+  );
+  assert.ok(source.includes("if (!Number.isFinite(parsedPage)) {"));
+  assert.ok(source.includes("setJumpPageInput(String(page));"));
+  assert.ok(source.includes('aria-label="Ir a la página"'));
+  assert.ok(source.includes('if (event.key === "Enter") {'));
+  assert.ok(source.includes("handleJumpToPage();"));
+  assert.ok(source.includes("disabled={disableUserActions || pageCount <= 1}"));
+});
+
 test("admin users roles card keeps empty state and pagination without sensitive-field notice", () => {
   const source = read(ADMIN_USERS_ROLES_CARD_PATH);
   const removedUsersRolesEndpoint = "GET " + "/api/admin/users-roles";


### PR DESCRIPTION
## Summary
- add desktop jump-to-page control to Admin Usuarios/Roles server pagination
- clamp target page and preserve existing limit/offset contract
- add source test coverage for jump-to-page behavior

## Validation
- git diff --check
- node --experimental-strip-types --experimental-specifier-resolution=node --test test/frontend-admin-users-roles-card.test.ts
- pnpm typecheck
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint