### PR TITLE
feat(admin): adapt failed-login alerts server pagination to viewport

### DIFF
--- a/docs/implementation/admin-failed-login-alerts-server-adaptive-pagination.md
+++ b/docs/implementation/admin-failed-login-alerts-server-adaptive-pagination.md
@@ -1,0 +1,230 @@
+# R-01 — Admin Failed-Login Alerts server adaptive pagination
+
+## PR
+
+`feat(admin): adapt failed-login alerts server pagination to viewport`
+
+Tercer módulo Admin **servidor** (`limit`/`offset`, familia C) migrado a cardinalidad
+adaptativa Zero-Scroll, ejecutando **R-01** del roadmap rector
+(`docs/audit/final-global-vetneb-50-60-pr-roadmap.md`, Fase 1) con la política de
+PR-SRV-0 y la plantilla ya probada en Sesiones (#1221) y Usuarios/Roles (#1222).
+
+## Base
+
+- Rama de trabajo: `feat/admin-failed-login-alerts-server-adaptive-pagination`.
+- Base: `main @ 1f2dfdd feat(admin): add users jump to page (#1262)`.
+- Fecha: 2026-07-02.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-01, Fase 1, reglas §6/§8.
+2. `docs/implementation/server-adaptive-pagination-strategy.md` (PR-SRV-0) — módulo #7,
+   colapso con #12, política de offset (§6), anti-race (§7), límites (§8).
+3. `docs/implementation/admin-sessions-server-adaptive-pagination.md` (SRV-1) — plantilla.
+4. `docs/implementation/admin-users-roles-server-adaptive-pagination.md` (SRV-2) — trato de
+   contratos legacy (piso desktop) y decisión de no ampliar data-attributes.
+5. `docs/implementation/clinic-logistics-master-detail-workspace.md` — sólo para confirmar
+   que Logística summary está cerrada; **no se reabrió**.
+
+## Skills / modelo / esfuerzo
+
+| Rol | Valor |
+|---|---|
+| Principal | `vetneb-production-web-optimization-engineer` |
+| Complementaria | `vetneb-briefing-planificacion-diseno-desarrollo-pruebas` |
+| Complementaria | `vetneb-web-end-to-end-global` |
+| Complementaria | `vetneb-admin-dashboard-operational-actions` |
+| Guardrail | `vetneb-security-production-invariants` |
+| Modelo | Claude Fable 5 (`claude-fable-5`) |
+| Esfuerzo | Máximo |
+
+El ZIP/carpeta de skills **no** fue copiado, descomprimido, editado, versionado ni
+ejecutado dentro de `C:\PORTAL-VETNEB`.
+
+## Contrato anterior
+
+- Dos runtimes con dos fetch independientes:
+  - `AdminFailedLoginAlertsReadOnlyCard` (desktop, `PAGE_SIZE=5`, filtros
+    Superficie/Motivo, CSV, `total` expuesto), montada sólo en la tab desktop
+    "Alertas" de `ModuleTabs` (panel activo único).
+  - `AdminMobileFailedLoginSection` **interna** a `AdminMobileCommandModule`
+    (chip "Alertas" de la familia status mobile), `FAILED_LOGIN_PAGE_SIZE=10`,
+    `matchMedia("(max-width: 767px)")` como gate de fetch, sin filtros/CSV,
+    formatters duplicados.
+- `limit` fijo por dispositivo (5 vs 10); pager con constante fija.
+- Sin recompute de `offset`, sin guard anti-carrera.
+
+## Contrato nuevo
+
+- **Runtime único** en `AdminFailedLoginAlertsReadOnlyCard`: una sola fuente de datos,
+  filtros, `offset` y paginación. Renderiza dos presentaciones responsive
+  (`Card` desktop `hidden md:flex` primero en el DOM + sección mobile `md:hidden`),
+  nunca ambas visibles a la vez.
+- `FAILED_LOGIN_FALLBACK_ROWS = 5` (ex `PAGE_SIZE`) sólo como fallback pre-medición.
+- `FAILED_LOGIN_LIMIT_CAP = 25` como cota de payload del re-fetch (`maxItems` del hook).
+- `useAdaptiveItemsPerPage` mide el **contenedor de filas visible** (región de tabla
+  desktop o lista mobile, elegido por altura medida, no por `matchMedia`) y una
+  **fila real** (`ref` en la primera fila/ítem); el header de la tabla desktop se
+  descuenta (`FAILED_LOGIN_TABLE_HEADER_PX = 44`, el `h-11` por defecto de `TableHead`).
+- `effectiveLimit = rowsPerPage` (clamp `[1, 25]`); `query.limit = effectiveLimit`.
+- `page`/`pageCount` y Anterior/Siguiente usan `effectiveLimit`, no una constante fija.
+- Filtros server-side (Superficie/Motivo) resetean `offset` a 0 en su handler;
+  "Limpiar filtros" también. La cardinalidad (resize/zoom) nunca toca los filtros.
+- CSV conserva su contrato: sólo filtros, sin `limit`/`offset`.
+- Sin `matchMedia`, sin `FAILED_LOGIN_PAGE_SIZE`, sin `isMobileViewport`.
+- **Prop `presentation` estática por punto de montaje** (`"responsive"` default /
+  `"mobile"` en el chip del command module). Es señal de presentación permitida por
+  PR-SRV-0 §7.4 (nunca cardinalidad, nunca `matchMedia`): evita montar la tabla
+  desktop oculta (`dashboard-table-responsive`, `overflow-x: auto`) dentro del módulo
+  status mobile, cuyo contrato e2e escanea el computed style de **todos** los
+  descendientes en busca de overflow auto/scroll.
+
+## Estrategia elegida: RF debounced con cap 25
+
+PR-SRV-0 §5 daba dos opciones para Alertas login: "RF debounced (o OF cap 25 si el
+volumen bajo lo justifica)", con el paso previo de confirmar volumen real (R-01).
+
+**Verificación read-only ejecutada:** `login_failed_attempts` sólo recibe inserts
+(`server/db.ts` → `insert(loginFailedAttempts)`); **no existe ninguna purga, retención
+ni job de limpieza** en `server/**`. El volumen crece sin cota con cada intento fallido
+(incluye tormentas de fuerza bruta) → "volumen bajo" **no es confirmable** desde el
+repo y puede dejar de ser cierto en cualquier incidente. Por PR-SRV-0 §8.3 (datasets de
+alto volumen no usan over-fetch), se elige **RF debounced**:
+
+- `limit` derivado exacto de la medición (`effectiveLimit = rowsPerPage`), nunca un
+  superset por encima de lo visible;
+- cap 25 (§8.1) como cota superior de payload;
+- re-fetch sólo cuando la medición **cambia** (debounce por `requestAnimationFrame` +
+  comparación de igualdad `measurementsEqual`; el hook global sólo cambia `rowsPerPage`
+  si el valor derivado difiere);
+- request-id anti-carrera (idéntico a SRV-1/2).
+
+Mecánicamente es la misma plantilla que Sesiones/Usuarios; la diferencia doctrinal es
+que el cap es cota RF de payload, no techo de superset OF. Backend: el endpoint
+normaliza `limit` con `MAX_LIST_LIMIT=100` (`server/lib/list-pagination.ts`) → cap 25
+entra sin ningún cambio de API.
+
+## Cómo se mide `rowsPerPage`
+
+Igual que SRV-1: refs de estado (`setDesktopBodyNode`/`setMobileBodyNode` +
+`setDesktopRowNode`/`setMobileRowNode`), `ResizeObserver` agenda con
+`requestAnimationFrame`, la región visible se elige por altura medida (mobile primero,
+desktop después), la fila real medida reemplaza el fallback
+(`FAILED_LOGIN_ROW_HEIGHT_FALLBACK_PX = 48`, celdas `p-3.5` de dos líneas), y el header
+de tabla desktop se descuenta. `minItems = 1` en ambas presentaciones: **no se replica
+el piso desktop de Users/Roles** porque ningún contrato legacy exige N filas exactas
+para Alertas (verificado: ninguna spec e2e ni test pinnea conteos fijos desktop de esta
+card; el fixture poblado ni siquiera sirve el endpoint).
+
+## Cómo se recomputa `offset`
+
+PR-SRV-0 §6, idéntico a SRV-1/2:
+
+```
+nextOffset = Math.floor(currentOffset / effectiveLimit) * effectiveLimit;
+if (total != null) {
+  lastValidOffset = Math.max(0, (Math.ceil(total / effectiveLimit) - 1) * effectiveLimit);
+  nextOffset = Math.min(nextOffset, lastValidOffset);
+}
+nextOffset = Math.max(0, nextOffset);
+```
+
+`total` se lee de `snapshotRef` (última respuesta; el endpoint lo expone — subgrupo 1).
+Los filtros resetean `offset` a 0 aparte.
+
+## Cómo se evita la carrera
+
+- **Request id** (`latestRequestRef`): cada carga incrementa el id; una respuesta cuyo
+  id ya no es el vigente se descarta (éxito y error).
+- **Debounce de medición**: rAF + `measurementsEqual`; sin ráfaga de queries en
+  resize/zoom.
+- **Fallback estable**: sin contenedor medido, el hook devuelve el fallback (5) y no
+  re-fetchea por cardinalidad; loading/empty/error tienen geometría estable.
+
+## Qué shim mobile queda
+
+`AdminMobileCommandModule` **no** se reduce a `return null` (a diferencia de
+`AdminMobileSessionsModule`/`AdminMobileUsersModule`): sólo su chip "Alertas" era
+failed-login; Resumen y Actividad son contenido propio del command center mobile.
+El colapso "si corresponde" del roadmap se resolvió así:
+
+- eliminados de `AdminMobileCommandModule`: `AdminMobileFailedLoginSection`,
+  `FAILED_LOGIN_PAGE_SIZE`, `matchMedia`, `getAdminFailedLoginAlerts`, formatters y
+  tipos duplicados, `AdminMobileOpsPager` import;
+- el chip "Alertas" monta `<AdminFailedLoginAlertsReadOnlyCard presentation="mobile" />`
+  (lazy: `AdminMobileStatusModule` sólo monta la sección activa, y `ModuleTabs` sólo el
+  panel activo → nunca hay doble fetch);
+- selectores e2e preservados: `data-admin-mobile-status-item="true"` por fila,
+  `AdminMobileOpsPager` con `aria-label="Paginación de intentos fallidos"`, botón
+  "Actualizar".
+- **Sin data attributes nuevos** (decisión SRV-2): la medición es por `ref` y no se
+  amplía la superficie DevTools (además `login`/`failed` en nombres `data-*` no aportan).
+
+La limpieza final de shims sigue agendada en R-09 (este módulo no deja shim `return null`).
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx` — runtime único.
+- `frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx` — colapso de la sección
+  failed-login duplicada; chip monta la card.
+- `test/frontend-admin-failed-login-alerts-card.test.ts` — source-contract alineado
+  (autorizado: test del módulo) al contrato adaptativo + guards de colapso.
+- `frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts` — **sólo** las partes de
+  Alertas: mock 13→40 (página 2 existe para cualquier fit ≤ 25) y el test dedicado pasa
+  de "exactamente 10" al contrato adaptativo (fit asentado > fallback, ≤ cap, última
+  fila dentro del content band, página 2 navegable). *Nota de desvío:* el roadmap
+  nombraba "la spec e2e admin-mobile-ops"; el bloque real de Alertas vive en la spec
+  **status** (el chip es familia status, no ops) — es el bloque e2e propio equivalente.
+  Los bloques de otros módulos quedaron intactos.
+- `docs/implementation/admin-failed-login-alerts-server-adaptive-pagination.md` — este doc.
+
+## Validaciones ejecutadas
+
+PNPM 10.8.1 (coincide con `packageManager`).
+
+- `node --test test/frontend-admin-failed-login-alerts-card.test.ts` — 20/20.
+- `pnpm test` — 2939/2939.
+- `pnpm typecheck:test` — OK.
+- `pnpm security:public-surface` — PASS (sólo marcadores server-only esperados en
+  `frontend/src/proxy.ts`).
+- `pnpm --dir frontend lint` — OK.
+- `pnpm --dir frontend typecheck` — OK.
+- `pnpm --dir frontend build` — OK.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-status-modules-no-scroll.spec.ts`
+  — 23/23 (bloque propio de Alertas + loops de chips con el colapso).
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts
+  e2e/dashboard-viewport-zoom-adaptability.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts
+  e2e/dashboard-global-masked-master-detail.spec.ts` — 97/97.
+
+`frontend/next-env.d.ts` fue regenerado por Playwright/next dev durante los e2e y se
+restauró (`git checkout --`) antes del diff review, por estar fuera de scope.
+
+## Riesgos residuales
+
+- **Flake medición↔fetch (P2):** primer paint con fallback 5 (menos filas que el fit
+  real) → nunca overflow antes del ajuste; el test dedicado espera el asentamiento
+  (conteo estable > fallback) antes de paginar. Mitigado con `toPass`/tolerancias.
+- **Altura de fila representativa:** se mide la primera fila; `safetyGap` del hook
+  sesga a subestimar (seguro). Filas desktop con `user agent` largo truncan (`truncate`),
+  no crecen.
+- **Doble instancia teórica:** la card monta una instancia por punto de montaje
+  (tab desktop / chip mobile); nunca coexisten visibles ni fetchean a la vez
+  (panel/sección activos únicos + CSS breakpoints). Aceptado y documentado.
+- **QA manual pendiente:** iOS/Android real y zoom físico 100–175 % siguen siendo
+  obligatorios antes de cualquier gate bloqueante (PR-SRV-0 §10.5).
+
+## Fuera de scope (no tocado)
+
+- Otros módulos Admin (`AdminClinicsManagementCard`, `AdminReportsCard`,
+  `AdminParticularTokensCard`, `AdminAuditCard`, Sesiones, Usuarios/Roles).
+- Backend/API/auth/DB/migrations (verificación de `limit` fue sólo lectura).
+- CI/workflows, deps/lockfiles, snapshots, `globals.css`.
+- Rutas Clínica/Particular/Público; Logística summary (cerrada, no reabierta).
+- R-02..R-09 (no se adelantó ningún PR posterior).
+
+## Confirmaciones
+
+- Un solo módulo Admin tocado: Alertas login (+ su colapso mobile).
+- No `matchMedia` como cardinalidad; `PAGE_SIZE` sólo fallback; offset recomputado;
+  anti-race por request-id.
+- No se hizo `git add`/`commit`/`push`/`gh pr create`.

--- a/frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-status-modules-no-scroll.spec.ts
@@ -65,7 +65,9 @@ const STATUS_MODULES: StatusModule[] = [
   },
 ];
 
-const MOCK_FAILED_LOGIN_ALERTS = Array.from({ length: 13 }, (_, index) => ({
+// 40 alerts so a second page exists for any adaptive fit (RF cap 25): the
+// failed-login list is now sized by the measured viewport, not a fixed 10.
+const MOCK_FAILED_LOGIN_ALERTS = Array.from({ length: 40 }, (_, index) => ({
   id: 6100 + index,
   surface: (["admin", "clinic", "particular"] as const)[index % 3],
   username: index % 4 === 0 ? null : `intento_${index}`,
@@ -74,8 +76,13 @@ const MOCK_FAILED_LOGIN_ALERTS = Array.from({ length: 13 }, (_, index) => ({
   )[index % 3],
   ipAddress: `203.0.113.${10 + index}`,
   userAgent: "Mozilla/5.0 (e2e-status-module)",
-  createdAt: `2026-06-${String(10 + index).padStart(2, "0")}T09:30:00.000Z`,
+  createdAt: `2026-06-${String((index % 28) + 1).padStart(2, "0")}T09:30:00.000Z`,
 }));
+
+// Pre-measurement fallback and re-fetch cap of the adaptive failed-login
+// contract (mirrors AdminFailedLoginAlertsReadOnlyCard).
+const FAILED_LOGIN_FALLBACK_ROWS = 5;
+const FAILED_LOGIN_LIMIT_CAP = 25;
 
 const STATUS_SNAPSHOT_PHASE =
   process.env.STATUS_SNAPSHOT_PHASE === "before" ? "before" : "after";
@@ -439,7 +446,7 @@ for (const moduleSpec of STATUS_MODULES) {
   });
 }
 
-test("Admin mobile Alertas chip shows 10 failed-login alerts per page", async ({
+test("Admin mobile Alertas chip paginates failed-login alerts by measured fit", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -455,12 +462,35 @@ test("Admin mobile Alertas chip shows 10 failed-login alerts per page", async ({
   const panel = moduleRoot.locator('[data-admin-mobile-status-panel="alertas"]');
   const items = panel.locator('[data-admin-mobile-status-item="true"]');
   await expect(items.first()).toBeVisible({ timeout: 10_000 });
-  await expect(items).toHaveCount(10);
 
+  // Cardinality is measured (Zero-Scroll adaptive), not a fixed 10. At
+  // 390x844 the measured fit is strictly above the pre-measurement fallback
+  // (the legacy fixed mobile page already fit 10 rows here), so waiting for
+  // the count to settle past the fallback pins the settled adaptive state and
+  // absorbs the measurement -> re-fetch transitions.
+  let settledCount = -1;
+  await expect(async () => {
+    const current = await items.count();
+    const stable = current === settledCount;
+    settledCount = current;
+    expect(current).toBeGreaterThan(FAILED_LOGIN_FALLBACK_ROWS);
+    expect(stable).toBe(true);
+  }).toPass({ timeout: 15_000, intervals: [400, 600, 800] });
+  expect(settledCount).toBeLessThanOrEqual(FAILED_LOGIN_LIMIT_CAP);
+
+  // Every rendered row fits the content band (no clipping under the pager).
+  await expectInsideContentBand(
+    page,
+    items.last(),
+    { name: "iphone-standard-390x844", width: 390, height: 844 },
+    "alertas last item",
+  );
+
+  // With 40 mocked alerts a second page always exists for any measured fit.
   const pager = panel.getByRole("navigation", { name: "Paginación de intentos fallidos" });
-  await expect(pager.getByText("Pág. 1 / 2")).toBeVisible();
+  await expect(pager.getByText(/Pág\. 1 \/ \d+/)).toBeVisible();
   await pager.getByRole("button", { name: "Siguiente" }).click();
 
-  await expect(items).toHaveCount(3);
-  await expect(pager.getByText("Pág. 2 / 2")).toBeVisible();
+  await expect(pager.getByText(/Pág\. 2 \/ \d+/)).toBeVisible();
+  await expect(items.first()).not.toContainText("#6100");
 });

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { Loader2 } from "lucide-react";
 import { PublicExternalControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +30,7 @@ import {
   buildAdminFailedLoginAlertsCsvUrl,
   getAdminFailedLoginAlerts,
 } from "@/lib/api";
+import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";
 import { formatDateTime } from "@/lib/utils";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { LoadingState } from "@/components/dashboard/LoadingState";
@@ -31,8 +39,35 @@ import type {
   AdminFailedLoginAlertsSnapshot,
   AdminFailedLoginAlertSurface,
 } from "@/types";
+import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
 
-const PAGE_SIZE = 5;
+// Server pagination is now sized by the measured rows container (Zero-Scroll
+// adaptive contract). The legacy PAGE_SIZE survives only as the
+// pre-measurement fallback.
+const FAILED_LOGIN_FALLBACK_ROWS = 5;
+// Re-fetch payload bound: `login_failed_attempts` only grows (no retention
+// job), so the strategy is debounced re-fetch with a derived limit, never an
+// unbounded superset. The effective `limit` never exceeds this cap.
+const FAILED_LOGIN_LIMIT_CAP = 25;
+// Default `TableHead` height (`h-11`), discounted from the measured desktop
+// region so the row math never counts the header as a data row.
+const FAILED_LOGIN_TABLE_HEADER_PX = 44;
+// Fallback item height used until a real row is measured.
+const FAILED_LOGIN_ROW_HEIGHT_FALLBACK_PX = 48;
+
+type Measurement = {
+  containerNode: HTMLElement | null;
+  rowHeightPx: number;
+  headerHeightPx: number;
+};
+
+function measurementsEqual(a: Measurement, b: Measurement) {
+  return (
+    a.containerNode === b.containerNode &&
+    a.rowHeightPx === b.rowHeightPx &&
+    a.headerHeightPx === b.headerHeightPx
+  );
+}
 
 function formatSurface(value: AdminFailedLoginAlertSurface) {
   if (value === "admin") return "Admin";
@@ -66,7 +101,20 @@ function formatNullable(value: string | null) {
   return value && value.trim() ? value : "—";
 }
 
-export function AdminFailedLoginAlertsReadOnlyCard() {
+type AdminFailedLoginAlertsReadOnlyCardProps = {
+  /**
+   * Static presentation signal per mount point (never a media query, never a
+   * cardinality source). The default renders the responsive pair (desktop
+   * Card + mobile section, CSS-switched). The Admin mobile command module
+   * mounts `"mobile"` so its no-scroll contract never sees the hidden desktop
+   * table wrapper (`dashboard-table-responsive`, overflow-x auto).
+   */
+  presentation?: "responsive" | "mobile";
+};
+
+export function AdminFailedLoginAlertsReadOnlyCard({
+  presentation = "responsive",
+}: AdminFailedLoginAlertsReadOnlyCardProps = {}) {
   const [snapshot, setSnapshot] =
     useState<AdminFailedLoginAlertsSnapshot | null>(null);
   const [surface, setSurface] = useState<
@@ -79,14 +127,112 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
+  // One collapsed runtime feeds both presentations, so the visible container
+  // (desktop table region or mobile list region) drives a single cardinality.
+  const [desktopBodyNode, setDesktopBodyNode] = useState<HTMLElement | null>(
+    null,
+  );
+  const [mobileBodyNode, setMobileBodyNode] = useState<HTMLElement | null>(null);
+  const [desktopRowNode, setDesktopRowNode] = useState<HTMLElement | null>(null);
+  const [mobileRowNode, setMobileRowNode] = useState<HTMLElement | null>(null);
+  const [measurement, setMeasurement] = useState<Measurement>({
+    containerNode: null,
+    rowHeightPx: FAILED_LOGIN_ROW_HEIGHT_FALLBACK_PX,
+    headerHeightPx: 0,
+  });
+
+  const latestRequestRef = useRef(0);
+  const snapshotRef = useRef<AdminFailedLoginAlertsSnapshot | null>(null);
+
+  useEffect(() => {
+    snapshotRef.current = snapshot;
+  }, [snapshot]);
+
+  useLayoutEffect(() => {
+    const nodes = [
+      desktopBodyNode,
+      mobileBodyNode,
+      desktopRowNode,
+      mobileRowNode,
+    ].filter((node): node is HTMLElement => node !== null);
+    if (nodes.length === 0) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const recompute = () => {
+      frame = null;
+
+      const mobileHeight = mobileBodyNode?.getBoundingClientRect().height ?? 0;
+      if (mobileHeight > 0 && mobileBodyNode) {
+        const rowHeight = mobileRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: mobileBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : FAILED_LOGIN_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: 0,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+        return;
+      }
+
+      const desktopHeight = desktopBodyNode?.getBoundingClientRect().height ?? 0;
+      if (desktopHeight > 0 && desktopBodyNode) {
+        const rowHeight = desktopRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: desktopBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : FAILED_LOGIN_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: FAILED_LOGIN_TABLE_HEADER_PX,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+      }
+    };
+
+    const scheduleRecompute = () => {
+      if (frame === null) {
+        frame = requestAnimationFrame(recompute);
+      }
+    };
+
+    const observer = new ResizeObserver(scheduleRecompute);
+    nodes.forEach((node) => observer.observe(node));
+    scheduleRecompute();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [desktopBodyNode, mobileBodyNode, desktopRowNode, mobileRowNode]);
+
+  const { itemsPerPage: rowsPerPage } = useAdaptiveItemsPerPage({
+    containerNode: measurement.containerNode,
+    fallbackItems: FAILED_LOGIN_FALLBACK_ROWS,
+    itemHeightPx: measurement.rowHeightPx,
+    headerHeightPx: measurement.headerHeightPx,
+    minItems: 1,
+    maxItems: FAILED_LOGIN_LIMIT_CAP,
+  });
+
+  // Effective server page size: the measured rows, bounded by the re-fetch
+  // cap. The hook already clamps to [1, FAILED_LOGIN_LIMIT_CAP].
+  const effectiveLimit = rowsPerPage;
+
   const query = useMemo(
     () => ({
       ...(surface !== "all" ? { surface } : {}),
       ...(reason !== "all" ? { reason } : {}),
-      limit: PAGE_SIZE,
+      limit: effectiveLimit,
       offset,
     }),
-    [offset, reason, surface],
+    [effectiveLimit, offset, reason, surface],
   );
 
   const csvUrl = useMemo(
@@ -107,12 +253,17 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
   function loadFailedLoginAlerts() {
     setError(null);
 
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+
     startTransition(() => {
       void (async () => {
         try {
           const result = await getAdminFailedLoginAlerts(query);
+          if (requestId !== latestRequestRef.current) return;
           setSnapshot(result);
         } catch (err) {
+          if (requestId !== latestRequestRef.current) return;
           setError(
             err instanceof Error
               ? err.message
@@ -123,18 +274,64 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
     });
   }
 
+  // Recompute offset when the effective limit changes so the same first record
+  // stays visible; clamp against the known total.
+  const previousLimitRef = useRef(effectiveLimit);
+  useEffect(() => {
+    if (previousLimitRef.current === effectiveLimit) {
+      return;
+    }
+    previousLimitRef.current = effectiveLimit;
+
+    setOffset((currentOffset) => {
+      let nextOffset = Math.floor(currentOffset / effectiveLimit) * effectiveLimit;
+      const total = snapshotRef.current?.total;
+      if (typeof total === "number") {
+        const lastValidOffset = Math.max(
+          0,
+          (Math.ceil(total / effectiveLimit) - 1) * effectiveLimit,
+        );
+        nextOffset = Math.min(nextOffset, lastValidOffset);
+      }
+      nextOffset = Math.max(0, nextOffset);
+      return nextOffset === currentOffset ? currentOffset : nextOffset;
+    });
+  }, [effectiveLimit]);
+
   useEffect(() => {
     loadFailedLoginAlerts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
+  const alerts = snapshot?.failedLoginAlerts ?? [];
   const hasPreviousPage = offset > 0;
   const hasNextPage = snapshot
     ? offset + snapshot.failedLoginAlerts.length < snapshot.total
     : false;
+  const page = Math.floor(offset / effectiveLimit) + 1;
+  const pageCount = snapshot
+    ? Math.max(1, Math.ceil(snapshot.total / effectiveLimit))
+    : 1;
+  const rangeStart = alerts.length ? offset + 1 : 0;
+  const rangeEnd = offset + alerts.length;
+
+  function goToPreviousPage() {
+    setOffset(Math.max(offset - effectiveLimit, 0));
+  }
+
+  function goToNextPage() {
+    setOffset(offset + effectiveLimit);
+  }
+
+  const showDesktopPresentation = presentation !== "mobile";
 
   return (
-    <Card id="failed-login-alerts" className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
+    <>
+      {showDesktopPresentation ? (
+      <Card
+        id="failed-login-alerts"
+        className="dashboard-surface hidden min-h-0 flex-1 flex-col overflow-hidden md:flex"
+      >
       <CardHeader className="flex flex-col gap-3 border-b border-vetneb-line/70 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <CardTitle className="text-base">
@@ -171,7 +368,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
       </CardHeader>
 
       <CardContent className="flex min-h-0 flex-1 flex-col gap-3 pt-4">
-        <div className="dashboard-filter-stats-grid">
+        <div className="dashboard-filter-stats-grid shrink-0">
           <div className="surface-soft">
             <p className="text-xs text-muted-foreground">Total filtrado</p>
             <p className="mt-1 text-2xl font-bold text-vetneb-ink">
@@ -220,7 +417,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           <div className="surface-soft">
             <p className="text-xs text-muted-foreground">Página</p>
             <p className="mt-1 text-sm font-semibold text-vetneb-ink">
-              {Math.floor(offset / PAGE_SIZE) + 1}
+              {page}
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
               {snapshot
@@ -236,79 +433,84 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           </div>
         ) : null}
 
-        <div className="dashboard-table-responsive min-h-0 flex-1">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>ID</TableHead>
-                <TableHead>Superficie</TableHead>
-                <TableHead>Usuario</TableHead>
-                <TableHead>Motivo</TableHead>
-                <TableHead>IP</TableHead>
-                <TableHead>User agent</TableHead>
-                <TableHead>Fecha</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {snapshot?.failedLoginAlerts.length ? (
-                snapshot.failedLoginAlerts.map((alert) => (
-                  <TableRow key={alert.id}>
-                    <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-                      #{alert.id}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={getSurfaceVariant(alert.surface)}>
-                        {formatSurface(alert.surface)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-vetneb-ink/88">
-                      {formatNullable(alert.username)}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={getReasonVariant(alert.reason)}>
-                        {formatReason(alert.reason)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      {formatNullable(alert.ipAddress)}
-                    </TableCell>
-                    <TableCell className="max-w-xs truncate text-xs text-muted-foreground">
-                      {formatNullable(alert.userAgent)}
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      {formatDateTime(alert.createdAt)}
+        <div ref={setDesktopBodyNode} className="min-h-0 flex-1">
+          <div className="dashboard-table-responsive">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Superficie</TableHead>
+                  <TableHead>Usuario</TableHead>
+                  <TableHead>Motivo</TableHead>
+                  <TableHead>IP</TableHead>
+                  <TableHead>User agent</TableHead>
+                  <TableHead>Fecha</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {snapshot?.failedLoginAlerts.length ? (
+                  snapshot.failedLoginAlerts.map((alert, index) => (
+                    <TableRow
+                      key={alert.id}
+                      ref={index === 0 ? setDesktopRowNode : undefined}
+                    >
+                      <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                        #{alert.id}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getSurfaceVariant(alert.surface)}>
+                          {formatSurface(alert.surface)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-vetneb-ink/88">
+                        {formatNullable(alert.username)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={getReasonVariant(alert.reason)}>
+                          {formatReason(alert.reason)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {formatNullable(alert.ipAddress)}
+                      </TableCell>
+                      <TableCell className="max-w-xs truncate text-xs text-muted-foreground">
+                        {formatNullable(alert.userAgent)}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {formatDateTime(alert.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : isPending ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="p-3">
+                      <LoadingState
+                        variant="table"
+                        compact
+                        rows={3}
+                        className="border-0 bg-transparent shadow-none rounded-none"
+                      />
                     </TableCell>
                   </TableRow>
-                ))
-              ) : isPending ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="p-3">
-                    <LoadingState
-                      variant="table"
-                      compact
-                      rows={3}
-                      className="border-0 bg-transparent shadow-none rounded-none"
-                    />
-                  </TableCell>
-                </TableRow>
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={7} className="clinical-table-state">
-                    {error ? (
-                      "No se pudieron cargar los intentos fallidos."
-                    ) : (
-                      <EmptyState
-                        title="Sin intentos fallidos"
-                        description="No hay intentos fallidos para los filtros seleccionados."
-                        size="sm"
-                        className="border-0 bg-transparent"
-                      />
-                    )}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={7} className="clinical-table-state">
+                      {error ? (
+                        "No se pudieron cargar los intentos fallidos."
+                      ) : (
+                        <EmptyState
+                          title="Sin intentos fallidos"
+                          description="No hay intentos fallidos para los filtros seleccionados."
+                          size="sm"
+                          className="border-0 bg-transparent"
+                        />
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
         </div>
 
         <div className="dashboard-table-pagination shrink-0">
@@ -317,7 +519,7 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
               type="button"
               variant="outline"
               disabled={!hasPreviousPage || isPending}
-              onClick={() => setOffset(Math.max(offset - PAGE_SIZE, 0))}
+              onClick={goToPreviousPage}
               className="flex-1 sm:flex-none"
             >
               Anterior
@@ -327,14 +529,14 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
               aria-live="polite"
               aria-atomic="true"
             >
-              Pág.&nbsp;{Math.floor(offset / PAGE_SIZE) + 1}
-              {snapshot ? ` / ${Math.max(1, Math.ceil(snapshot.total / PAGE_SIZE))}` : null}
+              Pág.&nbsp;{page}
+              {snapshot ? ` / ${pageCount}` : null}
             </span>
             <Button
               type="button"
               variant="outline"
               disabled={!hasNextPage || isPending}
-              onClick={() => setOffset(offset + PAGE_SIZE)}
+              onClick={goToNextPage}
               className="flex-1 sm:flex-none"
             >
               Siguiente
@@ -342,6 +544,101 @@ export function AdminFailedLoginAlertsReadOnlyCard() {
           </div>
         </div>
       </CardContent>
-    </Card>
+      </Card>
+      ) : null}
+
+      <section
+        aria-label="Intentos fallidos de login"
+        className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden md:hidden"
+      >
+        <div className="flex shrink-0 items-center justify-between gap-2">
+          <p className="min-w-0 truncate text-xs font-semibold text-vetneb-ink">
+            {snapshot ? `${snapshot.total} intentos fallidos` : "Intentos fallidos"}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 px-2 text-xs"
+            onClick={loadFailedLoginAlerts}
+            disabled={isPending}
+            aria-busy={isPending ? true : undefined}
+          >
+            {isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : null}
+            Actualizar
+          </Button>
+        </div>
+
+        <div
+          ref={setMobileBodyNode}
+          className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
+        >
+          {alerts.length ? (
+            alerts.map((alert, index) => (
+              <article
+                key={alert.id}
+                ref={index === 0 ? setMobileRowNode : undefined}
+                data-admin-mobile-status-item="true"
+                className="flex min-h-9 items-center gap-2 overflow-hidden px-2.5 py-0.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <Badge
+                      variant={getSurfaceVariant(alert.surface)}
+                      className="h-5 px-1.5 text-[10px]"
+                    >
+                      {formatSurface(alert.surface)}
+                    </Badge>
+                    <Badge
+                      variant={getReasonVariant(alert.reason)}
+                      className="h-5 px-1.5 text-[10px]"
+                    >
+                      {formatReason(alert.reason)}
+                    </Badge>
+                    <span className="min-w-0 truncate text-xs font-medium text-vetneb-ink">
+                      {alert.username && alert.username.trim()
+                        ? alert.username
+                        : "Sin usuario"}
+                    </span>
+                  </div>
+                  <p className="truncate text-[10px] text-muted-foreground">
+                    {alert.ipAddress ?? "IP —"} · {formatDateTime(alert.createdAt)}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                  #{alert.id}
+                </span>
+              </article>
+            ))
+          ) : (
+            <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted-foreground">
+              {error
+                ? "No se pudieron cargar los intentos fallidos."
+                : isPending
+                  ? "Cargando intentos fallidos..."
+                  : "Sin intentos fallidos registrados."}
+            </div>
+          )}
+        </div>
+
+        <AdminMobileOpsPager
+          ariaLabel="Paginación de intentos fallidos"
+          page={page}
+          pageCount={pageCount}
+          rangeLabel={
+            alerts.length
+              ? `${rangeStart}–${rangeEnd} de ${snapshot?.total ?? 0}`
+              : "Sin intentos"
+          }
+          previousDisabled={!hasPreviousPage}
+          nextDisabled={!hasNextPage}
+          disabled={isPending}
+          onPrevious={goToPreviousPage}
+          onNext={goToNextPage}
+        />
+      </section>
+    </>
   );
 }

--- a/frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx
+++ b/frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx
@@ -1,19 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
-import { Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { getAdminFailedLoginAlerts } from "@/lib/api";
-import { formatDateTime } from "@/lib/utils";
 import { cn } from "@/lib/utils";
-import type {
-  AdminFailedLoginAlertReason,
-  AdminFailedLoginAlertSurface,
-  AdminFailedLoginAlertsSnapshot,
-} from "@/types";
+import { AdminFailedLoginAlertsReadOnlyCard } from "./AdminFailedLoginAlertsReadOnlyCard";
 import { AdminMobileStatusModule } from "./AdminMobileStatusModule";
-import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
 import { AdminOverviewQuickLinks } from "./AdminOverviewQuickLinks";
 
 type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
@@ -34,181 +24,6 @@ type AdminMobileCommandModuleProps = {
   hasSystemHealthFetchError: boolean;
   recentActivity: RecentAdminActivity | null;
 };
-
-const FAILED_LOGIN_PAGE_SIZE = 10;
-
-function formatSurface(value: AdminFailedLoginAlertSurface) {
-  if (value === "admin") return "Admin";
-  if (value === "clinic") return "Clínica";
-  return "Particular";
-}
-
-function formatReason(value: AdminFailedLoginAlertReason) {
-  if (value === "missing_credentials") return "Credenciales faltantes";
-  if (value === "invalid_credentials") return "Credenciales inválidas";
-  return "Bloqueo temporal";
-}
-
-function getSurfaceVariant(value: AdminFailedLoginAlertSurface): BadgeVariant {
-  if (value === "admin") return "default";
-  if (value === "clinic") return "secondary";
-  return "outline";
-}
-
-function getReasonVariant(value: AdminFailedLoginAlertReason): BadgeVariant {
-  if (value === "rate_limited" || value === "invalid_credentials") {
-    return "secondary";
-  }
-  return "outline";
-}
-
-// Compact, paginated mobile view of the failed-login alerts (the desktop
-// "Alertas" tab table). Fetches lazily — only mounted when the chip is active —
-// and only on mobile so the hidden desktop copy never triggers a network call.
-function AdminMobileFailedLoginSection() {
-  const [isMobileViewport, setIsMobileViewport] = useState(false);
-  const [snapshot, setSnapshot] = useState<AdminFailedLoginAlertsSnapshot | null>(
-    null,
-  );
-  const [offset, setOffset] = useState(0);
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
-
-  const query = useMemo(
-    () => ({ limit: FAILED_LOGIN_PAGE_SIZE, offset }),
-    [offset],
-  );
-
-  function loadAlerts() {
-    if (!isMobileViewport) return;
-    setError(null);
-    startTransition(() => {
-      void (async () => {
-        try {
-          setSnapshot(await getAdminFailedLoginAlerts(query));
-        } catch (err) {
-          setError(
-            err instanceof Error
-              ? err.message
-              : "No se pudieron cargar los intentos fallidos.",
-          );
-        }
-      })();
-    });
-  }
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 767px)");
-    const syncViewport = () => setIsMobileViewport(mediaQuery.matches);
-    syncViewport();
-    mediaQuery.addEventListener("change", syncViewport);
-    return () => mediaQuery.removeEventListener("change", syncViewport);
-  }, []);
-
-  useEffect(() => {
-    if (!isMobileViewport) return;
-    loadAlerts();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMobileViewport, query]);
-
-  const alerts = snapshot?.failedLoginAlerts ?? [];
-  const total = snapshot?.total ?? 0;
-  const page = Math.floor(offset / FAILED_LOGIN_PAGE_SIZE) + 1;
-  const pageCount = snapshot
-    ? Math.max(1, Math.ceil(total / FAILED_LOGIN_PAGE_SIZE))
-    : 1;
-  const rangeStart = alerts.length ? offset + 1 : 0;
-  const rangeEnd = offset + alerts.length;
-  const hasNextPage = snapshot ? rangeEnd < total : false;
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
-      <div className="flex shrink-0 items-center justify-between gap-2">
-        <p className="min-w-0 truncate text-xs font-semibold text-vetneb-ink">
-          {snapshot ? `${total} intentos fallidos` : "Intentos fallidos"}
-        </p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-7 shrink-0 px-2 text-xs"
-          onClick={loadAlerts}
-          disabled={isPending || !isMobileViewport}
-          aria-busy={isPending ? true : undefined}
-        >
-          {isPending ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-          ) : null}
-          Actualizar
-        </Button>
-      </div>
-
-      <div className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75">
-        {alerts.length ? (
-          alerts.map((alert) => (
-            <article
-              key={alert.id}
-              data-admin-mobile-status-item="true"
-              className="flex min-h-9 items-center gap-2 overflow-hidden px-2.5 py-0.5"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <Badge
-                    variant={getSurfaceVariant(alert.surface)}
-                    className="h-5 px-1.5 text-[10px]"
-                  >
-                    {formatSurface(alert.surface)}
-                  </Badge>
-                  <Badge
-                    variant={getReasonVariant(alert.reason)}
-                    className="h-5 px-1.5 text-[10px]"
-                  >
-                    {formatReason(alert.reason)}
-                  </Badge>
-                  <span className="min-w-0 truncate text-xs font-medium text-vetneb-ink">
-                    {alert.username && alert.username.trim()
-                      ? alert.username
-                      : "Sin usuario"}
-                  </span>
-                </div>
-                <p className="truncate text-[10px] text-muted-foreground">
-                  {alert.ipAddress ?? "IP —"} · {formatDateTime(alert.createdAt)}
-                </p>
-              </div>
-              <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-                #{alert.id}
-              </span>
-            </article>
-          ))
-        ) : (
-          <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted-foreground">
-            {error
-              ? "No se pudieron cargar los intentos fallidos."
-              : isPending
-                ? "Cargando intentos fallidos..."
-                : "Sin intentos fallidos registrados."}
-          </div>
-        )}
-      </div>
-
-      <AdminMobileOpsPager
-        ariaLabel="Paginación de intentos fallidos"
-        page={page}
-        pageCount={pageCount}
-        rangeLabel={
-          alerts.length ? `${rangeStart}–${rangeEnd} de ${total}` : "Sin intentos"
-        }
-        previousDisabled={offset === 0}
-        nextDisabled={!hasNextPage}
-        disabled={isPending}
-        onPrevious={() =>
-          setOffset(Math.max(0, offset - FAILED_LOGIN_PAGE_SIZE))
-        }
-        onNext={() => setOffset(offset + FAILED_LOGIN_PAGE_SIZE)}
-      />
-    </div>
-  );
-}
 
 function MetricTile({
   label,
@@ -353,7 +168,13 @@ export function AdminMobileCommandModule({
         {
           id: "alertas",
           label: "Alertas",
-          content: <AdminMobileFailedLoginSection />,
+          // Collapsed duality: the failed-login alerts runtime (fetch, adaptive
+          // cardinality, offset, anti-race) lives in the read-only card, which
+          // renders its mobile presentation here. Mounted lazily — only when
+          // the chip is active — so the hidden desktop copy in ModuleTabs
+          // (active-panel-only) never double-fetches. `presentation` is a
+          // static per-mount signal, not a media-query/cardinality source.
+          content: <AdminFailedLoginAlertsReadOnlyCard presentation="mobile" />,
         },
       ]}
     />

--- a/test/frontend-admin-failed-login-alerts-card.test.ts
+++ b/test/frontend-admin-failed-login-alerts-card.test.ts
@@ -5,6 +5,8 @@ import test from "node:test";
 
 const ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH =
   "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx";
+const ADMIN_MOBILE_COMMAND_MODULE_PATH =
+  "frontend/src/app/dashboard/admin/AdminMobileCommandModule.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -17,22 +19,135 @@ test("admin failed login alerts card is client-side and imports required depende
   const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
 
   assert.ok(source.includes('"use client";'));
-  assert.ok(source.includes('import { useEffect, useMemo, useState, useTransition } from "react";'));
   assert.ok(source.includes('import { Badge } from "@/components/ui/badge";'));
   assert.ok(source.includes('import { Button } from "@/components/ui/button";'));
   assert.ok(source.includes('import { PublicExternalControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes("buildAdminFailedLoginAlertsCsvUrl"));
   assert.ok(source.includes("getAdminFailedLoginAlerts"));
   assert.ok(source.includes('import { formatDateTime } from "@/lib/utils";'));
+  assert.ok(source.includes('import { AdminMobileOpsPager } from "./AdminMobileOpsPager";'));
 });
 
-test("admin failed login alerts card keeps typed contracts and pagination size", () => {
+test("admin failed login alerts card keeps PAGE_SIZE only as fallback, not as the direct limit", () => {
   const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
 
-  assert.ok(source.includes("AdminFailedLoginAlertReason"));
-  assert.ok(source.includes("AdminFailedLoginAlertsSnapshot"));
-  assert.ok(source.includes("AdminFailedLoginAlertSurface"));
-  assert.ok(source.includes("const PAGE_SIZE = 5;"));
+  assert.ok(source.includes("const FAILED_LOGIN_FALLBACK_ROWS = 5;"));
+  assert.ok(source.includes("fallbackItems: FAILED_LOGIN_FALLBACK_ROWS,"));
+  assert.equal(source.includes("const PAGE_SIZE = 5;"), false);
+  assert.equal(source.includes("limit: PAGE_SIZE"), false);
+});
+
+test("admin failed login alerts card bounds the re-fetch limit at 25", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.ok(source.includes("const FAILED_LOGIN_LIMIT_CAP = 25;"));
+  assert.ok(source.includes("maxItems: FAILED_LOGIN_LIMIT_CAP,"));
+});
+
+test("admin failed login alerts card derives the effective limit from the adaptive hook", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";',
+    ),
+  );
+  assert.ok(source.includes("const { itemsPerPage: rowsPerPage } = useAdaptiveItemsPerPage({"));
+  assert.ok(source.includes("const effectiveLimit = rowsPerPage;"));
+  assert.ok(source.includes("limit: effectiveLimit,"));
+  assert.ok(source.includes("[effectiveLimit, offset, reason, surface]"));
+});
+
+test("admin failed login alerts card measures a real rows container per presentation", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.ok(source.includes("containerNode: measurement.containerNode,"));
+  assert.ok(source.includes("itemHeightPx: measurement.rowHeightPx,"));
+  assert.ok(source.includes("headerHeightPx: measurement.headerHeightPx,"));
+  assert.ok(source.includes("new ResizeObserver("));
+  assert.ok(source.includes("ref={index === 0 ? setDesktopRowNode : undefined}"));
+  assert.ok(source.includes("ref={index === 0 ? setMobileRowNode : undefined}"));
+  assert.ok(source.includes("ref={setDesktopBodyNode}"));
+  assert.ok(source.includes("ref={setMobileBodyNode}"));
+});
+
+test("admin failed login alerts card recomputes offset when the limit changes and clamps to total", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.ok(
+    source.includes(
+      "let nextOffset = Math.floor(currentOffset / effectiveLimit) * effectiveLimit;",
+    ),
+  );
+  assert.ok(source.includes("const total = snapshotRef.current?.total;"));
+  assert.ok(
+    source.includes(
+      "(Math.ceil(total / effectiveLimit) - 1) * effectiveLimit,",
+    ),
+  );
+  assert.ok(source.includes("nextOffset = Math.min(nextOffset, lastValidOffset);"));
+});
+
+test("admin failed login alerts card guards concurrent fetches with a request id", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.ok(source.includes("const latestRequestRef = useRef(0);"));
+  assert.ok(source.includes("const requestId = latestRequestRef.current + 1;"));
+  assert.ok(source.includes("latestRequestRef.current = requestId;"));
+  assert.ok(source.includes("if (requestId !== latestRequestRef.current) return;"));
+});
+
+test("admin failed login alerts card pages by the effective limit, not a fixed size", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.ok(source.includes("const page = Math.floor(offset / effectiveLimit) + 1;"));
+  assert.ok(
+    source.includes(
+      "Math.max(1, Math.ceil(snapshot.total / effectiveLimit))",
+    ),
+  );
+  assert.ok(source.includes("setOffset(Math.max(offset - effectiveLimit, 0));"));
+  assert.ok(source.includes("setOffset(offset + effectiveLimit);"));
+});
+
+test("admin failed login alerts card no longer uses matchMedia or a mobile page size", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  assert.equal(source.includes("matchMedia"), false);
+  assert.equal(source.includes("MOBILE_PAGE_SIZE"), false);
+  assert.equal(source.includes("FAILED_LOGIN_PAGE_SIZE"), false);
+  assert.equal(source.includes("isDesktopViewport"), false);
+  assert.equal(source.includes("isMobileViewport"), false);
+});
+
+test("admin failed login alerts card collapses the mobile duality into a single runtime", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+  const commandModule = read(ADMIN_MOBILE_COMMAND_MODULE_PATH);
+
+  // Desktop Card precedes the mobile section in the DOM (unscoped `.first()`
+  // desktop locators must resolve against the desktop node).
+  const desktopIndex = source.indexOf('id="failed-login-alerts"');
+  const mobileIndex = source.indexOf('data-admin-mobile-status-item="true"');
+  assert.ok(desktopIndex >= 0);
+  assert.ok(mobileIndex > desktopIndex);
+  assert.ok(source.includes("hidden min-h-0 flex-1 flex-col overflow-hidden md:flex"));
+  assert.ok(source.includes("md:hidden"));
+  assert.ok(source.includes('ariaLabel="Paginación de intentos fallidos"'));
+
+  // The presentation prop is a static per-mount signal, never matchMedia.
+  assert.ok(source.includes('presentation?: "responsive" | "mobile";'));
+  assert.ok(source.includes('presentation = "responsive",'));
+
+  // The command module keeps no failed-login data source of its own.
+  assert.equal(commandModule.includes("getAdminFailedLoginAlerts"), false);
+  assert.equal(commandModule.includes("FAILED_LOGIN_PAGE_SIZE"), false);
+  assert.equal(commandModule.includes("matchMedia"), false);
+  assert.equal(commandModule.includes("AdminMobileFailedLoginSection"), false);
+  assert.ok(
+    commandModule.includes(
+      '<AdminFailedLoginAlertsReadOnlyCard presentation="mobile" />',
+    ),
+  );
 });
 
 test("admin failed login alerts card keeps surface reason and nullable formatters", () => {
@@ -60,7 +175,6 @@ test("admin failed login alerts card keeps badge variants for surfaces and reaso
   assert.ok(source.includes("function getReasonVariant("));
   assert.ok(source.includes('if (value === "rate_limited") return "secondary";'));
   assert.ok(source.includes('if (value === "invalid_credentials") return "secondary";'));
-  assert.ok(source.includes('return "outline";'));
 });
 
 test("admin failed login alerts card keeps state for filters pagination and errors", () => {
@@ -81,9 +195,6 @@ test("admin failed login alerts card builds API query and CSV URL from filters",
   assert.ok(source.includes("const query = useMemo("));
   assert.ok(source.includes('...(surface !== "all" ? { surface } : {})'));
   assert.ok(source.includes('...(reason !== "all" ? { reason } : {})'));
-  assert.ok(source.includes("limit: PAGE_SIZE"));
-  assert.ok(source.includes("offset"));
-  assert.ok(source.includes("[offset, reason, surface]"));
   assert.ok(source.includes("const csvUrl = useMemo("));
   assert.ok(source.includes("buildAdminFailedLoginAlertsCsvUrl({"));
   assert.ok(source.includes("[reason, surface]"));
@@ -102,6 +213,14 @@ test("admin failed login alerts card keeps reversible filters and load behavior"
   assert.ok(source.includes('"No se pudieron cargar los intentos fallidos."'));
   assert.ok(source.includes("useEffect(() => {"));
   assert.ok(source.includes("loadFailedLoginAlerts();"));
+});
+
+test("admin failed login alerts filters reset offset to zero on change", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  // Both selects plus the clear-filters handler reset the offset.
+  const resetCount = source.split("setOffset(0);").length - 1;
+  assert.ok(resetCount >= 3, `expected filter handlers to reset offset, got ${resetCount}`);
 });
 
 test("admin failed login alerts card renders header and actions without technical copy", () => {
@@ -134,7 +253,7 @@ test("admin failed login alerts card renders filters table columns and rows", ()
   assert.ok(source.includes("<TableHead>IP</TableHead>"));
   assert.ok(source.includes("<TableHead>User agent</TableHead>"));
   assert.ok(source.includes("<TableHead>Fecha</TableHead>"));
-  assert.ok(source.includes("snapshot.failedLoginAlerts.map((alert) =>"));
+  assert.ok(source.includes("snapshot.failedLoginAlerts.map((alert, index) =>"));
   assert.ok(source.includes("formatSurface(alert.surface)"));
   assert.ok(source.includes("formatReason(alert.reason)"));
   assert.ok(source.includes("formatNullable(alert.username)"));
@@ -161,4 +280,21 @@ test("admin failed login alerts card keeps empty state and pagination without en
   assert.equal(source.includes(removedAlertsCsvEndpoint), false);
   assert.equal(source.includes(removedReadOnlyFilters), false);
   assert.equal(source.includes("no bloquea usuarios, no revoca sesiones y no dispara notificaciones."), false);
+});
+
+test("admin failed login alerts card does not leak secrets or widen the network surface", () => {
+  const source = read(ADMIN_FAILED_LOGIN_ALERTS_CARD_PATH);
+
+  for (const forbidden of [
+    "sessionToken",
+    "tokenHash",
+    "password",
+    "cookie",
+    "fetch(",
+    "console.log",
+    "console.info",
+    "dangerouslySetInnerHTML",
+  ]) {
+    assert.equal(source.includes(forbidden), false, `forbidden marker: ${forbidden}`);
+  }
 });


### PR DESCRIPTION
R-01 del roadmap final.

Implementa Alertas login Admin server-adaptive:
- RF debounced con cap 25.
- effectiveLimit derivado de viewport real.
- recompute de offset con clamp por total.
- request-id anti-race.
- dualidad mobile/desktop colapsada en AdminMobileCommandModule.
- e2e status actualizado al contrato adaptativo.

Docs:
- docs/implementation/admin-failed-login-alerts-server-adaptive-pagination.md

Scope:
- Sin backend/API/auth/DB.
- Sin CI/workflows.
- Sin deps/lockfiles.
- Sin snapshots.
- Sin globals.css.
- Sin otros módulos Admin.
- Sin Clínica/Particular/Público.

Validaciones locales reportadas:
- pnpm test: 2939/2939
- pnpm typecheck:test OK
- pnpm security:public-surface PASS
- frontend lint/typecheck/build OK
- e2e status 23/23
- e2e dirigidos adicionales 97/97