### PR TITLE
refactor(dashboard): extract module config catalog

### DIFF
--- a/docs/implementation/dashboard-module-config-catalog.md
+++ b/docs/implementation/dashboard-module-config-catalog.md
@@ -1,0 +1,134 @@
+# Dashboard Module Config Catalog (PR-PRES-3)
+
+> **Tipo:** extracción *behavior-preserving* de configuración. **No cambia UI, CSS,
+> rutas Next, permisos, datos ni navegación.**
+> **Base:** `main` limpio · **HEAD:** `e29b711` refactor(dashboard): introduce presentation boundaries (#1292)
+> **Rama:** `refactor/dashboard-module-config-catalog`
+> **Documentos rectores:**
+> [`docs/audit/dashboard-presentation-primitives-architecture-audit.md`](../audit/dashboard-presentation-primitives-architecture-audit.md) (H1)
+> · [`docs/implementation/dashboard-presentation-boundaries.md`](./dashboard-presentation-boundaries.md)
+> **Modelo / esfuerzo:** Claude Opus 4.8 · high.
+
+## 1. Objetivo
+
+Materializar el primer catálogo real de la capa `config` del dashboard como
+**fuente única de verdad** del registro de módulos por rol, cerrando la parte
+segura del hallazgo **H1** de la auditoría (registro de módulos copiado
+literalmente en 8+ archivos). La extracción es puramente estructural: mismo
+comportamiento, mismos textos visibles, mismas rutas y URLs `?module=`.
+
+Este PR implementa la porción **behavior-preserving y de bajo riesgo** de la
+centralización: los *ids* canónicos, el orden, los alias admin, el default de
+clínica, los helpers puros de parseo y la tabla de etiquetas de navegación de
+clínica (que estaba duplicada literalmente entre el rail y el bottom-nav). Las
+migraciones de las superficies admin con **labels específicos por superficie**
+(sidebar, nav horizontal, quick-links, menú móvil, topbar) quedan para un PR
+posterior porque unificar esos textos no es seguro sin cambiar lo visible.
+
+## 2. Qué se creó
+
+```
+frontend/src/features/dashboard/config/
+  dashboardModules.ts   ← catálogo: ids/orden por rol, alias admin, default
+                          clínica, parse puro, labels de navegación clínica
+  index.ts              ← barrel: ahora reexporta el catálogo (antes vacío)
+```
+
+`config/dashboardModules.ts` es **TypeScript puro**: sin `import` de React, sin
+JSX y sin llamadas a API/`@/lib/api`. Los iconos son componentes React, así que
+**no** entran al catálogo; cada superficie mantiene su propio *icon map* local
+indexado por id (regla de frontera de la capa `config`).
+
+### API pública del catálogo
+
+| Export | Tipo | Reemplaza a |
+|--------|------|-------------|
+| `ADMIN_MODULE_IDS` | tupla `as const` (orden canónico) | `ADMIN_MODULE_VALUES` (controller) + `VALID_ADMIN_MODULES` (route) |
+| `AdminModule` | tipo derivado de la tupla | unión declarada a mano en el controller |
+| `ADMIN_MODULE_ALIASES` | mapa alias→id | copias en controller + route |
+| `parseAdminModule(value)` | helper puro alias-aware | `parseModuleFromUrl` (controller) + `parseAdminModule` (route) |
+| `CLINIC_MODULE_IDS` | tupla `as const` | `CLINIC_MODULE_VALUES` (controller) + `VALID_CLINIC_MODULES` (route) |
+| `ClinicModule` | tipo derivado de la tupla | unión declarada a mano en el controller |
+| `DEFAULT_CLINIC_MODULE` | `"operaciones"` | constante en el controller (ahora reexportada) |
+| `parseClinicModule(value)` | helper puro | `parseModuleFromUrl` (controller) + `parseClinicModule` (route) |
+| `CLINIC_MODULE_NAV_LABELS` | `{ moduleId, label, shortLabel }[]` | labels/shortLabels duplicados en rail + bottom-nav |
+
+## 3. Consumidores migrados (mínimos y seguros)
+
+| Archivo | Cambio | Compatibilidad |
+|---------|--------|----------------|
+| `app/dashboard/admin/AdminDashboardWorkspaceController.tsx` | consume `parseAdminModule` + `type AdminModule` del catálogo; borra la unión, la lista y el parse locales | **reexporta** `AdminModule` (`export type { AdminModule }`) para no romper `admin/page.tsx` |
+| `app/dashboard/admin/page.tsx` | consume `parseAdminModule`; borra `VALID_ADMIN_MODULES` + alias + parse locales | — |
+| `components/dashboard/ClinicDashboardWorkspaceController.tsx` | consume `DEFAULT_CLINIC_MODULE` + `parseClinicModule` + `type ClinicModule`; borra la unión, la lista, el default y el parse locales | **reexporta** `ClinicModule` y `DEFAULT_CLINIC_MODULE` para no romper sus importadores |
+| `app/dashboard/page.tsx` | consume `parseClinicModule`; borra `VALID_CLINIC_MODULES` + parse locales; sigue importando `DEFAULT_CLINIC_MODULE` del controller | — |
+| `components/dashboard/DashboardModuleRail.tsx` | `CLINIC_MODULE_RAIL_ITEMS` se deriva de `CLINIC_MODULE_NAV_LABELS` + icon map local | export y forma del array idénticos |
+| `components/dashboard/ClinicMobileBottomNav.tsx` | `CLINIC_DESTINATIONS` se deriva de `CLINIC_MODULE_NAV_LABELS` + icon map local | forma del array idéntica |
+
+Las superficies admin con labels por-superficie (`AdminDashboardSidebar`,
+`DashboardHorizontalNav`, `AdminOverviewQuickLinks`, `AdminMobileModuleMenu`,
+`AdminMobileBottomNav`, `DashboardTopbar` → `ADMIN_MOBILE_TITLES`) **no se
+tocaron**: sus textos difieren entre superficies y unificarlos cambiaría lo
+visible. Migrarlas a referenciar los ids del catálogo es trabajo del próximo PR.
+
+## 4. Duplicación eliminada
+
+- Lista de ids **admin**: 2 copias literales → 1 (`ADMIN_MODULE_IDS`).
+- Mapa de alias **admin**: 2 copias → 1 (`ADMIN_MODULE_ALIASES`).
+- Parse **admin**: 2 implementaciones → 1 (`parseAdminModule`).
+- Representación doble del tipo **admin** (unión + array) → 1 (tipo derivado).
+- Lista de ids **clínica**: 2 copias → 1 (`CLINIC_MODULE_IDS`).
+- Parse **clínica**: 2 implementaciones → 1 (`parseClinicModule`).
+- Representación doble del tipo **clínica** (unión + array) → 1 (tipo derivado).
+- Tabla `label`/`shortLabel` de navegación **clínica**: 2 copias literales
+  (rail + bottom-nav) → 1 (`CLINIC_MODULE_NAV_LABELS`).
+
+## 5. Invariantes preservados
+
+- Textos visibles: sin altas ni cambios; solo se reubican strings existentes.
+- Orden visual: el orden canónico del catálogo es exactamente el orden actual.
+- URLs `?module=` y aliases (`admin-upload-report`, `maintenance`): idénticos.
+- Default de clínica: sigue `operaciones`; `/dashboard` abre directo el módulo.
+- Iconos: sin cambios; siguen siendo componentes React locales por superficie.
+- Frontera `config`: sin React/JSX/API en el catálogo.
+- Contrato E2E/CSS (clases, anidamiento, `data-*`): intacto.
+
+## 6. Guardrails de tests ajustados
+
+Cinco aserciones *source-invariant* fijaban la **ubicación previa** de literales
+que ahora viven en el catálogo. Se reubicaron para verificar el catálogo + el
+cableado del consumidor, **sin cambiar su semántica** (cada módulo sigue
+conocido/alcanzable, el default sigue `operaciones`, el sync por URL sigue vía
+parse):
+
+- `test/frontend-dashboard-remove-home-unified-workspace.test.ts` (3 aserciones)
+- `test/frontend-dashboard-hub-hero.test.ts` (1 aserción)
+- `test/frontend-dashboard-admin.test.ts` (1 aserción)
+
+## 7. Validación
+
+```powershell
+# raíz (backend)
+cd C:\PORTAL-VETNEB
+pnpm test      # 2961 pass · 0 fail
+pnpm build     # esbuild OK
+
+# frontend
+cd C:\PORTAL-VETNEB\frontend
+pnpm typecheck # tsc --noEmit OK
+pnpm build     # next build OK
+
+# superficie de cambios
+git -C C:\PORTAL-VETNEB diff --check
+git -C C:\PORTAL-VETNEB diff -- frontend/next-env.d.ts   # sin cambios
+```
+
+Nota: si `pnpm build` (frontend) reescribe `frontend/next-env.d.ts`, se restaura
+a su contenido original — no forma parte de este cambio.
+
+## 8. Continuación
+
+`config/dashboardModules.ts` deja la base para que **PR-PRES-4** migre las
+superficies de navegación admin (sidebar, nav horizontal, quick-links, menú
+móvil, bottom-nav, topbar) a derivar del catálogo, y para extraer
+`useDashboardModuleNavigation` + `moduleActivationBus` a `application`, según la
+sección 10 del documento rector.

--- a/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
+++ b/frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx
@@ -42,48 +42,11 @@ import {
   subscribeAdminModuleActivate,
 } from "@/lib/admin-hub-reset";
 import type { AdminAccessErrorStatus } from "@/lib/api-error";
+import { parseAdminModule } from "@/features/dashboard/config";
+import type { AdminModule } from "@/features/dashboard/config";
 import { AdminAccessErrorState } from "./AdminAccessErrorState";
 
-export type AdminModule =
-  | "admin"
-  | "admin-report-upload"
-  | "admin-health"
-  | "admin-clinics"
-  | "admin-particular-tokens"
-  | "admin-pricing"
-  | "admin-sessions"
-  | "admin-users-roles"
-  | "audit-log"
-  | "admin-maintenance";
-
-const ADMIN_MODULE_VALUES = [
-  "admin",
-  "admin-report-upload",
-  "admin-health",
-  "admin-clinics",
-  "admin-particular-tokens",
-  "admin-pricing",
-  "admin-sessions",
-  "admin-users-roles",
-  "audit-log",
-  "admin-maintenance",
-] as const;
-
-const ADMIN_MODULE_ALIASES: Partial<Record<string, AdminModule>> = {
-  "admin-upload-report": "admin-report-upload",
-  maintenance: "admin-maintenance",
-};
-
-function parseModuleFromUrl(value: string | null): AdminModule | null {
-  if (!value) return null;
-  const alias = ADMIN_MODULE_ALIASES[value];
-  if (alias) {
-    return alias;
-  }
-  return (ADMIN_MODULE_VALUES as readonly string[]).includes(value)
-    ? (value as AdminModule)
-    : null;
-}
+export type { AdminModule };
 
 type AdminWorkspaceSlots = {
   admin: ReactNode;
@@ -202,7 +165,7 @@ export function AdminDashboardWorkspaceController({
     useState(false);
 
   useEffect(() => {
-    const nextModule = parseModuleFromUrl(searchParams.get("module"));
+    const nextModule = parseAdminModule(searchParams.get("module"));
 
     if (previousUrlModule.current !== nextModule) {
       clearAdminAccessError();
@@ -228,7 +191,7 @@ export function AdminDashboardWorkspaceController({
       }
     }
 
-    setActiveModule(parseModuleFromUrl(searchParams.get("module")));
+    setActiveModule(parseAdminModule(searchParams.get("module")));
   }, [searchParams]);
 
   useEffect(() => () => clearAdminAccessError(), []);
@@ -256,7 +219,7 @@ export function AdminDashboardWorkspaceController({
   useEffect(
     () =>
       subscribeAdminModuleActivate((moduleId) => {
-        const parsed = parseModuleFromUrl(moduleId);
+        const parsed = parseAdminModule(moduleId);
         if (!parsed) return;
         clearAdminAccessError();
         pendingNavigationIntent.current = { target: parsed };
@@ -274,7 +237,7 @@ export function AdminDashboardWorkspaceController({
   useEffect(() => {
     if (hasRestoredLastModule.current || hasManuallyReturnedToHub) return;
     if (searchParams.get("module")) return;
-    const lastModule = parseModuleFromUrl(
+    const lastModule = parseAdminModule(
       readDashboardLastModule(ADMIN_LAST_MODULE_STORAGE_KEY),
     );
     if (!lastModule) return;

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -23,7 +23,6 @@ import { AdminSessionsReadOnlyCard } from "./AdminSessionsReadOnlyCard";
 import { AdminUsersRolesReadOnlyCard } from "./AdminUsersRolesReadOnlyCard";
 import { PasswordChangePanel } from "@/components/dashboard/PasswordChangePanel";
 import { AdminDashboardWorkspaceController } from "./AdminDashboardWorkspaceController";
-import type { AdminModule } from "./AdminDashboardWorkspaceController";
 import { AdminMobileCommandModule } from "./AdminMobileCommandModule";
 import { AdminMobileHealthModule } from "./AdminMobileHealthModule";
 import { AdminMobilePricingModule } from "./AdminMobilePricingModule";
@@ -42,6 +41,7 @@ import {
   type AdminAuditSnapshot,
 } from "@/lib/api";
 import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
+import { parseAdminModule } from "@/features/dashboard/config";
 import { getAdminAccessErrorStatus } from "@/lib/api-error";
 import { formatDateTime } from "@/lib/utils";
 import {
@@ -55,35 +55,6 @@ export const metadata: Metadata = {
   title: "Administración — Portal VETNEB",
   robots: { index: false, follow: false },
 };
-
-const VALID_ADMIN_MODULES: AdminModule[] = [
-  "admin",
-  "admin-report-upload",
-  "admin-health",
-  "admin-clinics",
-  "admin-particular-tokens",
-  "admin-pricing",
-  "admin-sessions",
-  "admin-users-roles",
-  "audit-log",
-  "admin-maintenance",
-];
-
-const ADMIN_MODULE_ALIASES: Partial<Record<string, AdminModule>> = {
-  "admin-upload-report": "admin-report-upload",
-  maintenance: "admin-maintenance",
-};
-
-function parseAdminModule(value: string | undefined): AdminModule | null {
-  if (!value) return null;
-  const alias = ADMIN_MODULE_ALIASES[value];
-  if (alias) {
-    return alias;
-  }
-  return VALID_ADMIN_MODULES.includes(value as AdminModule)
-    ? (value as AdminModule)
-    : null;
-}
 
 function getServiceVariant(
   value: unknown,

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import {
   ClinicDashboardWorkspaceController,
   DEFAULT_CLINIC_MODULE,
 } from "@/components/dashboard/ClinicDashboardWorkspaceController";
-import type { ClinicModule } from "@/components/dashboard/ClinicDashboardWorkspaceController";
 import { ClinicMobileModuleFrame } from "@/components/dashboard/ClinicMobileModuleFrame";
 import { ClinicCommandCenter } from "./ClinicCommandCenter";
 import { ClinicParticularTokensCard } from "@/components/dashboard/ClinicParticularTokensCard";
@@ -19,26 +18,12 @@ import {
   getReports,
 } from "@/lib/api";
 import { redirectToLoginOnUnauthorized } from "@/lib/dashboard-server-auth";
+import { parseClinicModule } from "@/features/dashboard/config";
 
 export const metadata: Metadata = {
   title: "Dashboard Clínica — Portal VETNEB",
   robots: { index: false, follow: false },
 };
-
-const VALID_CLINIC_MODULES: ClinicModule[] = [
-  "operaciones",
-  "informes",
-  "logistica",
-  "perfil",
-  "tokens",
-];
-
-function parseClinicModule(value: string | undefined): ClinicModule | null {
-  if (!value) return null;
-  return VALID_CLINIC_MODULES.includes(value as ClinicModule)
-    ? (value as ClinicModule)
-    : null;
-}
 
 async function getDashboardRequestOptions(): Promise<RequestInit> {
   const cookieHeader = (await cookies()).toString();

--- a/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
+++ b/frontend/src/components/dashboard/ClinicDashboardWorkspaceController.tsx
@@ -14,35 +14,14 @@ import {
   subscribeClinicHubReset,
   subscribeClinicModuleActivate,
 } from "@/lib/clinic-hub-reset";
+import {
+  DEFAULT_CLINIC_MODULE,
+  parseClinicModule,
+} from "@/features/dashboard/config";
+import type { ClinicModule } from "@/features/dashboard/config";
 
-export type ClinicModule =
-  | "operaciones"
-  | "informes"
-  | "logistica"
-  | "perfil"
-  | "tokens";
-
-const CLINIC_MODULE_VALUES = [
-  "operaciones",
-  "informes",
-  "logistica",
-  "perfil",
-  "tokens",
-] as const;
-
-/**
- * Operational default. The clinic dashboard has NO module hub/home: `/dashboard`
- * resolves straight into this workspace, and any legacy "back to overview"
- * intent (hub reset) also lands here instead of a landing screen.
- */
-export const DEFAULT_CLINIC_MODULE: ClinicModule = "operaciones";
-
-function parseModuleFromUrl(value: string | null): ClinicModule | null {
-  if (!value) return null;
-  return (CLINIC_MODULE_VALUES as readonly string[]).includes(value)
-    ? (value as ClinicModule)
-    : null;
-}
+export type { ClinicModule };
+export { DEFAULT_CLINIC_MODULE };
 
 type ClinicWorkspaceSlots = {
   operaciones: ReactNode;
@@ -104,7 +83,7 @@ export function ClinicDashboardWorkspaceController({
   useEffect(() => {
     // No module in the URL means the operational default — never a hub.
     const nextModule =
-      parseModuleFromUrl(searchParams.get("module")) ?? DEFAULT_CLINIC_MODULE;
+      parseClinicModule(searchParams.get("module")) ?? DEFAULT_CLINIC_MODULE;
 
     // A sync activation swaps the stage before its URL commit. Under load the
     // SUPERSEDED previous navigation can still commit after that optimistic
@@ -129,7 +108,7 @@ export function ClinicDashboardWorkspaceController({
   useEffect(
     () =>
       subscribeClinicModuleActivate((moduleId) => {
-        const parsed = parseModuleFromUrl(moduleId);
+        const parsed = parseClinicModule(moduleId);
         if (!parsed) return;
         pendingNavigationIntent.current = { target: parsed };
         setHasManuallyReturnedToHub(false);
@@ -161,7 +140,7 @@ export function ClinicDashboardWorkspaceController({
   useEffect(() => {
     if (hasRestoredLastModule.current || hasManuallyReturnedToHub) return;
     if (searchParams.get("module")) return;
-    const lastModule = parseModuleFromUrl(
+    const lastModule = parseClinicModule(
       readDashboardLastModule(CLINIC_LAST_MODULE_STORAGE_KEY),
     );
     if (!lastModule) return;

--- a/frontend/src/components/dashboard/ClinicMobileBottomNav.tsx
+++ b/frontend/src/components/dashboard/ClinicMobileBottomNav.tsx
@@ -23,25 +23,31 @@ import {
 } from "@/lib/dashboard-last-module";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
+import { CLINIC_MODULE_NAV_LABELS } from "@/features/dashboard/config";
 import type { ClinicModule } from "./ClinicDashboardWorkspaceController";
+
+// Icons are React components, so they stay local; the id/label/shortLabel/order
+// come from the shared catalog (config/dashboardModules) so this bottom-nav and
+// the module rail never drift apart on module labels or ordering.
+const CLINIC_BOTTOM_NAV_ICONS: Record<ClinicModule, typeof Home> = {
+  operaciones: LayoutDashboard,
+  informes: FileText,
+  logistica: Route,
+  perfil: Building2,
+  tokens: KeyRound,
+};
 
 const CLINIC_DESTINATIONS: Array<{
   label: string;
   shortLabel: string;
   moduleId: ClinicModule;
   icon: typeof Home;
-}> = [
-  {
-    label: "Operaciones",
-    shortLabel: "Ops",
-    moduleId: "operaciones",
-    icon: LayoutDashboard,
-  },
-  { label: "Informes", shortLabel: "Info", moduleId: "informes", icon: FileText },
-  { label: "Logística", shortLabel: "Log", moduleId: "logistica", icon: Route },
-  { label: "Perfil", shortLabel: "Perfil", moduleId: "perfil", icon: Building2 },
-  { label: "Tokens", shortLabel: "Tokens", moduleId: "tokens", icon: KeyRound },
-];
+}> = CLINIC_MODULE_NAV_LABELS.map((item) => ({
+  label: item.label,
+  shortLabel: item.shortLabel,
+  moduleId: item.moduleId,
+  icon: CLINIC_BOTTOM_NAV_ICONS[item.moduleId],
+}));
 
 function parseClinicModuleFromLocation(): ClinicModule | null {
   if (typeof window === "undefined") return null;

--- a/frontend/src/components/dashboard/DashboardModuleRail.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleRail.tsx
@@ -14,6 +14,7 @@ import { PublicRouteControl } from "@/components/public/PublicRouteControl";
 import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
+import { CLINIC_MODULE_NAV_LABELS } from "@/features/dashboard/config";
 import type { ClinicModule } from "./ClinicDashboardWorkspaceController";
 
 /**
@@ -42,38 +43,27 @@ type ClinicModuleRailItem = {
   icon: typeof LayoutDashboard;
 };
 
-export const CLINIC_MODULE_RAIL_ITEMS: ClinicModuleRailItem[] = [
-  {
-    moduleId: "operaciones",
-    label: "Operaciones",
-    shortLabel: "Ops",
-    icon: LayoutDashboard,
-  },
-  {
-    moduleId: "informes",
-    label: "Informes",
-    shortLabel: "Info",
-    icon: FileText,
-  },
-  {
-    moduleId: "logistica",
-    label: "Logística",
-    shortLabel: "Log",
-    icon: Route,
-  },
-  {
-    moduleId: "perfil",
-    label: "Perfil",
-    shortLabel: "Perfil",
-    icon: Building2,
-  },
-  {
-    moduleId: "tokens",
-    label: "Tokens",
-    shortLabel: "Tokens",
-    icon: KeyRound,
-  },
-];
+// Icons are React components, so they stay local; the id/label/shortLabel/order
+// come from the shared catalog (config/dashboardModules) so this rail and the
+// mobile bottom-nav never drift apart on module labels or ordering.
+const CLINIC_MODULE_RAIL_ICONS: Record<
+  ClinicModule,
+  ClinicModuleRailItem["icon"]
+> = {
+  operaciones: LayoutDashboard,
+  informes: FileText,
+  logistica: Route,
+  perfil: Building2,
+  tokens: KeyRound,
+};
+
+export const CLINIC_MODULE_RAIL_ITEMS: ClinicModuleRailItem[] =
+  CLINIC_MODULE_NAV_LABELS.map((item) => ({
+    moduleId: item.moduleId,
+    label: item.label,
+    shortLabel: item.shortLabel,
+    icon: CLINIC_MODULE_RAIL_ICONS[item.moduleId],
+  }));
 
 function moduleHref(moduleId: ClinicModule): string {
   return `${ROUTES.dashboard}?module=${moduleId}`;

--- a/frontend/src/features/dashboard/config/dashboardModules.ts
+++ b/frontend/src/features/dashboard/config/dashboardModules.ts
@@ -1,0 +1,127 @@
+/**
+ * Dashboard · module config catalog (PR-PRES-3).
+ *
+ * Single source of truth for the dashboard module registry per role: canonical
+ * ids, canonical order, admin aliases, the clinic operational default, pure
+ * lookup/parse helpers and the clinic navigation label table.
+ *
+ * Before this catalog the same truth ("which modules exist, in what order, and
+ * how the `?module=` value is validated") was copied literally across the admin
+ * controller + admin route, the clinic controller + clinic route, and the clinic
+ * rail + mobile bottom-nav (audit H1). Those surfaces now derive their view from
+ * here instead of re-declaring the id list, the alias map and the parse routine.
+ *
+ * Boundary rule (config layer): **no React imports** — pure data, types and
+ * functions only. Icons stay in the presentation components (they are React
+ * components) and are mapped there by module id; this catalog only owns the
+ * id/label/order data that is safe to centralize without touching JSX or CSS.
+ *
+ * @see docs/implementation/dashboard-module-config-catalog.md
+ * @see docs/audit/dashboard-presentation-primitives-architecture-audit.md (H1)
+ */
+
+// ── Admin ───────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical admin module ids in hub/order-of-record. Replaces the twin literal
+ * lists previously kept in `AdminDashboardWorkspaceController` (`ADMIN_MODULE_VALUES`)
+ * and `admin/page.tsx` (`VALID_ADMIN_MODULES`).
+ */
+export const ADMIN_MODULE_IDS = [
+  "admin",
+  "admin-report-upload",
+  "admin-health",
+  "admin-clinics",
+  "admin-particular-tokens",
+  "admin-pricing",
+  "admin-sessions",
+  "admin-users-roles",
+  "audit-log",
+  "admin-maintenance",
+] as const;
+
+export type AdminModule = (typeof ADMIN_MODULE_IDS)[number];
+
+/**
+ * Legacy `?module=` values still honoured as redirects to a canonical id. Kept
+ * identical to the previous copies in the controller and the route.
+ */
+export const ADMIN_MODULE_ALIASES: Partial<Record<string, AdminModule>> = {
+  "admin-upload-report": "admin-report-upload",
+  maintenance: "admin-maintenance",
+};
+
+/**
+ * Resolve a raw `?module=` value into a canonical admin module id, applying the
+ * alias table first. Returns `null` for absent/unknown values (callers decide
+ * the fallback). Pure — safe on server and client.
+ */
+export function parseAdminModule(
+  value: string | null | undefined,
+): AdminModule | null {
+  if (!value) return null;
+  const alias = ADMIN_MODULE_ALIASES[value];
+  if (alias) {
+    return alias;
+  }
+  return (ADMIN_MODULE_IDS as readonly string[]).includes(value)
+    ? (value as AdminModule)
+    : null;
+}
+
+// ── Clinic ──────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical clinic module ids in navigation order. Replaces the twin literal
+ * lists previously kept in `ClinicDashboardWorkspaceController`
+ * (`CLINIC_MODULE_VALUES`) and `app/dashboard/page.tsx` (`VALID_CLINIC_MODULES`).
+ */
+export const CLINIC_MODULE_IDS = [
+  "operaciones",
+  "informes",
+  "logistica",
+  "perfil",
+  "tokens",
+] as const;
+
+export type ClinicModule = (typeof CLINIC_MODULE_IDS)[number];
+
+/**
+ * Operational default. The clinic dashboard has NO module hub/home: `/dashboard`
+ * resolves straight into this workspace, and any legacy "back to overview"
+ * intent (hub reset) also lands here instead of a landing screen.
+ */
+export const DEFAULT_CLINIC_MODULE: ClinicModule = "operaciones";
+
+/**
+ * Resolve a raw `?module=` value into a canonical clinic module id. Returns
+ * `null` for absent/unknown values (callers fall back to
+ * {@link DEFAULT_CLINIC_MODULE}). Pure — safe on server and client.
+ */
+export function parseClinicModule(
+  value: string | null | undefined,
+): ClinicModule | null {
+  if (!value) return null;
+  return (CLINIC_MODULE_IDS as readonly string[]).includes(value)
+    ? (value as ClinicModule)
+    : null;
+}
+
+/**
+ * Clinic module navigation labels in canonical order. The full `label` and the
+ * compact `shortLabel` were previously duplicated verbatim between the shared
+ * module rail (`DashboardModuleRail`) and the mobile bottom-nav
+ * (`ClinicMobileBottomNav`); both now read the strings from here and keep only
+ * their own icon mapping locally.
+ */
+export const CLINIC_MODULE_NAV_LABELS: readonly {
+  moduleId: ClinicModule;
+  label: string;
+  shortLabel: string;
+}[] = [
+  { moduleId: "operaciones", label: "Operaciones", shortLabel: "Ops" },
+  { moduleId: "informes", label: "Informes", shortLabel: "Info" },
+  { moduleId: "logistica", label: "Logística", shortLabel: "Log" },
+  { moduleId: "perfil", label: "Perfil", shortLabel: "Perfil" },
+  { moduleId: "tokens", label: "Tokens", shortLabel: "Tokens" },
+];

--- a/frontend/src/features/dashboard/config/index.ts
+++ b/frontend/src/features/dashboard/config/index.ts
@@ -9,8 +9,9 @@
  *
  * Boundary rule: no React imports — pure data/config only.
  *
- * Empty on purpose: PR-PRES-2 only draws the architecture boundary; the real
- * catalog exports land in a later PRES PR (see the plan in
- * docs/implementation/dashboard-presentation-boundaries.md).
+ * PR-PRES-3 lands the first real catalog: the per-role module registry
+ * (canonical ids/order, admin aliases, clinic default, pure parse helpers and
+ * the clinic navigation label table). See
+ * docs/implementation/dashboard-module-config-catalog.md.
  */
-export {};
+export * from "./dashboardModules";

--- a/test/frontend-dashboard-admin.test.ts
+++ b/test/frontend-dashboard-admin.test.ts
@@ -14,6 +14,8 @@ const ADMIN_AUDIT_FILTER_PATH =
   "frontend/src/app/dashboard/admin/AdminAuditFilterBar.tsx";
 const ADMIN_AUDIT_SHARED_PATH =
   "frontend/src/app/dashboard/admin/admin-audit-shared.ts";
+const CATALOG_PATH =
+  "frontend/src/features/dashboard/config/dashboardModules.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -337,13 +339,23 @@ test("AdminDashboardWorkspaceController syncs module from URL with useSearchPara
 
   assert.ok(source.includes('useSearchParams'));
   assert.ok(source.includes('useEffect'));
-  assert.ok(source.includes('const ADMIN_MODULE_VALUES = ['));
-  assert.ok(source.includes('function parseModuleFromUrl(value: string | null): AdminModule | null'));
+  // The admin module list + alias-aware parse are the single source of truth in
+  // the config catalog; the controller consumes the shared parse helper instead
+  // of a locally re-declared ADMIN_MODULE_VALUES / parseModuleFromUrl.
+  assert.ok(
+    source.includes('import { parseAdminModule } from "@/features/dashboard/config";'),
+  );
   assert.ok(source.includes('searchParams.get("module")'));
-  assert.ok(source.includes('setActiveModule(parseModuleFromUrl(searchParams.get("module")));'));
+  assert.ok(
+    source.includes('setActiveModule(parseAdminModule(searchParams.get("module")));'),
+  );
   assert.ok(source.includes('[searchParams]'));
   assert.ok(source.includes('from "next/navigation"'));
   assert.ok(source.includes('useRouter, useSearchParams'));
+
+  const catalog = read(CATALOG_PATH);
+  assert.ok(catalog.includes('export const ADMIN_MODULE_IDS = ['));
+  assert.ok(catalog.includes('export function parseAdminModule('));
 });
 
 test("admin page wraps AdminDashboardWorkspaceController in Suspense for useSearchParams", () => {

--- a/test/frontend-dashboard-hub-hero.test.ts
+++ b/test/frontend-dashboard-hub-hero.test.ts
@@ -10,6 +10,8 @@ const CLINIC_CONTROLLER_PATH =
 const ADMIN_CONTROLLER_PATH =
   "frontend/src/app/dashboard/admin/AdminDashboardWorkspaceController.tsx";
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
+const CATALOG_PATH =
+  "frontend/src/features/dashboard/config/dashboardModules.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -122,7 +124,18 @@ test("clinic controller opens directly into a module workspace with the shared r
   // controller always resolves to a real module (operational default).
   assert.ok(source.includes('import { DashboardModuleRail } from "./DashboardModuleRail";'));
   assert.ok(source.includes('<DashboardModuleRail activeModule={activeModule} />'));
-  assert.ok(source.includes('export const DEFAULT_CLINIC_MODULE: ClinicModule = "operaciones";'));
+  // The operational default lives in the config catalog (single source of
+  // truth); the controller imports and re-exports it for compatibility and
+  // always resolves to it.
+  assert.ok(
+    source.includes('import type { ClinicModule } from "@/features/dashboard/config";'),
+  );
+  assert.ok(source.includes('export { DEFAULT_CLINIC_MODULE };'));
+  assert.ok(
+    read(CATALOG_PATH).includes(
+      'export const DEFAULT_CLINIC_MODULE: ClinicModule = "operaciones";',
+    ),
+  );
   assert.ok(source.includes('initialModule ?? DEFAULT_CLINIC_MODULE'));
 
   // The operational stage wrapper contract is preserved.

--- a/test/frontend-dashboard-remove-home-unified-workspace.test.ts
+++ b/test/frontend-dashboard-remove-home-unified-workspace.test.ts
@@ -13,6 +13,8 @@ const HORIZONTAL_NAV_PATH =
   "frontend/src/components/dashboard/DashboardHorizontalNav.tsx";
 const MOBILE_BOTTOM_NAV_PATH =
   "frontend/src/components/dashboard/ClinicMobileBottomNav.tsx";
+const CATALOG_PATH =
+  "frontend/src/features/dashboard/config/dashboardModules.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
@@ -46,11 +48,16 @@ test("/dashboard resolves to the operational default module (operaciones)", () =
   const page = read(PAGE_PATH);
   const controller = read(CONTROLLER_PATH);
 
+  // The operational default is the single source of truth in the config
+  // catalog; the controller imports and re-exports it (compat) and resolves to
+  // it, so `/dashboard` still opens straight into operaciones.
+  const catalog = read(CATALOG_PATH);
   assert.ok(
-    controller.includes(
+    catalog.includes(
       'export const DEFAULT_CLINIC_MODULE: ClinicModule = "operaciones";',
     ),
   );
+  assert.ok(controller.includes("export { DEFAULT_CLINIC_MODULE };"));
   // Server render already opens the default (no client-only flash to a hub).
   assert.ok(
     page.includes(
@@ -61,7 +68,7 @@ test("/dashboard resolves to the operational default module (operaciones)", () =
   assert.ok(controller.includes("initialModule ?? DEFAULT_CLINIC_MODULE"));
   assert.ok(
     controller.includes(
-      'parseModuleFromUrl(searchParams.get("module")) ?? DEFAULT_CLINIC_MODULE',
+      'parseClinicModule(searchParams.get("module")) ?? DEFAULT_CLINIC_MODULE',
     ),
   );
 });
@@ -74,6 +81,12 @@ test("clinic deep links (?module=) still drive the active module", () => {
 
   assert.ok(page.includes("parseClinicModule(resolvedSearchParams.module)"));
   assert.ok(controller.includes('searchParams.get("module")'));
+  // The canonical clinic module list is the single source of truth in the
+  // config catalog; the route + controller drive the active module through the
+  // shared `parseClinicModule` helper instead of a re-declared list.
+  const catalog = read(CATALOG_PATH);
+  assert.ok(catalog.includes("export const CLINIC_MODULE_IDS = ["));
+  assert.ok(catalog.includes("export function parseClinicModule("));
   for (const moduleId of [
     "operaciones",
     "informes",
@@ -82,8 +95,8 @@ test("clinic deep links (?module=) still drive the active module", () => {
     "tokens",
   ]) {
     assert.ok(
-      controller.includes(`"${moduleId}"`),
-      `controller must know module ${moduleId}`,
+      catalog.includes(`"${moduleId}"`),
+      `catalog must know module ${moduleId}`,
     );
   }
 });
@@ -122,7 +135,17 @@ test("DashboardModuleRail is the single shared module navigation/pager", () => {
   assert.equal(/from "next\/link"/.test(rail), false);
   assert.equal(/<a\s/.test(rail), false);
 
-  // Every clinic module is reachable from the single rail via ?module=.
+  // Every clinic module is reachable from the single rail via ?module=. The
+  // rail derives its items (id/label/shortLabel/order) from the shared config
+  // catalog and keeps only its local icon map, so the module list is declared
+  // once and can never drift from the mobile bottom-nav.
+  assert.ok(
+    rail.includes(
+      'import { CLINIC_MODULE_NAV_LABELS } from "@/features/dashboard/config";',
+    ),
+  );
+  assert.ok(rail.includes("CLINIC_MODULE_NAV_LABELS.map("));
+  const catalog = read(CATALOG_PATH);
   for (const moduleId of [
     "operaciones",
     "informes",
@@ -131,8 +154,8 @@ test("DashboardModuleRail is the single shared module navigation/pager", () => {
     "tokens",
   ]) {
     assert.ok(
-      rail.includes(`moduleId: "${moduleId}"`),
-      `rail must list module ${moduleId}`,
+      catalog.includes(`moduleId: "${moduleId}"`),
+      `catalog must list module ${moduleId}`,
     );
   }
 });


### PR DESCRIPTION
PR-PRES-3. Extracts a shared dashboard module config catalog as the initial single source of truth for role module ids, order, aliases, defaults, parsing, and clinic navigation labels. Updates minimal consumers and text-contract tests. No visual redesign, CSS, backend, API, auth, DB, Supabase, dependency, lockfile, CI, stash, or .claude/worktrees changes.