### PR TITLE
test(e2e): add particular authenticated session fixture

### DIFF
--- a/docs/implementation/particular-authenticated-session-fixture.md
+++ b/docs/implementation/particular-authenticated-session-fixture.md
@@ -1,0 +1,97 @@
+# R-17 — Fixture e2e de sesión Particular autenticada (token-gated)
+
+- **Rama:** `test/particular-authenticated-session-fixture`
+- **Base:** `main` @ `43023d7` (feat(clinic): derive tokens fetch limit from adaptive superset, #1279)
+- **Fecha:** 2026-07-03
+- **Tipo:** e2e / test-only. **Visual: NO.**
+- **Documento rector:** `docs/audit/final-global-vetneb-50-60-pr-roadmap.md` — FASE 3 (Particular, R-17..R-19).
+
+## Hueco original
+
+El rol Particular (`/particulares`) nunca tuvo un fixture e2e de sesión autenticada. El baseline previo (#1214 / `public-routes.spec.ts`, suites `PR-PUX1` y `PR-PUX4`) sólo cubre la entrada **pública no autenticada**: hero, acción primaria y ausencia de overflow horizontal antes de ingresar el token. El estado autenticado del rol —panel de sesión, seguimiento del estudio, informe— nunca había sido validado por e2e.
+
+## Fixture creado
+
+Dos archivos nuevos, siguiendo el patrón ya establecido para sesiones admin/clínica (`frontend/e2e/helpers/admin-mobile-contracts.ts`):
+
+- [`frontend/e2e/helpers/particular-session-contracts.ts`](../../frontend/e2e/helpers/particular-session-contracts.ts) — helper reutilizable: cookie de sesión, mocks de los dos endpoints que `ParticularesContent` consulta al montar, datos mock tipados según los contratos de `frontend/src/types/index.ts` y `frontend/src/lib/api.ts`, y el contrato de medición no-scroll.
+- [`frontend/e2e/particular-authenticated-session-fixture.spec.ts`](../../frontend/e2e/particular-authenticated-session-fixture.spec.ts) — spec dirigido con 2 tests.
+
+## Ruta cubierta
+
+`/particulares` (`frontend/src/app/particulares/page.tsx` → `PublicLayout` → `ParticularesContent`), en su **estado autenticado**.
+
+## Contrato de autenticación simulado
+
+`ParticularesContent` no usa `localStorage`. La sesión es 100% cookie-based vía `apiFetch()` (`credentials: "include"`, ver `frontend/src/lib/api.ts:250-254`); el frontend nunca lee la cookie directamente, sólo confía en que el backend la setea/valida. Al montar, el componente llama `getParticularSession()` (`GET /api/particular/auth/me`) y, si hay sesión, `getParticularStudyTrackingCase()` (`GET /api/particular/study-tracking/me`).
+
+El fixture simula esto en dos capas, replicando el patrón admin/clínica:
+
+1. **Cookie** `particular_session_id` (nombre real del backend: `server/lib/env.ts` → `PARTICULAR_COOKIE_NAME`, default `"particular_session_id"`) seteada vía `page.context().addCookies()`. Documenta el contrato real, aunque su valor no es validado server-side en el fixture (ver punto 2).
+2. **Interceptación client-side** con `page.route()` sobre los dos endpoints anteriores, devolviendo un `ParticularAuthResponse` y un `AdminStudyTrackingCaseSummary` mock con `route.fulfill()`. Esto es lo que efectivamente "autentica" la sesión en el fixture — no depende de un servidor mock real ni de datos productivos.
+
+No se creó backend, API, ni servidor mock nuevo (`e2e/fixtures/admin-populated-api-server.mjs` no fue tocado ni extendido).
+
+## Endpoints interceptados
+
+| Método | Endpoint | Respuesta mock |
+|---|---|---|
+| `GET` | `**/api/particular/auth/me` | `{ success: true, particular: MOCK_PARTICULAR_SESSION }` |
+| `GET` | `**/api/particular/study-tracking/me` | `{ success: true, trackingCase: MOCK_PARTICULAR_TRACKING_CASE }` |
+
+`MOCK_PARTICULAR_SESSION` incluye un informe vinculado (`report` no nulo) para ejercitar también el estado "informe disponible" (`data-particulares-report-state="available"`), y `MOCK_PARTICULAR_TRACKING_CASE.currentStage = "delivered"`. Ningún dato proviene de la base productiva; todos los IDs/textos son sintéticos.
+
+## Viewports cubiertos
+
+- **390×844** (`iphone-standard-390x844`) — mínimo mobile crítico exigido por R-17, único viewport cubierto.
+- Tablet: **no agregado**. La suite de `/particulares` (`public-routes.spec.ts`) tampoco cubre tablet hoy; no había convención existente que extender sin inventar una nueva, así que se mantuvo fuera de scope.
+
+## Assertions de contenido autenticado
+
+- `[data-particular-session-panel="true"]` visible.
+- Texto "Sesión particular activa" visible.
+- `[data-particular-mobile-safe-summary="true"]` visible con `tutorLastName`/`petName` del mock.
+- `[data-particular-mobile-flat-card="tracking"]` visible con el label de etapa ("Informe disponible / Publicado").
+- `[data-particular-mobile-flat-card="report"][data-particulares-report-state="available"]` visible, con botones "Ver informe" / "Descargar".
+- Botón "Cerrar sesión particular" visible.
+- El formulario de token (`#particular-token`) **no** está presente (confirma que no quedó el estado no-autenticado).
+
+## Assertions no-scroll (baseline)
+
+Se midió el contrato no-scroll real en 390×844 con el fixture autenticado, usando Playwright headless directo (no forma parte del spec, medición exploratoria puntual):
+
+```json
+{ "html": { "scrollHeight": 3159, "clientHeight": 844 },
+  "body": { "scrollHeight": 3159, "clientHeight": 3159 } }
+```
+
+El documento **sí scrollea verticalmente** (~2315px de contenido por encima del viewport): hero informativo colapsado (`hidden lg:block` cuando hay sesión) igual deja panel de sesión + tracking + informe + próximos pasos + header/footer públicos, que no fueron diseñados para caber en un viewport mobile. Ese ajuste a `100dvh` es **exactamente el objetivo declarado de R-18** ("sub-contrato F completo en `/particulares` autenticado: `100dvh` + safe-area + touch ≥44px + estados loading/empty/error estables"), no de R-17.
+
+Por eso el contrato no-scroll que quedó en el spec (`assertParticularNoScrollContract`) sólo afirma lo que **ya es cierto hoy** y no requiere ningún fix de producción:
+
+- `document.documentElement.scrollWidth <= clientWidth + 1px` (sin overflow horizontal).
+- `document.body.scrollWidth <= clientWidth + 1px` (sin overflow horizontal).
+- Ningún elemento dentro de `[data-particulares-hero="true"]` tiene `overflow-x`/`overflow-y` computado en `auto`/`scroll` (sin contenedores internos scrolleables no declarados).
+
+No se afirma `scrollHeight <= clientHeight` (fit de página completa en un viewport) porque **no es cierto hoy** y R-17 tiene prohibido corregir UI (contrato punto 11). Afirmarlo habría producido un test frágil/rojo o forzado un fix de producción fuera de scope.
+
+## Validaciones ejecutadas
+
+- `git diff --check` — sin conflictos de whitespace.
+- `pnpm test` — guardrails PR-N por diff.
+- `pnpm typecheck:test` — OK.
+- `pnpm typecheck` — OK.
+- `pnpm --dir frontend lint` — OK.
+- `pnpm --dir frontend build` — OK.
+- `pnpm --dir frontend exec playwright test particular-authenticated-session-fixture.spec.ts --project=chromium` — **2/2 passed**.
+
+## Confirmaciones de scope
+
+- **Test-only.** No se modificó `frontend/src/**` (producción), backend/API/DB, CI/workflows, dependencias/lockfiles, snapshots, `globals.css`, ni superficies Admin/Clínica/Público.
+- No se avanzó R-18 (polish viewport-fit) ni R-19 (timeline del caso).
+- No se corrigieron los defectos visuales detectados (overflow vertical en mobile autenticado); quedan documentados arriba para R-18.
+
+## Qué queda para R-18
+
+- Ajustar `frontend/src/components/public/ParticularesContent.tsx` para que el estado autenticado en mobile quepa en `100dvh` (safe-area, touch ≥44px, estados loading/empty/error estables), según el sub-contrato F del roadmap.
+- Una vez resuelto, extender `assertParticularNoScrollContract` (o el spec de R-17) para exigir también `scrollHeight <= clientHeight`, alineándolo con el patrón usado en los shells de Admin/Dashboard (`admin-mobile-contracts.ts`).

--- a/frontend/e2e/helpers/particular-session-contracts.ts
+++ b/frontend/e2e/helpers/particular-session-contracts.ts
@@ -1,0 +1,217 @@
+import { expect, type Page } from "@playwright/test";
+
+// Mirrors the admin/clinic e2e session-cookie pattern (see admin-mobile-contracts.ts):
+// the cookie name matches the backend default (server/lib/env.ts: PARTICULAR_COOKIE_NAME
+// falls back to "particular_session_id"). The cookie value itself is never validated by
+// the mock server-side, since the /api/particular/auth/* calls are intercepted directly
+// via page.route() below — the cookie only documents the real transport contract
+// (apiFetch uses credentials: "include", no localStorage).
+export const PARTICULAR_SESSION_COOKIE_NAME = "particular_session_id";
+export const PARTICULAR_SESSION_COOKIE_VALUE = "e2e_test_particular_session";
+
+export const PARTICULAR_MOBILE_VIEWPORT = {
+  name: "iphone-standard-390x844",
+  width: 390,
+  height: 844,
+} as const;
+
+export const PARTICULAR_NO_SCROLL_TOLERANCE = 1;
+
+export const MOCK_PARTICULAR_SESSION = {
+  id: 9001,
+  clinicId: 12,
+  reportId: 7301,
+  tokenLast4: "4201",
+  tutorLastName: "Gómez",
+  petName: "Mora",
+  petAge: "4 años",
+  petBreed: "Labrador",
+  petSex: "Hembra",
+  petSpecies: "Canino",
+  sampleLocation: "Piel",
+  sampleEvolution: "48 horas",
+  detailsLesion: null,
+  extractionDate: "2026-06-10T00:00:00.000Z",
+  shippingDate: "2026-06-11T00:00:00.000Z",
+  isActive: true,
+  lastLoginAt: "2026-06-20T09:00:00.000Z",
+  createdAt: "2026-06-01T09:00:00.000Z",
+  updatedAt: "2026-06-20T09:00:00.000Z",
+  createdByAdminId: 41,
+  createdByClinicUserId: null,
+  hasLinkedReport: true,
+  report: {
+    id: 7301,
+    clinicId: 12,
+    uploadDate: "2026-06-19T12:00:00.000Z",
+    studyType: "Histopatología",
+    patientName: "Mora",
+    fileName: "informe-e2e-7301.pdf",
+    createdAt: "2026-06-19T12:00:00.000Z",
+    updatedAt: "2026-06-19T12:00:00.000Z",
+  },
+};
+
+export const MOCK_PARTICULAR_TRACKING_CASE = {
+  id: 5501,
+  clinicId: 12,
+  reportId: 7301,
+  particularTokenId: 9001,
+  createdByAdminId: 41,
+  createdByClinicUserId: null,
+  labReceivedAt: "2026-06-12T09:00:00.000Z",
+  receptionAt: "2026-06-12T09:00:00.000Z",
+  estimatedDeliveryAt: "2026-06-22T09:00:00.000Z",
+  estimatedDeliveryAutoCalculatedAt: "2026-06-22T09:00:00.000Z",
+  estimatedDeliveryWasManuallyAdjusted: false,
+  currentStage: "delivered" as const,
+  processingAt: "2026-06-13T09:00:00.000Z",
+  evaluationAt: "2026-06-15T09:00:00.000Z",
+  reportDevelopmentAt: "2026-06-18T09:00:00.000Z",
+  deliveredAt: "2026-06-19T12:00:00.000Z",
+  specialStainRequired: false,
+  specialStainNotifiedAt: null,
+  paymentUrl: null,
+  adminContactEmail: null,
+  adminContactPhone: null,
+  notes: null,
+  createdAt: "2026-06-12T09:00:00.000Z",
+  updatedAt: "2026-06-19T12:00:00.000Z",
+};
+
+export async function setParticularSessionCookie(page: Page) {
+  await page.context().addCookies([
+    {
+      name: PARTICULAR_SESSION_COOKIE_NAME,
+      value: PARTICULAR_SESSION_COOKIE_VALUE,
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+// Token-gated session fixture: intercepts the two client-side reads
+// ParticularesContent issues on mount (getParticularSession -> GET
+// /api/particular/auth/me, then getParticularStudyTrackingCase -> GET
+// /api/particular/study-tracking/me) so the page renders its authenticated
+// state without a real backend.
+export async function mockParticularAuthenticatedSession(page: Page) {
+  await page.route("**/api/particular/auth/me", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        particular: MOCK_PARTICULAR_SESSION,
+      }),
+    });
+  });
+
+  await page.route("**/api/particular/study-tracking/me", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        trackingCase: MOCK_PARTICULAR_TRACKING_CASE,
+      }),
+    });
+  });
+}
+
+export type ParticularDocumentNoScrollContract = {
+  html: {
+    scrollHeight: number;
+    clientHeight: number;
+    scrollWidth: number;
+    clientWidth: number;
+  };
+  body: {
+    scrollHeight: number;
+    clientHeight: number;
+    scrollWidth: number;
+    clientWidth: number;
+  };
+  forbiddenOverflow: Array<{
+    tag: string;
+    className: string;
+    overflowX: string;
+    overflowY: string;
+  }>;
+};
+
+export async function readParticularDocumentNoScrollContract(
+  page: Page,
+): Promise<ParticularDocumentNoScrollContract> {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>(
+      '[data-particulares-hero="true"]',
+    );
+    const candidates = root
+      ? [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))]
+      : [];
+
+    const forbiddenOverflow = candidates.flatMap((element) => {
+      const style = window.getComputedStyle(element);
+      const className =
+        typeof element.className === "string" ? element.className : "";
+      return ["auto", "scroll"].includes(style.overflowX) ||
+        ["auto", "scroll"].includes(style.overflowY)
+        ? [
+            {
+              tag: element.tagName,
+              className,
+              overflowX: style.overflowX,
+              overflowY: style.overflowY,
+            },
+          ]
+        : [];
+    });
+
+    return {
+      html: {
+        scrollHeight: document.documentElement.scrollHeight,
+        clientHeight: document.documentElement.clientHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      },
+      body: {
+        scrollHeight: document.body.scrollHeight,
+        clientHeight: document.body.clientHeight,
+        scrollWidth: document.body.scrollWidth,
+        clientWidth: document.body.clientWidth,
+      },
+      forbiddenOverflow,
+    };
+  });
+}
+
+// Horizontal-overflow + forbidden-internal-scroll-container invariants are
+// already established for /particulares (see public-routes.spec.ts PR-PUX1 /
+// PR-PUX4). Full vertical viewport-fit (100dvh) for the *authenticated*
+// state is the explicit target of R-18, not R-17 — so this contract only
+// asserts what already holds today, per the R-17 test-only/no-fix scope.
+export function assertParticularNoScrollContract(
+  contract: ParticularDocumentNoScrollContract,
+  label: string,
+) {
+  expect(
+    contract.html.scrollWidth,
+    `${label}: html horizontal overflow`,
+  ).toBeLessThanOrEqual(contract.html.clientWidth + PARTICULAR_NO_SCROLL_TOLERANCE);
+  expect(
+    contract.body.scrollWidth,
+    `${label}: body horizontal overflow`,
+  ).toBeLessThanOrEqual(contract.body.clientWidth + PARTICULAR_NO_SCROLL_TOLERANCE);
+  expect(
+    contract.forbiddenOverflow,
+    `${label}: forbidden overflow auto/scroll`,
+  ).toEqual([]);
+}

