### PR TITLE
feat(admin): adapt reports workflow server pagination to viewport

### DIFF
--- a/docs/implementation/admin-reports-workflow-server-adaptive-pagination.md
+++ b/docs/implementation/admin-reports-workflow-server-adaptive-pagination.md
@@ -1,0 +1,289 @@
+# R-03 — Admin Reports workflow server adaptive pagination
+
+## PR
+
+`feat(admin): adapt reports workflow server pagination to viewport`
+
+Quinto módulo Admin **servidor** (`limit`/`offset`, familia C) migrado a cardinalidad
+adaptativa Zero-Scroll, ejecutando **R-03** del roadmap rector
+(`docs/audit/final-global-vetneb-50-60-pr-roadmap.md`, Fase 1) con la política de
+PR-SRV-0 y la plantilla probada en Sesiones (#1221), Usuarios/Roles (#1222), R-01
+Alertas login (#1263) y R-02 Clínicas (#1264).
+
+Es el módulo con el **peor acoplamiento** del subgrupo 2 de PR-SRV-0: a diferencia de
+Clínicas (un solo pipeline con `effectivePageSize` por `matchMedia`), Reports tenía **dos
+pipelines de fetch independientes** (desktop + mobile) con `limit`/`offset` divergentes.
+
+## Base
+
+- Rama de trabajo: `feat/admin-reports-workflow-server-adaptive-pagination`.
+- Base: `main @ 298a605 feat(admin): adapt clinics management server pagination to viewport (#1264)`.
+- Fecha: 2026-07-03.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-03, Fase 1, reglas §5/§6/§8.
+2. `docs/implementation/server-adaptive-pagination-strategy.md` (PR-SRV-0) — módulo #4
+   (Informes workflow): decisión **HY cap 36 + unificar `limit`**, política de offset
+   (§6, incluida la regla 2 para endpoints **sin `total`**), anti-race (§7), límites (§8).
+3. `docs/implementation/admin-sessions-server-adaptive-pagination.md` (SRV-1) — plantilla
+   de medición/anti-race/recompute.
+4. `docs/implementation/admin-users-roles-server-adaptive-pagination.md` (SRV-2) — trato
+   de contratos legacy de N filas (piso desktop `minItems`) — **replicado aquí**.
+5. `docs/implementation/admin-failed-login-alerts-server-adaptive-pagination.md` (R-01) —
+   patrón de filtros/búsqueda server-side.
+6. `docs/implementation/admin-clinics-management-server-adaptive-pagination.md` (R-02) —
+   módulo mm-cardinalidad + fix de settle en CI (patrón de conteo asentado en e2e).
+
+## Skills / modelo / esfuerzo
+
+| Rol | Valor |
+|---|---|
+| Principal | `vetneb-production-web-optimization-engineer` |
+| Complementaria | `vetneb-briefing-planificacion-diseno-desarrollo-pruebas` |
+| Complementaria | `vetneb-web-end-to-end-global` |
+| Guardrail | `vetneb-security-production-invariants` |
+| Admin operativo | `vetneb-admin-dashboard-operational-actions` |
+| Modelo | Claude Opus 4.8 (`claude-opus-4-8`) |
+| Esfuerzo | Alto / máximo |
+
+El ZIP/carpeta de skills **no** fue copiado, descomprimido, editado, versionado ni
+ejecutado dentro de `C:\PORTAL-VETNEB`.
+
+## Contrato anterior
+
+Runtime único (`AdminReportsCard`, sin módulo mobile separado) pero con **dos pipelines
+de fetch reales y divergentes**:
+
+- **Desktop:** estado `reports`/`page`/`hasMore`/`isLoading`, `loadReports(nextPage)` con
+  `getAdminReportWorkflow({ limit: PAGE_SIZE(9), offset: nextPage * PAGE_SIZE })`.
+- **Mobile:** estado `mobileReports`/`mobilePage`/`mobileHasMore`/`isMobileLoading`,
+  `loadMobileReports(nextPage)` con `getAdminReportWorkflow({ limit: MOBILE_PAGE_SIZE(10),
+  offset: nextPage * MOBILE_PAGE_SIZE })`.
+- **`isMobileViewport`** resuelto por `window.matchMedia("(max-width: 767px)")` decidía qué
+  pipeline se hidrataba/mostraba. Cuando mobile estaba activo, **ambos** pipelines corrían
+  → **doble fetch** por el mismo dato.
+- Modelo `page`; filtros **client-side** (`matchesAdminReportFilters` sobre la página ya
+  cargada). El endpoint expone `pagination.hasMore`, **no `total`**.
+
+## Contrato nuevo
+
+- **Runtime único colapsado:** una sola fuente de datos (`reports`), un solo `offset`, un
+  solo `loadReports`. El segundo pipeline mobile (`mobileReports`, `loadMobileReports`,
+  `isMobileViewport`, `mobilePage`, `mobileHasMore`, `isMobileLoading`,
+  `filteredMobileReports`) queda **eliminado** → sin doble fetch, sin `limit`/`offset`
+  divergentes. Sigue renderizando dos presentaciones responsive (tabla desktop
+  `hidden md:block` + lista mobile `md:hidden`, en ese orden en el DOM).
+- `REPORTS_FALLBACK_ROWS = 9` (ex `PAGE_SIZE`) sólo como fallback antes de la primera
+  medición y como **piso desktop**.
+- `REPORTS_SUPERSET_CAP = 36` como techo híbrido (`maxItems` del hook), igual a
+  Usuarios/Roles y Clínicas.
+- `useAdaptiveItemsPerPage` mide el **contenedor de filas visible** (región de tabla
+  desktop o lista mobile, elegido por altura medida, no por `matchMedia`) y una **fila
+  real** (`ref` en la primera fila/artículo); el header de la tabla desktop se descuenta
+  (`REPORTS_TABLE_HEADER_PX = 28`, el `[&_th]:h-7` existente).
+- `effectiveLimit = rowsPerPage`; `getAdminReportWorkflow({ limit: query.limit, offset:
+  query.offset })`.
+- `page`/`hasPrev`/`hasNext`/rango usan `effectiveLimit` y `offset`; `hasNext = hasMore`
+  (heurística de página llena; el endpoint no expone `total`, ver §6 regla 2 de PR-SRV-0).
+- Filtros client-side (idénticos): aplicar/limpiar resetea `offset` a 0; la cardinalidad
+  (resize/zoom) nunca toca los filtros.
+- Sin `matchMedia`, sin `MOBILE_PAGE_SIZE`, sin `isMobileViewport`, sin
+  `loadMobileReports`, sin `filteredMobileReports`.
+
+## Divergencia anterior mobile/desktop y cómo se unificó `limit`/`offset`
+
+| Aspecto | Antes (desktop / mobile) | Ahora (unificado) |
+|---|---|---|
+| Constante `limit` | `PAGE_SIZE=9` / `MOBILE_PAGE_SIZE=10` | `effectiveLimit = rowsPerPage` medido, cap 36 |
+| Estado de página | `page` / `mobilePage` | `offset` único |
+| Fetch | `loadReports` / `loadMobileReports` | `loadReports` único (deriva de `query = {limit, offset}`) |
+| Fuente de cardinalidad | `matchMedia` elige pipeline | medición del contenedor visible |
+| Nº de fetch en mobile | 2 (desktop + mobile) | 1 |
+
+La unificación consiste en borrar el pipeline mobile completo y hacer que la lista mobile
+consuma el **mismo** `reports`/`offset`/`effectiveLimit` que la tabla desktop, con el hook
+midiendo la región realmente visible en cada viewport.
+
+## Estrategia HY cap 36
+
+Estrategia **HY** (híbrida) de PR-SRV-0 §5/§8, la asignada a Informes workflow en el
+inventario: se pide **al menos** `rowsPerPage`, con **cap 36**. El hook clampa
+`rowsPerPage` a `[minItems, 36]`, por lo que `effectiveLimit = rowsPerPage`. El re-fetch
+sólo ocurre cuando cambia `effectiveLimit` (medición distinta) o `offset` (paginación /
+filtros / upload); si `rowsPerPage` no cambió, el `query` memoizado no cambia y no hay
+request.
+
+## Evidencia de `matchMedia` / `MOBILE_PAGE_SIZE` / segundo pipeline eliminado
+
+`grep` sobre `AdminReportsCard.tsx` tras la migración: `mobileReports`, `mobilePage`,
+`mobileHasMore`, `isMobileLoading`, `isMobileViewport`, `filteredMobileReports`,
+`MOBILE_PAGE_SIZE`, `PAGE_SIZE`, `setPage`, `loadMobileReports`, `window.matchMedia`
+**no aparecen como código** — sólo subsisten menciones en comentarios que documentan la
+migración. Fijado por los tests source-contract:
+
+- `admin-reports-enterprise-density.test.ts`: `REPORTS_FALLBACK_ROWS`/`REPORTS_SUPERSET_CAP`
+  presentes; `PAGE_SIZE`/`MOBILE_PAGE_SIZE`/`window.matchMedia`/`isMobileViewport`/
+  `loadMobileReports`/`filteredMobileReports` ausentes; `useAdaptiveItemsPerPage`,
+  `effectiveLimit = rowsPerPage`, request-id y recompute de offset presentes.
+- `admin-mobile-core-pager-canonical-layout.test.ts`: pager mobile `Pág. {page}`; page-size
+  mobile medido (no constante); pipeline único.
+
+## Cómo se mide `rowsPerPage`
+
+Igual que SRV-1/SRV-2/R-01/R-02: refs de estado (`setDesktopBodyNode`/`setMobileBodyNode`
++ `setDesktopRowNode`/`setMobileRowNode`), `ResizeObserver` agenda con
+`requestAnimationFrame`, la región visible se elige por altura medida (mobile primero,
+desktop después), la fila real medida reemplaza el fallback
+(`REPORTS_ROW_HEIGHT_FALLBACK_PX = 36`), y el header de tabla desktop se descuenta.
+
+**Piso desktop (excepción documentada, patrón SRV-2):** Reports está pinneado por el
+contrato App Shell `expectNinePopulatedRows` (`dashboard-real-app-shell-no-scroll-
+contract.spec.ts`, 1440×900 y 1366×768). Un `safetyGap` positivo podría bajar el fit
+medido a ocho y romper ese contrato, así que el contexto desktop —detectado por el header
+descontado (`isDesktopMeasurement = measurement.headerHeightPx > 0`)— mantiene
+`minItems = REPORTS_FALLBACK_ROWS (9)`, mientras la lista mobile mantiene `minItems = 1`
+para poder encoger en teléfonos cortos. **Clínicas (R-02) usa piso 1** porque no tiene ese
+contrato; **Reports lo replica de Usuarios/Roles (SRV-2)** porque sí lo tiene.
+
+## Cómo se recomputa `offset`
+
+PR-SRV-0 §6, con la **regla 2** para endpoints sin `total`:
+
+```
+nextOffset = Math.max(0, Math.floor(currentOffset / effectiveLimit) * effectiveLimit);
+```
+
+No hay clamp contra `total` porque el endpoint `report-workflow` no lo expone: sólo se
+clampa `offset ≥ 0` y el avance de página lo gobierna `hasMore` (página llena). Nunca se
+salta a "última página" ni se computa `pageCount`. El recompute sólo corre cuando cambia
+`effectiveLimit` (`previousLimitRef`); la búsqueda/filtros resetean `offset` a 0 aparte.
+
+## Cómo se evita la carrera
+
+- **Request id** (`latestRequestRef`): cada `loadReports()` incrementa el id; una respuesta
+  cuyo id ya no es el vigente se descarta (éxito y error), y `setIsLoading(false)` sólo
+  corre para la respuesta vigente. Esto evita que una respuesta con `L0` pise el estado con
+  `L1`.
+- **Debounce de medición**: `ResizeObserver` + `requestAnimationFrame` +
+  `measurementsEqual`; el hook global sólo cambia `rowsPerPage` si el valor derivado
+  difiere. El resize/zoom continuo no genera ráfaga.
+- **Sin doble fetch**: al eliminar el pipeline mobile, un viewport mobile ya no dispara dos
+  cargas. `loadReports()` deriva del `query` memoizado (`{limit, offset}`); un solo efecto
+  `[loadReports]` reacciona a cambios de `query`.
+- **Fallback estable**: sin contenedor medido, el hook devuelve el fallback (9) y no
+  re-fetchea por cardinalidad; loading/empty tienen geometría estable.
+
+## Cómo filtros server-side (client-side aquí) resetean offset
+
+Los filtros de Reports son **client-side** (`matchesAdminReportFilters` sobre la página
+cargada) — no se convierten a server-side (eso tocaría backend/API, fuera de scope). El
+comportamiento previo de "aplicar/limpiar filtro vuelve a la primera página" se preserva:
+`applyAdvancedFilters` y `clearAdvancedFilters` hacen `setOffset(0)` (antes `setPage(0)` +
+`setMobilePage(0)`). Una cardinalidad (resize/zoom) nunca toca los filtros ni el offset por
+filtro.
+
+## Cómo se preservó `AdminReportsUploadPanel` sin tocarlo
+
+`AdminReportsUploadPanel.tsx` **no se modificó**. Sigue montándose igual
+(`<AdminReportsUploadPanel open={isUploadOpen} onOpenChange={setIsUploadOpen}
+onUploaded={handleUploaded} />`). El único punto de contacto, `handleUploaded`, se simplificó
+al pipeline único: tras subir un informe vuelve a la primera página sin doble fetch (si
+`offset === 0` recarga directo; si no, `setOffset(0)` deja que el efecto `[loadReports]`
+dispare el único fetch). El panel de subida y su contrato de API quedan intactos.
+
+## Sin módulo mobile separado
+
+`AdminReportsCard` nunca tuvo un archivo `AdminMobileReportsModule` independiente — la
+dualidad vivía **dentro** del componente como un segundo pipeline de estado/fetch. R-03 no
+crea ni elimina ningún shim de archivo; colapsa el segundo pipeline dentro del mismo
+componente. Selectores e2e preservados: `data-admin-mobile-core-module="reports"`,
+`data-admin-reports-mobile-list="true"`, `data-admin-mobile-core-item="true"`,
+`data-admin-mobile-core-pager="true"`, `data-admin-reports-toolbar="true"`,
+`aria-label="Paginación de informes admin"`.
+
+## `total`/`hasNext` sin backend nuevo
+
+El endpoint `GET /api/admin/report-workflow` ya aceptaba `limit`/`offset` y devuelve
+`pagination.hasMore` (verificado read-only en `api.ts`: `AdminReportWorkflowSnapshot` no
+tiene campo `total`). R-03 no modifica ningún contrato de backend/API; usa `hasMore` como
+`hasNext` (subgrupo 3 de PR-SRV-0: sin `total`, sin `pageCount`).
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/admin/AdminReportsCard.tsx` — runtime único adaptativo
+  (medición con piso desktop, anti-race por request-id, recompute de offset sin clamp por
+  total, filtros resetean offset, colapso del segundo pipeline mobile).
+- `test/admin-reports-enterprise-density.test.ts` — source-contract alineado al contrato
+  adaptativo (constantes, ausencia de `matchMedia`/`MOBILE_PAGE_SIZE`/segundo pipeline,
+  request-id, recompute, piso desktop, filtros client-side sin nuevo contrato API).
+- `test/admin-mobile-core-pager-canonical-layout.test.ts` — **sólo** las aserciones de
+  `AdminReportsCard` alineadas (pager `Pág. {page}`, page-size medido, pipeline único); las
+  de Clínicas quedaron intactas.
+- `frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts` — entrada `reports` de
+  `MODULES` (`maxItemsPerPage: 10 → 36`, `MOCK_REPORTS: 13 → 40`) y el test de paginación
+  mobile de reports pasa de "10-record pages" fijas a contrato adaptativo (conteo asentado
+  > 0, ≤ cap 36, cambio de contenido en página 2); las entradas `clinics`/`tokens` quedaron
+  intactas.
+- `docs/implementation/admin-reports-workflow-server-adaptive-pagination.md` — este
+  documento.
+
+## Validaciones ejecutadas
+
+PNPM 10.8.1 (coincide con `packageManager`).
+
+- `node --test` dirigido a los 2 archivos de test de Reports — 17/17.
+- `pnpm test` — 2942/2942.
+- `pnpm typecheck:test` — OK.
+- `pnpm security:public-surface` — PASS (sólo marcadores server-only esperados en
+  `frontend/src/proxy.ts`).
+- `pnpm --dir frontend lint` — OK.
+- `pnpm --dir frontend typecheck` — OK.
+- `pnpm --dir frontend build` — OK.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts`
+  — 14/14 (bloque `reports` + `clinics`/`tokens` sin regresión; test de paginación mobile
+  adaptativo).
+- `pnpm --dir frontend exec playwright test e2e/dashboard-real-app-shell-no-scroll-contract.spec.ts`
+  — 37/37 (`admin reports populated` con `expectNinePopulatedRows` preservado por el piso
+  desktop=9).
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-ops-modules-no-scroll.spec.ts
+  e2e/admin-mobile-status-modules-no-scroll.spec.ts e2e/admin-mobile-final-polish-no-scroll.spec.ts
+  e2e/dashboard-viewport-zoom-adaptability.spec.ts e2e/dashboard-internal-no-scroll-contract.spec.ts
+  e2e/dashboard-global-masked-master-detail.spec.ts` — 124/124.
+
+`frontend/next-env.d.ts` fue regenerado por Next/Playwright durante los e2e y se restauró
+(`git checkout --`) antes del diff review, por estar fuera de scope.
+
+## Riesgos residuales
+
+- **Flake medición↔fetch (P2):** el primer paint puede usar el fallback (9) antes de que la
+  fila real se mida, disparando un segundo fetch con el `effectiveLimit` asentado. Mismo
+  riesgo documentado en Sesiones/Usuarios/Alertas/Clínicas; mitigado en e2e con espera de
+  conteo estable (dos lecturas iguales) antes de aserciones de paginación.
+- **Sin `total` → sin salto a última página:** el pager sólo avanza/retrocede de a una
+  página vía `hasMore`; no hay `pageCount` ni "ir a última". Es la limitación conocida del
+  endpoint (subgrupo 3 de PR-SRV-0), no una regresión.
+- **Piso desktop = 9:** excepción de contrato legacy (igual que SRV-2); se revisa cuando se
+  regeneren los contratos desktop legacy (nota en R-26 del roadmap).
+- **QA manual pendiente:** iOS/Android real y zoom físico 100–175 % siguen siendo
+  obligatorios antes de cualquier gate bloqueante (PR-SRV-0 §10.5).
+
+## Fuera de scope (no tocado)
+
+- `AdminReportsUploadPanel.tsx` (upload panel) — sin cambios.
+- Otros módulos Admin (`AdminClinicsManagementCard`, `AdminParticularTokensCard`,
+  `AdminAuditCard`, `AdminFailedLoginAlertsReadOnlyCard`, Sesiones, Usuarios/Roles).
+- Backend/API/auth/DB/migrations (verificación del endpoint fue sólo lectura; no se pidió
+  nada nuevo).
+- CI/workflows, deps/lockfiles, snapshots, `globals.css`.
+- Rutas Clínica/Particular/Público; ruta full `/dashboard/informes` (R-07).
+- R-04..R-09 (no se adelantó ningún PR posterior).
+
+## Confirmaciones
+
+- Un solo módulo Admin tocado: Informes workflow.
+- No `matchMedia` como cardinalidad; `MOBILE_PAGE_SIZE`/segundo pipeline eliminados;
+  `PAGE_SIZE` renombrado a `REPORTS_FALLBACK_ROWS` (fallback + piso desktop); offset
+  recomputado; anti-race por request-id; filtros resetean offset; `AdminReportsUploadPanel`
+  preservado sin tocar.
+- No se hizo `git add`/`commit`/`push`/`gh pr create`.

--- a/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
@@ -33,7 +33,10 @@ const MOCK_CLINICS = Array.from({ length: 40 }, (_, index) => {
 });
 
 const REPORT_STAGES = ["sample_received", "processing", "delivered"] as const;
-const MOCK_REPORTS = Array.from({ length: 13 }, (_, index) => {
+// R-03: reports pages are now measured (HY cap 36) instead of a fixed 10, so
+// the fixture must have enough rows to fill the tallest measured page and still
+// leave a populated page 2 (same reasoning as the R-02 clinics bump 13 → 40).
+const MOCK_REPORTS = Array.from({ length: 40 }, (_, index) => {
   const id = 7400 + index;
   return {
     id,
@@ -146,7 +149,7 @@ const MODULES: ModuleSpec[] = [
   // Clinics: R-02 raised the ceiling to the HY superset cap (36); the real
   // guarantee is per-item viewport fit, not a fixed page size.
   { key: "clinics", moduleId: "admin-clinics", mock: mockAdminClinics, maxItemsPerPage: 36 },
-  { key: "reports", moduleId: "admin-report-upload", mock: mockAdminReportWorkflow, maxItemsPerPage: 10 },
+  { key: "reports", moduleId: "admin-report-upload", mock: mockAdminReportWorkflow, maxItemsPerPage: 36 },
   { key: "tokens", moduleId: "admin-particular-tokens", mock: mockAdminParticularTokens, maxItemsPerPage: 10 },
 ];
 
@@ -313,7 +316,7 @@ test("Admin mobile core modules reachable from bottom nav and Más menu", async 
   ).toBeVisible({ timeout: 15_000 });
 });
 
-test("Admin mobile reports pagination advances through 10-record pages with pager anchored at the bottom", async ({
+test("Admin mobile reports pagination advances through measured pages with pager anchored at the bottom", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -327,9 +330,26 @@ test("Admin mobile reports pagination advances through 10-record pages with page
 
   const list = page.locator("[data-admin-reports-mobile-list='true']");
   await expect(list).toBeVisible();
+  // R-03: the page size is measured (HY cap 36), not a fixed 10. The first
+  // record is always on page 1; assert the adaptive contract instead of a
+  // hard-coded per-page count.
+  const items = list.locator("[data-admin-mobile-core-item='true']");
+  await expect(items.first()).toBeVisible();
   await expect(list.getByText("#7400 ", { exact: false })).toBeVisible();
-  await expect(list.getByText("#7409 ", { exact: false })).toBeVisible();
-  await expect(list.getByText("#7410 ", { exact: false })).toHaveCount(0);
+
+  // Wait for the measurement↔fetch settle (two consecutive equal counts)
+  // before reading the page-1 contents, same pattern as the no-scroll loop.
+  let settledCount = -1;
+  await expect(async () => {
+    const current = await items.count();
+    expect(current).toBeGreaterThan(0);
+    if (settledCount !== current) {
+      settledCount = current;
+      throw new Error(`reports item count not yet stable: ${current}`);
+    }
+  }).toPass({ intervals: [250, 350, 500, 750, 1_000], timeout: 10_000 });
+  expect(settledCount).toBeGreaterThan(0);
+  expect(settledCount).toBeLessThanOrEqual(36);
 
   const pager = page.locator("[data-admin-mobile-core-pager='true']");
   await expect(pager.getByText("Pág. 1")).toBeVisible();
@@ -342,9 +362,12 @@ test("Admin mobile reports pagination advances through 10-record pages with page
   expect(bottomNavBox).not.toBeNull();
   expect(pagerBox!.y + pagerBox!.height).toBeLessThanOrEqual(bottomNavBox!.y + 2);
 
+  const firstPageLabels = (await items.allTextContents()).join("|");
   await pager.getByRole("button", { name: "Página siguiente" }).click();
-  await expect(list.getByText("#7410 ", { exact: false })).toBeVisible();
-  await expect(list.getByText("#7412 ", { exact: false })).toBeVisible();
+  // Page 2 shows different records; the first record (#7400) is no longer here.
+  await expect
+    .poll(async () => (await items.allTextContents()).join("|"))
+    .not.toBe(firstPageLabels);
   await expect(list.getByText("#7400 ", { exact: false })).toHaveCount(0);
   await expect(pager.getByText("Pág. 2")).toBeVisible();
 });

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -38,16 +46,43 @@ import {
   type AdminReportWorkflowItem,
   type AdminReportWorkflowStage,
 } from "@/lib/api";
+import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";
 import {
   ADMIN_REPORT_STAGE_OPTIONS,
   AdminReportStatusBadge,
 } from "./AdminReportStatusBadge";
 import { AdminReportsUploadPanel } from "./AdminReportsUploadPanel";
 
-// PR-3 established nine dense rows as the safe 1366x768 limit while the App
-// Shell intentionally has no vertical scroll region.
-const PAGE_SIZE = 9;
-const MOBILE_PAGE_SIZE = 10;
+// Server pagination is now sized by the measured rows container (Zero-Scroll
+// adaptive contract, R-03/PR-SRV-0 module #4). PR-3 established nine dense rows
+// as the safe 1366x768 desktop limit; that constant survives only as the
+// pre-measurement fallback and as the desktop floor. A media query no longer
+// decides cardinality, and the mobile/desktop `limit`/`offset` divergence
+// (PAGE_SIZE=9 vs MOBILE_PAGE_SIZE=10, two independent fetch pipelines) is
+// collapsed into a single measured runtime.
+const REPORTS_FALLBACK_ROWS = 9;
+// Hybrid cap: the effective `limit` never exceeds this superset ceiling even on
+// very tall viewports; recompute of offset always clamps against it.
+const REPORTS_SUPERSET_CAP = 36;
+// Fixed header row height of the desktop table (`[&_th]:h-7`), discounted from
+// the measured region so the row math never counts the header as a data row.
+const REPORTS_TABLE_HEADER_PX = 28;
+// Fallback item height used until a real row is measured.
+const REPORTS_ROW_HEIGHT_FALLBACK_PX = 36;
+
+type Measurement = {
+  containerNode: HTMLElement | null;
+  rowHeightPx: number;
+  headerHeightPx: number;
+};
+
+function measurementsEqual(a: Measurement, b: Measurement) {
+  return (
+    a.containerNode === b.containerNode &&
+    a.rowHeightPx === b.rowHeightPx &&
+    a.headerHeightPx === b.headerHeightPx
+  );
+}
 
 const STUDY_LABELS: Record<string, string> = {
   histopatologia: "Histopatología",
@@ -166,7 +201,7 @@ function matchesAdminReportFilters(
 
 export function AdminReportsCard() {
   const [reports, setReports] = useState<AdminReportWorkflowItem[]>([]);
-  const [page, setPage] = useState(0);
+  const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [busyReportId, setBusyReportId] = useState<number | null>(null);
@@ -179,31 +214,118 @@ export function AdminReportsCard() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  // Mobile renders a smaller, independently paginated slice of the same
-  // server-side workflow queue. Desktop keeps its own PAGE_SIZE=9 fetch
-  // untouched so the dense viewport-safe contract stays pinned.
-  const [mobileReports, setMobileReports] = useState<AdminReportWorkflowItem[]>([]);
-  const [mobilePage, setMobilePage] = useState(0);
-  const [mobileHasMore, setMobileHasMore] = useState(false);
-  const [isMobileLoading, setIsMobileLoading] = useState(true);
-  // Start false so SSR and the client's first render agree. The media-query
-  // effect below promotes this to the real viewport value right after mount,
-  // which avoids a hydration mismatch on the mobile-only branches.
-  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  // One collapsed runtime feeds both presentations, so the visible container
+  // (desktop table region or mobile list region) drives a single cardinality.
+  // The old second `mobileReports` fetch pipeline (MOBILE_PAGE_SIZE=10 gated by
+  // matchMedia) is gone: no more double fetch, no more divergent limit/offset.
+  const [desktopBodyNode, setDesktopBodyNode] = useState<HTMLElement | null>(
+    null,
+  );
+  const [mobileBodyNode, setMobileBodyNode] = useState<HTMLElement | null>(null);
+  const [desktopRowNode, setDesktopRowNode] = useState<HTMLElement | null>(null);
+  const [mobileRowNode, setMobileRowNode] = useState<HTMLElement | null>(null);
+  const [measurement, setMeasurement] = useState<Measurement>({
+    containerNode: null,
+    rowHeightPx: REPORTS_ROW_HEIGHT_FALLBACK_PX,
+    headerHeightPx: 0,
+  });
+
+  const latestRequestRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const nodes = [
+      desktopBodyNode,
+      mobileBodyNode,
+      desktopRowNode,
+      mobileRowNode,
+    ].filter((node): node is HTMLElement => node !== null);
+    if (nodes.length === 0) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const recompute = () => {
+      frame = null;
+
+      const mobileHeight = mobileBodyNode?.getBoundingClientRect().height ?? 0;
+      if (mobileHeight > 0 && mobileBodyNode) {
+        const rowHeight = mobileRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: mobileBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : REPORTS_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: 0,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+        return;
+      }
+
+      const desktopHeight = desktopBodyNode?.getBoundingClientRect().height ?? 0;
+      if (desktopHeight > 0 && desktopBodyNode) {
+        const rowHeight = desktopRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: desktopBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : REPORTS_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: REPORTS_TABLE_HEADER_PX,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+      }
+    };
+
+    const scheduleRecompute = () => {
+      if (frame === null) {
+        frame = requestAnimationFrame(recompute);
+      }
+    };
+
+    const observer = new ResizeObserver(scheduleRecompute);
+    nodes.forEach((node) => observer.observe(node));
+    scheduleRecompute();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [desktopBodyNode, mobileBodyNode, desktopRowNode, mobileRowNode]);
+
+  // The desktop table is pinned to nine populated rows at the shortest
+  // supported desktop viewport (1366×768) by the App Shell contract
+  // (`expectNinePopulatedRows`). A positive safety cushion could floor the
+  // measured fit to eight and break that contract, so the desktop context
+  // (detected by the discounted table header) keeps a floor of nine — matching
+  // the pre-adaptive fixed page size — while still adapting upward on taller
+  // viewports. The mobile list (no table header) keeps a floor of one so it can
+  // shrink freely on short phones. Same exception documented for Users/Roles
+  // (SRV-2); Clínicas (R-02) has no such contract and uses a floor of one.
+  const isDesktopMeasurement = measurement.headerHeightPx > 0;
+  const { itemsPerPage: rowsPerPage } = useAdaptiveItemsPerPage({
+    containerNode: measurement.containerNode,
+    fallbackItems: REPORTS_FALLBACK_ROWS,
+    itemHeightPx: measurement.rowHeightPx,
+    headerHeightPx: measurement.headerHeightPx,
+    minItems: isDesktopMeasurement ? REPORTS_FALLBACK_ROWS : 1,
+    maxItems: REPORTS_SUPERSET_CAP,
+  });
+
+  // Effective server page size: at least the measured rows, capped at the
+  // superset ceiling. The hook already clamps to [minItems, REPORTS_SUPERSET_CAP].
+  const effectiveLimit = rowsPerPage;
 
   const selectedReport = useMemo(
-    () =>
-      reports.find((report) => report.id === selectedReportId) ??
-      mobileReports.find((report) => report.id === selectedReportId) ??
-      null,
-    [mobileReports, reports, selectedReportId],
+    () => reports.find((report) => report.id === selectedReportId) ?? null,
+    [reports, selectedReportId],
   );
 
   const hasActiveFilters = !isFilterStateEmpty(appliedFilters);
   const filteredReports = reports.filter((report) =>
-    matchesAdminReportFilters(report, appliedFilters),
-  );
-  const filteredMobileReports = mobileReports.filter((report) =>
     matchesAdminReportFilters(report, appliedFilters),
   );
   const deliveredCount = filteredReports.filter(
@@ -212,24 +334,40 @@ export function AdminReportsCard() {
   const specialStainCount = filteredReports.filter(
     (report) => report.specialStainRequested,
   ).length;
-  const rangeStart = filteredReports.length ? page * PAGE_SIZE + 1 : 0;
-  const rangeEnd = page * PAGE_SIZE + filteredReports.length;
+  // The report-workflow endpoint exposes no `total`, only `hasMore` per full
+  // page (PR-SRV-0 §6 rule 2): offset is clamped to ≥ 0 and next-page is driven
+  // by `hasMore`; there is no pageCount / jump-to-last.
+  const page = Math.floor(offset / effectiveLimit) + 1;
+  const hasPrev = offset > 0;
+  const hasNext = hasMore;
+  const rangeStart = filteredReports.length ? offset + 1 : 0;
+  const rangeEnd = offset + filteredReports.length;
 
-  const loadReports = useCallback(async (nextPage: number) => {
+  const query = useMemo(
+    () => ({ limit: effectiveLimit, offset }),
+    [effectiveLimit, offset],
+  );
+
+  const loadReports = useCallback(async () => {
     setIsLoading(true);
     setErrorMessage(null);
 
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+
     try {
       const snapshot = await getAdminReportWorkflow({
-        limit: PAGE_SIZE,
-        offset: nextPage * PAGE_SIZE,
+        limit: query.limit,
+        offset: query.offset,
       });
+      if (requestId !== latestRequestRef.current) return;
       setReports(snapshot.reports);
       setHasMore(snapshot.pagination.hasMore);
       setSelectedReportId((current) =>
         snapshot.reports.some((report) => report.id === current) ? current : null,
       );
     } catch (error) {
+      if (requestId !== latestRequestRef.current) return;
       setReports([]);
       setHasMore(false);
       setSelectedReportId(null);
@@ -239,57 +377,38 @@ export function AdminReportsCard() {
           : "No se pudo cargar la cola de informes.",
       );
     } finally {
-      setIsLoading(false);
+      if (requestId === latestRequestRef.current) {
+        setIsLoading(false);
+      }
     }
-  }, []);
+  }, [query]);
 
-  const loadMobileReports = useCallback(async (nextPage: number) => {
-    setIsMobileLoading(true);
-
-    try {
-      const snapshot = await getAdminReportWorkflow({
-        limit: MOBILE_PAGE_SIZE,
-        offset: nextPage * MOBILE_PAGE_SIZE,
-      });
-      setMobileReports(snapshot.reports);
-      setMobileHasMore(snapshot.pagination.hasMore);
-    } catch {
-      setMobileReports([]);
-      setMobileHasMore(false);
-    } finally {
-      setIsMobileLoading(false);
+  // Recompute offset when the effective limit changes so the same first record
+  // stays visible (PR-SRV-0 §6). No `total` clamp is possible here (endpoint
+  // exposes none), so only the `offset ≥ 0` floor applies; `hasMore` still
+  // gates the next page.
+  const previousLimitRef = useRef(effectiveLimit);
+  useEffect(() => {
+    if (previousLimitRef.current === effectiveLimit) {
+      return;
     }
-  }, []);
+    previousLimitRef.current = effectiveLimit;
+
+    setOffset((currentOffset) => {
+      const nextOffset = Math.max(
+        0,
+        Math.floor(currentOffset / effectiveLimit) * effectiveLimit,
+      );
+      return nextOffset === currentOffset ? currentOffset : nextOffset;
+    });
+  }, [effectiveLimit]);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 767px)");
-
-    const updateMobileViewport = () => {
-      setIsMobileViewport(mediaQuery.matches);
-    };
-
-    updateMobileViewport();
-    mediaQuery.addEventListener("change", updateMobileViewport);
-
-    return () => {
-      mediaQuery.removeEventListener("change", updateMobileViewport);
-    };
-  }, []);
-
-  useEffect(() => {
-    void loadReports(page);
-  }, [loadReports, page]);
-
-  useEffect(() => {
-    if (!isMobileViewport) return;
-    void loadMobileReports(mobilePage);
-  }, [isMobileViewport, loadMobileReports, mobilePage]);
+    void loadReports();
+  }, [loadReports]);
 
   function replaceReport(updated: AdminReportWorkflowItem) {
     setReports((current) =>
-      current.map((report) => (report.id === updated.id ? updated : report)),
-    );
-    setMobileReports((current) =>
       current.map((report) => (report.id === updated.id ? updated : report)),
     );
   }
@@ -349,17 +468,14 @@ export function AdminReportsCard() {
   async function handleUploaded(message: string) {
     setStatusMessage(message);
     setErrorMessage(null);
-    if (page === 0) {
-      await loadReports(0);
+    // Jump back to the first page after an upload. If offset is already 0,
+    // `query` won't change on its own, so reload directly; otherwise the offset
+    // change flows into `query` and the load effect reloads once (no double
+    // fetch).
+    if (offset === 0) {
+      await loadReports();
     } else {
-      setPage(0);
-    }
-    if (isMobileViewport) {
-      if (mobilePage === 0) {
-        await loadMobileReports(0);
-      } else {
-        setMobilePage(0);
-      }
+      setOffset(0);
     }
   }
 
@@ -383,17 +499,27 @@ export function AdminReportsCard() {
       from: filterDraft.from,
       to: filterDraft.to,
     });
-    setPage(0);
-    setMobilePage(0);
+    // Applying a filter resets the page to the first record (PR-SRV-0 §6.3);
+    // a cardinality change (resize/zoom) never touches the filters.
+    setOffset(0);
     setErrorMessage(null);
   }
 
   function clearAdvancedFilters() {
     setFilterDraft(INITIAL_FILTER_STATE);
     setAppliedFilters(INITIAL_FILTER_STATE);
-    setPage(0);
-    setMobilePage(0);
+    setOffset(0);
     setErrorMessage(null);
+  }
+
+  function goToPreviousPage() {
+    setErrorMessage(null);
+    setOffset(Math.max(offset - effectiveLimit, 0));
+  }
+
+  function goToNextPage() {
+    setErrorMessage(null);
+    setOffset(offset + effectiveLimit);
   }
 
   function renderAdvancedFilterForm(mobile = false) {
@@ -529,7 +655,7 @@ export function AdminReportsCard() {
             variant="outline"
             size="sm"
             className="h-8 px-2.5 text-xs md:h-7 md:px-2"
-            onClick={() => void loadReports(page)}
+            onClick={() => void loadReports()}
             disabled={isLoading || busyReportId !== null}
           >
             {isLoading ? (
@@ -569,12 +695,12 @@ export function AdminReportsCard() {
           </div>
           <span className="min-w-0 flex-1 truncate md:hidden">
             {hasActiveFilters
-              ? `${filteredMobileReports.length} filtrados`
-              : `${mobileReports.length} en página`}
+              ? `${filteredReports.length} filtrados`
+              : `${filteredReports.length} en página`}
           </span>
           <div className="flex shrink-0 items-center gap-1.5">
             <span className="hidden tabular-nums md:inline">
-              {hasActiveFilters ? "Filtros activos" : `Página ${page + 1}`}
+              {hasActiveFilters ? "Filtros activos" : `Página ${page}`}
             </span>
             <div className="md:hidden">
               <ModuleDialog
@@ -609,7 +735,10 @@ export function AdminReportsCard() {
           aria-label="Cola administrativa de informes"
           className="flex min-h-0 flex-1 flex-col"
         >
-          <div className="dashboard-table-responsive hidden min-h-0 flex-1 md:block">
+          <div
+            ref={setDesktopBodyNode}
+            className="dashboard-table-responsive hidden min-h-0 flex-1 md:block"
+          >
             {filteredReports.length ? (
               <Table className="table-fixed text-xs [&_th]:h-7 [&_th]:px-2 [&_td]:px-2">
                 <TableHeader>
@@ -624,8 +753,11 @@ export function AdminReportsCard() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredReports.map((report) => (
-                    <TableRow key={report.id}>
+                  {filteredReports.map((report, index) => (
+                    <TableRow
+                      key={report.id}
+                      ref={index === 0 ? setDesktopRowNode : undefined}
+                    >
                       <TableCell className="py-0.5">
                         <p className="truncate font-medium text-vetneb-ink">
                           {report.patientName || "Paciente sin registrar"}
@@ -688,51 +820,51 @@ export function AdminReportsCard() {
             className="flex min-h-0 flex-1 flex-col gap-2 md:hidden"
             data-admin-mobile-core-module="reports"
           >
-            {filteredMobileReports.length ? (
-              <>
-                <div
-                  className="divide-y divide-vetneb-line/60 overflow-hidden rounded-md border border-vetneb-line/75"
-                  data-admin-reports-mobile-list="true"
-                >
-                  {filteredMobileReports.map((report) => (
-                    <div
-                      key={report.id}
-                      className="flex min-h-9 items-center gap-2 px-2.5 py-0.5"
-                      data-admin-mobile-core-item="true"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-semibold">
-                          #{report.id} · {report.patientName || "Sin paciente"}
-                        </p>
-                        <p className="truncate text-[0.6875rem] text-muted-foreground">
-                          {report.clinicName || `Clínica #${report.clinicId}`} · {studyLabel(report.studyType)}
-                        </p>
-                      </div>
-                      <AdminReportStatusBadge stage={report.workflowStage} />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-7 px-2 text-xs"
-                        onClick={() => setSelectedReportId(report.id)}
-                      >
-                        Ver
-                      </Button>
+            <div
+              ref={setMobileBodyNode}
+              className="min-h-0 flex-1 divide-y divide-vetneb-line/60 overflow-hidden rounded-md border border-vetneb-line/75"
+              data-admin-reports-mobile-list="true"
+            >
+              {filteredReports.length ? (
+                filteredReports.map((report, index) => (
+                  <div
+                    key={report.id}
+                    ref={index === 0 ? setMobileRowNode : undefined}
+                    className="flex min-h-9 items-center gap-2 px-2.5 py-0.5"
+                    data-admin-mobile-core-item="true"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-semibold">
+                        #{report.id} · {report.patientName || "Sin paciente"}
+                      </p>
+                      <p className="truncate text-[0.6875rem] text-muted-foreground">
+                        {report.clinicName || `Clínica #${report.clinicId}`} · {studyLabel(report.studyType)}
+                      </p>
                     </div>
-                  ))}
-                </div>
-              </>
-            ) : isMobileViewport ? (
-              <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
-                {isMobileLoading
-                  ? "Cargando informes…"
-                  : hasActiveFilters
-                    ? "No hay informes que coincidan con los filtros aplicados."
-                    : "No hay informes en esta página."}
-              </p>
-            ) : null}
+                    <AdminReportStatusBadge stage={report.workflowStage} />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => setSelectedReportId(report.id)}
+                    >
+                      Ver
+                    </Button>
+                  </div>
+                ))
+              ) : (
+                <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
+                  {isLoading
+                    ? "Cargando informes…"
+                    : hasActiveFilters
+                      ? "No hay informes que coincidan con los filtros aplicados."
+                      : "No hay informes en esta página."}
+                </p>
+              )}
+            </div>
 
