### PR TITLE
feat(admin): adapt clinics management server pagination to viewport

### DIFF
--- a/docs/implementation/admin-clinics-management-server-adaptive-pagination.md
+++ b/docs/implementation/admin-clinics-management-server-adaptive-pagination.md
@@ -1,0 +1,262 @@
+# R-02 — Admin Clinics Management server adaptive pagination
+
+## PR
+
+`feat(admin): adapt clinics management server pagination to viewport`
+
+Cuarto módulo Admin **servidor** (`limit`/`offset`, familia C) migrado a cardinalidad
+adaptativa Zero-Scroll, ejecutando **R-02** del roadmap rector
+(`docs/audit/final-global-vetneb-50-60-pr-roadmap.md`, Fase 1) con la política de
+PR-SRV-0 y la plantilla probada en Sesiones (#1221), Usuarios/Roles (#1222) y R-01
+Alertas login (#1263).
+
+## Base
+
+- Rama de trabajo: `feat/admin-clinics-management-server-adaptive-pagination`.
+- Base: `main @ 173995d feat(admin): adapt failed-login alerts server pagination to viewport (#1263)`.
+- Fecha: 2026-07-02.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-02, Fase 1, reglas §6/§8.
+2. `docs/implementation/server-adaptive-pagination-strategy.md` (PR-SRV-0) — módulo #3,
+   política de offset (§6), anti-race (§7), límites (§8), decisión HY cap 36 (§5).
+3. `docs/implementation/admin-sessions-server-adaptive-pagination.md` (SRV-1) — plantilla
+   de medición/anti-race/recompute.
+4. `docs/implementation/admin-users-roles-server-adaptive-pagination.md` (SRV-2) — trato
+   de contratos legacy (piso desktop) y decisión de no ampliar data-attributes.
+5. `docs/implementation/admin-failed-login-alerts-server-adaptive-pagination.md` (R-01) —
+   patrón más reciente, manejo de búsqueda/filtros server-side.
+6. `docs/implementation/clinic-logistics-master-detail-workspace.md` — sólo para
+   confirmar que Logística está cerrada; **no se reabrió**.
+
+## Skills / modelo / esfuerzo
+
+| Rol | Valor |
+|---|---|
+| Principal | `vetneb-production-web-optimization-engineer` |
+| Complementaria | `vetneb-briefing-planificacion-diseno-desarrollo-pruebas` |
+| Complementaria | `vetneb-web-end-to-end-global` |
+| Guardrail | `vetneb-security-production-invariants` |
+| Admin operativo | `vetneb-admin-dashboard-operational-actions` |
+| Modelo | Claude Sonnet 5 con Extended Thinking |
+| Esfuerzo | Alto / exhaustivo |
+
+El ZIP/carpeta de skills **no** fue copiado, descomprimido, editado, versionado ni
+ejecutado dentro de `C:\PORTAL-VETNEB`.
+
+## Hallazgo de fuente relevante: `total` sí está confirmado
+
+PR-SRV-0 §1/§4 marcaba Clínicas como "`total` NO CONFIRMADO (heurística `hasNext` por
+página llena)". Verificación read-only en `server/db-admin-clinics.ts:258-310`: el
+endpoint ejecuta `db.select({ total: sql\`count(*)\` }).from(clinics).where(whereClause)`
+en paralelo al `select` paginado y devuelve `total: Number(totalRows[0]?.total ?? 0)` —
+un conteo real, igual que Sesiones/Roles/Alertas (subgrupo 1). El componente anterior ya
+usaba `snapshot?.total` para `hasPrev`/`hasNext`/`pageCount`. R-02 mantiene ese uso; no
+fue necesario diseñar una heurística de página llena ni pedir backend nuevo.
+
+## Contrato anterior
+
+- Runtime único (`AdminClinicsManagementCard`, sin módulo mobile separado) con
+  `effectivePageSize = isMobileViewport ? MOBILE_PAGE_SIZE(10) : PAGE_SIZE(9)`.
+- `isMobileViewport`/`isViewportResolved` resueltos por
+  `window.matchMedia("(max-width: 767px)")`: **matchMedia decidía la cardinalidad**
+  del `limit` enviado a `getAdminClinics`, no sólo la presentación (peor acoplamiento
+  del inventario PR-SRV-0 §4, subgrupo 2).
+- `currentOffset` fijo por `loadClinics(offset, search)` imperativo; búsqueda debounced
+  300 ms recargaba desde `offset=0`.
+- Sin recompute de `offset` al cambiar cardinalidad (no existía, porque la cardinalidad
+  sólo cambiaba en breakpoints fijos de `matchMedia`), sin guard anti-carrera.
+
+## Contrato nuevo
+
+- **Runtime único** (ya lo era; no había módulo mobile separado que colapsar): una sola
+  fuente de datos, búsqueda, `offset`, creación/edición/credenciales/eliminación y
+  paginación. Sigue renderizando dos presentaciones responsive (tabla desktop
+  `hidden md:block` + sección mobile `md:hidden`, en ese orden en el DOM — ya era el
+  orden correcto, sin necesidad del fix de orden que sí requirió Sesiones).
+- `CLINICS_FALLBACK_ROWS = 9` (ex `PAGE_SIZE`) sólo como fallback antes de la primera
+  medición.
+- `CLINICS_SUPERSET_CAP = 36` como techo híbrido (`maxItems` del hook), igual al cap de
+  Usuarios/Roles.
+- `useAdaptiveItemsPerPage` mide el **contenedor de filas visible** (región de tabla
+  desktop o lista mobile, elegido por altura medida, no por `matchMedia`) y una **fila
+  real** (`ref` en la primera fila/artículo); el header de la tabla desktop se descuenta
+  (`CLINICS_TABLE_HEADER_PX = 36`, el `[&_th]:h-9` existente).
+- `effectiveLimit = rowsPerPage` (clamp `[1, 36]`); `query.limit = effectiveLimit`.
+- `page`/`pageCount`/`hasPrev`/`hasNext` usan `effectiveLimit` y `snapshot?.total` real,
+  no una constante fija.
+- Búsqueda server-side (`searchQuery` → debounce 300 ms → `submittedSearch`) resetea
+  `offset` a 0 en su propio efecto; la cardinalidad (resize/zoom) nunca toca la búsqueda.
+- Sin `matchMedia`, sin `MOBILE_PAGE_SIZE`, sin `isMobileViewport`/`isViewportResolved`,
+  sin `effectivePageSize`.
+
+## Decisión HY cap 36
+
+Estrategia **HY** (híbrida) de PR-SRV-0 §5/§8, la misma asignada a Clínicas en el
+inventario: se pide **al menos** `rowsPerPage`, con **cap 36**. El hook ya clampa
+`rowsPerPage` a `[1, 36]`, por lo que `effectiveLimit = rowsPerPage`. El re-fetch sólo
+ocurre cuando cambia `effectiveLimit` (medición distinta), `offset` o la búsqueda
+enviada; si `rowsPerPage` no cambió, el `query` memoizado no cambia y no hay request.
+`total` (real, confirmado arriba) permite `pageCount` y clamp exactos, sin heurística.
+
+## Cómo se mide `rowsPerPage`
+
+Igual que SRV-1/SRV-2/R-01: refs de estado (`setDesktopBodyNode`/`setMobileBodyNode` +
+`setDesktopRowNode`/`setMobileRowNode`), `ResizeObserver` agenda con
+`requestAnimationFrame`, la región visible se elige por altura medida (mobile primero,
+desktop después), la fila real medida reemplaza el fallback
+(`CLINICS_ROW_HEIGHT_FALLBACK_PX = 36`), y el header de tabla desktop se descuenta.
+`minItems = 1` en ambas presentaciones: **no se replica el piso desktop de
+Usuarios/Roles** porque no existe contrato legacy de N filas exactas para Clínicas
+(verificado: `dashboard-real-app-shell-no-scroll-contract.spec.ts` sólo exige que
+`"Clinica Veterinaria de Prueba Numero 1"` sea visible, sin `expectNinePopulatedRows`
+ni conteo fijo).
+
+## Cómo se recomputa `offset`
+
+PR-SRV-0 §6, idéntico a SRV-1/2/R-01:
+
+```
+nextOffset = Math.floor(currentOffset / effectiveLimit) * effectiveLimit;
+if (total != null) {
+  lastValidOffset = Math.max(0, (Math.ceil(total / effectiveLimit) - 1) * effectiveLimit);
+  nextOffset = Math.min(nextOffset, lastValidOffset);
+}
+nextOffset = Math.max(0, nextOffset);
+```
+
+`total` se lee de `snapshotRef` (última respuesta). La búsqueda resetea `offset` a 0
+aparte, en su propio efecto debounced; la cardinalidad (resize/zoom) nunca la toca.
+
+## Cómo se evita la carrera
+
+- **Request id** (`latestRequestRef`): cada `loadClinics()` incrementa el id; una
+  respuesta cuyo id ya no es el vigente se descarta (éxito y error).
+- **Debounce de medición**: `ResizeObserver` + `requestAnimationFrame` +
+  `measurementsEqual`; el hook global sólo cambia `rowsPerPage` si el valor derivado
+  difiere. El resize/zoom continuo no genera ráfaga.
+- **Sin doble fetch en mutaciones**: `loadClinics()` sin argumentos siempre usa el
+  `query` vigente (mismo `effectiveLimit`/`offset`/búsqueda) — usado por
+  "Actualizar", `handleSaveClinic`, `handleSaveCredentials` y `handleDeleteClinic`.
+  `resetToFirstPageAndReload()` (usado tras crear una clínica) evita el doble fetch
+  del patrón "cambiar offset + recargar": si `offset` ya es 0 recarga directo con
+  `loadClinics()`; si no, sólo cambia `offset` a 0 y deja que el efecto `[query]`
+  dispare el único fetch.
+- **Fallback estable**: sin contenedor medido, el hook devuelve el fallback (9) y no
+  re-fetchea por cardinalidad; loading/empty/error tienen geometría estable.
+
+## Cómo se preservó `ClinicEditDrawer`
+
+`editingClinic` es estado independiente: guarda el objeto `AdminClinicManagementSummary`
+capturado al hacer clic en "Editar", no un índice de fila ni una referencia derivada de
+`rows`/`snapshot`. Ningún efecto nuevo (medición, recompute de `offset`, búsqueda,
+carga) lee ni escribe `editingClinic`; sólo tres puntos lo tocan, sin cambios en R-02:
+
+- `setEditingClinic(clinic)` al hacer clic en "Editar" (desktop o mobile).
+- `onClose={() => setEditingClinic(null)}` — cierre explícito del usuario.
+- `handleDeleteClinic` — cierre tras eliminación confirmada (`setEditingClinic(null)`
+  antes de recargar), como exige el invariante de la eliminación.
+
+Por diseño, un cambio de `effectiveLimit`/`offset` por resize, zoom o paginación nunca
+cierra ni reapunta el drawer: la clínica en edición sigue siendo el mismo objeto en
+memoria, independientemente de si sigue o no visible en la página actual del listado.
+Esto se verifica con el e2e existente `admin-clinic-edit-drawer.spec.ts` (búsqueda +
+apertura/cierre del drawer sin resetear estado) y se preserva sin modificaciones.
+
+## Sin módulo mobile separado
+
+`AdminClinicsManagementCard` nunca tuvo un `AdminMobileClinicsModule` independiente — la
+dualidad desktop/mobile ya vivía dentro del mismo archivo (sección `md:hidden` con
+`data-admin-mobile-core-module="clinics"`). R-02 no crea ningún shim nuevo; sólo
+colapsa la fuente de cardinalidad de ambas presentaciones en la única medición.
+Selectores e2e preservados: `data-admin-mobile-core-module="clinics"`,
+`data-admin-mobile-core-item="true"`, `data-admin-mobile-core-pager="true"`,
+`data-admin-clinics-mobile-list="true"`, `data-admin-clinic-mobile-card="true"`.
+
+## `total`/`hasNext` sin backend nuevo
+
+Como se documentó arriba, `total` ya era un conteo real expuesto por el endpoint
+existente. R-02 no modifica `server/db-admin-clinics.ts` ni ningún contrato de API; sólo
+usa el `total` ya disponible para clamp y `pageCount`, igual que Sesiones/Roles/Alertas.
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx` — runtime único
+  adaptativo (medición, anti-race, recompute de offset, búsqueda debounced).
+- `test/frontend-admin-clinics-management-card.test.ts` — source-contract alineado al
+  contrato nuevo (constantes, ausencia de `matchMedia`/`MOBILE_PAGE_SIZE`, guard de
+  "sin módulo mobile separado").
+- `test/admin-overview-clinics-enterprise-density.test.ts` — assertions de constantes
+  alineadas (`CLINICS_FALLBACK_ROWS`/`CLINICS_SUPERSET_CAP`).
+- `test/admin-mobile-core-pager-canonical-layout.test.ts` — **sólo** las assertions de
+  Clínicas alineadas al contrato adaptativo; las de `AdminReportsCard` quedaron
+  intactas (fuera de scope de R-02).
+- `frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts` — **sólo** la entrada
+  `clinics` de `MODULES` (`maxItemsPerPage: 10 → 36`, `MOCK_CLINICS: 13 → 40`); las
+  entradas `reports`/`tokens` quedaron intactas.
+- `frontend/e2e/admin-clinics-mobile-card-layout.spec.ts` — `MOCK_CLINICS: 13 → 40`;
+  `assertMobileClinicsContract` pasa de "exactamente 10" a contrato adaptativo (fit
+  asentado > 0, ≤ cap 36, consistencia interna); el test de paginación deriva
+  `pageCount` del conteo asentado en vez de asumir 10 por página.
+- `docs/implementation/admin-clinics-management-server-adaptive-pagination.md` — este
+  documento.
+
+## Validaciones ejecutadas
+
+PNPM 10.8.1 (coincide con `packageManager`).
+
+- `node --test` dirigido a los 3 archivos de test de Clínicas — 32/32.
+- `pnpm test` — 2941/2941.
+- `pnpm typecheck:test` — OK.
+- `pnpm security:public-surface` — PASS (sólo marcadores server-only esperados en
+  `frontend/src/proxy.ts`).
+- `pnpm --dir frontend lint` — OK.
+- `pnpm --dir frontend typecheck` — OK.
+- `pnpm --dir frontend build` — OK.
+- `pnpm --dir frontend exec playwright test e2e/admin-clinic-edit-drawer.spec.ts
+  e2e/admin-clinics-mobile-card-layout.spec.ts` — 16/16.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts`
+  — 14/14 (bloque `clinics` + `reports`/`tokens` sin regresión).
+- `pnpm --dir frontend exec playwright test
+  e2e/dashboard-viewport-zoom-adaptability.spec.ts
+  e2e/dashboard-internal-no-scroll-contract.spec.ts
+  e2e/dashboard-global-masked-master-detail.spec.ts` — 84/84.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-final-polish-no-scroll.spec.ts`
+  (regresión extra, no mandatorio) — 4/4 en el re-run; un primer intento tuvo un fallo de
+  cold-start del dev server ajeno al cambio (confirmado por el re-run limpio).
+
+`frontend/next-env.d.ts` fue regenerado por Next/Playwright durante los e2e y se
+restauró (`git checkout --`) antes del diff review, por estar fuera de scope.
+
+## Riesgos residuales
+
+- **Flake medición↔fetch (P2):** el primer paint puede usar el fallback (9) antes de
+  que la fila real se mida (la fila necesita datos ya cargados para existir en el DOM),
+  lo que puede disparar un segundo fetch con el `effectiveLimit` asentado. Mismo riesgo
+  documentado en Sesiones/Usuarios/Alertas; mitigado en e2e con espera de conteo
+  estable (dos lecturas iguales) antes de aserciones de paginación.
+- **Altura de fila representativa:** se mide la primera fila; `safetyGap` del hook
+  sesga a subestimar (seguro). Filas desktop con contenido largo truncan (`truncate`),
+  no crecen.
+- **QA manual pendiente:** iOS/Android real y zoom físico 100–175 % siguen siendo
+  obligatorios antes de cualquier gate bloqueante (PR-SRV-0 §10.5).
+
+## Fuera de scope (no tocado)
+
+- Otros módulos Admin (`AdminReportsCard`, `AdminParticularTokensCard`,
+  `AdminAuditCard`, `AdminFailedLoginAlertsReadOnlyCard`, `AdminMobileCommandModule`,
+  Sesiones, Usuarios/Roles).
+- Backend/API/auth/DB/migrations (verificación de `total` fue sólo lectura; no se pidió
+  nada nuevo).
+- CI/workflows, deps/lockfiles, snapshots, `globals.css`.
+- Rutas Clínica/Particular/Público; Logística (cerrada, no reabierta).
+- R-03..R-09 (no se adelantó ningún PR posterior).
+
+## Confirmaciones
+
+- Un solo módulo Admin tocado: Clínicas.
+- No `matchMedia` como cardinalidad; `MOBILE_PAGE_SIZE`/`effectivePageSize` eliminados;
+  `PAGE_SIZE` renombrado a `CLINICS_FALLBACK_ROWS` (sólo fallback); offset recomputado;
+  anti-race por request-id; búsqueda resetea offset; `ClinicEditDrawer` preservado.
+- No se hizo `git add`/`commit`/`push`/`gh pr create`.

--- a/docs/implementation/admin-clinics-management-server-adaptive-pagination.md
+++ b/docs/implementation/admin-clinics-management-server-adaptive-pagination.md
@@ -229,6 +229,32 @@ PNPM 10.8.1 (coincide con `packageManager`).
 `frontend/next-env.d.ts` fue regenerado por Next/Playwright durante los e2e y se
 restauró (`git checkout --`) antes del diff review, por estar fuera de scope.
 
+## Fix post-CI: conteo asentado en `admin-mobile-core-modules-no-scroll`
+
+CI (`validate-frontend` → `pnpm --dir frontend e2e:admin-mobile`) reportó los tres
+viewports de `Admin mobile core module "clinics" is no-scroll` en rojo: el spec esperaba
+`clinics item 10/13/15` (`.nth(9)/.nth(12)/.nth(14)`) que ya no existían.
+
+**Causa raíz:** el spec leía `items.count()` **una sola vez** inmediatamente después de
+que el primer ítem fuera visible, sin esperar el asentamiento medición↔fetch propio del
+contrato adaptativo (riesgo ya documentado arriba): el primer paint usa el fallback, el
+re-fetch con el fit medido re-renderiza la lista, y en CI Linux el conteo transitorio
+capturado quedaba obsoleto cuando el loop llegaba a `.nth(count - 1)`. No es un bug de
+renderizado del componente — es el spec iterando sobre un conteo de un render superado.
+
+**Fix (sólo e2e, acotado al loop compartido):** antes de iterar, se espera un conteo
+**asentado** (dos lecturas consecutivas iguales vía `expect(...).toPass`, mismo patrón
+que ya usaba `admin-clinics-mobile-card-layout.spec.ts`). Las aserciones del contrato
+adaptativo quedan: `renderedCount > 0`, `renderedCount ≤ maxItemsPerPage` (36 para
+Clínicas), cada ítem renderizado dentro del viewport, pager visible/operable y
+navegación a página 2 verificada por cambio de contenido. Sin conteos fijos por
+dispositivo. La espera es inofensiva para `reports`/`tokens` (tamaño fijo 10, conteo
+estable de inmediato): sus expectativas no cambiaron.
+
+**No relacionado:** el fallo local de `theme-mode.spec.ts`
+(`meta[name="theme-color"]` resuelto a 2 elementos / `removeChild`) es ajeno a R-02;
+queda registrado como flake/deuda separada, no se tocó en este PR.
+
 ## Riesgos residuales
 
 - **Flake medición↔fetch (P2):** el primer paint puede usar el fallback (9) antes de

--- a/frontend/e2e/admin-clinics-mobile-card-layout.spec.ts
+++ b/frontend/e2e/admin-clinics-mobile-card-layout.spec.ts
@@ -9,7 +9,9 @@ const MOBILE_VIEWPORTS = [
   { name: "iphone-pro-max-430x932", width: 430, height: 932 },
 ] as const;
 
-const MOCK_CLINICS = Array.from({ length: 13 }, (_, index) => {
+// 40 clinics (R-02): guarantees a page 2 exists for any effectiveLimit <= 36
+// (HY superset cap), same margin used by Sessions/Users/Alerts.
+const MOCK_CLINICS = Array.from({ length: 40 }, (_, index) => {
   const id = index + 1;
 
   return {
@@ -18,7 +20,7 @@ const MOCK_CLINICS = Array.from({ length: 13 }, (_, index) => {
     contactEmail: `clinica.mobile.${id}@example.test`,
     contactPhone: `+54 11 5555-${String(id).padStart(4, "0")}`,
     createdAt: "2026-06-01T10:00:00.000Z",
-    updatedAt: `2026-06-${String(id).padStart(2, "0")}T12:00:00.000Z`,
+    updatedAt: `2026-06-${String((id % 28) + 1).padStart(2, "0")}T12:00:00.000Z`,
     users: [
       {
         userId: 100 + id,
@@ -190,19 +192,26 @@ async function readMobileClinicsContract(
   }, TOLERANCE);
 }
 
+// R-02: the mobile page size is derived from the measured list container (HY
+// cap 36), not a fixed constant, so the contract asserts bounds and internal
+// consistency instead of an exact count.
 function assertMobileClinicsContract(
   contract: MobileClinicsContract,
   label: string,
 ) {
   expect(
     contract.visibleMobileCards,
-    `${label}: mobile page size must show exactly 10 clinics`,
-  ).toBe(10);
+    `${label}: mobile page must show at least one clinic`,
+  ).toBeGreaterThan(0);
+  expect(
+    contract.visibleMobileCards,
+    `${label}: mobile page size must stay within the HY superset cap (36)`,
+  ).toBeLessThanOrEqual(36);
   expect(contract.visibleDesktopTables, `${label}: desktop table hidden on mobile`).toBe(0);
   expect(
     contract.cardsShowingEmail,
     `${label}: every card must show the clinic email`,
-  ).toBe(10);
+  ).toBe(contract.visibleMobileCards);
   expect(
     contract.secondaryDetailLineCount,
     `${label}: secondary details (user/updated date) must not render on the card body`,
@@ -273,7 +282,9 @@ for (const viewport of MOBILE_VIEWPORTS) {
   });
 }
 
-test("admin clinics mobile pagination advances through 10-record pages", async ({
+// R-02: the mobile page size is measured (HY cap 36), not a fixed 10, so the
+// page count is derived from the settled first-page count instead of assumed.
+test("admin clinics mobile pagination advances through adaptive pages", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -287,16 +298,41 @@ test("admin clinics mobile pagination advances through 10-record pages", async (
 
   const list = page.locator("[data-admin-clinics-mobile-list='true']");
   await expect(list).toBeVisible();
-  await expect(list.getByText("Clínica Mobile 1", { exact: true })).toBeVisible();
-  await expect(list.getByText("Clínica Mobile 10", { exact: true })).toBeVisible();
-  await expect(list.getByText("Clínica Mobile 11", { exact: true })).toHaveCount(0);
 
+  const cards = page.locator("[data-admin-clinic-mobile-card='true']");
+  await expect(cards.first()).toBeVisible({ timeout: 15_000 });
+
+  // The first fetch can use the pre-measurement fallback before the real row
+  // is measured and a follow-up fetch settles the final count (documented
+  // measurement<->fetch settle risk, same as Sessions/Users/Alerts). Wait for
+  // two consecutive equal reads before trusting the count.
+  let settledCount: number | null = null;
+  await expect(async () => {
+    const current = await cards.count();
+    expect(current, "clinics mobile item count settles").toBeGreaterThan(0);
+    if (settledCount !== current) {
+      settledCount = current;
+      throw new Error(`count not yet stable: ${current}`);
+    }
+  }).toPass({ intervals: [200, 300, 400, 600, 800], timeout: 6_000 });
+
+  const firstPageCount = settledCount!;
+  const firstPageLabels = await cards.allTextContents();
+  expect(firstPageLabels.length).toBe(firstPageCount);
+  expect(firstPageCount).toBeLessThanOrEqual(36);
+
+  const pageCount = Math.max(1, Math.ceil(MOCK_CLINICS.length / firstPageCount));
   const pager = page.locator("[data-admin-mobile-core-pager='true']");
-  await expect(pager.getByText("Pág. 1 / 2")).toBeVisible();
+  await expect(pager.getByText(`Pág. 1 / ${pageCount}`)).toBeVisible();
+
   await pager.getByRole("button", { name: "Página siguiente" }).click();
 
-  await expect(list.getByText("Clínica Mobile 11", { exact: true })).toBeVisible();
-  await expect(list.getByText("Clínica Mobile 13", { exact: true })).toBeVisible();
+  await expect
+    .poll(async () => (await cards.allTextContents()).join("|"), {
+      message: "clinics mobile page changes after pagination",
+    })
+    .not.toBe(firstPageLabels.join("|"));
+
   await expect(list.getByText("Clínica Mobile 1", { exact: true })).toHaveCount(0);
-  await expect(pager.getByText("Pág. 2 / 2")).toBeVisible();
+  await expect(pager.getByText(`Pág. 2 / ${pageCount}`)).toBeVisible();
 });

--- a/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
@@ -10,7 +10,9 @@ import {
   suppressNextDevIndicator,
 } from "./helpers/admin-mobile-contracts";
 
-const MOCK_CLINICS = Array.from({ length: 13 }, (_, index) => {
+// 40 clinics (R-02): guarantees a page 2 exists for any effectiveLimit <= 36
+// (HY superset cap), same margin used by Sessions/Users/Alerts.
+const MOCK_CLINICS = Array.from({ length: 40 }, (_, index) => {
   const id = index + 1;
   return {
     clinicId: id,
@@ -18,7 +20,7 @@ const MOCK_CLINICS = Array.from({ length: 13 }, (_, index) => {
     contactEmail: `clinica.core.${id}@example.test`,
     contactPhone: `+54 11 5555-${String(id).padStart(4, "0")}`,
     createdAt: "2026-06-01T10:00:00.000Z",
-    updatedAt: `2026-06-${String(id).padStart(2, "0")}T12:00:00.000Z`,
+    updatedAt: `2026-06-${String((id % 28) + 1).padStart(2, "0")}T12:00:00.000Z`,
     users: [
       {
         userId: 100 + id,
@@ -141,7 +143,9 @@ type ModuleSpec = {
 };
 
 const MODULES: ModuleSpec[] = [
-  { key: "clinics", moduleId: "admin-clinics", mock: mockAdminClinics, maxItemsPerPage: 10 },
+  // Clinics: R-02 raised the ceiling to the HY superset cap (36); the real
+  // guarantee is per-item viewport fit, not a fixed page size.
+  { key: "clinics", moduleId: "admin-clinics", mock: mockAdminClinics, maxItemsPerPage: 36 },
   { key: "reports", moduleId: "admin-report-upload", mock: mockAdminReportWorkflow, maxItemsPerPage: 10 },
   { key: "tokens", moduleId: "admin-particular-tokens", mock: mockAdminParticularTokens, maxItemsPerPage: 10 },
 ];

--- a/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
@@ -198,7 +198,30 @@ for (const moduleSpec of MODULES) {
         items.first(),
         `${viewport.name}: ${moduleSpec.key} first item visible`,
       ).toBeVisible({ timeout: 15_000 });
-      const itemCount = await items.count();
+
+      // R-02: clinics derives its page size from the measured list container
+      // (adaptive, HY cap 36), so the first paint can render the fallback
+      // count and a follow-up fetch re-renders with the settled fit. Reading
+      // count() once mid-settle made .nth(i) chase items from a superseded
+      // render (CI failure: "item 10/13/15 not found"). Wait for two
+      // consecutive equal counts before iterating; harmless for the fixed-size
+      // modules (reports/tokens), whose count is stable immediately.
+      let settledCount = -1;
+      await expect(async () => {
+        const current = await items.count();
+        expect(
+          current,
+          `${viewport.name}: ${moduleSpec.key} has visible items`,
+        ).toBeGreaterThan(0);
+        if (settledCount !== current) {
+          settledCount = current;
+          throw new Error(
+            `${moduleSpec.key} item count not yet stable: ${current}`,
+          );
+        }
+      }).toPass({ intervals: [250, 350, 500, 750, 1_000], timeout: 10_000 });
+
+      const itemCount = settledCount;
       expect(itemCount, `${viewport.name}: ${moduleSpec.key} has visible items`).toBeGreaterThan(0);
       expect(
         itemCount,

--- a/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { FormEvent, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import {
+  FormEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import dynamic from "next/dynamic";
 import { ChevronLeft, ChevronRight, Eye, EyeOff, Loader2, Pencil, Plus, RefreshCw, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -28,6 +36,7 @@ import {
   updateAdminClinic,
   updateAdminClinicUserCredentials,
 } from "@/lib/api";
+import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";
 import { formatDateTime } from "@/lib/utils";
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { LoadingState } from "@/components/dashboard/LoadingState";
@@ -47,13 +56,32 @@ const ClinicEditDrawer = dynamic(
   { ssr: false },
 );
 
-// Enterprise density without breaking the App Shell no-scroll contract: denser
-// rows/header let a full page fit the 1366×768 minimum viewport, so the server
-// page size is raised from 5 to a conservative value that leaves one dense-row
-// margin in the 1366×768 viewport without internal scroll. True 25/50/100 needs
-// the no-scroll contract relaxation (audit §3) and is deferred.
-const PAGE_SIZE = 9;
-const MOBILE_PAGE_SIZE = 10;
+// Server pagination is now sized by the measured rows container (Zero-Scroll
+// adaptive contract, R-02/PR-SRV-0). The legacy PAGE_SIZE survives only as the
+// pre-measurement fallback; a media query no longer decides cardinality.
+const CLINICS_FALLBACK_ROWS = 9;
+// Hybrid cap: the effective `limit` never exceeds this superset ceiling even on
+// very tall viewports; recompute of offset always clamps against it.
+const CLINICS_SUPERSET_CAP = 36;
+// Fixed header row height of the desktop table (`[&_th]:h-9`), discounted from
+// the measured region so the row math never counts the header as a data row.
+const CLINICS_TABLE_HEADER_PX = 36;
+// Fallback item height used until a real row is measured.
+const CLINICS_ROW_HEIGHT_FALLBACK_PX = 36;
+
+type Measurement = {
+  containerNode: HTMLElement | null;
+  rowHeightPx: number;
+  headerHeightPx: number;
+};
+
+function measurementsEqual(a: Measurement, b: Measurement) {
+  return (
+    a.containerNode === b.containerNode &&
+    a.rowHeightPx === b.rowHeightPx &&
+    a.headerHeightPx === b.headerHeightPx
+  );
+}
 
 type CreateClinicForm = {
   clinicName: string;
@@ -108,7 +136,8 @@ function formatAdminClinicsError(error: unknown, fallback: string) {
 export function AdminClinicsManagementCard() {
   const [snapshot, setSnapshot] = useState<AdminClinicsSnapshot | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [currentOffset, setCurrentOffset] = useState(0);
+  const [submittedSearch, setSubmittedSearch] = useState("");
+  const [offset, setOffset] = useState(0);
   const [createForm, setCreateForm] = useState<CreateClinicForm>(getInitialCreateForm);
   const [editingClinic, setEditingClinic] = useState<AdminClinicManagementSummary | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -117,48 +146,157 @@ export function AdminClinicsManagementCard() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeActionKey, setActiveActionKey] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  // Start false so SSR and the client's first render agree. The media-query
-  // effect below promotes this to the real viewport value right after mount,
-  // which avoids a hydration mismatch on the mobile-only branches.
-  const [isMobileViewport, setIsMobileViewport] = useState(false);
-  // Gates the initial fetch below until the viewport is known, so the first
-  // load uses the resolved effectivePageSize instead of the SSR-safe default.
-  const [isViewportResolved, setIsViewportResolved] = useState(false);
+
+  // One collapsed runtime feeds both presentations, so the visible container
+  // (desktop table region or mobile list region) drives a single cardinality.
+  const [desktopBodyNode, setDesktopBodyNode] = useState<HTMLElement | null>(
+    null,
+  );
+  const [mobileBodyNode, setMobileBodyNode] = useState<HTMLElement | null>(null);
+  const [desktopRowNode, setDesktopRowNode] = useState<HTMLElement | null>(null);
+  const [mobileRowNode, setMobileRowNode] = useState<HTMLElement | null>(null);
+  const [measurement, setMeasurement] = useState<Measurement>({
+    containerNode: null,
+    rowHeightPx: CLINICS_ROW_HEIGHT_FALLBACK_PX,
+    headerHeightPx: 0,
+  });
+
+  const latestRequestRef = useRef(0);
+  const snapshotRef = useRef<AdminClinicsSnapshot | null>(null);
+
+  useEffect(() => {
+    snapshotRef.current = snapshot;
+  }, [snapshot]);
+
+  useLayoutEffect(() => {
+    const nodes = [
+      desktopBodyNode,
+      mobileBodyNode,
+      desktopRowNode,
+      mobileRowNode,
+    ].filter((node): node is HTMLElement => node !== null);
+    if (nodes.length === 0) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const recompute = () => {
+      frame = null;
+
+      const mobileHeight = mobileBodyNode?.getBoundingClientRect().height ?? 0;
+      if (mobileHeight > 0 && mobileBodyNode) {
+        const rowHeight = mobileRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: mobileBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : CLINICS_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: 0,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+        return;
+      }
+
+      const desktopHeight = desktopBodyNode?.getBoundingClientRect().height ?? 0;
+      if (desktopHeight > 0 && desktopBodyNode) {
+        const rowHeight = desktopRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: desktopBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : CLINICS_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: CLINICS_TABLE_HEADER_PX,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+      }
+    };
+
+    const scheduleRecompute = () => {
+      if (frame === null) {
+        frame = requestAnimationFrame(recompute);
+      }
+    };
+
+    const observer = new ResizeObserver(scheduleRecompute);
+    nodes.forEach((node) => observer.observe(node));
+    scheduleRecompute();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [desktopBodyNode, mobileBodyNode, desktopRowNode, mobileRowNode]);
+
+  const { itemsPerPage: rowsPerPage } = useAdaptiveItemsPerPage({
+    containerNode: measurement.containerNode,
+    fallbackItems: CLINICS_FALLBACK_ROWS,
+    itemHeightPx: measurement.rowHeightPx,
+    headerHeightPx: measurement.headerHeightPx,
+    minItems: 1,
+    maxItems: CLINICS_SUPERSET_CAP,
+  });
+
+  // Effective server page size: at least the measured rows, capped at the
+  // superset ceiling. The hook already clamps to [1, CLINICS_SUPERSET_CAP].
+  const effectiveLimit = rowsPerPage;
 
   const rows = useMemo(() => getClinicUserRows(snapshot), [snapshot]);
 
-  const effectivePageSize = isMobileViewport ? MOBILE_PAGE_SIZE : PAGE_SIZE;
   const totalClinics = snapshot?.total ?? 0;
-  const pageStart = totalClinics > 0 ? currentOffset + 1 : 0;
-  const pageEnd = Math.min(currentOffset + effectivePageSize, totalClinics);
-  const hasPrev = currentOffset > 0;
-  const hasNext = currentOffset + effectivePageSize < totalClinics;
-  const page = Math.floor(currentOffset / effectivePageSize) + 1;
-  const pageCount = Math.max(1, Math.ceil(totalClinics / effectivePageSize));
+  const pageStart = totalClinics > 0 ? offset + 1 : 0;
+  const pageEnd = Math.min(offset + effectiveLimit, totalClinics);
+  const hasPrev = offset > 0;
+  const hasNext = offset + effectiveLimit < totalClinics;
+  const page = Math.floor(offset / effectiveLimit) + 1;
+  const pageCount = Math.max(1, Math.ceil(totalClinics / effectiveLimit));
   const isBusy = isPending || activeActionKey !== null;
 
-  function loadClinics(offset = currentOffset, search = searchQuery) {
+  const query = useMemo(
+    () => ({
+      limit: effectiveLimit,
+      offset,
+      ...(submittedSearch ? { search: submittedSearch } : {}),
+    }),
+    [effectiveLimit, offset, submittedSearch],
+  );
+
+  function loadClinics() {
     setError(null);
+
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
 
     startTransition(() => {
       void (async () => {
         try {
-          const trimmedSearch = search.trim();
-          setSnapshot(
-            await getAdminClinics({
-              limit: effectivePageSize,
-              offset,
-              ...(trimmedSearch ? { search: trimmedSearch } : {}),
-            }),
-          );
-          setCurrentOffset(offset);
+          const result = await getAdminClinics(query);
+          if (requestId !== latestRequestRef.current) return;
+          setSnapshot(result);
         } catch (err) {
+          if (requestId !== latestRequestRef.current) return;
           setError(
             formatAdminClinicsError(err, "No se pudieron cargar las clínicas."),
           );
         }
       })();
     });
+  }
+
+  // Jumps back to the first page after a mutation that can change result
+  // ordering (create). If offset is already 0, `query` won't change on its
+  // own, so a manual reload is needed; otherwise the offset change below
+  // flows into `query` and the effect below reloads once.
+  function resetToFirstPageAndReload() {
+    if (offset === 0) {
+      loadClinics();
+    } else {
+      setOffset(0);
+    }
   }
 
   function updateCreateField<K extends keyof CreateClinicForm>(
@@ -197,7 +335,7 @@ export function AdminClinicsManagementCard() {
       );
       setIsCreatePasswordVisible(false);
       setIsCreateOpen(false);
-      loadClinics(0);
+      resetToFirstPageAndReload();
     } catch (err) {
       setError(formatAdminClinicsError(err, "No se pudo crear la clínica."));
     } finally {
@@ -236,42 +374,62 @@ export function AdminClinicsManagementCard() {
     loadClinics();
   }
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 767px)");
-
-    const updateMobileViewport = () => {
-      setIsMobileViewport(mediaQuery.matches);
-      setIsViewportResolved(true);
-    };
-
-    updateMobileViewport();
-    mediaQuery.addEventListener("change", updateMobileViewport);
-
-    return () => {
-      mediaQuery.removeEventListener("change", updateMobileViewport);
-    };
-  }, []);
-
-  const isFirstRender = useRef(true);
+  // Search is server-side and debounced; a cardinality change (resize/zoom)
+  // never touches the search state, so it never resets the offset here.
+  const isFirstSearchRender = useRef(true);
 
   useEffect(() => {
-    // Wait for the viewport to resolve so the first fetch below uses the
-    // settled effectivePageSize, not the SSR-safe desktop default.
-    if (!isViewportResolved) return;
-
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      loadClinics(0, searchQuery);
+    if (isFirstSearchRender.current) {
+      isFirstSearchRender.current = false;
       return;
     }
 
     const timer = setTimeout(() => {
-      loadClinics(0, searchQuery);
+      setOffset(0);
+      setSubmittedSearch(searchQuery.trim());
     }, 300);
 
     return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Recompute offset when the effective limit changes so the same first
+  // record stays visible; clamp against the known total (PR-SRV-0 §6).
+  const previousLimitRef = useRef(effectiveLimit);
+  useEffect(() => {
+    if (previousLimitRef.current === effectiveLimit) {
+      return;
+    }
+    previousLimitRef.current = effectiveLimit;
+
+    setOffset((currentOffset) => {
+      let nextOffset = Math.floor(currentOffset / effectiveLimit) * effectiveLimit;
+      const total = snapshotRef.current?.total;
+      if (typeof total === "number") {
+        const lastValidOffset = Math.max(
+          0,
+          (Math.ceil(total / effectiveLimit) - 1) * effectiveLimit,
+        );
+        nextOffset = Math.min(nextOffset, lastValidOffset);
+      }
+      nextOffset = Math.max(0, nextOffset);
+      return nextOffset === currentOffset ? currentOffset : nextOffset;
+    });
+  }, [effectiveLimit]);
+
+  useEffect(() => {
+    loadClinics();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isViewportResolved, searchQuery, effectivePageSize]);
+  }, [query]);
+
+  function goToPreviousPage() {
+    setError(null);
+    setOffset(Math.max(offset - effectiveLimit, 0));
+  }
+
+  function goToNextPage() {
+    setError(null);
+    setOffset(offset + effectiveLimit);
+  }
 
   return (
     <Card id="admin-clinics" className="dashboard-surface flex min-h-0 flex-1 flex-col">
@@ -464,7 +622,7 @@ export function AdminClinicsManagementCard() {
                 size="sm"
                 variant="outline"
                 className="h-8 w-8 p-0"
-                onClick={() => loadClinics(currentOffset - effectivePageSize)}
+                onClick={goToPreviousPage}
                 disabled={isBusy || !hasPrev}
                 aria-label="Página anterior"
               >
@@ -475,7 +633,7 @@ export function AdminClinicsManagementCard() {
                 size="sm"
                 variant="outline"
                 className="h-8 w-8 p-0"
-                onClick={() => loadClinics(currentOffset + effectivePageSize)}
+                onClick={goToNextPage}
                 disabled={isBusy || !hasNext}
                 aria-label="Página siguiente"
               >
@@ -485,7 +643,10 @@ export function AdminClinicsManagementCard() {
           ) : null}
         </div>
 
-        <div className="dashboard-table-responsive hidden md:block">
+        <div
+          ref={setDesktopBodyNode}
+          className="dashboard-table-responsive hidden md:block"
+        >
           <Table className="text-[0.8125rem] [&_th]:h-9 [&_th]:px-3 [&_td]:px-3">
             <TableHeader>
               <TableRow>
@@ -498,9 +659,10 @@ export function AdminClinicsManagementCard() {
             </TableHeader>
             <TableBody>
               {rows.length ? (
-                rows.map(({ clinic, user, extraUsers }) => (
+                rows.map(({ clinic, user, extraUsers }, index) => (
                   <TableRow
                     key={`${clinic.clinicId}-${user?.userId ?? "empty"}`}
+                    ref={index === 0 ? setDesktopRowNode : undefined}
                   >
                     <TableCell className="py-1">
                       <span className="flex items-center gap-1.5">
@@ -615,13 +777,15 @@ export function AdminClinicsManagementCard() {
           </div>
 
           <div
+            ref={setMobileBodyNode}
             className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-lg border border-vetneb-line/75"
             data-admin-clinics-mobile-list="true"
           >
           {rows.length ? (
-            rows.map(({ clinic, user, extraUsers }) => (
+            rows.map(({ clinic, user, extraUsers }, index) => (
               <article
                 key={`mobile-${clinic.clinicId}-${user?.userId ?? "empty"}`}
+                ref={index === 0 ? setMobileRowNode : undefined}
                 className="flex min-h-9 items-center justify-between gap-2 px-2.5 py-0.5"
                 data-admin-clinic-mobile-card="true"
                 data-admin-mobile-core-item="true"
@@ -687,7 +851,7 @@ export function AdminClinicsManagementCard() {
                 size="sm"
                 variant="outline"
                 className="h-9 px-2.5 text-xs"
-                onClick={() => loadClinics(currentOffset - effectivePageSize)}
+                onClick={goToPreviousPage}
                 disabled={isBusy || !hasPrev}
                 aria-label="Página anterior"
               >
@@ -701,7 +865,7 @@ export function AdminClinicsManagementCard() {
                 size="sm"
                 variant="outline"
                 className="h-9 px-2.5 text-xs"
-                onClick={() => loadClinics(currentOffset + effectivePageSize)}
+                onClick={goToNextPage}
                 disabled={isBusy || !hasNext}
                 aria-label="Página siguiente"
               >

--- a/test/admin-mobile-core-pager-canonical-layout.test.ts
+++ b/test/admin-mobile-core-pager-canonical-layout.test.ts
@@ -157,18 +157,16 @@ test("admin core pagers preserve accessible labels, data hooks and the no-scroll
   }
 });
 
-// Clinics intentionally raised its mobile page size from 3 to 10 (PR2,
-// admin-mobile-clinics-density): 10 clinics per mobile page, compacted to a
-// borderless name+email row so the list stays viewport-safe/no-scroll. The
-// fetch call and desktop PAGE_SIZE are untouched — only the mobile page-size
-// constant and row density changed.
-test("admin clinics mobile pager: page size intentionally raised to 10, fetch/desktop untouched", () => {
+// R-02 (admin-clinics-management-server-adaptive-pagination): the mobile page
+// size is no longer a fixed constant — it is derived from the measured list
+// container (HY cap 36), same runtime that feeds the desktop table. The fetch
+// call is untouched; only the cardinality source changed from matchMedia to
+// measurement.
+test("admin clinics mobile pager: page size is measured (HY cap 36), fetch untouched", () => {
   const clinicsSource = read(CLINICS_CARD_PATH);
-  assert.ok(clinicsSource.includes("const PAGE_SIZE = 9;"));
-  assert.ok(
-    clinicsSource.includes("const MOBILE_PAGE_SIZE = 10;"),
-    "clinics mobile page size must be 10 (intentional density change, PR2)",
-  );
+  assert.ok(clinicsSource.includes("const CLINICS_FALLBACK_ROWS = 9;"));
+  assert.ok(clinicsSource.includes("const CLINICS_SUPERSET_CAP = 36;"));
+  assert.equal(clinicsSource.includes("const MOBILE_PAGE_SIZE"), false);
   assert.ok(clinicsSource.includes("getAdminClinics("));
 });
 

--- a/test/admin-overview-clinics-enterprise-density.test.ts
+++ b/test/admin-overview-clinics-enterprise-density.test.ts
@@ -66,15 +66,17 @@ test("admin overview keeps the four compact operational panels", () => {
   assert.ok(linksSource.includes('module: "admin-clinics"'));
 });
 
-test("admin clinics console raises the server page size while respecting no-scroll", () => {
+test("admin clinics console derives the server page size from measurement while respecting no-scroll", () => {
   const source = read(CLINICS_CARD_PATH);
 
-  // Nine dense rows preserve a full-row margin in the minimum viewport.
-  assert.ok(source.includes("const PAGE_SIZE = 9;"));
-  // Mobile intentionally raised to 10 (PR2, admin-mobile-clinics-density):
-  // a compacted borderless name+email row keeps 10 rows viewport-safe.
-  assert.ok(source.includes("const MOBILE_PAGE_SIZE = 10;"));
-  assert.ok(source.includes("limit: effectivePageSize"));
+  // R-02: cardinality is measured (Zero-Scroll adaptive contract), not a
+  // matchMedia-driven fixed constant. CLINICS_FALLBACK_ROWS is only the
+  // pre-measurement fallback; CLINICS_SUPERSET_CAP is the HY ceiling.
+  assert.ok(source.includes("const CLINICS_FALLBACK_ROWS = 9;"));
+  assert.ok(source.includes("const CLINICS_SUPERSET_CAP = 36;"));
+  assert.equal(source.includes("const MOBILE_PAGE_SIZE"), false);
+  assert.equal(source.includes("effectivePageSize"), false);
+  assert.ok(source.includes("limit: effectiveLimit"));
   assert.ok(source.includes("snapshot?.total"));
 
   // No-scroll contract: the table body must NOT become an internal scroll region

--- a/test/frontend-admin-clinics-management-card.test.ts
+++ b/test/frontend-admin-clinics-management-card.test.ts
@@ -165,13 +165,27 @@ test("admin clinics management card renders server-side pagination controls usin
 
   assert.ok(source.includes('aria-label="Página anterior"'));
   assert.ok(source.includes('aria-label="Página siguiente"'));
-  assert.ok(source.includes("currentOffset"));
-  assert.ok(source.includes("setCurrentOffset"));
+  assert.ok(source.includes("offset"));
+  assert.ok(source.includes("setOffset"));
   assert.ok(source.includes("totalClinics"));
   assert.ok(source.includes("hasPrev"));
   assert.ok(source.includes("hasNext"));
   assert.ok(source.includes("snapshot?.total"));
-  assert.ok(source.includes("PAGE_SIZE"));
+  assert.ok(source.includes("CLINICS_FALLBACK_ROWS"));
+});
+
+test("admin clinics management card derives cardinality from measurement, not matchMedia", () => {
+  const source = read(ADMIN_CLINICS_CARD_PATH);
+
+  assert.ok(source.includes("useAdaptiveItemsPerPage"));
+  assert.ok(source.includes("effectiveLimit"));
+  assert.ok(source.includes("CLINICS_SUPERSET_CAP = 36"));
+  assert.ok(source.includes("ResizeObserver"));
+  assert.ok(source.includes("latestRequestRef"));
+  assert.equal(source.includes("matchMedia"), false);
+  assert.equal(source.includes("MOBILE_PAGE_SIZE"), false);
+  assert.equal(source.includes("effectivePageSize"), false);
+  assert.equal(source.includes("isMobileViewport"), false);
 });
 
 test("admin clinics management card shows no-results state when search finds no matches", () => {
@@ -184,9 +198,10 @@ test("admin clinics management card shows no-results state when search finds no 
 test("admin clinics management card resets to page 0 when search changes", () => {
   const source = read(ADMIN_CLINICS_CARD_PATH);
 
-  // useEffect depends on searchQuery and calls loadClinics with offset 0
-  assert.ok(source.includes("searchQuery, effectivePageSize]"));
-  assert.ok(source.includes("loadClinics(0"));
+  // Debounced search effect resets offset to 0 before the query re-fetches.
+  assert.ok(source.includes("}, [searchQuery]);"));
+  assert.ok(source.includes("setOffset(0);"));
+  assert.ok(source.includes("setSubmittedSearch(searchQuery.trim());"));
 });
 
 test("admin clinics management card does not double-filter rows client-side", () => {
@@ -225,12 +240,8 @@ test("admin clinics management card renders mobile cards while preserving deskto
   const source = read(ADMIN_CLINICS_CARD_PATH);
 
   assert.ok(
-    source.includes("const MOBILE_PAGE_SIZE = 10;"),
-    "mobile page size intentionally raised to 10 (PR2); the compacted borderless name+email row keeps the list viewport-safe",
-  );
-  assert.ok(
-    source.includes("effectivePageSize"),
-    "admin clinics must use responsive page size",
+    source.includes("data-admin-mobile-core-module=\"clinics\""),
+    "single collapsed runtime keeps the mobile core module landmark",
   );
   assert.ok(
     source.includes('data-admin-clinics-mobile-list="true"'),
@@ -241,6 +252,14 @@ test("admin clinics management card renders mobile cards while preserving deskto
     "mobile clinic cards must exist",
   );
   assert.ok(
+    source.includes('data-admin-mobile-core-item="true"'),
+    "mobile clinic cards must keep the core item landmark",
+  );
+  assert.ok(
+    source.includes('data-admin-mobile-core-pager="true"'),
+    "mobile pager must keep the core pager landmark",
+  );
+  assert.ok(
     source.includes('dashboard-table-responsive hidden md:block'),
     "desktop table must be hidden on mobile and preserved from md upward",
   );
@@ -248,4 +267,14 @@ test("admin clinics management card renders mobile cards while preserving deskto
     source.includes('aria-label={`Editar clínica ${clinic.clinicName}`}'),
     "mobile edit action must keep the accessible clinic-specific label",
   );
+});
+
+test("admin clinics management card keeps a single runtime — no separate mobile module", () => {
+  const source = read(ADMIN_CLINICS_CARD_PATH);
+
+  // Unlike Sessions/Users, Clinics never had a standalone AdminMobileClinicsModule;
+  // the desktop/mobile duality already lived inside this single component, so
+  // R-02 collapses cardinality here without introducing a compat shim.
+  assert.ok(source.includes("export function AdminClinicsManagementCard()"));
+  assert.equal(source.includes("AdminMobileClinicsModule"), false);
 });


### PR DESCRIPTION
R-02 del roadmap final.

Implementa Clínicas Admin server-adaptive:
- HY cap 36.
- effectiveLimit derivado de viewport real.
- useAdaptiveItemsPerPage con contenedor + fila real.
- offset recomputado al cambiar cardinalidad.
- request-id anti-race.
- búsqueda server-side resetea offset.
- ClinicEditDrawer preservado durante resize/zoom/recompute.
- sin matchMedia como cardinalidad.
- MOBILE_PAGE_SIZE eliminado como fuente de verdad.

Docs:
- docs/implementation/admin-clinics-management-server-adaptive-pagination.md

Scope:
- Sin backend/API/auth/DB.
- Sin total nuevo.
- Sin CI/workflows.
- Sin deps/lockfiles.
- Sin snapshots.
- Sin globals.css.
- Sin otros módulos Admin.
- Sin Clínica/Particular/Público.
- Sin R-03 adelantado.

Validaciones locales reportadas:
- node --test clínicas: 32/32
- pnpm test: 2941/2941
- pnpm typecheck:test OK
- pnpm security:public-surface PASS
- frontend lint/typecheck/build OK
- e2e edit drawer + clinics mobile layout: 16/16
- e2e mobile core modules no-scroll: 14/14
- e2e viewport/internal/global: 84/84
- extra admin-mobile-final-polish-no-scroll: 4/4