### PR TITLE
feat(clinic): derive tokens fetch limit from adaptive superset

### DIFF
--- a/docs/implementation/clinic-tokens-adaptive-fetch-limit.md
+++ b/docs/implementation/clinic-tokens-adaptive-fetch-limit.md
@@ -1,0 +1,123 @@
+# R-16: Clinic Tokens adaptive fetch limit (C6)
+
+## Estado base
+
+- Rama: `feat/clinic-tokens-adaptive-fetch-limit`, creada desde `main` limpio en
+  `84751cd`.
+- Documento rector: `docs/audit/final-global-vetneb-50-60-pr-roadmap.md`.
+
+## Deuda C6 (origen)
+
+`clinic-tokens-adaptive-rows-per-page.md` (PR-PILOT-1 / PR-FIX-1 / PR-CORE-1)
+activó `useAdaptiveRowsPerPage` en `ClinicParticularTokensCard`: `rowsPerPage`
+pasó a medirse contra el contenedor real, con `minRows` por defecto `2` y
+`maxRows` por defecto `50` (fundación `useAdaptiveItemsPerPage`, sin `maxRows`
+explícito en la llamada del componente). Esos mismos PRs dejaron señalado como
+riesgo residual (§"Riesgos residuales", PR-PILOT-1) que `loadTokens` seguía
+pidiendo un cap fijo de fetch de diez filas, de forma explícitamente fuera de
+scope. La matriz de auditoría (`global-zero-scroll-adaptive-dashboard-matrix.md`
+§4.3, entrada C6) formalizó la contradicción: la medición de cardinalidad
+visible quedó desacoplada del fetch que la alimenta.
+
+## Por qué el cap fijo era insuficiente
+
+`rowsPerPage` puede medir un valor mayor al cap de fetch en viewports altos
+(hasta el techo de `50` del hook). Cuando eso ocurre, la UI mide espacio para
+más filas de las que el fetch trajo: `filteredTokens` nunca supera las filas
+efectivamente descargadas, `usePagedRows` no tiene con qué llenar la página
+medida, y reaparece el mismo gap vertical que el piloto adaptativo vino a
+eliminar — sólo que ahora causado por el fetch, no por la cardinalidad fija
+original (`TOKENS_PAGE_SIZE`).
+
+## Fórmula del superset
+
+```
+TOKENS_FETCH_PAGE_MULTIPLIER = 3
+TOKENS_FETCH_LIMIT_FALLBACK = 12
+TOKENS_FETCH_LIMIT_MAX = 36
+
+effectiveFetchLimit = clamp(
+  rowsPerPage * TOKENS_FETCH_PAGE_MULTIPLIER,
+  TOKENS_FETCH_LIMIT_FALLBACK,
+  TOKENS_FETCH_LIMIT_MAX,
+)
+```
+
+Implementada como `resolveTokensFetchLimit(rowsPerPage)` en
+`ClinicParticularTokensCard.tsx`, junto a las tres constantes. `loadTokens`
+pasa a recibir `limit: number` como parámetro explícito en lugar de un literal
+hardcodeado, y todos los llamadores (`useEffect` de montaje, botón
+"Actualizar", recarga post-alta) le pasan `effectiveFetchLimit`.
+
+## Cap máximo
+
+`TOKENS_FETCH_LIMIT_MAX = 36` acota el over-fetch incluso si `rowsPerPage`
+llega a su techo de `50` (`50 * 3 = 150` sin cap). El cap es deliberadamente
+mayor al techo práctico observado en viewports reales para el módulo (evita
+reintroducir gap en pantallas altas) sin llegar a pedir cientos de filas al
+backend en un único fetch sin `total`/`cargar más`.
+
+## Relación rowsPerPage visible vs fetchLimit superset
+
+- `rowsPerPage` (medido por `useAdaptiveRowsPerPage`, sin cambios) sigue siendo
+  la única fuente de cardinalidad **visible**: `usePagedRows(filteredTokens,
+  rowsPerPage)` no se toca.
+- `effectiveFetchLimit` es exclusivamente el tamaño del **snapshot** que se le
+  pide al backend (`getClinicParticularTokens({ limit: effectiveFetchLimit,
+  offset: 0 })`), siempre `>= rowsPerPage` gracias al multiplicador `3x` y al
+  fallback `12` (mayor al `minRows` mínimo de `2`). El superset garantiza que
+  siempre haya al menos una página completa de datos de sobra para filtrar y
+  paginar en cliente, sin que el fetch decida cuántas filas se muestran.
+
+## Garantías anti-loop
+
+- El `useEffect` de carga depende únicamente de `[effectiveFetchLimit]`, no de
+  `rowsPerPage`. Como `effectiveFetchLimit` es el resultado de un `clamp`,
+  múltiples valores de `rowsPerPage` colapsan al mismo `effectiveFetchLimit`
+  (p. ej. `rowsPerPage` 2, 3 o 4 devuelven igual `12` por el fallback), por lo
+  que la mayoría de los recálculos de `rowsPerPage` (ResizeObserver, ticks de
+  medición) no disparan un nuevo fetch.
+- Sólo se dispara un nuevo `loadTokens(effectiveFetchLimit)` cuando el
+  superset derivado efectivamente cambia de valor — exactamente el caso C6 que
+  había que resolver (viewport alto que cruza a un `rowsPerPage` que implica
+  más superset del ya cargado).
+- `effectiveFetchLimit` no depende de `tokens.length` ni de nada que el propio
+  fetch modifique, así que no hay retroalimentación circular: cargar tokens no
+  cambia la altura del contenedor medido ni `rowHeightPx`/`tableHeaderHeightPx`
+  (miden nodos de layout, no cantidad de filas).
+- La selección (`selectedTokenId`) sigue reseteándose sólo si el token
+  seleccionado desaparece del nuevo snapshot (`setSelectedTokenId` dentro de
+  `loadTokens`, sin cambios de lógica).
+- El tracking fan-out (`getClinicStudyTrackingCases` por token) sigue acotado
+  al snapshot efectivamente cargado (`nextTokens.map(...)`), nunca a
+  `effectiveFetchLimit` como techo teórico.
+
+## Validaciones
+
+- `git diff --check`
+- `git restore frontend/next-env.d.ts` (si el dev server lo regeneró)
+- `pnpm test`
+- `pnpm typecheck:test`
+- `pnpm typecheck`
+- `pnpm --dir frontend lint`
+- `pnpm --dir frontend build`
+- e2e dirigido de Clínica Tokens (`dashboard-clinic-tokens-mobile-parity.spec.ts`)
+  cuando aplica, sin editar sus contratos existentes.
+
+## Archivos tocados
+
+- `frontend/src/components/dashboard/ClinicParticularTokensCard.tsx`
+- `test/frontend-dashboard-clinic-tokens.test.ts`
+- `frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts` (el mock de
+  `/api/particular-tokens` verificaba `limit === "10"` en el request; pasó a
+  verificar el contrato observable — un entero dentro de `[12, 36]` — en vez
+  de un literal que la fórmula del superset vuelve obsoleto)
+- `docs/implementation/clinic-tokens-adaptive-fetch-limit.md` (nuevo)
+
+## Confirmación de scope
+
+Este PR no toca backend, `frontend/src/lib/api.ts` (el endpoint ya aceptaba
+`limit`/`offset`), `frontend/src/app/globals.css`, Admin, Particular, Público,
+logística, CI/workflows, dependencias, lockfiles ni snapshots visuales. No
+restaura `MasterDetailWorkspace` (eliminado en R-15). No introduce
+`matchMedia` ni scroll interno/global nuevo.

