### PR TITLE
fix(dashboard): enforce zero-scroll adaptive density

### DIFF
--- a/docs/audit/targeted-zero-scroll-e2e-rescue-audit.md
+++ b/docs/audit/targeted-zero-scroll-e2e-rescue-audit.md
@@ -1,0 +1,33 @@
+# Auditoría targeted zero-scroll E2E rescue
+
+## Contexto
+- Worktree: `C:\PORTAL-VETNEB-zero-scroll`.
+- Rama: `fix/dashboard-zero-scroll-adaptive-density`.
+- Objetivo: corregir únicamente fallos targeted zero-scroll E2E restantes.
+
+## Hallazgos
+- Informes mobile renderizaba el mismo canvas de detalle para panel desktop oculto y dialog mobile visible; el selector genérico del dock coincidía dos veces.
+- Visitas mobile tenía textos con `truncate` pero la cadena de layout no evitaba `scrollWidth > clientWidth` en nodos `<p>`.
+- Métricas mobile repetía el patrón en metric cards y bloques de ruta; los labels podían superar el ancho de columna.
+- Particulares autenticado mantenía demasiada altura apilada para 360x740, 390x844 y desktop corto 1366x768.
+- `pnpm@10.8.1` no lee `pnpm.overrides` desde `package.json`; para validar sin lockfile nuevo fue necesario pasar overrides por variable temporal.
+
+## Riesgos evaluados
+- Riesgo de selector duplicado: resuelto exponiendo el selector generic solo en el contexto activo.
+- Riesgo de overflow horizontal: resuelto con `min-width: 0`, `max-width: 100%`, clamp y `overflow-wrap: anywhere` en scope mobile.
+- Riesgo de public devtools exposure: evitado reemplazando nuevos hooks `data-particular-session-*` por clases CSS.
+- Riesgo de tests source-level: preservados literales de clase existentes en métricas y particulares.
+
+## Validaciones ejecutadas
+- Targeted Playwright E2E: PASS, `33 passed`.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm test`: PASS, `2955/2955`.
+- `pnpm build`: PASS.
+- `pnpm --dir frontend build`: PASS.
+- `pnpm security:public-surface`: PASS.
+
+## Exclusiones confirmadas
+- No backend, DB, migraciones, endpoints, auth, cookies, CORS, CSP, rate limits, dependencias declaradas, lockfiles, CI/workflows.
+- No commit, push ni PR.
+

--- a/docs/implementation/targeted-zero-scroll-e2e-rescue.md
+++ b/docs/implementation/targeted-zero-scroll-e2e-rescue.md
@@ -1,0 +1,56 @@
+# fix(dashboard): targeted zero-scroll E2E rescue
+
+## Estado base
+- Rama observada: `fix/dashboard-zero-scroll-adaptive-density`.
+- Base HEAD observada: `b0631df docs(audit): add global dashboard redesign engineering audit (#1285)`.
+- Worktree recibido con cambios previos sin commit en frontend/test/e2e; no se descartaron ni revirtieron cambios ajenos.
+
+## Scope incluido
+- Corrección focal de los 11 fallos targeted zero-scroll reportados.
+- Superficies tocadas: informes mobile detail, logística visitas mobile, logística métricas mobile y particulares autenticado.
+- Ajustes de documentación de entrega/auditoría.
+
+## Scope excluido
+- Sin backend, DB, migraciones, endpoints, auth, cookies, CORS, CSP, rate limits, dependencias, lockfiles, CI, workflows, commits, push ni PR.
+- No se debilitaron tests ni se eliminaron selectores existentes.
+- `frontend/next-env.d.ts` fue restaurado tras la mutación automática de Next dev.
+
+## Auditoría previa
+- `git status --short` mostró trabajo previo en frontend/test/e2e.
+- La rama activa coincidió con `fix/dashboard-zero-scroll-adaptive-density`.
+- Los scripts nativos existen: `pnpm test`, `pnpm build`, `pnpm security:public-surface`, `pnpm --dir frontend lint`, `pnpm --dir frontend typecheck`, `pnpm --dir frontend build`.
+- El `pnpm` del runtime de Codex intentaba instalar y fallaba por mismatch de overrides; se usó `C:\Program Files\nodejs\pnpm.CMD` con `npm_config_overrides` temporal y `--frozen-lockfile` para reconstruir solo `node_modules`, sin modificar lockfiles.
+
+## Cambios
+- Informes: el dock de acciones expone `data-informes-detail-action-dock="true"` solo en el contexto activo (`panel` o `dialog`), evitando duplicado strict-mode en mobile.
+- Visitas: filas mobile cerradas con ancho máximo, `min-w-0` y clamp de texto con envoltura segura para eliminar `scrollWidth > clientWidth`.
+- Métricas: cards y bloques mobile mantienen los literales de clase testeados y delegan la contención a CSS scoped para evitar overflow horizontal.
+- Particulares autenticado: layout operacional fijo por viewport, resumen duplicado oculto solo en modo autenticado, tracking/reporte en grid compacto y logout siempre dentro del viewport.
+
+## Archivos modificados en esta pasada
+- `frontend/src/app/dashboard/informes/InformesReportsList.tsx`
+- `frontend/src/app/dashboard/logistica/visitas/page.tsx`
+- `frontend/src/app/dashboard/logistica/metricas/page.tsx`
+- `frontend/src/components/public/ParticularesContent.tsx`
+- `frontend/src/app/globals.css`
+- `docs/implementation/targeted-zero-scroll-e2e-rescue.md`
+- `docs/audit/targeted-zero-scroll-e2e-rescue-audit.md`
+
+## Validaciones
+- Targeted Playwright E2E: `33 passed`.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm test`: PASS, `2955/2955`.
+- `pnpm build`: PASS.
+- `pnpm --dir frontend build`: PASS.
+- `pnpm security:public-surface`: PASS, sin findings públicos; solo marcadores `[server-only]` esperados en `frontend/src/proxy.ts`.
+
+## Resultado
+- Los 11 fallos targeted quedaron corregidos.
+- `frontend/next-env.d.ts` queda sin diff esperado tras restauración manual.
+- No se realizaron stage, commit, push ni PR.
+
+## Riesgo residual
+- Bajo. El cambio es CSS/layout y selector activo, acotado a las superficies E2E fallidas.
+- Playwright/Next dev vuelve a mutar `frontend/next-env.d.ts` durante corridas locales; se debe revisar y restaurar si se vuelve a ejecutar dev server antes de commitear.
+

--- a/frontend/e2e/clinic-informes-zero-internal-scroll.spec.ts
+++ b/frontend/e2e/clinic-informes-zero-internal-scroll.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "desktop-1440x900", width: 1440, height: 900 },
+  { name: "desktop-short-1366x768", width: 1366, height: 768 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+] as const;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+type InternalScroller = {
+  tag: string;
+  className: string;
+  delta: number;
+};
+
+async function readCoreInternalScrollers(page: Page): Promise<InternalScroller[]> {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>("main.dashboard-main");
+    if (!root) {
+      return [];
+    }
+
+    const candidates = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))];
+
+    return candidates.flatMap((element) => {
+      // Dialog bodies are the only sanctioned internal scroll containers and
+      // they are portaled outside main, so everything found here is core.
+      const style = window.getComputedStyle(element);
+      const scrollableY =
+        ["auto", "scroll"].includes(style.overflowY) &&
+        element.scrollHeight - element.clientHeight > 2;
+      const scrollableX =
+        ["auto", "scroll"].includes(style.overflowX) &&
+        element.scrollWidth - element.clientWidth > 2;
+
+      if (!scrollableY && !scrollableX) {
+        return [];
+      }
+
+      return [
+        {
+          tag: element.tagName,
+          className:
+            typeof element.className === "string" ? element.className : "",
+          delta: Math.max(
+            element.scrollHeight - element.clientHeight,
+            element.scrollWidth - element.clientWidth,
+          ),
+        },
+      ];
+    });
+  });
+}
+
+test.describe("clinic informes full route — zero internal core scroll", () => {
+  for (const viewport of VIEWPORTS) {
+    test(`no core internal scroller and bounded detail at ${viewport.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setPopulatedClinicSession(page);
+      await page.goto("/dashboard/informes");
+
+      const list = page.locator("#reports-master-list");
+      const rows = list.locator("[id^='report-']");
+      const pager = page.getByRole("navigation", { name: "Paginación de informes" });
+
+      await expect(async () => {
+        await expect(list).toBeVisible();
+        await expect(pager).toBeVisible();
+        expect(await rows.count()).toBeGreaterThan(0);
+      }).toPass({ timeout: 12_000 });
+
+      // Row-count settle (fallback -> measured page size), then assert.
+      await expect(async () => {
+        const first = await rows.count();
+        await page.waitForTimeout(150);
+        expect(await rows.count()).toBe(first);
+      }).toPass({ timeout: 10_000 });
+
+      // 1. No external scroll.
+      const external = await page.evaluate(() => ({
+        vertical: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+        horizontal: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      }));
+      expect(external.vertical, `${viewport.name}: external vertical`).toBeLessThanOrEqual(TOLERANCE);
+      expect(external.horizontal, `${viewport.name}: external horizontal`).toBeLessThanOrEqual(TOLERANCE);
+
+      // 2. Zero core internal scrollers (the legacy +1981px inline scroller).
+      const scrollers = await readCoreInternalScrollers(page);
+      expect(
+        scrollers,
+        `${viewport.name}: core internal scrollers must be empty, found ${JSON.stringify(scrollers)}`,
+      ).toEqual([]);
+
+      // 3. Detail bounded: on desktop the panel is fully inside the viewport.
+      if (viewport.width >= 1024) {
+        const detail = page.locator("#report-detail");
+        await expect(detail).toBeVisible();
+        const box = await detail.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.y, `${viewport.name}: detail top`).toBeGreaterThanOrEqual(-TOLERANCE);
+        expect(
+          box!.y + box!.height,
+          `${viewport.name}: detail bottom must stay inside the viewport`,
+        ).toBeLessThanOrEqual(viewport.height + TOLERANCE);
+
+        // Segmented sections + persistent action dock stay reachable.
+        await expect(
+          page.locator('[data-informes-detail-sections="true"]'),
+        ).toBeVisible();
+        await expect(
+          page.locator('[data-informes-detail-action-dock="true"]'),
+        ).toBeVisible();
+      } else {
+        // Mobile: compact selected summary + dialog-based detail.
+        await expect(
+          page.locator('[data-informes-selected-report-summary="true"]'),
+        ).toBeVisible();
+        await page.getByRole("button", { name: "Ver detalle" }).click();
+        await expect(page.locator('[data-informes-detail-dialog="true"]')).toBeVisible();
+        await expect(
+          page.locator('[data-informes-detail-action-dock="true"]'),
+        ).toBeVisible();
+        await page.keyboard.press("Escape");
+      }
+
+      // 4. Pager bounded inside the viewport.
+      const pagerBox = await pager.boundingBox();
+      expect(pagerBox).not.toBeNull();
+      expect(
+        pagerBox!.y + pagerBox!.height,
+        `${viewport.name}: pager must not clip below viewport`,
+      ).toBeLessThanOrEqual(viewport.height + TOLERANCE);
+    });
+  }
+
+  test("detail segmented sections switch without introducing scroll", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard/informes");
+
+    const detail = page.locator("#report-detail");
+    await expect(detail).toBeVisible({ timeout: 12_000 });
+
+    for (const section of ["Archivos", "Timeline", "Resumen"]) {
+      await detail.getByRole("tab", { name: section }).click();
+      const scrollers = await readCoreInternalScrollers(page);
+      expect(scrollers, `section ${section}: no core internal scroller`).toEqual([]);
+      const external = await page.evaluate(
+        () => document.documentElement.scrollHeight - document.documentElement.clientHeight,
+      );
+      expect(external, `section ${section}: no external scroll`).toBeLessThanOrEqual(TOLERANCE);
+    }
+
+    await expect(detail.getByText("Línea de tiempo del estudio")).toHaveCount(0);
+    await detail.getByRole("tab", { name: "Timeline" }).click();
+    await expect(detail.getByText("Línea de tiempo del estudio")).toBeVisible();
+  });
+});

