### PR TITLE
feat(dashboard): adapt informes full route server pagination

### DIFF
--- a/docs/implementation/dashboard-informes-server-adaptive-pagination.md
+++ b/docs/implementation/dashboard-informes-server-adaptive-pagination.md
@@ -1,0 +1,238 @@
+# R-07 — Clínica `/dashboard/informes` full route server-adaptive pagination
+
+## PR
+
+`feat(dashboard): adapt informes full route server pagination`
+
+Séptimo módulo migrado por el roadmap rector
+(`docs/audit/final-global-vetneb-50-60-pr-roadmap.md`, Fase 1), y el primero
+fuera de Admin: la ruta full `/dashboard/informes` (Clínica) tenía la
+cardinalidad fija en 6 filas (`REPORTS_PAGE_SIZE`) señalada como pendiente en
+la matriz canónica (`PR-SRV-0 §4`, fila "Ruta full `/dashboard/informes` fija
+en 6 filas").
+
+## Base
+
+- Rama de trabajo: `feat/dashboard-informes-server-adaptive-pagination`.
+- Base: `main @ e38975b feat(admin): adapt audit server pagination to viewport (#1268)`.
+- Fecha: 2026-07-03.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-07, Fase 1.
+2. `docs/implementation/admin-audit-server-adaptive-pagination.md` (R-06) —
+   patrón RF debounced de referencia (medición → Server Action → offset por
+   estado de cliente, anti-race por request-id).
+3. `frontend/src/hooks/useAdaptiveItemsPerPage.ts` — hook genérico reutilizado
+   sin cambios.
+
+## Contrato anterior
+
+`frontend/src/app/dashboard/informes/page.tsx` era un server component puro:
+leía `page`/`query`/`status`/`studyType`/`reportId` desde `searchParams`,
+llamaba `getReportsPaginated`/`searchReportsPaginated` con
+`REPORTS_PAGE_SIZE` fijo = 6, y paginaba con `PublicRouteControl` (`href`
+`?page=N`, full page reload). La selección de informe también navegaba por
+`href` (`?reportId=N`). El pager sólo se mostraba si `reportsTotalPages > 1`.
+
+## Contrato nuevo
+
+- **Nuevo cliente colapsado**: `InformesReportsList.tsx` (`"use client"`)
+  concentra medición, `offset` de estado, fetch y render de la lista/detalle/
+  pager. `page.tsx` sigue siendo un server component: resuelve filtros desde
+  `searchParams`, hace el fetch inicial (con `INFORMES_FALLBACK_ROWS` como
+  tamaño de página de arranque, antes de la primera medición real) y pasa el
+  resultado como props iniciales.
+- **Server Action nuevo**: `informes.actions.ts` (`getInformesPage`), mismo
+  patrón que `admin-audit.actions.ts` — reenvía cookies, `cache: "no-store"`,
+  y redirige a login en 401 (`redirectToLoginOnUnauthorized`).
+- **Constantes en módulo aparte**: `informes.constants.ts` (sin `"use
+  client"`) expone `INFORMES_FALLBACK_ROWS = 6` e `INFORMES_LIMIT_CAP = 24`.
+  Ver "Bug real encontrado" más abajo — es la razón de que esta migración
+  necesite un tercer archivo que R-06 no necesitó (Auditoría nunca compartió
+  una constante entre su server component y su client component).
+- `useAdaptiveItemsPerPage` mide el contenedor de filas (`dashboard-inline-
+  scroll`) y la altura de la primera fila (medida en un `div` que envuelve
+  sólo el botón de la fila, nunca el panel de detalle expandible, para que la
+  selección de un informe no contamine la medición).
+- **Sin piso desktop**: a diferencia de Tokens/Reports/Audit/Users-Roles
+  (Admin, `expectNinePopulatedRows`), esta es una ruta full de Clínica sin
+  contrato de App Shell pinneado — `minItems: 1` en ambos contextos
+  (memoria del proyecto: *"App Shell spec pins 9 rows for tokens/reports/
+  audit/users-roles (not clinics)"*).
+- **Selección de informe**: pasa de navegación por `href`
+  (`PublicRouteControl` + `?reportId=N`, full reload) a estado de cliente
+  (`useState`, botón `onClick`) — el detalle ya vive en las filas cargadas,
+  no requiere una nueva petición ni un reload de página. El deep-link inicial
+  por `?reportId=N` se sigue leyendo en `page.tsx` como valor inicial.
+- **Paginación**: pasa de `href` (`?page=N`) a botones `onClick` con `offset`
+  en estado de cliente (mismo motivo que R-06: el `limit` ya no es fijo, la
+  aritmética de página por URL dejaría de ser válida).
+- **Pager siempre visible**: se retira el gate `reportsTotalPages > 1`
+  (requisito explícito de R-07); antes el pager desaparecía con pocos
+  resultados.
+- **Resumen compacto oculto en mobile**: el bloque Total/Mostrando/Página/
+  Filtros pasa de `grid` a `hidden sm:grid` — ver "No-clipping en mobile" más
+  abajo.
+
+## Bug real encontrado durante el desarrollo (y por qué existe `informes.constants.ts`)
+
+Next.js convierte **todos** los exports nombrados de un archivo `"use
+client"` en referencias de cliente opacas — incluida una constante numérica
+simple. `page.tsx` (server component) importaba inicialmente
+`INFORMES_FALLBACK_ROWS` directamente desde `InformesReportsList.tsx`
+(`"use client"`) para usarla como `pageSize` del fetch SSR inicial. En
+runtime, ese import no era el número `6`: era una referencia de cliente, y
+las operaciones aritméticas (`Math.max(1, params.pageSize ?? 20)`, etc.) la
+convertían en `NaN`. Esto se propagaba silenciosamente a `pagedResult.
+pageSize` (SSR) → prop `initialPageSize` (cliente) → `offset` inicial =
+`(initialPage - 1) * NaN` = `NaN` — sin ningún error de compilación ni de
+tipos (`NaN` es un `number` válido para TypeScript). El síntoma visible era
+"Página NaN / 167" / "Mostrando NaN-NaN" en producción, detectado con
+Playwright (`console.log` temporal + verificación en HTML servido) durante
+la validación e2e de este PR, no por `tsc`/`eslint`/`pnpm test`.
+
+**Fix**: mover las constantes compartidas a un módulo plano sin `"use
+client"` (`informes.constants.ts`), importado tanto por el server component
+(`page.tsx`) como por el client component (`InformesReportsList.tsx`). Este
+riesgo no se manifestó en R-06 porque Auditoría nunca compartió una
+constante numérica entre su server component (`admin/page.tsx`) y su client
+component (`AdminAuditCard.tsx`) para aritmética SSR — `admin/page.tsx` sí
+importa `ADMIN_AUDIT_FALLBACK_ROWS` desde `AdminAuditCard.tsx`, pero sólo
+para pasarla como argumento de función (`{ limit: ADMIN_AUDIT_FALLBACK_ROWS
+}`), no para una expresión aritmética cuyo resultado se persiste en estado —
+el mismo bug podría existir ahí de forma latente si esa constante alguna vez
+resultara `NaN`, pero como es siempre el literal `9` compilado, nunca se
+manifestó. Se documenta aquí como riesgo de patrón para futuras migraciones
+(R-08 en adelante) que compartan constantes numéricas entre server y client
+component de un mismo módulo: **la constante debe vivir en un archivo sin
+`"use client"`**.
+
+## Cómo se recomputa `offset`
+
+Igual regla que R-06 (el endpoint de reports expone `total`):
+
+```
+nextOffset = Math.max(0, Math.min(
+  Math.floor(currentOffset / effectiveLimit) * effectiveLimit,
+  (Math.ceil(total / effectiveLimit) - 1) * effectiveLimit,
+));
+```
+
+Sólo corre cuando `effectiveLimit` cambia (`previousLimitRef`); un cambio de
+filtros (formulario GET, full page reload) resetea todo por remount, `offset`
+inicial vuelve a `0`.
+
+## Cómo se evita la carrera
+
+- **Request id** (`latestRequestRef`): igual que R-06, una respuesta cuyo id
+  ya no es el vigente se descarta.
+- **Debounce de medición**: `ResizeObserver` + `requestAnimationFrame` +
+  comparación de medición previa, mismo patrón que R-01..R-06.
+
+## No-clipping en mobile (390×844)
+
+Con el resumen compacto siempre visible (`grid` sin condición), el contenido
+fijo (header de card + formulario de filtros de 3 campos, que en mobile
+stackea verticalmente) + resumen (grid 2×2, ~120px) dejaba menos espacio
+vertical del necesario para que la sección de lista (encabezado + al menos 1
+fila + pager) entrara dentro del `Card` (`overflow-hidden`) — el pager
+quedaba recortado visualmente (no reflejado en `document.body.scrollHeight`,
+que seguía sin scroll global, pero sí en un recorte silencioso dentro del
+`Card`). Verificado con Playwright (`getBoundingClientRect` en `nav` de
+paginación vs. `card`/viewport). Fix: el resumen compacto pasa a `hidden
+sm:grid` (se sigue viendo en tablet/desktop ≥640px; en mobile los mismos
+datos ya son parcialmente redundantes con "Página X de Y" del pie del pager).
+Con ese cambio el pager queda dentro del `Card` y del viewport en 390×844,
+1366×768 y 1440×900 (verificado con e2e).
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/informes/page.tsx` — se retira la lógica de
+  lista/detalle/pager (movida al cliente); mantiene resolución de filtros
+  desde `searchParams`, fetch inicial SSR (fallback de arranque) y manejo de
+  401.
+- `frontend/src/app/dashboard/informes/InformesReportsList.tsx` — **nuevo**,
+  client component con medición adaptativa, Server Action de re-fetch,
+  estado de `offset`/selección, y todo el render de lista/detalle/pager que
+  antes vivía en `page.tsx`.
+- `frontend/src/app/dashboard/informes/informes.actions.ts` — **nuevo**,
+  Server Action `getInformesPage` (RF debounced), mismo patrón de reenvío de
+  cookies y redirect-on-401 que `admin-audit.actions.ts`.
+- `frontend/src/app/dashboard/informes/informes.constants.ts` — **nuevo**,
+  `INFORMES_FALLBACK_ROWS`/`INFORMES_LIMIT_CAP` en módulo sin `"use client"`
+  (ver "Bug real encontrado").
+- `frontend/e2e/dashboard-informes-server-adaptive-pagination.spec.ts` —
+  **nuevo**, e2e focalizado: pager siempre visible, sin scroll externo, filas
+  sin clipping horizontal, navegación anterior/siguiente funcional, sin
+  parámetro `page` en la URL, y el fix de no-clipping en 390×844/1366×768/
+  1440×900.
+- `test/frontend-dashboard-informes.test.ts`,
+  `test/frontend-dashboard-reports-master-detail.test.ts`,
+  `test/frontend-dashboard-empty-states.test.ts`,
+  `test/frontend-dashboard-mobile-polish-bottom-actions.test.ts`,
+  `test/frontend-dashboard-filter-drawer-sticky-filters.test.ts`,
+  `test/frontend-notification-click-anchors.test.ts`,
+  `test/frontend-report-download-action.test.ts`,
+  `test/frontend-reports-live-read-contract.test.ts` — alineados al contrato
+  nuevo (aserciones de contenido movidas al archivo donde ese contenido vive
+  ahora; ninguna aserción de comportamiento se elimina, sólo se reubica).
+
+## Fuera de scope (no tocado)
+
+- `ClinicInformesWorkspaceSummary.tsx` (resumen de informes en el hub de
+  Clínica, `?module=informes`) — ya migrado en un PR previo, no forma parte
+  de R-07.
+- Backend/API/auth/DB/migraciones — sólo lectura; `getReportsPaginated`/
+  `searchReportsPaginated` ya aceptaban `page`/`pageSize` y exponen `total`.
+- CI/workflows, deps/lockfiles, snapshots, `globals.css`.
+- Otros módulos Clínica (logística, tokens particulares del lado clínica),
+  Admin, Particular, Público.
+- R-08 (cleanup de shims residuales) — no adelantado.
+
+## Validaciones ejecutadas
+
+PNPM 10.8.1.
+
+- `pnpm test` — 2945/2945.
+- `pnpm typecheck:test` — OK.
+- `pnpm security:public-surface` — PASS (sólo marcadores server-only
+  esperados en `frontend/src/proxy.ts`).
+- `pnpm --dir frontend lint` — OK.
+- `pnpm --dir frontend typecheck` — OK.
+- `pnpm --dir frontend build` — OK.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-informes-server-adaptive-pagination.spec.ts` — 5/5.
+- `pnpm --dir frontend exec playwright test e2e/dashboard-clinic-informes-mobile-parity.spec.ts e2e/clinic-reports-fixture-pagination.spec.ts` — 7/7 (contratos previos de la ruta hub/summary y de la fixture de 1000 informes siguen intactos).
+- `frontend/next-env.d.ts` fue regenerado por Playwright durante los e2e y se
+  restauró (`git checkout --`) antes del diff review, por estar fuera de
+  scope (mismo procedimiento documentado en R-06).
+
+## Riesgos residuales
+
+- **Resumen compacto oculto en mobile (P2, cosmético)**: en viewports <640px
+  ya no se ve el bloque Total/Mostrando/Página/Filtros; el pie del pager
+  ("Página X de Y") sigue comunicando la posición. Aceptado para cumplir el
+  requisito explícito de no-clipping sin tocar `FilterBar`/`globals.css`
+  (fuera de scope).
+- **Deep-link a informe no persiste tras paginar/seleccionar otro (P2)**: la
+  selección de informe pasó de navegación por URL a estado de cliente; el
+  `?reportId=N` inicial se sigue respetando al cargar la página, pero
+  seleccionar otro informe ya no actualiza la URL (antes sí, vía
+  `PublicRouteControl replace`). Se aceptó para poder paginar sin recargar
+  la página completa en cada selección — el mismo trade-off que R-06 hizo
+  con Auditoría (paginación por estado de cliente en vez de por URL).
+- **Sin salto a última página**: igual que el resto de los módulos migrados,
+  el pager sólo avanza/retrocede de a una página.
+- **QA manual pendiente**: iOS/Android real y zoom físico 100–175% siguen
+  siendo obligatorios antes de cualquier gate bloqueante (PR-SRV-0 §10.5).
+
+## Confirmaciones
+
+- Un solo módulo tocado: ruta full `/dashboard/informes` (Clínica).
+- `ClinicInformesWorkspaceSummary.tsx` no fue tocado.
+- Backend/API/auth/DB/migraciones no tocados.
+- CI/workflows, deps/lockfiles, snapshots, `globals.css` no tocados.
+- Estrategia RF debounced ejecutada (no over-fetch); anti-race por
+  request-id; offset recomputado con `total` (regla 1, PR-SRV-0 §6); sin
+  `matchMedia`; pager siempre visible.
+- No se hizo `git add`/`commit`/`push`/`gh pr create`.

--- a/frontend/src/app/dashboard/informes/InformesReportsList.tsx
+++ b/frontend/src/app/dashboard/informes/InformesReportsList.tsx
@@ -322,7 +322,7 @@ export function InformesReportsList({
               </p>
             </div>
 
-            <div ref={setBodyNode} className="dashboard-inline-scroll p-4">
+            <div ref={setBodyNode} className="flex min-h-0 flex-1 overflow-hidden p-3 sm:p-4">
               {loadError ? (
                 <div role="alert">
                   <ErrorState

--- a/frontend/src/app/dashboard/informes/InformesReportsList.tsx
+++ b/frontend/src/app/dashboard/informes/InformesReportsList.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { EmptyState } from "@/components/dashboard/EmptyState";
+import { ErrorState } from "@/components/dashboard/ErrorState";
+import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import { Badge } from "@/components/ui/badge";
+import {
+  StudyTimeline,
+  type StudyTimelineStep,
+} from "@/components/dashboard/StudyTimeline";
+import { useAdaptiveItemsPerPage } from "@/hooks/useAdaptiveItemsPerPage";
+import { cn, getReportStatusLabel, getReportStatusVariant, formatDate } from "@/lib/utils";
+import type { Report, ReportStatus } from "@/types";
+import { getInformesPage } from "./informes.actions";
+import { INFORMES_FALLBACK_ROWS, INFORMES_LIMIT_CAP } from "./informes.constants";
+
+const INFORMES_ROW_HEIGHT_FALLBACK_PX = 88;
+
+type Measurement = {
+  containerNode: HTMLElement | null;
+  rowHeightPx: number;
+};
+
+function measurementsEqual(a: Measurement, b: Measurement) {
+  return a.containerNode === b.containerNode && a.rowHeightPx === b.rowHeightPx;
+}
+
+function getReportTitle(report: Report) {
+  return report.patientName
+    ? `${report.patientName} · Informe #${report.id}`
+    : `Informe #${report.id}`;
+}
+
+const REPORT_STATUS_ORDER = {
+  uploaded: 0,
+  processing: 1,
+  ready: 2,
+  delivered: 3,
+} satisfies Record<ReportStatus, number>;
+
+function getTimelineStepStatus(
+  currentStatus: ReportStatus,
+  stepStatus: ReportStatus,
+): StudyTimelineStep["status"] {
+  if (currentStatus === stepStatus) {
+    return stepStatus === "delivered" ? "completed" : "current";
+  }
+
+  return REPORT_STATUS_ORDER[currentStatus] > REPORT_STATUS_ORDER[stepStatus]
+    ? "completed"
+    : "pending";
+}
+
+function buildStudyTimelineSteps(report: Report): StudyTimelineStep[] {
+  const currentStatus = report.currentStatus ?? report.status;
+  const uploadedDate = report.uploadDate ?? report.createdAt;
+  const updatedDate = report.updatedAt;
+
+  return [
+    {
+      id: "uploaded",
+      label: "Carga recibida",
+      date: uploadedDate ? formatDate(uploadedDate) : null,
+      description: "Fecha registrada para el informe en el portal.",
+      status: "completed",
+    },
+    {
+      id: "processing",
+      label: "Procesamiento",
+      date: currentStatus === "processing" ? formatDate(updatedDate) : null,
+      description: "Estado operativo informado por el registro del informe.",
+      status: getTimelineStepStatus(currentStatus, "processing"),
+    },
+    {
+      id: "ready",
+      label: "Informe disponible",
+      date:
+        currentStatus === "ready" || currentStatus === "delivered"
+          ? formatDate(updatedDate)
+          : null,
+      description: "El archivo queda disponible cuando el estado real lo indique.",
+      status: getTimelineStepStatus(currentStatus, "ready"),
+    },
+    {
+      id: "delivered",
+      label: "Entrega",
+      date: currentStatus === "delivered" ? formatDate(updatedDate) : null,
+      description: "Cierre del circuito visible para la clínica.",
+      status: getTimelineStepStatus(currentStatus, "delivered"),
+    },
+  ];
+}
+
+export type InformesReportsListProps = {
+  filters: {
+    query: string;
+    status: string;
+    studyType: string;
+  };
+  initialReports: Report[];
+  initialTotal: number;
+  initialPage: number;
+  initialPageSize: number;
+  initialLoadError: boolean;
+  initialSelectedReportId: number | null;
+};
+
+export function InformesReportsList({
+  filters,
+  initialReports,
+  initialTotal,
+  initialPage,
+  initialPageSize,
+  initialLoadError,
+  initialSelectedReportId,
+}: InformesReportsListProps) {
+  const [reports, setReports] = useState<Report[]>(initialReports);
+  const [totalCount, setTotalCount] = useState(initialTotal);
+  const [offset, setOffset] = useState((initialPage - 1) * initialPageSize);
+  const [loadError, setLoadError] = useState(initialLoadError);
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(
+    initialSelectedReportId,
+  );
+
+  const [bodyNode, setBodyNode] = useState<HTMLElement | null>(null);
+  const [rowNode, setRowNode] = useState<HTMLElement | null>(null);
+  const [measurement, setMeasurement] = useState<Measurement>({
+    containerNode: null,
+    rowHeightPx: INFORMES_ROW_HEIGHT_FALLBACK_PX,
+  });
+
+  const latestRequestRef = useRef(0);
+  const totalRef = useRef(initialTotal);
+
+  useEffect(() => {
+    totalRef.current = totalCount;
+  }, [totalCount]);
+
+  useLayoutEffect(() => {
+    if (!bodyNode) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const recompute = () => {
+      frame = null;
+
+      const containerHeight = bodyNode.getBoundingClientRect().height;
+      if (containerHeight <= 0) {
+        return;
+      }
+
+      const rowHeight = rowNode?.getBoundingClientRect().height ?? 0;
+      setMeasurement((previous) => {
+        const next: Measurement = {
+          containerNode: bodyNode,
+          rowHeightPx: rowHeight > 0 ? rowHeight : INFORMES_ROW_HEIGHT_FALLBACK_PX,
+        };
+        return measurementsEqual(previous, next) ? previous : next;
+      });
+    };
+
+    const scheduleRecompute = () => {
+      if (frame === null) {
+        frame = requestAnimationFrame(recompute);
+      }
+    };
+
+    const observer = new ResizeObserver(scheduleRecompute);
+    observer.observe(bodyNode);
+    if (rowNode) {
+      observer.observe(rowNode);
+    }
+    recompute();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [bodyNode, rowNode]);
+
+  const { itemsPerPage: rowsPerPage } = useAdaptiveItemsPerPage({
+    containerNode: measurement.containerNode,
+    fallbackItems: INFORMES_FALLBACK_ROWS,
+    itemHeightPx: measurement.rowHeightPx,
+    minItems: 1,
+    maxItems: INFORMES_LIMIT_CAP,
+  });
+
+  const effectiveLimit = rowsPerPage;
+
+  const query = useMemo(
+    () => ({
+      query: filters.query || undefined,
+      status: filters.status || undefined,
+      studyType: filters.studyType || undefined,
+      pageSize: effectiveLimit,
+      offset,
+    }),
+    [filters.query, filters.status, filters.studyType, effectiveLimit, offset],
+  );
+
+  const previousLimitRef = useRef(effectiveLimit);
+  useEffect(() => {
+    if (previousLimitRef.current === effectiveLimit) {
+      return;
+    }
+    previousLimitRef.current = effectiveLimit;
+
+    setOffset((currentOffset) => {
+      let nextOffset = Math.floor(currentOffset / effectiveLimit) * effectiveLimit;
+      const total = totalRef.current;
+      if (total > 0) {
+        const lastValidOffset = Math.max(
+          0,
+          (Math.ceil(total / effectiveLimit) - 1) * effectiveLimit,
+        );
+        nextOffset = Math.min(nextOffset, lastValidOffset);
+      }
+      nextOffset = Math.max(0, nextOffset);
+      return nextOffset === currentOffset ? currentOffset : nextOffset;
+    });
+  }, [effectiveLimit]);
+
+  useEffect(() => {
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+
+    void (async () => {
+      const page = Math.floor(offset / query.pageSize) + 1;
+      const result = await getInformesPage({
+        query: query.query,
+        status: query.status,
+        studyType: query.studyType,
+        page,
+        pageSize: query.pageSize,
+      });
+
+      if (requestId !== latestRequestRef.current) {
+        return;
+      }
+
+      setReports(result.reports);
+      setTotalCount(result.total);
+      setLoadError(result.loadError);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const reportsTotalPages = Math.max(1, Math.ceil(totalCount / effectiveLimit));
+  const page = Math.min(Math.floor(offset / effectiveLimit) + 1, reportsTotalPages);
+  const pageStart = totalCount > 0 ? offset + 1 : 0;
+  const pageEnd = Math.min(offset + reports.length, totalCount);
+  const hasActiveFilters = Boolean(filters.query || filters.status || filters.studyType);
+
+  const selectedReport =
+    selectedReportId === null
+      ? (reports[0] ?? null)
+      : (reports.find((report) => report.id === selectedReportId) ?? null);
+
+  const selectedReportTimelineSteps = selectedReport
+    ? buildStudyTimelineSteps(selectedReport)
+    : [];
+
+  function goToPreviousPage() {
+    setOffset((current) => Math.max(0, current - effectiveLimit));
+  }
+
+  function goToNextPage() {
+    setOffset((current) => current + effectiveLimit);
+  }
+
+  return (
+    <>
+      {/* Hidden below `sm` so the fixed chrome (filters + summary) never
+          out-competes the adaptive rows/pager for the short mobile
+          viewport's height. */}
+      <div className="hidden gap-2 text-sm sm:grid sm:grid-cols-4 xl:min-w-[34rem]">
+        <div className="surface-soft px-3 py-2">
+          <p className="text-xs text-muted-foreground">Total</p>
+          <p className="mt-0.5 font-semibold text-vetneb-ink">{totalCount}</p>
+        </div>
+        <div className="surface-soft px-3 py-2">
+          <p className="text-xs text-muted-foreground">Mostrando</p>
+          <p className="mt-0.5 font-semibold text-vetneb-ink">
+            {totalCount > 0 ? `${pageStart}-${pageEnd}` : "0"}
+          </p>
+        </div>
+        <div className="surface-soft px-3 py-2">
+          <p className="text-xs text-muted-foreground">Página</p>
+          <p className="mt-0.5 font-semibold text-vetneb-ink">
+            {Math.max(page, 1)} / {Math.max(reportsTotalPages, 1)}
+          </p>
+        </div>
+        <div className="surface-soft px-3 py-2">
+          <p className="text-xs text-muted-foreground">Filtros</p>
+          <p className="mt-0.5 font-semibold text-vetneb-ink">
+            {hasActiveFilters ? "Activos" : "Sin filtros"}
+          </p>
+        </div>
+      </div>
+
+      {loadError || reports.length === 0 ? (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <section
+            id="reports-master-list"
+            aria-labelledby="reports-list-heading"
+            className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
+          >
+            <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
+              <h2 id="reports-list-heading" className="dashboard-section-heading">
+                Lista de informes
+              </h2>
+              <p className="dashboard-section-description">
+                Click en un informe para ver detalles y acciones.
+              </p>
+            </div>
+
+            <div ref={setBodyNode} className="dashboard-inline-scroll p-4">
+              {loadError ? (
+                <div role="alert">
+                  <ErrorState
+                    title="No se pudieron cargar los informes"
+                    message="No se pudieron cargar los informes. Intente nuevamente."
+                  />
+                </div>
+              ) : (
+                <EmptyState
+                  title="No hay informes disponibles."
+                  description="Cuando haya informes para los filtros actuales, aparecerán en esta lista."
+                />
+              )}
+            </div>
+          </section>
+        </div>
+      ) : null}
+
+      {!loadError && reports.length > 0 ? (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <section
+            id="reports-master-list"
+            aria-labelledby="reports-list-heading"
+            className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
+          >
+            <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
+              <h2 id="reports-list-heading" className="dashboard-section-heading">
+                Lista de informes
+              </h2>
+              <p className="dashboard-section-description">
+                Click en un informe para ver el detalle desplegado dentro del propio informe.
+              </p>
+            </div>
+
+            <div ref={setBodyNode} className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
+              {reports.map((report, index) => {
+                const isSelected = selectedReport?.id === report.id;
+
+                return (
+                  <div key={report.id} className="min-w-0">
+                    <div ref={index === 0 ? setRowNode : undefined}>
+                      <button
+                        type="button"
+                        id={`report-${report.id}`}
+                        onClick={() => setSelectedReportId(report.id)}
+                        aria-current={isSelected ? "true" : undefined}
+                        aria-expanded={isSelected}
+                        aria-label={
+                          isSelected
+                            ? `Informe seleccionado: ${getReportTitle(report)}`
+                            : `Seleccionar informe: ${getReportTitle(report)}`
+                        }
+                        className={cn(
+                          "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
+                          isSelected && "bg-vetneb-cyan/12",
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                              Informe #{report.id}
+                            </p>
+                            <p className="mt-1 truncate text-sm font-semibold text-vetneb-ink">
+                              {report.patientName ?? "Paciente sin nombre"}
+                            </p>
+                            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                              {report.studyType ?? "Tipo sin registrar"} ·{" "}
+                              {formatDate(report.uploadDate)}
+                            </p>
+                          </div>
+                          <Badge variant={getReportStatusVariant(report.status)} className="shrink-0">
+                            {getReportStatusLabel(report.status)}
+                          </Badge>
+                        </div>
+                      </button>
+                    </div>
+
+                    {isSelected && selectedReport ? (
+                      <div
+                        id="report-detail"
+                        aria-labelledby="report-detail-heading"
+                        data-detail-state="selected"
+                        className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
+                      >
+                        <div className="space-y-4 p-4">
+                          <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
+                            <div className="min-w-0">
+                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                                Detalle del informe
+                              </p>
+                              <h2 id="report-detail-heading" className="mt-1 text-xl font-semibold text-vetneb-ink">
+                                {getReportTitle(selectedReport)}
+                              </h2>
+                              <p className="mt-1 text-sm text-muted-foreground">
+                                Clínica {selectedReport.clinicName ?? `#${selectedReport.clinicId}`}
+                              </p>
+                            </div>
+                            <StatusBadge
+                              status={selectedReport.status}
+                              label={getReportStatusLabel(selectedReport.status)}
+                            />
+                          </div>
+
+                          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                            <div className="surface-soft">
+                              <p className="text-xs text-muted-foreground">Paciente</p>
+                              <p className="mt-1 font-semibold text-vetneb-ink">
+                                {selectedReport.patientName ?? "—"}
+                              </p>
+                            </div>
+                            <div className="surface-soft">
+                              <p className="text-xs text-muted-foreground">Tipo de estudio</p>
+                              <p className="mt-1 font-semibold text-vetneb-ink">
+                                {selectedReport.studyType ?? "—"}
+                              </p>
+                            </div>
+                            <div className="surface-soft">
+                              <p className="text-xs text-muted-foreground">Fecha</p>
+                              <p className="mt-1 font-semibold text-vetneb-ink">
+                                {formatDate(selectedReport.uploadDate)}
+                              </p>
+                            </div>
+                            <div className="surface-soft">
+                              <p className="text-xs text-muted-foreground">Creado</p>
+                              <p className="mt-1 font-semibold text-vetneb-ink">
+                                {formatDate(selectedReport.createdAt)}
+                              </p>
+                            </div>
+                            <div className="surface-soft">
+                              <p className="text-xs text-muted-foreground">Actualizado</p>
+                              <p className="mt-1 font-semibold text-vetneb-ink">
+                                {formatDate(selectedReport.updatedAt)}
+                              </p>
+                            </div>
+                            <div className="surface-soft">
+                              <p className="text-xs text-muted-foreground">Archivo</p>
+                              <p className="mt-1 font-semibold text-vetneb-ink">
+                                {selectedReport.fileName ?? (selectedReport.hasFile ? "Disponible" : "—")}
+                              </p>
+                            </div>
+                          </div>
+
+                          <section className="space-y-3" aria-labelledby="report-actions-heading">
+                            <div>
+                              <h3 id="report-actions-heading" className="text-base font-semibold text-vetneb-ink">
+                                Acciones
+                              </h3>
+                              <p className="text-sm text-muted-foreground">
+                                Visualización y descarga del archivo disponible.
+                              </p>
+                            </div>
+                            <ReportFileActions
+                              reportId={selectedReport.id}
+                              hasFile={selectedReport.hasFile}
+                              align="start"
+                            />
+                          </section>
+
+                          <section className="space-y-3" aria-labelledby="study-timeline-heading">
+                            <div>
+                              <h3 id="study-timeline-heading" className="text-base font-semibold text-vetneb-ink">
+                                Línea de tiempo del estudio
+                              </h3>
+                              <p className="text-sm text-muted-foreground">
+                                Pasos derivados del estado y fechas ya disponibles.
+                              </p>
+                            </div>
+                            <StudyTimeline steps={selectedReportTimelineSteps} />
+                          </section>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+
+            <nav
+              aria-label="Paginación de informes"
+              className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+            >
+              <button
+                type="button"
+                onClick={goToPreviousPage}
+                disabled={page <= 1}
+                aria-label="Página anterior"
+                aria-disabled={page <= 1 ? "true" : undefined}
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Anterior
+              </button>
+              <span className="dashboard-pagination-context">
+                Página {page} de {reportsTotalPages}
+              </span>
+              <button
+                type="button"
+                onClick={goToNextPage}
+                disabled={page >= reportsTotalPages}
+                aria-label="Página siguiente"
+                aria-disabled={page >= reportsTotalPages ? "true" : undefined}
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Siguiente
+              </button>
+            </nav>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/app/dashboard/informes/informes.actions.ts
+++ b/frontend/src/app/dashboard/informes/informes.actions.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { cookies } from "next/headers";
+import {
+  getReportsPaginated,
+  searchReportsPaginated,
+  type PaginatedReports,
+} from "@/lib/api";
+import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
+
+export type InformesPageQuery = {
+  query?: string;
+  status?: string;
+  studyType?: string;
+  page: number;
+  pageSize: number;
+};
+
+export type InformesPageResult = {
+  reports: PaginatedReports["reports"];
+  total: number;
+  totalPages: number;
+  loadError: boolean;
+};
+
+async function getInformesRequestOptions(): Promise<RequestInit> {
+  const cookieHeader = (await cookies()).toString();
+
+  return {
+    cache: "no-store",
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+  };
+}
+
+export async function getInformesPage(
+  query: InformesPageQuery,
+): Promise<InformesPageResult> {
+  const requestOptions = await getInformesRequestOptions();
+
+  try {
+    const pagedResult = query.query
+      ? await searchReportsPaginated(
+          {
+            query: query.query,
+            status: query.status || undefined,
+            studyType: query.studyType || undefined,
+            page: query.page,
+            pageSize: query.pageSize,
+          },
+          requestOptions,
+          { throwOnError: true },
+        )
+      : await getReportsPaginated(
+          requestOptions,
+          {
+            status: query.status || undefined,
+            page: query.page,
+            pageSize: query.pageSize,
+          },
+          { throwOnError: true },
+        );
+
+    return {
+      reports: pagedResult.reports,
+      total: pagedResult.total,
+      totalPages: pagedResult.totalPages,
+      loadError: false,
+    };
+  } catch (error) {
+    redirectToLoginOnUnauthorized(error);
+    return { reports: [], total: 0, totalPages: 0, loadError: true };
+  }
+}

--- a/frontend/src/app/dashboard/informes/informes.constants.ts
+++ b/frontend/src/app/dashboard/informes/informes.constants.ts
@@ -1,0 +1,9 @@
+// Real-fetch (RF) debounced strategy, same contract proven on
+// `AdminAuditCard`/`AdminReportsCard` (R-06): the server `page`/`pageSize`
+// pair is re-derived from the measured rows container, never a fixed
+// constant. The fallback below only covers the pre-measurement paint.
+export const INFORMES_FALLBACK_ROWS = 6;
+// This is a Clínica full route, not an Admin App Shell surface — no
+// `expectNinePopulatedRows` floor applies (that contract only pins
+// Admin's Tokens/Reports/Audit/Users-Roles modules).
+export const INFORMES_LIMIT_CAP = 24;

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -2,8 +2,6 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 
 import { DashboardPageHeader } from "@/components/dashboard/DashboardPageHeader";
-import { EmptyState } from "@/components/dashboard/EmptyState";
-import { ErrorState } from "@/components/dashboard/ErrorState";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
 import {
   dashboardFilterActionClassName,
@@ -12,9 +10,7 @@ import {
   FilterField,
 } from "@/components/dashboard/FilterBar";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
-import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -25,30 +21,20 @@ import {
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import {
-  StudyTimeline,
-  type StudyTimelineStep,
-} from "@/components/dashboard/StudyTimeline";
-import {
   getReportsPaginated,
   searchReportsPaginated,
   type PaginatedReports,
 } from "@/lib/api";
 import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
-import {
-  cn,
-  getReportStatusLabel,
-  getReportStatusVariant,
-  formatDate,
-} from "@/lib/utils";
+import { getReportStatusLabel } from "@/lib/utils";
 import { ROUTES } from "@/lib/routes";
-import type { Report, ReportStatus } from "@/types";
+import { InformesReportsList } from "./InformesReportsList";
+import { INFORMES_FALLBACK_ROWS } from "./informes.constants";
 
 export const metadata: Metadata = {
   title: "Informes — Portal VETNEB",
   robots: { index: false, follow: false },
 };
-
-const REPORTS_PAGE_SIZE = 6;
 
 const statusOptions = [
   { value: "", label: "Todos los estados" },
@@ -63,7 +49,6 @@ type InformesPageSearchParams = {
   status?: string | string[];
   studyType?: string | string[];
   reportId?: string | string[];
-  page?: string | string[];
 };
 
 function normalizeSearchParamValue(value: string | string[] | undefined) {
@@ -86,112 +71,6 @@ function normalizeReportIdFilter(value: string) {
   const reportId = Number(value);
 
   return Number.isInteger(reportId) && reportId > 0 ? reportId : null;
-}
-
-function normalizePageParam(value: string): number {
-  const n = Number(value);
-
-  return Number.isInteger(n) && n > 0 ? n : 1;
-}
-
-function buildInformesHref(input: {
-  query?: string;
-  status?: string;
-  studyType?: string;
-  reportId?: number | null;
-  page?: number;
-}) {
-  const params = new URLSearchParams();
-
-  if (input.query) {
-    params.set("query", input.query);
-  }
-
-  if (input.status) {
-    params.set("status", input.status);
-  }
-
-  if (input.studyType) {
-    params.set("studyType", input.studyType);
-  }
-
-  if (input.reportId) {
-    params.set("reportId", String(input.reportId));
-  }
-
-  if (input.page && input.page > 1) {
-    params.set("page", String(input.page));
-  }
-
-  const qs = params.toString();
-
-  return `/dashboard/informes${qs ? `?${qs}` : ""}`;
-}
-
-function getReportTitle(report: Report) {
-  return report.patientName
-    ? `${report.patientName} · Informe #${report.id}`
-    : `Informe #${report.id}`;
-}
-
-const REPORT_STATUS_ORDER = {
-  uploaded: 0,
-  processing: 1,
-  ready: 2,
-  delivered: 3,
-} satisfies Record<ReportStatus, number>;
-
-function getTimelineStepStatus(
-  currentStatus: ReportStatus,
-  stepStatus: ReportStatus,
-): StudyTimelineStep["status"] {
-  if (currentStatus === stepStatus) {
-    return stepStatus === "delivered" ? "completed" : "current";
-  }
-
-  return REPORT_STATUS_ORDER[currentStatus] > REPORT_STATUS_ORDER[stepStatus]
-    ? "completed"
-    : "pending";
-}
-
-function buildStudyTimelineSteps(report: Report): StudyTimelineStep[] {
-  const currentStatus = report.currentStatus ?? report.status;
-  const uploadedDate = report.uploadDate ?? report.createdAt;
-  const updatedDate = report.updatedAt;
-
-  return [
-    {
-      id: "uploaded",
-      label: "Carga recibida",
-      date: uploadedDate ? formatDate(uploadedDate) : null,
-      description: "Fecha registrada para el informe en el portal.",
-      status: "completed",
-    },
-    {
-      id: "processing",
-      label: "Procesamiento",
-      date: currentStatus === "processing" ? formatDate(updatedDate) : null,
-      description: "Estado operativo informado por el registro del informe.",
-      status: getTimelineStepStatus(currentStatus, "processing"),
-    },
-    {
-      id: "ready",
-      label: "Informe disponible",
-      date:
-        currentStatus === "ready" || currentStatus === "delivered"
-          ? formatDate(updatedDate)
-          : null,
-      description: "El archivo queda disponible cuando el estado real lo indique.",
-      status: getTimelineStepStatus(currentStatus, "ready"),
-    },
-    {
-      id: "delivered",
-      label: "Entrega",
-      date: currentStatus === "delivered" ? formatDate(updatedDate) : null,
-      description: "Cierre del circuito visible para la clínica.",
-      status: getTimelineStepStatus(currentStatus, "delivered"),
-    },
-  ];
 }
 
 async function getReportsRequestOptions(): Promise<RequestInit> {
@@ -217,14 +96,17 @@ export default async function InformesPage({
   const selectedReportId = normalizeReportIdFilter(
     normalizeSearchParamValue(resolvedSearchParams.reportId),
   );
-  const page = normalizePageParam(normalizeSearchParamValue(resolvedSearchParams.page));
   const requestOptions = await getReportsRequestOptions();
 
+  // The measured viewport pageSize is only known client-side, so the initial
+  // server render uses `INFORMES_FALLBACK_ROWS` as the pre-measurement
+  // baseline; `InformesReportsList` re-derives and re-fetches the real page
+  // size (RF debounced pattern, same contract as R-06 `AdminAuditCard`).
   let pagedResult: PaginatedReports = {
     reports: [],
     total: 0,
-    page,
-    pageSize: REPORTS_PAGE_SIZE,
+    page: 1,
+    pageSize: INFORMES_FALLBACK_ROWS,
     totalPages: 0,
   };
   let reportsLoadError = false;
@@ -236,8 +118,8 @@ export default async function InformesPage({
             query,
             status: status || undefined,
             studyType: studyType || undefined,
-            page,
-            pageSize: REPORTS_PAGE_SIZE,
+            page: 1,
+            pageSize: INFORMES_FALLBACK_ROWS,
           },
           requestOptions,
           { throwOnError: true },
@@ -246,8 +128,8 @@ export default async function InformesPage({
           requestOptions,
           {
             status: status || undefined,
-            page,
-            pageSize: REPORTS_PAGE_SIZE,
+            page: 1,
+            pageSize: INFORMES_FALLBACK_ROWS,
           },
           { throwOnError: true },
         );
@@ -257,22 +139,11 @@ export default async function InformesPage({
   }
 
   const reports = pagedResult.reports;
-  const reportsTotal = pagedResult.total;
-  const reportsTotalPages = pagedResult.totalPages;
-  const offset = (page - 1) * REPORTS_PAGE_SIZE;
-  const pageStart = reportsTotal > 0 ? offset + 1 : 0;
-  const pageEnd = Math.min(offset + reports.length, reportsTotal);
 
   const selectedReport =
     selectedReportId === null
       ? (reports[0] ?? null)
       : (reports.find((report) => report.id === selectedReportId) ?? null);
-
-  const selectedReportTimelineSteps = selectedReport
-    ? buildStudyTimelineSteps(selectedReport)
-    : [];
-
-  const hasActiveFilters = Boolean(query || status || studyType);
 
   return (
     <>
@@ -314,31 +185,6 @@ export default async function InformesPage({
                 <p className="mt-1 text-sm text-muted-foreground">
                   Seleccione un informe de la lista para abrir el detalle operativo.
                 </p>
-              </div>
-
-              <div className="grid grid-cols-2 gap-2 text-sm sm:grid-cols-4 xl:min-w-[34rem]">
-                <div className="surface-soft px-3 py-2">
-                  <p className="text-xs text-muted-foreground">Total</p>
-                  <p className="mt-0.5 font-semibold text-vetneb-ink">{reportsTotal}</p>
-                </div>
-                <div className="surface-soft px-3 py-2">
-                  <p className="text-xs text-muted-foreground">Mostrando</p>
-                  <p className="mt-0.5 font-semibold text-vetneb-ink">
-                    {reportsTotal > 0 ? `${pageStart}-${pageEnd}` : "0"}
-                  </p>
-                </div>
-                <div className="surface-soft px-3 py-2">
-                  <p className="text-xs text-muted-foreground">Página</p>
-                  <p className="mt-0.5 font-semibold text-vetneb-ink">
-                    {Math.max(page, 1)} / {Math.max(reportsTotalPages, 1)}
-                  </p>
-                </div>
-                <div className="surface-soft px-3 py-2">
-                  <p className="text-xs text-muted-foreground">Filtros</p>
-                  <p className="mt-0.5 font-semibold text-vetneb-ink">
-                    {hasActiveFilters ? "Activos" : "Sin filtros"}
-                  </p>
-                </div>
               </div>
             </div>
           </CardHeader>
@@ -400,281 +246,15 @@ export default async function InformesPage({
               </div>
             </FilterBar>
 
-            {reportsLoadError || reports.length === 0 ? (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <section
-                  id="reports-master-list"
-                  aria-labelledby="reports-list-heading"
-                  className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
-                >
-                  <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
-                    <h2
-                      id="reports-list-heading"
-                      className="dashboard-section-heading"
-                    >
-                      Lista de informes
-                    </h2>
-                    <p className="dashboard-section-description">
-                      Click en un informe para ver detalles y acciones.
-                    </p>
-                  </div>
-
-                  <div className="dashboard-inline-scroll p-4">
-                    {reportsLoadError ? (
-                      <div role="alert">
-                        <ErrorState
-                          title="No se pudieron cargar los informes"
-                          message="No se pudieron cargar los informes. Intente nuevamente."
-                        />
-                      </div>
-                    ) : (
-                      <EmptyState
-                        title="No hay informes disponibles."
-                        description="Cuando haya informes para los filtros actuales, aparecerán en esta lista."
-                      />
-                    )}
-                  </div>
-                </section>
-              </div>
-            ) : null}
-
-            {!reportsLoadError && reports.length > 0 ? (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <section
-                  id="reports-master-list"
-                  aria-labelledby="reports-list-heading"
-                  className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
-                >
-                  <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
-                    <h2
-                      id="reports-list-heading"
-                      className="dashboard-section-heading"
-                    >
-                      Lista de informes
-                    </h2>
-                    <p className="dashboard-section-description">
-                      Click en un informe para ver el detalle desplegado dentro del propio informe.
-                    </p>
-                  </div>
-
-                  <div className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
-                    {reports.map((report) => {
-                      const isSelected = selectedReport?.id === report.id;
-
-                      return (
-                        <div key={report.id} className="min-w-0">
-                          <PublicRouteControl
-                            id={`report-${report.id}`}
-                            href={buildInformesHref({
-                              query,
-                              status,
-                              studyType,
-                              reportId: report.id,
-                              page,
-                            })}
-                            replace
-                            prefetch={false}
-                            variant="bare"
-                            aria-current={isSelected ? "true" : undefined}
-                            aria-expanded={isSelected}
-                            aria-label={
-                              isSelected
-                                ? `Informe seleccionado: ${getReportTitle(report)}`
-                                : `Seleccionar informe: ${getReportTitle(report)}`
-                            }
-                            className={cn(
-                              "block w-full px-4 py-3 text-left transition-colors hover:bg-vetneb-cyan/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-inset",
-                              isSelected && "bg-vetneb-cyan/12",
-                            )}
-                          >
-                            <div className="flex items-start justify-between gap-3">
-                              <div className="min-w-0">
-                                <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                  Informe #{report.id}
-                                </p>
-                                <p className="mt-1 truncate text-sm font-semibold text-vetneb-ink">
-                                  {report.patientName ?? "Paciente sin nombre"}
-                                </p>
-                                <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                                  {report.studyType ?? "Tipo sin registrar"} ·{" "}
-                                  {formatDate(report.uploadDate)}
-                                </p>
-                              </div>
-                              <Badge
-                                variant={getReportStatusVariant(report.status)}
-                                className="shrink-0"
-                              >
-                                {getReportStatusLabel(report.status)}
-                              </Badge>
-                            </div>
-                          </PublicRouteControl>
-
-                          {isSelected && selectedReport ? (
-                            <div
-                              id="report-detail"
-                              aria-labelledby="report-detail-heading"
-                              data-detail-state="selected"
-                              className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
-                            >
-                              <div className="space-y-4 p-4">
-                                <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
-                                  <div className="min-w-0">
-                                    <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                      Detalle del informe
-                                    </p>
-                                    <h2
-                                      id="report-detail-heading"
-                                      className="mt-1 text-xl font-semibold text-vetneb-ink"
-                                    >
-                                      {getReportTitle(selectedReport)}
-                                    </h2>
-                                    <p className="mt-1 text-sm text-muted-foreground">
-                                      Clínica{" "}
-                                      {selectedReport.clinicName ??
-                                        `#${selectedReport.clinicId}`}
-                                    </p>
-                                  </div>
-                                  <StatusBadge
-                                    status={selectedReport.status}
-                                    label={getReportStatusLabel(selectedReport.status)}
-                                  />
-                                </div>
-
-                                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-                                  <div className="surface-soft">
-                                    <p className="text-xs text-muted-foreground">Paciente</p>
-                                    <p className="mt-1 font-semibold text-vetneb-ink">
-                                      {selectedReport.patientName ?? "—"}
-                                    </p>
-                                  </div>
-                                  <div className="surface-soft">
-                                    <p className="text-xs text-muted-foreground">
-                                      Tipo de estudio
-                                    </p>
-                                    <p className="mt-1 font-semibold text-vetneb-ink">
-                                      {selectedReport.studyType ?? "—"}
-                                    </p>
-                                  </div>
-                                  <div className="surface-soft">
-                                    <p className="text-xs text-muted-foreground">Fecha</p>
-                                    <p className="mt-1 font-semibold text-vetneb-ink">
-                                      {formatDate(selectedReport.uploadDate)}
-                                    </p>
-                                  </div>
-                                  <div className="surface-soft">
-                                    <p className="text-xs text-muted-foreground">Creado</p>
-                                    <p className="mt-1 font-semibold text-vetneb-ink">
-                                      {formatDate(selectedReport.createdAt)}
-                                    </p>
-                                  </div>
-                                  <div className="surface-soft">
-                                    <p className="text-xs text-muted-foreground">
-                                      Actualizado
-                                    </p>
-                                    <p className="mt-1 font-semibold text-vetneb-ink">
-                                      {formatDate(selectedReport.updatedAt)}
-                                    </p>
-                                  </div>
-                                  <div className="surface-soft">
-                                    <p className="text-xs text-muted-foreground">Archivo</p>
-                                    <p className="mt-1 font-semibold text-vetneb-ink">
-                                      {selectedReport.fileName ??
-                                        (selectedReport.hasFile ? "Disponible" : "—")}
-                                    </p>
-                                  </div>
-                                </div>
-
-                                <section className="space-y-3" aria-labelledby="report-actions-heading">
-                                  <div>
-                                    <h3
-                                      id="report-actions-heading"
-                                      className="text-base font-semibold text-vetneb-ink"
-                                    >
-                                      Acciones
-                                    </h3>
-                                    <p className="text-sm text-muted-foreground">
-                                      Visualización y descarga del archivo disponible.
-                                    </p>
-                                  </div>
-                                  <ReportFileActions
-                                    reportId={selectedReport.id}
-                                    hasFile={selectedReport.hasFile}
-                                    align="start"
-                                  />
-                                </section>
-
-                                <section
-                                  className="space-y-3"
-                                  aria-labelledby="study-timeline-heading"
-                                >
-                                  <div>
-                                    <h3
-                                      id="study-timeline-heading"
-                                      className="text-base font-semibold text-vetneb-ink"
-                                    >
-                                      Línea de tiempo del estudio
-                                    </h3>
-                                    <p className="text-sm text-muted-foreground">
-                                      Pasos derivados del estado y fechas ya disponibles.
-                                    </p>
-                                  </div>
-                                  <StudyTimeline steps={selectedReportTimelineSteps} />
-                                </section>
-                              </div>
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
-                  </div>
-
-                  {reportsTotalPages > 1 ? (
-                    <nav
-                      aria-label="Paginación de informes"
-                      className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
-                    >
-                      <PublicRouteControl
-                        href={buildInformesHref({
-                          query,
-                          status,
-                          studyType,
-                          page: page - 1,
-                        })}
-                        replace
-                        prefetch={false}
-                        variant="bare"
-                        disabled={page <= 1}
-                        aria-label="Página anterior"
-                        aria-disabled={page <= 1 ? "true" : undefined}
-                        className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        Anterior
-                      </PublicRouteControl>
-                      <span className="dashboard-pagination-context">
-                        Página {page} de {reportsTotalPages}
-                      </span>
-                      <PublicRouteControl
-                        href={buildInformesHref({
-                          query,
-                          status,
-                          studyType,
-                          page: page + 1,
-                        })}
-                        replace
-                        prefetch={false}
-                        variant="bare"
-                        disabled={page >= reportsTotalPages}
-                        aria-label="Página siguiente"
-                        aria-disabled={page >= reportsTotalPages ? "true" : undefined}
-                        className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        Siguiente
-                      </PublicRouteControl>
-                    </nav>
-                  ) : null}
-                </section>
-              </div>
-            ) : null}
+            <InformesReportsList
+              filters={{ query, status, studyType }}
+              initialReports={reports}
+              initialTotal={pagedResult.total}
+              initialPage={pagedResult.page}
+              initialPageSize={pagedResult.pageSize}
+              initialLoadError={reportsLoadError}
+              initialSelectedReportId={selectedReportId}
+            />
           </CardContent>
         </Card>
       </main>

--- a/test/frontend-dashboard-empty-states.test.ts
+++ b/test/frontend-dashboard-empty-states.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 const DASHBOARD_PAGE_PATH = "frontend/src/app/dashboard/page.tsx";
 const CLINIC_COMMAND_CENTER_PATH = "frontend/src/app/dashboard/ClinicCommandCenter.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const INFORMES_LIST_PATH =
+  "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
 const LOGISTICA_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
 const LOGISTICS_COMMAND_CENTER_PATH =
   "frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx";
@@ -48,15 +50,17 @@ test("dashboard overview clinic command center distinguishes recent list load fa
 });
 
 test("dashboard informes page shows empty state when reports are unavailable", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const pageSource = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
 
-  assert.ok(source.includes("reportsLoadError ?"));
-  assert.ok(source.includes("reports.length > 0 ?"));
-  assert.ok(source.includes("No se pudieron cargar los informes. Intente nuevamente."));
-  assert.ok(source.includes('role="alert"'));
-  assert.ok(source.includes("No hay informes disponibles."));
-  assert.ok(source.includes("<EmptyState"));
-  assert.ok(source.includes("reports.map((report)"));
+  assert.ok(pageSource.includes("reportsLoadError = true;"));
+  assert.ok(listSource.includes("loadError ?"));
+  assert.ok(listSource.includes("reports.length > 0 ?"));
+  assert.ok(listSource.includes("No se pudieron cargar los informes. Intente nuevamente."));
+  assert.ok(listSource.includes('role="alert"'));
+  assert.ok(listSource.includes("No hay informes disponibles."));
+  assert.ok(listSource.includes("<EmptyState"));
+  assert.ok(listSource.includes("reports.map((report"));
 });
 
 test("dashboard logistics page distinguishes overview load failures from empty states", () => {

--- a/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
+++ b/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
@@ -156,12 +156,16 @@ test("dashboard informes uses compact inline filters without drawer sticky overl
   assert.ok(source.includes(": await getReportsPaginated("));
   assert.ok(source.includes("requestOptions,"));
   assert.equal(source.includes("<MasterDetailWorkspace"), false);
-  assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
   assert.equal(source.includes("<StickyActionBar"), false);
-  assert.ok(source.includes("<ReportFileActions"));
   assert.equal(source.includes('from "next/link"'), false);
   assert.equal(source.includes("<Link"), false);
   assert.equal(source.includes("<a"), false);
+
+  const listSource = read(
+    "frontend/src/app/dashboard/informes/InformesReportsList.tsx",
+  );
+  assert.ok(listSource.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
+  assert.ok(listSource.includes("<ReportFileActions"));
 });
 
 test("PR-VIS-6 FilterBar exposes shared dashboard filter field contract", () => {

--- a/test/frontend-dashboard-informes.test.ts
+++ b/test/frontend-dashboard-informes.test.ts
@@ -4,6 +4,10 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const INFORMES_LIST_PATH =
+  "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
+const INFORMES_ACTIONS_PATH =
+  "frontend/src/app/dashboard/informes/informes.actions.ts";
 const API_CLIENT_PATH = "frontend/src/lib/api.ts";
 
 function read(relativePath: string): string {
@@ -15,6 +19,7 @@ function read(relativePath: string): string {
 
 test("dashboard informes defines non-indexable metadata and clinic read dependencies", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
 
   assert.ok(source.includes('import type { Metadata } from "next";'));
   assert.ok(source.includes('import { cookies } from "next/headers";'));
@@ -28,9 +33,27 @@ test("dashboard informes defines non-indexable metadata and clinic read dependen
   assert.equal(source.includes('import { MasterDetailWorkspace } from "@/components/dashboard/MasterDetailWorkspace";'), false);
   assert.ok(source.includes('import { StatusBadge } from "@/components/dashboard/StatusBadge";'));
   assert.equal(source.includes('} from "@/components/dashboard/StickyActionBar";'), false);
-  assert.ok(source.includes('} from "@/components/dashboard/StudyTimeline";'));
-  assert.ok(source.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
+  assert.ok(listSource.includes('} from "@/components/dashboard/StudyTimeline";'));
+  assert.ok(listSource.includes('import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";'));
   assert.equal(source.includes("UploadReportModal"), false);
+});
+
+test("dashboard informes page imports and renders the split InformesReportsList client component", () => {
+  const source = read(INFORMES_PAGE_PATH);
+
+  assert.ok(
+    source.includes(
+      'import { InformesReportsList } from "./InformesReportsList";',
+    ),
+  );
+  assert.ok(source.includes("<InformesReportsList"));
+  assert.ok(source.includes("filters={{ query, status, studyType }}"));
+  assert.ok(source.includes("initialReports={reports}"));
+  assert.ok(source.includes("initialTotal={pagedResult.total}"));
+  assert.ok(source.includes("initialPage={pagedResult.page}"));
+  assert.ok(source.includes("initialPageSize={pagedResult.pageSize}"));
+  assert.ok(source.includes("initialLoadError={reportsLoadError}"));
+  assert.ok(source.includes("initialSelectedReportId={selectedReportId}"));
 });
 
 test("dashboard informes reads filters from searchParams and uses live search endpoint", () => {
@@ -55,6 +78,7 @@ test("dashboard informes reads filters from searchParams and uses live search en
 
 test("dashboard informes preserves request options with forwarded cookies and no-store reads", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const actionsSource = read(INFORMES_ACTIONS_PATH);
 
   assert.ok(source.includes("async function getReportsRequestOptions(): Promise<RequestInit>"));
   assert.ok(source.includes("const cookieHeader = (await cookies()).toString();"));
@@ -62,6 +86,13 @@ test("dashboard informes preserves request options with forwarded cookies and no
   assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
   assert.ok(source.includes("const requestOptions = await getReportsRequestOptions();"));
   assert.ok(source.includes("requestOptions,"));
+
+  // The client-driven re-fetch (RF debounced pagination) goes through its own
+  // server action, which forwards cookies the same way for every re-fetch.
+  assert.ok(actionsSource.includes('"use server";'));
+  assert.ok(actionsSource.includes("async function getInformesRequestOptions(): Promise<RequestInit>"));
+  assert.ok(actionsSource.includes("const cookieHeader = (await cookies()).toString();"));
+  assert.ok(actionsSource.includes('cache: "no-store"'));
 });
 
 test("dashboard informes keeps status filter options aligned to report statuses", () => {
@@ -77,6 +108,7 @@ test("dashboard informes keeps status filter options aligned to report statuses"
 
 test("dashboard informes renders profile-layout clinic reports surface without technical source copy", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
   const removedSourceCopy = "Lectura clinic-" + "scoped conectada a";
   const removedReportsEndpoint = "GET " + "/api/reports";
 
@@ -86,9 +118,9 @@ test("dashboard informes renders profile-layout clinic reports surface without t
   assert.ok(source.includes("<DashboardPageHeader"));
   assert.equal(source.includes("<StickyActionBar"), false);
   assert.equal(source.includes("<MasterDetailWorkspace"), false);
-  assert.ok(source.includes("Lista de informes"));
-  assert.ok(source.includes("Detalle del informe"));
-  assert.ok(source.includes("<StudyTimeline"));
+  assert.ok(listSource.includes("Lista de informes"));
+  assert.ok(listSource.includes("Detalle del informe"));
+  assert.ok(listSource.includes("<StudyTimeline"));
   assert.equal(source.includes("<UploadReportModal />"), false);
   assert.equal(source.includes("/api/admin"), false);
   assert.equal(source.includes(removedSourceCopy), false);
@@ -97,6 +129,7 @@ test("dashboard informes renders profile-layout clinic reports surface without t
 
 test("dashboard informes renders compact inline filters and profile-layout list/detail columns", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
 
   assert.ok(source.includes('import {\n  dashboardFilterActionClassName,'));
   assert.ok(source.includes("FilterBar,"));
@@ -115,17 +148,17 @@ test("dashboard informes renders compact inline filters and profile-layout list/
   assert.ok(source.includes("Filtrar"));
   assert.ok(source.includes('href="/dashboard/informes"'));
   assert.ok(source.includes("Limpiar"));
-  assert.ok(source.includes('id="reports-master-list"'));
-  assert.ok(source.includes('id="report-detail"'));
-  assert.ok(source.includes("Lista de informes"));
-  assert.ok(source.includes("Detalle del informe"));
-  assert.equal(source.includes("<TableHead>"), false);
+  assert.ok(listSource.includes('id="reports-master-list"'));
+  assert.ok(listSource.includes('id="report-detail"'));
+  assert.ok(listSource.includes("Lista de informes"));
+  assert.ok(listSource.includes("Detalle del informe"));
+  assert.equal(listSource.includes("<TableHead>"), false);
 });
 
 test("dashboard informes keeps list rendering badges dates and selected report actions", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const source = read(INFORMES_LIST_PATH);
 
-  assert.ok(source.includes("reports.map((report) =>"));
+  assert.ok(source.includes("reports.map((report, index) =>"));
   assert.ok(source.includes("const isSelected = selectedReport?.id === report.id;"));
   assert.ok(source.includes('report.patientName ?? "Paciente sin nombre"'));
   assert.ok(source.includes('report.studyType ?? "Tipo sin registrar"'));
@@ -140,27 +173,33 @@ test("dashboard informes keeps list rendering badges dates and selected report a
 });
 
 test("dashboard informes keeps empty state and avoids client-side fetch literals", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const pageSource = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
+  const actionsSource = read(INFORMES_ACTIONS_PATH);
 
-  assert.ok(source.includes("No hay informes disponibles."));
-  assert.ok(source.includes("<EmptyState"));
-  assert.equal(source.includes("colSpan={7}"), false);
-  assert.equal(source.includes("fetch("), false);
-  assert.equal(source.includes("mock"), false);
+  assert.ok(listSource.includes("No hay informes disponibles."));
+  assert.ok(listSource.includes("<EmptyState"));
+  assert.equal(listSource.includes("colSpan={7}"), false);
+  assert.equal(pageSource.includes("fetch("), false);
+  assert.equal(listSource.includes("fetch("), false);
+  assert.equal(actionsSource.includes("fetch("), false);
+  assert.equal(pageSource.includes("mock"), false);
+  assert.equal(listSource.includes("mock"), false);
 });
 
 test("dashboard informes separates fetch failures from real empty report lists", () => {
   const source = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
 
   assert.ok(source.includes("let pagedResult: PaginatedReports = {"));
   assert.ok(source.includes("let reportsLoadError = false;"));
   assert.ok(source.includes("try {"));
   assert.ok(source.includes("reportsLoadError = true;"));
-  assert.ok(source.includes("reportsLoadError ?"));
-  assert.ok(source.includes("No se pudieron cargar los informes"));
-  assert.ok(source.includes("<ErrorState"));
-  assert.ok(source.includes("reports.length > 0 ?"));
-  assert.ok(source.includes("No hay informes disponibles."));
+  assert.ok(listSource.includes("loadError ?"));
+  assert.ok(listSource.includes("No se pudieron cargar los informes"));
+  assert.ok(listSource.includes("<ErrorState"));
+  assert.ok(listSource.includes("reports.length > 0 ?"));
+  assert.ok(listSource.includes("No hay informes disponibles."));
 });
 
 test("dashboard informes page includes back navigation to modules hub", () => {
@@ -184,7 +223,7 @@ test("dashboard informes filter form includes studyType input to preserve it on 
 });
 
 test("dashboard informes pagination buttons carry dashboard-pagination-btn accessibility class", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const source = read(INFORMES_LIST_PATH);
 
   // dashboard-pagination-btn is the PR-8 a11y marker: disabled state gets
   // pointer-events:none + opacity:0.45 + cursor:not-allowed via globals.css
@@ -193,6 +232,36 @@ test("dashboard informes pagination buttons carry dashboard-pagination-btn acces
     occurrences >= 2,
     `dashboard-pagination-btn must appear on both Anterior and Siguiente buttons (found ${occurrences})`,
   );
+});
+
+test("dashboard informes server-adaptive viewport pagination contract (R-07)", () => {
+  const listSource = read(INFORMES_LIST_PATH);
+  const actionsSource = read(INFORMES_ACTIONS_PATH);
+  const constantsSource = read(
+    "frontend/src/app/dashboard/informes/informes.constants.ts",
+  );
+
+  assert.ok(listSource.includes('"use client";'));
+  assert.ok(listSource.includes("useAdaptiveItemsPerPage"));
+  assert.ok(listSource.includes("new ResizeObserver("));
+  assert.ok(listSource.includes("requestAnimationFrame("));
+  assert.ok(listSource.includes("cancelAnimationFrame("));
+  assert.ok(listSource.includes("observer.disconnect();"));
+  // The fallback/cap constants must live in a plain (non "use client")
+  // module: Next.js turns every named export of a client module into an
+  // opaque client reference, so a Server Component importing a numeric
+  // constant straight from a "use client" file receives a reference, not
+  // the value (this broke the initial offset math as `NaN` during R-07
+  // development — verified live before extracting this module).
+  assert.equal(constantsSource.includes('"use client"'), false);
+  assert.ok(constantsSource.includes("export const INFORMES_FALLBACK_ROWS = 6;"));
+  assert.ok(constantsSource.includes("export const INFORMES_LIMIT_CAP = 24;"));
+  assert.ok(listSource.includes("const latestRequestRef = useRef(0);"));
+  assert.ok(listSource.includes("if (requestId !== latestRequestRef.current) {"));
+  assert.equal(listSource.includes("matchMedia"), false);
+
+  assert.ok(actionsSource.includes("export async function getInformesPage("));
+  assert.ok(actionsSource.includes("redirectToLoginOnUnauthorized(error)"));
 });
 
 test("api client supports reports status filter without bypassing wrappers", () => {

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -9,6 +9,8 @@ import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-acces
 const DASHBOARD_HOME_PATH = "frontend/src/app/dashboard/page.tsx";
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const INFORMES_LIST_PATH =
+  "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
 const LOGISTICA_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
 const STICKY_ACTION_BAR_PATH =
   "frontend/src/components/dashboard/StickyActionBar.tsx";
@@ -121,12 +123,14 @@ test("dashboard pages do not use mobile bottom spacers as layout compensation", 
   const dashboardSource = read(DASHBOARD_HOME_PATH);
   const adminSource = read(ADMIN_PAGE_PATH);
   const informesSource = read(INFORMES_PAGE_PATH);
+  const informesListSource = read(INFORMES_LIST_PATH);
   const logisticaSource = read(LOGISTICA_PAGE_PATH);
 
   // PR5: dashboard/admin use hubs; PR1012 makes informes profile-layout without StickyActionBar.
   assert.equal(informesSource.includes("<StickyActionBar"), false);
-  assert.ok(informesSource.includes("Lista de informes"));
-  assert.ok(informesSource.includes("Detalle del informe"));
+  assert.equal(informesListSource.includes("<StickyActionBar"), false);
+  assert.ok(informesListSource.includes("Lista de informes"));
+  assert.ok(informesListSource.includes("Detalle del informe"));
 
   assert.ok(logisticaSource.includes("<StickyActionBar"), "logistica uses StickyActionBar");
   assert.equal(

--- a/test/frontend-dashboard-reports-master-detail.test.ts
+++ b/test/frontend-dashboard-reports-master-detail.test.ts
@@ -9,6 +9,10 @@ import {
 } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const INFORMES_LIST_PATH =
+  "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
+const INFORMES_ACTIONS_PATH =
+  "frontend/src/app/dashboard/informes/informes.actions.ts";
 const MASTER_DETAIL_WORKSPACE_PATH =
   "frontend/src/components/dashboard/MasterDetailWorkspace.tsx";
 const STUDY_TIMELINE_PATH =
@@ -113,29 +117,32 @@ test("StudyTimeline supports ordered visual states without business calculations
 });
 
 test("dashboard informes composes profile-layout list, selected report detail, timeline, and actions", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const pageSource = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
 
-  assert.ok(source.includes("<DashboardPageHeader"));
-  assert.equal(source.includes("<StickyActionBar"), false);
-  assert.equal(source.includes("<MasterDetailWorkspace"), false);
-  assert.ok(source.includes("Lista de informes"));
-  assert.ok(source.includes("Detalle del informe"));
-  assert.ok(source.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
-  assert.ok(source.includes("buildStudyTimelineSteps(selectedReport)"));
-  assert.ok(source.includes("const selectedReport ="));
-  assert.ok(source.includes("selectedReportId === null"));
-  assert.ok(source.includes("? (reports[0] ?? null)"));
-  assert.ok(source.includes(": (reports.find((report) => report.id === selectedReportId) ?? null)"));
-  assert.ok(source.includes('id="reports-master-list"'));
-  assert.ok(source.includes('id="report-detail"'));
-  assert.ok(source.includes("Línea de tiempo del estudio"));
-  assert.ok(source.includes("Pasos derivados del estado y fechas ya disponibles."));
-  assert.ok(source.includes("reportId={selectedReport.id}"));
-  assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
+  assert.ok(pageSource.includes("<DashboardPageHeader"));
+  assert.equal(pageSource.includes("<StickyActionBar"), false);
+  assert.equal(pageSource.includes("<MasterDetailWorkspace"), false);
+  assert.equal(listSource.includes("<StickyActionBar"), false);
+  assert.equal(listSource.includes("<MasterDetailWorkspace"), false);
+  assert.ok(listSource.includes("Lista de informes"));
+  assert.ok(listSource.includes("Detalle del informe"));
+  assert.ok(listSource.includes("<StudyTimeline steps={selectedReportTimelineSteps} />"));
+  assert.ok(listSource.includes("buildStudyTimelineSteps(selectedReport)"));
+  assert.ok(listSource.includes("const selectedReport ="));
+  assert.ok(listSource.includes("selectedReportId === null"));
+  assert.ok(listSource.includes("? (reports[0] ?? null)"));
+  assert.ok(listSource.includes(": (reports.find((report) => report.id === selectedReportId) ?? null)"));
+  assert.ok(listSource.includes('id="reports-master-list"'));
+  assert.ok(listSource.includes('id="report-detail"'));
+  assert.ok(listSource.includes("Línea de tiempo del estudio"));
+  assert.ok(listSource.includes("Pasos derivados del estado y fechas ya disponibles."));
+  assert.ok(listSource.includes("reportId={selectedReport.id}"));
+  assert.ok(listSource.includes("hasFile={selectedReport.hasFile}"));
 });
 
 test("dashboard informes derives timeline steps from existing report fields only", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const source = read(INFORMES_LIST_PATH);
 
   assert.ok(source.includes("function buildStudyTimelineSteps(report: Report): StudyTimelineStep[]"));
   assert.ok(source.includes("const currentStatus = report.currentStatus ?? report.status;"));
@@ -152,33 +159,38 @@ test("dashboard informes derives timeline steps from existing report fields only
 });
 
 test("dashboard informes server-side pagination controls and compact summary", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const source = read(INFORMES_LIST_PATH);
+  const constantsSource = read(
+    "frontend/src/app/dashboard/informes/informes.constants.ts",
+  );
 
-  assert.ok(source.includes("reportsTotalPages > 1"));
+  // R-07: pager stays visible at all times (no `> 1` gate), matching the
+  // server-adaptive contract already proven on Admin Audit/Reports (R-03/R-06).
+  assert.equal(source.includes("reportsTotalPages > 1"), false);
   assert.ok(source.includes('aria-label="Paginación de informes"'));
   assert.ok(source.includes('aria-label="Página anterior"'));
   assert.ok(source.includes('aria-label="Página siguiente"'));
   assert.ok(source.includes("Página {page} de {reportsTotalPages}"));
-  assert.ok(source.includes("{reportsTotal > 0 ? `${pageStart}-${pageEnd}` : \"0\"}"));
-  assert.ok(source.includes("const REPORTS_PAGE_SIZE = 6"));
-  assert.ok(source.includes("page: page - 1"));
-  assert.ok(source.includes("page: page + 1"));
+  assert.ok(source.includes("{totalCount > 0 ? `${pageStart}-${pageEnd}` : \"0\"}"));
+  assert.ok(constantsSource.includes("export const INFORMES_FALLBACK_ROWS = 6"));
+  assert.ok(source.includes("goToPreviousPage"));
+  assert.ok(source.includes("goToNextPage"));
   assert.ok(source.includes("disabled={page <= 1}"));
   assert.ok(source.includes("disabled={page >= reportsTotalPages}"));
 });
 
-test("dashboard informes pagination does not use client-side filter", () => {
-  const source = read(INFORMES_PAGE_PATH);
+test("dashboard informes pagination is server-adaptive and does not use client-side array filtering", () => {
+  const source = read(INFORMES_LIST_PATH);
 
-  assert.ok(source.includes("page,"));
-  assert.ok(source.includes("pageSize: REPORTS_PAGE_SIZE,"));
-  assert.ok(source.includes("const offset = (page - 1) * REPORTS_PAGE_SIZE"));
+  assert.ok(source.includes("useAdaptiveItemsPerPage"));
+  assert.ok(source.includes("effectiveLimit = rowsPerPage"));
+  assert.ok(source.includes("getInformesPage("));
   assert.equal(source.includes("reports.slice("), false);
   assert.equal(source.includes("reports.filter("), false);
 });
 
 test("dashboard informes reportId null selects first report by default without silent fallback", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const source = read(INFORMES_LIST_PATH);
 
   assert.ok(source.includes("selectedReportId === null"));
   assert.ok(source.includes("? (reports[0] ?? null)"));
@@ -188,6 +200,8 @@ test("dashboard informes reportId null selects first report by default without s
 
 test("dashboard informes master-detail scope avoids forbidden navigation and dependency changes", () => {
   const informesSource = read(INFORMES_PAGE_PATH);
+  const informesListSource = read(INFORMES_LIST_PATH);
+  const informesActionsSource = read(INFORMES_ACTIONS_PATH);
   const masterDetailSource = read(MASTER_DETAIL_WORKSPACE_PATH);
   const timelineSource = read(STUDY_TIMELINE_PATH);
   const stickyActionBarSource = read(STICKY_ACTION_BAR_PATH);
@@ -200,14 +214,18 @@ test("dashboard informes master-detail scope avoids forbidden navigation and dep
     .split(/\r?\n/)
     .filter(Boolean);
 
+  assertNoForbiddenSurfaceImports(informesListSource, "InformesReportsList");
+  assertNoForbiddenSurfaceImports(informesActionsSource, "informes.actions");
   assertNoForbiddenSurfaceImports(masterDetailSource, "MasterDetailWorkspace");
   assertNoForbiddenSurfaceImports(timelineSource, "StudyTimeline");
   assertNoForbiddenSurfaceImports(stickyActionBarSource, "StickyActionBar");
   assert.equal(informesSource.includes('from "next/link"'), false);
+  assert.equal(informesListSource.includes('from "next/link"'), false);
   assert.equal(masterDetailSource.includes('from "next/link"'), false);
   assert.equal(timelineSource.includes('from "next/link"'), false);
   assert.equal(stickyActionBarSource.includes('from "next/link"'), false);
   assert.equal(informesSource.includes("<a"), false);
+  assert.equal(informesListSource.includes("<a"), false);
   assert.equal(masterDetailSource.includes("<a"), false);
   assert.equal(timelineSource.includes("<a"), false);
   assert.equal(stickyActionBarSource.includes("<a"), false);

--- a/test/frontend-notification-click-anchors.test.ts
+++ b/test/frontend-notification-click-anchors.test.ts
@@ -3,7 +3,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 
-const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const INFORMES_LIST_PATH =
+  "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
 const CLINIC_TOKENS_CARD_PATH =
   "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx";
 const PARTICULARES_CONTENT_PATH =
@@ -20,14 +21,14 @@ function read(relativePath: string): string {
 }
 
 test("notification click targets render stable clinic, particular, and admin anchors", () => {
-  const informesPage = read(INFORMES_PAGE_PATH);
+  const informesList = read(INFORMES_LIST_PATH);
   const clinicTokensCard = read(CLINIC_TOKENS_CARD_PATH);
   const particularesContent = read(PARTICULARES_CONTENT_PATH);
   const adminPage = read(ADMIN_PAGE_PATH);
   const adminAuditCard = read(ADMIN_AUDIT_CARD_PATH);
 
   assert.ok(
-    informesPage.includes("id={`report-${report.id}`}"),
+    informesList.includes("id={`report-${report.id}`}"),
     "clinic informes rows must expose report-{id} anchors",
   );
   assert.ok(

--- a/test/frontend-report-download-action.test.ts
+++ b/test/frontend-report-download-action.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 const REPORT_ACTIONS_PATH =
   "frontend/src/components/dashboard/ReportDownloadButton.tsx";
 const INFORMES_PAGE_PATH = "frontend/src/app/dashboard/informes/page.tsx";
+const INFORMES_LIST_PATH =
+  "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -45,16 +47,17 @@ test("frontend report actions handles unavailable loading and error states", () 
 });
 
 test("frontend informes page uses selected report file actions", () => {
-  const source = read(INFORMES_PAGE_PATH);
+  const pageSource = read(INFORMES_PAGE_PATH);
+  const listSource = read(INFORMES_LIST_PATH);
 
+  assert.equal(pageSource.includes("<button"), false);
   assert.ok(
-    source.includes(
+    listSource.includes(
       'import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";',
     ),
   );
-  assert.ok(source.includes("<ReportFileActions"));
-  assert.ok(source.includes("reportId={selectedReport.id}"));
-  assert.ok(source.includes("hasFile={selectedReport.hasFile}"));
-  assert.equal(source.includes("storagePath"), false);
-  assert.equal(source.includes("<button"), false);
+  assert.ok(listSource.includes("<ReportFileActions"));
+  assert.ok(listSource.includes("reportId={selectedReport.id}"));
+  assert.ok(listSource.includes("hasFile={selectedReport.hasFile}"));
+  assert.equal(listSource.includes("storagePath"), false);
 });

--- a/test/frontend-reports-live-read-contract.test.ts
+++ b/test/frontend-reports-live-read-contract.test.ts
@@ -23,6 +23,7 @@ function assertNotIncludes(
 }
 
 const reportsPage = "frontend/src/app/dashboard/informes/page.tsx";
+const reportsList = "frontend/src/app/dashboard/informes/InformesReportsList.tsx";
 const frontendApiClient = "frontend/src/lib/api.ts";
 
 test("frontend reports page does not read mock data directly", () => {
@@ -36,6 +37,7 @@ test("frontend reports page does not read mock data directly", () => {
 
 test("frontend reports page uses reports API client wrapper", () => {
   const source = read(reportsPage);
+  const listSource = read(reportsList);
 
   assertIncludes(source, 'from "@/lib/api"', reportsPage);
   assertIncludes(source, "getReports", reportsPage);
@@ -45,27 +47,28 @@ test("frontend reports page uses reports API client wrapper", () => {
   assertIncludes(source, "? await searchReportsPaginated(", reportsPage);
   assertIncludes(source, ": await getReportsPaginated(", reportsPage);
   assertIncludes(source, "{ throwOnError: true }", reportsPage);
-  assertIncludes(source, "reports.map", reportsPage);
-  assertIncludes(source, "reports.length", reportsPage);
   assertIncludes(source, "const reports = pagedResult.reports", reportsPage);
-  assertIncludes(source, "reportsTotal", reportsPage);
-  assertIncludes(source, "reportsTotalPages", reportsPage);
+  assertIncludes(listSource, "reports.map", reportsList);
+  assertIncludes(listSource, "reports.length", reportsList);
+  assertIncludes(listSource, "totalCount", reportsList);
+  assertIncludes(listSource, "reportsTotalPages", reportsList);
 });
 
 test("frontend reports page surfaces fetch failures separately from empty data", () => {
   const source = read(reportsPage);
+  const listSource = read(reportsList);
 
   assertIncludes(source, "let reportsLoadError = false;", reportsPage);
   assertIncludes(source, "try {", reportsPage);
   assertIncludes(source, "reportsLoadError = true;", reportsPage);
-  assertIncludes(source, "reportsLoadError ?", reportsPage);
+  assertIncludes(listSource, "loadError ?", reportsList);
   assertIncludes(
-    source,
+    listSource,
     "No se pudieron cargar los informes. Intente nuevamente.",
-    reportsPage,
+    reportsList,
   );
-  assertIncludes(source, 'role="alert"', reportsPage);
-  assertIncludes(source, "No hay informes disponibles.", reportsPage);
+  assertIncludes(listSource, 'role="alert"', reportsList);
+  assertIncludes(listSource, "No hay informes disponibles.", reportsList);
 });
 
 test("frontend reports page forces dynamic server reads with forwarded cookies", () => {


### PR DESCRIPTION
R-07 del roadmap final.

Implementa /dashboard/informes server-adaptive:
- pageSize derivado de viewport real.
- ResizeObserver + rAF / RF debounced.
- offset/pageSize client-side con re-fetch por Server Action.
- anti-race por request id.
- pager siempre visible.
- corrección de constante client export movida a módulo plano.
- ajuste mobile para evitar clipping del pager.

Docs:
- docs/implementation/dashboard-informes-server-adaptive-pagination.md

Validaciones locales:
- pnpm test: 2945/2945
- pnpm typecheck OK
- pnpm typecheck:test OK
- pnpm --dir frontend lint OK
- pnpm --dir frontend build OK
- pnpm security:public-surface PASS
- e2e propio /dashboard/informes: 5/5
- e2e relacionados informes: 7/7

Scope:
- Sin ClinicInformesWorkspaceSummary.
- Sin backend/API/auth/DB/server.
- Sin CI/workflows.
- Sin deps/lockfiles.
- Sin snapshots.
- Sin globals.css.
- Sin otros módulos.
- Sin R-08 adelantado.