--- a/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-tokens-mobile-parity.spec.ts
@@ -99,7 +99,23 @@ async function mockClinicTokens(page: Page) {
       }
 
       const url = new URL(request.url());
-      expect(url.searchParams.get("limit")).toBe("10");
+      const limit = Number(url.searchParams.get("limit"));
+      // R-16 (C6): the fetch limit is now derived from the adaptive
+      // rowsPerPage superset (clamp(rowsPerPage * 3, 12, 36)), not a fixed
+      // literal -- assert the observable contract (a valid superset bound),
+      // not a specific number.
+      expect(
+        Number.isInteger(limit),
+        "limit must be sent as an integer",
+      ).toBe(true);
+      expect(
+        limit,
+        "limit must respect the fetch superset fallback",
+      ).toBeGreaterThanOrEqual(12);
+      expect(
+        limit,
+        "limit must respect the fetch superset cap",
+      ).toBeLessThanOrEqual(36);
       expect(url.searchParams.get("offset")).toBe("0");
 
       await route.fulfill({
@@ -109,7 +125,7 @@ async function mockClinicTokens(page: Page) {
           success: true,
           count: MOCK_TOKENS.length,
           particularTokens: MOCK_TOKENS,
-          pagination: { limit: 10, offset: 0 },
+          pagination: { limit, offset: 0 },
         }),
       });
     },

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -73,6 +73,23 @@ const TOKENS_PAGE_SIZE = 4;
 /** Row height fallback (px) before the first real row/card can be measured. */
 const TOKENS_ROW_HEIGHT_FALLBACK_PX = 44;
 