--- a/frontend/e2e/particular-authenticated-session-fixture.spec.ts
+++ b/frontend/e2e/particular-authenticated-session-fixture.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  MOCK_PARTICULAR_SESSION,
+  PARTICULAR_MOBILE_VIEWPORT,
+  assertParticularNoScrollContract,
+  mockParticularAuthenticatedSession,
+  readParticularDocumentNoScrollContract,
+  setParticularSessionCookie,
+} from "./helpers/particular-session-contracts";
+
+// R-17: first e2e fixture for an authenticated/token-gated Particular
+// session. Covers /particulares in its authenticated state (previously only
+// the unauthenticated entry was covered, see public-routes.spec.ts PR-PUX1/
+// PR-PUX4) and establishes the first no-scroll baseline for this role.
+test.describe("particular authenticated session fixture (R-17)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(PARTICULAR_MOBILE_VIEWPORT);
+    await setParticularSessionCookie(page);
+    await mockParticularAuthenticatedSession(page);
+  });
+
+  test("renders the authenticated /particulares state from the token-gated session fixture", async ({
+    page,
+  }) => {
+    await page.goto("/particulares");
+
+    const sessionPanel = page.locator('[data-particular-session-panel="true"]');
+    await expect(sessionPanel).toBeVisible({ timeout: 12_000 });
+
+    await expect(page.getByText("Sesión particular activa")).toBeVisible();
+
+    const mobileSummary = page.locator('[data-particular-mobile-safe-summary="true"]');
+    await expect(mobileSummary).toBeVisible();
+    await expect(mobileSummary.getByText(MOCK_PARTICULAR_SESSION.tutorLastName)).toBeVisible();
+    await expect(mobileSummary.getByText(MOCK_PARTICULAR_SESSION.petName)).toBeVisible();
+
+    const trackingCard = page.locator('[data-particular-mobile-flat-card="tracking"]');
+    await expect(trackingCard).toBeVisible();
+    await expect(trackingCard.getByText("Informe disponible / Publicado")).toBeVisible();
+
+    const reportCard = page.locator(
+      '[data-particular-mobile-flat-card="report"][data-particulares-report-state="available"]',
+    );
+    await expect(reportCard).toBeVisible();
+    await expect(reportCard.getByRole("button", { name: "Ver informe" })).toBeVisible();
+    await expect(reportCard.getByRole("button", { name: "Descargar" })).toBeVisible();
+
+    await expect(page.getByRole("button", { name: "Cerrar sesión particular" })).toBeVisible();
+
+    // Unauthenticated token form must not be present once the session is active.
+    await expect(page.locator("#particular-token")).toHaveCount(0);
+  });
+
+  test("keeps the authenticated state free of horizontal overflow and forbidden internal scroll at 390x844", async ({
+    page,
+  }) => {
+    await page.goto("/particulares");
+
+    await expect(
+      page.locator('[data-particular-session-panel="true"]'),
+    ).toBeVisible({ timeout: 12_000 });
+    await expect(
+      page.locator('[data-particular-mobile-flat-card="report"]'),
+    ).toBeVisible();
+
+    const contract = await readParticularDocumentNoScrollContract(page);
+    assertParticularNoScrollContract(
+      contract,
+      `${PARTICULAR_MOBILE_VIEWPORT.name} /particulares authenticated`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Particular authenticated/token-gated e2e fixture contract
- Adds a directed authenticated /particulares no-scroll baseline
- Documents the simulated Particular session contract, covered route, and remaining R-18 scope

## Visual
- Visual: NO
- Test-only/e2e fixture coverage
- No runtime UI changes

## Contract
- Covers /particulares in authenticated Particular state
- Uses deterministic mocked Particular session/tracking data
- Asserts global no-scroll geometry on the authenticated role surface
- Avoids snapshots and real/productive data

## Validations
- git diff --check
- pnpm test
- pnpm typecheck:test
- pnpm typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend build
- pnpm --dir frontend exec playwright test e2e/particular-authenticated-session-fixture.spec.ts --project=chromium

## Scope
- No production frontend/src changes
- No backend/API/auth/DB/server/migrations changes
- No globals.css changes
- No Admin/Clínica/Público changes
- No CI/workflows changes
- No deps/lockfiles/snapshots changes
- No R-18/R-19 changes