### PR TITLE
feat(clinic): adapt logistics metricas full route

### DIFF
--- a/docs/implementation/adapt-logistics-metricas-full-route.md
+++ b/docs/implementation/adapt-logistics-metricas-full-route.md
@@ -1,0 +1,229 @@
+# R-14 — Clínica `/dashboard/logistica/metricas` full route adaptive contract
+
+## PR
+
+`feat(clinic): adapt logistics metricas full route`
+
+## Base
+
+- Rama: `feat/clinic-logistics-metricas-full-route-adaptive`.
+- Base: `main @ 12a7ae4 feat(clinic): adapt logistics rutas full route (#1276)`.
+- Fecha: 2026-07-03.
+
+## Documentos usados
+
+1. `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — R-14, Fase 2.
+2. `docs/audit/clinic-logistics-full-routes-adaptive-contract-audit.md` (R-11) —
+   auditoría rectora; contrato exacto de esta migración.
+3. `docs/implementation/adapt-logistics-rutas-full-route.md` (R-13) — patrón
+   de pager/limit/offset que esta migración reutiliza, adaptado al fan-out
+   propio de métricas.
+
+## Deuda original (R-11) y fan-out P1
+
+`frontend/src/app/dashboard/logistica/metricas/page.tsx` llamaba
+`getRoutePlans(requestOptions, { throwOnError: true })` sin `limit`/`offset`
+(truncamiento silencioso a 50 planes, offset 0 — mismo defecto que R-12/R-13),
+y además hacía **fan-out**: por cada plan de ruta devuelto, disparaba una
+request adicional en paralelo vía `getRoutePlanMetrics(plan.id, ...)` dentro
+de un `Promise.all`. Con el default silencioso de 50 planes, una sola carga
+de página podía emitir **hasta 50 requests HTTP paralelos** al backend
+(`GET /api/logistics/route-plans/:id/metrics` × N), sin paginación, sin cap,
+sin indicio en la UI. Este es el hallazgo P1 que R-11 dejó documentado y
+fuera de scope de R-12/R-13 (que explícitamente no tocaron `metricas/`).
+
+## Contrato nuevo
+
+- `metricas/page.tsx` **sigue siendo un server component puro** — sin
+  wrapper cliente, `matchMedia` ni `ResizeObserver`.
+- Lee `offset` y `limit` desde `searchParams` (Next 15,
+  `searchParams?: Promise<MetricasPageSearchParams>`, mismo patrón que
+  `rutas/page.tsx` y `visitas/page.tsx`).
+- El fetch de planes pasa `{ limit, offset }` explícitos a `getRoutePlans`:
+  `getRoutePlans(requestOptions, { throwOnError: true }, { limit, offset })`.
+- El fan-out de métricas (`routePlans.map(plan => getRoutePlanMetrics(...))`)
+  se ejecuta **únicamente sobre el array `routePlans` ya paginado** — nunca
+  sobre un universo mayor. Al acotar `routePlans` a la página visible, el
+  número de requests de métricas queda acotado a esa misma página.
+- Pager real (`<nav aria-label="Paginación de métricas de ruta">`) con
+  botones "Anterior"/"Siguiente" (`PublicRouteControl` variant `bare`,
+  navegación por `href` `?offset=N&limit=M`), idéntico en estructura al de
+  `rutas`/`visitas`.
+- Copy explícito: `Mostrando {routeMetrics.length} métricas de ruta · página
+  {currentPage}` y, cuando corresponde, `· puede haber más planes de ruta
+  disponibles` — nunca se menciona un "total" porque el endpoint no lo
+  expone.
+- Las 4 cards resumen (Cumplimiento promedio / Paradas completadas /
+  Duración promedio / Planes analizados) **no cambiaron su cálculo** —
+  siguen agregando sobre `routeMetrics` — pero ahora `routeMetrics` está
+  acotado a la página visible, y se agregó una leyenda explícita debajo de
+  la grilla: `Métricas calculadas sobre la página visible (máximo {limit}
+  planes), no sobre el total general de rutas.`
+
+## Cap específico de métricas — por qué NO hereda el default de rutas/visitas
+
+`rutas`/`visitas` usan `DEFAULT_LIMIT = 50` / `MAX_LIMIT = 100` porque su
+endpoint backend expone ese default/max
+(`parsePositiveInt(request.query.limit, 50, 100)`) y hacen **1 sola request**
+por página. `métricas` en cambio hace **1 request adicional por plan
+devuelto** (`getRoutePlanMetrics` por cada elemento de `routePlans`). Heredar
+`limit=50` habría dejado intacto el fan-out P1 (hasta 50 requests de
+métricas en paralelo), sólo que ahora "paginado" en vez de "todo el rato".
+Por eso este PR define límites **propios y más bajos**, independientes del
+default/max del endpoint `route-plans`:
+
+```ts
+const METRICAS_DEFAULT_LIMIT = 12;
+const METRICAS_MAX_LIMIT = 24;
+```
+
+- Default `12`: una carga de página sin querystring dispara como máximo 12
+  requests de métricas en paralelo (antes: hasta 50).
+- Cap máximo `24` (clamp vía `Math.min(parsed, METRICAS_MAX_LIMIT)` en
+  `normalizeLimit`): ningún valor de `limit` en la URL, por más alto que se
+  pida, puede forzar más de 24 requests de métricas simultáneos. Esto es
+  intencional y **distinto** del cap de `rutas`/`visitas` (100) porque el
+  costo por ítem no es 1 request sino 1 request de planes + 1 request de
+  métricas por plan.
+
+## limit/offset — sin tocar `frontend/src/lib/api.ts`
+
+`getRoutePlans` ya soporta `{ limit?, offset? }` desde R-13
+(`LogisticsRoutePlansParams`), de forma backwards-compatible. Este PR **no
+modificó `frontend/src/lib/api.ts`** — sólo cambió el call-site en
+`metricas/page.tsx` para pasar el tercer argumento que antes no enviaba.
+`getRoutePlanMetrics` tampoco se tocó: sigue aceptando un `planId` y
+devolviendo `RouteMetrics[]` (0 o 1 elemento).
+
+## Paginación sin `total` — heurística de página llena
+
+El endpoint `route-plans` no expone un `total` de universo, igual que en
+R-13:
+
+- `canGoPrevious = !routePlansLoadError && offset > 0`.
+- `canGoNext = !routePlansLoadError && routePlans.length === limit` (página
+  llena ⇒ posible más). Mismo trade-off documentado que R-12/R-13 (falso
+  positivo posible en un múltiplo exacto del `limit`).
+- No se calcula `pageCount` en ningún momento.
+
+## Métricas sobre la página visible
+
+`routeMetrics` se deriva exclusivamente de `routePlans` (el array ya
+paginado): las 4 cards resumen, el listado detallado por plan y el conteo
+"Mostrando N métricas de ruta" reflejan **sólo la página actual**, nunca el
+total general de rutas. Esto está declarado explícitamente en la UI (ver
+"Contrato nuevo" arriba) para que no se interprete como una métrica global.
+
+## E2E — `frontend/e2e/dashboard-logistica-metricas-full-route-adaptive.spec.ts`
+
+5 tests, `chromium`, sesión fixture (`app_session_id=e2e_populated_clinic_session`)
+servida por `frontend/e2e/fixtures/admin-populated-api-server.mjs`.
+
+### Fixture: excepción R-14, aditiva y gateada
+
+`metricas/page.tsx` ahora envía `limit`/`offset` explícitos, por lo que sus
+requests a `/api/logistics/route-plans` empiezan a coincidir con el handler
+que R-13 ya había agregado (gateado por presencia de `limit` **y** `offset`
+en el querystring) y reciben los 3 `CLINIC_ROUTE_PLANS` fijos (ids 8601,
+8602, 8603). Ese handler **no se modificó**.
+
+Se agregó un handler nuevo, exclusivo de R-14, para
+`GET /api/logistics/route-plans/:id/metrics` (antes inexistente en el
+fixture): responde `{ metrics }` con una entrada fija por cada id de
+`CLINIC_ROUTE_PLANS` (`CLINIC_ROUTE_METRICS_BY_PLAN_ID`), gateado también
+por sesión de clínica poblada. Es **aditivo y aislado**:
+
+- No modifica el handler de `route-plans` ni el de `field-visits`.
+- No afecta ningún test existente de `rutas`, `visitas` ni del hub
+  (`dashboard-clinic-module-state-parity.spec.ts` sigue sin ver este path).
+- Sólo responde a un path (`/api/logistics/route-plans/:id/metrics`) que
+  ningún otro spec del fixture compartido ejercitaba.
+
+### Por qué el fan-out se valida por contenido renderizado y no por red
+
+`metricas/page.tsx` es un server component puro: las llamadas a
+`getRoutePlans`/`getRoutePlanMetrics` ocurren en el servidor de Next.js
+(SSR → fixture), no en el navegador. `page.on("request")` de Playwright sólo
+observa tráfico del navegador, así que no puede contar las requests
+servidor-a-servidor. Por eso el fan-out acotado a la página visible se
+valida verificando que se renderiza **exactamente 1 card de detalle por
+plan de la página** (`.surface-soft` count === 3, ni más ni menos), en vez
+de instrumentar contadores de red en el fixture compartido (evitado a
+propósito para no introducir estado global que interfiera con tests
+concurrentes de otros specs sobre el mismo servidor).
+
+### Tests
+
+1. **3 viewports críticos** (`1440x900`, `1366x768` desktop corto,
+   `390x844` mobile), sin querystring (limit default = 12): pager siempre
+   visible, `Anterior`/`Siguiente` deshabilitados (dataset fixture = 3
+   planes, muy por debajo de 12 ⇒ no hay página siguiente real), exactamente
+   3 cards de detalle (`.surface-soft`) renderizadas, leyenda de página
+   visible con el cap (`máximo 12 planes`) presente, y **sin scroll externo**
+   ni overflow horizontal del pager.
+2. **Agregados reales calculados end-to-end**: navega sin querystring y
+   verifica que las 4 cards resumen reflejan los valores exactos derivados
+   de las 3 métricas fixture (cumplimiento promedio 85%, paradas
+   completadas 15/23, duración promedio 49 min) y que los 3 badges de
+   cumplimiento por plan (90%/65%/100%) están presentes — confirma que el
+   pipeline fetch→fan-out→agregación funciona con datos reales del fixture,
+   no sólo que el markup existe.
+3. **Heurística de página llena + navegación real**: navega con
+   `?limit=3&offset=0` (fuerza `routePlans.length === limit` de forma
+   determinística); confirma `Siguiente` habilitado, click, la URL pasa a
+   `offset=3&limit=3`, el indicador pasa a "Página 2", `Anterior` se
+   habilita; click en `Anterior` vuelve a `offset=0` / "Página 1".
+
+No se depende de datos de producción en ningún test.
+
+## Validaciones ejecutadas
+
+- `git diff --check` — limpio (sólo warning informativo de line-endings
+  LF→CRLF de Git en Windows, no bloqueante).
+- `pnpm test` — verde, 2960/2960 (incluye tests actualizados en
+  `test/frontend-dashboard-logistica-metricas.test.ts` y el contrato
+  compartido `test/frontend-logistics-metrics-live-read-contract.test.ts`,
+  que siguió pasando sin modificaciones).
+- `pnpm typecheck:test` — sin errores.
+- `pnpm typecheck` — sin errores.
+- `pnpm --dir frontend lint` — sin errores.
+- `pnpm --dir frontend build` — build de producción exitoso;
+  `/dashboard/logistica/metricas` sigue listada como ruta dinámica (`ƒ`,
+  server-rendered), confirmando que sigue siendo server component.
+- `pnpm --dir frontend exec playwright test
+  e2e/dashboard-logistica-metricas-full-route-adaptive.spec.ts
+  --project=chromium` — 5/5 passed.
+- `git restore frontend/next-env.d.ts` ejecutado después de correr
+  Playwright (regenera la ruta de dev del dev server) y antes de repetir
+  `pnpm test` / `pnpm typecheck:test`, que se re-confirmaron en verde tras
+  el restore.
+
+## Confirmaciones de scope
+
+- **Sin backend/API/auth/DB/server/migraciones**: no se modificó ningún
+  archivo de `server/`; `frontend/src/lib/api.ts` tampoco se tocó (las
+  funciones que este PR usa ya existían con la firma necesaria desde R-13).
+- **Sin `globals.css`**: el pager reutiliza clases ya existentes
+  (`dashboard-pagination-btn`, `dashboard-pagination-context`,
+  `dashboard-surface`, `surface-soft`, etc.); no se agregó ni modificó
+  ninguna regla CSS.
+- **Sin `visitas/`, `rutas/` ni `LogisticsCommandCenter.tsx`**: no se tocó
+  ningún archivo de esas rutas ni del hub.
+- **Sin R-15/R-16**: no se avanzó `MasterDetailWorkspace` (R-15) ni Tokens
+  Clínica (R-16). Quedan documentados en R-11/R-13 como próximos PRs, fuera
+  de este scope.
+- **Sin Admin, Particular ni Público**: archivos tocados son
+  `frontend/src/app/dashboard/logistica/metricas/page.tsx`,
+  `test/frontend-dashboard-logistica-metricas.test.ts`, el e2e nuevo, el
+  fixture compartido de e2e (adición aditiva y gateada, ver sección de
+  E2E), y este documento.
+
+## Archivos tocados
+
+- `frontend/src/app/dashboard/logistica/metricas/page.tsx`
+- `test/frontend-dashboard-logistica-metricas.test.ts`
+- `frontend/e2e/dashboard-logistica-metricas-full-route-adaptive.spec.ts` (nuevo)
+- `frontend/e2e/fixtures/admin-populated-api-server.mjs` (adición aditiva y
+  gateada, fuera de la lista de scope original — ver justificación en la
+  sección de E2E)
+- `docs/implementation/adapt-logistics-metricas-full-route.md` (nuevo, este documento)

--- a/frontend/e2e/dashboard-logistica-metricas-full-route-adaptive.spec.ts
+++ b/frontend/e2e/dashboard-logistica-metricas-full-route-adaptive.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "desktop-1440x900", width: 1440, height: 900 },
+  { name: "desktop-short-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+// Fixture (frontend/e2e/fixtures/admin-populated-api-server.mjs) serves a
+// fixed 3-plan CLINIC_ROUTE_PLANS array (ids 8601/8602/8603) whenever the
+// request carries limit/offset, plus one metrics entry per id. Because
+// metricas/page.tsx is a pure server component, its route-plans/metrics
+// fetches happen server-to-server (Next.js SSR -> fixture) and are never
+// visible to the browser's network stack, so fan-out scoping is asserted
+// via rendered content (exactly 1 metric detail card per page-visible route
+// plan) rather than via page.on("request").
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readNoExternalScroll(page: Page) {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    return {
+      htmlScrollHeight: html.scrollHeight,
+      htmlClientHeight: html.clientHeight,
+      bodyScrollHeight: body.scrollHeight,
+      bodyClientHeight: body.clientHeight,
+    };
+  });
+}
+
+test.describe("clinic Logística Métricas full route adaptive contract (R-14)", () => {
+  for (const viewport of VIEWPORTS) {
+    test(`renders an always-visible pager sized to ${viewport.name} without external scroll`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setPopulatedClinicSession(page);
+
+      await page.goto("/dashboard/logistica/metricas");
+
+      const pager = page.getByRole("navigation", { name: "Paginación de métricas de ruta" });
+      const previousButton = page.getByRole("button", { name: "Página anterior" });
+      const nextButton = page.getByRole("button", { name: "Página siguiente" });
+      const pageIndicator = pager.locator(".dashboard-pagination-context");
+      const metricCards = page.locator(".surface-soft");
+
+      await expect(async () => {
+        await expect(pager).toBeVisible();
+        await expect(previousButton).toBeVisible();
+        await expect(nextButton).toBeVisible();
+
+        const cardCount = await metricCards.count();
+        expect(cardCount, `${viewport.name}: metrics fan-out`).toBe(3);
+      }).toPass({ timeout: 12_000 });
+
+      // Fixture dataset (3 route plans) is far below the metrics default
+      // page-size limit (12), so this is the "everything fits on page 1"
+      // contract state: no previous page, and the page-full heuristic
+      // correctly reports no further page either.
+      await expect(previousButton).toBeDisabled();
+      await expect(nextButton).toBeDisabled();
+      await expect(pageIndicator).toHaveText("Página 1");
+      await expect(
+        page.getByText(
+          "Métricas calculadas sobre la página visible (máximo 12 planes), no sobre el total general de rutas.",
+        ),
+      ).toBeVisible();
+
+      // Fan-out is bounded to exactly the visible-page route plans (one
+      // metric detail card per plan) — never more, never fewer.
+      await expect(metricCards).toHaveCount(3);
+
+      await expect(async () => {
+        const metrics = await readNoExternalScroll(page);
+        expect(
+          metrics.htmlScrollHeight,
+          `${viewport.name}: documentElement must not scroll globally`,
+        ).toBeLessThanOrEqual(metrics.htmlClientHeight + TOLERANCE);
+        expect(
+          metrics.bodyScrollHeight,
+          `${viewport.name}: body must not scroll globally`,
+        ).toBeLessThanOrEqual(metrics.bodyClientHeight + TOLERANCE);
+      }).toPass({ timeout: 10_000 });
+
+      const pagerBox = await pager.boundingBox();
+      expect(pagerBox, `${viewport.name}: pager bounding box`).not.toBeNull();
+      expect(
+        pagerBox!.x + pagerBox!.width,
+        `${viewport.name}: pager right edge`,
+      ).toBeLessThanOrEqual(viewport.width + TOLERANCE);
+      expect(pagerBox!.x, `${viewport.name}: pager left edge`).toBeGreaterThanOrEqual(-TOLERANCE);
+    });
+  }
+
+  test("renders real aggregate metrics computed from the visible page only", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await setPopulatedClinicSession(page);
+
+    await page.goto("/dashboard/logistica/metricas");
+
+    // Fixture metrics: compliance 90/65/100 -> avg 85%; completed 3+2+10=15
+    // of total 8+5+10=23; durations 42/55/null -> avg of [42,55] = 49min.
+    await expect(async () => {
+      await expect(page.getByText("85%")).toBeVisible();
+      await expect(page.getByText("15/23")).toBeVisible();
+      await expect(page.getByText("49 min")).toBeVisible();
+    }).toPass({ timeout: 12_000 });
+
+    await expect(page.getByText("Mostrando 3 métricas de ruta · página 1")).toBeVisible();
+    await expect(page.getByText("90% cumplimiento")).toBeVisible();
+    await expect(page.getByText("65% cumplimiento")).toBeVisible();
+    await expect(page.getByText("100% cumplimiento")).toBeVisible();
+  });
+
+  test("page-full heuristic enables next/previous navigation and keeps the offset contract in the URL", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await setPopulatedClinicSession(page);
+
+    // The fixture serves exactly 3 route plans regardless of limit/offset,
+    // so requesting `limit=3` forces the deterministic "page full" state
+    // (routePlans.length === limit) without depending on real production data.
+    await page.goto("/dashboard/logistica/metricas?limit=3&offset=0");
+
+    const pager = page.getByRole("navigation", { name: "Paginación de métricas de ruta" });
+    const previousButton = page.getByRole("button", { name: "Página anterior" });
+    const nextButton = page.getByRole("button", { name: "Página siguiente" });
+    const pageIndicator = pager.locator(".dashboard-pagination-context");
+
+    await expect(async () => {
+      await expect(nextButton).toBeEnabled();
+      await expect(previousButton).toBeDisabled();
+    }).toPass({ timeout: 12_000 });
+
+    await expect(pageIndicator).toHaveText("Página 1");
+    await expect(page.getByText(/puede haber más planes de ruta disponibles/)).toBeVisible();
+
+    await nextButton.click();
+
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("offset")).toBe("3");
+      expect(url.searchParams.get("limit")).toBe("3");
+    }).toPass({ timeout: 10_000 });
+
+    await expect(pageIndicator).toHaveText("Página 2");
+    await expect(previousButton).toBeEnabled();
+
+    await previousButton.click();
+
+    await expect(async () => {
+      const url = new URL(page.url());
+      expect(url.searchParams.get("offset")).toBe("0");
+    }).toPass({ timeout: 10_000 });
+    await expect(pageIndicator).toHaveText("Página 1");
+    await expect(previousButton).toBeDisabled();
+  });
+});

--- a/frontend/e2e/fixtures/admin-populated-api-server.mjs
+++ b/frontend/e2e/fixtures/admin-populated-api-server.mjs
@@ -184,6 +184,41 @@ const CLINIC_ROUTE_PLANS = [
   },
 ];
 
+// R-14 exception: additive-only, keyed by CLINIC_ROUTE_PLANS id. Serves
+// GET /api/logistics/route-plans/:id/metrics so metricas/page.tsx (which now
+// requests limit/offset and therefore matches the route-plans handler above)
+// can resolve its per-page-visible-plan metrics fan-out end to end. Does not
+// touch the route-plans or field-visits handlers or their gating.
+const CLINIC_ROUTE_METRICS_BY_PLAN_ID = {
+  8601: {
+    routePlanId: 8601,
+    totalStops: 8,
+    completedStops: 3,
+    skippedStops: 1,
+    noShowStops: 0,
+    complianceRate: 90,
+    averageDurationMinutes: 42,
+  },
+  8602: {
+    routePlanId: 8602,
+    totalStops: 5,
+    completedStops: 2,
+    skippedStops: 1,
+    noShowStops: 1,
+    complianceRate: 65,
+    averageDurationMinutes: 55,
+  },
+  8603: {
+    routePlanId: 8603,
+    totalStops: 10,
+    completedStops: 10,
+    skippedStops: 0,
+    noShowStops: 0,
+    complianceRate: 100,
+    averageDurationMinutes: null,
+  },
+};
+
 // PR-R06: audit is RF debounced (high-volume, no over-fetch superset), so the
 // mobile adaptive list can request a limit up to ADMIN_AUDIT_LIMIT_CAP (32).
 // The base 11 hand-authored entries are cycled to reach the fixture's
@@ -826,6 +861,20 @@ const server = createServer((request, response) => {
     (url.searchParams.has("limit") && url.searchParams.has("offset"))
   ) {
     sendJson(response, 200, { routePlans: CLINIC_ROUTE_PLANS });
+    return;
+  }
+
+  const routePlanMetricsMatch = url.pathname.match(
+    /^\/api\/logistics\/route-plans\/(\d+)\/metrics$/,
+  );
+  if (hasPopulatedClinicSession(request) && routePlanMetricsMatch) {
+    const planId = Number(routePlanMetricsMatch[1]);
+    const metrics = CLINIC_ROUTE_METRICS_BY_PLAN_ID[planId];
+    if (metrics) {
+      sendJson(response, 200, { metrics });
+    } else {
+      sendJson(response, 404, { error: "route plan metrics not found" });
+    }
     return;
   }
 

--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import {
   Card,
   CardContent,
@@ -17,6 +18,43 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// getRoutePlanMetrics issues 1 backend request per visible route plan.
+// Unlike rutas/visitas, this page must NOT inherit the backend route-plans
+// default (50): that would fan out up to 50 parallel metrics requests per
+// page load. These metrics-specific limits cap that fan-out independently
+// of the backend route-plans default/max (parsePositiveInt(..., 50, 100)).
+const METRICAS_DEFAULT_LIMIT = 12;
+const METRICAS_MAX_LIMIT = 24;
+
+type MetricasPageSearchParams = {
+  offset?: string | string[];
+  limit?: string | string[];
+};
+
+function normalizeSearchParamValue(
+  value: string | string[] | undefined,
+): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+function normalizeOffset(value: string | string[] | undefined): number {
+  const parsed = Number(normalizeSearchParamValue(value));
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function normalizeLimit(value: string | string[] | undefined): number {
+  const parsed = Number(normalizeSearchParamValue(value));
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return METRICAS_DEFAULT_LIMIT;
+  }
+
+  return Math.min(parsed, METRICAS_MAX_LIMIT);
+}
+
+function buildMetricasHref(offset: number, limit: number): string {
+  return `/dashboard/logistica/metricas?offset=${offset}&limit=${limit}`;
+}
+
 async function getLogisticsRequestOptions(): Promise<RequestInit> {
   const cookieHeader = (await cookies()).toString();
 
@@ -26,7 +64,15 @@ async function getLogisticsRequestOptions(): Promise<RequestInit> {
   };
 }
 
-export default async function MetricasPage() {
+export default async function MetricasPage({
+  searchParams,
+}: {
+  searchParams?: Promise<MetricasPageSearchParams>;
+}) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const offset = normalizeOffset(resolvedSearchParams.offset);
+  const limit = normalizeLimit(resolvedSearchParams.limit);
+
   const requestOptions = await getLogisticsRequestOptions();
   let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
   let routePlansLoadError = false;
@@ -34,8 +80,9 @@ export default async function MetricasPage() {
   let routeMetricsLoadError = false;
 
   try {
-    routePlans = await getRoutePlans(requestOptions, {
-      throwOnError: true,
+    routePlans = await getRoutePlans(requestOptions, { throwOnError: true }, {
+      limit,
+      offset,
     });
   } catch (error) {
     redirectToLoginOnUnauthorized(error);
@@ -58,6 +105,16 @@ export default async function MetricasPage() {
       routeMetricsLoadError = true;
     }
   }
+
+  // No `total` is exposed by the route-plans endpoint: page-full is the
+  // only signal available, so `canGoNext` may false-positive on an
+  // exact-multiple last page — same documented tradeoff as rutas/visitas
+  // (docs/audit/clinic-logistics-full-routes-adaptive-contract-audit.md).
+  const canGoPrevious = !routePlansLoadError && offset > 0;
+  const canGoNext = !routePlansLoadError && routePlans.length === limit;
+  const currentPage = Math.floor(offset / limit) + 1;
+  const previousHref = buildMetricasHref(Math.max(0, offset - limit), limit);
+  const nextHref = buildMetricasHref(offset + limit, limit);
 
   const totalStops = routeMetrics.reduce(
     (sum, metric) => sum + metric.totalStops,
@@ -147,6 +204,10 @@ export default async function MetricasPage() {
             </CardContent>
           </Card>
         </div>
+        <p className="text-xs text-muted-foreground">
+          Métricas calculadas sobre la página visible (máximo {limit} planes),
+          no sobre el total general de rutas.
+        </p>
 
         <Card className="dashboard-surface">
           <CardHeader>
@@ -154,6 +215,10 @@ export default async function MetricasPage() {
             <CardDescription>
               Detalle de cumplimiento por cada plan ejecutado
             </CardDescription>
+            <p className="text-sm text-muted-foreground">
+              Mostrando {routeMetrics.length} métricas de ruta · página {currentPage}
+              {canGoNext ? " · puede haber más planes de ruta disponibles" : ""}
+            </p>
           </CardHeader>
           <CardContent className="space-y-4">
             {routePlansLoadError ? (
@@ -234,6 +299,32 @@ export default async function MetricasPage() {
               </div>
             )}
           </CardContent>
+          <nav
+            aria-label="Paginación de métricas de ruta"
+            className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+          >
+            <PublicRouteControl
+              href={previousHref}
+              variant="bare"
+              disabled={!canGoPrevious}
+              aria-label="Página anterior"
+              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Anterior
+            </PublicRouteControl>
+            <span className="dashboard-pagination-context">
+              Página {currentPage}
+            </span>
+            <PublicRouteControl
+              href={nextHref}
+              variant="bare"
+              disabled={!canGoNext}
+              aria-label="Página siguiente"
+              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Siguiente
+            </PublicRouteControl>
+          </nav>
         </Card>
       </main>
     </>

--- a/test/frontend-dashboard-logistica-metricas.test.ts
+++ b/test/frontend-dashboard-logistica-metricas.test.ts
@@ -20,6 +20,7 @@ test("dashboard logistica metricas defines non-indexable metadata and dependenci
   assert.ok(source.includes('title: "Métricas de logística — Portal VETNEB"'));
   assert.ok(source.includes("robots: { index: false, follow: false },"));
   assert.ok(source.includes('import { DashboardTopbar } from "@/components/dashboard/DashboardTopbar";'));
+  assert.ok(source.includes('import { PublicRouteControl } from "@/components/public/PublicRouteControl";'));
   assert.ok(source.includes('import { Badge } from "@/components/ui/badge";'));
   assert.ok(source.includes('import { getRoutePlanMetrics, getRoutePlans } from "@/lib/api";'));
 });
@@ -34,12 +35,30 @@ test("dashboard logistica metricas forwards cookies and disables cache for live 
   assert.ok(source.includes("const requestOptions = await getLogisticsRequestOptions();"));
 });
 
-test("dashboard logistica metricas reads route plans and plan metrics", () => {
+test("dashboard logistica metricas sends explicit limit/offset with a metrics-specific fan-out cap (R-14)", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const METRICAS_DEFAULT_LIMIT = 12;"));
+  assert.ok(source.includes("const METRICAS_MAX_LIMIT = 24;"));
+  assert.ok(source.includes("function normalizeOffset(value: string | string[] | undefined): number {"));
+  assert.ok(source.includes("function normalizeLimit(value: string | string[] | undefined): number {"));
+  assert.ok(source.includes("searchParams?: Promise<MetricasPageSearchParams>;"));
+  assert.ok(
+    source.includes(
+      "getRoutePlans(requestOptions, { throwOnError: true }, {\n      limit,\n      offset,\n    });",
+    ),
+  );
+  // Metrics fan-out must never inherit the rutas/visitas backend default (50).
+  assert.equal(source.includes("RUTAS_DEFAULT_LIMIT"), false);
+  assert.equal(source.includes("= 50;"), false);
+});
+
+test("dashboard logistica metricas reads route plans and plan metrics scoped to the visible page", () => {
   const source = read(METRICAS_PAGE_PATH);
 
   assert.ok(source.includes("let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];"));
   assert.ok(source.includes("let routePlansLoadError = false;"));
-  assert.ok(source.includes("routePlans = await getRoutePlans(requestOptions, {"));
+  assert.ok(source.includes("routePlans = await getRoutePlans("));
   assert.ok(source.includes("throwOnError: true,"));
   assert.ok(source.includes("let routeMetrics: Awaited<ReturnType<typeof getRoutePlanMetrics>> = [];"));
   assert.ok(source.includes("await Promise.all("));
@@ -47,6 +66,33 @@ test("dashboard logistica metricas reads route plans and plan metrics", () => {
   assert.ok(source.includes("routePlans.map((plan) =>"));
   assert.ok(source.includes("getRoutePlanMetrics(plan.id, requestOptions, {"));
   assert.ok(source.includes(").flat();"));
+});
+
+test("dashboard logistica metricas computes canGoNext/canGoPrevious without a backend total (R-14)", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes("const canGoPrevious = !routePlansLoadError && offset > 0;"));
+  assert.ok(source.includes("const canGoNext = !routePlansLoadError && routePlans.length === limit;"));
+  assert.equal(source.includes("pageCount"), false);
+  assert.equal(source.includes("matchMedia"), false);
+  assert.equal(source.includes("ResizeObserver"), false);
+});
+
+test("dashboard logistica metricas renders a pager and page-scope disclosure (R-14)", () => {
+  const source = read(METRICAS_PAGE_PATH);
+
+  assert.ok(source.includes('aria-label="Paginación de métricas de ruta"'));
+  assert.ok(source.includes('aria-label="Página anterior"'));
+  assert.ok(source.includes('aria-label="Página siguiente"'));
+  assert.ok(source.includes("disabled={!canGoPrevious}"));
+  assert.ok(source.includes("disabled={!canGoNext}"));
+  assert.ok(source.includes("Mostrando {routeMetrics.length} métricas de ruta · página {currentPage}"));
+  assert.ok(
+    source.includes(
+      "Métricas calculadas sobre la página visible (máximo {limit} planes),",
+    ),
+  );
+  assert.ok(source.includes("no sobre el total general de rutas."));
 });
 
 test("dashboard logistica metricas computes aggregate operational metrics", () => {


### PR DESCRIPTION
## Summary
- Adds explicit limit/offset pagination contract for the clinic logistics metricas full route
- Reduces metrics fan-out by requesting route metrics only for the visible paginated route-plans page
- Caps metricas to 12 default / 24 max route plans because each plan triggers one metrics request
- Documents the no-total backend contract and canGoNext page-full heuristic
- Adds directed e2e coverage for /dashboard/logistica/metricas

## Scope note
- Includes one e2e fixture change in frontend/e2e/fixtures/admin-populated-api-server.mjs
- The fixture change is additive for metricas route-plan metrics coverage
- Existing visitas/rutas/hub fixture behavior is preserved

## Validations
- git diff --check
- pnpm test
- pnpm typecheck:test
- pnpm typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend build
- pnpm --dir frontend exec playwright test e2e/dashboard-logistica-metricas-full-route-adaptive.spec.ts --project=chromium

## Scope
- No backend/API/auth/DB/server/migrations changes
- No frontend/src/lib/api.ts changes
- No globals.css changes
- No visitas/rutas/LogisticsCommandCenter changes
- No Admin/Particular/Público changes
- No R-15/R-16 changes