+// C6 (docs/audit/final-global-vetneb-50-60-pr-roadmap.md §4.3): rowsPerPage is
+// measured adaptively (up to 50 on tall viewports) but the fetch used to stay
+// fixed at a cap of ten, so the list could show fewer rows than the layout
+// measured space for. The fetch now over-fetches a superset sized off
+// rowsPerPage itself, capped so a very tall viewport can't ask for unbounded
+// rows.
+const TOKENS_FETCH_PAGE_MULTIPLIER = 3;
+const TOKENS_FETCH_LIMIT_FALLBACK = 12;
+const TOKENS_FETCH_LIMIT_MAX = 36;
+
+function resolveTokensFetchLimit(rowsPerPage: number): number {
+  return Math.min(
+    TOKENS_FETCH_LIMIT_MAX,
+    Math.max(TOKENS_FETCH_LIMIT_FALLBACK, rowsPerPage * TOKENS_FETCH_PAGE_MULTIPLIER),
+  );
+}
+
 const CREATE_TOKEN_STEP_ORDER = ["contact", "patient", "sample"] as const;
 type CreateTokenStep = (typeof CREATE_TOKEN_STEP_ORDER)[number];
 
@@ -438,6 +455,7 @@ export function ClinicParticularTokensCard() {
     rowHeightPx,
     headerHeightPx: tableHeaderHeightPx,
   });
