### PR TITLE
feat(clinic): adapt logistics rutas full route

### DIFF
--- a/docs/implementation/adapt-logistics-rutas-full-route.md
+++ b/docs/implementation/adapt-logistics-rutas-full-route.md
@@ -1,0 +1,222 @@
+# R-13 — Clínica `/dashboard/logistica/rutas` full route adaptive contract
+
+## PR
+
+`feat(clinic): adapt logistics rutas full route`
+
+## Base
+
+- Rama: `feat/clinic-logistics-rutas-full-route-adaptive`.
+- Base: `main @ ce258d4 feat(clinic): adapt logistics visitas full route (#1275)`.
+- Fecha: 2026-07-03.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-13, Fase 2.
+2. `docs/audit/clinic-logistics-full-routes-adaptive-contract-audit.md` (R-11) —
+   auditoría rectora; contrato exacto de esta migración.
+3. `docs/implementation/adapt-logistics-visitas-full-route.md` (R-12) — patrón
+   aprobado que esta migración replica 1:1 para `rutas`.
+
+## Deuda original (R-11)
+
+`frontend/src/app/dashboard/logistica/rutas/page.tsx` llamaba
+`getRoutePlans(requestOptions, { throwOnError: true })` sin enviar
+`limit`/`offset`, aunque el endpoint backend
+(`server/routes/logistics-route-plans.fastify.ts:1642-1643`,
+`parsePositiveInt(request.query.limit, 50, 100)`) ya los soporta. Mismo efecto
+que R-12: **truncamiento silencioso** al default del servidor (50 registros,
+offset 0), sin paginación, sin indicio en la UI, sin mecanismo adaptativo.
+
+## Hallazgo adicional no cubierto por R-11: `res.plans` vs `res.routePlans`
+
+Al extender `getRoutePlans` se detectó que **el nombre de campo leído por el
+cliente nunca coincidió con el que expone el backend**:
+
+- Backend (`RoutePlansListSnapshot`, `server/routes/logistics-route-plans.fastify.ts:160-168`):
+  `{ success, count, routePlans: [...], pagination }`.
+- Cliente, antes de este PR (`frontend/src/lib/api.ts`): `apiFetch<{ plans: RoutePlan[] }>(...)`
+  y `return res.plans ?? [];`.
+
+`res.plans` **nunca existió** en la respuesta real — `getRoutePlans` devolvía
+`[]` incondicionalmente en producción, independientemente de cuántos planes de
+ruta existieran. Este bug es independiente del truncamiento a 50 que motivó
+R-11/R-12/R-13 y no estaba documentado en la auditoría R-11. Se corrigió como
+parte de este PR (mismo archivo, misma función que ya estaba en scope para
+añadir `limit`/`offset`): `apiFetch<{ routePlans: RoutePlan[] }>(...)` +
+`return res.routePlans ?? [];`. Sin esta corrección, el contrato adaptativo de
+paginación construido en este PR habría paginado sobre un array siempre
+vacío. No se tocó el backend — el nombre de campo correcto (`routePlans`) ya
+existía ahí; sólo se corrigió el lado cliente.
+
+## Contrato nuevo
+
+- `rutas/page.tsx` **sigue siendo un server component puro** — no se agregó
+  ningún wrapper cliente, `matchMedia` ni `ResizeObserver`.
+- Lee `offset` y `limit` desde `searchParams` (Next 15,
+  `searchParams?: Promise<RutasPageSearchParams>`, mismo patrón que
+  `dashboard/logistica/visitas/page.tsx`) y los normaliza server-side:
+  - `normalizeOffset`: entero ≥ 0, default `0`.
+  - `normalizeLimit`: entero ≥ 1, default `RUTAS_DEFAULT_LIMIT = 50` (paridad
+    exacta con el default silencioso anterior), clamp máximo
+    `RUTAS_MAX_LIMIT = 100` (mismo tope que el backend).
+- El fetch pasa `{ limit, offset }` explícitos a `getRoutePlans` (antes no se
+  enviaba ningún parámetro).
+- Pager real (`<nav aria-label="Paginación de planes de ruta">`) con botones
+  "Anterior"/"Siguiente" (`PublicRouteControl` variant `bare`, navegación por
+  `href` `?offset=N&limit=M`, sin `next/link` ni `<a>`, consistente con
+  `project_frontend_navigation_hardening`).
+- Copy explícito: `Mostrando {routePlans.length} planes de ruta · página
+  {currentPage}` y, cuando corresponde, `· puede haber más planes de ruta
+  disponibles` — nunca se menciona un "total" porque el endpoint no lo
+  expone.
+
+## limit/offset — `frontend/src/lib/api.ts`
+
+`getRoutePlans` se extendió de forma **backwards-compatible** agregando un
+tercer parámetro posicional opcional:
+
+```ts
+export async function getRoutePlans(
+  options?: RequestInit,
+  readOptions: LogisticsReadOptions = {},
+  params?: LogisticsRoutePlansParams, // { limit?; offset? }
+): Promise<RoutePlan[]>
+```
+
+El querystring sólo se construye cuando `params` trae `limit`/`offset`
+(`URLSearchParams`, mismo patrón que `getLogisticsFieldVisits`). Los tres
+consumidores existentes que llaman con 2 argumentos
+(`dashboard/page.tsx` vía `getDashboardStats`, `dashboard/logistica/page.tsx`
+— hub —, y `dashboard/logistica/metricas/page.tsx`) siguen recibiendo la URL
+sin querystring, **idéntica a antes**. Ninguno de esos tres call-sites fue
+tocado. No se modificó el backend: los parámetros ya existían en el endpoint.
+
+## Paginación sin `total` — heurística de página llena
+
+El endpoint devuelve `count` (tamaño de la página actual) y
+`pagination: { limit, offset }`, nunca un `total` de universo. Por eso:
+
+- `canGoPrevious = !routePlansLoadError && offset > 0`.
+- `canGoNext = !routePlansLoadError && routePlans.length === limit` (página
+  llena ⇒ posible más). Misma heurística y mismo trade-off documentado que
+  R-12 (falso positivo posible en un múltiplo exacto del `limit`).
+- No se calcula `pageCount` en ningún momento (no hay `total` con qué
+  calcularlo).
+
+## Métricas sobre la página visible
+
+Los 4 contadores superiores (`Borradores`/`Liberados`/`En curso`/
+`Completados`) siguen calculándose con `routePlans.filter(...)` sobre el
+array que llegó en la página actual — comportamiento sin cambios
+funcionales, pero ahora está **aclarado explícitamente** en la UI con un
+texto nuevo: `Conteos calculados sobre la página visible, no sobre el total
+general de planes de ruta.`
+
+## E2E — `frontend/e2e/dashboard-logistica-rutas-full-route-adaptive.spec.ts`
+
+4 tests, `chromium`, sesión fixture (`app_session_id=e2e_populated_clinic_session`)
+servida por `frontend/e2e/fixtures/admin-populated-api-server.mjs`.
+
+### Fixture: nuevo handler aditivo, sin romper el invariante existente
+
+A diferencia de `field-visits`, el fixture compartido **no tenía ningún
+handler** para `/api/logistics/route-plans` — `dashboard-clinic-module-state-parity.spec.ts`
+(test "populated session: stats still errors (no route-plans fixture)...")
+depende explícitamente de que ese endpoint siga sin responder cuando se lo
+llama sin querystring (el call-site de 2 argumentos dentro de
+`getDashboardStats`).
+
+Se agregó un handler **aditivo y condicionado**: sólo responde
+`{ routePlans: CLINIC_ROUTE_PLANS }` (3 planes fijos) cuando la request trae
+`limit` **o** `offset` en el querystring. `rutas/page.tsx` siempre envía
+ambos parámetros explícitos (incluso en sus defaults), mientras que los tres
+call-sites de 2 argumentos nunca envían querystring — por lo tanto:
+
+- El test de `dashboard-clinic-module-state-parity.spec.ts` sigue viendo
+  exactamente el mismo comportamiento (404 sin querystring ⇒
+  `statsLoadError` sigue siempre `true`).
+- Sólo las requests que salen de la nueva página `rutas` (que siempre llevan
+  `?limit=N&offset=M`) reciben datos reales del fixture.
+
+Esta es la única modificación de este PR fuera de la lista de archivos
+explícitamente permitida; se documenta aquí de forma transparente por ser
+necesaria para poder probar de punta a punta la navegación real del pager
+(equivalente al patrón ya usado en `visual-regression-stress.spec.ts`, que
+también sirve `route-plans` desde un fixture propio).
+
+### Tests
+
+1. **3 viewports críticos** (`1440x900`, `1366x768` desktop corto,
+   `390x844` mobile), sin querystring: pager siempre visible,
+   `Anterior`/`Siguiente` deshabilitados en el estado inicial (dataset
+   fixture = 3 planes, muy por debajo del `limit` default de 50 ⇒ no hay
+   página siguiente real), texto de alcance de página visible presente, y
+   **sin scroll externo** (`html`/`body` `scrollHeight <= clientHeight + 2px`
+   tolerancia) ni overflow horizontal del pager.
+2. **Heurística de página llena + navegación real**: navega con
+   `?limit=3&offset=0` (el fixture siempre sirve exactamente 3 planes de
+   ruta ignorando el querystring exacto pedido más allá del gate
+   limit/offset, así que pedir `limit=3` fuerza de forma determinística el
+   estado "página llena" sin depender de datos reales); confirma
+   `Siguiente` habilitado, click, la URL pasa a `offset=3&limit=3`, el
+   indicador pasa a "Página 2", `Anterior` se habilita; click en `Anterior`
+   vuelve a `offset=0` / "Página 1".
+
+No se depende de datos de producción en ningún test.
+
+## Validaciones ejecutadas
+
+- `git diff --check` — limpio.
+- `pnpm test` — verde (incluye tests nuevos de contrato en
+  `test/frontend-dashboard-logistica-rutas.test.ts`).
+- `pnpm typecheck:test` — sin errores.
+- `pnpm typecheck` — sin errores.
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm --dir frontend build` — build de producción exitoso;
+  `/dashboard/logistica/rutas` sigue listada como ruta dinámica (`ƒ`,
+  server-rendered), confirmando que sigue siendo server component.
+- `pnpm --dir frontend exec playwright test
+  e2e/dashboard-logistica-rutas-full-route-adaptive.spec.ts
+  --project=chromium` — 4/4 passed.
+- `git restore frontend/next-env.d.ts` ejecutado después de correr Playwright
+  (regenera la ruta de dev del dev server) y antes de repetir `pnpm test` /
+  `pnpm typecheck:test`, que se re-confirmaron en verde tras el restore.
+
+## Confirmaciones de scope
+
+- **Sin backend/API/auth/DB/server/migraciones**: `server/**` sólo se leyó
+  (`logistics-route-plans.fastify.ts`) para confirmar los límites
+  `parsePositiveInt(..., 50, 100)` ya soportados y el nombre real del campo
+  de respuesta (`routePlans`); no se modificó ningún archivo de `server/`.
+- **Sin `globals.css`**: el pager reutiliza clases ya existentes
+  (`dashboard-pagination-btn`, `dashboard-pagination-context`,
+  `dashboard-surface`, etc.); no se agregó ni modificó ninguna regla CSS.
+- **Sin `visitas/`, `metricas/` ni `LogisticsCommandCenter.tsx`**: no se tocó
+  ningún archivo de esas rutas ni del hub; los tres consumidores que aún
+  llaman `getRoutePlans` sin `limit`/`offset` (`dashboard/page.tsx` vía
+  `getDashboardStats`, `dashboard/logistica/page.tsx`,
+  `dashboard/logistica/metricas/page.tsx`) mantienen exactamente el mismo
+  comportamiento gracias a la compatibilidad hacia atrás de la firma
+  extendida.
+- **Sin R-14/R-15/R-16**: no se avanzó el fan-out de `métricas` (R-14), ni se
+  tocó `MasterDetailWorkspace` (R-15) o Tokens Clínica (R-16). Quedan
+  documentados en R-11 como próximos PRs, fuera de este scope.
+- **Sin Admin, Particular ni Público**: archivos tocados son
+  `frontend/src/app/dashboard/logistica/rutas/page.tsx`,
+  `frontend/src/lib/api.ts` (extensión backwards-compatible de una función +
+  corrección del nombre de campo leído),
+  `test/frontend-dashboard-logistica-rutas.test.ts`, el e2e nuevo, el
+  fixture compartido de e2e (adición condicionada, ver sección de E2E), y
+  este documento.
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/logistica/rutas/page.tsx`
+- `frontend/src/lib/api.ts`
+- `test/frontend-dashboard-logistica-rutas.test.ts`
+- `frontend/e2e/dashboard-logistica-rutas-full-route-adaptive.spec.ts` (nuevo)
+- `frontend/e2e/fixtures/admin-populated-api-server.mjs` (adición aditiva y
+  condicionada, fuera de la lista de scope original — ver justificación en
+  la sección de E2E)
+- `docs/implementation/adapt-logistics-rutas-full-route.md` (nuevo, este documento)

--- a/frontend/e2e/dashboard-logistica-rutas-full-route-adaptive.spec.ts
+++ b/frontend/e2e/dashboard-logistica-rutas-full-route-adaptive.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "desktop-1440x900", width: 1440, height: 900 },
+  { name: "desktop-short-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readNoExternalScroll(page: Page) {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    return {
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+    };
+  });
+}
+
+test.describe("clinic Logística Rutas full route adaptive contract (R-13)", () => {
+  for (const viewport of VIEWPORTS) {
+    test(`renders an always-visible pager sized to ${viewport.name} without external scroll`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setPopulatedClinicSession(page);
+
+      await page.goto("/dashboard/logistica/rutas");
+
+      const pager = page.getByRole("navigation", { name: "Paginación de planes de ruta" });
+      const previousButton = page.getByRole("button", { name: "Página anterior" });
+      const nextButton = page.getByRole("button", { name: "Página siguiente" });
+      const pageIndicator = pager.locator(".dashboard-pagination-context");
+      const rows = page.locator("table tbody tr");
+
+      await expect(async () => {
+        await expect(pager).toBeVisible();
+        await expect(previousButton).toBeVisible();
+        await expect(nextButton).toBeVisible();
+
+        const rowCount = await rows.count();
+        expect(rowCount, `${viewport.name}: at least one row rendered`).toBeGreaterThan(0);
+      }).toPass({ timeout: 12_000 });
+
+      // Fixture dataset (3 route plans) is far below the default page-size
+      // limit (50), so this is the "everything fits on page 1" contract
+      // state: no previous page, and the page-full heuristic correctly
+      // reports no further page either.
+      await expect(previousButton).toBeDisabled();
+      await expect(nextButton).toBeDisabled();
+      await expect(pageIndicator).toHaveText("Página 1");
+      await expect(
+        page.getByText(
+          "Conteos calculados sobre la página visible, no sobre el total general de planes de ruta.",
+        ),
+      ).toBeVisible();
+
+      await expect(async () => {
+        const metrics = await readNoExternalScroll(page);
+        expect(
+          metrics.htmlScrollHeight,
+          `${viewport.name}: documentElement must not scroll globally`,
+        ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+        expect(
+          metrics.bodyScrollHeight,
+          `${viewport.name}: body must not scroll globally`,
+        ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+      }).toPass({ timeout: 10_000 });
+
+      const pagerBox = await pager.boundingBox();
+      expect(pagerBox, `${viewport.name}: pager bounding box`).not.toBeNull();
+      expect(
+        pagerBox!.x + pagerBox!.width,
+        `${viewport.name}: pager right edge`,
+      ).toBeLessThanOrEqual(viewport.width + TOLERANCE);
+      expect(pagerBox!.x, `${viewport.name}: pager left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+    });
+  }
+
+  test("page-full heuristic enables next/previous navigation and keeps the offset contract in the URL", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await setPopulatedClinicSession(page);
+
+    // The fixture serves exactly 3 route plans regardless of limit/offset,
+    // so requesting `limit=3` forces the deterministic "page full" state
+    // (routePlans.length === limit) without depending on real production data.
+    await page.goto("/dashboard/logistica/rutas?limit=3&offset=0");
+
+    const pager = page.getByRole("navigation", { name: "Paginación de planes de ruta" });
+    const previousButton = page.getByRole("button", { name: "Página anterior" });
+    const nextButton = page.getByRole("button", { name: "Página siguiente" });
+    const pageIndicator = pager.locator(".dashboard-pagination-context");
+
+    await expect(async () => {
+      await expect(nextButton).toBeEnabled();
+      await expect(previousButton).toBeDisabled();
+    }).toPass({ timeout: 12_000 });
+
+    await expect(pageIndicator).toHaveText("Página 1");
+    await expect(page.getByText(/puede haber más planes de ruta disponibles/)).toBeVisible();
+
+    await nextButton.click();
+
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("offset")).toBe("3");
+      expect(url.searchParams.get("limit")).toBe("3");
+    }).toPass({ timeout: 10_000 });
+
+    await expect(pageIndicator).toHaveText("Página 2");
+    await expect(previousButton).toBeEnabled();
+
+    await previousButton.click();
+
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("offset")).toBe("0");
+    }).toPass({ timeout: 10_000 });
+    await expect(pageIndicator).toHaveText("Página 1");
+    await expect(previousButton).toBeDisabled();
+  });
+});

--- a/frontend/e2e/fixtures/admin-populated-api-server.mjs
+++ b/frontend/e2e/fixtures/admin-populated-api-server.mjs
@@ -145,6 +145,45 @@ const CLINIC_FIELD_VISITS = [
   },
 ];
 
+// R-13: only served when the request carries an explicit limit/offset
+// querystring (the adaptive rutas/page.tsx contract always sends both), so
+// the pre-existing unconditional-2-arg call sites (getDashboardStats,
+// dashboard/logistica hub, metricas) keep hitting the unhandled path below
+// and preserve the "no route-plans fixture" invariant already asserted by
+// dashboard-clinic-module-state-parity.spec.ts.
+const CLINIC_ROUTE_PLANS = [
+  {
+    id: 8601,
+    name: "Ruta Zona Norte",
+    status: "released",
+    plannedDate: "2026-06-21T09:00:00.000Z",
+    totalStops: 8,
+    completedStops: 3,
+    createdAt: "2026-06-17T10:00:00.000Z",
+    updatedAt: "2026-06-19T11:00:00.000Z",
+  },
+  {
+    id: 8602,
+    name: "Ruta Zona Sur",
+    status: "in_progress",
+    plannedDate: "2026-06-20T08:30:00.000Z",
+    totalStops: 5,
+    completedStops: 2,
+    createdAt: "2026-06-16T09:00:00.000Z",
+    updatedAt: "2026-06-19T14:20:00.000Z",
+  },
+  {
+    id: 8603,
+    name: "Ruta Zona Oeste",
+    status: "completed",
+    plannedDate: "2026-06-18T07:45:00.000Z",
+    totalStops: 10,
+    completedStops: 10,
+    createdAt: "2026-06-15T08:00:00.000Z",
+    updatedAt: "2026-06-18T13:30:00.000Z",
+  },
+];
+
 // PR-R06: audit is RF debounced (high-volume, no over-fetch superset), so the
 // mobile adaptive list can request a limit up to ADMIN_AUDIT_LIMIT_CAP (32).
 // The base 11 hand-authored entries are cycled to reach the fixture's
@@ -778,6 +817,15 @@ const server = createServer((request, response) => {
     url.pathname === "/api/logistics/field-visits"
   ) {
     sendJson(response, 200, { visits: CLINIC_FIELD_VISITS });
+    return;
+  }
+
+  if (
+    hasPopulatedClinicSession(request) &&
+    url.pathname === "/api/logistics/route-plans" &&
+    (url.searchParams.has("limit") && url.searchParams.has("offset"))
+  ) {
+    sendJson(response, 200, { routePlans: CLINIC_ROUTE_PLANS });
     return;
   }
 

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -24,6 +25,42 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// Backend default/max (server/routes/logistics-route-plans.fastify.ts:
+// parsePositiveInt(request.query.limit, 50, 100)). The endpoint exposes no
+// total record count, so pagination relies on the page-full heuristic below
+// instead of a computed page count.
+const RUTAS_DEFAULT_LIMIT = 50;
+const RUTAS_MAX_LIMIT = 100;
+
+type RutasPageSearchParams = {
+  offset?: string | string[];
+  limit?: string | string[];
+};
+
+function normalizeSearchParamValue(
+  value: string | string[] | undefined,
+): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+function normalizeOffset(value: string | string[] | undefined): number {
+  const parsed = Number(normalizeSearchParamValue(value));
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function normalizeLimit(value: string | string[] | undefined): number {
+  const parsed = Number(normalizeSearchParamValue(value));
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return RUTAS_DEFAULT_LIMIT;
+  }
+
+  return Math.min(parsed, RUTAS_MAX_LIMIT);
+}
+
+function buildRutasHref(offset: number, limit: number): string {
+  return `/dashboard/logistica/rutas?offset=${offset}&limit=${limit}`;
+}
+
 async function getLogisticsRequestOptions(): Promise<RequestInit> {
   const cookieHeader = (await cookies()).toString();
 
@@ -33,18 +70,37 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
   };
 }
 
-export default async function RutasPage() {
+export default async function RutasPage({
+  searchParams,
+}: {
+  searchParams?: Promise<RutasPageSearchParams>;
+}) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const offset = normalizeOffset(resolvedSearchParams.offset);
+  const limit = normalizeLimit(resolvedSearchParams.limit);
+
   let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
   let routePlansLoadError = false;
 
   try {
-    routePlans = await getRoutePlans(await getLogisticsRequestOptions(), {
-      throwOnError: true,
-    });
+    routePlans = await getRoutePlans(
+      await getLogisticsRequestOptions(),
+      { throwOnError: true },
+      { limit, offset },
+    );
   } catch (error) {
     redirectToLoginOnUnauthorized(error);
     routePlansLoadError = true;
   }
+
+  // No `total` is exposed by the endpoint: page-full is the only signal
+  // available, so `canGoNext` may false-positive on an exact-multiple last
+  // page — documented tradeoff, not a bug (docs/audit/clinic-logistics-full-routes-adaptive-contract-audit.md).
+  const canGoPrevious = !routePlansLoadError && offset > 0;
+  const canGoNext = !routePlansLoadError && routePlans.length === limit;
+  const currentPage = Math.floor(offset / limit) + 1;
+  const previousHref = buildRutasHref(Math.max(0, offset - limit), limit);
+  const nextHref = buildRutasHref(offset + limit, limit);
 
   return (
     <>
@@ -74,12 +130,19 @@ export default async function RutasPage() {
             );
           })}
         </div>
+        <p className="text-xs text-muted-foreground">
+          Conteos calculados sobre la página visible, no sobre el total general de planes de ruta.
+        </p>
 
         <Card className="dashboard-surface">
           <CardHeader>
             <CardTitle className="text-base">
               Planes de ruta ({routePlans.length})
             </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Mostrando {routePlans.length} planes de ruta · página {currentPage}
+              {canGoNext ? " · puede haber más planes de ruta disponibles" : ""}
+            </p>
           </CardHeader>
           <CardContent className="p-0">
             <Table>
@@ -164,6 +227,32 @@ export default async function RutasPage() {
               </TableBody>
             </Table>
           </CardContent>
+          <nav
+            aria-label="Paginación de planes de ruta"
+            className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+          >
+            <PublicRouteControl
+              href={previousHref}
+              variant="bare"
+              disabled={!canGoPrevious}
+              aria-label="Página anterior"
+              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Anterior
+            </PublicRouteControl>
+            <span className="dashboard-pagination-context">
+              Página {currentPage}
+            </span>
+            <PublicRouteControl
+              href={nextHref}
+              variant="bare"
+              disabled={!canGoNext}
+              aria-label="Página siguiente"
+              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Siguiente
+            </PublicRouteControl>
+          </nav>
         </Card>
       </main>
     </>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1430,16 +1430,33 @@ export async function getLogisticsFieldVisits(
   }
 }
 
+type LogisticsRoutePlansParams = {
+  limit?: number;
+  offset?: number;
+};
+
 export async function getRoutePlans(
   options?: RequestInit,
   readOptions: LogisticsReadOptions = {},
+  params?: LogisticsRoutePlansParams,
 ): Promise<RoutePlan[]> {
   try {
-    const res = await apiFetch<{ plans: RoutePlan[] }>(
-      "/api/logistics/route-plans",
+    const path = "/api/logistics/route-plans";
+    const query = new URLSearchParams();
+
+    if (params?.limit !== undefined) {
+      query.set("limit", String(params.limit));
+    }
+    if (params?.offset !== undefined) {
+      query.set("offset", String(params.offset));
+    }
+
+    const qs = query.toString();
+    const res = await apiFetch<{ routePlans: RoutePlan[] }>(
+      qs ? `${path}?${qs}` : path,
       options,
     );
-    return res.plans ?? [];
+    return res.routePlans ?? [];
   } catch (error) {
     warnApiFallback("getRoutePlans", error);
     if (readOptions.throwOnError) {

--- a/test/frontend-dashboard-logistica-rutas.test.ts
+++ b/test/frontend-dashboard-logistica-rutas.test.ts
@@ -33,8 +33,42 @@ test("dashboard logistica rutas forwards cookies and disables cache for live rea
   assert.ok(source.includes("headers: cookieHeader ? { Cookie: cookieHeader } : {},"));
   assert.ok(source.includes("let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];"));
   assert.ok(source.includes("let routePlansLoadError = false;"));
-  assert.ok(source.includes("routePlans = await getRoutePlans(await getLogisticsRequestOptions(), {"));
-  assert.ok(source.includes("throwOnError: true,"));
+  assert.ok(source.includes("routePlans = await getRoutePlans("));
+  assert.ok(source.includes("await getLogisticsRequestOptions(),"));
+  assert.ok(source.includes("{ throwOnError: true },"));
+});
+
+test("dashboard logistica rutas sends explicit limit/offset instead of truncating silently (R-13)", () => {
+  const source = read(RUTAS_PAGE_PATH);
+
+  assert.ok(source.includes("{ limit, offset },"));
+  assert.ok(source.includes("const RUTAS_DEFAULT_LIMIT = 50;"));
+  assert.ok(source.includes("const RUTAS_MAX_LIMIT = 100;"));
+  assert.ok(source.includes("function normalizeOffset(value: string | string[] | undefined): number {"));
+  assert.ok(source.includes("function normalizeLimit(value: string | string[] | undefined): number {"));
+  assert.ok(source.includes("searchParams?: Promise<RutasPageSearchParams>;"));
+});
+
+test("dashboard logistica rutas computes canGoNext/canGoPrevious without a backend total (R-13)", () => {
+  const source = read(RUTAS_PAGE_PATH);
+
+  assert.ok(source.includes("const canGoPrevious = !routePlansLoadError && offset > 0;"));
+  assert.ok(source.includes("const canGoNext = !routePlansLoadError && routePlans.length === limit;"));
+  assert.equal(source.includes("pageCount"), false);
+  assert.equal(source.includes("matchMedia"), false);
+  assert.equal(source.includes("ResizeObserver"), false);
+});
+
+test("dashboard logistica rutas renders a pager and page-scope disclosure (R-13)", () => {
+  const source = read(RUTAS_PAGE_PATH);
+
+  assert.ok(source.includes('aria-label="Paginación de planes de ruta"'));
+  assert.ok(source.includes('aria-label="Página anterior"'));
+  assert.ok(source.includes('aria-label="Página siguiente"'));
+  assert.ok(source.includes("disabled={!canGoPrevious}"));
+  assert.ok(source.includes("disabled={!canGoNext}"));
+  assert.ok(source.includes("Mostrando {routePlans.length} planes de ruta · página {currentPage}"));
+  assert.ok(source.includes("Conteos calculados sobre la página visible, no sobre el total general de planes de ruta."));
 });
 
 test("dashboard logistica rutas renders topbar without technical source copy", () => {


### PR DESCRIPTION
## Summary
- Adds explicit limit/offset pagination contract for the clinic logistics rutas full route
- Removes silent default truncation by surfacing page state and next-page affordance
- Extends getRoutePlans with backwards-compatible limit/offset params and reads the backend routePlans payload key
- Documents the no-total backend contract and canGoNext page-full heuristic
- Adds directed e2e coverage for /dashboard/logistica/rutas

## Scope note
- Includes one e2e fixture change in frontend/e2e/fixtures/admin-populated-api-server.mjs
- The fixture handler is gated to /api/logistics/route-plans requests that include both limit and offset
- Legacy no-querystring call paths remain unhandled to preserve existing state-parity coverage

## Validations
- git diff --check
- pnpm test
- pnpm typecheck:test
- pnpm typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend build
- pnpm --dir frontend exec playwright test e2e/dashboard-logistica-rutas-full-route-adaptive.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-module-state-parity.spec.ts --project=chromium --grep "operaciones/informes/logistica"

## Regression triage
- Full state-parity run exposes two unrelated pre-existing/flaky failures in tokens/perfil
- R-13 route-plans fixture cannot affect those tests because they use independent page.route mocks for /api/particular-tokens and /api/clinic/profile
- Logistica state-parity subset is green and preserves the no-querystring route-plans invariant

## Scope
- No backend/API/auth/DB/server/migrations changes
- No globals.css changes
- No visitas page changes
- No metricas/LogisticsCommandCenter changes
- No Admin/Particular/Público changes
- No R-14/R-15/R-16 changes