### PR TITLE
refactor(dashboard): introduce presentation boundaries

### DIFF
--- a/docs/implementation/dashboard-presentation-boundaries.md
+++ b/docs/implementation/dashboard-presentation-boundaries.md
@@ -1,0 +1,117 @@
+# Dashboard Presentation Architecture Boundaries (PR-PRES-2)
+
+> **Tipo:** estructura + índices. **No mueve componentes, no cambia comportamiento, no toca CSS ni rutas públicas.**
+> **Base:** `main` limpio · **HEAD:** `63ea30d` docs(dashboard): audit presentation primitives architecture (#1291)
+> **Rama:** `refactor/dashboard-presentation-boundaries`
+> **Documento rector:** [`docs/audit/dashboard-presentation-primitives-architecture-audit.md`](../audit/dashboard-presentation-primitives-architecture-audit.md)
+> **Modelo / esfuerzo:** Claude Opus 4.8 · high.
+
+## 1. Objetivo
+
+Introducir la **frontera de arquitectura de presentación** del dashboard como
+carpeta declarada, para habilitar extracciones *behavior-preserving* en los PRs
+siguientes (PR-PRES-3..6) sin seguir acumulando duplicación. Este PR crea la
+estructura y los índices; **no mueve ningún componente existente**.
+
+Es la implementación del **PR-PRES-2** definido en la sección 10 del documento
+rector, que a su vez espeja en la capa TSX/React la modularización que el CSS
+del dashboard ya logró en #1289 (modularización) y #1290 (composition root).
+
+## 2. Qué se creó
+
+```
+frontend/src/features/dashboard/
+  README.md                         ← mapa de capas + reglas de frontera
+  config/index.ts                   ← barrel placeholder (export {})
+  domain/index.ts                   ← barrel placeholder
+  application/index.ts              ← barrel placeholder
+  presentation/index.ts             ← barrel placeholder
+  presentation/shell/index.ts       ← barrel placeholder
+  presentation/navigation/index.ts  ← barrel placeholder
+  presentation/layout/index.ts      ← barrel placeholder
+  presentation/surfaces/index.ts    ← barrel placeholder
+  presentation/admin/index.ts       ← barrel placeholder
+  presentation/clinic/index.ts      ← barrel placeholder
+```
+
+Cada `index.ts` es un **barrel vacío** (`export {};`) con un encabezado JSDoc
+que documenta el contrato de su capa. El `export {};` mantiene el archivo como
+módulo válido bajo `isolatedModules` y deja lista la superficie de importación
+(`@/features/dashboard/<capa>`) para que los PRs siguientes solo agreguen
+`export * from './<archivo-real>'` sin crear el índice.
+
+## 3. Responsabilidad por capa (espeja la taxonomía CSS aprobada)
+
+| Capa | Contenido futuro | Regla de frontera |
+|------|------------------|-------------------|
+| `config` | Catálogo de módulos por rol (id, alias, label, shortLabel, icon, title, description, storageKey, destinos nav). Fuente única de verdad. | No importa React. |
+| `domain` | Tipos `ClinicModule`/`AdminModule`, `parse`/validación de módulo, view-models puros (systemHealth, audit labels, status→variant). | No importa React. |
+| `application` | `useDashboardModuleNavigation` (URL-sync optimista, last-module, intent one-shot, two-commit), `moduleActivationBus`, access-error store, server-auth/redirect, wrappers de carga de datos. | No renderiza JSX. |
+| `presentation/shell` | PrivateDashboardShell, DashboardShellRouter, DashboardTopbar, DashboardModuleWorkspace, DashboardModuleHub, DashboardHubHero, stage. | No importa `@/lib/api`. |
+| `presentation/navigation` | DashboardModuleRail, Admin/ClinicMobileBottomNav, DashboardHorizontalNav, Admin/ClinicDashboardSidebar, pagers, menús móviles, kebab. | No importa `@/lib/api`. |
+| `presentation/layout` | DashboardPageHeader, DashboardSidebarFrame, viewport-switch, stage wrappers. | No importa `@/lib/api`. |
+| `presentation/surfaces` | EmptyState/ErrorState/LoadingState, StatsCards, StatusBadge, FilterBar/Drawer, StickyActionBar, ModuleSurface, ModuleTabs/Dialog, tablas. | No importa `@/lib/api`. |
+| `presentation/admin` | Admin*Card + Admin*Mobile*Module (wrappers de workspace admin). | No importa `@/lib/api`. |
+| `presentation/clinic` | Clinic*Card + Clinic*WorkspaceSummary + ClinicCommandCenter (wrappers de workspace clínica). | No importa `@/lib/api`. |
+
+Regla transversal: al reubicar componentes en `presentation`, **preservar el
+anidamiento del DOM, las clases y los atributos `data-*`** (contrato entre TSX,
+el CSS compuesto y los selectores Playwright). Mover ≠ renombrar.
+
+## 4. Alcance y no-alcance
+
+**Alcance de este PR**
+
+- Crear la carpeta `frontend/src/features/dashboard/` con sus subcapas y
+  subcarpetas.
+- Barrels `index.ts` placeholder + `README.md` del feature.
+- Este documento de implementación.
+
+**No-alcance (queda para PR-PRES-3..6)**
+
+- No se mueve ningún componente (`page.tsx`, controllers, cards, shell).
+- No se extrae el catálogo de módulos ni la máquina de navegación.
+- No se cambia CSS, rutas Next, auth, datos ni comportamiento.
+- No se tocan backend/API/DB/Supabase, deps/lockfiles ni CI.
+
+## 5. Plan de continuación
+
+Según la sección 10 del documento rector:
+
+| PR | Objetivo |
+|----|----------|
+| **PR-PRES-3** | Extraer shell primitives ya-limpios a `presentation/shell` con re-export de compatibilidad. |
+| **PR-PRES-4** | `config/*ModuleCatalog` como fuente única; navegación → `application`. |
+| **PR-PRES-5** | Surface primitives (estados, StatsCards, tabs, tablas) → `presentation/surfaces`. |
+| **PR-PRES-6** | Wrappers clinic/admin + `domain/systemHealthViewModel`; rutas adelgazan a composición. |
+| **PR-UX-1** | Rediseño visual premium, solo después de PRES-2..6. |
+
+Orden y dependencias: PRES-2 → PRES-3 → PRES-4 → PRES-5 → PRES-6 → UX-1.
+
+## 6. Validación
+
+Ejecutada para este PR (estructura sin cambios de comportamiento):
+
+```powershell
+# raíz backend
+cd C:\PORTAL-VETNEB
+pnpm test
+pnpm build
+
+# frontend
+cd C:\PORTAL-VETNEB\frontend
+pnpm typecheck
+pnpm build
+```
+
+Superficie de cambios (solo carpetas/documentación nuevas; sin archivos
+modificados):
+
+```powershell
+git -C C:\PORTAL-VETNEB diff --check
+git -C C:\PORTAL-VETNEB status --short --untracked-files=all
+git -C C:\PORTAL-VETNEB diff -- frontend/next-env.d.ts   # sin cambios
+```
+
+Nota: si `pnpm build` (frontend) reescribe `frontend/next-env.d.ts`, se
+restaura a su contenido original — no forma parte de este cambio.

--- a/frontend/src/features/dashboard/README.md
+++ b/frontend/src/features/dashboard/README.md
@@ -1,0 +1,47 @@
+# `features/dashboard/` — presentation architecture boundary
+
+> **PR-PRES-2.** Structural boundary only. **No components were moved, no CSS
+> was touched, no routes changed, no behavior changed.** Every `index.ts` here
+> is an empty placeholder barrel (`export {}`) that documents the layer
+> contract and reserves the import surface for later PRES PRs.
+
+This folder mirrors, in the TSX/React layer, the modularization the dashboard
+CSS already achieved in #1289/#1290. It exists to give future
+behavior-preserving extractions a declared home, so that a module or style
+change touches one file instead of the 8+ duplication points documented in the
+audit.
+
+## Layers
+
+```
+features/dashboard/
+  config/          module catalog per role — single source of truth
+  domain/          module types, parse/validation, pure view-models
+  application/     navigation hook, activation bus, access-error store,
+                   server-auth/redirect, data-load wrappers
+  presentation/    UI only, mirroring the CSS taxonomy
+    shell/         app-shell chrome + module workspace/hub + stage
+    navigation/    rail, bottom-nav, horizontal nav, sidebars, menus
+    layout/        page header, sidebar frame, viewport-switch, stages
+    surfaces/      states, StatsCards, StatusBadge, filters, tabs, tables
+    admin/         admin workspace wrappers (Admin*Card / Admin*Mobile*)
+    clinic/        clinic workspace wrappers (Clinic*Card / summaries)
+```
+
+## Boundary rules
+
+- `config` and `domain` **do not import React** — pure data, types and
+  functions.
+- `application` **does not render JSX** — it coordinates state and data.
+- `presentation` **does not import `@/lib/api` directly** — data arrives via
+  props or via `application` hooks.
+- Relocations into `presentation` must **preserve DOM nesting, class names and
+  `data-*` contract attributes** (the contract between TSX, the composed CSS
+  and the Playwright selectors). Move ≠ rename.
+
+## Status
+
+Empty on purpose. The migration plan (PR-PRES-3..6) lives in
+[`docs/implementation/dashboard-presentation-boundaries.md`](../../../../docs/implementation/dashboard-presentation-boundaries.md)
+and the full rationale in
+[`docs/audit/dashboard-presentation-primitives-architecture-audit.md`](../../../../docs/audit/dashboard-presentation-primitives-architecture-audit.md).

--- a/frontend/src/features/dashboard/application/index.ts
+++ b/frontend/src/features/dashboard/application/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Dashboard · application layer (boundary placeholder).
+ *
+ * Intended home for orchestration that is not presentation: the optimistic
+ * module-navigation hook (URL sync, last-module, one-shot intent, two-commit
+ * buffer), the module activation bus, the access-error store, server
+ * auth/redirect helpers, and data-load wrappers (audit H2/H5/H6).
+ *
+ * Boundary rule: no JSX rendering — application coordinates state and data;
+ * it does not render UI.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary; real
+ * exports land in a later PRES PR (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/config/index.ts
+++ b/frontend/src/features/dashboard/config/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Dashboard · config layer (boundary placeholder).
+ *
+ * Intended single source of truth for the dashboard module catalog per role
+ * (id, alias, label, shortLabel, icon, title, description, storageKey and
+ * navigation destinations). Downstream surfaces (rail, bottom-nav, sidebar,
+ * topbar, quick-links) should derive their view from here instead of
+ * re-declaring literals (audit H1).
+ *
+ * Boundary rule: no React imports — pure data/config only.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary; the real
+ * catalog exports land in a later PRES PR (see the plan in
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/domain/index.ts
+++ b/frontend/src/features/dashboard/domain/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard · domain layer (boundary placeholder).
+ *
+ * Intended home for role module types (ClinicModule / AdminModule), module
+ * parse/validation over the config catalog, and pure view-models
+ * (systemHealth, audit labels, status→variant). No side effects, no data
+ * fetching (audit H3/H7).
+ *
+ * Boundary rule: no React imports — pure functions and types only.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary; real
+ * exports land in a later PRES PR (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/admin/index.ts
+++ b/frontend/src/features/dashboard/presentation/admin/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard · presentation/admin (boundary placeholder).
+ *
+ * Intended home for admin workspace wrappers: Admin*Card and
+ * Admin*Mobile*Module surfaces (audit §6). These compose `surfaces`
+ * primitives and consume `application` hooks / `config` catalog.
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly; data
+ * arrives via props or `application`. Splitting the admin god-cards is out of
+ * scope for the PRES structural PRs.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/clinic/index.ts
+++ b/frontend/src/features/dashboard/presentation/clinic/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard · presentation/clinic (boundary placeholder).
+ *
+ * Intended home for clinic workspace wrappers: Clinic*Card,
+ * Clinic*WorkspaceSummary and ClinicCommandCenter (audit §6). These compose
+ * `surfaces` primitives and consume `application` hooks / `config` catalog.
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly; data
+ * arrives via props or `application`. Splitting the clinic god-cards is out of
+ * scope for the PRES structural PRs.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/index.ts
+++ b/frontend/src/features/dashboard/presentation/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Dashboard · presentation layer (boundary placeholder).
+ *
+ * UI only, mirroring the CSS taxonomy already approved in #1289/#1290:
+ * shell · navigation · layout · surfaces · admin · clinic.
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly; it
+ * receives data via props or via `application` hooks (audit §6).
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary; concrete
+ * components are relocated here (with compatibility re-exports) in later PRES
+ * PRs (see docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/layout/index.ts
+++ b/frontend/src/features/dashboard/presentation/layout/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard · presentation/layout (boundary placeholder).
+ *
+ * Intended home for layout primitives: DashboardPageHeader,
+ * DashboardSidebarFrame, the viewport-switch primitive (desktop vs mobile
+ * branches) and stage wrappers (audit §6).
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly. The
+ * no-scroll height chain depends on `min-h-0`/`flex-1` and classes such as
+ * `dashboard-module-stage`; preserve classes and DOM nesting when relocating.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/navigation/index.ts
+++ b/frontend/src/features/dashboard/presentation/navigation/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Dashboard · presentation/navigation (boundary placeholder).
+ *
+ * Intended home for module navigation surfaces: DashboardModuleRail,
+ * Admin/ClinicMobileBottomNav, DashboardHorizontalNav,
+ * Admin/ClinicDashboardSidebar, pagers, AdminMobile menus / hub launcher and
+ * the kebab (audit §6). These consume the `config` catalog and the
+ * `application` navigation hook rather than re-declaring module literals.
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly. Preserve
+ * DOM nesting, class names and `data-*` contract attributes when relocating.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/shell/index.ts
+++ b/frontend/src/features/dashboard/presentation/shell/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard · presentation/shell (boundary placeholder).
+ *
+ * Intended home for the persistent app-shell chrome: PrivateDashboardShell,
+ * DashboardShellRouter, DashboardTopbar, DashboardModuleWorkspace,
+ * DashboardModuleHub, DashboardHubHero and the module stage (audit §6).
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly; it
+ * receives data via props or via `application` hooks. Preserve DOM nesting,
+ * class names and `data-*` contract attributes when relocating here.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};

--- a/frontend/src/features/dashboard/presentation/surfaces/index.ts
+++ b/frontend/src/features/dashboard/presentation/surfaces/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard · presentation/surfaces (boundary placeholder).
+ *
+ * Intended home for reusable surface primitives: EmptyState / ErrorState /
+ * LoadingState, StatsCards, StatusBadge, FilterBar/Drawer, StickyActionBar,
+ * ModuleSurface, ModuleTabs/Dialog, StudyTimeline, ReportDownloadButton and
+ * table primitives (audit §5/§6).
+ *
+ * Boundary rule: presentation does not import `@/lib/api` directly; surfaces
+ * are pure presentation driven by props.
+ *
+ * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
+ * docs/implementation/dashboard-presentation-boundaries.md).
+ */
+export {};


### PR DESCRIPTION
PR-PRES-2. Introduces dashboard feature architecture boundaries under frontend/src/features/dashboard with minimal documentation and empty public indexes for future scoped extractions. No visual redesign, CSS, routes, backend, API, auth, DB, Supabase, dependency, lockfile, CI, stash, or .claude/worktrees changes.