### PR TITLE
feat(clinic): adapt logistics visitas full route

### DIFF
--- a/docs/implementation/adapt-logistics-visitas-full-route.md
+++ b/docs/implementation/adapt-logistics-visitas-full-route.md
@@ -1,0 +1,173 @@
+# R-12 — Clínica `/dashboard/logistica/visitas` full route adaptive contract
+
+## PR
+
+`feat(clinic): adapt logistics visitas full route`
+
+## Base
+
+- Rama: `feat/clinic-logistics-visitas-full-route-adaptive`.
+- Base: `main @ 52b0602 docs(clinic): audit logistics full routes adaptive contract (#1274)`.
+- Fecha: 2026-07-03.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-12, Fase 2.
+2. `docs/audit/clinic-logistics-full-routes-adaptive-contract-audit.md` (R-11) —
+   auditoría rectora; contrato exacto de esta migración.
+
+## Deuda original (R-11)
+
+`frontend/src/app/dashboard/logistica/visitas/page.tsx` llamaba
+`getLogisticsFieldVisits(requestOptions, { throwOnError: true })` sin enviar
+`limit`/`offset`, aunque el endpoint backend
+(`server/routes/logistics-field-visits.fastify.ts:1061-1062`,
+`parsePositiveInt(request.query.limit, 50, 100)`) ya los soporta. Efecto real:
+**truncamiento silencioso** al default del servidor (50 registros, offset 0),
+sin paginación, sin indicio en la UI de que pudiera haber más datos, y sin
+mecanismo adaptativo — el contrato "sin scroll" dependía únicamente de que
+nunca hubiera más de 50 filas (P1, ver matriz de riesgos de R-11).
+
+## Contrato nuevo
+
+- `visitas/page.tsx` **sigue siendo un server component puro** — no se agregó
+  ningún wrapper cliente, `matchMedia` ni `ResizeObserver`.
+- Lee `offset` y `limit` desde `searchParams` (Next 15,
+  `searchParams?: Promise<VisitasPageSearchParams>`, mismo patrón que
+  `dashboard/informes/page.tsx`) y los normaliza server-side:
+  - `normalizeOffset`: entero ≥ 0, default `0`.
+  - `normalizeLimit`: entero ≥ 1, default `VISITAS_DEFAULT_LIMIT = 50`
+    (paridad exacta con el default silencioso anterior), clamp máximo
+    `VISITAS_MAX_LIMIT = 100` (mismo tope que el backend).
+- El fetch pasa `{ limit, offset }` explícitos a `getLogisticsFieldVisits`
+  (antes no se enviaba ningún parámetro).
+- Pager real (`<nav aria-label="Paginación de visitas">`) con botones
+  "Anterior"/"Siguiente" (`PublicRouteControl` variant `bare`, navegación por
+  `href` `?offset=N&limit=M`, sin `next/link` ni `<a>`, consistente con
+  `project_frontend_navigation_hardening`).
+- Copy explícito: `Mostrando {visits.length} visitas · página {currentPage}`
+  y, cuando corresponde, `· puede haber más visitas disponibles` — nunca se
+  menciona un "total" porque el endpoint no lo expone.
+
+## limit/offset — `frontend/src/lib/api.ts`
+
+`getLogisticsFieldVisits` se extendió de forma **backwards-compatible**
+agregando un tercer parámetro posicional opcional:
+
+```ts
+export async function getLogisticsFieldVisits(
+  options?: RequestInit,
+  readOptions: LogisticsReadOptions = {},
+  params?: LogisticsFieldVisitsParams, // { limit?; offset? }
+): Promise<FieldVisit[]>
+```
+
+El querystring sólo se construye cuando `params` trae `limit`/`offset`
+(`URLSearchParams`, mismo patrón que `getReportsPaginated`). Los tres
+consumidores existentes que llaman con 2 argumentos
+(`dashboard/page.tsx`, `dashboard/logistica/page.tsx` — hub —, y
+`getDashboardStats` dentro del propio `api.ts`) siguen recibiendo la URL sin
+querystring, **idéntica a antes**. Ninguno de esos tres call-sites fue
+tocado. No se modificó el backend: los parámetros ya existían en el endpoint.
+
+## Paginación sin `total` — heurística de página llena
+
+El endpoint devuelve `count` (tamaño de la página actual) y
+`pagination: { limit, offset }`, nunca un `total` de universo. Por eso:
+
+- `canGoPrevious = !visitsLoadError && offset > 0`.
+- `canGoNext = !visitsLoadError && visits.length === limit` (página llena ⇒
+  posible más). Esta heurística puede dar un falso positivo cuando el total
+  real es un múltiplo exacto del `limit` pedido (ej. exactamente 50 registros
+  con `limit=50`) — es un trade-off documentado y aceptado (mismo perfil que
+  "Tokens admin" en `server-adaptive-pagination-strategy.md` §4), no un bug.
+- No se calcula `pageCount` en ningún momento (no hay `total` con qué
+  calcularlo).
+
+## Métricas sobre la página visible
+
+Los 4 contadores superiores (`Pendientes`/`Programadas`/`En curso`/
+`Completadas`) siguen calculándose con `visits.filter(...)` sobre el array
+que llegó en la página actual — comportamiento sin cambios funcionales, pero
+ahora está **aclarado explícitamente** en la UI con un texto nuevo:
+`Conteos calculados sobre la página visible, no sobre el total general de
+visitas.` Antes esta ambigüedad no estaba señalizada (los 50 registros por
+default hacían que "página visible" y "todo lo que existe" se confundieran
+visualmente).
+
+## E2E — `frontend/e2e/dashboard-logistica-visitas-full-route-adaptive.spec.ts`
+
+4 tests, `chromium`, sesión fixture ya establecida
+(`app_session_id=e2e_populated_clinic_session`, servida por
+`frontend/e2e/fixtures/admin-populated-api-server.mjs`, **sin modificar** ese
+archivo):
+
+1. **3 viewports críticos** (`1440x900`, `1366x768` desktop corto,
+   `390x844` mobile): pager siempre visible, `Anterior`/`Siguiente`
+   deshabilitados en el estado inicial (dataset fixture = 3 visitas, muy por
+   debajo del `limit` default de 50 ⇒ no hay página siguiente real), texto de
+   alcance de página visible presente, y **sin scroll externo**
+   (`html`/`body` `scrollHeight <= clientHeight + 2px` tolerancia) ni overflow
+   horizontal del pager.
+2. **Heurística de página llena + navegación real**: navega con
+   `?limit=3&offset=0` (el fixture siempre sirve exactamente 3 visitas
+   ignorando el querystring, así que pedir `limit=3` fuerza de forma
+   determinística el estado "página llena" sin depender de datos reales ni
+   de modificar el fixture compartido); confirma `Siguiente` habilitado,
+   click, la URL pasa a `offset=3&limit=3`, el indicador pasa a "Página 2",
+   `Anterior` se habilita; click en `Anterior` vuelve a `offset=0` /
+   "Página 1".
+
+No se depende de datos de producción en ningún test.
+
+## Validaciones ejecutadas
+
+- `git diff --check` — limpio.
+- `pnpm test` — 2954/2954 (incluye 3 tests nuevos de contrato en
+  `test/frontend-dashboard-logistica-visitas.test.ts`).
+- `pnpm typecheck:test` — sin errores.
+- `pnpm typecheck` — sin errores.
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm --dir frontend build` — build de producción exitoso;
+  `/dashboard/logistica/visitas` sigue listada como ruta dinámica (`ƒ`,
+  server-rendered), confirmando que sigue siendo server component.
+- `pnpm --dir frontend exec playwright test
+  e2e/dashboard-logistica-visitas-full-route-adaptive.spec.ts
+  --project=chromium` — 4/4 passed.
+- `git restore frontend/next-env.d.ts` ejecutado después de correr Playwright
+  (regenera la ruta de dev del dev server) y antes de repetir `pnpm test` /
+  `pnpm typecheck:test`, que se re-confirmaron en verde tras el restore.
+
+## Confirmaciones de scope
+
+- **Sin backend/API/auth/DB/server/migraciones**: `server/**` sólo se leyó
+  (`logistics-field-visits.fastify.ts`) para confirmar los límites
+  `parsePositiveInt(..., 50, 100)` ya soportados; no se modificó ningún
+  archivo de `server/`.
+- **Sin `globals.css`**: el pager reutiliza clases ya existentes
+  (`dashboard-pagination-btn`, `dashboard-pagination-context`,
+  `dashboard-surface`, etc.) creadas por PRs anteriores (`informes`); no se
+  agregó ni modificó ninguna regla CSS.
+- **Sin `rutas/`, `metricas/` ni `LogisticsCommandCenter.tsx`**: no se tocó
+  ningún archivo de esas rutas ni del hub; los tres consumidores que aún
+  llaman `getLogisticsFieldVisits` sin `limit`/`offset`
+  (`dashboard/page.tsx`, `dashboard/logistica/page.tsx`,
+  `getDashboardStats`) mantienen exactamente el mismo comportamiento gracias
+  a la compatibilidad hacia atrás de la firma extendida.
+- **Sin R-13/R-14/R-15/R-16**: no se avanzó paginación de `rutas` (R-13),
+  fan-out de `métricas` (R-14), ni se tocó `MasterDetailWorkspace` (R-15) o
+  Tokens Clínica (R-16). Quedan documentados en R-11 como próximos PRs,
+  fuera de este scope.
+- **Sin Admin, Particular ni Público**: archivos tocados son exclusivamente
+  `frontend/src/app/dashboard/logistica/visitas/page.tsx`,
+  `frontend/src/lib/api.ts` (extensión backwards-compatible de una función),
+  `test/frontend-dashboard-logistica-visitas.test.ts`, el e2e nuevo, y este
+  documento.
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/logistica/visitas/page.tsx`
+- `frontend/src/lib/api.ts`
+- `test/frontend-dashboard-logistica-visitas.test.ts`
+- `frontend/e2e/dashboard-logistica-visitas-full-route-adaptive.spec.ts` (nuevo)
+- `docs/implementation/adapt-logistics-visitas-full-route.md` (nuevo, este documento)

--- a/frontend/e2e/dashboard-logistica-visitas-full-route-adaptive.spec.ts
+++ b/frontend/e2e/dashboard-logistica-visitas-full-route-adaptive.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "desktop-1440x900", width: 1440, height: 900 },
+  { name: "desktop-short-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readNoExternalScroll(page: Page) {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    return {
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+    };
+  });
+}
+
+test.describe("clinic Logística Visitas full route adaptive contract (R-12)", () => {
+  for (const viewport of VIEWPORTS) {
+    test(`renders an always-visible pager sized to ${viewport.name} without external scroll`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setPopulatedClinicSession(page);
+
+      await page.goto("/dashboard/logistica/visitas");
+
+      const pager = page.getByRole("navigation", { name: "Paginación de visitas" });
+      const previousButton = page.getByRole("button", { name: "Página anterior" });
+      const nextButton = page.getByRole("button", { name: "Página siguiente" });
+      const pageIndicator = pager.locator(".dashboard-pagination-context");
+      const rows = page.locator("table tbody tr");
+
+      await expect(async () => {
+        await expect(pager).toBeVisible();
+        await expect(previousButton).toBeVisible();
+        await expect(nextButton).toBeVisible();
+
+        const rowCount = await rows.count();
+        expect(rowCount, `${viewport.name}: at least one row rendered`).toBeGreaterThan(0);
+      }).toPass({ timeout: 12_000 });
+
+      // Fixture dataset (3 visits) is far below the default page-size limit
+      // (50), so this is the "everything fits on page 1" contract state:
+      // no previous page, and the page-full heuristic correctly reports no
+      // further page either.
+      await expect(previousButton).toBeDisabled();
+      await expect(nextButton).toBeDisabled();
+      await expect(pageIndicator).toHaveText("Página 1");
+      await expect(
+        page.getByText(
+          "Conteos calculados sobre la página visible, no sobre el total general de visitas.",
+        ),
+      ).toBeVisible();
+
+      await expect(async () => {
+        const metrics = await readNoExternalScroll(page);
+        expect(
+          metrics.htmlScrollHeight,
+          `${viewport.name}: documentElement must not scroll globally`,
+        ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+        expect(
+          metrics.bodyScrollHeight,
+          `${viewport.name}: body must not scroll globally`,
+        ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+      }).toPass({ timeout: 10_000 });
+
+      const pagerBox = await pager.boundingBox();
+      expect(pagerBox, `${viewport.name}: pager bounding box`).not.toBeNull();
+      expect(
+        pagerBox!.x + pagerBox!.width,
+        `${viewport.name}: pager right edge`,
+      ).toBeLessThanOrEqual(viewport.width + TOLERANCE);
+      expect(pagerBox!.x, `${viewport.name}: pager left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+    });
+  }
+
+  test("page-full heuristic enables next/previous navigation and keeps the offset contract in the URL", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await setPopulatedClinicSession(page);
+
+    // The fixture serves exactly 3 field visits regardless of limit/offset,
+    // so requesting `limit=3` forces the deterministic "page full" state
+    // (visits.length === limit) without depending on real production data.
+    await page.goto("/dashboard/logistica/visitas?limit=3&offset=0");
+
+    const pager = page.getByRole("navigation", { name: "Paginación de visitas" });
+    const previousButton = page.getByRole("button", { name: "Página anterior" });
+    const nextButton = page.getByRole("button", { name: "Página siguiente" });
+    const pageIndicator = pager.locator(".dashboard-pagination-context");
+
+    await expect(async () => {
+      await expect(nextButton).toBeEnabled();
+      await expect(previousButton).toBeDisabled();
+    }).toPass({ timeout: 12_000 });
+
+    await expect(pageIndicator).toHaveText("Página 1");
+    await expect(page.getByText(/puede haber más visitas disponibles/)).toBeVisible();
+
+    await nextButton.click();
+
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("offset")).toBe("3");
+      expect(url.searchParams.get("limit")).toBe("3");
+    }).toPass({ timeout: 10_000 });
+
+    await expect(pageIndicator).toHaveText("Página 2");
+    await expect(previousButton).toBeEnabled();
+
+    await previousButton.click();
+
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("offset")).toBe("0");
+    }).toPass({ timeout: 10_000 });
+    await expect(pageIndicator).toHaveText("Página 1");
+    await expect(previousButton).toBeDisabled();
+  });
+});

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -24,6 +25,42 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// Backend default/max (server/routes/logistics-field-visits.fastify.ts:
+// parsePositiveInt(request.query.limit, 50, 100)). The endpoint exposes no
+// total record count, so pagination relies on the page-full heuristic below
+// instead of a computed page count.
+const VISITAS_DEFAULT_LIMIT = 50;
+const VISITAS_MAX_LIMIT = 100;
+
+type VisitasPageSearchParams = {
+  offset?: string | string[];
+  limit?: string | string[];
+};
+
+function normalizeSearchParamValue(
+  value: string | string[] | undefined,
+): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+function normalizeOffset(value: string | string[] | undefined): number {
+  const parsed = Number(normalizeSearchParamValue(value));
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function normalizeLimit(value: string | string[] | undefined): number {
+  const parsed = Number(normalizeSearchParamValue(value));
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return VISITAS_DEFAULT_LIMIT;
+  }
+
+  return Math.min(parsed, VISITAS_MAX_LIMIT);
+}
+
+function buildVisitasHref(offset: number, limit: number): string {
+  return `/dashboard/logistica/visitas?offset=${offset}&limit=${limit}`;
+}
+
 async function getLogisticsRequestOptions(): Promise<RequestInit> {
   const cookieHeader = (await cookies()).toString();
 
@@ -33,7 +70,15 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
   };
 }
 
-export default async function VisitasPage() {
+export default async function VisitasPage({
+  searchParams,
+}: {
+  searchParams?: Promise<VisitasPageSearchParams>;
+}) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const offset = normalizeOffset(resolvedSearchParams.offset);
+  const limit = normalizeLimit(resolvedSearchParams.limit);
+
   let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];
   let visitsLoadError = false;
 
@@ -41,11 +86,21 @@ export default async function VisitasPage() {
     visits = await getLogisticsFieldVisits(
       await getLogisticsRequestOptions(),
       { throwOnError: true },
+      { limit, offset },
     );
   } catch (error) {
     redirectToLoginOnUnauthorized(error);
     visitsLoadError = true;
   }
+
+  // No `total` is exposed by the endpoint: page-full is the only signal
+  // available, so `canGoNext` may false-positive on an exact-multiple last
+  // page — documented tradeoff, not a bug (docs/audit/clinic-logistics-full-routes-adaptive-contract-audit.md).
+  const canGoPrevious = !visitsLoadError && offset > 0;
+  const canGoNext = !visitsLoadError && visits.length === limit;
+  const currentPage = Math.floor(offset / limit) + 1;
+  const previousHref = buildVisitasHref(Math.max(0, offset - limit), limit);
+  const nextHref = buildVisitasHref(offset + limit, limit);
 
   return (
     <>
@@ -75,12 +130,19 @@ export default async function VisitasPage() {
             );
           })}
         </div>
+        <p className="text-xs text-muted-foreground">
+          Conteos calculados sobre la página visible, no sobre el total general de visitas.
+        </p>
 
         <Card className="dashboard-surface">
           <CardHeader>
             <CardTitle className="text-base">
               Visitas ({visits.length})
             </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Mostrando {visits.length} visitas · página {currentPage}
+              {canGoNext ? " · puede haber más visitas disponibles" : ""}
+            </p>
           </CardHeader>
           <CardContent className="p-0">
             <Table>
@@ -149,6 +211,32 @@ export default async function VisitasPage() {
               </TableBody>
             </Table>
           </CardContent>
+          <nav
+            aria-label="Paginación de visitas"
+            className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+          >
+            <PublicRouteControl
+              href={previousHref}
+              variant="bare"
+              disabled={!canGoPrevious}
+              aria-label="Página anterior"
+              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Anterior
+            </PublicRouteControl>
+            <span className="dashboard-pagination-context">
+              Página {currentPage}
+            </span>
+            <PublicRouteControl
+              href={nextHref}
+              variant="bare"
+              disabled={!canGoNext}
+              aria-label="Página siguiente"
+              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Siguiente
+            </PublicRouteControl>
+          </nav>
         </Card>
       </main>
     </>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1393,13 +1393,30 @@ type LogisticsReadOptions = {
   throwOnError?: boolean;
 };
 
+type LogisticsFieldVisitsParams = {
+  limit?: number;
+  offset?: number;
+};
+
 export async function getLogisticsFieldVisits(
   options?: RequestInit,
   readOptions: LogisticsReadOptions = {},
+  params?: LogisticsFieldVisitsParams,
 ): Promise<FieldVisit[]> {
   try {
+    const path = "/api/logistics/field-visits";
+    const query = new URLSearchParams();
+
+    if (params?.limit !== undefined) {
+      query.set("limit", String(params.limit));
+    }
+    if (params?.offset !== undefined) {
+      query.set("offset", String(params.offset));
+    }
+
+    const qs = query.toString();
     const res = await apiFetch<{ visits: FieldVisit[] }>(
-      "/api/logistics/field-visits",
+      qs ? `${path}?${qs}` : path,
       options,
     );
     return res.visits ?? [];

--- a/test/frontend-dashboard-logistica-visitas.test.ts
+++ b/test/frontend-dashboard-logistica-visitas.test.ts
@@ -36,6 +36,39 @@ test("dashboard logistica visitas forwards cookies and disables cache for live r
   assert.ok(source.includes("{ throwOnError: true },"));
 });
 
+test("dashboard logistica visitas sends explicit limit/offset instead of truncating silently (R-12)", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("{ limit, offset },"));
+  assert.ok(source.includes("const VISITAS_DEFAULT_LIMIT = 50;"));
+  assert.ok(source.includes("const VISITAS_MAX_LIMIT = 100;"));
+  assert.ok(source.includes("function normalizeOffset(value: string | string[] | undefined): number {"));
+  assert.ok(source.includes("function normalizeLimit(value: string | string[] | undefined): number {"));
+  assert.ok(source.includes("searchParams?: Promise<VisitasPageSearchParams>;"));
+});
+
+test("dashboard logistica visitas computes canGoNext/canGoPrevious without a backend total (R-12)", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes("const canGoPrevious = !visitsLoadError && offset > 0;"));
+  assert.ok(source.includes("const canGoNext = !visitsLoadError && visits.length === limit;"));
+  assert.equal(source.includes("pageCount"), false);
+  assert.equal(source.includes("matchMedia"), false);
+  assert.equal(source.includes("ResizeObserver"), false);
+});
+
+test("dashboard logistica visitas renders a pager and page-scope disclosure (R-12)", () => {
+  const source = read(VISITAS_PAGE_PATH);
+
+  assert.ok(source.includes('aria-label="Paginación de visitas"'));
+  assert.ok(source.includes('aria-label="Página anterior"'));
+  assert.ok(source.includes('aria-label="Página siguiente"'));
+  assert.ok(source.includes("disabled={!canGoPrevious}"));
+  assert.ok(source.includes("disabled={!canGoNext}"));
+  assert.ok(source.includes("Mostrando {visits.length} visitas · página {currentPage}"));
+  assert.ok(source.includes("Conteos calculados sobre la página visible, no sobre el total general de visitas."));
+});
+
 test("dashboard logistica visitas renders topbar without technical source copy", () => {
   const source = read(VISITAS_PAGE_PATH);
   const removedSourcePrefix = "Lectura conectada " + "a";


### PR DESCRIPTION
## Summary
- Adds explicit limit/offset pagination contract for the clinic logistics visits full route
- Removes silent default truncation by surfacing page state and next-page affordance
- Documents the no-total backend contract and canGoNext page-full heuristic
- Adds directed e2e coverage for /dashboard/logistica/visitas

## Validations
- git diff --check
- pnpm test
- pnpm typecheck:test
- pnpm typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend build
- pnpm --dir frontend exec playwright test e2e/dashboard-logistica-visitas-full-route-adaptive.spec.ts --project=chromium

## Scope
- No backend/API/auth/DB/server/migrations changes
- No globals.css changes
- No rutas/metricas/LogisticsCommandCenter changes
- No Admin/Particular/Público changes
- No R-13/R-14/R-15/R-16 changes