-            {mobileReports.length ? (
+            {filteredReports.length || hasPrev ? (
               <div
                 className="flex shrink-0 items-center justify-center gap-1.5 border-t border-vetneb-line/65 pt-1.5 text-xs text-muted-foreground"
                 data-admin-mobile-core-pager="true"
@@ -742,20 +874,20 @@ export function AdminReportsCard() {
                   variant="outline"
                   size="sm"
                   className="h-9 px-2.5 text-xs"
-                  disabled={mobilePage === 0 || isMobileLoading}
-                  onClick={() => setMobilePage((current) => Math.max(0, current - 1))}
+                  disabled={!hasPrev || isLoading}
+                  onClick={goToPreviousPage}
                   aria-label="Página anterior"
                 >
                   Anterior
                 </Button>
-                <span className="min-w-12 text-center">Pág. {mobilePage + 1}</span>
+                <span className="min-w-12 text-center">Pág. {page}</span>
                 <Button
                   type="button"
                   variant="outline"
                   size="sm"
                   className="h-9 px-2.5 text-xs"
-                  disabled={!mobileHasMore || isMobileLoading}
-                  onClick={() => setMobilePage((current) => current + 1)}
+                  disabled={!hasNext || isLoading}
+                  onClick={goToNextPage}
                   aria-label="Página siguiente"
                 >
                   Siguiente
@@ -769,7 +901,7 @@ export function AdminReportsCard() {
             aria-label="Paginación de informes admin"
           >
             <span>
-              {filteredReports.length ? `${rangeStart}–${rangeEnd}` : "0 resultados"} · {PAGE_SIZE} por página
+              {filteredReports.length ? `${rangeStart}–${rangeEnd}` : "0 resultados"} · {effectiveLimit} por página
             </span>
             <div className="flex items-center gap-1.5">
               <Button
@@ -777,20 +909,20 @@ export function AdminReportsCard() {
                 variant="outline"
                 size="sm"
                 className="h-8 w-8 p-0 md:h-7 md:w-7"
-                disabled={page === 0 || isLoading}
-                onClick={() => setPage((current) => Math.max(0, current - 1))}
+                disabled={!hasPrev || isLoading}
+                onClick={goToPreviousPage}
                 aria-label="Página anterior"
               >
                 <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
               </Button>
-              <span className="min-w-16 text-center">Página {page + 1}</span>
+              <span className="min-w-16 text-center">Página {page}</span>
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="h-8 w-8 p-0 md:h-7 md:w-7"
-                disabled={!hasMore || isLoading}
-                onClick={() => setPage((current) => current + 1)}
+                disabled={!hasNext || isLoading}
+                onClick={goToNextPage}
                 aria-label="Página siguiente"
               >
                 <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />

--- a/test/admin-mobile-core-pager-canonical-layout.test.ts
+++ b/test/admin-mobile-core-pager-canonical-layout.test.ts
@@ -90,7 +90,7 @@ test("admin reports mobile pager matches the canonical Tokens pager layout", () 
   assert.ok(pager.includes("Anterior"), "reports mobile pager must render Anterior text");
   assert.ok(pager.includes("Siguiente"), "reports mobile pager must render Siguiente text");
   assert.ok(
-    pager.includes("Pág. {mobilePage + 1}"),
+    pager.includes("Pág. {page}"),
     "reports mobile pager must render Pág. X (no fabricated total; the report-workflow API has no count)",
   );
   assert.equal(
@@ -170,16 +170,19 @@ test("admin clinics mobile pager: page size is measured (HY cap 36), fetch untou
   assert.ok(clinicsSource.includes("getAdminClinics("));
 });
 
-// Reports intentionally raised its mobile page size from 3 to 10 (PR5,
- // admin-mobile-reports-density): 10 reports per mobile page, compacted and
- // anchored to the bottom pager while desktop PAGE_SIZE and fetch semantics
- // stay untouched.
-test("admin reports mobile pager: page size intentionally raised to 10, fetch/desktop untouched", () => {
+// R-03 (admin-reports-workflow-server-adaptive-pagination): the mobile page
+// size is no longer a fixed constant — it is derived from the measured list
+// container (HY cap 36), the same collapsed runtime that feeds the desktop
+// table. The old MOBILE_PAGE_SIZE=10 second fetch pipeline (gated by
+// matchMedia) is gone; the fetch stays limit/offset only.
+test("admin reports mobile page size is measured (HY cap 36), single fetch pipeline", () => {
   const reportsSource = read(REPORTS_CARD_PATH);
-  assert.ok(reportsSource.includes("const PAGE_SIZE = 9;"));
-  assert.ok(
-    reportsSource.includes("const MOBILE_PAGE_SIZE = 10;"),
-    "reports mobile page size must be 10 (intentional density change, PR5)",
-  );
+  assert.ok(reportsSource.includes("const REPORTS_FALLBACK_ROWS = 9;"));
+  assert.ok(reportsSource.includes("const REPORTS_SUPERSET_CAP = 36;"));
+  assert.equal(reportsSource.includes("const PAGE_SIZE = 9;"), false);
+  assert.equal(reportsSource.includes("const MOBILE_PAGE_SIZE"), false);
+  assert.equal(reportsSource.includes("window.matchMedia"), false);
+  assert.equal(reportsSource.includes("loadMobileReports"), false);
+  assert.ok(reportsSource.includes("useAdaptiveItemsPerPage"));
   assert.ok(reportsSource.includes("getAdminReportWorkflow({"));
 });

--- a/test/admin-reports-enterprise-density.test.ts
+++ b/test/admin-reports-enterprise-density.test.ts
@@ -46,18 +46,53 @@ test("Admin Informes preserva el identificador real y monta la consola dedicada"
   );
 });
 
-test("Admin Informes usa paginación server-side viewport-safe de nueve filas", () => {
+test("Admin Informes usa paginación server-side adaptativa por viewport (HY cap 36)", () => {
   const card = read(CARD_PATH);
 
-  assert.ok(card.includes("const PAGE_SIZE = 9;"));
+  // R-03: cardinality is measured, not fixed. The legacy PAGE_SIZE=9 survives
+  // only as the fallback/desktop floor, renamed; MOBILE_PAGE_SIZE and the
+  // matchMedia second pipeline are gone (single collapsed runtime).
+  assert.ok(card.includes("const REPORTS_FALLBACK_ROWS = 9;"));
+  assert.ok(card.includes("const REPORTS_SUPERSET_CAP = 36;"));
+  assert.ok(card.includes("useAdaptiveItemsPerPage"));
+  assert.ok(card.includes("const effectiveLimit = rowsPerPage;"));
+  assert.equal(card.includes("const PAGE_SIZE = 9;"), false);
+  assert.equal(card.includes("const MOBILE_PAGE_SIZE"), false);
+  assert.equal(card.includes("window.matchMedia"), false);
+  assert.equal(card.includes("isMobileViewport"), false);
+  assert.equal(card.includes("loadMobileReports"), false);
+
   assert.ok(card.includes("getAdminReportWorkflow({"));
-  assert.ok(card.includes("limit: PAGE_SIZE"));
-  assert.ok(card.includes("offset: nextPage * PAGE_SIZE"));
+  assert.ok(card.includes("limit: query.limit"));
+  assert.ok(card.includes("offset: query.offset"));
   assert.ok(card.includes("snapshot.pagination.hasMore"));
   assert.equal(card.includes("slice("), false);
   assert.ok(card.includes('aria-label="Paginación de informes admin"'));
   assert.ok(card.includes("Página anterior"));
   assert.ok(card.includes("Página siguiente"));
+});
+
+test("Admin Informes recomputa offset y descarta respuestas viejas (anti-race)", () => {
+  const card = read(CARD_PATH);
+
+  // Request-id guard: a stale response whose id is no longer current is dropped.
+  assert.ok(card.includes("const latestRequestRef = useRef(0);"));
+  assert.ok(card.includes("const requestId = latestRequestRef.current + 1;"));
+  assert.ok(card.includes("if (requestId !== latestRequestRef.current) return;"));
+
+  // Offset recompute keeps the same first visible record when the limit
+  // changes; no `total` clamp is possible (endpoint exposes none).
+  assert.ok(card.includes("const previousLimitRef = useRef(effectiveLimit);"));
+  assert.ok(
+    card.includes("Math.floor(currentOffset / effectiveLimit) * effectiveLimit"),
+  );
+
+  // Desktop keeps the nine-row floor (App Shell contract), mobile floors at one.
+  assert.ok(
+    card.includes(
+      "minItems: isDesktopMeasurement ? REPORTS_FALLBACK_ROWS : 1,",
+    ),
+  );
 });
 
 test("Admin Informes presenta tabla y lista mobile densas con detalle en diálogo", () => {
@@ -152,8 +187,8 @@ test("Admin Informes filtra sobre datos cargados sin cambiar contrato API", () =
   );
   const apiBlock = sectionBetween(
     card,
-    "const loadReports = useCallback(async (nextPage: number) => {",
-    "const loadMobileReports = useCallback(async (nextPage: number) => {",
+    "const loadReports = useCallback(async () => {",
+    "// Recompute offset when the effective limit changes",
   );
 
   assert.ok(filterBlock.includes("const reportDisplay = `Informe #${report.id}`;"));
@@ -165,9 +200,9 @@ test("Admin Informes filtra sobre datos cargados sin cambiar contrato API", () =
   assert.ok(filterBlock.includes("matchesReportDateRange(report, filters.from, filters.to)"));
   assert.ok(card.includes("return report.uploadDate ?? report.createdAt;"));
   assert.ok(card.includes("const filteredReports = reports.filter((report) =>"));
-  assert.ok(card.includes("const filteredMobileReports = mobileReports.filter((report) =>"));
-  assert.ok(card.includes("{filteredReports.map((report) => ("));
-  assert.ok(card.includes("{filteredMobileReports.map((report) => ("));
+  // Single collapsed runtime: no second mobile-only filtered list.
+  assert.equal(card.includes("filteredMobileReports"), false);
+  assert.ok(card.includes("{filteredReports.map((report, index) => ("));
 
   assert.ok(applyBlock.includes("setAppliedFilters({"));
   assert.ok(applyBlock.includes("report: filterDraft.report.trim(),"));
@@ -178,12 +213,16 @@ test("Admin Informes filtra sobre datos cargados sin cambiar contrato API", () =
   assert.ok(applyBlock.includes("file: filterDraft.file.trim(),"));
   assert.ok(applyBlock.includes("from: filterDraft.from,"));
   assert.ok(applyBlock.includes("to: filterDraft.to,"));
-  assert.ok(applyBlock.includes("setPage(0);"));
-  assert.ok(applyBlock.includes("setMobilePage(0);"));
+  // Applying/clearing a filter resets to the first record (offset 0).
+  assert.ok(applyBlock.includes("setOffset(0);"));
+  assert.equal(applyBlock.includes("setMobilePage(0);"), false);
   assert.ok(clearBlock.includes("setFilterDraft(INITIAL_FILTER_STATE);"));
   assert.ok(clearBlock.includes("setAppliedFilters(INITIAL_FILTER_STATE);"));
-  assert.ok(apiBlock.includes("limit: PAGE_SIZE"));
-  assert.ok(apiBlock.includes("offset: nextPage * PAGE_SIZE"));
+  assert.ok(clearBlock.includes("setOffset(0);"));
+  // The fetch stays limit/offset only — filters remain client-side (no new
+  // server contract, no backend change).
+  assert.ok(apiBlock.includes("limit: query.limit"));
+  assert.ok(apiBlock.includes("offset: query.offset"));
   assert.equal(apiBlock.includes("search:"), false);
   assert.equal(apiBlock.includes("filters:"), false);
 });


### PR DESCRIPTION
R-03 del roadmap final.

Implementa Reports Admin server-adaptive:
- HY cap 36.
- effectiveLimit derivado de viewport real.
- runtime único en AdminReportsCard.
- eliminación del pipeline mobile separado.
- unificación de limit/offset mobile/desktop.
- offset reseteado por filtros.
- recompute de offset al cambiar cardinalidad.
- request-id anti-race.
- hasMore preservado sin pedir total nuevo.
- AdminReportsUploadPanel preservado sin tocar su archivo.

Docs:
- docs/implementation/admin-reports-workflow-server-adaptive-pagination.md

Scope:
- Sin AdminReportsUploadPanel.
- Sin backend/API/auth/DB.
- Sin CI/workflows.
- Sin deps/lockfiles.
- Sin snapshots.
- Sin globals.css.
- Sin otros módulos Admin.
- Sin Clínica/Particular/Público.
- Sin R-04 adelantado.

Validaciones locales reportadas:
- pnpm test: 2942/2942
- pnpm typecheck:test OK
- pnpm security:public-surface PASS
- frontend lint/typecheck/build OK
- admin-mobile-core-modules-no-scroll: 14/14
- dashboard-real-app-shell-no-scroll-contract: 37/37
- ops/status/final-polish/viewport/internal/global e2e: 124/124