### PR TITLE
cleanup(frontend): remove mobile page size cardinality residues

### DIFF
--- a/docs/implementation/remove-mobile-page-size-matchmedia-cardinality.md
+++ b/docs/implementation/remove-mobile-page-size-matchmedia-cardinality.md
@@ -1,0 +1,101 @@
+# R-08 — cleanup: remove residual MOBILE_PAGE_SIZE / matchMedia cardinality sources
+
+Ref: `docs/audit/final-global-vetneb-50-60-pr-roadmap.md`, `docs/implementation/server-adaptive-pagination-strategy.md` PR-CLEAN-1.
+
+## Scope
+
+R-08 is a comment/doc cleanup pass, no runtime behavior change. By the time
+this PR ran, `MOBILE_PAGE_SIZE` and `matchMedia`-as-cardinality had already
+been removed as sources of truth in every migrated Admin module (Sessions,
+Roles, Clinics, Reports, Tokens, Audit, FailedLogin Alerts — PR-SRV-1/PR-SRV-2
+series). What remained were:
+
+1. Residual code comments in two already-migrated modules that still named
+   the old constants/mechanism for historical contrast.
+2. No native guard test recursing `frontend/src/app/dashboard/admin/**` to
+   pin the absence of these sources going forward (existing coverage was
+   per-module, e.g. `test/admin-reports-enterprise-density.test.ts`).
+
+## Grep inicial (runtime)
+
+```
+frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx: window.matchMedia real
+frontend/src/app/dashboard/admin/AdminMobileMaintenanceModule.tsx: window.matchMedia real
+frontend/src/app/dashboard/admin/AdminMobilePricingModule.tsx: window.matchMedia real
+frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx: comentarios con MOBILE_PAGE_SIZE/matchMedia
+frontend/src/app/dashboard/admin/AdminReportsCard.tsx: comentarios con MOBILE_PAGE_SIZE/matchMedia
+```
+
+## Clasificación
+
+- `AdminParticularTokensCard.tsx` (lines ~105-113, ~540-543) and
+  `AdminReportsCard.tsx` (lines ~55-62, ~217-220): comment-only residue.
+  Rewritten to describe the removed mechanism ("the old fixed mobile row
+  count", "a media query") without repeating the literal identifiers
+  `MOBILE_PAGE_SIZE` / `matchMedia`. No code changed.
+- `AdminMobileHealthModule.tsx`, `AdminMobileMaintenanceModule.tsx`,
+  `AdminMobilePricingModule.tsx`: real `window.matchMedia("(max-width:
+  767px)")` calls, but they gate which lazy mobile chunk mounts (schema
+  health / maintenance / pricing panels), never row count, `limit`,
+  `offset`, or pagination. Left untouched — these are legitimate
+  presentation gates, not cardinality sources, per
+  `server-adaptive-pagination-strategy.md` §7.4.
+
+## Qué se eliminó
+
+- The literal strings `MOBILE_PAGE_SIZE` and `matchMedia` from comments in
+  `AdminParticularTokensCard.tsx` and `AdminReportsCard.tsx` (4 comment
+  blocks total). No executable code, constants, or logic changed.
+
+## Guard test agregado
+
+`test/admin-mobile-page-size-matchmedia-cardinality-guard.test.ts`:
+
+- Recurses `frontend/src/app/dashboard/admin/**` (`.ts`/`.tsx`, excluding
+  test files).
+- Fails if `MOBILE_PAGE_SIZE` appears anywhere in Admin runtime.
+- Fails if `matchMedia` appears in any Admin file **except** the three-file
+  allowlist below.
+- A third test asserts the allowlist itself stays truthful (files exist and
+  still use `matchMedia`), so a future removal of the lazy-load gate doesn't
+  leave a stale allow entry masking a real regression.
+
+### Allowlist razonada (matchMedia permitido, no cardinal)
+
+```
+frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx
+frontend/src/app/dashboard/admin/AdminMobileMaintenanceModule.tsx
+frontend/src/app/dashboard/admin/AdminMobilePricingModule.tsx
+```
+
+Each uses `window.matchMedia("(max-width: 767px)")` solely to decide whether
+to lazy-load its mobile-only panel component. None of the three reads,
+computes, or forwards a page size, `limit`, `offset`, or row count from the
+media query result.
+
+## Grep final
+
+```
+$ git grep -n "MOBILE_PAGE_SIZE" -- frontend/src/app/dashboard/admin test docs/implementation
+(only docs/implementation/*.md historical write-ups and this file — no runtime code)
+
+$ git grep -n "matchMedia" -- frontend/src/app/dashboard/admin test docs/implementation
+frontend/src/app/dashboard/admin/AdminMobileHealthModule.tsx       (allowlisted, non-cardinal)
+frontend/src/app/dashboard/admin/AdminMobileMaintenanceModule.tsx  (allowlisted, non-cardinal)
+frontend/src/app/dashboard/admin/AdminMobilePricingModule.tsx      (allowlisted, non-cardinal)
+test/admin-mobile-page-size-matchmedia-cardinality-guard.test.ts   (new guard test)
+(plus existing per-module tests and docs/implementation/*.md historical write-ups)
+```
+
+## Confirmación sin cambio de comportamiento
+
+- Only comments were rewritten in `AdminParticularTokensCard.tsx` and
+  `AdminReportsCard.tsx`; no identifiers, constants, JSX, or logic touched.
+- The new test file only reads source files and asserts string absence — it
+  does not import or execute Admin components.
+- `AdminMobileHealthModule.tsx`, `AdminMobileMaintenanceModule.tsx`,
+  `AdminMobilePricingModule.tsx` were not modified.
+
+## R-09
+
+R-09 not executed. Out of scope for this PR.

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -108,9 +108,9 @@ const CREATE_STEP_LABELS: Record<CreateStep, string> = {
 // below), paginate it client-side with usePagedRows, and offer "Cargar más"
 // only when the last fetched batch filled the cap (heuristic there may be
 // more on the server). TOKENS_FALLBACK_ROWS survives only as the
-// pre-measurement fallback and desktop floor; MOBILE_PAGE_SIZE and the
-// matchMedia cardinality gate are gone — one measured runtime feeds both the
-// desktop table and the mobile list.
+// pre-measurement fallback and desktop floor; the old fixed mobile row count
+// and the media-query cardinality gate are gone — one measured runtime feeds
+// both the desktop table and the mobile list.
 const TOKENS_FALLBACK_ROWS = 9;
 // Over-fetch cap: a single superset fetch never asks the server for more than
 // this many rows. Per docs/implementation/server-adaptive-pagination-strategy.md
@@ -539,8 +539,8 @@ export function AdminParticularTokensCard() {
 
   // One collapsed runtime feeds both presentations, so the visible container
   // (desktop table region or mobile list region) drives a single cardinality.
-  // The old second fetch pipeline (MOBILE_PAGE_SIZE=10 gated by matchMedia) is
-  // gone: no more double fetch, no more divergent limit/offset.
+  // The old second fetch pipeline (a fixed mobile row count gated by a media
+  // query) is gone: no more double fetch, no more divergent limit/offset.
   const [desktopBodyNode, setDesktopBodyNode] = useState<HTMLElement | null>(
     null,
   );

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -58,8 +58,8 @@ import { AdminReportsUploadPanel } from "./AdminReportsUploadPanel";
 // as the safe 1366x768 desktop limit; that constant survives only as the
 // pre-measurement fallback and as the desktop floor. A media query no longer
 // decides cardinality, and the mobile/desktop `limit`/`offset` divergence
-// (PAGE_SIZE=9 vs MOBILE_PAGE_SIZE=10, two independent fetch pipelines) is
-// collapsed into a single measured runtime.
+// (nine desktop rows vs a fixed ten-row mobile page, two independent fetch
+// pipelines) is collapsed into a single measured runtime.
 const REPORTS_FALLBACK_ROWS = 9;
 // Hybrid cap: the effective `limit` never exceeds this superset ceiling even on
 // very tall viewports; recompute of offset always clamps against it.
@@ -216,8 +216,9 @@ export function AdminReportsCard() {
 
   // One collapsed runtime feeds both presentations, so the visible container
   // (desktop table region or mobile list region) drives a single cardinality.
-  // The old second `mobileReports` fetch pipeline (MOBILE_PAGE_SIZE=10 gated by
-  // matchMedia) is gone: no more double fetch, no more divergent limit/offset.
+  // The old second `mobileReports` fetch pipeline (a fixed ten-row mobile page
+  // gated by a media query) is gone: no more double fetch, no more divergent
+  // limit/offset.
   const [desktopBodyNode, setDesktopBodyNode] = useState<HTMLElement | null>(
     null,
   );

--- a/test/admin-mobile-page-size-matchmedia-cardinality-guard.test.ts
+++ b/test/admin-mobile-page-size-matchmedia-cardinality-guard.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import test from "node:test";
+
+// R-08 cleanup guard: MOBILE_PAGE_SIZE and matchMedia-as-cardinality were
+// removed module-by-module across PR-SRV-1/PR-SRV-2 (Sessions, Roles,
+// Clinics, Reports, Tokens, Audit, FailedLogin Alerts). This test pins that
+// state so neither source of truth can silently reappear in Admin runtime.
+
+const ADMIN_ROOT = "frontend/src/app/dashboard/admin";
+const CODE_EXTENSIONS = new Set([".ts", ".tsx"]);
+
+// These three modules keep a real `window.matchMedia` call, but only to gate
+// which lazy mobile chunk loads (schema health / maintenance / pricing
+// panels) — never to decide row count, limit, offset, or pagination. They
+// are explicitly out of scope for the cardinality migration (see
+// docs/audit/final-global-vetneb-50-60-pr-roadmap.md R-08).
+const NON_CARDINAL_MATCHMEDIA_ALLOWLIST = new Set([
+  `${ADMIN_ROOT}/AdminMobileHealthModule.tsx`,
+  `${ADMIN_ROOT}/AdminMobileMaintenanceModule.tsx`,
+  `${ADMIN_ROOT}/AdminMobilePricingModule.tsx`,
+]);
+
+function collectFiles(relativeRoot: string): string[] {
+  const absoluteRoot = resolve(process.cwd(), relativeRoot);
+  if (!existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const workspacePrefix = resolve(process.cwd(), "").replace(/\\/g, "/") + "/";
+
+  function walk(currentPath: string): void {
+    for (const entry of readdirSync(currentPath)) {
+      const fullPath = `${currentPath}/${entry}`;
+      const info = statSync(fullPath);
+      if (info.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      files.push(fullPath.replace(/\\/g, "/").replace(workspacePrefix, ""));
+    }
+  }
+
+  walk(absoluteRoot.replace(/\\/g, "/"));
+  return files;
+}
+
+function isAdminCodeFile(file: string): boolean {
+  return (
+    CODE_EXTENSIONS.has(extname(file).toLowerCase()) &&
+    !/\.(test|spec)\.[cm]?[jt]sx?$/i.test(file)
+  );
+}
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(/\r\n/g, "\n");
+}
+
+test("admin runtime never reintroduces MOBILE_PAGE_SIZE as a source of truth", () => {
+  const files = collectFiles(ADMIN_ROOT).filter(isAdminCodeFile);
+  const violations = files.filter((file) => read(file).includes("MOBILE_PAGE_SIZE"));
+
+  assert.deepEqual(
+    violations,
+    [],
+    `MOBILE_PAGE_SIZE must not reappear in Admin runtime: ${violations.join(", ")}`,
+  );
+});
+
+test("admin runtime never reintroduces matchMedia as a cardinality source outside the documented lazy-load allowlist", () => {
+  const files = collectFiles(ADMIN_ROOT).filter(isAdminCodeFile);
+  const matchMediaFiles = files.filter((file) => read(file).includes("matchMedia"));
+  const violations = matchMediaFiles.filter((file) => !NON_CARDINAL_MATCHMEDIA_ALLOWLIST.has(file));
+
+  assert.deepEqual(
+    violations,
+    [],
+    `matchMedia must not decide cardinality outside the lazy-load allowlist: ${violations.join(", ")}`,
+  );
+});
+
+test("non-cardinal matchMedia allowlist only contains files that still exist and use matchMedia", () => {
+  const stale = Array.from(NON_CARDINAL_MATCHMEDIA_ALLOWLIST).filter((file) => {
+    if (!existsSync(resolve(process.cwd(), file))) {
+      return true;
+    }
+    return !read(file).includes("matchMedia");
+  });
+
+  assert.deepEqual(
+    stale,
+    [],
+    `Allowlist entries must exist and still use matchMedia (remove stale entries): ${stale.join(", ")}`,
+  );
+});


### PR DESCRIPTION
R-08 del roadmap final.

Objetivo:
- Eliminar residuos de fuentes ilegítimas de cardinalidad Admin.
- Bloquear reintroducción de MOBILE_PAGE_SIZE y matchMedia cardinality sources mediante guard test nativo.

Cambios:
- Reescritura de comentarios residuales en AdminParticularTokensCard.tsx.
- Reescritura de comentarios residuales en AdminReportsCard.tsx.
- Nuevo guard: test/admin-mobile-page-size-matchmedia-cardinality-guard.test.ts.
- Doc: docs/implementation/remove-mobile-page-size-matchmedia-cardinality.md.

Allowlist explícita:
- AdminMobileHealthModule.tsx
- AdminMobileMaintenanceModule.tsx
- AdminMobilePricingModule.tsx

Motivo:
- Sus matchMedia existentes no deciden cardinalidad/pageSize/filas/paginación.
- Sólo gatean carga lazy mobile/config/status.
- No se modifica comportamiento.

Validaciones locales:
- pnpm test: 2949/2949
- pnpm typecheck:test OK
- pnpm typecheck OK
- pnpm --dir frontend lint OK

Scope:
- Sin backend/API/auth/DB/server.
- Sin migrations.
- Sin CI/workflows.
- Sin deps/lockfiles.
- Sin snapshots.
- Sin globals.css.
- Sin Clínica/Particular/Público.
- Sin R-09.
- Sin eliminar shims mobile compat.
- Sin cambios de comportamiento.