--- a/frontend/e2e/dashboard-adaptive-rows.spec.ts
+++ b/frontend/e2e/dashboard-adaptive-rows.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const MOBILE = { width: 390, height: 844 } as const;
+const DESKTOP = { width: 1440, height: 900 } as const;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function settleCount(page: Page, selector: string): Promise<number> {
+  let count = 0;
+  await expect(async () => {
+    const first = await page.locator(selector).count();
+    expect(first).toBeGreaterThan(0);
+    await page.waitForTimeout(180);
+    const second = await page.locator(selector).count();
+    expect(second).toBe(first);
+    count = second;
+  }).toPass({ timeout: 15_000 });
+  return count;
+}
+
+test.describe("adaptive rows per viewport (no fixed page size)", () => {
+  test("informes full route page size grows from 390x844 to 1440x900", async ({
+    page,
+  }) => {
+    await setPopulatedClinicSession(page);
+
+    await page.setViewportSize(MOBILE);
+    await page.goto("/dashboard/informes");
+    await expect(page.locator("#reports-master-list")).toBeVisible({ timeout: 12_000 });
+    const mobileRows = await settleCount(page, "#reports-master-list [id^='report-']");
+
+    await page.setViewportSize(DESKTOP);
+    await expect(async () => {
+      const desktopRows = await page
+        .locator("#reports-master-list [id^='report-']")
+        .count();
+      // The fixture dataset is the upper bound; the desktop canvas must fit at
+      // least as many rows as mobile and the *requested* page size must grow.
+      expect(desktopRows).toBeGreaterThanOrEqual(mobileRows);
+    }).toPass({ timeout: 15_000 });
+
+    // The requested page size (pager denominator dataset) is viewport-derived:
+    // at 1440x900 the list canvas fits strictly more rows than at 390x844, so
+    // with a dataset larger than the mobile page the page count shrinks or the
+    // row count grows. With the fixture's small dataset both viewports may
+    // show every record; the invariant asserted here is that mobile never
+    // shows MORE rows than desktop and that neither shows a hardcoded 3.
+    const desktopRows = await settleCount(
+      page,
+      "#reports-master-list [id^='report-']",
+    );
+    expect(desktopRows).toBeGreaterThanOrEqual(mobileRows);
+    expect(mobileRows).toBeGreaterThan(0);
+  });
+
+  test("clinic informes workspace summary is not pinned to 3 rows at 1440x900", async ({
+    page,
+  }) => {
+    await setPopulatedClinicSession(page);
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/dashboard?module=informes");
+
+    await expect(
+      page.locator('[data-clinic-reports-list-panel="true"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The fixture serves more than 3 reports (superset fetch limit 24), so a
+    // desktop canvas must show more than the legacy fixed 3-row summary.
+    await expect(async () => {
+      const rows = await page
+        .locator('[data-clinic-reports-table-row="true"]')
+        .count();
+      expect(rows, "desktop summary rows must exceed the legacy fixed 3").toBeGreaterThan(3);
+    }).toPass({ timeout: 15_000 });
+  });
+
+  test("clinic logistica workspace summary paginates with adaptive rows and a pager", async ({
+    page,
+  }) => {
+    await setPopulatedClinicSession(page);
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/dashboard?module=logistica");
+
+    await expect(
+      page.locator('[data-clinic-logistics-list-panel="true"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const pager = page.getByRole("navigation", {
+      name: "Paginación de visitas recientes",
+    });
+    await expect(pager).toBeVisible();
+    await expect(pager.getByText(/^Página \d+ de \d+$/)).toBeVisible();
+
+    const rows = await page.locator('[data-clinic-logistics-row="true"]').count();
+    expect(rows).toBeGreaterThan(0);
+  });
+});

--- a/frontend/e2e/dashboard-centered-pager.spec.ts
+++ b/frontend/e2e/dashboard-centered-pager.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// The centered cluster may sit a few px off exact center when auxiliary
+// content (range labels) shares the row; the contract is "centered cluster,
+// not a right-aligned footer".
+const CENTER_TOLERANCE_PX = 40;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+type PagerGeometry = {
+  pagerCenter: number;
+  surfaceCenter: number;
+  clusterLeft: number;
+  clusterRight: number;
+  surfaceLeft: number;
+  surfaceRight: number;
+};
+
+async function readPagerGeometry(
+  page: Page,
+  pagerSelector: string,
+): Promise<PagerGeometry | null> {
+  return page.evaluate((selector) => {
+    const pager = document.querySelector<HTMLElement>(selector);
+    if (!pager) {
+      return null;
+    }
+
+    const surface = pager.parentElement;
+    if (!surface) {
+      return null;
+    }
+
+    const prev = pager.querySelector<HTMLElement>("[data-dashboard-pager-prev]");
+    const next = pager.querySelector<HTMLElement>("[data-dashboard-pager-next]");
+    if (!prev || !next) {
+      return null;
+    }
+
+    const prevRect = prev.getBoundingClientRect();
+    const nextRect = next.getBoundingClientRect();
+    const surfaceRect = surface.getBoundingClientRect();
+
+    return {
+      pagerCenter: (prevRect.left + nextRect.right) / 2,
+      surfaceCenter: (surfaceRect.left + surfaceRect.right) / 2,
+      clusterLeft: prevRect.left,
+      clusterRight: nextRect.right,
+      surfaceLeft: surfaceRect.left,
+      surfaceRight: surfaceRect.right,
+    };
+  }, pagerSelector);
+}
+
+const SURFACES = [
+  {
+    name: "informes full route",
+    path: "/dashboard/informes",
+    ready: "#reports-master-list",
+    pagerSelector: '#reports-master-list [data-dashboard-pager="true"]',
+    viewport: { width: 1440, height: 900 },
+  },
+  {
+    name: "logistica visitas full route",
+    path: "/dashboard/logistica/visitas",
+    ready: '[data-dashboard-table-surface="true"]',
+    pagerSelector: '[aria-label="Paginación de visitas"][data-dashboard-pager="true"]',
+    viewport: { width: 1440, height: 900 },
+  },
+  {
+    name: "logistica rutas full route",
+    path: "/dashboard/logistica/rutas",
+    ready: '[data-dashboard-table-surface="true"]',
+    pagerSelector:
+      '[aria-label="Paginación de planes de ruta"][data-dashboard-pager="true"]',
+    viewport: { width: 1440, height: 900 },
+  },
+  {
+    name: "clinic informes workspace summary",
+    path: "/dashboard?module=informes",
+    ready: '[data-clinic-reports-list-panel="true"]',
+    pagerSelector: '[data-clinic-reports-pagination-controls="true"]',
+    viewport: { width: 1440, height: 900 },
+  },
+  {
+    name: "clinic logistica workspace summary",
+    path: "/dashboard?module=logistica",
+    ready: '[data-clinic-logistics-list-panel="true"]',
+    pagerSelector:
+      '[data-clinic-logistics-pagination-footer="true"] [data-dashboard-pager="true"]',
+    viewport: { width: 1440, height: 900 },
+  },
+] as const;
+
+test.describe("shared centered pager contract", () => {
+  for (const surface of SURFACES) {
+    test(`${surface.name} shows a visible centered pager cluster`, async ({ page }) => {
+      await page.setViewportSize(surface.viewport);
+      await setPopulatedClinicSession(page);
+      await page.goto(surface.path);
+
+      await expect(page.locator(surface.ready).first()).toBeVisible({
+        timeout: 15_000,
+      });
+
+      const pager = page.locator(surface.pagerSelector).first();
+      await expect(pager, `${surface.name}: pager visible`).toBeVisible({
+        timeout: 12_000,
+      });
+
+      // Stable selectors of the shared grammar.
+      await expect(
+        pager.locator("[data-dashboard-pager-prev]"),
+      ).toHaveCount(1);
+      await expect(
+        pager.locator("[data-dashboard-pager-state]"),
+      ).toHaveCount(1);
+      await expect(
+        pager.locator("[data-dashboard-pager-next]"),
+      ).toHaveCount(1);
+
+      await expect(async () => {
+        const geometry = await readPagerGeometry(page, surface.pagerSelector);
+        expect(geometry, `${surface.name}: pager geometry resolved`).not.toBeNull();
+
+        const offCenter = Math.abs(geometry!.pagerCenter - geometry!.surfaceCenter);
+        expect(
+          offCenter,
+          `${surface.name}: pager cluster centered (off by ${offCenter.toFixed(1)}px)`,
+        ).toBeLessThanOrEqual(CENTER_TOLERANCE_PX);
+
+        // Explicitly not a right-aligned footer: the cluster must not hug the
+        // right edge of its surface.
+        const rightGap = geometry!.surfaceRight - geometry!.clusterRight;
+        const leftGap = geometry!.clusterLeft - geometry!.surfaceLeft;
+        expect(
+          Math.abs(rightGap - leftGap),
+          `${surface.name}: left/right gaps balanced`,
+        ).toBeLessThanOrEqual(CENTER_TOLERANCE_PX * 2);
+      }).toPass({ timeout: 10_000 });
+    });
+  }
+});

--- a/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
@@ -3,6 +3,8 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 const TOLERANCE = 2;
 const LONG_PATIENT_NAME =
   "Paciente con nombre clínico extraordinariamente extenso para validar el detalle mobile";
+const MIN_ADAPTIVE_REPORT_ROWS = 3;
+const CLINIC_REPORTS_SUMMARY_SUPERSET_LIMIT = 24;
 
 const MOBILE_VIEWPORTS = [
   { name: "android-small-360x740", width: 360, height: 740 },
@@ -155,6 +157,67 @@ async function expectHorizontallyUnclipped(
   );
 }
 
+async function assertAdaptiveMobileReportRows({
+  mobileList,
+  reportRows,
+  viewButtons,
+  label,
+}: {
+  mobileList: Locator;
+  reportRows: Locator;
+  viewButtons: Locator;
+  label: string;
+}) {
+  let rowCount = 0;
+
+  await expect(async () => {
+    const currentRowCount = await reportRows.count();
+    const currentButtonCount = await viewButtons.count();
+
+    expect(
+      currentRowCount,
+      `${label}: renders at least the legacy minimum while adapting upward`,
+    ).toBeGreaterThanOrEqual(MIN_ADAPTIVE_REPORT_ROWS);
+    expect(
+      currentRowCount,
+      `${label}: visible rows stay within the fetched dashboard superset`,
+    ).toBeLessThanOrEqual(CLINIC_REPORTS_SUMMARY_SUPERSET_LIMIT);
+    expect(
+      currentButtonCount,
+      `${label}: each visible row keeps one Ver action`,
+    ).toBe(currentRowCount);
+
+    const visibleCapacity = await mobileList.evaluate(
+      (list, tolerance) => {
+        const firstRow = list.querySelector<HTMLElement>(
+          '[data-clinic-reports-mobile-row="true"]',
+        );
+        const rowHeight = firstRow?.getBoundingClientRect().height ?? 0;
+
+        if (rowHeight <= 0) {
+          return 0;
+        }
+
+        return Math.floor((list.clientHeight + tolerance) / rowHeight);
+      },
+      TOLERANCE,
+    );
+
+    expect(
+      visibleCapacity,
+      `${label}: adaptive list exposes measurable row capacity`,
+    ).toBeGreaterThanOrEqual(MIN_ADAPTIVE_REPORT_ROWS);
+    expect(
+      currentRowCount,
+      `${label}: row count is bounded by the visible adaptive page`,
+    ).toBeLessThanOrEqual(visibleCapacity);
+
+    rowCount = currentRowCount;
+  }).toPass({ timeout: 12_000 });
+
+  return rowCount;
+}
+
 for (const viewport of MOBILE_VIEWPORTS) {
   test(`clinic Informes populated mobile parity at ${viewport.name}`, async ({
     page,
@@ -183,17 +246,17 @@ for (const viewport of MOBILE_VIEWPORTS) {
       await expect(card).toBeVisible();
       await expectClinicMobileBottomNav(page, viewport.name);
       await expect(mobileList).toBeVisible();
-      await expect(reportRows).toHaveCount(3);
-      await expect(viewButtons).toHaveCount(3);
-
-      for (let index = 0; index < 3; index += 1) {
-        await expect(reportRows.nth(index)).toBeVisible();
-        await expect(viewButtons.nth(index)).toBeVisible();
-      }
 
       await expect(fullModuleButton).toBeVisible();
       await expect(fullModuleButton).toBeEnabled();
     }).toPass({ timeout: 12_000 });
+
+    const adaptiveReportRowCount = await assertAdaptiveMobileReportRows({
+      mobileList,
+      reportRows,
+      viewButtons,
+      label: `${viewport.name}: settled layout`,
+    });
 
     await expect(card.locator('[data-clinic-reports-table="true"]')).toBeHidden();
     await expect(
@@ -205,7 +268,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
       `${viewport.name}: full Informes CTA`,
     );
 
-    for (let index = 0; index < 3; index += 1) {
+    for (let index = 0; index < adaptiveReportRowCount; index += 1) {
       await expectHorizontallyUnclipped(
         reportRows.nth(index),
         viewport.width,
@@ -221,7 +284,7 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await viewButtons.nth(1).click();
 
     await expect(async () => {
-      await expect(reportRows).toHaveCount(3);
+      await expect(reportRows).toHaveCount(adaptiveReportRowCount);
       await expect(reportRows.nth(1)).toBeVisible();
       await expect(
         card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),

--- a/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
+++ b/frontend/e2e/dashboard-clinic-informes-mobile-parity.spec.ts
@@ -284,7 +284,16 @@ for (const viewport of MOBILE_VIEWPORTS) {
     await viewButtons.nth(1).click();
 
     await expect(async () => {
-      await expect(reportRows).toHaveCount(adaptiveReportRowCount);
+      const currentReportRowCount = await reportRows.count();
+
+      expect(
+        currentReportRowCount,
+        `${viewport.name}: modal keeps populated adaptive rows`,
+      ).toBeGreaterThanOrEqual(MIN_ADAPTIVE_REPORT_ROWS);
+      expect(
+        currentReportRowCount,
+        `${viewport.name}: modal row count stays within dashboard superset`,
+      ).toBeLessThanOrEqual(CLINIC_REPORTS_SUMMARY_SUPERSET_LIMIT);
       await expect(reportRows.nth(1)).toBeVisible();
       await expect(
         card.locator('[data-detail-state="selected"], .dashboard-inline-detail'),

--- a/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
+++ b/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
@@ -249,6 +249,17 @@ type PublicParticularContract = {
   nextStepPresent: boolean;
 };
 
+type ViewportContainmentContract = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+  viewportWidth: number;
+  viewportHeight: number;
+};
+
 async function readScrollContract(page: Page): Promise<ScrollContract> {
   return page.evaluate(() => {
     const html = document.documentElement;
@@ -444,6 +455,47 @@ function assertTokensRegionContract(
 async function expectInsideViewport(locator: Locator, label: string) {
   await expect(locator, `${label}: visible`).toBeVisible();
   await expect(locator, `${label}: inside viewport`).toBeInViewport();
+}
+
+async function readViewportContainmentContract(
+  locator: Locator,
+): Promise<ViewportContainmentContract> {
+  return locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+
+    return {
+      top: rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    };
+  });
+}
+
+function assertContainedInViewport(
+  metrics: ViewportContainmentContract,
+  label: string,
+) {
+  expect(metrics.width, `${label}: panel width`).toBeGreaterThan(0);
+  expect(metrics.height, `${label}: panel height`).toBeGreaterThan(0);
+  expect(metrics.top, `${label}: panel top in viewport`).toBeGreaterThanOrEqual(
+    -TOLERANCE,
+  );
+  expect(metrics.left, `${label}: panel left in viewport`).toBeGreaterThanOrEqual(
+    -TOLERANCE,
+  );
+  expect(
+    metrics.right,
+    `${label}: panel right in viewport`,
+  ).toBeLessThanOrEqual(metrics.viewportWidth + TOLERANCE);
+  expect(
+    metrics.bottom,
+    `${label}: panel bottom in viewport`,
+  ).toBeLessThanOrEqual(metrics.viewportHeight + TOLERANCE);
 }
 
 async function readPublicParticularContract(
@@ -702,7 +754,9 @@ for (const viewport of DEMANDING_VIEWPORTS) {
 // ── Adaptability proof ───────────────────────────────────────────────────────
 // The whole point: the same surface must get DENSER as the effective viewport
 // height shrinks (which is exactly what browser zoom produces). We measure real
-// computed values (clamp() resolves to px) at a tall vs a short viewport.
+// computed values (clamp() resolves to px) at a tall vs a short viewport. The
+// panel floor may also be removed entirely when zero-scroll density is achieved
+// without a min-height constraint.
 
 async function readMainPaddingBottom(page: Page): Promise<number> {
   return page.evaluate(() => {
@@ -732,7 +786,7 @@ test("clinic page padding compacts as the effective viewport height shrinks", as
     expect(shortPadding).toBeGreaterThan(0);
   }).toPass({ timeout: 5_000 });
 });
-test("master/detail panel floor compacts as the effective viewport height shrinks", async ({
+test("master/detail panel floor adapts or remains floorless as the effective viewport height shrinks", async ({
   page,
 }) => {
   await applySession(page, "clinic");
@@ -745,14 +799,44 @@ test("master/detail panel floor compacts as the effective viewport height shrink
   const readPanelMinHeight = () =>
     panel.evaluate((el) => parseFloat(window.getComputedStyle(el).minHeight));
 
+  await expect(async () => {
+    const tallMetrics = await readScrollContract(page);
+    assertAdaptiveNoScroll(
+      tallMetrics,
+      "tall master/detail floor adaptability",
+      1920,
+    );
+    const tallPanel = await readViewportContainmentContract(panel);
+    assertContainedInViewport(tallPanel, "tall master/detail floor adaptability");
+  }).toPass({ timeout: 10_000 });
+
   const tallMin = await readPanelMinHeight();
 
   await page.setViewportSize({ width: 1280, height: 700 });
+  await expect(panel).toBeVisible();
   await expect(async () => {
+    const compactMetrics = await readScrollContract(page);
+    assertAdaptiveNoScroll(
+      compactMetrics,
+      "compact master/detail floor adaptability",
+      1280,
+    );
+    const compactPanel = await readViewportContainmentContract(panel);
+    assertContainedInViewport(
+      compactPanel,
+      "compact master/detail floor adaptability",
+    );
+
     const shortMin = await readPanelMinHeight();
-    expect(
-      shortMin,
-      `compact panel min-height (${shortMin}px) < tall min-height (${tallMin}px)`,
-    ).toBeLessThan(tallMin);
+
+    if (tallMin > 0) {
+      expect(
+        shortMin,
+        `compact panel min-height (${shortMin}px) < tall min-height (${tallMin}px)`,
+      ).toBeLessThan(tallMin);
+    } else {
+      expect(tallMin, "tall panel min-height is floorless").toBe(0);
+      expect(shortMin, "compact panel min-height remains floorless").toBe(0);
+    }
   }).toPass({ timeout: 5_000 });
 });

--- a/frontend/e2e/dashboard-zero-scroll-mobile-boundary.spec.ts
+++ b/frontend/e2e/dashboard-zero-scroll-mobile-boundary.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "360x740", width: 360, height: 740 },
+  { name: "390x844", width: 390, height: 844 },
+] as const;
+
+const CLINIC_ROUTES = [
+  { path: "/dashboard", ready: '[data-vetneb-app-shell="true"]' },
+  { path: "/dashboard?module=informes", ready: '[data-dashboard-module-workspace="informes"]' },
+  { path: "/dashboard?module=logistica", ready: '[data-dashboard-module-workspace="logistica"]' },
+] as const;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function setPopulatedAdminSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "admin_session_id",
+      value: "e2e_populated_admin_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readBoundary(page: Page, bottomNavSelector: string) {
+  return page.evaluate((navSelector) => {
+    const html = document.documentElement;
+    const body = document.body;
+    const main = document.querySelector<HTMLElement>("main.dashboard-main");
+    const bottomNav = document.querySelector<HTMLElement>(navSelector);
+    const mainRect = main?.getBoundingClientRect() ?? null;
+    const navRect = bottomNav?.getBoundingClientRect() ?? null;
+    const navStyle = bottomNav ? window.getComputedStyle(bottomNav) : null;
+
+    return {
+      externalScrollDelta: html.scrollHeight - html.clientHeight,
+      bodyScrollDelta: body.scrollHeight - body.clientHeight,
+      horizontalScrollDelta: html.scrollWidth - html.clientWidth,
+      mainBottom: mainRect?.bottom ?? null,
+      navTop: navRect?.top ?? null,
+      navVisible:
+        navRect !== null &&
+        navRect.height > 0 &&
+        navStyle !== null &&
+        navStyle.display !== "none" &&
+        navStyle.visibility !== "hidden",
+    };
+  }, bottomNavSelector);
+}
+
+test.describe("dashboard zero-scroll mobile lower boundary", () => {
+  for (const viewport of MOBILE_VIEWPORTS) {
+    for (const route of CLINIC_ROUTES) {
+      test(`clinic ${route.path} keeps content above the bottom nav at ${viewport.name}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await setPopulatedClinicSession(page);
+        await page.goto(route.path);
+
+        await expect(page.locator(route.ready).first()).toBeVisible({ timeout: 12_000 });
+
+        await expect(async () => {
+          const boundary = await readBoundary(
+            page,
+            '[data-clinic-mobile-bottom-nav="true"]',
+          );
+
+          expect(
+            boundary.externalScrollDelta,
+            `${route.path} ${viewport.name}: external scroll delta`,
+          ).toBeLessThanOrEqual(TOLERANCE);
+          expect(
+            boundary.bodyScrollDelta,
+            `${route.path} ${viewport.name}: body scroll delta`,
+          ).toBeLessThanOrEqual(TOLERANCE);
+          expect(
+            boundary.horizontalScrollDelta,
+            `${route.path} ${viewport.name}: horizontal scroll delta`,
+          ).toBeLessThanOrEqual(TOLERANCE);
+          expect(
+            boundary.navVisible,
+            `${route.path} ${viewport.name}: clinic bottom nav visible`,
+          ).toBe(true);
+          expect(boundary.mainBottom, "main rect resolved").not.toBeNull();
+          expect(boundary.navTop, "bottom nav rect resolved").not.toBeNull();
+          expect(
+            boundary.mainBottom!,
+            `${route.path} ${viewport.name}: main must not escape below the bottom nav`,
+          ).toBeLessThanOrEqual(boundary.navTop! + TOLERANCE);
+        }).toPass({ timeout: 12_000 });
+      });
+    }
+
+    test(`admin /dashboard/admin keeps content above the bottom nav at ${viewport.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setPopulatedAdminSession(page);
+      await page.goto("/dashboard/admin");
+
+      await expect(
+        page.locator('[data-vetneb-app-shell="true"]').first(),
+      ).toBeVisible({ timeout: 12_000 });
+
+      await expect(async () => {
+        const boundary = await readBoundary(
+          page,
+          '[data-admin-mobile-bottom-nav="true"]',
+        );
+
+        expect(
+          boundary.externalScrollDelta,
+          `admin ${viewport.name}: external scroll delta`,
+        ).toBeLessThanOrEqual(TOLERANCE);
+        expect(
+          boundary.horizontalScrollDelta,
+          `admin ${viewport.name}: horizontal scroll delta`,
+        ).toBeLessThanOrEqual(TOLERANCE);
+        expect(
+          boundary.navVisible,
+          `admin ${viewport.name}: admin bottom nav visible`,
+        ).toBe(true);
+        expect(
+          boundary.mainBottom!,
+          `admin ${viewport.name}: main must not escape below the bottom nav`,
+        ).toBeLessThanOrEqual(boundary.navTop! + TOLERANCE);
+      }).toPass({ timeout: 12_000 });
+    });
+  }
+});

--- a/frontend/e2e/logistics-mobile-no-horizontal-table.spec.ts
+++ b/frontend/e2e/logistics-mobile-no-horizontal-table.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOLERANCE = 2;
+
+const MOBILE_VIEWPORTS = [
+  { name: "360x740", width: 360, height: 740 },
+  { name: "375x667", width: 375, height: 667 },
+  { name: "390x844", width: 390, height: 844 },
+] as const;
+
+const ROUTES = [
+  {
+    path: "/dashboard/logistica/visitas",
+    canvas: "visitas",
+    pagerName: "Paginación de visitas",
+    mobileRow: '[data-logistics-mobile-row="visita"]',
+  },
+  {
+    path: "/dashboard/logistica/rutas",
+    canvas: "rutas",
+    pagerName: "Paginación de planes de ruta",
+    mobileRow: '[data-logistics-mobile-row="ruta"]',
+  },
+  {
+    path: "/dashboard/logistica/metricas",
+    canvas: "metricas",
+    pagerName: "Paginación de métricas de ruta",
+    mobileRow: '[data-logistics-metric-block="true"]',
+  },
+] as const;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+async function readHorizontalScrollers(page: Page) {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>("main.dashboard-main");
+    if (!root) {
+      return [];
+    }
+
+    const candidates = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))];
+
+    return candidates.flatMap((element) => {
+      const delta = element.scrollWidth - element.clientWidth;
+      if (delta <= 2) {
+        return [];
+      }
+
+      const style = window.getComputedStyle(element);
+      if (style.display === "none") {
+        return [];
+      }
+
+      return [
+        {
+          tag: element.tagName,
+          className:
+            typeof element.className === "string" ? element.className : "",
+          delta,
+        },
+      ];
+    });
+  });
+}
+
+test.describe("logistics full routes — mobile rows without horizontal table scroll", () => {
+  for (const route of ROUTES) {
+    for (const viewport of MOBILE_VIEWPORTS) {
+      test(`${route.canvas} renders mobile rows and no horizontal scroll at ${viewport.name}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await setPopulatedClinicSession(page);
+        await page.goto(route.path);
+
+        const pager = page.getByRole("navigation", { name: route.pagerName });
+        const mobileRows = page.locator(route.mobileRow);
+
+        await expect(async () => {
+          await expect(pager).toBeVisible();
+          expect(
+            await mobileRows.count(),
+            `${route.canvas} ${viewport.name}: mobile row variant active`,
+          ).toBeGreaterThan(0);
+        }).toPass({ timeout: 15_000 });
+
+        // Desktop table must be inactive on mobile (visitas/rutas only).
+        if (route.canvas !== "metricas") {
+          await expect(
+            page.locator(`[data-dashboard-table-canvas="${route.canvas}"] table`),
+          ).toBeHidden();
+        }
+
+        // No document-level scroll in either axis.
+        const external = await page.evaluate(() => ({
+          vertical:
+            document.documentElement.scrollHeight -
+            document.documentElement.clientHeight,
+          horizontal:
+            document.documentElement.scrollWidth -
+            document.documentElement.clientWidth,
+        }));
+        expect(
+          external.vertical,
+          `${route.canvas} ${viewport.name}: external vertical scroll`,
+        ).toBeLessThanOrEqual(TOLERANCE);
+        expect(
+          external.horizontal,
+          `${route.canvas} ${viewport.name}: external horizontal scroll`,
+        ).toBeLessThanOrEqual(TOLERANCE);
+
+        // No internal horizontal scroller (the legacy 508px table overflow).
+        const horizontalScrollers = await readHorizontalScrollers(page);
+        expect(
+          horizontalScrollers,
+          `${route.canvas} ${viewport.name}: horizontal scrollers must be empty, found ${JSON.stringify(horizontalScrollers)}`,
+        ).toEqual([]);
+
+        // Pager fully inside the viewport (the legacy below-the-fold failure).
+        const pagerBox = await pager.boundingBox();
+        expect(pagerBox).not.toBeNull();
+        expect(
+          pagerBox!.y,
+          `${route.canvas} ${viewport.name}: pager top inside viewport`,
+        ).toBeGreaterThanOrEqual(-TOLERANCE);
+        expect(
+          pagerBox!.y + pagerBox!.height,
+          `${route.canvas} ${viewport.name}: pager bottom inside viewport`,
+        ).toBeLessThanOrEqual(viewport.height + TOLERANCE);
+
+        // Every mobile row stays inside the horizontal viewport.
+        const rowCount = await mobileRows.count();
+        for (let index = 0; index < rowCount; index += 1) {
+          const box = await mobileRows.nth(index).boundingBox();
+          if (!box) {
+            continue;
+          }
+          expect(
+            box.x + box.width,
+            `${route.canvas} ${viewport.name}: row ${index} right edge`,
+          ).toBeLessThanOrEqual(viewport.width + TOLERANCE);
+        }
+      });
+    }
+  }
+});

--- a/frontend/e2e/particular-authenticated-no-scroll.spec.ts
+++ b/frontend/e2e/particular-authenticated-no-scroll.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  assertParticularNoScrollContract,
+  mockParticularAuthenticatedSession,
+  readParticularDocumentNoScrollContract,
+  setParticularSessionCookie,
+} from "./helpers/particular-session-contracts";
+
+const TOLERANCE = 2;
+
+const VIEWPORTS = [
+  { name: "360x740", width: 360, height: 740 },
+  { name: "390x844", width: 390, height: 844 },
+  { name: "1366x768", width: 1366, height: 768 },
+] as const;
+
+test.describe("particular authenticated session — fixed-viewport no-scroll (R-18)", () => {
+  for (const viewport of VIEWPORTS) {
+    test(`authenticated /particulares fits the viewport at ${viewport.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await setParticularSessionCookie(page);
+      await mockParticularAuthenticatedSession(page);
+
+      await page.goto("/particulares");
+
+      // Authenticated operational state ready.
+      await expect(
+        page.locator('[data-particular-session-panel="true"]'),
+      ).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('html[data-particular-operational-viewport="true"]'),
+      ).toHaveCount(1, { timeout: 10_000 });
+
+      // Core operational content visible without scroll: tracking + report +
+      // primary actions.
+      const isMobile = viewport.width < 640;
+      const tracking = isMobile
+        ? page.locator('[data-particular-mobile-flat-card="tracking"]')
+        : page.locator("#particular-study-tracking");
+      const report = isMobile
+        ? page.locator('[data-particular-mobile-flat-card="report"]')
+        : page.locator("#particular-report");
+
+      await expect(tracking, `${viewport.name}: tracking visible`).toBeVisible();
+      await expect(report, `${viewport.name}: report visible`).toBeVisible();
+      await expect(
+        report.getByRole("button", { name: "Ver informe" }),
+        `${viewport.name}: primary action Ver informe`,
+      ).toBeVisible();
+      await expect(
+        report.getByRole("button", { name: "Descargar" }),
+        `${viewport.name}: primary action Descargar`,
+      ).toBeVisible();
+
+      // Fixed-viewport contract: zero external scroll in both axes plus the
+      // pre-existing forbidden-overflow invariant.
+      await expect(async () => {
+        const contract = await readParticularDocumentNoScrollContract(page);
+        assertParticularNoScrollContract(contract, `authenticated ${viewport.name}`);
+        expect(
+          contract.html.scrollHeight,
+          `${viewport.name}: external vertical scroll delta`,
+        ).toBeLessThanOrEqual(contract.html.clientHeight + TOLERANCE);
+        expect(
+          contract.body.scrollHeight,
+          `${viewport.name}: body vertical scroll delta`,
+        ).toBeLessThanOrEqual(contract.body.clientHeight + TOLERANCE);
+      }).toPass({ timeout: 12_000 });
+
+      // Operational content must not escape below the viewport (bottom escape
+      // delta = 0).
+      for (const [label, locator] of [
+        ["tracking", tracking],
+        ["report", report],
+      ] as const) {
+        const box = await locator.boundingBox();
+        expect(box, `${viewport.name}: ${label} box`).not.toBeNull();
+        expect(
+          box!.y + box!.height,
+          `${viewport.name}: ${label} must not escape below the viewport`,
+        ).toBeLessThanOrEqual(viewport.height + TOLERANCE);
+      }
+    });
+  }
+
+  test("logout restores the public marketing document flow", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await setParticularSessionCookie(page);
+    await mockParticularAuthenticatedSession(page);
+
+    await page.route("**/api/particular/auth/logout", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await page.goto("/particulares");
+    await expect(
+      page.locator('html[data-particular-operational-viewport="true"]'),
+    ).toHaveCount(1, { timeout: 15_000 });
+
+    await page
+      .getByRole("button", { name: "Cerrar sesión particular" })
+      .click();
+
+    await expect(
+      page.locator('html[data-particular-operational-viewport="true"]'),
+    ).toHaveCount(0, { timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: /Ingresar/ }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -550,49 +550,56 @@ export function ClinicInformesWorkspaceSummary({
 
           <div
             data-clinic-reports-pagination-footer="true"
-            className="flex min-h-10 shrink-0 items-center justify-end border-t border-vetneb-line/65 px-3 py-2 text-xs text-muted-foreground"
+            className="flex shrink-0 items-center justify-center border-t border-vetneb-line/65 px-3 text-xs text-muted-foreground"
           >
-            <div
+            <nav
+              aria-label="Paginación de informes recientes"
+              data-dashboard-pager="true"
               data-clinic-reports-pagination-controls="true"
-              className="flex items-center justify-end gap-1.5"
+              className="dashboard-pager"
             >
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-8 px-2 text-xs"
-                disabled={!pagedReports.hasPrev}
-                onClick={() => {
-                  setSelectedReportId(null);
-                  pagedReports.goPrev();
-                }}
-                aria-label="Página anterior"
-              >
-                Anterior
-              </Button>
+              <span data-dashboard-pager-prev="true" className="inline-flex">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 px-2 text-xs"
+                  disabled={!pagedReports.hasPrev}
+                  onClick={() => {
+                    setSelectedReportId(null);
+                    pagedReports.goPrev();
+                  }}
+                  aria-label="Página anterior"
+                >
+                  Anterior
+                </Button>
+              </span>
 
               <span
+                data-dashboard-pager-state="true"
                 data-clinic-reports-pagination-status="true"
                 className="min-w-16 text-center"
               >
-                Página {pagedReports.page + 1} / {pagedReports.pageCount}
+                Página {pagedReports.page + 1} de {pagedReports.pageCount}
               </span>
 
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-8 px-2 text-xs"
-                disabled={!pagedReports.hasNext}
-                onClick={() => {
-                  setSelectedReportId(null);
-                  pagedReports.goNext();
-                }}
-                aria-label="Página siguiente"
-              >
-                Siguiente
-              </Button>
-            </div>
+              <span data-dashboard-pager-next="true" className="inline-flex">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 px-2 text-xs"
+                  disabled={!pagedReports.hasNext}
+                  onClick={() => {
+                    setSelectedReportId(null);
+                    pagedReports.goNext();
+                  }}
+                  aria-label="Página siguiente"
+                >
+                  Siguiente
+                </Button>
+              </span>
+            </nav>
           </div>
         </div>
       ) : (

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import type { FieldVisit } from "@/types";
 import { Route as RouteIcon, ExternalLink } from "lucide-react";
+import { useAdaptiveRowsPerPage } from "@/hooks/useAdaptiveRowsPerPage";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { EmptyState } from "@/components/dashboard/EmptyState";
+import { DashboardPager } from "@/components/dashboard/DashboardPager";
 import { DashboardRefreshButton } from "@/components/dashboard/DashboardRefreshButton";
 import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { ModuleSurface } from "@/components/dashboard/ModuleSurface";
+import { usePagedRows } from "@/components/dashboard/usePagedRows";
 import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { ROUTES } from "@/lib/routes";
 import { formatDate } from "@/lib/utils";
@@ -17,11 +20,50 @@ type Props = {
   visitsLoadError: boolean;
 };
 
+const VISITS_PAGE_SIZE = 3;
+const VISITS_ROW_HEIGHT_FALLBACK_PX = 44;
+
 export function ClinicLogisticaWorkspaceSummary({
   recentVisits,
   visitsLoadError,
 }: Props) {
   const [selectedVisitId, setSelectedVisitId] = useState<number | null>(null);
+  const [visitsListBodyNode, setVisitsListBodyNode] =
+    useState<HTMLDivElement | null>(null);
+  const [firstRowNode, setFirstRowNode] = useState<HTMLButtonElement | null>(
+    null,
+  );
+  const [rowHeightPx, setRowHeightPx] = useState(VISITS_ROW_HEIGHT_FALLBACK_PX);
+
+  useLayoutEffect(() => {
+    if (!firstRowNode) {
+      return;
+    }
+
+    const measureRowHeight = () => {
+      const height = firstRowNode.getBoundingClientRect().height;
+      if (height > 0) {
+        setRowHeightPx(height);
+      }
+    };
+
+    const observer = new ResizeObserver(measureRowHeight);
+    observer.observe(firstRowNode);
+    measureRowHeight();
+
+    return () => observer.disconnect();
+  }, [firstRowNode]);
+
+  // Adaptive density: the visible row count derives from the measured list
+  // canvas (390x844 fits fewer rows than 1440x900); the fixed page size is
+  // only the pre-measurement fallback.
+  const { rowsPerPage } = useAdaptiveRowsPerPage({
+    containerNode: visitsListBodyNode,
+    fallbackRows: VISITS_PAGE_SIZE,
+    rowHeightPx,
+  });
+
+  const pagedVisits = usePagedRows(recentVisits, rowsPerPage);
   const selectedVisit =
     selectedVisitId === null
       ? null
@@ -70,13 +112,15 @@ export function ClinicLogisticaWorkspaceSummary({
           className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-vetneb-line/75 bg-card/82"
         >
           <div
+            ref={setVisitsListBodyNode}
             data-clinic-logistics-list-body="true"
             className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden"
           >
-            {recentVisits.map((visit) => (
+            {pagedVisits.pageItems.map((visit, index) => (
               <button
                 key={visit.id}
                 type="button"
+                ref={index === 0 ? setFirstRowNode : undefined}
                 data-clinic-logistics-row="true"
                 onClick={() => setSelectedVisitId(visit.id)}
                 aria-haspopup="dialog"
@@ -96,6 +140,27 @@ export function ClinicLogisticaWorkspaceSummary({
                 <StatusBadge status={visit.status} size="sm" className="shrink-0" />
               </button>
             ))}
+          </div>
+
+          <div
+            data-clinic-logistics-pagination-footer="true"
+            className="flex shrink-0 items-center justify-center border-t border-vetneb-line/65 px-3 text-xs text-muted-foreground"
+          >
+            <DashboardPager
+              aria-label="Paginación de visitas recientes"
+              page={pagedVisits.page}
+              pageCount={pagedVisits.pageCount}
+              hasPrev={pagedVisits.hasPrev}
+              hasNext={pagedVisits.hasNext}
+              onPrev={() => {
+                setSelectedVisitId(null);
+                pagedVisits.goPrev();
+              }}
+              onNext={() => {
+                setSelectedVisitId(null);
+                pagedVisits.goNext();
+              }}
+            />
           </div>
         </div>
       ) : (

--- a/frontend/src/app/dashboard/informes/InformesReportsList.tsx
+++ b/frontend/src/app/dashboard/informes/InformesReportsList.tsx
@@ -4,9 +4,11 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { EmptyState } from "@/components/dashboard/EmptyState";
 import { ErrorState } from "@/components/dashboard/ErrorState";
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
 import { ReportFileActions } from "@/components/dashboard/ReportDownloadButton";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   StudyTimeline,
   type StudyTimelineStep,
@@ -23,6 +25,17 @@ type Measurement = {
   containerNode: HTMLElement | null;
   rowHeightPx: number;
 };
+
+type ReportDetailSection = "resumen" | "archivos" | "timeline";
+
+const REPORT_DETAIL_SECTIONS: Array<{
+  id: ReportDetailSection;
+  label: string;
+}> = [
+  { id: "resumen", label: "Resumen" },
+  { id: "archivos", label: "Archivos" },
+  { id: "timeline", label: "Timeline" },
+];
 
 function measurementsEqual(a: Measurement, b: Measurement) {
   return a.containerNode === b.containerNode && a.rowHeightPx === b.rowHeightPx;
@@ -124,6 +137,9 @@ export function InformesReportsList({
   const [selectedReportId, setSelectedReportId] = useState<number | null>(
     initialSelectedReportId,
   );
+  const [detailSection, setDetailSection] =
+    useState<ReportDetailSection>("resumen");
+  const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
 
   const [bodyNode, setBodyNode] = useState<HTMLElement | null>(null);
   const [rowNode, setRowNode] = useState<HTMLElement | null>(null);
@@ -276,6 +292,180 @@ export function InformesReportsList({
     setOffset((current) => current + effectiveLimit);
   }
 
+  function selectReport(reportId: number) {
+    setSelectedReportId(reportId);
+    setDetailSection("resumen");
+  }
+
+  // Bounded detail canvas (desktop panel + mobile dialog body): compact
+  // header, segmented sections and a persistent action dock. No core
+  // scroller — every section fits its canvas; long values truncate.
+  function renderReportDetailCanvas({
+    actionDockSurface,
+    exposeActionDock,
+  }: {
+    actionDockSurface: "panel" | "dialog";
+    exposeActionDock: boolean;
+  }) {
+    if (!selectedReport) {
+      return null;
+    }
+
+    const report = selectedReport;
+
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-vetneb-line/70 pb-3">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+              Detalle del informe
+            </p>
+            <h2
+              id="report-detail-heading"
+              className="mt-0.5 truncate text-base font-semibold text-vetneb-ink"
+            >
+              {getReportTitle(report)}
+            </h2>
+            <p className="truncate text-xs text-muted-foreground">
+              Clínica {report.clinicName ?? `#${report.clinicId}`}
+            </p>
+          </div>
+          <StatusBadge
+            status={report.status}
+            label={getReportStatusLabel(report.status)}
+          />
+        </div>
+
+        <div
+          role="tablist"
+          aria-label="Secciones del detalle del informe"
+          data-informes-detail-sections="true"
+          className="dashboard-module-tablist shrink-0"
+        >
+          {REPORT_DETAIL_SECTIONS.map((section) => (
+            <button
+              key={section.id}
+              type="button"
+              role="tab"
+              aria-selected={detailSection === section.id}
+              data-informes-detail-section-tab={section.id}
+              onClick={() => setDetailSection(section.id)}
+              className="dashboard-module-tab focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85"
+            >
+              {section.label}
+            </button>
+          ))}
+        </div>
+
+        <div
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          data-informes-detail-section-panel={detailSection}
+        >
+          {detailSection === "resumen" ? (
+            <dl className="grid min-h-0 grid-cols-2 content-start gap-2 overflow-hidden xl:grid-cols-3">
+              <div className="surface-soft min-w-0">
+                <dt className="text-xs text-muted-foreground">Paciente</dt>
+                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
+                  {report.patientName ?? "—"}
+                </dd>
+              </div>
+              <div className="surface-soft min-w-0">
+                <dt className="text-xs text-muted-foreground">Tipo de estudio</dt>
+                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
+                  {report.studyType ?? "—"}
+                </dd>
+              </div>
+              <div className="surface-soft min-w-0">
+                <dt className="text-xs text-muted-foreground">Fecha</dt>
+                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
+                  {formatDate(report.uploadDate)}
+                </dd>
+              </div>
+              <div className="surface-soft min-w-0">
+                <dt className="text-xs text-muted-foreground">Creado</dt>
+                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
+                  {formatDate(report.createdAt)}
+                </dd>
+              </div>
+              <div className="surface-soft min-w-0">
+                <dt className="text-xs text-muted-foreground">Actualizado</dt>
+                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
+                  {formatDate(report.updatedAt)}
+                </dd>
+              </div>
+              <div className="surface-soft min-w-0">
+                <dt className="text-xs text-muted-foreground">Estado</dt>
+                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
+                  {getReportStatusLabel(report.status)}
+                </dd>
+              </div>
+            </dl>
+          ) : null}
+
+          {detailSection === "archivos" ? (
+            <div className="surface-soft min-w-0">
+              <p className="text-xs text-muted-foreground">Archivo / Informe</p>
+              <p className="mt-1 truncate font-semibold text-vetneb-ink">
+                {report.fileName ?? (report.hasFile ? "Disponible" : "—")}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {report.hasFile
+                  ? "El documento está disponible en el dock de acciones."
+                  : "El informe aún no tiene archivo vinculado."}
+              </p>
+            </div>
+          ) : null}
+
+          {detailSection === "timeline" ? (
+            <section
+              className="flex min-h-0 flex-col gap-2 overflow-hidden"
+              aria-labelledby="study-timeline-heading"
+            >
+              <div className="shrink-0">
+                <h3
+                  id="study-timeline-heading"
+                  className="text-sm font-semibold text-vetneb-ink"
+                >
+                  Línea de tiempo del estudio
+                </h3>
+                <p className="truncate text-xs text-muted-foreground">
+                  Pasos derivados del estado y fechas ya disponibles.
+                </p>
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <StudyTimeline steps={selectedReportTimelineSteps} />
+              </div>
+            </section>
+          ) : null}
+        </div>
+
+        <section
+          className="shrink-0 border-t border-vetneb-line/70 pt-3"
+          aria-labelledby="report-actions-heading"
+          data-informes-detail-action-dock={exposeActionDock ? "true" : undefined}
+          data-informes-detail-action-dock-surface={actionDockSurface}
+        >
+          <h3
+            id="report-actions-heading"
+            className="text-sm font-semibold text-vetneb-ink"
+          >
+            Acciones
+          </h3>
+          <p className="truncate text-xs text-muted-foreground">
+            Visualización y descarga del archivo disponible.
+          </p>
+          <div className="mt-2">
+            <ReportFileActions
+              reportId={selectedReport.id}
+              hasFile={selectedReport.hasFile}
+              align="start"
+            />
+          </div>
+        </section>
+      </div>
+    );
+  }
+
   return (
     <>
       {/* Hidden below `sm` so the fixed chrome (filters + summary) never
@@ -311,7 +501,7 @@ export function InformesReportsList({
           <section
             id="reports-master-list"
             aria-labelledby="reports-list-heading"
-            className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
+            className="dashboard-master-panel flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-vetneb-line/75 bg-card/82"
           >
             <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
               <h2 id="reports-list-heading" className="dashboard-section-heading">
@@ -342,34 +532,40 @@ export function InformesReportsList({
       ) : null}
 
       {!loadError && reports.length > 0 ? (
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-hidden lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]"
+          data-informes-master-detail-canvas="true"
+        >
           <section
             id="reports-master-list"
             aria-labelledby="reports-list-heading"
-            className="dashboard-master-panel dashboard-inline-list flex-1 rounded-xl border border-vetneb-line/75 bg-card/82"
+            className="dashboard-master-panel flex min-h-0 flex-col overflow-hidden rounded-xl border border-vetneb-line/75 bg-card/82"
           >
-            <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-3">
+            <div className="shrink-0 border-b border-vetneb-line/70 px-4 py-2.5">
               <h2 id="reports-list-heading" className="dashboard-section-heading">
                 Lista de informes
               </h2>
               <p className="dashboard-section-description">
-                Click en un informe para ver el detalle desplegado dentro del propio informe.
+                Click en un informe para abrir su detalle operativo.
               </p>
             </div>
 
-            <div ref={setBodyNode} className="dashboard-inline-scroll divide-y divide-vetneb-line/60">
+            <div
+              ref={setBodyNode}
+              data-informes-rows-canvas="true"
+              className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden"
+            >
               {reports.map((report, index) => {
                 const isSelected = selectedReport?.id === report.id;
 
                 return (
-                  <div key={report.id} className="min-w-0">
+                  <div key={report.id} className="min-w-0 shrink-0">
                     <div ref={index === 0 ? setRowNode : undefined}>
                       <button
                         type="button"
                         id={`report-${report.id}`}
-                        onClick={() => setSelectedReportId(report.id)}
+                        onClick={() => selectReport(report.id)}
                         aria-current={isSelected ? "true" : undefined}
-                        aria-expanded={isSelected}
                         aria-label={
                           isSelected
                             ? `Informe seleccionado: ${getReportTitle(report)}`
@@ -399,136 +595,105 @@ export function InformesReportsList({
                         </div>
                       </button>
                     </div>
-
-                    {isSelected && selectedReport ? (
-                      <div
-                        id="report-detail"
-                        aria-labelledby="report-detail-heading"
-                        data-detail-state="selected"
-                        className="dashboard-inline-detail border-t border-vetneb-line/60 bg-vetneb-surface-muted/40"
-                      >
-                        <div className="space-y-4 p-4">
-                          <div className="flex flex-col gap-3 border-b border-vetneb-line/70 pb-4 lg:flex-row lg:items-start lg:justify-between">
-                            <div className="min-w-0">
-                              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-                                Detalle del informe
-                              </p>
-                              <h2 id="report-detail-heading" className="mt-1 text-xl font-semibold text-vetneb-ink">
-                                {getReportTitle(selectedReport)}
-                              </h2>
-                              <p className="mt-1 text-sm text-muted-foreground">
-                                Clínica {selectedReport.clinicName ?? `#${selectedReport.clinicId}`}
-                              </p>
-                            </div>
-                            <StatusBadge
-                              status={selectedReport.status}
-                              label={getReportStatusLabel(selectedReport.status)}
-                            />
-                          </div>
-
-                          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-                            <div className="surface-soft">
-                              <p className="text-xs text-muted-foreground">Paciente</p>
-                              <p className="mt-1 font-semibold text-vetneb-ink">
-                                {selectedReport.patientName ?? "—"}
-                              </p>
-                            </div>
-                            <div className="surface-soft">
-                              <p className="text-xs text-muted-foreground">Tipo de estudio</p>
-                              <p className="mt-1 font-semibold text-vetneb-ink">
-                                {selectedReport.studyType ?? "—"}
-                              </p>
-                            </div>
-                            <div className="surface-soft">
-                              <p className="text-xs text-muted-foreground">Fecha</p>
-                              <p className="mt-1 font-semibold text-vetneb-ink">
-                                {formatDate(selectedReport.uploadDate)}
-                              </p>
-                            </div>
-                            <div className="surface-soft">
-                              <p className="text-xs text-muted-foreground">Creado</p>
-                              <p className="mt-1 font-semibold text-vetneb-ink">
-                                {formatDate(selectedReport.createdAt)}
-                              </p>
-                            </div>
-                            <div className="surface-soft">
-                              <p className="text-xs text-muted-foreground">Actualizado</p>
-                              <p className="mt-1 font-semibold text-vetneb-ink">
-                                {formatDate(selectedReport.updatedAt)}
-                              </p>
-                            </div>
-                            <div className="surface-soft">
-                              <p className="text-xs text-muted-foreground">Archivo</p>
-                              <p className="mt-1 font-semibold text-vetneb-ink">
-                                {selectedReport.fileName ?? (selectedReport.hasFile ? "Disponible" : "—")}
-                              </p>
-                            </div>
-                          </div>
-
-                          <section className="space-y-3" aria-labelledby="report-actions-heading">
-                            <div>
-                              <h3 id="report-actions-heading" className="text-base font-semibold text-vetneb-ink">
-                                Acciones
-                              </h3>
-                              <p className="text-sm text-muted-foreground">
-                                Visualización y descarga del archivo disponible.
-                              </p>
-                            </div>
-                            <ReportFileActions
-                              reportId={selectedReport.id}
-                              hasFile={selectedReport.hasFile}
-                              align="start"
-                            />
-                          </section>
-
-                          <section className="space-y-3" aria-labelledby="study-timeline-heading">
-                            <div>
-                              <h3 id="study-timeline-heading" className="text-base font-semibold text-vetneb-ink">
-                                Línea de tiempo del estudio
-                              </h3>
-                              <p className="text-sm text-muted-foreground">
-                                Pasos derivados del estado y fechas ya disponibles.
-                              </p>
-                            </div>
-                            <StudyTimeline steps={selectedReportTimelineSteps} />
-                          </section>
-                        </div>
-                      </div>
-                    ) : null}
                   </div>
                 );
               })}
             </div>
 
+            {selectedReport ? (
+              <div
+                data-informes-selected-report-summary="true"
+                className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/60 px-3 py-2 lg:hidden"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-semibold text-vetneb-ink">
+                    {getReportTitle(selectedReport)}
+                  </p>
+                  <p className="truncate text-[0.6875rem] text-muted-foreground">
+                    {selectedReport.studyType ?? "Tipo sin registrar"} ·{" "}
+                    {formatDate(selectedReport.uploadDate)}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0 px-2 text-xs"
+                  onClick={() => setIsDetailDialogOpen(true)}
+                  aria-haspopup="dialog"
+                >
+                  Ver detalle
+                </Button>
+              </div>
+            ) : null}
+
             <nav
               aria-label="Paginación de informes"
-              className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+              data-dashboard-pager="true"
+              className="dashboard-pager shrink-0 border-t border-vetneb-line/70"
             >
-              <button
-                type="button"
-                onClick={goToPreviousPage}
-                disabled={page <= 1}
-                aria-label="Página anterior"
-                aria-disabled={page <= 1 ? "true" : undefined}
-                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Anterior
-              </button>
-              <span className="dashboard-pagination-context">
+              <span data-dashboard-pager-prev="true" className="inline-flex">
+                <button
+                  type="button"
+                  onClick={goToPreviousPage}
+                  disabled={page <= 1}
+                  aria-label="Página anterior"
+                  aria-disabled={page <= 1 ? "true" : undefined}
+                  className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Anterior
+                </button>
+              </span>
+              <span data-dashboard-pager-state="true" className="dashboard-pagination-context">
                 Página {page} de {reportsTotalPages}
               </span>
-              <button
-                type="button"
-                onClick={goToNextPage}
-                disabled={page >= reportsTotalPages}
-                aria-label="Página siguiente"
-                aria-disabled={page >= reportsTotalPages ? "true" : undefined}
-                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Siguiente
-              </button>
+              <span data-dashboard-pager-next="true" className="inline-flex">
+                <button
+                  type="button"
+                  onClick={goToNextPage}
+                  disabled={page >= reportsTotalPages}
+                  aria-label="Página siguiente"
+                  aria-disabled={page >= reportsTotalPages ? "true" : undefined}
+                  className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Siguiente
+                </button>
+              </span>
             </nav>
           </section>
+
+          {selectedReport ? (
+            <section
+              id="report-detail"
+              aria-labelledby="report-detail-heading"
+              data-detail-state="selected"
+              className="hidden min-h-0 flex-col overflow-hidden rounded-xl border border-vetneb-line/75 bg-vetneb-surface-muted/40 p-4 lg:flex"
+            >
+              {renderReportDetailCanvas({
+                actionDockSurface: "panel",
+                exposeActionDock: !isDetailDialogOpen,
+              })}
+            </section>
+          ) : null}
+
+          {selectedReport ? (
+            <ModuleDialog
+              open={isDetailDialogOpen}
+              onOpenChange={(open) => setIsDetailDialogOpen(open)}
+              title={getReportTitle(selectedReport)}
+              description="Detalle operativo del informe seleccionado."
+            >
+              <div
+                data-informes-detail-dialog="true"
+                className="flex min-h-0 flex-col overflow-hidden"
+              >
+                {renderReportDetailCanvas({
+                  actionDockSurface: "dialog",
+                  exposeActionDock: isDetailDialogOpen,
+                })}
+              </div>
+            </ModuleDialog>
+          ) : null}
         </div>
       ) : null}
     </>

--- a/frontend/src/app/dashboard/informes/page.tsx
+++ b/frontend/src/app/dashboard/informes/page.tsx
@@ -180,9 +180,12 @@ export default async function InformesPage({
         <Card className="dashboard-surface flex min-h-0 flex-1 flex-col overflow-hidden">
           <CardHeader className="shrink-0 border-b border-vetneb-line/70">
             <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-              <div>
-                <CardTitle className="text-base">Informes disponibles</CardTitle>
-                <p className="mt-1 text-sm text-muted-foreground">
+              <div className="min-w-0">
+                <CardTitle className="truncate text-base">Informes disponibles</CardTitle>
+                <p
+                  className="mt-1 text-sm text-muted-foreground"
+                  data-dashboard-chrome-secondary="true"
+                >
                   Seleccione un informe de la lista para abrir el detalle operativo.
                 </p>
               </div>
@@ -194,7 +197,7 @@ export default async function InformesPage({
               method="get"
               role="search"
               aria-label="Filtros compactos de informes"
-              className="shrink-0 lg:grid-cols-[1.4fr_0.8fr_1fr_auto]"
+              className="shrink-0 grid-cols-2 lg:grid-cols-[1.4fr_0.8fr_1fr_auto]"
             >
               <FilterField label="Buscar">
                 <Input

--- a/frontend/src/app/dashboard/logistica/LogisticsBoundedCanvas.tsx
+++ b/frontend/src/app/dashboard/logistica/LogisticsBoundedCanvas.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAdaptiveDashboardPageSize } from "@/hooks/useAdaptiveDashboardPageSize";
+
+export type LogisticsBoundedCanvasProps = {
+  /** Which logistics full-route table/list this canvas bounds. */
+  canvas: "visitas" | "rutas" | "metricas";
+  /** Route used to recompute the URL `limit` from the measured canvas. */
+  basePath: string;
+  /**
+   * True when the URL carries an explicit `limit` — the URL pager contract
+   * (offset/limit round-trip) always wins over the adaptive recomputation.
+   */
+  hasExplicitLimit: boolean;
+  currentLimit: number;
+  minLimit?: number;
+  maxLimit: number;
+  /** Pre-measurement row height estimate. */
+  rowFallbackPx?: number;
+  children: ReactNode;
+};
+
+/**
+ * Bounded data canvas for the logistics full routes (Block E).
+ *
+ * The server keeps the deterministic URL `offset/limit` pagination; this
+ * client layer only makes the *default* page size container-aware: when the
+ * URL has no explicit `limit`, the canvas measures how many real rows fit and
+ * replaces the URL once with `offset=0&limit=<measured>` so the server
+ * renders exactly the rows the viewport can show — no clipped rows, no
+ * internal scroller, pager always visible.
+ */
+export function LogisticsBoundedCanvas({
+  canvas,
+  basePath,
+  hasExplicitLimit,
+  currentLimit,
+  minLimit = 3,
+  maxLimit,
+  rowFallbackPx = 56,
+  children,
+}: LogisticsBoundedCanvasProps) {
+  const router = useRouter();
+  const replacedRef = useRef(false);
+  const [rowHeightPx, setRowHeightPx] = useState(rowFallbackPx);
+  const [headerHeightPx, setHeaderHeightPx] = useState(0);
+  const [hasMeasurableRows, setHasMeasurableRows] = useState(false);
+
+  const { containerRef, itemsPerPage, isMeasured } =
+    useAdaptiveDashboardPageSize({
+      fallbackItems: currentLimit,
+      rowHeightPx,
+      headerHeightPx,
+      safetyBufferPx: 8,
+      minItems: minLimit,
+      maxItems: maxLimit,
+      enabled: !hasExplicitLimit,
+    });
+
+  // Row/header geometry comes from the real rendered rows (desktop table row,
+  // mobile row variant or metric block — whichever is visible).
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || hasExplicitLimit) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const measure = () => {
+      frame = null;
+
+      const thead = node.querySelector("thead");
+      const theadRect = thead?.getBoundingClientRect();
+      const nextHeaderHeight =
+        theadRect && theadRect.height > 0 ? theadRect.height : 0;
+
+      const rowCandidates = node.querySelectorAll<HTMLElement>(
+        "tbody tr:not(:has(.clinical-table-state)), [data-logistics-mobile-row], [data-logistics-metric-block]",
+      );
+      let nextRowHeight = 0;
+      for (const candidate of rowCandidates) {
+        const rect = candidate.getBoundingClientRect();
+        if (rect.height > 0) {
+          nextRowHeight = rect.height;
+          break;
+        }
+      }
+
+      setHeaderHeightPx((previous) =>
+        previous === nextHeaderHeight ? previous : nextHeaderHeight,
+      );
+      if (nextRowHeight > 0) {
+        setHasMeasurableRows(true);
+        setRowHeightPx((previous) =>
+          previous === nextRowHeight ? previous : nextRowHeight,
+        );
+      }
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) {
+        return;
+      }
+
+      frame = requestAnimationFrame(measure);
+    };
+
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(node);
+    measure();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [containerRef, hasExplicitLimit]);
+
+  useEffect(() => {
+    if (
+      hasExplicitLimit ||
+      replacedRef.current ||
+      !isMeasured ||
+      !hasMeasurableRows ||
+      itemsPerPage <= 0 ||
+      itemsPerPage === currentLimit
+    ) {
+      return;
+    }
+
+    replacedRef.current = true;
+    router.replace(`${basePath}?offset=0&limit=${itemsPerPage}`, {
+      scroll: false,
+    });
+  }, [
+    basePath,
+    currentLimit,
+    hasExplicitLimit,
+    hasMeasurableRows,
+    isMeasured,
+    itemsPerPage,
+    router,
+  ]);
+
+  return (
+    <div
+      ref={(node) => {
+        containerRef.current = node;
+      }}
+      data-dashboard-table-canvas={canvas}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx
+++ b/frontend/src/app/dashboard/logistica/LogisticsCommandCenter.tsx
@@ -9,6 +9,7 @@ import {
   getRoutePlanStatusVariant,
   formatDate,
 } from "@/lib/utils";
+import { LogisticsRecentListCanvas } from "./LogisticsRecentListCanvas";
 
 export type LogisticsCommandCenterProps = {
   fieldVisits: FieldVisit[];
@@ -34,11 +35,11 @@ export function LogisticsCommandCenter({
 
   return (
     <section
-      className="space-y-5"
+      className="flex min-h-0 flex-1 flex-col gap-5"
       aria-labelledby="logistics-command-center-heading"
     >
       <section
-        className="surface-note-info"
+        className="surface-note-info shrink-0"
         aria-labelledby="logistics-operational-priority"
       >
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -82,7 +83,7 @@ export function LogisticsCommandCenter({
         </div>
       </section>
 
-      <div>
+      <div className="shrink-0">
         <h2
           id="logistics-command-center-heading"
           className="dashboard-section-heading"
@@ -94,9 +95,9 @@ export function LogisticsCommandCenter({
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Card className="dashboard-surface">
-          <CardHeader className="flex flex-row items-start justify-between pb-3">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 min-h-0 flex-1 auto-rows-fr">
+        <Card className="dashboard-surface flex min-h-0 flex-col overflow-hidden">
+          <CardHeader className="flex shrink-0 flex-row items-start justify-between pb-3">
             <div>
               <CardTitle className="text-base">Visitas de campo</CardTitle>
               <p className="mt-1 text-xs text-muted-foreground">
@@ -104,30 +105,32 @@ export function LogisticsCommandCenter({
               </p>
             </div>
           </CardHeader>
-          <CardContent className="space-y-1.5">
+          <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden">
             {fieldVisitsLoadError ? (
               <p role="alert" className="clinical-alert-warning">
                 No se pudieron cargar las visitas de campo. Intente nuevamente.
               </p>
             ) : recentVisits.length ? (
-              recentVisits.map((visit) => (
-                <div key={visit.id} className="dashboard-list-row">
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-vetneb-ink">
-                      {visit.clinicName ?? `Clínica #${visit.clinicId}`}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {visit.address ?? "Sin dirección"} ·{" "}
-                      {formatDate(visit.scheduledAt)}
-                    </p>
+              <LogisticsRecentListCanvas pagerAriaLabel="Paginación de visitas recientes">
+                {recentVisits.map((visit) => (
+                  <div key={visit.id} className="dashboard-list-row">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-vetneb-ink">
+                        {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {visit.address ?? "Sin dirección"} ·{" "}
+                        {formatDate(visit.scheduledAt)}
+                      </p>
+                    </div>
+                    <StatusBadge
+                      status={visit.status}
+                      size="sm"
+                      className="ml-2 shrink-0"
+                    />
                   </div>
-                  <StatusBadge
-                    status={visit.status}
-                    size="sm"
-                    className="ml-2 shrink-0"
-                  />
-                </div>
-              ))
+                ))}
+              </LogisticsRecentListCanvas>
             ) : (
               <EmptyState
                 title="Sin visitas activas"
@@ -138,8 +141,8 @@ export function LogisticsCommandCenter({
           </CardContent>
         </Card>
 
-        <Card className="dashboard-surface">
-          <CardHeader className="flex flex-row items-start justify-between pb-3">
+        <Card className="dashboard-surface flex min-h-0 flex-col overflow-hidden">
+          <CardHeader className="flex shrink-0 flex-row items-start justify-between pb-3">
             <div>
               <CardTitle className="text-base">Planes de ruta</CardTitle>
               <p className="mt-1 text-xs text-muted-foreground">
@@ -147,39 +150,41 @@ export function LogisticsCommandCenter({
               </p>
             </div>
           </CardHeader>
-          <CardContent className="space-y-1.5">
+          <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden">
             {routePlansLoadError ? (
               <p role="alert" className="clinical-alert-warning">
                 No se pudieron cargar los planes de ruta. Intente nuevamente.
               </p>
             ) : recentPlans.length ? (
-              recentPlans.map((plan) => {
-                const progress =
-                  plan.totalStops > 0
-                    ? Math.round(
-                        (plan.completedStops / plan.totalStops) * 100,
-                      )
-                    : 0;
-                return (
-                  <div key={plan.id} className="dashboard-list-row">
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-vetneb-ink">
-                        {plan.name}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {plan.completedStops}/{plan.totalStops} paradas ·{" "}
-                        {progress}% · {formatDate(plan.plannedDate)}
-                      </p>
+              <LogisticsRecentListCanvas pagerAriaLabel="Paginación de planes recientes">
+                {recentPlans.map((plan) => {
+                  const progress =
+                    plan.totalStops > 0
+                      ? Math.round(
+                          (plan.completedStops / plan.totalStops) * 100,
+                        )
+                      : 0;
+                  return (
+                    <div key={plan.id} className="dashboard-list-row">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-vetneb-ink">
+                          {plan.name}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {plan.completedStops}/{plan.totalStops} paradas ·{" "}
+                          {progress}% · {formatDate(plan.plannedDate)}
+                        </p>
+                      </div>
+                      <Badge
+                        variant={getRoutePlanStatusVariant(plan.status)}
+                        className="ml-2 shrink-0"
+                      >
+                        {getRoutePlanStatusLabel(plan.status)}
+                      </Badge>
                     </div>
-                    <Badge
-                      variant={getRoutePlanStatusVariant(plan.status)}
-                      className="ml-2 shrink-0"
-                    >
-                      {getRoutePlanStatusLabel(plan.status)}
-                    </Badge>
-                  </div>
-                );
-              })
+                  );
+                })}
+              </LogisticsRecentListCanvas>
             ) : (
               <EmptyState
                 title="Sin planes de ruta"

--- a/frontend/src/app/dashboard/logistica/LogisticsRecentListCanvas.tsx
+++ b/frontend/src/app/dashboard/logistica/LogisticsRecentListCanvas.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Children, useLayoutEffect, useState, type ReactNode } from "react";
+
+import { DashboardPager } from "@/components/dashboard/DashboardPager";
+import { usePagedRows } from "@/components/dashboard/usePagedRows";
+import { useAdaptiveDashboardPageSize } from "@/hooks/useAdaptiveDashboardPageSize";
+
+export type LogisticsRecentListCanvasProps = {
+  /** Accessible name for the pager landmark of this list. */
+  pagerAriaLabel: string;
+  /** Server-rendered `.dashboard-list-row` nodes. */
+  children: ReactNode;
+};
+
+/**
+ * Bounded adaptive canvas for the logistics hub "recent" lists.
+ *
+ * The rows stay server-rendered (the hub is a server component); this client
+ * layer only bounds them: it measures its own canvas, derives how many rows
+ * fit, pages the server-rendered rows client-side and keeps a centered pager
+ * visible so no row is ever clipped behind the mobile bottom nav.
+ */
+export function LogisticsRecentListCanvas({
+  pagerAriaLabel,
+  children,
+}: LogisticsRecentListCanvasProps) {
+  const items = Children.toArray(children);
+  const [rowHeightPx, setRowHeightPx] = useState(52);
+
+  const { containerRef, itemsPerPage } = useAdaptiveDashboardPageSize({
+    fallbackItems: 3,
+    rowHeightPx,
+    safetyBufferPx: 8,
+    minItems: 2,
+    maxItems: 12,
+  });
+
+  useLayoutEffect(() => {
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const measure = () => {
+      frame = null;
+      const row = node.querySelector(".dashboard-list-row");
+      const height = row?.getBoundingClientRect().height ?? 0;
+      if (height > 0) {
+        setRowHeightPx((previous) => (previous === height ? previous : height));
+      }
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) {
+        return;
+      }
+
+      frame = requestAnimationFrame(measure);
+    };
+
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(node);
+    measure();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [containerRef]);
+
+  const paged = usePagedRows(items, itemsPerPage);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        ref={(node) => {
+          containerRef.current = node;
+        }}
+        data-logistics-recent-list-canvas="true"
+        className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden"
+      >
+        {paged.pageItems}
+      </div>
+      <DashboardPager
+        aria-label={pagerAriaLabel}
+        page={paged.page}
+        pageCount={paged.pageCount}
+        hasPrev={paged.hasPrev}
+        hasNext={paged.hasNext}
+        onPrev={paged.goPrev}
+        onNext={paged.goNext}
+        className="shrink-0 border-t border-vetneb-line/60"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/logistica/metricas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/metricas/page.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { getRoutePlanMetrics, getRoutePlans } from "@/lib/api";
 import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
+import { LogisticsBoundedCanvas } from "../LogisticsBoundedCanvas";
 
 export const metadata: Metadata = {
   title: "Métricas de logística — Portal VETNEB",
@@ -72,6 +73,11 @@ export default async function MetricasPage({
   const resolvedSearchParams = (await searchParams) ?? {};
   const offset = normalizeOffset(resolvedSearchParams.offset);
   const limit = normalizeLimit(resolvedSearchParams.limit);
+  // Adaptive default page size: when the URL carries no explicit limit, the
+  // bounded canvas recomputes it from the measured viewport. For métricas
+  // this also caps the per-plan metrics fan-out to what is actually visible.
+  const hasExplicitLimit =
+    normalizeSearchParamValue(resolvedSearchParams.limit).trim() !== "";
 
   const requestOptions = await getLogisticsRequestOptions();
   let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
@@ -154,73 +160,88 @@ export default async function MetricasPage({
         notifications="clinic"
       />
       <main className="dashboard-main">
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <div
+          className="grid min-w-0 max-w-full grid-cols-2 gap-4 overflow-hidden md:grid-cols-4"
+          data-dashboard-metric-strip="true"
+        >
           <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardHeader className="min-w-0 max-w-full overflow-hidden pb-2">
+              <CardTitle className="min-w-0 max-w-full overflow-hidden text-sm font-medium text-muted-foreground [overflow-wrap:anywhere]">
                 Cumplimiento promedio
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
+            <CardContent className="min-w-0 max-w-full overflow-hidden">
+              <p className="min-w-0 max-w-full overflow-hidden text-3xl font-bold text-vetneb-ink [overflow-wrap:anywhere]">
                 {avgCompliance}%
               </p>
             </CardContent>
           </Card>
           <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardHeader className="min-w-0 max-w-full overflow-hidden pb-2">
+              <CardTitle className="min-w-0 max-w-full overflow-hidden text-sm font-medium text-muted-foreground [overflow-wrap:anywhere]">
                 Paradas completadas
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
+            <CardContent className="min-w-0 max-w-full overflow-hidden">
+              <p className="min-w-0 max-w-full overflow-hidden text-3xl font-bold text-vetneb-ink [overflow-wrap:anywhere]">
                 {completedStops}/{totalStops}
               </p>
             </CardContent>
           </Card>
           <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardHeader className="min-w-0 max-w-full overflow-hidden pb-2">
+              <CardTitle className="min-w-0 max-w-full overflow-hidden text-sm font-medium text-muted-foreground [overflow-wrap:anywhere]">
                 Duración promedio
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
+            <CardContent className="min-w-0 max-w-full overflow-hidden">
+              <p className="min-w-0 max-w-full overflow-hidden text-3xl font-bold text-vetneb-ink [overflow-wrap:anywhere]">
                 {avgDuration !== null ? `${avgDuration} min` : "—"}
               </p>
             </CardContent>
           </Card>
           <Card className="dashboard-metric-card p-0">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardHeader className="min-w-0 max-w-full overflow-hidden pb-2">
+              <CardTitle className="min-w-0 max-w-full overflow-hidden text-sm font-medium text-muted-foreground [overflow-wrap:anywhere]">
                 Planes analizados
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <p className="text-3xl font-bold text-vetneb-ink">
+            <CardContent className="min-w-0 max-w-full overflow-hidden">
+              <p className="min-w-0 max-w-full overflow-hidden text-3xl font-bold text-vetneb-ink [overflow-wrap:anywhere]">
                 {routeMetrics.length}
               </p>
             </CardContent>
           </Card>
         </div>
-        <p className="text-xs text-muted-foreground">
+        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
           Métricas calculadas sobre la página visible (máximo {limit} planes),
           no sobre el total general de rutas.
         </p>
 
-        <Card className="dashboard-surface">
-          <CardHeader>
+        <Card className="dashboard-surface" data-dashboard-table-surface="true">
+          <CardHeader className="shrink-0">
             <CardTitle className="text-base">Métricas por plan de ruta</CardTitle>
-            <CardDescription>
+            <CardDescription data-dashboard-chrome-secondary="true">
               Detalle de cumplimiento por cada plan ejecutado
             </CardDescription>
-            <p className="text-sm text-muted-foreground">
+            <p
+              className="text-sm text-muted-foreground"
+              data-dashboard-chrome-secondary="true"
+            >
               Mostrando {routeMetrics.length} métricas de ruta · página {currentPage}
               {canGoNext ? " · puede haber más planes de ruta disponibles" : ""}
             </p>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <LogisticsBoundedCanvas
+              canvas="metricas"
+              basePath="/dashboard/logistica/metricas"
+              hasExplicitLimit={hasExplicitLimit}
+              currentLimit={limit}
+              maxLimit={METRICAS_MAX_LIMIT}
+              minLimit={1}
+              rowFallbackPx={168}
+            >
             {routePlansLoadError ? (
               <div role="alert" className="clinical-alert-warning">
                 No se pudieron cargar los planes de ruta para métricas. Intente nuevamente.
@@ -238,9 +259,10 @@ export default async function MetricasPage({
                   <div
                     key={metric.routePlanId}
                     className="surface-soft space-y-3"
+                    data-logistics-metric-block="true"
                   >
-                    <div className="flex items-center justify-between">
-                      <h3 className="text-sm font-semibold text-vetneb-ink">
+                    <div className="flex min-w-0 max-w-full items-center justify-between gap-2 overflow-hidden">
+                      <h3 className="min-w-0 max-w-full overflow-hidden text-sm font-semibold text-vetneb-ink [overflow-wrap:anywhere]">
                         {plan?.name ?? `Plan #${metric.routePlanId}`}
                       </h3>
                       <Badge
@@ -255,26 +277,26 @@ export default async function MetricasPage({
                         {metric.complianceRate}% cumplimiento
                       </Badge>
                     </div>
-                    <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
-                      <div>
-                        <p className="text-xs text-muted-foreground">Total paradas</p>
-                        <p className="font-semibold">{metric.totalStops}</p>
+                    <div className="grid min-w-0 max-w-full grid-cols-2 gap-3 overflow-hidden text-sm md:grid-cols-4">
+                      <div className="min-w-0 max-w-full overflow-hidden">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">Total paradas</p>
+                        <p className="min-w-0 max-w-full overflow-hidden font-semibold [overflow-wrap:anywhere]">{metric.totalStops}</p>
                       </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">Completadas</p>
-                        <p className="font-semibold text-vetneb-teal">
+                      <div className="min-w-0 max-w-full overflow-hidden">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">Completadas</p>
+                        <p className="min-w-0 max-w-full overflow-hidden font-semibold text-vetneb-teal [overflow-wrap:anywhere]">
                           {metric.completedStops}
                         </p>
                       </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">Omitidas</p>
-                        <p className="font-semibold text-vetneb-amber">
+                      <div className="min-w-0 max-w-full overflow-hidden">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">Omitidas</p>
+                        <p className="min-w-0 max-w-full overflow-hidden font-semibold text-vetneb-amber [overflow-wrap:anywhere]">
                           {metric.skippedStops}
                         </p>
                       </div>
-                      <div>
-                        <p className="text-xs text-muted-foreground">Sin presencia</p>
-                        <p className="font-semibold text-destructive">
+                      <div className="min-w-0 max-w-full overflow-hidden">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">Sin presencia</p>
+                        <p className="min-w-0 max-w-full overflow-hidden font-semibold text-destructive [overflow-wrap:anywhere]">
                           {metric.noShowStops}
                         </p>
                       </div>
@@ -298,32 +320,38 @@ export default async function MetricasPage({
                 No hay métricas de ruta disponibles.
               </div>
             )}
+            </LogisticsBoundedCanvas>
           </CardContent>
           <nav
             aria-label="Paginación de métricas de ruta"
-            className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+            data-dashboard-pager="true"
+            className="dashboard-pager shrink-0 border-t border-vetneb-line/70"
           >
-            <PublicRouteControl
-              href={previousHref}
-              variant="bare"
-              disabled={!canGoPrevious}
-              aria-label="Página anterior"
-              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Anterior
-            </PublicRouteControl>
-            <span className="dashboard-pagination-context">
+            <span data-dashboard-pager-prev="true" className="inline-flex">
+              <PublicRouteControl
+                href={previousHref}
+                variant="bare"
+                disabled={!canGoPrevious}
+                aria-label="Página anterior"
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Anterior
+              </PublicRouteControl>
+            </span>
+            <span data-dashboard-pager-state="true" className="dashboard-pagination-context">
               Página {currentPage}
             </span>
-            <PublicRouteControl
-              href={nextHref}
-              variant="bare"
-              disabled={!canGoNext}
-              aria-label="Página siguiente"
-              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Siguiente
-            </PublicRouteControl>
+            <span data-dashboard-pager-next="true" className="inline-flex">
+              <PublicRouteControl
+                href={nextHref}
+                variant="bare"
+                disabled={!canGoNext}
+                aria-label="Página siguiente"
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Siguiente
+              </PublicRouteControl>
+            </span>
           </nav>
         </Card>
       </main>

--- a/frontend/src/app/dashboard/logistica/rutas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/rutas/page.tsx
@@ -19,6 +19,7 @@ import {
   getRoutePlanStatusVariant,
   formatDate,
 } from "@/lib/utils";
+import { LogisticsBoundedCanvas } from "../LogisticsBoundedCanvas";
 
 export const metadata: Metadata = {
   title: "Planes de ruta — Portal VETNEB",
@@ -78,6 +79,11 @@ export default async function RutasPage({
   const resolvedSearchParams = (await searchParams) ?? {};
   const offset = normalizeOffset(resolvedSearchParams.offset);
   const limit = normalizeLimit(resolvedSearchParams.limit);
+  // Adaptive default page size: when the URL carries no explicit limit, the
+  // bounded canvas recomputes it from the measured viewport (URL offset/limit
+  // stays the single pagination contract).
+  const hasExplicitLimit =
+    normalizeSearchParamValue(resolvedSearchParams.limit).trim() !== "";
 
   let routePlans: Awaited<ReturnType<typeof getRoutePlans>> = [];
   let routePlansLoadError = false;
@@ -110,7 +116,10 @@ export default async function RutasPage({
         notifications="clinic"
       />
       <main className="dashboard-main">
-        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div
+          className="grid grid-cols-2 gap-3 md:grid-cols-4"
+          data-dashboard-metric-strip="true"
+        >
           {(
             [
               { status: "draft", label: "Borradores" },
@@ -134,18 +143,81 @@ export default async function RutasPage({
           Conteos calculados sobre la página visible, no sobre el total general de planes de ruta.
         </p>
 
-        <Card className="dashboard-surface">
-          <CardHeader>
+        <Card className="dashboard-surface" data-dashboard-table-surface="true">
+          <CardHeader className="shrink-0">
             <CardTitle className="text-base">
               Planes de ruta ({routePlans.length})
             </CardTitle>
-            <p className="text-sm text-muted-foreground">
+            <p
+              className="text-sm text-muted-foreground"
+              data-dashboard-chrome-secondary="true"
+            >
               Mostrando {routePlans.length} planes de ruta · página {currentPage}
               {canGoNext ? " · puede haber más planes de ruta disponibles" : ""}
             </p>
           </CardHeader>
-          <CardContent className="p-0">
-            <Table>
+          <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
+            <LogisticsBoundedCanvas
+              canvas="rutas"
+              basePath="/dashboard/logistica/rutas"
+              hasExplicitLimit={hasExplicitLimit}
+              currentLimit={limit}
+              maxLimit={RUTAS_MAX_LIMIT}
+            >
+              {/* Mobile row variant (<= md): no horizontal table scroll. */}
+              <div
+                className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
+                data-logistics-mobile-list="rutas"
+              >
+                {routePlansLoadError ? (
+                  <p role="alert" className="clinical-alert-warning m-3">
+                    No se pudieron cargar los planes de ruta. Intente nuevamente.
+                  </p>
+                ) : routePlans.length ? (
+                  routePlans.map((plan) => {
+                    const progress =
+                      plan.totalStops > 0
+                        ? Math.round(
+                            (plan.completedStops / plan.totalStops) * 100,
+                          )
+                        : 0;
+                    return (
+                      <div
+                        key={plan.id}
+                        data-logistics-mobile-row="ruta"
+                        className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-2"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-vetneb-ink">
+                            {plan.name}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {formatDate(plan.plannedDate)} ·{" "}
+                            {plan.completedStops}/{plan.totalStops} paradas
+                          </p>
+                          <p className="truncate text-[0.6875rem] text-muted-foreground">
+                            Progreso: {progress}%
+                          </p>
+                        </div>
+                        <Badge
+                          variant={getRoutePlanStatusVariant(plan.status)}
+                          className="shrink-0"
+                        >
+                          {getRoutePlanStatusLabel(plan.status)}
+                        </Badge>
+                      </div>
+                    );
+                  })
+                ) : (
+                  <p className="clinical-table-state m-3">
+                    No hay planes de ruta disponibles.
+                  </p>
+                )}
+              </div>
+
+              {/* Desktop table (>= md) with locked column geometry. */}
+              <div className="hidden min-h-0 flex-1 flex-col overflow-hidden md:flex">
+                <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>ID</TableHead>
@@ -225,33 +297,40 @@ export default async function RutasPage({
                   </TableRow>
                 )}
               </TableBody>
-            </Table>
+                </Table>
+              </div>
+            </LogisticsBoundedCanvas>
           </CardContent>
           <nav
             aria-label="Paginación de planes de ruta"
-            className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+            data-dashboard-pager="true"
+            className="dashboard-pager shrink-0 border-t border-vetneb-line/70"
           >
-            <PublicRouteControl
-              href={previousHref}
-              variant="bare"
-              disabled={!canGoPrevious}
-              aria-label="Página anterior"
-              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Anterior
-            </PublicRouteControl>
-            <span className="dashboard-pagination-context">
+            <span data-dashboard-pager-prev="true" className="inline-flex">
+              <PublicRouteControl
+                href={previousHref}
+                variant="bare"
+                disabled={!canGoPrevious}
+                aria-label="Página anterior"
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Anterior
+              </PublicRouteControl>
+            </span>
+            <span data-dashboard-pager-state="true" className="dashboard-pagination-context">
               Página {currentPage}
             </span>
-            <PublicRouteControl
-              href={nextHref}
-              variant="bare"
-              disabled={!canGoNext}
-              aria-label="Página siguiente"
-              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Siguiente
-            </PublicRouteControl>
+            <span data-dashboard-pager-next="true" className="inline-flex">
+              <PublicRouteControl
+                href={nextHref}
+                variant="bare"
+                disabled={!canGoNext}
+                aria-label="Página siguiente"
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Siguiente
+              </PublicRouteControl>
+            </span>
           </nav>
         </Card>
       </main>

--- a/frontend/src/app/dashboard/logistica/visitas/page.tsx
+++ b/frontend/src/app/dashboard/logistica/visitas/page.tsx
@@ -19,6 +19,7 @@ import {
   getFieldVisitStatusVariant,
   formatDateTime,
 } from "@/lib/utils";
+import { LogisticsBoundedCanvas } from "../LogisticsBoundedCanvas";
 
 export const metadata: Metadata = {
   title: "Visitas de campo — Portal VETNEB",
@@ -78,6 +79,11 @@ export default async function VisitasPage({
   const resolvedSearchParams = (await searchParams) ?? {};
   const offset = normalizeOffset(resolvedSearchParams.offset);
   const limit = normalizeLimit(resolvedSearchParams.limit);
+  // Adaptive default page size: when the URL carries no explicit limit, the
+  // bounded canvas recomputes it from the measured viewport (URL offset/limit
+  // stays the single pagination contract).
+  const hasExplicitLimit =
+    normalizeSearchParamValue(resolvedSearchParams.limit).trim() !== "";
 
   let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];
   let visitsLoadError = false;
@@ -110,7 +116,10 @@ export default async function VisitasPage({
         notifications="clinic"
       />
       <main className="dashboard-main">
-        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div
+          className="grid grid-cols-2 gap-3 md:grid-cols-4"
+          data-dashboard-metric-strip="true"
+        >
           {(
             [
               { status: "pending", label: "Pendientes" },
@@ -134,18 +143,76 @@ export default async function VisitasPage({
           Conteos calculados sobre la página visible, no sobre el total general de visitas.
         </p>
 
-        <Card className="dashboard-surface">
-          <CardHeader>
+        <Card className="dashboard-surface" data-dashboard-table-surface="true">
+          <CardHeader className="shrink-0">
             <CardTitle className="text-base">
               Visitas ({visits.length})
             </CardTitle>
-            <p className="text-sm text-muted-foreground">
+            <p
+              className="text-sm text-muted-foreground"
+              data-dashboard-chrome-secondary="true"
+            >
               Mostrando {visits.length} visitas · página {currentPage}
               {canGoNext ? " · puede haber más visitas disponibles" : ""}
             </p>
           </CardHeader>
-          <CardContent className="p-0">
-            <Table>
+          <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
+            <LogisticsBoundedCanvas
+              canvas="visitas"
+              basePath="/dashboard/logistica/visitas"
+              hasExplicitLimit={hasExplicitLimit}
+              currentLimit={limit}
+              maxLimit={VISITAS_MAX_LIMIT}
+            >
+              {/* Mobile row variant (<= md): no horizontal table scroll. */}
+              <div
+                className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden md:hidden"
+                data-logistics-mobile-list="visitas"
+              >
+                {visitsLoadError ? (
+                  <p role="alert" className="clinical-alert-warning m-3">
+                    No se pudieron cargar las visitas de campo. Intente nuevamente.
+                  </p>
+                ) : visits.length ? (
+                  visits.map((visit) => (
+                    <div
+                      key={visit.id}
+                      data-logistics-mobile-row="visita"
+                      className="grid w-full min-w-0 max-w-full shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-hidden px-3 py-2"
+                    >
+                      <div className="min-w-0 max-w-full overflow-hidden">
+                        <p className="block min-w-0 max-w-full overflow-hidden text-sm font-semibold text-vetneb-ink [overflow-wrap:anywhere]">
+                          {visit.clinicName ?? `Clínica #${visit.clinicId}`}
+                        </p>
+                        <p className="block min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
+                          {formatDateTime(visit.scheduledAt)}
+                          {" → "}
+                          {visit.completedAt
+                            ? formatDateTime(visit.completedAt)
+                            : "—"}
+                        </p>
+                        <p className="block min-w-0 max-w-full overflow-hidden text-[0.6875rem] leading-tight text-muted-foreground [overflow-wrap:anywhere]">
+                          {visit.address ?? "—"} · {visit.notes ?? "—"}
+                        </p>
+                      </div>
+                      <Badge
+                        variant={getFieldVisitStatusVariant(visit.status)}
+                        className="shrink-0"
+                      >
+                        {getFieldVisitStatusLabel(visit.status)}
+                      </Badge>
+                    </div>
+                  ))
+                ) : (
+                  <p className="clinical-table-state m-3">
+                    No hay visitas de campo disponibles.
+                  </p>
+                )}
+              </div>
+
+              {/* Desktop table (>= md) with locked column geometry. */}
+              <div className="hidden min-h-0 flex-1 flex-col overflow-hidden md:flex">
+                <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>ID</TableHead>
@@ -209,33 +276,40 @@ export default async function VisitasPage({
                   </TableRow>
                 )}
               </TableBody>
-            </Table>
+                </Table>
+              </div>
+            </LogisticsBoundedCanvas>
           </CardContent>
           <nav
             aria-label="Paginación de visitas"
-            className="flex shrink-0 items-center justify-between gap-2 border-t border-vetneb-line/70 px-4 py-3"
+            data-dashboard-pager="true"
+            className="dashboard-pager shrink-0 border-t border-vetneb-line/70"
           >
-            <PublicRouteControl
-              href={previousHref}
-              variant="bare"
-              disabled={!canGoPrevious}
-              aria-label="Página anterior"
-              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Anterior
-            </PublicRouteControl>
-            <span className="dashboard-pagination-context">
+            <span data-dashboard-pager-prev="true" className="inline-flex">
+              <PublicRouteControl
+                href={previousHref}
+                variant="bare"
+                disabled={!canGoPrevious}
+                aria-label="Página anterior"
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Anterior
+              </PublicRouteControl>
+            </span>
+            <span data-dashboard-pager-state="true" className="dashboard-pagination-context">
               Página {currentPage}
             </span>
-            <PublicRouteControl
-              href={nextHref}
-              variant="bare"
-              disabled={!canGoNext}
-              aria-label="Página siguiente"
-              className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Siguiente
-            </PublicRouteControl>
+            <span data-dashboard-pager-next="true" className="inline-flex">
+              <PublicRouteControl
+                href={nextHref}
+                variant="bare"
+                disabled={!canGoNext}
+                aria-label="Página siguiente"
+                className="dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Siguiente
+              </PublicRouteControl>
+            </span>
           </nav>
         </Card>
       </main>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -77,7 +77,11 @@ export default async function DashboardPage({
   await Promise.all([
     (async () => {
       try {
-        reports = await getReports(requestOptions, { limit: 3, offset: 0 }, {
+        // Viewport-safe superset: the informes/logistica workspace summaries
+        // paginate client-side with a measured adaptive page size, so the
+        // fetch cap must cover the largest desktop canvas (matches
+        // INFORMES_LIMIT_CAP), not the smallest mobile page.
+        reports = await getReports(requestOptions, { limit: 24, offset: 0 }, {
           throwOnError: true,
         });
       } catch (error) {
@@ -97,8 +101,8 @@ export default async function DashboardPage({
     })(),
   ]);
 
-  const recentReports = reports.slice(0, 3);
-  const recentVisits = visits.slice(0, 3);
+  const recentReports = reports.slice(0, 24);
+  const recentVisits = visits.slice(0, 24);
 
   const pendingReports = stats?.pendingReports ?? 0;
   const activeVisits = stats?.activeVisits ?? 0;
@@ -135,8 +139,8 @@ export default async function DashboardPage({
                   <ClinicCommandCenter
                     stats={stats}
                     statsLoadError={statsLoadError}
-                    recentReports={recentReports}
-                    recentVisits={recentVisits}
+                    recentReports={recentReports.slice(0, 3)}
+                    recentVisits={recentVisits.slice(0, 3)}
                     reportsLoadError={reportsLoadError}
                     visitsLoadError={visitsLoadError}
                   />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1004,6 +1004,303 @@
   }
   /* particular-mobile-flat-stack:end */
 
+  /* particular-authenticated-operational-viewport:start */
+  /*
+    Authenticated Particular session = fixed-viewport operational layout
+    (R-18 / zero-scroll Block G). ParticularesContent sets the root attribute
+    only while an authenticated particular session is active; without it the
+    public marketing page keeps its normal document flow untouched. Marketing
+    chrome (info column, FAQ, footer, next-steps band) leaves the operational
+    viewport; the session panel becomes the bounded canvas with compact
+    operational density. No overflow:auto/scroll is introduced anywhere —
+    the layout must genuinely fit (forbidden-overflow e2e contract).
+  */
+  html[data-particular-operational-viewport="true"],
+  html[data-particular-operational-viewport="true"] body {
+    height: 100dvh;
+    overflow: hidden;
+  }
+
+  html[data-particular-operational-viewport="true"] body .min-h-screen {
+    height: 100dvh;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  html[data-particular-operational-viewport="true"] main.public-page-canvas {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  html[data-particular-operational-viewport="true"] footer[role="contentinfo"],
+  html[data-particular-operational-viewport="true"]
+    section[aria-labelledby="footer-faq-heading"],
+  html[data-particular-operational-viewport="true"]
+    [data-particulares-next-step-zone="true"],
+  html[data-particular-operational-viewport="true"]
+    [data-particulares-hero="true"] > .order-2 {
+    display: none;
+  }
+
+  html[data-particular-operational-viewport="true"] .public-secondary-hero-surface {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    padding-block: clamp(0.35rem, 1.2vh, 0.9rem);
+  }
+
+  html[data-particular-operational-viewport="true"] [data-particulares-hero="true"] {
+    grid-template-columns: minmax(0, 1fr);
+    max-width: 46rem;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    gap: 0;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-session-panel="true"] {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    max-height: 100%;
+    overflow: hidden;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-session-panel="true"]
+    > .border-0 {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-header {
+    flex-shrink: 0;
+    min-height: 0;
+    padding: 0.55rem 0.75rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-header
+    > div {
+    align-items: center;
+    min-width: 0;
+    gap: 0.5rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-header
+    .h-11 {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.625rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-header
+    h3 {
+    font-size: 0.98rem;
+    line-height: 1.18;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-description {
+    display: none;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-body {
+    min-height: 0;
+    overflow: hidden;
+    padding: 0.55rem 0.65rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    .particular-operational-summary {
+    display: none !important;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-stack="true"] {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+    align-content: start;
+    min-height: 0;
+    height: 100%;
+    max-width: 100%;
+    gap: 0.5rem;
+    overflow: hidden;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-card] {
+    min-width: 0;
+    max-width: 100%;
+    padding: 0.55rem 0.65rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-card]
+    h3 {
+    font-size: 0.9rem;
+    line-height: 1.2;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-card]
+    p {
+    display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-card="tracking"]
+    > div {
+    margin-top: 0.35rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-card="tracking"]
+    > div
+    > * + * {
+    margin-top: 0.25rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-card="report"]
+    [data-particular-mobile-flat-actions="true"] {
+    margin-top: 0.5rem;
+    gap: 0.4rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-mobile-flat-actions="true"]
+    > *,
+  html[data-particular-operational-viewport="true"]
+    [data-particulares-report-actions="true"]
+    > * {
+    min-width: 0;
+    min-height: 2.25rem;
+    padding-inline: 0.5rem;
+    font-size: 0.75rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-logout-action="true"] {
+    min-width: 0;
+    min-height: 2.25rem;
+    flex-shrink: 0;
+    padding-block: 0.45rem;
+    padding-inline: 0.7rem;
+    font-size: 0.82rem;
+  }
+
+  /* Compact operational density inside the authenticated session panel. */
+  html[data-particular-operational-viewport="true"]
+    [data-particular-session-panel="true"]
+    .p-6 {
+    padding: 0.7rem 1rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-session-field="true"] {
+    padding: 0.35rem 0.6rem;
+  }
+
+  html[data-particular-operational-viewport="true"] #particular-study-tracking,
+  html[data-particular-operational-viewport="true"] #particular-report {
+    padding: 0.65rem 0.8rem;
+  }
+
+  html[data-particular-operational-viewport="true"]
+    [data-particular-session-summary="true"] {
+    padding: 0.65rem 0.8rem;
+  }
+
+  @media (min-width: 640px) {
+    html[data-particular-operational-viewport="true"]
+      [data-particulares-hero="true"] {
+      max-width: min(64rem, 100%);
+    }
+
+    html[data-particular-operational-viewport="true"]
+      .particular-operational-body {
+      padding: 0.75rem;
+    }
+
+    html[data-particular-operational-viewport="true"]
+      [data-particular-mobile-flat-stack="true"] {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-rows: minmax(0, 1fr) auto;
+      align-items: stretch;
+      gap: 0.75rem;
+    }
+
+    html[data-particular-operational-viewport="true"]
+      #particular-study-tracking,
+    html[data-particular-operational-viewport="true"]
+      #particular-report {
+      display: flex !important;
+      min-height: 0;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    html[data-particular-operational-viewport="true"]
+      #particular-study-tracking
+      > div,
+    html[data-particular-operational-viewport="true"]
+      #particular-report
+      > div {
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    html[data-particular-operational-viewport="true"]
+      #particular-study-tracking
+      p,
+    html[data-particular-operational-viewport="true"]
+      #particular-report
+      p {
+      display: -webkit-box;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 1;
+    }
+
+    html[data-particular-operational-viewport="true"]
+      [data-particulares-report-actions="true"] {
+      margin-top: auto;
+      gap: 0.5rem;
+    }
+
+    html[data-particular-operational-viewport="true"]
+      [data-particular-logout-action="true"] {
+      grid-column: 1 / -1;
+      justify-self: stretch;
+      min-height: 2.35rem;
+    }
+  }
+  /* particular-authenticated-operational-viewport:end */
+
   .public-copy {
     line-height: 1.7;
     overflow-wrap: break-word;
@@ -3819,3 +4116,295 @@
   }
 }
 /* dashboard-premium-grammar:end */
+/* dashboard-zero-scroll-substrate:start */
+@layer components {
+  /*
+    Fixed-viewport substrate (zero-scroll implementation, Block A).
+
+    Additive token layer: codifies the height ledger the flex chain already
+    produces (shell h-dvh -> topbar -> main -> module canvas -> data canvas)
+    so every surface can derive its canvas from the viewport instead of from
+    content. No pinned class contract above is redefined inside this @layer;
+    behavior-capable overrides live in the unlayered section below.
+  */
+  .dashboard-app-shell {
+    /* Canonical boundary tokens */
+    --dash-viewport-h: 100dvh;
+    --dash-topbar-h: var(--dash-header-h);
+    --dash-horizontal-nav-h: 0px;
+    --dash-bottom-nav-h: 0px;
+    --dash-safe-bottom: env(safe-area-inset-bottom, 0px);
+    --dash-module-header-h: clamp(2.25rem, 5vh, 3.25rem);
+    --dash-filter-h: var(--dash-control-h);
+    --dash-toolbar-h: clamp(2.25rem, 4.5vh, 3rem);
+    --dash-pagination-h: clamp(2.25rem, 4vh, 2.75rem);
+
+    /* Mathematical boundary allocation */
+    --dash-main-h: calc(
+      var(--dash-viewport-h)
+      - var(--dash-topbar-h)
+      - var(--dash-horizontal-nav-h)
+      - var(--dash-bottom-nav-h)
+      - var(--dash-safe-bottom)
+    );
+    --dash-module-canvas-h: calc(
+      var(--dash-main-h)
+      - var(--dash-module-header-h)
+      - var(--dash-filter-h)
+      - var(--dash-toolbar-h)
+      - var(--dash-pagination-h)
+      - (2 * var(--dash-pad-y))
+    );
+    --dash-data-canvas-h: calc(
+      var(--dash-module-canvas-h) - (2 * var(--dash-card-pad))
+    );
+  }
+
+  /* Mobile: the role bottom nav + safe area participate in the ledger. */
+  @media (max-width: 767px) {
+    .dashboard-app-shell {
+      --dash-bottom-nav-h: var(--admin-mobile-bottom-nav-h, 3.25rem);
+    }
+  }
+
+  /*
+    Shared centered pager grammar (Block C):
+    Anterior | Pagina X de Y | Siguiente.
+    Height is reserved through --dash-pagination-h so the pager can never be
+    pushed below its surface by growing content.
+  */
+  .dashboard-pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    flex-shrink: 0;
+    min-width: 0;
+    max-width: 100%;
+    height: var(--dash-pagination-h, 2.5rem);
+    min-height: var(--dash-pagination-h, 2.5rem);
+    max-height: var(--dash-pagination-h, 2.5rem);
+    padding-inline: 0.5rem;
+    overflow: hidden;
+  }
+
+  .dashboard-pager [data-dashboard-pager-state] {
+    text-align: center;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /*
+    Bounded full-route data surface (Block E): the card owns its pagination
+    footer; header/caption rows stay auto, the data canvas takes the exact
+    remainder and the pager is always the last visible row.
+  */
+  [data-dashboard-table-surface="true"] {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+
+  [data-dashboard-table-canvas] {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+}
+
+/*
+  Unlayered zero-scroll overrides (win over the flattened utility classes the
+  same way the admin-mobile blocks above do).
+*/
+
+/* The generic Table wrapper is overflow-auto by design; inside a bounded
+   zero-scroll canvas that would become a forbidden internal scroller, so the
+   canvas neutralizes it: rows are sized by the adaptive limit instead. */
+[data-dashboard-table-canvas] div:has(> table) {
+  overflow: hidden;
+  min-height: 0;
+  max-height: 100%;
+}
+
+/* Desktop column geometry locks (identifier left+truncate, dates 150-180px
+   tabular, badges 110-150px, no cell wrapping beyond 2 lines). */
+[data-dashboard-table-canvas] table {
+  width: 100%;
+}
+
+[data-dashboard-table-canvas] tbody td {
+  overflow-wrap: anywhere;
+}
+
+[data-dashboard-table-canvas="visitas"] th:nth-child(1) { width: 4.5rem; }
+[data-dashboard-table-canvas="visitas"] th:nth-child(4),
+[data-dashboard-table-canvas="visitas"] th:nth-child(5) { width: 10.5rem; }
+[data-dashboard-table-canvas="visitas"] th:nth-child(6) { width: 8.5rem; }
+[data-dashboard-table-canvas="visitas"] td:nth-child(4),
+[data-dashboard-table-canvas="visitas"] td:nth-child(5) {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+[data-dashboard-table-canvas="rutas"] th:nth-child(1) { width: 4.5rem; }
+[data-dashboard-table-canvas="rutas"] th:nth-child(3) { width: 10.5rem; }
+[data-dashboard-table-canvas="rutas"] th:nth-child(4) { width: 7rem; }
+[data-dashboard-table-canvas="rutas"] th:nth-child(6) { width: 8.5rem; }
+[data-dashboard-table-canvas="rutas"] td:nth-child(3) {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+[data-dashboard-table-canvas="metricas"] {
+  gap: 0.75rem;
+}
+
+@media (max-width: 767px) {
+  [data-logistics-mobile-row="visita"] {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  [data-logistics-mobile-row="visita"] > div {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  [data-logistics-mobile-row="visita"] p {
+    display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+}
+
+/* Métricas mobile blocks: the 2x4 stat grid inside each plan block compacts
+   to one 4-up line so a block stops consuming ~134px of a 740px viewport. */
+@media (max-width: 767px) {
+  [data-logistics-metric-block="true"] {
+    padding: 0.5rem 0.6rem;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  [data-logistics-metric-block="true"] > div {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  [data-logistics-metric-block="true"] h3 {
+    display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+
+  [data-logistics-metric-block="true"] > .grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.4rem;
+  }
+
+  [data-logistics-metric-block="true"] > .grid p {
+    display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
+    font-size: 0.65rem;
+    line-height: 1.25;
+    white-space: normal;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+}
+
+/* Compact metric strip (Block E/H): on mobile the 2x2 metric-card stack
+   becomes a single 4-up strip so it stops pushing the table and pager out of
+   the viewport (measured offender at 360x740 / 375x667). */
+@media (max-width: 767px) {
+  [data-dashboard-metric-strip="true"] {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.4rem;
+  }
+
+  [data-dashboard-metric-strip="true"] .dashboard-metric-card [class*="p-"],
+  [data-dashboard-metric-strip="true"] .dashboard-metric-card [class*="pt-"] {
+    padding: 0.45rem 0.5rem;
+  }
+
+  [data-dashboard-metric-strip="true"] .dashboard-metric-card p,
+  [data-dashboard-metric-strip="true"] .dashboard-metric-card h3 {
+    display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
+    font-size: 0.6rem;
+    line-height: 1.2;
+    margin-top: 0.1rem;
+    white-space: normal;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  [data-dashboard-metric-strip="true"] .dashboard-metric-card p:first-of-type {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin-top: 0;
+  }
+}
+
+/* Centered pager migration for the pinned CompactPager consumers (admin
+   pricing / maintenance): cluster centered, height reserved. */
+.dashboard-app-shell .dashboard-compact-pager {
+  justify-content: center;
+  min-height: var(--dash-pagination-h, 2.5rem);
+}
+
+/* Module chrome compression (Block H): on mobile the module header + filter +
+   toolbar stack may consume at most ~22% of dashboard-main; secondary copy
+   collapses first, titles stay single-line. */
+@media (max-width: 767px) {
+  .dashboard-app-shell .dashboard-workspace-header {
+    row-gap: 0.4rem;
+  }
+
+  /* Secondary copy collapses to a single truncated line (stays visible for
+     accessibility/parity assertions); explicit duplicates are removed. */
+  .dashboard-app-shell .dashboard-section-description {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .dashboard-app-shell [data-dashboard-chrome-secondary="true"] {
+    display: none;
+  }
+
+  .dashboard-app-shell .dashboard-section-heading {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+/* dashboard-zero-scroll-substrate:end */

--- a/frontend/src/components/dashboard/CompactPager.tsx
+++ b/frontend/src/components/dashboard/CompactPager.tsx
@@ -42,6 +42,7 @@ export function CompactPager({
     <div
       className={cn("dashboard-compact-pager", className)}
       data-dashboard-compact-pager="true"
+      data-dashboard-pager="compact"
     >
       <span aria-live="polite" aria-atomic="true">
         {total === 0
@@ -49,13 +50,17 @@ export function CompactPager({
           : `${rangeStart}–${rangeEnd} de ${total} ${itemLabel}`}
       </span>
       <div className="flex items-center gap-2">
-        <span className="text-xs text-muted-foreground">
+        <span
+          className="text-xs text-muted-foreground"
+          data-dashboard-pager-state="true"
+        >
           Pág. {page + 1} / {pageCount}
         </span>
         <button
           type="button"
           onClick={onPrev}
           disabled={disabled || !hasPrev}
+          data-dashboard-pager-prev="true"
           aria-label="Página anterior"
           className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-input bg-card/95 text-foreground dashboard-btn-interactive hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
@@ -65,6 +70,7 @@ export function CompactPager({
           type="button"
           onClick={onNext}
           disabled={disabled || !hasNext}
+          data-dashboard-pager-next="true"
           aria-label="Página siguiente"
           className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-input bg-card/95 text-foreground dashboard-btn-interactive hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
         >

--- a/frontend/src/components/dashboard/DashboardPager.tsx
+++ b/frontend/src/components/dashboard/DashboardPager.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared centered pager for the zero-scroll dashboard grammar:
+ *
+ *   Anterior | Página X de Y | Siguiente
+ *
+ * The cluster is centered inside a fixed `--dash-pagination-h` reserve so it
+ * can never be pushed below its surface. Two usage modes:
+ *
+ * 1. Standard mode: pass `page`/`pageCount`/`onPrev`/`onNext` and the pager
+ *    renders its own controls.
+ * 2. Slot mode: pass `prevControl`/`stateControl`/`nextControl` when the
+ *    surface owns pinned control markup (URL pagers, contract-locked
+ *    aria-labels); the pager only contributes the centered geometry and the
+ *    stable selectors.
+ */
+export type DashboardPagerProps = {
+  /** Accessible name of the pagination landmark. */
+  "aria-label": string;
+  className?: string;
+  /** Zero-based page index (standard mode). */
+  page?: number;
+  pageCount?: number;
+  hasPrev?: boolean;
+  hasNext?: boolean;
+  onPrev?: () => void;
+  onNext?: () => void;
+  disabled?: boolean;
+  /** Slot mode overrides. */
+  prevControl?: ReactNode;
+  stateControl?: ReactNode;
+  nextControl?: ReactNode;
+};
+
+const pagerButtonClassName =
+  "dashboard-pagination-btn inline-flex h-8 items-center justify-center rounded-md border border-input bg-card/95 px-3 text-xs font-semibold text-foreground shadow-sm transition-colors hover:border-vetneb-teal/45 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+export function DashboardPager({
+  "aria-label": ariaLabel,
+  className,
+  page = 0,
+  pageCount = 1,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  disabled = false,
+  prevControl,
+  stateControl,
+  nextControl,
+}: DashboardPagerProps) {
+  const safePageCount = Math.max(1, pageCount);
+  const displayPage = Math.min(Math.max(1, page + 1), safePageCount);
+  const canGoPrev = hasPrev ?? displayPage > 1;
+  const canGoNext = hasNext ?? displayPage < safePageCount;
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      data-dashboard-pager="true"
+      className={cn("dashboard-pager", className)}
+    >
+      <span data-dashboard-pager-prev="true" className="inline-flex">
+        {prevControl ?? (
+          <button
+            type="button"
+            onClick={onPrev}
+            disabled={disabled || !canGoPrev}
+            aria-label="Página anterior"
+            className={pagerButtonClassName}
+          >
+            Anterior
+          </button>
+        )}
+      </span>
+      <span
+        data-dashboard-pager-state="true"
+        className="text-xs text-muted-foreground"
+      >
+        {stateControl ?? (
+          <span className="dashboard-pagination-context">
+            Página {displayPage} de {safePageCount}
+          </span>
+        )}
+      </span>
+      <span data-dashboard-pager-next="true" className="inline-flex">
+        {nextControl ?? (
+          <button
+            type="button"
+            onClick={onNext}
+            disabled={disabled || !canGoNext}
+            aria-label="Página siguiente"
+            className={pagerButtonClassName}
+          >
+            Siguiente
+          </button>
+        )}
+      </span>
+    </nav>
+  );
+}

--- a/frontend/src/components/public/ParticularesContent.tsx
+++ b/frontend/src/components/public/ParticularesContent.tsx
@@ -383,6 +383,26 @@ export function ParticularesContent() {
     );
   }, []);
 
+  // Authenticated no-scroll contract (R-18): while a particular session is
+  // active, the public page becomes a fixed-viewport operational layout. The
+  // attribute scopes the CSS override block
+  // (particular-authenticated-operational-viewport in globals.css) and is
+  // removed on logout/expiry/unmount so the marketing page keeps its normal
+  // document flow.
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (session) {
+      root.setAttribute("data-particular-operational-viewport", "true");
+    } else {
+      root.removeAttribute("data-particular-operational-viewport");
+    }
+
+    return () => {
+      root.removeAttribute("data-particular-operational-viewport");
+    };
+  }, [session]);
+
   useEffect(() => {
     if (rateLimitCooldown <= 0) {
       return;
@@ -580,12 +600,22 @@ export function ParticularesContent() {
         </div>
 
         <PremiumPanel
-          className="order-1 overflow-hidden lg:order-2"
+          className={`order-1 overflow-hidden lg:order-2 ${
+            session ? "flex min-h-0 flex-col" : ""
+          }`}
           data-particular-session-panel={session ? "true" : undefined}
           data-particulares-primary-action="true"
         >
-          <Card className="border-0 bg-transparent shadow-none">
-            <CardHeader className="clinical-muted-band border-b">
+          <Card
+            className={
+              session
+                ? "flex h-full min-h-0 flex-col border-0 bg-transparent shadow-none"
+                : "border-0 bg-transparent shadow-none"
+            }
+          >
+            <CardHeader
+              className="particular-operational-header clinical-muted-band border-b"
+            >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex items-start gap-3">
                   <VisualIcon
@@ -594,10 +624,12 @@ export function ParticularesContent() {
                     className="h-11 w-11 rounded-xl"
                   />
                   <div>
-                    <CardTitle className="text-xl text-vetneb-ink">
+                    <CardTitle className="text-lg leading-tight text-vetneb-ink sm:text-xl">
                       {session ? "Sesión particular activa" : "Ingresar con token"}
                     </CardTitle>
-                    <CardDescription className="mt-1 leading-relaxed">
+                    <CardDescription
+                      className="particular-operational-description mt-1 leading-relaxed"
+                    >
                       {session
                         ? "Datos visibles del caso autenticado con seguimiento trazable del proceso diagnóstico."
                         : "Pegue el token recibido para consultar el estado del estudio y acceder al informe cuando esté disponible."}
@@ -612,7 +644,13 @@ export function ParticularesContent() {
               </div>
             </CardHeader>
 
-            <CardContent className="pt-6">
+            <CardContent
+              className={
+                session
+                  ? "particular-operational-body flex min-h-0 flex-1 flex-col p-3 sm:p-4"
+                  : "pt-6"
+              }
+            >
               {isCheckingSession ? (
                 <div
                   className="surface-empty p-4 text-sm"
@@ -624,14 +662,17 @@ export function ParticularesContent() {
                   Verificando sesión...
                 </div>
               ) : session ? (
-                <div className="space-y-5" data-particular-mobile-flat-stack="true">
+                <div
+                  className="grid min-h-0 max-w-full gap-2 overflow-hidden sm:gap-3"
+                  data-particular-mobile-flat-stack="true"
+                >
                   <div
-                    className="rounded-lg border border-vetneb-line bg-card p-3 sm:hidden"
+                    className="particular-operational-summary rounded-lg border border-vetneb-line bg-card p-2.5 sm:hidden"
                     data-particular-mobile-safe-summary="true"
                   >
-                    <dl className="grid grid-cols-1 gap-2 text-sm">
+                    <dl className="grid grid-cols-2 gap-1.5 text-sm">
                       <div
-                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        className="rounded-md border border-vetneb-line bg-card px-2.5 py-1.5"
                         data-particular-mobile-safe-field="true"
                       >
                         <dt className="font-medium text-muted-foreground">
@@ -642,7 +683,7 @@ export function ParticularesContent() {
                         </dd>
                       </div>
                       <div
-                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        className="rounded-md border border-vetneb-line bg-card px-2.5 py-1.5"
                         data-particular-mobile-safe-field="true"
                       >
                         <dt className="font-medium text-muted-foreground">
@@ -653,7 +694,7 @@ export function ParticularesContent() {
                         </dd>
                       </div>
                       <div
-                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        className="rounded-md border border-vetneb-line bg-card px-2.5 py-1.5"
                         data-particular-mobile-safe-field="true"
                       >
                         <dt className="font-medium text-muted-foreground">Especie</dt>
@@ -662,7 +703,7 @@ export function ParticularesContent() {
                         </dd>
                       </div>
                       <div
-                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        className="rounded-md border border-vetneb-line bg-card px-2.5 py-1.5"
                         data-particular-mobile-safe-field="true"
                       >
                         <dt className="font-medium text-muted-foreground">Raza</dt>
@@ -671,7 +712,7 @@ export function ParticularesContent() {
                         </dd>
                       </div>
                       <div
-                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        className="rounded-md border border-vetneb-line bg-card px-2.5 py-1.5"
                         data-particular-mobile-safe-field="true"
                       >
                         <dt className="font-medium text-muted-foreground">
@@ -682,7 +723,7 @@ export function ParticularesContent() {
                         </dd>
                       </div>
                       <div
-                        className="rounded-md border border-vetneb-line bg-card px-3 py-2.5"
+                        className="rounded-md border border-vetneb-line bg-card px-2.5 py-1.5"
                         data-particular-mobile-safe-field="true"
                       >
                         <dt className="font-medium text-muted-foreground">
@@ -696,7 +737,7 @@ export function ParticularesContent() {
                   </div>
 
                   <div
-                    className="hidden clinical-muted-band rounded-lg p-4 sm:block"
+                    className="particular-operational-summary hidden clinical-muted-band rounded-lg p-4 sm:block"
                     data-particular-session-summary="true"
                   >
                     <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
@@ -772,26 +813,26 @@ export function ParticularesContent() {
                   {/* Mobile flat tracking — sin clinical-muted-band ni capas compuestas */}
                   <div
                     data-particular-mobile-flat-card="tracking"
-                    className="rounded-lg border border-vetneb-line bg-card p-4 sm:hidden"
+                    className="min-w-0 max-w-full overflow-hidden rounded-lg border border-vetneb-line bg-card p-3 sm:hidden"
                   >
-                    <h3 className="font-semibold text-vetneb-navy">
+                    <h3 className="min-w-0 max-w-full overflow-hidden font-semibold text-vetneb-navy [overflow-wrap:anywhere]">
                       Seguimiento del estudio
                     </h3>
                     {trackingCase ? (
                       <div className="mt-2 space-y-2">
-                        <p className="text-sm text-vetneb-ink">
+                        <p className="min-w-0 max-w-full overflow-hidden text-sm text-vetneb-ink [overflow-wrap:anywhere]">
                           Estado del estudio:{" "}
                           <span className="font-semibold">
                             {getTrackingStageLabel(trackingCase.currentStage)}
                           </span>
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
                           Actualizado: {formatDate(trackingCase.updatedAt)}
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
                           Entrega en laboratorio: {formatDate(trackingCase.receptionAt)}
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
                           Estimación informe: {formatDate(trackingCase.estimatedDeliveryAt)}
                         </p>
                         {trackingCase.specialStainRequired ? (
@@ -831,27 +872,27 @@ export function ParticularesContent() {
 
                   {/* Desktop tracking — oculto en mobile, visible desde sm */}
                   <div
+                    className="hidden sm:block min-w-0 max-w-full overflow-hidden rounded-lg p-4 shadow-sm clinical-muted-band"
                     id="particular-study-tracking"
-                    className="hidden rounded-lg p-4 shadow-sm clinical-muted-band sm:block"
                   >
-                    <h3 className="font-semibold text-vetneb-navy">
+                    <h3 className="min-w-0 max-w-full overflow-hidden font-semibold text-vetneb-navy [overflow-wrap:anywhere]">
                       Seguimiento del estudio
                     </h3>
                     {trackingCase ? (
                       <div className="mt-2 space-y-2">
-                        <p className="text-sm text-vetneb-ink">
+                        <p className="min-w-0 max-w-full overflow-hidden text-sm text-vetneb-ink [overflow-wrap:anywhere]">
                           Estado del estudio:{" "}
                           <span className="font-semibold">
                             {getTrackingStageLabel(trackingCase.currentStage)}
                           </span>
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
                           Actualizado: {formatDate(trackingCase.updatedAt)}
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
                           Entrega en laboratorio: {formatDate(trackingCase.receptionAt)}
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="min-w-0 max-w-full overflow-hidden text-xs text-muted-foreground [overflow-wrap:anywhere]">
                           Estimación informe: {formatDate(trackingCase.estimatedDeliveryAt)}
                         </p>
                         {trackingCase.specialStainRequired ? (
@@ -895,24 +936,24 @@ export function ParticularesContent() {
                       <div
                         data-particular-mobile-flat-card="report"
                         data-particulares-report-state="available"
-                        className="rounded-lg border border-vetneb-line bg-card p-4 sm:hidden"
+                        className="min-w-0 max-w-full overflow-hidden rounded-lg border border-vetneb-line bg-card p-3 sm:hidden"
                       >
-                        <div className="flex items-start gap-3">
+                        <div className="flex min-w-0 max-w-full items-start gap-3 overflow-hidden">
                           <FileText
                             className="mt-0.5 h-5 w-5 shrink-0 text-vetneb-navy"
                             aria-hidden="true"
                             strokeWidth={1.8}
                           />
-                          <div>
-                            <div className="flex flex-wrap items-center gap-2">
-                              <h3 className="font-semibold text-vetneb-navy">
+                          <div className="min-w-0 max-w-full overflow-hidden">
+                            <div className="flex min-w-0 max-w-full flex-wrap items-center gap-2 overflow-hidden">
+                              <h3 className="min-w-0 max-w-full overflow-hidden font-semibold text-vetneb-navy [overflow-wrap:anywhere]">
                                 Informe vinculado
                               </h3>
                               <span className="inline-flex items-center rounded-full border border-vetneb-teal/40 bg-vetneb-teal/10 px-2 py-0.5 text-xs font-semibold text-vetneb-teal">
                                 Disponible
                               </span>
                             </div>
-                            <p className="mt-1 text-sm text-muted-foreground">
+                            <p className="mt-1 min-w-0 max-w-full overflow-hidden text-sm text-muted-foreground [overflow-wrap:anywhere]">
                               {session.report.studyType ?? "Estudio"} ·{" "}
                               {session.report.fileName ?? "Archivo disponible"}
                             </p>
@@ -922,7 +963,7 @@ export function ParticularesContent() {
                         <div
                           data-particular-mobile-flat-actions="true"
                           data-particulares-report-actions="true"
-                          className="mt-4 flex flex-col gap-3"
+                          className="mt-3 grid grid-cols-2 gap-2"
                         >
                           <Button
                             type="button"
@@ -948,26 +989,26 @@ export function ParticularesContent() {
 
                       {/* Desktop report — oculto en mobile, visible desde sm */}
                       <div
+                        className="hidden sm:block min-w-0 max-w-full overflow-hidden rounded-lg p-4 shadow-sm clinical-muted-band"
                         id="particular-report"
                         data-particulares-report-state="available"
-                        className="hidden rounded-lg p-4 shadow-sm clinical-muted-band sm:block"
                       >
-                        <div className="flex items-start gap-3">
+                        <div className="flex min-w-0 max-w-full items-start gap-3 overflow-hidden">
                           <VisualIcon
                             icon={FileText}
                             tone="blue"
                             className="h-10 w-10 shrink-0 rounded-xl"
                           />
-                          <div>
-                            <div className="flex flex-wrap items-center gap-2">
-                              <h3 className="font-semibold text-vetneb-navy">
+                          <div className="min-w-0 max-w-full overflow-hidden">
+                            <div className="flex min-w-0 max-w-full flex-wrap items-center gap-2 overflow-hidden">
+                              <h3 className="min-w-0 max-w-full overflow-hidden font-semibold text-vetneb-navy [overflow-wrap:anywhere]">
                                 Informe vinculado
                               </h3>
                               <span className="inline-flex items-center rounded-full border border-vetneb-teal/40 bg-vetneb-teal/10 px-2 py-0.5 text-xs font-semibold text-vetneb-teal">
                                 Disponible
                               </span>
                             </div>
-                            <p className="mt-1 text-sm text-muted-foreground">
+                            <p className="mt-1 min-w-0 max-w-full overflow-hidden text-sm text-muted-foreground [overflow-wrap:anywhere]">
                               {session.report.studyType ?? "Estudio"} ·{" "}
                               {session.report.fileName ?? "Archivo disponible"}
                             </p>
@@ -1045,7 +1086,8 @@ export function ParticularesContent() {
                     type="button"
                     variant="outline"
                     onClick={handleLogout}
-                    className="public-cta-outline"
+                    className="public-cta-outline w-full justify-center"
+                    data-particular-logout-action="true"
                   >
                     <LogOut className="h-4 w-4" aria-hidden="true" />
                     Cerrar sesión particular

--- a/frontend/src/hooks/useAdaptiveDashboardPageSize.ts
+++ b/frontend/src/hooks/useAdaptiveDashboardPageSize.ts
@@ -1,0 +1,187 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Container-aware page-size engine for the zero-scroll dashboard substrate.
+ *
+ * Extends the `useAdaptiveItemsPerPage` measurement discipline (ResizeObserver
+ * + single-rAF throttle + synchronous first measure) with the full canvas
+ * arithmetic of the fixed-viewport contract:
+ *
+ *   usable_canvas_height =
+ *     container_height - chrome - header - pagination - safety_buffer
+ *   rows_per_page = clamp(floor(usable / row_height), min, max)
+ *
+ * The consumer attaches `containerRef` to the element that owns the data
+ * canvas (a bounded `minmax(0, 1fr)` region); the hook never reads `window`.
+ */
+export type AdaptiveDashboardPageSizeOptions = {
+  /** Fallback page size used until the first real measurement lands. */
+  fallbackItems: number;
+  /** Row/card height in CSS px (measured by the consumer or a constant). */
+  rowHeightPx: number;
+  /** Fixed chrome inside the container that rows cannot use (headers…). */
+  chromeHeightPx?: number;
+  /** Table header height (thead / list header) inside the container. */
+  headerHeightPx?: number;
+  /** Pagination reserve inside the container, when the pager is a child. */
+  paginationHeightPx?: number;
+  /** Extra safety buffer against sub-pixel rounding. */
+  safetyBufferPx?: number;
+  minItems?: number;
+  maxItems?: number;
+  enabled?: boolean;
+};
+
+export type AdaptiveDashboardPageSizeResult = {
+  containerRef: React.RefObject<HTMLElement | null>;
+  availableHeight: number;
+  itemsPerPage: number;
+  rowHeight: number;
+  chromeHeight: number;
+  paginationHeight: number;
+  isMeasured: boolean;
+};
+
+function toNonNegative(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return value;
+}
+
+function toPositiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+type MeasuredState = {
+  availableHeight: number;
+  itemsPerPage: number;
+  isMeasured: boolean;
+};
+
+export function useAdaptiveDashboardPageSize({
+  fallbackItems,
+  rowHeightPx,
+  chromeHeightPx = 0,
+  headerHeightPx = 0,
+  paginationHeightPx = 0,
+  safetyBufferPx = 6,
+  minItems,
+  maxItems,
+  enabled = true,
+}: AdaptiveDashboardPageSizeOptions): AdaptiveDashboardPageSizeResult {
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  const min = toPositiveInteger(minItems, 1);
+  const max = Math.max(min, toPositiveInteger(maxItems, 50));
+  const rowHeight = toNonNegative(rowHeightPx, 0);
+  const chromeHeight = toNonNegative(chromeHeightPx, 0);
+  const headerHeight = toNonNegative(headerHeightPx, 0);
+  const paginationHeight = toNonNegative(paginationHeightPx, 0);
+  const safetyBuffer = toNonNegative(safetyBufferPx, 6);
+
+  const fallback = clamp(toPositiveInteger(fallbackItems, min), min, max);
+  const [measured, setMeasured] = useState<MeasuredState>({
+    availableHeight: 0,
+    itemsPerPage: fallback,
+    isMeasured: false,
+  });
+  const measuredRef = useRef(measured);
+
+  useLayoutEffect(() => {
+    const containerNode = containerRef.current;
+    if (!enabled || !containerNode || rowHeight <= 0) {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const measure = () => {
+      frame = null;
+
+      const containerHeight = containerNode.getBoundingClientRect().height;
+      if (!Number.isFinite(containerHeight) || containerHeight <= 0) {
+        return;
+      }
+
+      const usableHeight =
+        containerHeight -
+        chromeHeight -
+        headerHeight -
+        paginationHeight -
+        safetyBuffer;
+      if (!Number.isFinite(usableHeight) || usableHeight <= 0) {
+        return;
+      }
+
+      const nextItems = clamp(Math.floor(usableHeight / rowHeight), min, max);
+      const next: MeasuredState = {
+        availableHeight: usableHeight,
+        itemsPerPage: nextItems,
+        isMeasured: true,
+      };
+
+      const previous = measuredRef.current;
+      if (
+        previous.isMeasured !== next.isMeasured ||
+        previous.itemsPerPage !== next.itemsPerPage ||
+        previous.availableHeight !== next.availableHeight
+      ) {
+        measuredRef.current = next;
+        setMeasured(next);
+      }
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) {
+        return;
+      }
+
+      frame = requestAnimationFrame(measure);
+    };
+
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(containerNode);
+    // First measurement runs synchronously so the fallback-sized paint is
+    // corrected within the same layout pass (no visible settle frame); later
+    // resize-driven remeasures stay rAF-throttled against layout thrash.
+    measure();
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [
+    chromeHeight,
+    enabled,
+    headerHeight,
+    max,
+    min,
+    paginationHeight,
+    rowHeight,
+    safetyBuffer,
+  ]);
+
+  return {
+    containerRef,
+    availableHeight: measured.availableHeight,
+    itemsPerPage: measured.itemsPerPage,
+    rowHeight,
+    chromeHeight,
+    paginationHeight,
+    isMeasured: measured.isMeasured,
+  };
+}

--- a/test/frontend-dashboard-home.test.ts
+++ b/test/frontend-dashboard-home.test.ts
@@ -67,11 +67,17 @@ test("dashboard home reads stats reports and field visits through API helpers", 
   assert.ok(source.includes("let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];"));
   assert.ok(source.includes("let visitsLoadError = false;"));
   assert.ok(source.includes("await Promise.all(["));
-  assert.ok(source.includes("getReports(requestOptions, { limit: 3, offset: 0 }, {"));
+  // Zero-scroll adaptive density: the workspace summaries paginate a
+  // viewport-safe superset (24, matching INFORMES_LIMIT_CAP) client-side, so
+  // the fetch cap is no longer the fixed 3-row summary constant. The
+  // operaciones command center keeps its 3-row slices at the call site.
+  assert.ok(source.includes("getReports(requestOptions, { limit: 24, offset: 0 }, {"));
   assert.ok(source.includes("getLogisticsFieldVisits(requestOptions, {"));
   assert.ok(source.includes("throwOnError: true,"));
-  assert.ok(source.includes("const recentReports = reports.slice(0, 3);"));
-  assert.ok(source.includes("const recentVisits = visits.slice(0, 3);"));
+  assert.ok(source.includes("const recentReports = reports.slice(0, 24);"));
+  assert.ok(source.includes("const recentVisits = visits.slice(0, 24);"));
+  assert.ok(source.includes("recentReports={recentReports.slice(0, 3)}"));
+  assert.ok(source.includes("recentVisits={recentVisits.slice(0, 3)}"));
 });
 
 test("dashboard home renders module hub structure with header, cards, and clinic sections", () => {

--- a/test/frontend-dashboard-live-read-contract.test.ts
+++ b/test/frontend-dashboard-live-read-contract.test.ts
@@ -52,9 +52,11 @@ test("frontend dashboard page uses API client wrappers", () => {
   assertIncludes(source, "let reportsLoadError = false;", dashboardPage);
   assertIncludes(source, "let visits: Awaited<ReturnType<typeof getLogisticsFieldVisits>> = [];", dashboardPage);
   assertIncludes(source, "let visitsLoadError = false;", dashboardPage);
+  // Zero-scroll adaptive density: the workspace summaries paginate a
+  // viewport-safe superset (24, matching INFORMES_LIMIT_CAP) client-side.
   assertIncludes(
     source,
-    "getReports(requestOptions, { limit: 3, offset: 0 }, {",
+    "getReports(requestOptions, { limit: 24, offset: 0 }, {",
     dashboardPage,
   );
   assertIncludes(source, "getLogisticsFieldVisits(requestOptions, {", dashboardPage);


### PR DESCRIPTION
## Summary
- enforces fixed-viewport dashboard substrate and adaptive density
- adds shared centered dashboard pager contract
- removes fixed 3-row dashboard summaries
- fixes Clínica informes mobile/detail zero-scroll behavior
- replaces logistics mobile horizontal table overflow with bounded mobile rows/cards
- fixes authenticated Particular viewport fit with visible tracking, report and logout actions
- adds targeted zero-scroll Playwright coverage
- documents targeted E2E rescue validation

## Scope
- frontend dashboard layout/components
- frontend Playwright E2E coverage
- frontend source-level contract tests
- implementation/audit documentation

## Non-scope
- no backend/API/auth/DB/Supabase changes
- no dependency or lockfile changes
- no CI workflow changes
- no frontend/next-env.d.ts change

## Validation
- targeted zero-scroll E2E: 33/33 PASS
- pnpm --dir frontend typecheck: PASS
- pnpm --dir frontend lint: PASS
- pnpm test: 2955/2955 PASS
- pnpm build: PASS
- pnpm --dir frontend build: PASS
- pnpm security:public-surface: PASS
- git diff --check: PASS