### PR TITLE
feat(admin): adapt particular tokens server pagination to viewport

### DIFF
--- a/docs/implementation/admin-particular-tokens-server-adaptive-pagination.md
+++ b/docs/implementation/admin-particular-tokens-server-adaptive-pagination.md
@@ -1,0 +1,179 @@
+# R-05 · Admin Particular Tokens — server-adaptive pagination (OF cap + "Cargar más")
+
+- **PR:** R-05
+- **Fecha:** 2026-07-03
+- **Base:** `main` @ `86eeed5` (docs(admin): confirm particular tokens total contract, #1266)
+- **Rama:** `feat/admin-particular-tokens-server-adaptive-pagination`
+
+## Decisión de origen (R-04)
+
+`docs/implementation/admin-particular-tokens-total-contract.md` confirmó que `GET /api/admin/particular-tokens`
+**no expone `total`** (ni `hasMore`/`hasNext` de red) y que añadir un `COUNT` real queda prohibido salvo
+autorización explícita. La estrategia adoptada para R-05, ya fijada en
+`docs/implementation/server-adaptive-pagination-strategy.md` §5/§8/§9 (fila "Tokens admin"), es:
+
+> **OF (over-fetch) con cap + "Cargar más"**, `hasNext` derivado por heurística de página llena/superset,
+> sin `total`, sin `pageCount` real. Cap superset propuesto: **30**.
+
+## Contrato anterior (antes de este PR)
+
+`AdminParticularTokensCard.tsx` mantenía **dos pipelines de fetch independientes**, ambos con la misma
+heurística de página llena pero cardinalidad fija por dispositivo:
+
+- Desktop: `PAGE_SIZE = 9`, estado `page`, `getAdminParticularTokens({ limit: 9, offset: page * 9 })`,
+  `canGoNext = tokens.length === 9`.
+- Mobile: `MOBILE_PAGE_SIZE = 10`, estado `mobilePage`, segundo fetch independiente
+  `getAdminParticularTokens({ limit: 10, offset: mobilePage * 10 })`, `canGoNextMobile = mobileTokens.length === 10`.
+- `matchMedia("(max-width: 767px)")` decidía **qué pipeline correr** (`isMobileViewport` gateaba el efecto
+  que disparaba `loadMobileTokens`) — cardinalidad por dispositivo, el patrón que la matriz global prohíbe.
+
+## Contrato nuevo (este PR)
+
+Una única fuente de datos (`tokens`), una única medición (`useAdaptiveItemsPerPage`), una única paginación
+cliente (`usePagedRows`) que alimenta **ambas** presentaciones (tabla desktop y lista mobile), igual al
+patrón ya usado por Clínicas/Reportes/Sesiones (PR-SRV-1/2) pero con la variante **OF+cap** en vez de HY,
+porque este endpoint no tiene `total` para clampar un re-fetch por resize.
+
+### Fetch (over-fetch de superset, una sola vez)
+
+```ts
+const TOKENS_FALLBACK_ROWS = 9;   // fallback SSR/primer paint + piso desktop (App Shell "nueve filas")
+const TOKENS_SUPERSET_CAP = 30;   // cap de over-fetch, per server-adaptive-pagination-strategy.md §8
+
+const loadTokens = useCallback(async () => {
+  const snapshot = await getAdminParticularTokens({ limit: TOKENS_SUPERSET_CAP, offset: 0 });
+  setTokens(snapshot.particularTokens);
+  setHasMoreFromServer(snapshot.particularTokens.length === TOKENS_SUPERSET_CAP);
+}, []);
+```
+
+`loadTokens()` corre una vez al montar y en cada mutación/"Actualizar" (siempre desde `offset: 0`, reemplaza
+el superset completo). No hay re-fetch por resize/zoom: la cardinalidad visible (`rowsPerPage`) sólo decide
+cómo se pagina **en cliente** el superset ya cargado.
+
+### "Cargar más" (heurística de página llena, sin `total`)
+
+```ts
+const loadMoreTokens = useCallback(async () => {
+  if (isLoadingMoreTokens || !hasMoreFromServer) return;
+  const snapshot = await getAdminParticularTokens({
+    limit: TOKENS_SUPERSET_CAP,
+    offset: tokens.length,
+  });
+  setTokens((current) => [...current, ...snapshot.particularTokens]);
+  setHasMoreFromServer(snapshot.particularTokens.length === TOKENS_SUPERSET_CAP);
+}, [isLoadingMoreTokens, hasMoreFromServer, tokens.length]);
+```
+
+`hasMoreFromServer` es la única heurística de "puede haber más": el último lote recibido llenó el cap. El
+botón **"Cargar más"** sólo aparece cuando el admin llega a la última página cargada localmente
+(`!pagedTokens.hasNext`) y `hasMoreFromServer` es verdadero; nunca hay auto-scroll infinito ni salto a
+"última página" (no hay forma de calcular cuál es).
+
+### Paginación cliente sobre el superset (`usePagedRows`)
+
+```ts
+const filteredTokens = tokens.filter((token) => matchesAdminParticularTokenFilters(token, appliedFilters, clinicOptions));
+const pagedTokens = usePagedRows(filteredTokens, rowsPerPage);
+const visibleTokens = pagedTokens.pageItems; // renderizado por tabla desktop Y lista mobile
+```
+
+`rowsPerPage` viene de `useAdaptiveItemsPerPage` midiendo el contenedor visible (tabla desktop o lista
+mobile, exactamente uno de los dos vía CSS `hidden md:block` / `md:hidden`), con:
+
+- `fallbackItems: TOKENS_FALLBACK_ROWS` (9, SSR/primer paint).
+- `minItems: isDesktopMeasurement ? TOKENS_FALLBACK_ROWS : 1` — el piso de nueve filas en desktop preserva
+  el contrato `expectNinePopulatedRows` del App Shell a 1366×768 (igual excepción ya documentada para
+  Reportes/Users-Roles; Clínicas no tiene ese piso). Mobile no tiene piso (achica libremente en teléfonos
+  bajos).
+- `maxItems: TOKENS_SUPERSET_CAP` (30) — `rowsPerPage` nunca pide más filas por página de las que el
+  superset puede tener cargadas.
+
+### Eliminado
+
+- `matchMedia` como fuente de cardinalidad (y como cualquier otra cosa: el componente ya no usa
+  `window.matchMedia` en absoluto — la única señal de presentación es CSS).
+- `MOBILE_PAGE_SIZE` y el segundo pipeline de fetch (`loadMobileTokens`, `mobileTokens`, `mobilePage`,
+  `isLoadingMobileTokens`, `canGoNextMobile`, `isMobileViewport`).
+- `filteredMobileTokens` (duplicado de `filteredTokens`, ya no existe una lista mobile independiente).
+- `canGoNext`/`page` (estado de servidor por página); reemplazados por `pagedTokens.hasNext`/`pagedTokens.page`
+  (estado 100% cliente sobre el superset ya cargado).
+
+### Anti-carrera (§7 de la estrategia)
+
+`latestRequestRef` (un único contador compartido entre `loadTokens` y `loadMoreTokens`) descarta cualquier
+respuesta cuyo `requestId` ya no sea el vigente — evita que un "Actualizar" en vuelo pise el resultado de un
+"Cargar más" concurrente o viceversa.
+
+### Sin `pageCount` falso
+
+El pager nunca muestra "Página X / Y": conserva el copy previo ("Página {n}" / "Pág. {n}") sin denominador,
+igual que Reportes (que tampoco tiene `total`). `pagedTokens.pageCount` existe internamente (usePagedRows lo
+expone) pero sólo gobierna el clamp de la página activa cuando el dataset cargado cambia (filtros, carga
+más); nunca se renderiza como un total real de páginas del servidor.
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx` — migración completa descrita arriba.
+- `frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx` — `ParticularTokensMobileList` pasa
+  de `ComponentPropsWithoutRef<"div">` a `ComponentPropsWithRef<"div">` para poder medir su contenedor
+  (`ref={setMobileBodyNode}`); sin cambio visual ni de comportamiento para el consumidor existente (Clínica
+  no usa esta primitiva).
+- `test/frontend-admin-particular-tokens.test.ts` — actualiza aserciones de fuente que referenciaban
+  `filteredMobileTokens.map(...)` y `setPage(0); setMobilePage(0);` al nuevo contrato colapsado
+  (`visibleTokens.map(...)`, `pagedTokens.setPage(0)`).
+- `test/admin-tokens-enterprise-density.test.ts` — reemplaza el test de contrato de paginación fija (`PAGE_SIZE`,
+  `canGoNext`) por el contrato adaptativo (constantes, `useAdaptiveItemsPerPage`, `usePagedRows`,
+  `hasMoreFromServer`, ausencia de `matchMedia`/`MOBILE_PAGE_SIZE`/`isMobileViewport`) y agrega el test
+  anti-carrera (mismo patrón que Reportes).
+- `frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts` — sube el fixture de 11 a 40 tokens (margen sobre
+  el cap 30, mismo criterio que R-02/R-03) y reemplaza los `toHaveCount(10)`/`toHaveCount(6)` fijos por el
+  patrón de "settle" (`toPass` con conteo estable) + aserciones acotadas, igual precedente que
+  `admin-clinics-mobile-card-layout.spec.ts`.
+- `frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts` — sube `MOCK_TOKENS` de 13 a 40 y
+  `maxItemsPerPage` de Tokens en la tabla `MODULES` de 10 a 30 (cap real).
+- `docs/implementation/admin-particular-tokens-server-adaptive-pagination.md` — este documento.
+
+## Validaciones ejecutadas
+
+- `pnpm test` — 2943/2943 verdes.
+- `pnpm typecheck:test` — sin errores.
+- `pnpm security:public-surface` — PASS (mismos 2 findings server-only preexistentes, no relacionados).
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm --dir frontend typecheck` — sin errores.
+- `pnpm --dir frontend build` — build de producción exitoso.
+- `pnpm --dir frontend exec playwright test e2e/admin-tokens-mobile-toolbar-layout.spec.ts` — 12/12 verdes.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts --grep "tokens"` — 4/4 verdes.
+- `pnpm --dir frontend exec playwright test e2e/admin-mobile-core-modules-no-scroll.spec.ts` (suite completa,
+  para confirmar que Clínicas/Reportes no se rompieron por el cambio de config compartida) — 14/14 verdes.
+- `e2e/admin-mobile-core-pager.spec.ts` **no existe** en el repo (verificado con `ls frontend/e2e`); el
+  archivo equivalente por nombre es `test/admin-mobile-core-pager-canonical-layout.test.ts` (unit, no e2e),
+  que sólo referencia Clínicas/Reportes (no Tokens) y ya corrió dentro de `pnpm test`.
+- `frontend/next-env.d.ts` quedó modificado por Playwright (regenerado a `./.next/dev/types/routes.d.ts`) y
+  se revirtió con `git checkout -- frontend/next-env.d.ts` antes de cerrar el PR, después de lo cual se
+  re-corrió `pnpm test` (2943/2943 verdes) para confirmar que no quedó contaminado.
+
+## Fuera de scope
+
+- Backend/API/auth/DB/migrations — `server/routes/admin-particular-tokens.fastify.ts`,
+  `deps.listParticularTokens` y el tipo `AdminParticularTokensSnapshot` en `frontend/src/lib/api.ts` **no se
+  tocaron**. No se agregó ningún `total`/`COUNT` real.
+- CI/workflows, deps/lockfiles, snapshots, `globals.css`.
+- Otros módulos Admin (Clínicas, Reportes, Auditoría, Alertas) y Clínica/Particular/Público.
+- R-06 y cualquier PR posterior.
+
+## Riesgos residuales
+
+- Sin `total`, el admin no ve un conteo exacto de tokens particulares en el sistema ni un clamp garantizado
+  a la "última página" — mismo riesgo aceptado y documentado en R-04, mitigado con "Cargar más" +
+  heurística de página llena (idéntico patrón ya en producción en Reportes).
+- Tras cualquier mutación (alta/baja de token) o clic en "Actualizar", el superset se recarga desde
+  `offset: 0` con el cap base (30): si el admin había usado "Cargar más" varias veces antes de la mutación,
+  esas páginas adicionales se descartan y hay que volver a pedirlas. Comportamiento intencional (evita
+  aritmética de `offset` obsoleta tras un alta/baja que cambia el orden/conteo real) y consistente con que
+  "Actualizar" ya recargaba desde cero en el contrato anterior.
+
+## Confirmación
+
+Sin cambios en `server/**`, `migrations/**`, CI/workflows, deps/lockfiles, snapshots ni `globals.css`. No se
+ejecutó `git add/commit/push` ni se abrió PR — queda a cargo de Nico.

--- a/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
+++ b/frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
@@ -53,7 +53,11 @@ const MOCK_REPORTS = Array.from({ length: 40 }, (_, index) => {
   };
 });
 
-const MOCK_TOKENS = Array.from({ length: 13 }, (_, index) => ({
+// R-05: tokens pages are now measured (OF cap 30) instead of a fixed mobile
+// limit of 10, so the fixture must have enough rows to fill the tallest
+// measured page and still leave a populated page 2 (same reasoning as the
+// R-02 clinics bump 13 → 40 and R-03 reports bump 13 → 40).
+const MOCK_TOKENS = Array.from({ length: 40 }, (_, index) => ({
   id: 9300 + index,
   clinicId: 30 + index,
   reportId: index % 3 === 0 ? 7400 + index : null,
@@ -150,7 +154,9 @@ const MODULES: ModuleSpec[] = [
   // guarantee is per-item viewport fit, not a fixed page size.
   { key: "clinics", moduleId: "admin-clinics", mock: mockAdminClinics, maxItemsPerPage: 36 },
   { key: "reports", moduleId: "admin-report-upload", mock: mockAdminReportWorkflow, maxItemsPerPage: 36 },
-  { key: "tokens", moduleId: "admin-particular-tokens", mock: mockAdminParticularTokens, maxItemsPerPage: 10 },
+  // R-05 raised the ceiling to the OF superset cap (30); the real guarantee
+  // is per-item viewport fit, not a fixed page size.
+  { key: "tokens", moduleId: "admin-particular-tokens", mock: mockAdminParticularTokens, maxItemsPerPage: 30 },
 ];
 
 for (const moduleSpec of MODULES) {

--- a/frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
+++ b/frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
@@ -9,7 +9,11 @@ const MOBILE_VIEWPORTS = [
   { name: "iphone-pro-max-430x932", width: 430, height: 932 },
 ] as const;
 
-const MOCK_TOKENS = Array.from({ length: 11 }, (_, index) => ({
+// R-05 (admin-particular-tokens-server-adaptive-pagination): the mobile page
+// size is now measured (OF cap 30) instead of a fixed limit of 10, so the
+// fixture must have enough rows to fill the tallest measured page and still
+// leave a populated page 2 (same reasoning as the R-02/R-03 bumps to 40).
+const MOCK_TOKENS = Array.from({ length: 40 }, (_, index) => ({
   id: 9101 + index,
   clinicId: 12 + index,
   reportId: index % 3 === 0 ? 7301 + index : null,
@@ -219,10 +223,23 @@ for (const viewport of MOBILE_VIEWPORTS) {
     ).toBeHidden();
 
     const items = workspace.locator('[data-admin-mobile-core-item="true"]');
-    await expect(
-      items,
-      `${viewport.name}: ten tokens visible per mobile page`,
-    ).toHaveCount(10);
+    // R-05: the mobile page size is measured (OF cap 30), not a fixed 10, so
+    // the fallback-sized first paint can settle to a different count once the
+    // real row is measured. Wait for two consecutive equal reads before
+    // trusting it, same pattern as Clinics/Reports.
+    let settledCount: number | null = null;
+    await expect(async () => {
+      const current = await items.count();
+      expect(current, `${viewport.name}: tokens mobile item count settles`).toBeGreaterThan(0);
+      if (settledCount !== current) {
+        settledCount = current;
+        throw new Error(`count not yet stable: ${current}`);
+      }
+    }).toPass({ intervals: [200, 300, 400, 600, 800], timeout: 6_000 });
+    expect(
+      settledCount,
+      `${viewport.name}: tokens mobile page size must remain viewport-safe`,
+    ).toBeLessThanOrEqual(30);
 
     await expect(
       items.first(),
@@ -338,14 +355,26 @@ for (const viewport of MOBILE_VIEWPORTS) {
     const items = page.locator(
       '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-item="true"]',
     );
-    await expect(items).toHaveCount(10);
+    // R-05: the mobile page size is measured (OF cap 30), not a fixed 10.
+    // MOCK_TOKENS (40 rows) guarantees the first page is entirely full for any
+    // measured page size up to the cap; wait for the settle before reading it.
+    let settledCount: number | null = null;
+    await expect(async () => {
+      const current = await items.count();
+      expect(current, `${viewport.name}: full-page item count settles`).toBeGreaterThan(0);
+      if (settledCount !== current) {
+        settledCount = current;
+        throw new Error(`count not yet stable: ${current}`);
+      }
+    }).toPass({ intervals: [200, 300, 400, 600, 800], timeout: 6_000 });
+    expect(settledCount, `${viewport.name}: full page size stays within cap`).toBeLessThanOrEqual(30);
 
     await assertPagerAnchoredToModuleBottom(
       page,
-      `${viewport.name}: full page (10 tokens)`,
+      `${viewport.name}: full page (${settledCount} tokens)`,
     );
-    await assertPagerHasNoRangeText(page, `${viewport.name}: full page (10 tokens)`);
-    await assertPagerControlsCentered(page, `${viewport.name}: full page (10 tokens)`);
+    await assertPagerHasNoRangeText(page, `${viewport.name}: full page (${settledCount} tokens)`);
+    await assertPagerControlsCentered(page, `${viewport.name}: full page (${settledCount} tokens)`);
   });
 
   test(`admin tokens mobile pager stays bottom-anchored with a short dataset — ${viewport.name}`, async ({
@@ -364,7 +393,19 @@ for (const viewport of MOBILE_VIEWPORTS) {
     const items = page.locator(
       '[data-admin-mobile-core-module="tokens"] [data-admin-mobile-core-item="true"]',
     );
-    await expect(items).toHaveCount(6);
+    // R-05: the measured page size could in principle be smaller than the
+    // 6-row dataset on an unusually cramped viewport; settle first, then only
+    // assert it never exceeds the dataset itself.
+    let settledCount: number | null = null;
+    await expect(async () => {
+      const current = await items.count();
+      expect(current, `${viewport.name}: short-dataset item count settles`).toBeGreaterThan(0);
+      if (settledCount !== current) {
+        settledCount = current;
+        throw new Error(`count not yet stable: ${current}`);
+      }
+    }).toPass({ intervals: [200, 300, 400, 600, 800], timeout: 6_000 });
+    expect(settledCount, `${viewport.name}: short dataset never exceeds fetched rows`).toBeLessThanOrEqual(6);
 
     await assertPagerHasNoRangeText(page, `${viewport.name}: short dataset (6 tokens)`);
     await assertPagerControlsCentered(page, `${viewport.name}: short dataset (6 tokens)`);

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { Filter } from "lucide-react";
 import {
@@ -16,6 +23,7 @@ import {
   ParticularTokensMobileList,
 } from "@/components/dashboard/ParticularTokensCardPrimitives";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
+import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -29,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";
 import {
   createAdminParticularToken,
   deleteAdminParticularToken,
@@ -93,11 +102,39 @@ const CREATE_STEP_LABELS: Record<CreateStep, string> = {
   sample: "Muestra",
 };
 
-// Nine rows are the viewport-safe limit established by PR-3 at 1366x768.
-// The API supports limit/offset but does not expose a total, so pagination uses
-// the returned page length to enable the next-page control.
-const PAGE_SIZE = 9;
-const MOBILE_PAGE_SIZE = 10;
+// Server pagination is now sized by the measured rows container (Zero-Scroll
+// adaptive contract, R-05/PR-SRV-0 module #5, R-04 confirmed no `total` on
+// this endpoint). Strategy is over-fetch-with-cap: fetch a superset once (cap
+// below), paginate it client-side with usePagedRows, and offer "Cargar más"
+// only when the last fetched batch filled the cap (heuristic there may be
+// more on the server). TOKENS_FALLBACK_ROWS survives only as the
+// pre-measurement fallback and desktop floor; MOBILE_PAGE_SIZE and the
+// matchMedia cardinality gate are gone — one measured runtime feeds both the
+// desktop table and the mobile list.
+const TOKENS_FALLBACK_ROWS = 9;
+// Over-fetch cap: a single superset fetch never asks the server for more than
+// this many rows. Per docs/implementation/server-adaptive-pagination-strategy.md
+// §8 ("Tokens admin | 9 (sin total) | 30 + 'cargar más'").
+const TOKENS_SUPERSET_CAP = 30;
+// Fixed header row height of the desktop table (`[&_th]:h-7`), discounted from
+// the measured region so the row math never counts the header as a data row.
+const TOKENS_TABLE_HEADER_PX = 28;
+// Fallback item height used until a real row is measured.
+const TOKENS_ROW_HEIGHT_FALLBACK_PX = 36;
+
+type Measurement = {
+  containerNode: HTMLElement | null;
+  rowHeightPx: number;
+  headerHeightPx: number;
+};
+
+function measurementsEqual(a: Measurement, b: Measurement) {
+  return (
+    a.containerNode === b.containerNode &&
+    a.rowHeightPx === b.rowHeightPx &&
+    a.headerHeightPx === b.headerHeightPx
+  );
+}
 
 const INITIAL_FORM_STATE: AdminParticularTokenFormState = {
   clinicId: "",
@@ -448,7 +485,6 @@ export function AdminParticularTokensCard() {
   const [createStep, setCreateStep] = useState<CreateStep>("clinic");
   const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
   const [detailTab, setDetailTab] = useState<DetailTab>("summary");
-  const [page, setPage] = useState(0);
   const [filterDraft, setFilterDraft] =
     useState<AdminParticularTokenFilterState>(INITIAL_FILTER_STATE);
   const [appliedFilters, setAppliedFilters] =
@@ -494,20 +530,109 @@ export function AdminParticularTokensCard() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // Start false so SSR and the client's first render agree. The media-query
-  // effect below promotes this to the real viewport value right after mount,
-  // which avoids a hydration mismatch on the mobile-only branches (the empty
-  // state and mobile list/pager). A mismatch would make React discard the
-  // server tree and regenerate it, leaving the toolbar's filter handlers
-  // briefly unbound and racing the no-scroll mobile contract.
-  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  // The server exposes no `total` for this endpoint (R-04): hasMoreFromServer
+  // is a page-full heuristic (last fetched batch length === the cap), driving
+  // the explicit "Cargar más" affordance instead of a real page count.
+  const [hasMoreFromServer, setHasMoreFromServer] = useState(false);
+  const [isLoadingMoreTokens, setIsLoadingMoreTokens] = useState(false);
+  const latestRequestRef = useRef(0);
 
-  // Mobile renders a smaller, independently paginated slice of the same
-  // server-side token list. Desktop keeps its own PAGE_SIZE=9 fetch untouched
-  // so the dense viewport-safe contract stays pinned.
-  const [mobileTokens, setMobileTokens] = useState<AdminParticularTokenSummary[]>([]);
-  const [mobilePage, setMobilePage] = useState(0);
-  const [isLoadingMobileTokens, setIsLoadingMobileTokens] = useState(false);
+  // One collapsed runtime feeds both presentations, so the visible container
+  // (desktop table region or mobile list region) drives a single cardinality.
+  // The old second fetch pipeline (MOBILE_PAGE_SIZE=10 gated by matchMedia) is
+  // gone: no more double fetch, no more divergent limit/offset.
+  const [desktopBodyNode, setDesktopBodyNode] = useState<HTMLElement | null>(
+    null,
+  );
+  const [mobileBodyNode, setMobileBodyNode] = useState<HTMLElement | null>(null);
+  const [desktopRowNode, setDesktopRowNode] = useState<HTMLElement | null>(null);
+  const [mobileRowNode, setMobileRowNode] = useState<HTMLElement | null>(null);
+  const [measurement, setMeasurement] = useState<Measurement>({
+    containerNode: null,
+    rowHeightPx: TOKENS_ROW_HEIGHT_FALLBACK_PX,
+    headerHeightPx: 0,
+  });
+
+  useLayoutEffect(() => {
+    const nodes = [
+      desktopBodyNode,
+      mobileBodyNode,
+      desktopRowNode,
+      mobileRowNode,
+    ].filter((node): node is HTMLElement => node !== null);
+    if (nodes.length === 0) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const recompute = () => {
+      frame = null;
+
+      const mobileHeight = mobileBodyNode?.getBoundingClientRect().height ?? 0;
+      if (mobileHeight > 0 && mobileBodyNode) {
+        const rowHeight = mobileRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: mobileBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : TOKENS_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: 0,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+        return;
+      }
+
+      const desktopHeight = desktopBodyNode?.getBoundingClientRect().height ?? 0;
+      if (desktopHeight > 0 && desktopBodyNode) {
+        const rowHeight = desktopRowNode?.getBoundingClientRect().height ?? 0;
+        setMeasurement((previous) => {
+          const next: Measurement = {
+            containerNode: desktopBodyNode,
+            rowHeightPx:
+              rowHeight > 0 ? rowHeight : TOKENS_ROW_HEIGHT_FALLBACK_PX,
+            headerHeightPx: TOKENS_TABLE_HEADER_PX,
+          };
+          return measurementsEqual(previous, next) ? previous : next;
+        });
+      }
+    };
+
+    const scheduleRecompute = () => {
+      if (frame === null) {
+        frame = requestAnimationFrame(recompute);
+      }
+    };
+
+    const observer = new ResizeObserver(scheduleRecompute);
+    nodes.forEach((node) => observer.observe(node));
+    scheduleRecompute();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [desktopBodyNode, mobileBodyNode, desktopRowNode, mobileRowNode]);
+
+  // The desktop table is pinned to nine populated rows at the shortest
+  // supported desktop viewport (1366×768) by the App Shell contract
+  // (`expectNinePopulatedRows`). The desktop context (detected by the
+  // discounted table header) keeps a floor of nine — matching the
+  // pre-adaptive fixed page size — while still adapting upward on taller
+  // viewports. The mobile list (no table header) keeps a floor of one so it
+  // can shrink freely on short phones. Same exception as Reports/Users-Roles.
+  const isDesktopMeasurement = measurement.headerHeightPx > 0;
+  const { itemsPerPage: rowsPerPage } = useAdaptiveItemsPerPage({
+    containerNode: measurement.containerNode,
+    fallbackItems: TOKENS_FALLBACK_ROWS,
+    itemHeightPx: measurement.rowHeightPx,
+    headerHeightPx: measurement.headerHeightPx,
+    minItems: isDesktopMeasurement ? TOKENS_FALLBACK_ROWS : 1,
+    maxItems: TOKENS_SUPERSET_CAP,
+  });
 
   const selectedClinic = clinicOptions.find(
     (option) => String(option.id) === formState.clinicId,
@@ -523,9 +648,7 @@ export function AdminParticularTokensCard() {
   const selectedToken =
     selectedTokenId === null
       ? null
-      : (tokens.find((token) => token.id === selectedTokenId) ??
-        mobileTokens.find((token) => token.id === selectedTokenId) ??
-        null);
+      : (tokens.find((token) => token.id === selectedTokenId) ?? null);
   const selectedTrackingCase = selectedToken
     ? trackingCasesByTokenId[selectedToken.id]
     : null;
@@ -551,93 +674,85 @@ export function AdminParticularTokensCard() {
   const filteredTokens = tokens.filter((token) =>
     matchesAdminParticularTokenFilters(token, appliedFilters, clinicOptions),
   );
-  const filteredMobileTokens = mobileTokens.filter((token) =>
-    matchesAdminParticularTokenFilters(token, appliedFilters, clinicOptions),
-  );
-  const activeTokensCount = filteredTokens.filter((token) => token.isActive).length;
-  const linkedReportsCount = filteredTokens.filter(
+  const pagedTokens = usePagedRows(filteredTokens, rowsPerPage);
+  const visibleTokens = pagedTokens.pageItems;
+  const activeTokensCount = visibleTokens.filter((token) => token.isActive).length;
+  const linkedReportsCount = visibleTokens.filter(
     (token) => token.hasLinkedReport,
   ).length;
-  const rangeStart = filteredTokens.length ? page * PAGE_SIZE + 1 : 0;
-  const rangeEnd = page * PAGE_SIZE + filteredTokens.length;
-  const canGoNext = tokens.length === PAGE_SIZE;
-  const canGoNextMobile = mobileTokens.length === MOBILE_PAGE_SIZE;
   const createStepIndex = getCreateStepIndex(createStep);
   const isLastCreateStep = createStep === "sample";
 
-  const loadTokens = useCallback(
-    async (nextPage = page) => {
-      setIsLoadingTokens(true);
-      setErrorMessage(null);
+  // Single over-fetch of the superset (cap above); no `total` clamp is
+  // possible (endpoint exposes none — R-04), so pagination past this point is
+  // client-side (usePagedRows) and "Cargar más" only re-fetches when the
+  // admin reaches the edge of what is currently loaded.
+  const loadTokens = useCallback(async () => {
+    setIsLoadingTokens(true);
+    setErrorMessage(null);
+    const requestId = ++latestRequestRef.current;
 
-      try {
-        const snapshot = await getAdminParticularTokens({
-          limit: PAGE_SIZE,
-          offset: nextPage * PAGE_SIZE,
-        });
-        setTokens(snapshot.particularTokens);
-        setSelectedTokenId((current) =>
-          current && snapshot.particularTokens.some((token) => token.id === current)
-            ? current
-            : null,
-        );
-      } catch (error) {
-        setTokens([]);
-        setSelectedTokenId(null);
-        setErrorMessage(
-          error instanceof Error
-            ? error.message
-            : "No se pudieron cargar los tokens particulares.",
-        );
-      } finally {
-        setIsLoadingTokens(false);
-      }
-    },
-    [page],
-  );
-
-  const loadMobileTokens = useCallback(
-    async (nextPage = mobilePage) => {
-      setIsLoadingMobileTokens(true);
-
-      try {
-        const snapshot = await getAdminParticularTokens({
-          limit: MOBILE_PAGE_SIZE,
-          offset: nextPage * MOBILE_PAGE_SIZE,
-        });
-        setMobileTokens(snapshot.particularTokens);
-      } catch {
-        setMobileTokens([]);
-      } finally {
-        setIsLoadingMobileTokens(false);
-      }
-    },
-    [mobilePage],
-  );
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 767px)");
-
-    const updateMobileViewport = () => {
-      setIsMobileViewport(mediaQuery.matches);
-    };
-
-    updateMobileViewport();
-    mediaQuery.addEventListener("change", updateMobileViewport);
-
-    return () => {
-      mediaQuery.removeEventListener("change", updateMobileViewport);
-    };
+    try {
+      const snapshot = await getAdminParticularTokens({
+        limit: TOKENS_SUPERSET_CAP,
+        offset: 0,
+      });
+      if (requestId !== latestRequestRef.current) return;
+      setTokens(snapshot.particularTokens);
+      setHasMoreFromServer(
+        snapshot.particularTokens.length === TOKENS_SUPERSET_CAP,
+      );
+      setSelectedTokenId((current) =>
+        current && snapshot.particularTokens.some((token) => token.id === current)
+          ? current
+          : null,
+      );
+    } catch (error) {
+      if (requestId !== latestRequestRef.current) return;
+      setTokens([]);
+      setHasMoreFromServer(false);
+      setSelectedTokenId(null);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudieron cargar los tokens particulares.",
+      );
+    } finally {
+      if (requestId === latestRequestRef.current) setIsLoadingTokens(false);
+    }
   }, []);
+
+  const loadMoreTokens = useCallback(async () => {
+    if (isLoadingMoreTokens || !hasMoreFromServer) return;
+    setIsLoadingMoreTokens(true);
+    setErrorMessage(null);
+    const requestId = ++latestRequestRef.current;
+
+    try {
+      const snapshot = await getAdminParticularTokens({
+        limit: TOKENS_SUPERSET_CAP,
+        offset: tokens.length,
+      });
+      if (requestId !== latestRequestRef.current) return;
+      setTokens((current) => [...current, ...snapshot.particularTokens]);
+      setHasMoreFromServer(
+        snapshot.particularTokens.length === TOKENS_SUPERSET_CAP,
+      );
+    } catch (error) {
+      if (requestId !== latestRequestRef.current) return;
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "No se pudieron cargar más tokens particulares.",
+      );
+    } finally {
+      if (requestId === latestRequestRef.current) setIsLoadingMoreTokens(false);
+    }
+  }, [isLoadingMoreTokens, hasMoreFromServer, tokens.length]);
 
   useEffect(() => {
     void loadTokens();
   }, [loadTokens]);
-
-  useEffect(() => {
-    if (!isMobileViewport) return;
-    void loadMobileTokens();
-  }, [isMobileViewport, loadMobileTokens]);
 
   // The clinic catalogue resolves visible names in the list and powers the
   // advanced clinic filter without changing the tokens API contract.
@@ -874,16 +989,14 @@ export function AdminParticularTokensCard() {
       from: filterDraft.from,
       to: filterDraft.to,
     });
-    setPage(0);
-    setMobilePage(0);
+    pagedTokens.setPage(0);
     setErrorMessage(null);
   }
 
   function clearAdvancedFilters() {
     setFilterDraft(INITIAL_FILTER_STATE);
     setAppliedFilters(INITIAL_FILTER_STATE);
-    setPage(0);
-    setMobilePage(0);
+    pagedTokens.setPage(0);
     setErrorMessage(null);
   }
 
@@ -991,10 +1104,7 @@ export function AdminParticularTokensCard() {
             variant="outline"
             size="sm"
             className={buttonClassName}
-            onClick={() => {
-              void loadTokens();
-              if (isMobileViewport) void loadMobileTokens();
-            }}
+            onClick={() => void loadTokens()}
             disabled={isLoadingTokens}
           >
             {isLoadingTokens ? "Actualizando…" : "Actualizar"}
@@ -1059,10 +1169,8 @@ export function AdminParticularTokensCard() {
       setCopyErrorMessage(null);
       setStatusMessage(response.message);
       resetForm();
-      setPage(0);
-      setMobilePage(0);
-      await loadTokens(0);
-      if (isMobileViewport) await loadMobileTokens(0);
+      pagedTokens.setPage(0);
+      await loadTokens();
       setIsCreateDialogOpen(false);
     } catch (error) {
       setErrorMessage(
@@ -1101,8 +1209,7 @@ export function AdminParticularTokensCard() {
         delete next[token.id];
         return next;
       });
-      await loadTokens(page);
-      if (isMobileViewport) await loadMobileTokens(mobilePage);
+      await loadTokens();
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -1260,10 +1367,10 @@ export function AdminParticularTokensCard() {
           </div>
           <ParticularTokensMetricStrip
             metrics={[
-              { label: "En página", value: filteredTokens.length },
+              { label: "En página", value: visibleTokens.length },
               { label: "Activos", value: activeTokensCount },
               { label: "Con informe", value: linkedReportsCount },
-              { label: "Página", value: page + 1 },
+              { label: "Página", value: pagedTokens.page + 1 },
             ]}
             className="flex min-h-10 items-center rounded-lg md:min-h-8"
             itemClassName="min-w-[4.5rem] px-3 py-1 text-center md:px-2 md:py-0.5"
@@ -1341,10 +1448,7 @@ export function AdminParticularTokensCard() {
               variant="outline"
               size="sm"
               className="h-10 min-h-10 px-2 text-xs"
-              onClick={() => {
-                void loadTokens();
-                if (isMobileViewport) void loadMobileTokens();
-              }}
+              onClick={() => void loadTokens()}
               disabled={isLoadingTokens}
             >
               {isLoadingTokens ? "Actualizando…" : "Actualizar"}
@@ -1369,7 +1473,10 @@ export function AdminParticularTokensCard() {
           aria-label="Tabla de tokens particulares"
           className="flex min-h-0 flex-1 flex-col"
         >
-          <div className="dashboard-table-responsive hidden min-h-0 flex-1 md:block">
+          <div
+            ref={setDesktopBodyNode}
+            className="dashboard-table-responsive hidden min-h-0 flex-1 md:block"
+          >
             <Table className="table-fixed text-xs [&_th]:h-7 [&_th]:px-2 [&_td]:px-2">
               <TableHeader>
                 <TableRow>
@@ -1383,8 +1490,11 @@ export function AdminParticularTokensCard() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredTokens.map((token) => (
-                  <TableRow key={token.id}>
+                {visibleTokens.map((token, index) => (
+                  <TableRow
+                    key={token.id}
+                    ref={index === 0 ? setDesktopRowNode : undefined}
+                  >
                     <TableCell className="py-0.5">
                       <p className="truncate font-mono text-xs font-semibold text-vetneb-ink">
                         ****{token.tokenLast4}
@@ -1435,11 +1545,13 @@ export function AdminParticularTokensCard() {
             data-admin-mobile-core-module="tokens"
           >
             <ParticularTokensMobileList
+              ref={setMobileBodyNode}
               data-admin-particulars-mobile-list="true"
             >
-              {filteredMobileTokens.map((token) => (
+              {visibleTokens.map((token, index) => (
                 <div
                   key={token.id}
+                  ref={index === 0 ? setMobileRowNode : undefined}
                   className="flex min-h-9 items-center gap-2 px-2.5 py-1"
                   data-admin-mobile-core-item="true"
                 >
@@ -1471,9 +1583,9 @@ export function AdminParticularTokensCard() {
               ))}
             </ParticularTokensMobileList>
 
-            {!filteredMobileTokens.length && isMobileViewport ? (
+            {!filteredTokens.length ? (
               <p className="surface-empty flex min-h-20 flex-1 items-center justify-center text-xs">
-                {isLoadingMobileTokens
+                {isLoadingTokens
                   ? "Cargando tokens particulares…"
                   : hasActiveFilters
                     ? "No hay tokens que coincidan con los filtros aplicados."
@@ -1481,7 +1593,7 @@ export function AdminParticularTokensCard() {
               </p>
             ) : null}
 
-            {filteredMobileTokens.length ? (
+            {filteredTokens.length ? (
               <div
                 className="flex shrink-0 items-center justify-center gap-1.5 border-t border-vetneb-line/65 pt-1.5 text-xs text-muted-foreground"
                 data-admin-mobile-core-pager="true"
@@ -1491,28 +1603,41 @@ export function AdminParticularTokensCard() {
                   variant="outline"
                   size="sm"
                   className="h-9 px-2.5 text-xs"
-                  disabled={mobilePage === 0 || isLoadingMobileTokens}
+                  disabled={!pagedTokens.hasPrev || isLoadingTokens}
                   onClick={() => {
                     setIsDetailDialogOpen(false);
-                    setMobilePage((current) => Math.max(0, current - 1));
+                    pagedTokens.goPrev();
                   }}
                 >
                   Anterior
                 </Button>
-                <span className="min-w-12 text-center">Pág. {mobilePage + 1}</span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-9 px-2.5 text-xs"
-                  disabled={!canGoNextMobile || isLoadingMobileTokens}
-                  onClick={() => {
-                    setIsDetailDialogOpen(false);
-                    setMobilePage((current) => current + 1);
-                  }}
-                >
-                  Siguiente
-                </Button>
+                <span className="min-w-12 text-center">Pág. {pagedTokens.page + 1}</span>
+                {!pagedTokens.hasNext && hasMoreFromServer ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 text-xs"
+                    disabled={isLoadingMoreTokens}
+                    onClick={() => void loadMoreTokens()}
+                  >
+                    {isLoadingMoreTokens ? "Cargando…" : "Cargar más"}
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 px-2.5 text-xs"
+                    disabled={!pagedTokens.hasNext || isLoadingTokens}
+                    onClick={() => {
+                      setIsDetailDialogOpen(false);
+                      pagedTokens.goNext();
+                    }}
+                  >
+                    Siguiente
+                  </Button>
+                )}
               </div>
             ) : null}
           </div>
@@ -1529,7 +1654,10 @@ export function AdminParticularTokensCard() {
 
           <div className="mt-2 hidden min-h-10 shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/65 px-1 pt-2 text-xs text-muted-foreground md:mt-1 md:flex md:min-h-8 md:pt-1">
             <span>
-              {filteredTokens.length ? `${rangeStart}–${rangeEnd}` : "0 resultados"} · 9 por página
+              {filteredTokens.length
+                ? `${pagedTokens.rangeStart}–${pagedTokens.rangeEnd}`
+                : "0 resultados"}{" "}
+              · {rowsPerPage} por página
             </span>
             <div className="flex items-center gap-1.5">
               <Button
@@ -1537,28 +1665,41 @@ export function AdminParticularTokensCard() {
                 variant="outline"
                 size="sm"
                 className="md:h-8 md:px-2 md:text-xs"
-                disabled={page === 0 || isLoadingTokens}
+                disabled={!pagedTokens.hasPrev || isLoadingTokens}
                 onClick={() => {
                   setIsDetailDialogOpen(false);
-                  setPage((current) => Math.max(0, current - 1));
+                  pagedTokens.goPrev();
                 }}
               >
                 Anterior
               </Button>
-              <span className="min-w-16 text-center">Página {page + 1}</span>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="md:h-8 md:px-2 md:text-xs"
-                disabled={!canGoNext || isLoadingTokens}
-                onClick={() => {
-                  setIsDetailDialogOpen(false);
-                  setPage((current) => current + 1);
-                }}
-              >
-                Siguiente
-              </Button>
+              <span className="min-w-16 text-center">Página {pagedTokens.page + 1}</span>
+              {!pagedTokens.hasNext && hasMoreFromServer ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="md:h-8 md:px-2 md:text-xs"
+                  disabled={isLoadingMoreTokens}
+                  onClick={() => void loadMoreTokens()}
+                >
+                  {isLoadingMoreTokens ? "Cargando…" : "Cargar más"}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="md:h-8 md:px-2 md:text-xs"
+                  disabled={!pagedTokens.hasNext || isLoadingTokens}
+                  onClick={() => {
+                    setIsDetailDialogOpen(false);
+                    pagedTokens.goNext();
+                  }}
+                >
+                  Siguiente
+                </Button>
+              )}
             </div>
           </div>
         </section>

--- a/frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
+++ b/frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
@@ -1,4 +1,8 @@
-import type { ComponentPropsWithoutRef, ComponentPropsWithRef, ReactNode } from "react";
+import type {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  ReactNode,
+} from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -114,7 +118,7 @@ export function ParticularTokensPanelFooter({
 export function ParticularTokensMobileList({
   className,
   ...props
-}: ComponentPropsWithoutRef<"div">) {
+}: ComponentPropsWithRef<"div">) {
   return (
     <div
       className={cn(

--- a/test/admin-tokens-enterprise-density.test.ts
+++ b/test/admin-tokens-enterprise-density.test.ts
@@ -28,18 +28,48 @@ const FORBIDDEN_OVERSIZED = [
   "h-16",
 ];
 
-test("admin tokens uses viewport-safe server pagination with nine rows", () => {
+// R-05 (admin-particular-tokens-server-adaptive-pagination): the endpoint
+// exposes no `total` (R-04 confirmed), so the strategy is over-fetch with a
+// cap (30) paginated client-side (usePagedRows), plus an explicit "Cargar
+// más" affordance gated by the last fetched batch filling the cap
+// (hasMoreFromServer). TOKENS_FALLBACK_ROWS survives only as the
+// pre-measurement fallback/desktop floor; MOBILE_PAGE_SIZE and the
+// matchMedia cardinality gate are gone (single collapsed runtime).
+test("admin tokens uses viewport-safe server pagination adaptive by viewport (OF cap 30 + cargar más)", () => {
   const source = read(TOKENS_CARD_PATH);
 
-  assert.ok(source.includes("const PAGE_SIZE = 9;"));
-  assert.ok(source.includes("limit: PAGE_SIZE"));
-  assert.ok(source.includes("offset: nextPage * PAGE_SIZE"));
-  assert.ok(source.includes("const canGoNext = tokens.length === PAGE_SIZE;"));
+  assert.ok(source.includes("const TOKENS_FALLBACK_ROWS = 9;"));
+  assert.ok(source.includes("const TOKENS_SUPERSET_CAP = 30;"));
+  assert.ok(source.includes("useAdaptiveItemsPerPage"));
+  assert.ok(source.includes("usePagedRows"));
+  assert.ok(source.includes("hasMoreFromServer"));
+  assert.equal(source.includes("const PAGE_SIZE = 9;"), false);
+  assert.equal(source.includes("const MOBILE_PAGE_SIZE"), false);
+  assert.equal(source.includes("window.matchMedia"), false);
+  assert.equal(source.includes("isMobileViewport"), false);
+  assert.equal(source.includes("loadMobileTokens"), false);
+  assert.equal(source.includes("const canGoNext = tokens.length === PAGE_SIZE;"), false);
   assert.ok(source.includes("Anterior"));
   assert.ok(source.includes("Siguiente"));
+  assert.ok(source.includes("Cargar más"));
   assert.equal(source.includes("limit: 8, offset: 0"), false);
   assert.equal(source.includes("PAGE_SIZE_OPTIONS"), false);
   assert.equal(source.includes("25/50/100"), false);
+});
+
+test("admin tokens recomputa pagina localmente y descarta respuestas viejas (anti-race)", () => {
+  const source = read(TOKENS_CARD_PATH);
+
+  assert.ok(source.includes("const latestRequestRef = useRef(0);"));
+  assert.ok(source.includes("const requestId = ++latestRequestRef.current;"));
+  assert.ok(source.includes("if (requestId !== latestRequestRef.current) return;"));
+
+  // Desktop keeps the nine-row floor (App Shell contract), mobile floors at one.
+  assert.ok(
+    source.includes(
+      "minItems: isDesktopMeasurement ? TOKENS_FALLBACK_ROWS : 1,",
+    ),
+  );
 });
 
 test("admin tokens toolbar is mobile-safe and wraps actions", () => {

--- a/test/frontend-admin-particular-tokens.test.ts
+++ b/test/frontend-admin-particular-tokens.test.ts
@@ -203,8 +203,8 @@ test("admin particular tokens exposes advanced filter bar for real table fields"
   assert.ok(source.includes("dashboardFilterActionClassName(density)"));
   assert.ok(source.includes("Aplicar"));
   assert.ok(source.includes("Limpiar"));
-  assert.ok(source.includes("filteredTokens.map((token) => ("));
-  assert.ok(source.includes("filteredMobileTokens.map((token) => ("));
+  assert.ok(source.includes("visibleTokens.map((token, index) => ("));
+  assert.equal(source.includes("filteredMobileTokens"), false);
   assert.equal(source.includes("Email del particular") && source.includes('name="filterEmail"'), false);
   assert.ok(auditFilter.includes('aria-label={mobile ? "Filtros de auditoría mobile" : "Filtros de auditoría"}'));
   assert.ok(auditFilter.includes("Desde"));
@@ -240,10 +240,10 @@ test("admin particular tokens filters apply to visible token table fields", () =
   assert.ok(filterBlock.includes("matchesCreatedAtRange(token, filters.from, filters.to)"));
   assert.ok(source.includes("const createdAt = toDateInputValue(token.createdAt);"));
   assert.ok(applyBlock.includes("setAppliedFilters({"));
-  assert.ok(applyBlock.includes("setPage(0);"));
-  assert.ok(applyBlock.includes("setMobilePage(0);"));
+  assert.ok(applyBlock.includes("pagedTokens.setPage(0);"));
   assert.ok(clearBlock.includes("setFilterDraft(INITIAL_FILTER_STATE);"));
   assert.ok(clearBlock.includes("setAppliedFilters(INITIAL_FILTER_STATE);"));
+  assert.ok(clearBlock.includes("pagedTokens.setPage(0);"));
 });
 
 test("admin particular token generator keeps programmed fields", () => {


### PR DESCRIPTION
R-05 del roadmap final.

Implementa Admin Particular Tokens server-adaptive sin backend, usando la decisión R-04:
- No existe total global.
- No se pide total nuevo.
- OF con cap 30 + Cargar más.
- hasNext heurístico por página llena.
- Runtime único para desktop/mobile.
- Eliminado matchMedia como cardinalidad.
- Eliminado MOBILE_PAGE_SIZE como fuente de verdad.
- useAdaptiveItemsPerPage mide tabla/lista visible.
- usePagedRows pagina el superset cargado localmente.
- Anti-race con latestRequestRef.
- Sin pageCount/total falso.

Archivos:
- frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
- frontend/src/components/dashboard/ParticularTokensCardPrimitives.tsx
- test/admin-tokens-enterprise-density.test.ts
- test/frontend-admin-particular-tokens.test.ts
- frontend/e2e/admin-tokens-mobile-toolbar-layout.spec.ts
- frontend/e2e/admin-mobile-core-modules-no-scroll.spec.ts
- docs/implementation/admin-particular-tokens-server-adaptive-pagination.md

Validaciones locales reportadas:
- pnpm test: 2943/2943
- pnpm typecheck:test OK
- pnpm security:public-surface PASS
- frontend lint/typecheck/build OK
- e2e admin-tokens-mobile-toolbar-layout OK
- e2e admin-mobile-core-modules-no-scroll --grep tokens OK
- equivalente pager incluido en pnpm test OK

Scope:
- Sin backend/API/auth/DB/server.
- Sin CI/workflows.
- Sin deps/lockfiles.
- Sin snapshots.
- Sin globals.css.
- Sin otros módulos Admin.
- Sin Clínica/Particular/Público.
- Sin R-06 adelantado.