+  const effectiveFetchLimit = resolveTokensFetchLimit(rowsPerPage);
 
   const filteredTokens = tokens.filter((token) =>
     matchesClinicParticularTokenFilters(token, appliedFilters),
@@ -457,13 +475,13 @@ export function ClinicParticularTokensCard() {
   const isLastCreateStep = createStep === "sample";
   const hasActiveFilters = !isTokenFilterStateEmpty(appliedFilters);
 
-  async function loadTokens() {
+  async function loadTokens(limit: number) {
     setIsLoadingTokens(true);
     setTrackingLoadError(null);
     setErrorMessage(null);
 
     try {
-      const snapshot = await getClinicParticularTokens({ limit: 10, offset: 0 });
+      const snapshot = await getClinicParticularTokens({ limit, offset: 0 });
       const nextTokens = snapshot.particularTokens;
       setTokens(nextTokens);
       setSelectedTokenId((current) =>
@@ -519,9 +537,13 @@ export function ClinicParticularTokensCard() {
     }
   }
 
+  // effectiveFetchLimit only changes when rowsPerPage crosses a multiplier/cap
+  // boundary, so this effect reloads on mount and again whenever the adaptive
+  // measurement implies a materially different superset — never on every
+  // rowsPerPage tick, which is what keeps this from looping.
   useEffect(() => {
-    void loadTokens();
-  }, []);
+    void loadTokens(effectiveFetchLimit);
+  }, [effectiveFetchLimit]);
 
   function updateField(
     field: keyof ClinicParticularTokenFormState,
@@ -701,7 +723,7 @@ export function ClinicParticularTokensCard() {
       setCopyErrorMessage(null);
       setStatusMessage(response.message);
       resetForm();
-      await loadTokens();
+      await loadTokens(effectiveFetchLimit);
       setIsCreateDialogOpen(false);
     } catch (error) {
       setErrorMessage(
@@ -870,7 +892,7 @@ export function ClinicParticularTokensCard() {
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => void loadTokens()}
+                onClick={() => void loadTokens(effectiveFetchLimit)}
                 disabled={isLoadingTokens}
               >
                 {isLoadingTokens ? "Actualizando..." : "Actualizar"}

--- a/test/frontend-dashboard-clinic-tokens.test.ts
+++ b/test/frontend-dashboard-clinic-tokens.test.ts
@@ -405,13 +405,13 @@ test("clinic token generation keeps generated token block list refresh and reset
   assert.ok(source.includes("Cerrar token visible"));
   assert.ok(source.includes("disabled={!isGeneratedTokenConfirmed}"));
   assert.ok(source.includes("Últimos tokens de la clínica"));
-  assert.ok(source.includes('onClick={() => void loadTokens()}'));
+  assert.ok(source.includes('onClick={() => void loadTokens(effectiveFetchLimit)}'));
   assert.ok(source.includes("setFormState(INITIAL_FORM_STATE);"));
   assertOrdered(submitSuccess, [
     "setGeneratedToken(response.token);",
     "setStatusMessage(response.message);",
     "resetForm();",
-    "await loadTokens();",
+    "await loadTokens(effectiveFetchLimit);",
   ]);
 });
 
@@ -453,6 +453,50 @@ test("frontend api exposes clinic-scoped particular token helpers", () => {
   assert.ok(source.includes('"/api/particular-tokens"'));
   assert.ok(source.includes("`/api/particular-tokens${qs ? `?${qs}` : \"\"}`"));
   assert.ok(source.includes("`/api/particular-tokens/${tokenId}/report`"));
+});
+
+test("clinic tokens fetch limit derives from the adaptive rowsPerPage superset (C6)", () => {
+  const source = read(CLINIC_TOKENS_CARD_PATH);
+  const loadTokensFn = sectionBetween(
+    source,
+    "async function loadTokens(limit: number) {",
+    "\n  }\n",
+  );
+
+  // C6 regression guard: the fetch must never hardcode the old fixed cap again.
+  assert.equal(source.includes("limit: 10"), false);
+  assert.equal(source.includes("getClinicParticularTokens({ limit: 10"), false);
+
+  assert.ok(source.includes("const TOKENS_FETCH_PAGE_MULTIPLIER = 3;"));
+  assert.ok(source.includes("const TOKENS_FETCH_LIMIT_FALLBACK = 12;"));
+  assert.ok(source.includes("const TOKENS_FETCH_LIMIT_MAX = 36;"));
+  assert.ok(source.includes("function resolveTokensFetchLimit(rowsPerPage: number): number {"));
+  assert.ok(source.includes("TOKENS_FETCH_LIMIT_MAX,"));
+  assert.ok(
+    source.includes(
+      "Math.max(TOKENS_FETCH_LIMIT_FALLBACK, rowsPerPage * TOKENS_FETCH_PAGE_MULTIPLIER)",
+    ),
+  );
+
+  assert.ok(source.includes("const effectiveFetchLimit = resolveTokensFetchLimit(rowsPerPage);"));
+  assert.ok(loadTokensFn.includes("getClinicParticularTokens({ limit, offset: 0 })"));
+  assert.ok(source.includes("void loadTokens(effectiveFetchLimit);"));
+  assert.ok(source.includes("await loadTokens(effectiveFetchLimit);"));
+  assert.ok(source.includes("onClick={() => void loadTokens(effectiveFetchLimit)}"));
+  assert.equal(source.includes("void loadTokens();"), false);
+  assert.equal(source.includes("await loadTokens();"), false);
+
+  // Anti-loop guard: the reload effect keys off the derived limit, not rowsPerPage
+  // itself, so it only re-fires when the superset actually changes.
+  assert.ok(source.includes("}, [effectiveFetchLimit]);"));
+  assert.equal(source.includes("}, [rowsPerPage]);"), false);
+
+  // Visible cardinality must keep using the measured rowsPerPage, never the
+  // over-fetched superset.
+  assert.ok(source.includes("usePagedRows(filteredTokens, rowsPerPage)"));
+  assert.equal(source.includes("usePagedRows(filteredTokens, effectiveFetchLimit)"), false);
+
+  assert.equal(source.includes("matchMedia"), false);
 });
 
 test("clinic token card muestra seguimiento y alerta de tinción especial desde study-tracking", () => {


### PR DESCRIPTION
## Summary
- Replaces the fixed clinic tokens fetch limit of 10 with an adaptive superset derived from visible rows
- Adds explicit fetch cap constants: fallback 12, multiplier 3, max 36
- Keeps local pagination driven by visible rowsPerPage while fetching enough tokens for taller viewports
- Prevents refetch loops by depending on the clamped effectiveFetchLimit instead of raw rowsPerPage
- Updates source-contract and directed e2e coverage for the new adaptive fetch contract

## Contract
- effectiveFetchLimit = min(36, max(12, rowsPerPage * 3))
- getClinicParticularTokens uses effectiveFetchLimit with offset 0
- usePagedRows still uses rowsPerPage for visible pagination
- tracking fan-out remains bounded to the loaded token snapshot
- No matchMedia introduced

## Validations
- git diff --check
- pnpm test
- pnpm typecheck:test
- pnpm typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend build
- pnpm --dir frontend exec playwright test e2e/dashboard-clinic-tokens-mobile-parity.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-internal-no-scroll-contract.spec.ts e2e/dashboard-global-masked-master-detail.spec.ts --project=chromium
- pnpm --dir frontend exec playwright test e2e/dashboard-viewport-zoom-adaptability.spec.ts --project=chromium

## Scope
- No backend/API/auth/DB/server/migrations changes
- No frontend/src/lib/api.ts changes
- No globals.css changes
- No logistics changes
- No MasterDetailWorkspace restore
- No Admin/Particular/Público changes
- No CI/workflows changes
- No deps/lockfiles/snapshots changes
- No R-17 or later changes